### PR TITLE
[Connect] Enable file downloads

### DIFF
--- a/Example/StripeConnectExample/StripeConnect Example.xcodeproj/project.pbxproj
+++ b/Example/StripeConnectExample/StripeConnect Example.xcodeproj/project.pbxproj
@@ -519,7 +519,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -577,7 +577,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 17.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -594,13 +594,13 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StripeConnectExample/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -621,13 +621,13 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = StripeConnectExample/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Example/StripeConnectExample/StripeConnectExample/API/API.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/API/API.swift
@@ -26,7 +26,7 @@ struct API {
         guard let baseUrl = URL(string: baseURL) else {
             return .failure(.invalidURL)
         }
-        let url = baseUrl.appending(path: path)
+        let url = baseUrl.appendingPathComponent(path)
         var request = URLRequest(url: url)
         request.httpMethod = method
         request.allHTTPHeaderFields = headers

--- a/Example/StripeConnectExample/StripeConnectExample/Base.lproj/LaunchScreen.storyboard
+++ b/Example/StripeConnectExample/StripeConnectExample/Base.lproj/LaunchScreen.storyboard
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -16,9 +17,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="StripeConnect Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tpl-NI-fTA">
-                                <rect key="frame" x="49" y="409" width="294" height="35"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="StripeConnect Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tpl-NI-fTA">
+                                <rect key="frame" x="49.666666666666657" y="408.66666666666669" width="294" height="35"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="29"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -26,6 +26,10 @@
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="tpl-NI-fTA" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="MG3-T5-zZj"/>
+                            <constraint firstItem="tpl-NI-fTA" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="fIw-p1-lqC"/>
+                        </constraints>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/Example/StripeConnectExample/StripeConnectExample/Base.lproj/LaunchScreen.storyboard
+++ b/Example/StripeConnectExample/StripeConnectExample/Base.lproj/LaunchScreen.storyboard
@@ -17,8 +17,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="StripeConnect Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tpl-NI-fTA">
-                                <rect key="frame" x="49.666666666666657" y="408.66666666666669" width="294" height="35"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="StripeConnect Example" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tpl-NI-fTA">
+                                <rect key="frame" x="20" y="408.66666666666669" width="353" height="35"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="29"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
@@ -27,7 +27,8 @@
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
-                            <constraint firstItem="tpl-NI-fTA" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="MG3-T5-zZj"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="tpl-NI-fTA" secondAttribute="trailing" constant="20" id="C34-2d-4Rw"/>
+                            <constraint firstItem="tpl-NI-fTA" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="20" id="HH7-od-x32"/>
                             <constraint firstItem="tpl-NI-fTA" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="centerY" id="fIw-p1-lqC"/>
                         </constraints>
                     </view>

--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -88,8 +88,8 @@
 		41D17A6D2C5A7429007C6EE6 /* StripeiOS-Shared.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 41D17A622C5A7429007C6EE6 /* StripeiOS-Shared.xcconfig */; };
 		41D17A6E2C5A7429007C6EE6 /* Version.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 41D17A632C5A7429007C6EE6 /* Version.xcconfig */; };
 		E6165CBF2CA7BF2200B76DA5 /* FetchInitComponentPropsMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6165CBE2CA7BF2200B76DA5 /* FetchInitComponentPropsMessageHandler.swift */; };
-		E65691222CA52D5900E0DB00 /* StripeConnect+Exports.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65691212CA52D5900E0DB00 /* StripeConnect+Exports.swift */; };
 		E6165CC12CA7D09900B76DA5 /* FetchInitComponentPropsMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6165CC02CA7D09900B76DA5 /* FetchInitComponentPropsMessageHandlerTests.swift */; };
