### PR TITLE
Add `link_card_brand` as `link_context` in payment logs

### DIFF
--- a/StripeCore/StripeCore/Source/Connections Bindings/InstantDebitsLinkedBank.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/InstantDebitsLinkedBank.swift
@@ -11,13 +11,16 @@ import Foundation
     public let paymentMethodId: String
     public let bankName: String?
     public let last4: String?
+    public let linkMode: LinkMode?
     public init(
         paymentMethodId: String,
         bankName: String?,
-        last4: String?
+        last4: String?,
+        linkMode: LinkMode?
     ) {
         self.paymentMethodId = paymentMethodId
         self.bankName = bankName
         self.last4 = last4
+        self.linkMode = linkMode
     }
 }

--- a/StripeCore/StripeCore/Source/Connections Bindings/LinkMode.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/LinkMode.swift
@@ -15,4 +15,8 @@ import Foundation
     @_spi(STP) public var isPantherPayment: Bool {
         self == .linkCardBrand
     }
+
+    @_spi(STP) public var expectedPaymentMethodType: String {
+        isPantherPayment ? "card" : "bank_account"
+    }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -508,6 +508,7 @@ extension NativeFlowController {
 
         // Bank account details extraction for the linked bank
         var bankAccountDetails: BankAccountDetails?
+        let linkMode = dataManager.elementsSessionContext?.linkMode
         dataManager.createPaymentDetails(
             consumerSessionClientSecret: consumerSession.clientSecret,
             bankAccountId: bankAccountId
@@ -520,11 +521,11 @@ extension NativeFlowController {
             bankAccountDetails = paymentDetails.redactedPaymentDetails.bankAccountDetails
 
             // Decide which API to call based on the payment mode
-            if self.dataManager.elementsSessionContext?.linkMode?.isPantherPayment == true {
+            if let linkMode, linkMode.isPantherPayment {
                 return self.dataManager.apiClient.sharePaymentDetails(
                     consumerSessionClientSecret: consumerSession.clientSecret,
                     paymentDetailsId: paymentDetails.redactedPaymentDetails.id,
-                    expectedPaymentMethodType: "card"
+                    expectedPaymentMethodType: linkMode.expectedPaymentMethodType
                 )
                 .transformed { $0 as PaymentMethodIDProvider }
             } else {
@@ -541,7 +542,8 @@ extension NativeFlowController {
                 let linkedBank = InstantDebitsLinkedBank(
                     paymentMethodId: paymentMethod.id,
                     bankName: bankAccountDetails?.bankName,
-                    last4: bankAccountDetails?.last4
+                    last4: bankAccountDetails?.last4,
+                    linkMode: linkMode
                 )
                 completion(.success(linkedBank))
             case .failure(let error):

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -174,7 +174,8 @@ extension FinancialConnectionsWebFlowViewController {
                                 bankName: Self.extractValue(from: returnUrl, key: "bank_name")?
                                 // backend can return "+" instead of a more-common encoding of "%20" for spaces
                                     .replacingOccurrences(of: "+", with: " "),
-                                last4: Self.extractValue(from: returnUrl, key: "last4")
+                                last4: Self.extractValue(from: returnUrl, key: "last4"),
+                                linkMode: elementsSessionContext?.linkMode
                             )
                             self.notifyDelegateOfSuccess(result: .instantDebits(instantDebitsLinkedBank))
                         } else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -70,9 +70,13 @@ extension PaymentSheet {
                 return "wallet"
             } else if
                 case .new(let confirmParams) = self,
-                confirmParams.instantDebitsLinkedBank != nil
+                let linkedBank = confirmParams.instantDebitsLinkedBank
             {
-                return "instant_debits"
+                if linkedBank.linkMode == .linkCardBrand {
+                    return "link_card_brand"
+                } else {
+                    return "instant_debits"
+                }
             } else {
                 return nil
             }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
@@ -279,6 +279,51 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
         XCTAssertEqual(analyticsClient._testLogHistory.last!["link_context"] as? String, "wallet")
     }
 
+    func testLogPaymentLinkContextWithLinkedBank() {
+        let instantDebitsLinkedBank = InstantDebitsLinkedBank(
+            paymentMethodId: "paymentMethodId",
+            bankName: nil,
+            last4: nil,
+            linkMode: .linkPaymentMethod
+        )
+        let linkCardBrandLinkedBank = InstantDebitsLinkedBank(
+            paymentMethodId: "paymentMethodId",
+            bankName: nil,
+            last4: nil,
+            linkMode: .linkCardBrand
+        )
+
+        let instantDebitConfirmParams = IntentConfirmParams(type: .instantDebits)
+        instantDebitConfirmParams.instantDebitsLinkedBank = instantDebitsLinkedBank
+
+        let linkCardBrandConfirmParams = IntentConfirmParams(type: .linkCardBrand)
+        linkCardBrandConfirmParams.instantDebitsLinkedBank = linkCardBrandLinkedBank
+
+        let instantDebits = PaymentOption.new(confirmParams: instantDebitConfirmParams)
+        let linkCardBrand = PaymentOption.new(confirmParams: linkCardBrandConfirmParams)
+
+        let sut = PaymentSheetAnalyticsHelper(
+            isCustom: true,
+            configuration: .init(),
+            analyticsClient: analyticsClient
+        )
+        sut.intent = ._testValue()
+
+        sut.logPayment(
+            paymentOption: instantDebits,
+            result: .completed,
+            deferredIntentConfirmationType: nil
+        )
+        XCTAssertEqual(analyticsClient._testLogHistory.last!["link_context"] as? String, "instant_debits")
+
+        sut.logPayment(
+            paymentOption: linkCardBrand,
+            result: .completed,
+            deferredIntentConfirmationType: nil
+        )
+        XCTAssertEqual(analyticsClient._testLogHistory.last!["link_context"] as? String, "link_card_brand")
+    }
+
     // MARK: - Helpers
 
     func makeConfig(


### PR DESCRIPTION
## Summary

This adds `link_card_brand` as a possible value for `link_context`, which is passed in our payment analytics. This will allow us to monitor Panther payments.

Android equivalent: https://github.com/stripe/stripe-android/pull/9392

## Motivation

Observability!

## Testing

Unit test added

## Changelog

N/a