### PR TITLE
Fix us bank form regeneration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## X.Y.Z X-Y-Z
 ### PaymentSheet
-* [Fixed] Fixes an issue where ISK was not correctly formatted as a zero-decimal currency when using PaymentSheet or Apple Pay. (Thanks [@Thithip](https://github.com/Thithip)!)
+* [Fixed] Fixed an issue where ISK was not correctly formatted as a zero-decimal currency when using PaymentSheet or Apple Pay. (Thanks [@Thithip](https://github.com/Thithip)!)
+* [Fixed] Fixed an issue where US Bank Account forms would drop form field input when `FlowController.update` is called.
 
 ## 23.31.0 2024-09-23
 ### PaymentSheet

--- a/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsLinkedBank.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsLinkedBank.swift
@@ -16,7 +16,7 @@ import Foundation
     public let instantlyVerified: Bool
 
     public init(
-        with sessionId: String,
+        sessionId: String,
         accountId: String,
         displayName: String?,
         bankName: String?,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/FinancialConnectionsSDKImplementation.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/FinancialConnectionsSDKImplementation.swift
@@ -82,7 +82,7 @@ public class FinancialConnectionsSDKImplementation: FinancialConnectionsSDKInter
         switch paymentAccount {
         case .linkedAccount(let linkedAccount):
             return FinancialConnectionsLinkedBank(
-                with: session.id,
+                sessionId: session.id,
                 accountId: linkedAccount.id,
                 displayName: linkedAccount.displayName,
                 bankName: linkedAccount.institutionName,
@@ -91,7 +91,7 @@ public class FinancialConnectionsSDKImplementation: FinancialConnectionsSDKInter
             )
         case .bankAccount(let bankAccount):
             return FinancialConnectionsLinkedBank(
-                with: session.id,
+                sessionId: session.id,
                 accountId: bankAccount.id,
                 displayName: bankAccount.bankName,
                 bankName: bankAccount.bankName,

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		B6BF12392C2F2E790033601E /* PaymentSheetImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6BF12382C2F2E780033601E /* PaymentSheetImageTests.swift */; };
 		B6D1B3662C5DFCE800A9E0D7 /* PaymentSheetAnalyticsHelperTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6D1B3652C5DFCE800A9E0D7 /* PaymentSheetAnalyticsHelperTest.swift */; };
 		B6E8C7FB2C184A0300B977B2 /* PaymentSheetFormFactory+Mandates.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6E8C7FA2C184A0300B977B2 /* PaymentSheetFormFactory+Mandates.swift */; };
+		B6F4C5F82CADB0CB00AF3767 /* USBankAccountPaymentMethodElementTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F4C5F72CADB0CB00AF3767 /* USBankAccountPaymentMethodElementTest.swift */; };
 		B8A217F26AAEC592B9B0D2E1 /* CardScanButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24AB1D50F770A8A035EF31DF /* CardScanButton.swift */; };
 		B8A7575878C5124CF5482097 /* VerificationSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 441C3414745D483C9A47ED0B /* VerificationSession.swift */; };
 		B99DA5A48A9EF5E352DDA872 /* PaymentSheetFormFactory+Boleto.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FA13D5E18B38C4E475FB5A /* PaymentSheetFormFactory+Boleto.swift */; };
@@ -596,6 +597,7 @@
 		B6BF12382C2F2E780033601E /* PaymentSheetImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetImageTests.swift; sourceTree = "<group>"; };
 		B6D1B3652C5DFCE800A9E0D7 /* PaymentSheetAnalyticsHelperTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetAnalyticsHelperTest.swift; sourceTree = "<group>"; };
 		B6E8C7FA2C184A0300B977B2 /* PaymentSheetFormFactory+Mandates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentSheetFormFactory+Mandates.swift"; sourceTree = "<group>"; };
+		B6F4C5F72CADB0CB00AF3767 /* USBankAccountPaymentMethodElementTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = USBankAccountPaymentMethodElementTest.swift; sourceTree = "<group>"; };
 		B70D161E50723A8953665C4B /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		B829BC7EEE9576F724F7A9B3 /* StripePaymentSheetTestHostApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = StripePaymentSheetTestHostApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B8A49995CE949176F7A8C71F /* SimpleMandateTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleMandateTextView.swift; sourceTree = "<group>"; };
@@ -1406,47 +1408,46 @@
 				0C53358C028E528F0FC626A2 /* CustomerSheet */,
 				989C2E3E03E42DA64A2FAE0D /* CustomerSheetSnapshotTests.swift */,
 				31699A822BE183D40048677F /* DownloadManagerTest.swift */,
