### PR TITLE
Fix BottomSheet scroll indicator being slightly inset from the top

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -32,6 +32,7 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
     // MARK: - Views
     lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
+        scrollView.automaticallyAdjustsScrollIndicatorInsets = false
         scrollView.delegate = self
         return scrollView
     }()


### PR DESCRIPTION

Scroll view indicator was offset:
![CleanShot 2024-10-02 at 14 34 15](https://github.com/user-attachments/assets/3deb8f3a-a675-4b5f-a7e0-c5068e74f8f2)

Now it's fixed:
![CleanShot 2024-10-02 at 14 35 02@2x](https://github.com/user-attachments/assets/a47bd393-94ea-4651-8908-892fd67877ba)


## Testing
Manually tested

## Changelog
Tooo small for a changelog mention IMO.