### PR TITLE
Fixes `testWebInstantDebitsFlow()`

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -396,11 +396,12 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_playgroundCell.tap()
         app.fc_playgroundShowAuthFlowButton.tap()
 
-        let usesLinkText = app.webViews
-            .staticTexts
-            .containing(NSPredicate(format: "label CONTAINS 'Link'"))
+        let authFlowWebViewUrl = app
+            .otherElements["TopBrowserBar"]
+            .otherElements
+            .containing(NSPredicate(format: "value CONTAINS 'auth.stripe.com'"))
             .firstMatch
-        XCTAssertTrue(usesLinkText.waitForExistence(timeout: 120.0))  // glitch app can take time to load
+        XCTAssertTrue(authFlowWebViewUrl.waitForExistence(timeout: 120.0)) // glitch app can take time to load
 
         app.fc_secureWebViewCancelButton.tap()
 

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -398,7 +398,7 @@ final class FinancialConnectionsUITests: XCTestCase {
 
         let usesLinkText = app.webViews
             .staticTexts
-            .containing(NSPredicate(format: "label CONTAINS 'uses Link to connect your account'"))
+            .containing(NSPredicate(format: "label CONTAINS 'Link'"))
             .firstMatch
         XCTAssertTrue(usesLinkText.waitForExistence(timeout: 120.0))  // glitch app can take time to load
 


### PR DESCRIPTION
## Summary

This fixes the UI test `testWebInstantDebitsFlow()` which has been failing on master due to a server-side string change in the consent pane title. 

Copy before:

```
<brand> uses Link to connect your account
```

Now it says:

```
Pay with your bank using Link
```

I kept the expected value pretty vague (`Link`) since this string might change again in the future.

## Motivation

Fix CI

## Testing

Test passes

<img width=40% src="https://github.com/user-attachments/assets/8e1fa935-1508-4131-9b3c-56a424129ce8">


## Changelog

N/a