-				6103F2BD2BE53737002D67F8 /* SavedPaymentMethodManagerTest.swift */,
 				73FB30705EC36BD0868904A2 /* Elements+TestHelpers.swift */,
+				61FB6BCC2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift */,
 				64C8F350CDB5A29F62E86592 /* FlowControllerStateTests.swift */,
-				990304EF35A0EE37DCE20D5B /* IntentStatusPollerTest.swift */,
 				6B0E5AE62C08F4B5008AAFBE /* IntentConfirmParamsTest.swift */,
+				990304EF35A0EE37DCE20D5B /* IntentStatusPollerTest.swift */,
 				FCA28FF8CD5BA829A44CDCE7 /* Link */,
 				33B8F21A22FA091BC9D2924B /* LinkStubs.swift */,
+				B65B42962C013DED00EC565D /* PaymentMethodFormViewControllerTest.swift */,
 				C830FEC205E7162FF4D414BE /* PaymentMethodMessagingViewFunctionalTest.swift */,
 				5BA7BFC43DB3EFD38A460EB9 /* PaymentMethodMessagingViewSnapshotTests.swift */,
 				619AF0842BF56C5E00D1C981 /* PaymentMethodRowButtonSnapshotTests.swift */,
 				8A0B7F6E25D93C0C0ACE3B3D /* PaymentSheet+APITest.swift */,
-				619AF0882BF56F9100D1C981 /* VerticalSavedPaymentMethodsViewControllerTests.swift */,
+				82C21D5722BDEB8BAA71F69F /* PaymentSheet+DashboardConfirmParamsTest.swift */,
 				AA8F7F2824DFC78268ED6459 /* PaymentSheet+DeferredAPITest.swift */,
 				135B7354260E0E7CADCF3426 /* PaymentSheetAddressTests.swift */,
-				B65B42962C013DED00EC565D /* PaymentMethodFormViewControllerTest.swift */,
+				B6D1B3652C5DFCE800A9E0D7 /* PaymentSheetAnalyticsHelperTest.swift */,
+				E83494558F0C93C5B05A1DFB /* PaymentSheetConfigurationTests.swift */,
 				357B9EB0751819566843117E /* PaymentSheetDeferredValidatorTests.swift */,
 				5F884F7A5FF4FC6D0E24E6FC /* PaymentSheetErrorTest.swift */,
-				B63B2CF02BF8313D003810F3 /* VerticalPaymentMethodListViewControllerTest.swift */,
-				6141C5062C0A47A700E81735 /* RightAccessoryButtonTest.swift */,
 				35853BC78F9E64F5729EAE1E /* PaymentSheetExternalPaymentMethodTests.swift */,
 				EACC9F3AE667BDD05D6A0561 /* PaymentSheetFlowControllerViewControllerSnapshotTests.swift */,
 				4D595AA033BC84CB4E1C277F /* PaymentSheetFormFactorySnapshotTest.swift */,
 				A6C0EC1D4DC96A6917A2DFBA /* PaymentSheetFormFactoryTest.swift */,
+				6B76DBD02C530B6C0037CD63 /* PaymentSheetGDPRConfirmFlowTests.swift */,
+				B6BF12382C2F2E780033601E /* PaymentSheetImageTests.swift */,
 				0901281208BEB220D0B491A8 /* PaymentSheetLinkAccountTests.swift */,
 				492B254E43F3BB9F9CEAEA06 /* PaymentSheetLoaderStubbedTest.swift */,
 				C90A2636C2A577AF36FB793B /* PaymentSheetLoaderTest.swift */,
 				C47D00B9DE812D0801B4E33F /* PaymentSheetLPMConfirmFlowTests.swift */,
 				D926018024823367971A8907 /* PaymentSheetPaymentMethodTypeTest.swift */,
-				B6BF12382C2F2E780033601E /* PaymentSheetImageTests.swift */,
-				B6D1B3652C5DFCE800A9E0D7 /* PaymentSheetAnalyticsHelperTest.swift */,
 				7E2803AA0D975AF78D787757 /* PaymentSheetSnapshotTests.swift */,
-				E0838F23622121FEF4A15136 /* PaymentSheetViewControllerSnapshotTests.swift */,
-				B65FE7082BED33EA009A73FC /* VerticalPaymentMethodListViewControllerSnapshotTest.swift */,
 				B63B2CF62BFC116A003810F3 /* PaymentSheetVerticalViewControllerSnapshotTest.swift */,
 				B64FEF112C0FAC1E00F7CA26 /* PaymentSheetVerticalViewControllerTest.swift */,