+		E65691222CA52D5900E0DB00 /* StripeConnect+Exports.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65691212CA52D5900E0DB00 /* StripeConnect+Exports.swift */; };
 		E65691202CA5248300E0DB00 /* AccountManagementViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E656911F2CA5248300E0DB00 /* AccountManagementViewControllerTests.swift */; };
 		E6C5F5F62C9FEE0200861709 /* AccountManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5F5F52C9FEE0200861709 /* AccountManagementViewController.swift */; };
 		E6F485F82C9E35A5000D914F /* PaymentDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6F485F72C9E35A5000D914F /* PaymentDetailsViewController.swift */; };
@@ -190,11 +190,11 @@
 		41D17A612C5A7429007C6EE6 /* StripeiOS-Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "StripeiOS-Release.xcconfig"; sourceTree = "<group>"; };
 		41D17A622C5A7429007C6EE6 /* StripeiOS-Shared.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "StripeiOS-Shared.xcconfig"; sourceTree = "<group>"; };
 		41D17A632C5A7429007C6EE6 /* Version.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
-		E65691212CA52D5900E0DB00 /* StripeConnect+Exports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StripeConnect+Exports.swift"; sourceTree = "<group>"; };
 		E6165CBE2CA7BF2200B76DA5 /* FetchInitComponentPropsMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchInitComponentPropsMessageHandler.swift; sourceTree = "<group>"; };
 		E656911F2CA5248300E0DB00 /* AccountManagementViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManagementViewControllerTests.swift; sourceTree = "<group>"; };
 		E6C5F5F52C9FEE0200861709 /* AccountManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManagementViewController.swift; sourceTree = "<group>"; };
 		E6165CC02CA7D09900B76DA5 /* FetchInitComponentPropsMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchInitComponentPropsMessageHandlerTests.swift; sourceTree = "<group>"; };
+		E65691212CA52D5900E0DB00 /* StripeConnect+Exports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StripeConnect+Exports.swift"; sourceTree = "<group>"; };
 		E6F485F72C9E35A5000D914F /* PaymentDetailsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentDetailsViewController.swift; sourceTree = "<group>"; };
 		E6F485FB2C9E360A000D914F /* ConnectJSURLParams.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ConnectJSURLParams.swift; sourceTree = "<group>"; };
 		E6F485FD2C9E36B2000D914F /* PaymentDetailsViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentDetailsViewControllerTests.swift; sourceTree = "<group>"; };

--- a/StripeConnect/StripeConnect/Source/Internal/StripeConnectConstants.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/StripeConnectConstants.swift
@@ -12,7 +12,6 @@ enum StripeConnectConstants {
     /**'
      Pages or navigation requests matching any of these hosts will...
      - Automatically grant camera permissions
-     - Accept downloads (TODO MXMOBILE-2485)
      - Open popups in PopupWebViewController (instead of Safari)
      */
     static let allowedHosts: Set<String> = [

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
@@ -82,7 +82,7 @@ class ConnectWebView: WKWebView {
 
 @available(iOS 15, *)
 private extension ConnectWebView {
-    // Opens the given navigation in a PopupWebViewController
+    /// Opens the given navigation in a PopupWebViewController
     func openInPopupWebViewController(configuration: WKWebViewConfiguration,
                                       navigationAction: WKNavigationAction) -> WKWebView? {
         let popupVC = PopupWebViewController(configuration: configuration,
@@ -98,7 +98,7 @@ private extension ConnectWebView {
         return popupVC.webView
     }
 
-    // Opens the given URL in an SFSafariViewController
+    /// Opens the given URL in an SFSafariViewController
     func openInAppSafari(url: URL) {
         let safariVC = SFSafariViewController(url: url)
         safariVC.dismissButtonStyle = .done
@@ -106,14 +106,15 @@ private extension ConnectWebView {
         presentPopup(safariVC)
     }
 
-    // Opens with UIApplication.open, if supported
+    /// Opens with UIApplication.open, if supported
     func openOnSystem(url: URL) {
         urlOpener.openIfPossible(url)
     }
 
+    /// Returns true if this URL should open in an embedded web view
     func shouldNavigate(toURL url: URL) -> Bool {
-        // Only open popups to known hosts inside PopupWebViewController,
-        // otherwise use an SFSafariViewController
+        // Only open known hosts inside an embedded web view, otherwise use
+        // an SFSafariViewController so the user can have navigation controls
 
         ["http", "https"].contains(url.scheme)
         && url.host.map(StripeConnectConstants.allowedHosts.contains) != false
@@ -132,7 +133,7 @@ private extension ConnectWebView {
     }
 
     func showErrorAlert(for error: Error) {
-        // TODO: Log error
+        // TODO: MXMOBILE-2491 Log analytic when receiving an eror
         debugPrint(error)
 
         let alert = UIAlertController(

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
@@ -210,13 +210,6 @@ extension ConnectWebView: WKNavigationDelegate {
             return .download
         }
 
-        // Response is from an unrecognized host, don't open in an embedded web view
-        if let url = navigationResponse.response.url,
-           !shouldNavigate(toURL: url) {
-            openInSystemOrSafari(url)
-            return .cancel
-        }
-
         return .allow
     }
 

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
@@ -44,7 +44,7 @@ class ConnectWebView: WKWebView {
     /// The instance that will handle opening external urls
     let urlOpener: ApplicationURLOpener
 
-    /// The file manager responsible for creating temporary file directories
+    /// The file manager responsible for creating temporary file directories to store downloads
     let fileManager: FileManager
 
     /// The current version for the SDK
@@ -189,13 +189,15 @@ extension ConnectWebView: WKNavigationDelegate {
         _ webView: WKWebView,
         decidePolicyFor navigationAction: WKNavigationAction
     ) async -> WKNavigationActionPolicy {
-        // `shouldPerformDownload` will be true if the request has MIME types
-        // or a `Content-Type` header indicating it's a download or it originated
-        // as a JS download.
-        //
-        // This is not entirely accurate and we can't know a request should be a
-        // download until evaluating the response.
+        /*
+         `shouldPerformDownload` will be true if the request has MIME types
+         or a `Content-Type` header indicating it's a download or it originated
+         as a JS download.
 
+         NOTE: We sometimes can't know if a request should be a download until
+         after its response is received. Those cases are handled by
+         `decidePolicyFor navigationResponse` below.
+         */
         navigationAction.shouldPerformDownload ? .download : .allow
     }
 

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
@@ -84,7 +84,7 @@ class ConnectWebView: WKWebView {
 private extension ConnectWebView {
     // Opens the given navigation in a PopupWebViewController
     func openInPopupWebViewController(configuration: WKWebViewConfiguration,
-                             navigationAction: WKNavigationAction) -> WKWebView? {
+                                      navigationAction: WKNavigationAction) -> WKWebView? {
         let popupVC = PopupWebViewController(configuration: configuration,
                                              navigationAction: navigationAction,
                                              urlOpener: urlOpener,

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewTests.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+import QuickLook
 import SafariServices
 @testable import StripeConnect
 @_spi(STP) import StripeCore
@@ -15,14 +16,18 @@ import XCTest
 
 class ConnectWebViewTests: XCTestCase {
 
-    var mockURLOpener: MockURLOpener!
+    private var mockURLOpener: MockURLOpener!
+    private var mockFileManager: MockFileManager!
     var webView: ConnectWebView!
 
     override func setUp() {
+        super.setUp()
+        mockFileManager = .init()
         mockURLOpener = .init()
         webView = ConnectWebView(frame: .zero,
                                  configuration: .init(),
                                  urlOpener: mockURLOpener,
+                                 fileManager: mockFileManager,
                                  sdkVersion: "1.2.3")
     }
 
@@ -49,7 +54,8 @@ class ConnectWebViewTests: XCTestCase {
         wait(for: [expectation], timeout: TestHelpers.defaultTimeout)
     }
 
-    func testOpenSafariVCIfNotInAllowedHosts() {
+    /// HTTP/HTTPS navigations with no target from a non-allowlisted host should open in a SafariVC
+    func testPopupOpenSafariVCIfNotInAllowedHosts() {
         var safariVC: SFSafariViewController?
         webView.presentPopup = { vc in
             safariVC = vc as? SFSafariViewController
@@ -63,6 +69,7 @@ class ConnectWebViewTests: XCTestCase {
         XCTAssertNotNil(safariVC)
     }
 
+    /// HTTP/HTTPS navigations with no target and an allowlisted host should open in a popup webview
     func testOpenAsPopUpIfInAllowedHosts() {
         for url in [
             "https://connect-js.stripe.com",
@@ -90,7 +97,8 @@ class ConnectWebViewTests: XCTestCase {
         }
     }
 
-    func testCustomURLScheme() {
+    /// Non-HTTP/HTTPS navigations with no target should use the system's URL routing
+    func testPopupWithCustomURLScheme() {
         let url = URL(string: "connect://test")!
         let canOpenURLExpectation = XCTestExpectation(description: "Can open url called")
         let openURLExpectation = XCTestExpectation(description: "Open url called")
@@ -112,10 +120,11 @@ class ConnectWebViewTests: XCTestCase {
                                       windowFeatures: .init())
 
         XCTAssertNil(webView)
-        wait(for: [canOpenURLExpectation, openURLExpectation], timeout: 0.1)
+        wait(for: [canOpenURLExpectation, openURLExpectation], timeout: TestHelpers.defaultTimeout)
     }
 
-    func testJavascriptPopupHandling() {
+    /// Any navigation request with a non-nil target should not open a popup
+    func testNonPopupNavigations() {
         let url = URL(string: "connect://test")!
         mockURLOpener.canOpenURLOverride = { _ in
             XCTFail("Can open url should not be called")
@@ -134,9 +143,219 @@ class ConnectWebViewTests: XCTestCase {
 
         XCTAssertNil(webView)
     }
+
+    /// `window.close()` should close the view
+    func testWindowCloseDismissesView() {
+        var didCloseCalled = false
+        webView.didClose = { wv in
+            XCTAssertEqual(wv, self.webView)
+            didCloseCalled = true
+        }
+        webView.uiDelegate?.webViewDidClose?(webView)
+        XCTAssertTrue(didCloseCalled)
+    }
+
+    /// Download if `Content-Disposition` header is an attachment
+    @MainActor
+    func testResponsePolicyForAttachments() async {
+        // Use a non-allow listed URL to ensure these can be treated as a download
+        let response = HTTPURLResponse(
+            url: URL(string: "https://stripe-s3.com/path")!,
+            statusCode: 200,
+            httpVersion: nil,
+            headerFields: ["Content-Disposition": "attachment; filename=payouts.csv"]
+        )!
+
+        let policy = await webView.webView(
+            webView,
+            decidePolicyFor: MockNavigationResponse(
+                response: response,
+                canShowMIMEType: true
+            )
+        )
+        XCTAssertEqual(policy, .download)
+    }
+
+    /// Non-download and non-HTTP/HTTPS responses should use the system's URL routing
+    @MainActor
+    func testResponsePolicyForCustomURLScheme() async {
+        let response = URLResponse(
+            url: URL(string: "connect://test")!,
+            mimeType: nil,
+            expectedContentLength: 100,
+            textEncodingName: nil
+        )
+
+        let canOpenURLExpectation = XCTestExpectation(description: "Can open url called")
+        let openURLExpectation = XCTestExpectation(description: "Open url called")
+
+        mockURLOpener.canOpenURLOverride = { _ in
+            canOpenURLExpectation.fulfill()
+            return true
+        }
+        mockURLOpener.openURLOverride = { openURL, _, _ in
+            XCTAssertEqual(response.url, openURL)
+            openURLExpectation.fulfill()
+        }
+        webView.presentPopup = { _ in
+            XCTFail("Present pop up should not be called")
+        }
+
+        let policy = await webView.webView(
+            webView,
+            decidePolicyFor: MockNavigationResponse(
+                response: response,
+                canShowMIMEType: true
+            )
+        )
+        XCTAssertEqual(policy, .cancel)
+
+        await fulfillment(of: [canOpenURLExpectation, openURLExpectation], timeout: TestHelpers.defaultTimeout)
+    }
+
+    /// Non-download HTTP/HTTPS responses with from a non-allowlisted host should open in a SafariVC
+    @MainActor
+    func testResponsePolicyForDisallowedHosts() async {
+        var safariVC: SFSafariViewController?
+        webView.presentPopup = { vc in
+            safariVC = vc as? SFSafariViewController
+        }
+        let response = URLResponse(
+            url: URL(string: "https://stripe.com")!,
+            mimeType: nil,
+            expectedContentLength: 100,
+            textEncodingName: nil
+        )
+
+        let policy = await webView.webView(
+            webView,
+            decidePolicyFor: MockNavigationResponse(
+                response: response,
+                canShowMIMEType: true
+            )
+        )
+        XCTAssertEqual(policy, .cancel)
+        XCTAssertNotNil(safariVC)
+    }
+
+    /// Non-download HTTP/HTTPS responses with an allowlisted host should be allowed
+    @MainActor
+    func testResponsePolicyForNonAttachmentAllowedHosts() async {
+        for url in [
+            "https://connect-js.stripe.com",
+            "https://connect-js.stripe.com/hello",
+            "https://connect.stripe.com/",
+            "https://connect.stripe.com/test",
+            "http://connect-js.stripe.com",
+            "http://connect-js.stripe.com/hello",
+            "http://connect.stripe.com/",
+            "http://connect.stripe.com/test",
+        ] {
+            let response = URLResponse(
+                url: URL(string: url)!,
+                mimeType: nil,
+                expectedContentLength: 100,
+                textEncodingName: nil
+            )
+
+            let policy = await webView.webView(
+                webView,
+                decidePolicyFor: MockNavigationResponse(
+                    response: response,
+                    canShowMIMEType: true
+                )
+            )
+            XCTAssertEqual(policy, .allow)
+        }
+    }
+
+    @MainActor
+    func testDownloadDestination() async {
+        let destination = await webView.download(
+            decideDestinationUsing: .init(),
+            suggestedFilename: "example.csv"
+        )
+
+        XCTAssertEqual(destination?.lastPathComponent, "example.csv")
+        XCTAssert(destination?.absoluteString.starts(with: "file:///temp/") == true, String(describing: destination ))
+
+        XCTAssertEqual(webView.downloadedFile, destination)
+    }
+
+    @MainActor
+    func testDownloadDestinationIsTempUniqueFolder() async {
+        let destination1 = await webView.download(
+            decideDestinationUsing: .init(),
+            suggestedFilename: "example.csv"
+        )
+        let destination2 = await webView.download(
+            decideDestinationUsing: .init(),
+            suggestedFilename: "example.csv"
+        )
+
+        // Different file path is created for repeating the same download
+        XCTAssertNotEqual(destination1, destination2)
+
+        // Filename matches suggestion
+        XCTAssertEqual(destination1?.lastPathComponent, "example.csv")
+        XCTAssertEqual(destination2?.lastPathComponent, "example.csv")
+
+        // File located in temp directory
+        XCTAssertEqual(destination1?.absoluteString.starts(with: "file:///temp/"), true, String(describing: destination1?.absoluteString ))
+        XCTAssertEqual(destination2?.absoluteString.starts(with: "file:///temp/"), true, String(describing: destination2?.absoluteString ))
+    }
+
+    @MainActor
+    func testErrorCreatingDownloadDestinationShowsAlert() async {
+        var alertController: UIAlertController?
+        webView.presentPopup = { vc in
+            alertController = vc as? UIAlertController
+        }
+        mockFileManager.overrideCreateDirectory = { _, _, _ in
+            throw NSError(domain: "Test", code: 0)
+        }
+
+        let destination = await webView.download(
+            decideDestinationUsing: .init(),
+            suggestedFilename: "example.csv"
+        )
+        XCTAssertNil(destination)
+        XCTAssertNotNil(alertController)
+        XCTAssertEqual(alertController?.message,
+                       "There was an unexpected error -- try again in a few seconds")
+        XCTAssertEqual(alertController?.preferredStyle, .alert)
+    }
+
+    func testDownloadFailedShowsAlert() {
+        var alertController: UIAlertController?
+        webView.presentPopup = { vc in
+            alertController = vc as? UIAlertController
+        }
+        webView.download(
+            didFailWithError: NSError(domain: "Test", code: 0),
+            resumeData: nil
+        )
+        XCTAssertNotNil(alertController)
+        XCTAssertEqual(alertController?.message,
+                       "There was an unexpected error -- try again in a few seconds")
+        XCTAssertEqual(alertController?.preferredStyle, .alert)
+    }
+
+    func testDownloadFinishedShowsPreview() {
+        let mockFileURL = URL(string: "file:///temp/example.csv")!
+
+        var previewController: QLPreviewController?
+        webView.presentPopup = { vc in
+            previewController = vc as? QLPreviewController
+        }
+        webView.downloadedFile = mockFileURL
+
+        webView.downloadDidFinish()
+        XCTAssertNotNil(previewController)
+    }
 }
 
-class MockNavigationAction: WKNavigationAction {
+private class MockNavigationAction: WKNavigationAction {
     let requestOverride: URLRequest
     let targetFrameOverride: WKFrameInfo?
 
@@ -155,7 +374,27 @@ class MockNavigationAction: WKNavigationAction {
     }
 }
 
-class MockURLOpener: ApplicationURLOpener {
+private class MockNavigationResponse: WKNavigationResponse {
+    let responseOverride: URLResponse
+    let canShowMIMETypeOverride: Bool
+
+    override var response: URLResponse {
+        responseOverride
+    }
+
+    override var canShowMIMEType: Bool {
+        canShowMIMETypeOverride
+    }
+
+    init(response: URLResponse,
+         canShowMIMEType: Bool) {
+        self.responseOverride = response
+        self.canShowMIMETypeOverride = canShowMIMEType
+        super.init()
+    }
+}
+
+private class MockURLOpener: ApplicationURLOpener {
     var canOpenURLOverride: ((_ url: URL) -> Bool)?
     var openURLOverride: ((_ url: URL, _ options: [UIApplication.OpenExternalURLOptionsKey: Any], _ completion: OpenCompletionHandler?) -> Void)?
 
@@ -165,5 +404,17 @@ class MockURLOpener: ApplicationURLOpener {
 
     func open(_ url: URL, options: [UIApplication.OpenExternalURLOptionsKey: Any], completionHandler completion: OpenCompletionHandler?) {
         openURLOverride?(url, options, completion)
+    }
+}
+
+private class MockFileManager: FileManager {
+    override var temporaryDirectory: URL {
+        URL(string: "file:///temp")!
+    }
+
+    var overrideCreateDirectory: ((_ url: URL, _ createIntermediates: Bool, _ attributes: [FileAttributeKey: Any]?) throws -> Void)?
+
+    override func createDirectory(at url: URL, withIntermediateDirectories createIntermediates: Bool, attributes: [FileAttributeKey: Any]? = nil) throws {
+        try overrideCreateDirectory?(url, createIntermediates, attributes)
     }
 }


### PR DESCRIPTION
## Summary
- **Enables file downloads from embedded components**
  When the file is downloaded, it's previewed in a `QLPreviewController` and allows the user to save the file or open in an app installed on their system.

- **Lowers the min supported OS version of the example app to 15.0, the same as the SDK**
  This enables us to test on iOS 15 devices.

- **Adds constraints to the example app Launchscreen so the text is centered on all device sizes**

## Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2485

## Testing

- [x] Unit tests
- [x] Manual testing (see video)

https://github.com/user-attachments/assets/049e1f2a-b6ec-417b-bbb2-8e164be663d0
