### PR TITLE
Refactor elements UI theme (Part 1)

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneCountryCodeSelectorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneCountryCodeSelectorView.swift
@@ -45,9 +45,9 @@ final class PhoneCountryCodeSelectorView: UIView {
         return textField
     }()
     private lazy var keyboardToolbar: DoneButtonToolbar = {
-        var theme: ElementsUITheme = .default
+        var theme: ElementsAppearance = .default
         theme.colors = {
-            var colors = ElementsUITheme.Color()
+            var colors = ElementsAppearance.Color()
             colors.primary = self.theme.primaryColor
             colors.secondaryText = .textSubdued
             return colors

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -71,10 +71,10 @@ final class NetworkingOTPView: UIView {
         otpTextField.addTarget(self, action: #selector(otpTextFieldDidChange), for: .valueChanged)
         return otpTextField
     }()
-    private lazy var theme: ElementsUITheme = {
-        var theme: ElementsUITheme = .default
+    private lazy var theme: ElementsAppearance = {
+        var theme: ElementsAppearance = .default
         theme.colors = {
-            var colors = ElementsUITheme.Color()
+            var colors = ElementsAppearance.Color()
             colors.border = .borderDefault
             colors.background = .customBackgroundColor
             colors.textFieldText = .textDefault

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -76,7 +76,7 @@ final class NetworkingOTPView: UIView {
         theme.colors = {
             var colors = ElementsAppearance.Color()
             colors.border = .borderDefault
-            colors.background = .customBackgroundColor
+            colors.componentBackground = .customBackgroundColor
             colors.textFieldText = .textDefault
             colors.danger = .textFeedbackCritical
             return colors

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/RoundedTextField.swift
@@ -98,9 +98,9 @@ final class RoundedTextField: UIView {
     }()
     private var currentFooterView: UIView?
     private lazy var keyboardToolbar: DoneButtonToolbar = {
-        var theme: ElementsUITheme = .default
+        var theme: ElementsAppearance = .default
         theme.colors = {
-            var colors = ElementsUITheme.Color()
+            var colors = ElementsAppearance.Color()
             colors.primary = self.theme.primaryColor
             colors.secondaryText = .textSubdued
             return colors

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/IdentityUI.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/IdentityUI.swift
@@ -75,10 +75,10 @@ struct IdentityUI {
     static let scanningViewLabelMinHeightNumberOfLines: Int = 3
     static let scanningViewLabelBottomPadding: CGFloat = 24
 
-    static let identityElementsUITheme: ElementsUITheme = {
-        var identityElementsUITheme = ElementsUITheme.default
+    static let identityElementsUITheme: ElementsAppearance = {
+        var identityElementsUITheme = ElementsAppearance.default
 
-        var fonts = ElementsUITheme.Font()
+        var fonts = ElementsAppearance.Font()
         fonts.subheadline = preferredFont(forTextStyle: .body).withSize(14)
         fonts.subheadlineBold = preferredFont(forTextStyle: .body, weight: .bold).withSize(14)
         fonts.sectionHeader = preferredFont(forTextStyle: .body, weight: .semibold).withSize(13)

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/BottomSheetView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/BottomSheetView.swift
@@ -65,7 +65,7 @@ final class BottomSheetView: UIView {
         self.content = content
         self.didTapClose = didTapClose
         super.init(frame: .zero)
-        backgroundColor = IdentityUI.identityElementsUITheme.colors.background
+        backgroundColor = IdentityUI.identityElementsUITheme.colors.componentBackground
 
         closeButton.addTarget(self, action: #selector(tappedClose(button:)), for: .touchUpInside)
         closeButtonBackground.addAndPinSubviewToSafeArea(closeButton, insets: BottomSheetView.bottomSheetCloseButtonInsets)

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
@@ -57,8 +57,8 @@ final class SelfieScanningView: UIView {
             )
         }
 
-        static func consentCheckboxTheme(tintColor: UIColor) -> ElementsUITheme {
-            var theme = ElementsUITheme.default
+        static func consentCheckboxTheme(tintColor: UIColor) -> ElementsAppearance {
+            var theme = ElementsAppearance.default
             theme.colors.bodyText = IdentityUI.textColor
             theme.colors.secondaryText = IdentityUI.textColor
             theme.fonts.caption = IdentityUI.preferredFont(forTextStyle: .caption1)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
@@ -22,7 +22,7 @@ final class LinkInlineSignupView: UIView {
 
     let viewModel: LinkInlineSignupViewModel
 
-    private var theme: ElementsUITheme {
+    private var theme: ElementsAppearance {
         return viewModel.configuration.appearance.asElementsTheme
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkEmailElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkEmailElement.swift
@@ -87,7 +87,7 @@ class LinkEmailElement: Element {
         }
     }
 
-    public init(defaultValue: String? = nil, isOptional: Bool = false, showLogo: Bool, theme: ElementsUITheme = .default) {
+    public init(defaultValue: String? = nil, isOptional: Bool = false, showLogo: Bool, theme: ElementsAppearance = .default) {
         if showLogo {
             self.infoView = LinkMoreInfoView(theme: theme)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMoreInfoView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMoreInfoView.swift
@@ -22,7 +22,7 @@ final class LinkMoreInfoView: UIView {
     }
     private lazy var logoView: UIImageView = {
         let imageView: UIImageView
-        imageView = DynamicImageView(dynamicImage: Image.link_logo_knockout.makeImage(template: false), pairedColor: theme.colors.background)
+        imageView = DynamicImageView(dynamicImage: Image.link_logo_knockout.makeImage(template: false), pairedColor: theme.colors.componentBackground)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFit
         imageView.isAccessibilityElement = true

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMoreInfoView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMoreInfoView.swift
@@ -30,9 +30,9 @@ final class LinkMoreInfoView: UIView {
         return imageView
     }()
 
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
 
-    init(theme: ElementsUITheme = .default) {
+    init(theme: ElementsAppearance = .default) {
         self.theme = theme
         super.init(frame: .zero)
         let stackView = UIStackView(arrangedSubviews: [logoView])

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
@@ -57,7 +57,7 @@ final class CardSectionElement: ContainerElement {
     let cardBrandDropDown: DropdownFieldElement?
     let cvcElement: TextFieldElement
     let expiryElement: TextFieldElement
-    let theme: ElementsUITheme
+    let theme: ElementsAppearance
     let preferredNetworks: [STPCardBrand]?
     let hostedSurface: HostedSurface
 
@@ -67,7 +67,7 @@ final class CardSectionElement: ContainerElement {
         preferredNetworks: [STPCardBrand]? = nil,
         cardBrandChoiceEligible: Bool = false,
         hostedSurface: HostedSurface,
-        theme: ElementsUITheme = .default,
+        theme: ElementsAppearance = .default,
         analyticsHelper: PaymentSheetAnalyticsHelper
     ) {
         self.hostedSurface = hostedSurface

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
@@ -36,9 +36,9 @@ final class CardSectionWithScannerView: UIView {
         return scanningView
     }()
     weak var delegate: CardSectionWithScannerViewDelegate?
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
 
-    init(cardSectionView: UIView, delegate: CardSectionWithScannerViewDelegate, theme: ElementsUITheme = .default, analyticsHelper: PaymentSheetAnalyticsHelper) {
+    init(cardSectionView: UIView, delegate: CardSectionWithScannerViewDelegate, theme: ElementsAppearance = .default, analyticsHelper: PaymentSheetAnalyticsHelper) {
         self.cardSectionView = cardSectionView
         self.delegate = delegate
         self.theme = theme

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
@@ -61,7 +61,7 @@ class PaymentMethodElementWrapper<WrappedElementType: Element> {
     }
     convenience init(
         _ textFieldElementConfiguration: TextFieldElementConfiguration,
-        theme: ElementsUITheme,
+        theme: ElementsAppearance,
         defaultsApplier: DefaultsApplier? = nil,
         paramsUpdater: @escaping ParamsUpdater
     ) where WrappedElementType == TextFieldElement {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
@@ -37,7 +37,7 @@ class SimpleMandateElement: PaymentMethodElement {
     let mandateTextView: SimpleMandateTextView
     let customerAlreadySawMandate: Bool
 
-    init(mandateText: String, customerAlreadySawMandate: Bool, theme: ElementsUITheme = .default) {
+    init(mandateText: String, customerAlreadySawMandate: Bool, theme: ElementsAppearance = .default) {
         mandateTextView = SimpleMandateTextView(mandateText: mandateText, theme: theme)
         self.customerAlreadySawMandate = customerAlreadySawMandate
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
@@ -190,7 +190,7 @@ extension TextFieldElement {
         func accessoryView(for text: String, theme: ElementsAppearance) -> UIView? {
             return DynamicImageView(
                 dynamicImage: STPImageLibrary.cvcImage(for: cardBrandProvider()),
-                pairedColor: theme.colors.background
+                pairedColor: theme.colors.componentBackground
             )
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
@@ -28,7 +28,7 @@ extension TextFieldElement {
             self.cardBrandDropDown = cardBrandDropDown
         }
 
-        func accessoryView(for text: String, theme: ElementsUITheme) -> UIView? {
+        func accessoryView(for text: String, theme: ElementsAppearance) -> UIView? {
             // If CBC is enabled and the PAN is not empty...
             if let cardBrandDropDown = cardBrandDropDown, !text.isEmpty {
                 // Show unknown card brand if we have under 9 pan digits and no card brands
@@ -187,7 +187,7 @@ extension TextFieldElement {
 
             return .valid
         }
-        func accessoryView(for text: String, theme: ElementsUITheme) -> UIView? {
+        func accessoryView(for text: String, theme: ElementsAppearance) -> UIView? {
             return DynamicImageView(
                 dynamicImage: STPImageLibrary.cvcImage(for: cardBrandProvider()),
                 pairedColor: theme.colors.background
@@ -304,7 +304,7 @@ extension TextFieldElement {
             return NSAttributedString(string: lastFourFormatted)
         }
 
-        func accessoryView(for text: String, theme: ElementsUITheme) -> UIView? {
+        func accessoryView(for text: String, theme: ElementsAppearance) -> UIView? {
             // Re-use same logic from PANConfiguration for accessory view
             return TextFieldElement.PANConfiguration(cardBrandDropDown: cardBrandDropDown)
                                             .accessoryView(for: lastFourFormatted, theme: theme)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+IBAN.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+IBAN.swift
@@ -12,7 +12,7 @@ import Foundation
 import UIKit
 
 extension TextFieldElement {
-    static func makeIBAN(defaultValue: String? = nil, theme: ElementsUITheme = .default) -> TextFieldElement {
+    static func makeIBAN(defaultValue: String? = nil, theme: ElementsAppearance = .default) -> TextFieldElement {
         return TextFieldElement(configuration: IBANConfiguration(defaultValue: defaultValue), theme: theme)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -878,7 +878,7 @@ extension PaymentSheet.Appearance {
         var colors = ElementsAppearance.Color()
         colors.primary = self.colors.primary
         colors.parentBackground = self.colors.background
-        colors.background = self.colors.componentBackground
+        colors.componentBackground = self.colors.componentBackground
         colors.bodyText = self.colors.text
         colors.border = self.colors.componentBorder
         colors.divider = self.colors.componentDivider

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -50,7 +50,7 @@ class PaymentSheetFormFactory {
         }
     }
 
-    var theme: ElementsUITheme {
+    var theme: ElementsAppearance {
         return configuration.appearance.asElementsTheme
     }
 
@@ -810,7 +810,7 @@ extension PaymentSheetFormFactory {
 
 extension FormElement {
     /// Conveniently nests single TextField, PhoneNumber, and DropdownFields in a Section
-    convenience init(autoSectioningElements: [Element], theme: ElementsUITheme = .default) {
+    convenience init(autoSectioningElements: [Element], theme: ElementsAppearance = .default) {
         let elements: [Element] = autoSectioningElements.map {
             if $0 is PaymentMethodElementWrapper<TextFieldElement>
                 || $0 is PaymentMethodElementWrapper<DropdownFieldElement>
@@ -872,10 +872,10 @@ private extension PaymentSheet.Address {
 extension PaymentSheet.Appearance {
 
     /// Creates an `ElementsUITheme` based on this PaymentSheet appearance
-    var asElementsTheme: ElementsUITheme {
-        var theme = ElementsUITheme.default
+    var asElementsTheme: ElementsAppearance {
+        var theme = ElementsAppearance.default
 
-        var colors = ElementsUITheme.Color()
+        var colors = ElementsAppearance.Color()
         colors.primary = self.colors.primary
         colors.parentBackground = self.colors.background
         colors.background = self.colors.componentBackground
@@ -891,7 +891,7 @@ extension PaymentSheet.Appearance {
         theme.cornerRadius = cornerRadius
         theme.shadow = shadow.asElementThemeShadow
 
-        var fonts = ElementsUITheme.Font()
+        var fonts = ElementsAppearance.Font()
         fonts.subheadline = scaledFont(for: font.base.regular, style: .subheadline, maximumPointSize: 20)
         fonts.subheadlineBold = scaledFont(for: font.base.bold, style: .subheadline, maximumPointSize: 20)
         fonts.sectionHeader = scaledFont(for: font.base.medium, style: .footnote, maximumPointSize: 18)
@@ -909,11 +909,11 @@ extension PaymentSheet.Appearance {
 extension PaymentSheet.Appearance.Shadow {
 
     /// Creates an `ElementsUITheme.Shadow` based on this PaymentSheet appearance shadow
-    var asElementThemeShadow: ElementsUITheme.Shadow? {
-        return ElementsUITheme.Shadow(color: color, opacity: opacity, offset: offset, radius: radius)
+    var asElementThemeShadow: ElementsAppearance.Shadow? {
+        return ElementsAppearance.Shadow(color: color, opacity: opacity, offset: offset, radius: radius)
     }
 
-    init(elementShadow: ElementsUITheme.Shadow) {
+    init(elementShadow: ElementsAppearance.Shadow) {
         self.color = elementShadow.color
         self.opacity = elementShadow.opacity
         self.offset = elementShadow.offset

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/BankAccountInfoView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/BankAccountInfoView.swift
@@ -20,7 +20,7 @@ class BankAccountInfoView: UIView {
         static let spacing: CGFloat = 12
     }
 
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
 
     lazy var bankNameLabel: UILabel = {
         let label = UILabel()
@@ -69,7 +69,7 @@ class BankAccountInfoView: UIView {
         }
     }
 
-    init(frame: CGRect, theme: ElementsUITheme = .default) {
+    init(frame: CGRect, theme: ElementsAppearance = .default) {
         self.theme = theme
         super.init(frame: frame)
         addViewComponents()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -26,7 +26,7 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     private let emailElement: TextFieldElement
     private let linkedBankInfoView: BankAccountInfoView
     private var linkedBank: InstantDebitsLinkedBank?
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
     var presentingViewControllerDelegate: PresentingViewControllerDelegate?
 
     var delegate: ElementDelegate?
@@ -75,7 +75,7 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
         configuration: PaymentSheetFormFactoryConfig,
         titleElement: StaticElement?,
         emailElement: PaymentMethodElementWrapper<TextFieldElement>,
-        theme: ElementsUITheme = .default
+        theme: ElementsAppearance = .default
     ) {
         self.configuration = configuration
         self.linkedBankInfoView = BankAccountInfoView(frame: .zero, theme: theme)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
@@ -38,7 +38,7 @@ final class USBankAccountPaymentMethodElement: ContainerElement {
     private let bankInfoView: BankAccountInfoView
     private let checkboxElement: PaymentMethodElement?
     private var savingAccount: BoolReference
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
 
     private var linkedAccountElements: [Element] {
         [bankInfoSectionElement, checkboxElement].compactMap { $0 }
@@ -91,7 +91,7 @@ final class USBankAccountPaymentMethodElement: ContainerElement {
         savingAccount: BoolReference,
         merchantName: String,
         initialLinkedBank: FinancialConnectionsLinkedBank?,
-        theme: ElementsUITheme = .default
+        theme: ElementsAppearance = .default
     ) {
         let collectingName = configuration.billingDetailsCollectionConfiguration.name != .never
         let collectingEmail = configuration.billingDetailsCollectionConfiguration.email != .never
@@ -165,7 +165,7 @@ final class USBankAccountPaymentMethodElement: ContainerElement {
         merchantName: String,
         isSaving: Bool,
         configuration: PaymentSheetFormFactoryConfig,
-        theme: ElementsUITheme = .default
+        theme: ElementsAppearance = .default
     ) -> NSMutableAttributedString? {
         guard let linkedBank else {
             return nil
@@ -182,14 +182,14 @@ final class USBankAccountPaymentMethodElement: ContainerElement {
         return formattedString
     }
 
-    static func attributedMandateTextSavedPaymentMethod(alignment: NSTextAlignment = .center, theme: ElementsUITheme) -> NSMutableAttributedString {
+    static func attributedMandateTextSavedPaymentMethod(alignment: NSTextAlignment = .center, theme: ElementsAppearance) -> NSMutableAttributedString {
         let mandateText = Self.ContinueMandateText
         let formattedString = STPStringUtils.applyLinksToString(template: mandateText, links: links)
         applyStyle(formattedString: formattedString, alignment: alignment, theme: theme)
         return formattedString
     }
 
-    private static func applyStyle(formattedString: NSMutableAttributedString, alignment: NSTextAlignment, theme: ElementsUITheme = .default) {
+    private static func applyStyle(formattedString: NSMutableAttributedString, alignment: NSTextAlignment, theme: ElementsAppearance = .default) {
         let style = NSMutableParagraphStyle()
         style.alignment = alignment
         formattedString.addAttributes([.paragraphStyle: style,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
@@ -48,7 +48,7 @@ class AutoCompleteViewController: UIViewController {
             errorLabel.isHidden = latestError == nil
         }
     }
-    private var theme: ElementsUITheme {
+    private var theme: ElementsAppearance {
         return configuration.appearance.asElementsTheme
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AUBECSMandate.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AUBECSMandate.swift
@@ -19,7 +19,7 @@ final class AUBECSLegalTermsView: UIView {
     ]
     private let configuration: PaymentSheetFormFactoryConfig
 
-    private var theme: ElementsUITheme {
+    private var theme: ElementsAppearance {
         return configuration.appearance.asElementsTheme
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AffirmCopyLabel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AffirmCopyLabel.swift
@@ -15,7 +15,7 @@ class AffirmCopyLabel: UIView {
 
     let logo = NSTextAttachment()
 
-    convenience init(theme: ElementsUITheme = .default) {
+    convenience init(theme: ElementsAppearance = .default) {
         self.init(frame: .zero)
         let affirmLabel = UILabel()
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AfterpayPriceBreakdownView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AfterpayPriceBreakdownView.swift
@@ -17,7 +17,7 @@ import UIKit
 @objc(STP_Internal_AfterpayPriceBreakdownView)
 class AfterpayPriceBreakdownView: UIView {
     private let afterPayClearPayLabel = UILabel()
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
     private lazy var afterpayMarkImageView: UIImageView = {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
@@ -42,7 +42,7 @@ class AfterpayPriceBreakdownView: UIView {
 
     let locale: Locale
 
-    init(locale: Locale = Locale.autoupdatingCurrent, theme: ElementsUITheme = .default) {
+    init(locale: Locale = Locale.autoupdatingCurrent, theme: ElementsAppearance = .default) {
         self.locale = locale
         self.theme = theme
         super.init(frame: .zero)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanButton.swift
@@ -13,7 +13,7 @@ import CloudKit
 import UIKit
 
 extension UIButton {
-    static func makeCardScanButton(theme: ElementsUITheme = .default) -> UIButton {
+    static func makeCardScanButton(theme: ElementsAppearance = .default) -> UIButton {
         let fontMetrics = UIFontMetrics(forTextStyle: .body)
         let iconConfig = UIImage.SymbolConfiguration(
             font: fontMetrics.scaledFont(for: UIFont.systemFont(ofSize: 9, weight: .semibold))

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SimpleMandateTextView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SimpleMandateTextView.swift
@@ -12,7 +12,7 @@ import UIKit
 /// For internal SDK use only
 @objc(STP_Internal_SimpleMandateTextView)
 class SimpleMandateTextView: UIView {
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
     var viewDidAppear: Bool = false
     let textView: UITextView = UITextView()
     var attributedText: NSAttributedString? {
@@ -26,17 +26,17 @@ class SimpleMandateTextView: UIView {
         }
     }
 
-    convenience init(mandateText: NSAttributedString, theme: ElementsUITheme) {
+    convenience init(mandateText: NSAttributedString, theme: ElementsAppearance) {
         self.init(theme: theme)
         textView.attributedText = mandateText
     }
 
-    convenience init(mandateText: String, theme: ElementsUITheme) {
+    convenience init(mandateText: String, theme: ElementsAppearance) {
         self.init(theme: theme)
         textView.text = mandateText
     }
 
-    required init(theme: ElementsUITheme) {
+    required init(theme: ElementsAppearance) {
         self.theme = theme
         super.init(frame: .zero)
         installConstraints()

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/Categories/STPCardBrand+PaymentsUI.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/Categories/STPCardBrand+PaymentsUI.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 extension STPCardBrand {
-    func brandIconAttributedString(theme: ElementsUITheme = .default, maxWidth: CGFloat? = nil) -> NSAttributedString {
+    func brandIconAttributedString(theme: ElementsAppearance = .default, maxWidth: CGFloat? = nil) -> NSAttributedString {
         let brandImageAttachment = NSTextAttachment()
         let image: UIImage = self == .unknown ? STPImageLibrary.cardBrandChoiceImage() : STPImageLibrary.cardBrandImage(for: self)
         brandImageAttachment.image = image
@@ -26,7 +26,7 @@ extension STPCardBrand {
         return NSAttributedString(attachment: brandImageAttachment)
     }
 
-    func cardBrandItem(theme: ElementsUITheme = .default, maxWidth: CGFloat? = nil) -> DropdownFieldElement.DropdownItem {
+    func cardBrandItem(theme: ElementsAppearance = .default, maxWidth: CGFloat? = nil) -> DropdownFieldElement.DropdownItem {
         let brandName = STPCardBrandUtilities.stringFrom(self) ?? ""
 
         let displayText = NSMutableAttributedString(attributedString: brandIconAttributedString(theme: theme))

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Elements/DropDownFieldElement+CardBrand.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Elements/DropDownFieldElement+CardBrand.swift
@@ -14,7 +14,7 @@ import UIKit
 extension DropdownFieldElement {
 
     @_spi(STP) public static func makeCardBrandDropdown(cardBrands: Set<STPCardBrand> = Set<STPCardBrand>(),
-                                                        theme: ElementsUITheme = .default,
+                                                        theme: ElementsAppearance = .default,
                                                         includePlaceholder: Bool = true,
                                                         maxWidth: CGFloat? = nil,
                                                         hasPadding: Bool = true,
@@ -32,7 +32,7 @@ extension DropdownFieldElement {
         )
     }
 
-    @_spi(STP) public static func items(from cardBrands: Set<STPCardBrand>, theme: ElementsUITheme, includePlaceholder: Bool = true, maxWidth: CGFloat? = nil) -> [DropdownItem] {
+    @_spi(STP) public static func items(from cardBrands: Set<STPCardBrand>, theme: ElementsAppearance, includePlaceholder: Bool = true, maxWidth: CGFloat? = nil) -> [DropdownItem] {
         let placeholderItem = DropdownItem(
             pickerDisplayName: NSAttributedString(string: .Localized.card_brand_dropdown_placeholder),
             labelDisplayName: STPCardBrand.unknown.brandIconAttributedString(theme: theme, maxWidth: maxWidth),

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/DynamicImageView+Unknown.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/DynamicImageView+Unknown.swift
@@ -9,7 +9,7 @@ import Foundation
 @_spi(STP) import StripeUICore
 
 @_spi(STP) public extension DynamicImageView {
-    static func makeUnknownCardImageView(theme: ElementsUITheme) -> DynamicImageView {
+    static func makeUnknownCardImageView(theme: ElementsAppearance) -> DynamicImageView {
         return DynamicImageView(
             dynamicImage: STPImageLibrary.unknownCardCardImage(),
             pairedColor: theme.colors.background

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/DynamicImageView+Unknown.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/DynamicImageView+Unknown.swift
@@ -12,7 +12,7 @@ import Foundation
     static func makeUnknownCardImageView(theme: ElementsAppearance) -> DynamicImageView {
         return DynamicImageView(
             dynamicImage: STPImageLibrary.unknownCardCardImage(),
-            pairedColor: theme.colors.background
+            pairedColor: theme.colors.componentBackground
         )
     }
 }

--- a/StripeUICore/StripeUICore/Source/Categories/CALayer+StripeUICore.swift
+++ b/StripeUICore/StripeUICore/Source/Categories/CALayer+StripeUICore.swift
@@ -11,7 +11,7 @@ import UIKit
 
 @_spi(STP) public extension CALayer {
 
-    func applyShadow(shadow: ElementsUITheme.Shadow?) {
+    func applyShadow(shadow: ElementsAppearance.Shadow?) {
         guard let shadow = shadow else {
             shadowOpacity = 0
             return

--- a/StripeUICore/StripeUICore/Source/Controls/OneTimeCodeTextField.swift
+++ b/StripeUICore/StripeUICore/Source/Controls/OneTimeCodeTextField.swift
@@ -799,7 +799,7 @@ private extension OneTimeCodeTextField {
         }
 
         private func updateColors() {
-            borderLayer.backgroundColor = isEnabled ? theme.colors.background.cgColor : theme.colors.disabledBackground.cgColor
+            borderLayer.backgroundColor = isEnabled ? theme.colors.componentBackground.cgColor : theme.colors.disabledBackground.cgColor
             borderLayer.borderColor = theme.colors.border.cgColor
             caret.backgroundColor = label.textColor.cgColor
             focusRing.borderColor = tintColor.cgColor

--- a/StripeUICore/StripeUICore/Source/Controls/OneTimeCodeTextField.swift
+++ b/StripeUICore/StripeUICore/Source/Controls/OneTimeCodeTextField.swift
@@ -77,7 +77,7 @@ import UIKit
 
     // MARK: - Private properties
 
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
 
     private let textStorage: TextStorage
 
@@ -135,7 +135,7 @@ import UIKit
     // MARK: -
     public init(
         configuration: Configuration = Configuration(),
-        theme: ElementsUITheme = .default
+        theme: ElementsAppearance = .default
     ) {
         self.configuration = configuration
         self.textStorage = TextStorage(capacity: configuration.numberOfDigits)
@@ -704,7 +704,7 @@ private extension OneTimeCodeTextField {
 
         private let configuration: Configuration
 
-        private let theme: ElementsUITheme
+        private let theme: ElementsAppearance
 
         private(set) lazy var borderLayer: CALayer = {
             let borderLayer = CALayer()
@@ -746,7 +746,7 @@ private extension OneTimeCodeTextField {
             return CGSize(width: UIView.noIntrinsicMetric, height: configuration.itemHeight)
         }
 
-        init(configuration: Configuration, theme: ElementsUITheme) {
+        init(configuration: Configuration, theme: ElementsAppearance) {
             self.configuration = configuration
             self.theme = theme
             super.init(frame: .zero)

--- a/StripeUICore/StripeUICore/Source/Elements/Checkbox/CheckboxButton.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Checkbox/CheckboxButton.swift
@@ -104,7 +104,7 @@ import UIKit
         }
     }
 
-    public var theme: ElementsUITheme {
+    public var theme: ElementsAppearance {
         didSet {
             checkbox.theme = theme
             updateLabels()
@@ -113,7 +113,7 @@ import UIKit
 
     // MARK: - Initializers
 
-    public init(description: String? = nil, theme: ElementsUITheme = .default) {
+    public init(description: String? = nil, theme: ElementsAppearance = .default) {
         self.theme = theme
         super.init(frame: .zero)
 
@@ -130,12 +130,12 @@ import UIKit
         addGestureRecognizer(didTapGestureRecognizer)
     }
 
-    public convenience init(text: String, description: String? = nil, theme: ElementsUITheme = .default) {
+    public convenience init(text: String, description: String? = nil, theme: ElementsAppearance = .default) {
         self.init(description: description, theme: theme)
         setText(text)
     }
 
-    public convenience init(attributedText: NSAttributedString, description: String? = nil, theme: ElementsUITheme = .default) {
+    public convenience init(attributedText: NSAttributedString, description: String? = nil, theme: ElementsAppearance = .default) {
         self.init(description: description, theme: theme)
         setAttributedText(attributedText)
     }
@@ -268,7 +268,7 @@ class CheckBox: UIView {
         return theme.colors.parentBackground
     }
 
-    var theme: ElementsUITheme {
+    var theme: ElementsAppearance {
         didSet {
             layer.applyShadow(shadow: theme.shadow)
             setNeedsDisplay()
@@ -279,7 +279,7 @@ class CheckBox: UIView {
         return CGSize(width: 20, height: 20)
     }
 
-    init(theme: ElementsUITheme = .default) {
+    init(theme: ElementsAppearance = .default) {
         self.theme = theme
         super.init(frame: .zero)
 

--- a/StripeUICore/StripeUICore/Source/Elements/Checkbox/CheckboxElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Checkbox/CheckboxElement.swift
@@ -22,7 +22,7 @@ import UIKit
     }()
     let label: String
     let isSelectedByDefault: Bool
-    let theme: ElementsUITheme
+    let theme: ElementsAppearance
     var didToggle: (Bool) -> Void
     @_spi(STP) public var isSelected: Bool {
         get {
@@ -39,7 +39,7 @@ import UIKit
     }
 
     public init(
-        theme: ElementsUITheme,
+        theme: ElementsAppearance,
         label: String,
         isSelectedByDefault: Bool,
         didToggle: ((Bool) -> Void)? = nil

--- a/StripeUICore/StripeUICore/Source/Elements/DateFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/DateFieldElement.swift
@@ -65,7 +65,7 @@ import UIKit
     public var didUpdate: DidUpdateSelectedDate?
 
     private let label: String?
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
 
     /**
      - Parameters:
@@ -89,7 +89,7 @@ import UIKit
         maximumDate: Date? = nil,
         locale: Locale = .current,
         timeZone: TimeZone = .current,
-        theme: ElementsUITheme = .default,
+        theme: ElementsAppearance = .default,
         customDateFormatter: DateFormatter? = nil,
         didUpdate: DidUpdateSelectedDate? = nil
     ) {

--- a/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
@@ -72,7 +72,7 @@ import UIKit
     public var didPresent: DidPresent?
     public var didUpdate: DidUpdateSelectedIndex?
     public var didTapClose: DidTapClose?
-    public let theme: ElementsUITheme
+    public let theme: ElementsAppearance
     public let hasPadding: Bool
 
     /// A label displayed in the dropdown field UI e.g. "Country or region" for a country dropdown
@@ -145,7 +145,7 @@ import UIKit
         items: [DropdownItem],
         defaultIndex: Int = 0,
         label: String?,
-        theme: ElementsUITheme = .default,
+        theme: ElementsAppearance = .default,
         hasPadding: Bool = true,
         disableDropdownWithSingleElement: Bool = false,
         isOptional: Bool = false,

--- a/StripeUICore/StripeUICore/Source/Elements/ElementsUI.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/ElementsUI.swift
@@ -96,7 +96,7 @@ import UIKit
 
         public var primary = UIColor.systemBlue
         public var parentBackground = UIColor.systemBackground
-        public var background = ElementsUI.backgroundColor
+        public var componentBackground = ElementsUI.backgroundColor
         public var disabledBackground = ElementsUI.disabledBackgroundColor
         public var border = ElementsUI.fieldBorderColor
         public var divider = ElementsUI.fieldBorderColor

--- a/StripeUICore/StripeUICore/Source/Elements/ElementsUI.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/ElementsUI.swift
@@ -35,7 +35,7 @@ import UIKit
         )
     }()
 
-    public static func makeErrorLabel(theme: ElementsUITheme) -> UILabel {
+    public static func makeErrorLabel(theme: ElementsAppearance) -> UILabel {
         let label = UILabel()
         label.font = theme.fonts.footnote
         label.textColor = theme.colors.danger
@@ -44,7 +44,7 @@ import UIKit
         return label
     }
 
-    public static func makeNoticeTextField(theme: ElementsUITheme) -> UITextView {
+    public static func makeNoticeTextField(theme: ElementsAppearance) -> UITextView {
         let textView = UITextView()
         textView.isScrollEnabled = false
         textView.isEditable = false
@@ -55,7 +55,7 @@ import UIKit
         return textView
     }
 
-    public static func makeSectionTitleLabel(theme: ElementsUITheme) -> UILabel {
+    public static func makeSectionTitleLabel(theme: ElementsAppearance) -> UILabel {
         let label = UILabel()
         label.font = theme.fonts.sectionHeader
         label.textColor = theme.colors.secondaryText
@@ -65,10 +65,11 @@ import UIKit
 }
 
 /// Describes the appearance of an Element
-@_spi(STP) public struct ElementsUITheme {
+/// A superset of `StripePaymentSheet.PaymentSheetAppearance`. This exists b/c we can't see that type from `StripeUICore`, and we don't want to the public StripePaymentSheet API to be a typealias of this.
+@_spi(STP) public struct ElementsAppearance {
 
     /// The default appearance used for Elements
-    public static let `default` = ElementsUITheme()
+    public static let `default` = ElementsAppearance()
 
     public var fonts = Font()
     public var colors = Color()

--- a/StripeUICore/StripeUICore/Source/Elements/ElementsUI.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/ElementsUI.swift
@@ -78,12 +78,6 @@ import UIKit
     public var cornerRadius = ElementsUI.defaultCornerRadius
     public var shadow: Shadow? = Shadow()
 
-    /// Checks if the theme is bright.
-    public var isBright: Bool { colors.background.isBright }
-
-    /// Checks if the theme is dark.
-    public var isDark: Bool { !isBright }
-
     public struct Font {
         public init() {}
 

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement+DummyAddressLine.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement+DummyAddressLine.swift
@@ -39,7 +39,7 @@ extension AddressSectionElement {
             return .invalid(error: TextFieldElement.Error.empty, shouldDisplay: false)
         }
         let didTap: () -> Void
-        public let theme: ElementsUITheme
+        public let theme: ElementsAppearance
         private lazy var autocompleteLineTapRecognizer: UITapGestureRecognizer = {
             let tap = UITapGestureRecognizer(target: self, action: #selector(_didTap))
             tap.delegate = self
@@ -63,7 +63,7 @@ extension AddressSectionElement {
             return true
         }
 
-        public init(theme: ElementsUITheme, didTap: @escaping () -> Void = {}) {
+        public init(theme: ElementsAppearance, didTap: @escaping () -> Void = {}) {
             self.theme = theme
             self.didTap = didTap
             super.init()

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -148,7 +148,7 @@ import UIKit
 
     public let countryCodes: [String]
     let addressSpecProvider: AddressSpecProvider
-    let theme: ElementsUITheme
+    let theme: ElementsAppearance
     private(set) var defaults: AddressDetails
     let didTapAutocompleteButton: () -> Void
     public var didUpdate: DidUpdateAddress?
@@ -172,7 +172,7 @@ import UIKit
         defaults: AddressDetails = .empty,
         collectionMode: CollectionMode = .all(),
         additionalFields: AdditionalFields = .init(),
-        theme: ElementsUITheme = .default,
+        theme: ElementsAppearance = .default,
         presentAutoComplete: @escaping () -> Void = { }
     ) {
         let dropdownCountries = countries?.map { $0.uppercased() } ?? addressSpecProvider.countries

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSpec+ElementFactory.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSpec+ElementFactory.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// Convenience methods to create address fields that are localized according to the AddressSpec
 extension AddressSpec {
-    func makeCityElement(defaultValue: String?, theme: ElementsUITheme = .default) -> TextFieldElement {
+    func makeCityElement(defaultValue: String?, theme: ElementsAppearance = .default) -> TextFieldElement {
         return TextFieldElement.Address.CityConfiguration(
             label: cityNameType.localizedLabel,
             defaultValue: defaultValue,
@@ -18,7 +18,7 @@ extension AddressSpec {
         ).makeElement(theme: theme)
     }
 
-    func makeStateElement(defaultValue: String?, stateDict: [String: String], theme: ElementsUITheme = .default) -> TextOrDropdownElement {
+    func makeStateElement(defaultValue: String?, stateDict: [String: String], theme: ElementsAppearance = .default) -> TextOrDropdownElement {
         // If no state dict just use a textfield for state
         if stateDict.isEmpty {
             return TextFieldElement.Address.StateConfiguration(
@@ -44,7 +44,7 @@ extension AddressSpec {
                                     didUpdate: nil)
     }
 
-    func makePostalElement(countryCode: String, defaultValue: String?, theme: ElementsUITheme = .default) -> TextFieldElement {
+    func makePostalElement(countryCode: String, defaultValue: String?, theme: ElementsAppearance = .default) -> TextFieldElement {
         return TextFieldElement.Address.PostalCodeConfiguration(
             countryCode: countryCode,
             label: zipNameType.localizedLabel,

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/DropdownFieldElement+AddressFactory.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/DropdownFieldElement+AddressFactory.swift
@@ -19,7 +19,7 @@ import Foundation
         public static func makeCountry(
             label: String,
             countryCodes: [String],
-            theme: ElementsUITheme = .default,
+            theme: ElementsAppearance = .default,
             defaultCountry: String? = nil,
             locale: Locale = Locale.current,
             disableDropdownWithSingleCountry: Bool = false

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+AccountFactory.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+AccountFactory.swift
@@ -46,7 +46,7 @@ import UIKit
             }
         }
 
-        public static func makeBSB(defaultValue: String?, theme: ElementsUITheme = .default) -> TextFieldElement {
+        public static func makeBSB(defaultValue: String?, theme: ElementsAppearance = .default) -> TextFieldElement {
             return TextFieldElement(configuration: BSBConfiguration(defaultValue: defaultValue), theme: theme)
         }
 
@@ -75,7 +75,7 @@ import UIKit
             }
         }
 
-        public static func makeAUBECSAccountNumber(defaultValue: String?, theme: ElementsUITheme = .default) -> TextFieldElement {
+        public static func makeAUBECSAccountNumber(defaultValue: String?, theme: ElementsAppearance = .default) -> TextFieldElement {
             return TextFieldElement(configuration: AUBECSAccountNumberConfiguration(defaultValue: defaultValue), theme: theme)
         }
 
@@ -110,7 +110,7 @@ import UIKit
             }
         }
 
-        public static func makeSortCode(defaultValue: String?, theme: ElementsUITheme = .default) -> TextFieldElement {
+        public static func makeSortCode(defaultValue: String?, theme: ElementsAppearance = .default) -> TextFieldElement {
             return TextFieldElement(configuration: SortCodeConfiguration(defaultValue: defaultValue), theme: theme)
         }
 
@@ -138,7 +138,7 @@ import UIKit
             }
         }
 
-        public static func makeBacsAccountNumber(defaultValue: String?, theme: ElementsUITheme = .default) -> TextFieldElement {
+        public static func makeBacsAccountNumber(defaultValue: String?, theme: ElementsAppearance = .default) -> TextFieldElement {
             return TextFieldElement(configuration: BacsAccountNumberConfiguration(defaultValue: defaultValue), theme: theme)
         }
     }

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+AddressFactory.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+AddressFactory.swift
@@ -56,7 +56,7 @@ import UIKit
                 return false
             }
 
-            func accessoryView(for text: String, theme: ElementsUITheme) -> UIView? {
+            func accessoryView(for text: String, theme: ElementsAppearance) -> UIView? {
                 if case .line1Autocompletable(let didTapAutocomplete) = lineType {
                     let autocompleteIconButton = UIButton.make(type: .system, didTap: didTapAutocomplete)
                     let configuration = UIImage.SymbolConfiguration(pointSize: CGFloat(10), weight: .bold)
@@ -71,20 +71,20 @@ import UIKit
             }
         }
 
-        public static func makeLine1(defaultValue: String?, theme: ElementsUITheme) -> TextFieldElement {
+        public static func makeLine1(defaultValue: String?, theme: ElementsAppearance) -> TextFieldElement {
             return TextFieldElement(
                 configuration: LineConfiguration(lineType: .line1, defaultValue: defaultValue), theme: theme
             )
         }
 
-        static func makeLine2(defaultValue: String?, theme: ElementsUITheme) -> TextFieldElement {
+        static func makeLine2(defaultValue: String?, theme: ElementsAppearance) -> TextFieldElement {
             let line2 = TextFieldElement(
                 configuration: LineConfiguration(lineType: .line2, defaultValue: defaultValue), theme: theme
             )
             return line2
         }
 
-        public static func makeAutoCompleteLine(defaultValue: String?, theme: ElementsUITheme) -> TextFieldElement {
+        public static func makeAutoCompleteLine(defaultValue: String?, theme: ElementsAppearance) -> TextFieldElement {
             return TextFieldElement(
                 configuration: LineConfiguration(lineType: .autoComplete, defaultValue: defaultValue), theme: theme
             )

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+Factory.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+Factory.swift
@@ -63,7 +63,7 @@ import UIKit
         }
     }
 
-    static func makeName(label: String? = nil, defaultValue: String?, theme: ElementsUITheme = .default) -> TextFieldElement {
+    static func makeName(label: String? = nil, defaultValue: String?, theme: ElementsAppearance = .default) -> TextFieldElement {
         return TextFieldElement(configuration: NameConfiguration(type: .full, defaultValue: defaultValue, label: label), theme: theme)
     }
 
@@ -99,7 +99,7 @@ import UIKit
         }
     }
 
-    static func makeEmail(defaultValue: String?, isOptional: Bool = false, theme: ElementsUITheme = .default) -> TextFieldElement {
+    static func makeEmail(defaultValue: String?, isOptional: Bool = false, theme: ElementsAppearance = .default) -> TextFieldElement {
         return TextFieldElement(configuration: EmailConfiguration(defaultValue: defaultValue,
                                                                   isOptional: isOptional), theme: theme)
     }
@@ -127,7 +127,7 @@ import UIKit
 
     }
 
-    static func makeVPA(theme: ElementsUITheme = .default) -> TextFieldElement {
+    static func makeVPA(theme: ElementsAppearance = .default) -> TextFieldElement {
         return TextFieldElement(configuration: VPAConfiguration(), theme: theme)
     }
 
@@ -156,7 +156,7 @@ import UIKit
         }
     }
 
-    static func makeBlikCode(defaultValue: String?, theme: ElementsUITheme) -> TextFieldElement {
+    static func makeBlikCode(defaultValue: String?, theme: ElementsAppearance) -> TextFieldElement {
         return TextFieldElement(configuration: BlikCodeConfiguration(defaultValue: defaultValue), theme: theme)
     }
 
@@ -188,7 +188,7 @@ import UIKit
         }
     }
 
-    static func makeKonbini(theme: ElementsUITheme) -> TextFieldElement {
+    static func makeKonbini(theme: ElementsAppearance) -> TextFieldElement {
         return TextFieldElement(configuration: KonbiniPhoneNumberConfiguration(), theme: theme)
     }
 

--- a/StripeUICore/StripeUICore/Source/Elements/Form/FormElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Form/FormElement.swift
@@ -23,7 +23,7 @@ import UIKit
     public let elements: [Element]
     public let customSpacing: [(Element, CGFloat)]
     public let style: Style
-    public let theme: ElementsUITheme
+    public let theme: ElementsAppearance
 
     // MARK: - Style
     public enum Style {
@@ -37,9 +37,9 @@ import UIKit
     public struct ViewModel {
         let elements: [UIView]
         let bordered: Bool
-        let theme: ElementsUITheme
+        let theme: ElementsAppearance
         let customSpacing: [(UIView, CGFloat)]
-        public init(elements: [UIView], bordered: Bool, theme: ElementsUITheme = .default, customSpacing: [(UIView, CGFloat)] = []) {
+        public init(elements: [UIView], bordered: Bool, theme: ElementsAppearance = .default, customSpacing: [(UIView, CGFloat)] = []) {
             self.elements = elements
             self.bordered = bordered
             self.theme = theme
@@ -58,11 +58,11 @@ import UIKit
     ///   - elements: The list of elements
     ///   - theme: The ElementsUITheme
     ///   - customSpacing: A list of Elements and a CGFloat of custom spacing to use after the element
-    public convenience init(elements: [Element?], theme: ElementsUITheme = .default, customSpacing: [(Element, CGFloat)] = []) {
+    public convenience init(elements: [Element?], theme: ElementsAppearance = .default, customSpacing: [(Element, CGFloat)] = []) {
         self.init(elements: elements, style: .plain, theme: theme, customSpacing: customSpacing)
     }
 
-    public init(elements: [Element?], style: Style, theme: ElementsUITheme = .default, customSpacing: [(Element, CGFloat)] = []) {
+    public init(elements: [Element?], style: Style, theme: ElementsAppearance = .default, customSpacing: [(Element, CGFloat)] = []) {
         self.elements = elements.compactMap { $0 }
         self.style = style
         self.theme = theme

--- a/StripeUICore/StripeUICore/Source/Elements/Form/FormView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Form/FormView.swift
@@ -22,7 +22,7 @@ import UIKit
             let stack = StackViewWithSeparator(arrangedSubviews: viewModel.elements)
             self.stackView = stack
             stack.drawBorder = true
-            stack.customBackgroundColor = viewModel.theme.colors.background
+            stack.customBackgroundColor = viewModel.theme.colors.componentBackground
             stack.separatorColor = viewModel.theme.colors.divider
             stack.borderColor = viewModel.theme.colors.border
             stack.borderCornerRadius = viewModel.theme.cornerRadius

--- a/StripeUICore/StripeUICore/Source/Elements/PhoneNumber/PhoneNumberElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PhoneNumber/PhoneNumberElement.swift
@@ -77,7 +77,7 @@ import UIKit
         isOptional: Bool = false,
         infoView: UIView? = nil,
         locale: Locale = .current,
-        theme: ElementsUITheme = .default
+        theme: ElementsAppearance = .default
     ) {
         self.infoView = infoView
         let defaults = Self.deriveDefaults(countryCode: defaultCountryCode, phoneNumber: defaultPhoneNumber)
@@ -164,7 +164,7 @@ extension DropdownFieldElement {
         countryCodes: [String],
         defaultCountry: String? = nil,
         locale: Locale,
-        theme: ElementsUITheme
+        theme: ElementsAppearance
     ) -> DropdownFieldElement {
         let countryCodes = locale.sortedByTheirLocalizedNames(countryCodes)
         let countryDisplayStrings: [DropdownFieldElement.DropdownItem] = countryCodes.map {

--- a/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
@@ -78,7 +78,7 @@ final class PickerFieldView: UIView {
     private let label: String?
     private let shouldShowChevron: Bool
     private weak var delegate: PickerFieldViewDelegate?
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
     // When a PickerFieldView is optional it's chevron is smaller and takes the color of placeholder text
     private let isOptional: Bool
     private var _canBecomeFirstResponder = true
@@ -126,7 +126,7 @@ final class PickerFieldView: UIView {
         shouldShowChevron: Bool,
         pickerView: UIView,
         delegate: PickerFieldViewDelegate,
-        theme: ElementsUITheme,
+        theme: ElementsAppearance,
         hasPadding: Bool = true,
         isOptional: Bool = false
     ) {

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionContainerView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionContainerView.swift
@@ -36,18 +36,18 @@ class SectionContainerView: UIView {
     }()
 
     private(set) var views: [UIView]
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
 
     // MARK: - Initializers
 
-    convenience init(view: UIView, theme: ElementsUITheme = .default) {
+    convenience init(view: UIView, theme: ElementsAppearance = .default) {
         self.init(views: [view], theme: theme)
     }
 
     /**
      - Parameter views: A list of views to display in a row. To display multiple elements in a single row, put them inside a `MultiElementRowView`.
      */
-    init(views: [UIView], theme: ElementsUITheme = .default) {
+    init(views: [UIView], theme: ElementsAppearance = .default) {
         self.views = views
         self.theme = theme
         super.init(frame: .zero)
@@ -199,7 +199,7 @@ extension SectionContainerView {
     class MultiElementRowView: UIView {
         let views: [UIView]
 
-        init(views: [UIView], theme: ElementsUITheme = .default) {
+        init(views: [UIView], theme: ElementsAppearance = .default) {
             self.views = views
             super.init(frame: .zero)
             let stackView = buildStackView(views: views, theme: theme)
@@ -214,7 +214,7 @@ extension SectionContainerView {
 
 // MARK: - StackViewWithSeparator
 
-private func buildStackView(views: [UIView], theme: ElementsUITheme = .default) -> StackViewWithSeparator {
+private func buildStackView(views: [UIView], theme: ElementsAppearance = .default) -> StackViewWithSeparator {
     let stackView = StackViewWithSeparator(arrangedSubviews: views)
     stackView.axis = .vertical
     stackView.spacing = theme.borderWidth

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionContainerView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionContainerView.swift
@@ -119,7 +119,7 @@ class SectionContainerView: UIView {
         layer.cornerRadius = theme.cornerRadius
 
         if isUserInteractionEnabled || UITraitCollection.current.isDarkMode {
-            backgroundColor = theme.colors.background
+            backgroundColor = theme.colors.componentBackground
         } else {
             backgroundColor = .tertiarySystemGroupedBackground
         }
@@ -221,7 +221,7 @@ private func buildStackView(views: [UIView], theme: ElementsAppearance = .defaul
     stackView.separatorColor = theme.colors.divider
     stackView.borderColor = theme.colors.border
     stackView.borderCornerRadius = theme.cornerRadius
-    stackView.customBackgroundColor = theme.colors.background
+    stackView.customBackgroundColor = theme.colors.componentBackground
     stackView.drawBorder = true
     stackView.hideShadow = true // Shadow is handled by `SectionContainerView`
     return stackView

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionElement+MultiElementRow.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionElement+MultiElementRow.swift
@@ -17,9 +17,9 @@ public extension SectionElement {
             return SectionContainerView.MultiElementRowView(views: elements.map { $0.view }, theme: theme)
         }()
         public let elements: [Element]
-        public let theme: ElementsUITheme
+        public let theme: ElementsAppearance
 
-        public init(_ elements: [Element], theme: ElementsUITheme = .default) {
+        public init(_ elements: [Element], theme: ElementsAppearance = .default) {
             self.elements = elements
             self.theme = theme
             elements.forEach {

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionElement.swift
@@ -55,7 +55,7 @@ import UIKit
         elements.compactMap({ $0.subLabelText }).first
     }
 
-    let theme: ElementsUITheme
+    let theme: ElementsAppearance
 
     // MARK: - ViewModel
 
@@ -64,12 +64,12 @@ import UIKit
         let title: String?
         let errorText: String?
         var subLabel: String?
-        let theme: ElementsUITheme
+        let theme: ElementsAppearance
     }
 
     // MARK: - Initializers
 
-    public init(title: String? = nil, elements: [Element], theme: ElementsUITheme = .default) {
+    public init(title: String? = nil, elements: [Element], theme: ElementsAppearance = .default) {
         self.title = title
         self.elements = elements
         self.theme = theme
@@ -78,7 +78,7 @@ import UIKit
         }
     }
 
-    public convenience init(_ element: Element, theme: ElementsUITheme = .default) {
+    public convenience init(_ element: Element, theme: ElementsAppearance = .default) {
         self.init(title: nil, elements: [element], theme: theme)
     }
 }

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/FloatingPlaceholderTextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/FloatingPlaceholderTextFieldView.swift
@@ -19,7 +19,7 @@ class FloatingPlaceholderTextFieldView: UIView {
     // MARK: - Views
 
     private let textField: UITextField
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
     private lazy var placeholderLabel: UILabel = {
         let label = UILabel()
         label.textColor = theme.colors.placeholderText
@@ -38,7 +38,7 @@ class FloatingPlaceholderTextFieldView: UIView {
 
     // MARK: - Initializers
 
-    public init(textField: UITextField, theme: ElementsUITheme = .default) {
+    public init(textField: UITextField, theme: ElementsAppearance = .default) {
         self.textField = textField
         self.theme = theme
         super.init(frame: .zero)

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
@@ -39,7 +39,7 @@ import UIKit
         )
     }
 
-    private let theme: ElementsUITheme
+    private let theme: ElementsAppearance
 
 #if !canImport(CompositorServices)
     public var inputAccessoryView: UIView? {
@@ -75,7 +75,7 @@ import UIKit
         let accessoryView: UIView?
         let shouldShowClearButton: Bool
         let isEditable: Bool
-        let theme: ElementsUITheme
+        let theme: ElementsAppearance
     }
 
     var viewModel: ViewModel {
@@ -102,7 +102,7 @@ import UIKit
 
     // MARK: - Initializer
 
-    public required init(configuration: TextFieldElementConfiguration, theme: ElementsUITheme = .default) {
+    public required init(configuration: TextFieldElementConfiguration, theme: ElementsAppearance = .default) {
         self.configuration = configuration
         self.theme = theme
     }

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElementConfiguration.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElementConfiguration.swift
@@ -75,12 +75,12 @@ import UIKit
      This could be the logo of a network, a bank, etc.
      - Returns: a view.
      */
-    func accessoryView(for text: String, theme: ElementsUITheme) -> UIView?
+    func accessoryView(for text: String, theme: ElementsAppearance) -> UIView?
 
     /**
      Convenience method that creates a TextFieldElement using this Configuration
     */
-    func makeElement(theme: ElementsUITheme) -> TextFieldElement
+    func makeElement(theme: ElementsAppearance) -> TextFieldElement
 }
 
 // MARK: - Default implementation
@@ -134,11 +134,11 @@ public extension TextFieldElementConfiguration {
         return .max
     }
 
-    func accessoryView(for text: String, theme: ElementsUITheme) -> UIView? {
+    func accessoryView(for text: String, theme: ElementsAppearance) -> UIView? {
         return nil
     }
 
-    func makeElement(theme: ElementsUITheme) -> TextFieldElement {
+    func makeElement(theme: ElementsAppearance) -> TextFieldElement {
         return TextFieldElement(configuration: self, theme: theme)
     }
 }

--- a/StripeUICore/StripeUICore/Source/Views/DoneButtonToolbar.swift
+++ b/StripeUICore/StripeUICore/Source/Views/DoneButtonToolbar.swift
@@ -27,7 +27,7 @@ import UIKit
 
     // MARK: - Initializers
 
-    public init(delegate: DoneButtonToolbarDelegate?, showCancelButton: Bool = false, theme: ElementsUITheme = .default) {
+    public init(delegate: DoneButtonToolbarDelegate?, showCancelButton: Bool = false, theme: ElementsAppearance = .default) {
         // Initializing w/ an arbitrary frame stops autolayout from complaining on the first layout pass
         super.init(frame: CGRect(x: 0, y: 0, width: 100, height: 44))
 

--- a/StripeUICore/StripeUICoreTests/Snapshot/Elements/CheckboxButtonSnapshotTests.swift
+++ b/StripeUICore/StripeUICoreTests/Snapshot/Elements/CheckboxButtonSnapshotTests.swift
@@ -42,7 +42,7 @@ class CheckboxButtonSnapshotTests: STPSnapshotTestCase {
     }
 
     func testCustomFont() throws {
-        var theme = ElementsUITheme.default
+        var theme = ElementsAppearance.default
         theme.fonts.footnote = try XCTUnwrap(UIFont(name: "AmericanTypewriter", size: 13.0))
         theme.fonts.footnoteEmphasis = try XCTUnwrap(UIFont(name: "AmericanTypewriter-Semibold", size: 13.0))
 
@@ -82,7 +82,7 @@ class CheckboxButtonSnapshotTests: STPSnapshotTestCase {
     }
 
     func testAttributedTextCustomFont() throws {
-        var theme = ElementsUITheme.default
+        var theme = ElementsAppearance.default
         theme.fonts.footnote = try XCTUnwrap(UIFont(name: "AmericanTypewriter", size: 13.0))
         theme.fonts.footnoteEmphasis = try XCTUnwrap(UIFont(name: "AmericanTypewriter-Semibold", size: 13.0))
         let checkbox = CheckboxButton(


### PR DESCRIPTION
## Summary
- Rename `ElementsUITheme` to `ElementsAppearance`, add comment indicating it should be identical to `PaymentSheet.Appearance`
- Rename `ElementsAppearance.background` to `ElementsAppearance.componentBackground`, matching its actual  `PaymentSheet.Appearance` value 

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3567

## Testing
Existing tests

## Changelog
Not user facing