+				E0838F23622121FEF4A15136 /* PaymentSheetViewControllerSnapshotTests.swift */,
 				1ADE49E72DD5EDA448D12D88 /* PollingViewTests.swift */,
-				61FB6BCC2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift */,
+				6141C5062C0A47A700E81735 /* RightAccessoryButtonTest.swift */,
+				6103F2BD2BE53737002D67F8 /* SavedPaymentMethodManagerTest.swift */,
 				C1AED4473AD4C07D461E9E48 /* SavedPaymentOptionsViewControllerSnapshotTests.swift */,
+				6B50BCED2C29EE1F009702FB /* SavedPaymentOptionsViewControllerTests.swift */,
 				BA3902DA8D647E934686CB5C /* SepaMandateViewControllerSnapshotTest.swift */,
-				6151DDBF2B14FDCF00ED4F7E /* UpdateCardViewControllerSnapshotTests.swift */,
-				61CBE6672BED97EE005F7FEB /* VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift */,
 				7D8FE374BAAD0EDA9FEEF550 /* STPAnalyticsClient+PaymentSheetTests.swift */,
 				B68CB9622B0D2169006ACDB1 /* STPAPIClient+PaymentSheetTest.swift */,
 				D16926577504D37992F8917E /* STPApplePayContext+PaymentSheetTest.swift */,
@@ -1455,11 +1456,13 @@
 				A39F7EBA2E9E3CE55E7AADC9 /* STPFixtures+PaymentSheet.swift */,
 				AC0DBA7D63BAD0182695E436 /* Stubbed */,
 				D00C7F5905759525C9BF8BD4 /* TextFieldElement+CardTest.swift */,
-				82C21D5722BDEB8BAA71F69F /* PaymentSheet+DashboardConfirmParamsTest.swift */,
-				E83494558F0C93C5B05A1DFB /* PaymentSheetConfigurationTests.swift */,
+				6151DDBF2B14FDCF00ED4F7E /* UpdateCardViewControllerSnapshotTests.swift */,
+				B6F4C5F72CADB0CB00AF3767 /* USBankAccountPaymentMethodElementTest.swift */,
 				316B33112B5F171C0008D2E5 /* UserDefaults+StripePaymentSheetTest.swift */,
-				6B50BCED2C29EE1F009702FB /* SavedPaymentOptionsViewControllerTests.swift */,
-				6B76DBD02C530B6C0037CD63 /* PaymentSheetGDPRConfirmFlowTests.swift */,
+				B65FE7082BED33EA009A73FC /* VerticalPaymentMethodListViewControllerSnapshotTest.swift */,
+				B63B2CF02BF8313D003810F3 /* VerticalPaymentMethodListViewControllerTest.swift */,
+				61CBE6672BED97EE005F7FEB /* VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift */,
+				619AF0882BF56F9100D1C981 /* VerticalSavedPaymentMethodsViewControllerTests.swift */,
 			);
 			path = PaymentSheet;
 			sourceTree = "<group>";
@@ -1736,6 +1739,7 @@
 				E0E47773D3C0B432E26AA457 /* STPElementsSessionTest.swift in Sources */,
 				29C98FB712F3FB987CBE18B0 /* STPFixtures+PaymentSheet.swift in Sources */,
 				45D9849E9B36C56E15EAAE0A /* SavedPaymentOptionsViewControllerSnapshotTests.swift in Sources */,
