### PR TITLE
Prevent showing Panther for deferred intent flows

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -180,10 +180,12 @@ extension PaymentSheet {
             // We should manually add Link Card Brand as a payment method when:
             // - Link Funding Sources contains Bank Account.
             // - US Bank Account is *not* an available payment method.
+            // - Not a deferred intent flow.
             // - Link Card Brand is the Link Mode
             var eligibleForLinkCardBrand: Bool {
                 elementsSession.linkFundingSources?.contains(.bankAccount) == true &&
                 !elementsSession.orderedPaymentMethodTypes.contains(.USBankAccount) &&
+                !intent.isDeferredIntent &&
                 elementsSession.linkSettings?.linkMode == .linkCardBrand
             }
 


### PR DESCRIPTION
## Summary

Instant Debits, and in turn Panther, doesn't support deferred intents. This check will prevent us from showing the bank tab during the Panther flow.

Android equivalent logic: https://stripe.sourcegraphcloud.com/github.com/stripe/stripe-android/-/blob/paymentsheet/src/main/java/com/stripe/android/lpmfoundations/paymentmethod/AddPaymentMethodRequirement.kt?L67-84

## Motivation

Fixes issue found in Panther bug bash

## Testing
Both of these screenshots are otherwise eligible for Panther: 

| Non-deferred intent | Deferred intent |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 - 2024-10-02 at 16 48 44](https://github.com/user-attachments/assets/cfecb446-e913-4977-89d9-2760cc013fee) | ![Simulator Screenshot - iPhone 16 - 2024-10-02 at 16 48 38](https://github.com/user-attachments/assets/e04e5116-ea0d-4c55-953e-320a2533009a) | 

## Changelog

N/a
