### PR TITLE
[BANKCON-14535] Add E2E test for Panther flow

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2242,6 +2242,10 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         fillLinkAndPay(mode: .checkbox)
     }
 
+    func testLinkCardBrand() {
+        _testInstantDebits(mode: .payment, useLinkCardBrand: true)
+    }
+
     // MARK: Link test helpers
 
     private enum LinkMode {
@@ -2419,11 +2423,16 @@ extension PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
     }
 
-    func _testInstantDebits(mode: PaymentSheetTestPlaygroundSettings.Mode, vertical: Bool = false) {
+    func _testInstantDebits(
+        mode: PaymentSheetTestPlaygroundSettings.Mode,
+        vertical: Bool = false,
+        useLinkCardBrand: Bool = false
+    ) {
+        
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.mode = mode
         settings.apmsEnabled = .off
-        settings.supportedPaymentMethods = "card,link"
+        settings.supportedPaymentMethods = useLinkCardBrand ? "card" : "card,link"
         if vertical {
             settings.layout = .vertical
         }


### PR DESCRIPTION
## Summary

This adds a simple E2E going through the Panther / Link Card Brand flow. It reuses the existing instant debits helper, since the user experience here is the exact same, except without specifying `link` as a payment method.

## Motivation

BANKCON-14535

## Testing

Video of the test:

https://github.com/user-attachments/assets/8731a22e-032f-4817-9ac8-61836ce86f9d

## Changelog

N/a