+				B6F4C5F82CADB0CB00AF3767 /* USBankAccountPaymentMethodElementTest.swift in Sources */,
 				9787A622B527C1AD96A73827 /* SepaMandateViewControllerSnapshotTest.swift in Sources */,
 				B68CB9632B0D2169006ACDB1 /* STPAPIClient+PaymentSheetTest.swift in Sources */,
 				6141C5072C0A47A700E81735 /* RightAccessoryButtonTest.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -305,7 +305,7 @@ extension CustomerAddPaymentMethodViewController {
                 break
             case .completed(let completedResult):
                 if case .financialConnections(let linkedBank) = completedResult {
-                    usBankAccountPaymentMethodElement.setLinkedBank(linkedBank)
+                    usBankAccountPaymentMethodElement.linkedBank = linkedBank
                 } else {
                     self.delegate?.updateErrorLabel(for: genericError)
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -181,7 +181,7 @@ class CustomerAddPaymentMethodViewController: UIViewController {
         guard let usBankAccountPaymentMethodElement = self.paymentMethodFormElement as? USBankAccountPaymentMethodElement else {
             return false
         }
-        let customerHasLinkedBankAccount = usBankAccountPaymentMethodElement.getLinkedBank() != nil
+        let customerHasLinkedBankAccount = usBankAccountPaymentMethodElement.linkedBank != nil
         return customerHasLinkedBankAccount
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -531,6 +531,7 @@ extension PaymentSheetFormFactory {
             checkboxElement: shouldDisplaySaveCheckbox ? saveCheckbox : nil,
             savingAccount: isSaving,
             merchantName: merchantName,
+            initialLinkedBank: previousCustomerInput?.financialConnectionsLinkedBank,
             theme: theme
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
@@ -33,7 +33,7 @@ final class USBankAccountPaymentMethodElement: ContainerElement {
     private let checkboxElement: PaymentMethodElement?
     private var savingAccount: BoolReference
     private let theme: ElementsUITheme
-    private var linkedBank: FinancialConnectionsLinkedBank? {
+    private(set) var linkedBank: FinancialConnectionsLinkedBank? {
         didSet {
             self.mandateString = Self.attributedMandateText(for: linkedBank, merchantName: merchantName, isSaving: savingAccount.value, configuration: configuration, theme: theme)
         }
@@ -154,9 +154,6 @@ final class USBankAccountPaymentMethodElement: ContainerElement {
             formElement.toggleElements(linkedAccountElements, hidden: false, animated: true)
         }
         self.delegate?.didUpdate(element: self)
-    }
-    func getLinkedBank() -> FinancialConnectionsLinkedBank? {
-        return linkedBank
     }
 
     class func attributedMandateText(for linkedBank: FinancialConnectionsLinkedBank?,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
@@ -160,11 +160,13 @@ final class USBankAccountPaymentMethodElement: ContainerElement {
         )
     }
 
-    class func attributedMandateText(for linkedBank: FinancialConnectionsLinkedBank?,
-                                     merchantName: String,
-                                     isSaving: Bool,
-                                     configuration: PaymentSheetFormFactoryConfig,
-                                     theme: ElementsUITheme = .default) -> NSMutableAttributedString? {
+    static func attributedMandateText(
+        for linkedBank: FinancialConnectionsLinkedBank?,
+        merchantName: String,
+        isSaving: Bool,
+        configuration: PaymentSheetFormFactoryConfig,
+        theme: ElementsUITheme = .default
+    ) -> NSMutableAttributedString? {
         guard let linkedBank else {
             return nil
         }
@@ -180,14 +182,14 @@ final class USBankAccountPaymentMethodElement: ContainerElement {
         return formattedString
     }
 
-    class func attributedMandateTextSavedPaymentMethod(alignment: NSTextAlignment = .center, theme: ElementsUITheme) -> NSMutableAttributedString {
+    static func attributedMandateTextSavedPaymentMethod(alignment: NSTextAlignment = .center, theme: ElementsUITheme) -> NSMutableAttributedString {
         let mandateText = Self.ContinueMandateText
         let formattedString = STPStringUtils.applyLinksToString(template: mandateText, links: links)
         applyStyle(formattedString: formattedString, alignment: alignment, theme: theme)
         return formattedString
     }
 
-    private class func applyStyle(formattedString: NSMutableAttributedString, alignment: NSTextAlignment, theme: ElementsUITheme = .default) {
+    private static func applyStyle(formattedString: NSMutableAttributedString, alignment: NSTextAlignment, theme: ElementsUITheme = .default) {
         let style = NSMutableParagraphStyle()
         style.alignment = alignment
         formattedString.addAttributes([.paragraphStyle: style,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -300,7 +300,7 @@ extension PaymentMethodFormViewController {
                 break
             case .completed(let completedResult):
                 if case .financialConnections(let linkedBank) = completedResult {
-                    usBankAccountFormElement.setLinkedBank(linkedBank)
+                    usBankAccountFormElement.linkedBank = linkedBank
                 } else {
                     self.delegate?.updateErrorLabel(for: genericError)
                 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheet_ConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSheet_ConfirmFlowTests.swift
@@ -398,7 +398,7 @@ extension CustomerSheet_ConfirmFlowTests {
                 case .completed(let completedResult):
                     if case .financialConnections(let linkedBank) = completedResult {
                         if let usBankElement = paymentMethodForm as? USBankAccountPaymentMethodElement {
-                            usBankElement.setLinkedBank(linkedBank)
+                            usBankElement.linkedBank = linkedBank
                         }
                     } else {
                         XCTFail("no linked account")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/USBankAccountPaymentMethodElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/USBankAccountPaymentMethodElementTest.swift
@@ -1,0 +1,81 @@
+//
+//  USBankAccountPaymentMethodElementTest.swift
+//  StripePaymentSheetTests
+//
+//  Created by Yuki Tokuhiro on 10/2/24.
+//
+
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripePayments
+@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripePaymentsTestUtils
+@testable@_spi(STP) import StripePaymentsUI
+@testable@_spi(STP) import StripeUICore
+import XCTest
+
+final class USBankAccountPaymentMethodElementTest: XCTestCase {
+    let window: UIWindow = UIWindow(frame: .init(x: 0, y: 0, width: 428, height: 926))
+
+    func testPreservesPreviousCustomerInput() {
+        func makeForm(previousCustomerInput: IntentConfirmParams?) -> USBankAccountPaymentMethodElement {
+            let intent: Intent = ._testPaymentIntent(paymentMethodTypes: [.USBankAccount])
+            let formVC = PaymentMethodFormViewController(
+                type: .stripe(.USBankAccount),
+                intent: intent,
+                elementsSession: ._testValue(intent: intent),
+                previousCustomerInput: previousCustomerInput,
+                formCache: .init(),
+                configuration: configuration,
+                headerView: nil,
+                analyticsHelper: ._testValue(),
+                delegate: self
+            )
+
+            // Add to window to avoid layout errors due to zero size and presentation errors
+            window.rootViewController = formVC
+
+            // Simulate view appearance. This makes SimpleMandateElement mark its mandate as having been displayed.
+            formVC.viewDidAppear(false)
+            return formVC.form as! USBankAccountPaymentMethodElement
+        }
+        var configuration = PaymentSheet.Configuration()
+        configuration.customer = .init(id: "id", ephemeralKeySecret: "sec")
+        let form = makeForm(previousCustomerInput: nil)
+        let checkbox = form.getCheckboxElement(startingWith: "Save this account")!
+        XCTAssertNotNil(checkbox) // Checkbox should appear since this is a PI w/ customer
+        XCTAssertNil(form.mandateString) // Mandate should not appear until linked bank is set
+        form.getTextFieldElement("Full name").setText("Name")
+        form.getTextFieldElement("Email").setText("foo@bar.com")
+        // Simulate customer setting up a linked bank account
+        form.linkedBank = FinancialConnectionsLinkedBank(sessionId: "123", accountId: "123", displayName: "Success", bankName: "StripeBank", last4: "6789", instantlyVerified: true)
+        XCTAssertEqual(form.getAllUnwrappedSubElements().count, 10)
+        XCTAssertNotNil(form.mandateString)
+        checkbox.isSelected = true
+
+        // Generate params from the form
+        guard let intentConfirmParams = form.updateParams(params: IntentConfirmParams(type: .stripe(.USBankAccount))) else {
+            XCTFail("Form failed to create params. Validation state: \(form.validationState) \n Form: \(form)")
+            return
+        }
+
+        // Re-generate the form and validate that it carries over all previous customer input
+        let regeneratedForm = makeForm(previousCustomerInput: intentConfirmParams)
+        guard let regeneratedIntentConfirmParams = regeneratedForm.updateParams(params: IntentConfirmParams(type: .stripe(.USBankAccount))) else {
+            XCTFail("Regenerated form failed to create params. Validation state: \(regeneratedForm.validationState) \n Form: \(regeneratedForm)")
+            return
+        }
+        // Ensure checkbox remains selected
+        XCTAssertTrue(regeneratedForm.getCheckboxElement(startingWith: "Save this account")!.isSelected)
+        XCTAssertEqual(regeneratedIntentConfirmParams, intentConfirmParams)
+    }
+}
+
+extension USBankAccountPaymentMethodElementTest: PaymentMethodFormViewControllerDelegate {
+    func didUpdate(_ viewController: StripePaymentSheet.PaymentMethodFormViewController) {
+
+    }
+
+    func updateErrorLabel(for error: (any Error)?) {
+
+    }
+}

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -58,7 +58,7 @@ final class StubbedConnectionsSDKInterface: FinancialConnectionsSDKInterface {
     ) {
         DispatchQueue.main.async {
             let stubbedBank = FinancialConnectionsLinkedBank(
-                with: "las_123",
+                sessionId: "las_123",
                 accountId: "fca_123",
                 displayName: "Test Bank",
                 bankName: "Test Bank",


### PR DESCRIPTION
## Summary
Fix US Bank form not respecting previous customer input & cleans up some of the code.

## Testing
Manually tested + unit test

## Changelog
 [Fixed] Fixed an issue where US Bank Account forms would drop form field input when `FlowController.update` is called.