### PR TITLE
[Connect] Don't preview downloads + better error handling

### DIFF
--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
@@ -291,7 +291,6 @@ extension ConnectWebView {
             return
         }
 
-        // File is not previewable, so directly open share sheet instead
         let activityViewController = UIActivityViewController(activityItems: [downloadedFile], applicationActivities: nil)
         activityViewController.completionWithItemsHandler = { [weak self] _, _, _, _ in
             self?.cleanupDownloadedFile()

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
@@ -344,12 +344,8 @@ extension ConnectWebView: WKDownloadDelegate {
 extension ConnectWebView: QLPreviewControllerDataSource {
     func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
         guard let downloadedFile else {
-            // This should never happen, so log error if it does
-            // TODO: MXMOBILE-2491 Log error analytic
-            return 0
-        }
-        guard fileManager.fileExists(atPath: downloadedFile.path) else {
-            // The temp file was likely auto-deleted too quickly
+            // `downloadFile` should always be non-nil
+            // If the temp file doesn't exist, it was likely auto-deleted too quickly
             // TODO: MXMOBILE-2491 Log error analytic
             return 0
         }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebView.swift
@@ -287,7 +287,7 @@ extension ConnectWebView {
 
     func downloadDidFinish() {
         guard let downloadedFile,
-        fileManager.fileExists(atPath: downloadedFile.path) else {
+              fileManager.fileExists(atPath: downloadedFile.path) else {
             // `downloadedFile` should never be nil here
             // If file doesn't exist, it indicates something went wrong creating
             // the temp file or the system deleted the temp file too quickly
@@ -343,7 +343,8 @@ extension ConnectWebView: WKDownloadDelegate {
 @available(iOS 15, *)
 extension ConnectWebView: QLPreviewControllerDataSource {
     func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
-        guard let downloadedFile else {
+        guard let downloadedFile,
+              fileManager.fileExists(atPath: downloadedFile.path) else {
             // `downloadFile` should always be non-nil
             // If the temp file doesn't exist, it was likely auto-deleted too quickly
             // TODO: MXMOBILE-2491 Log error analytic

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewTests.swift
@@ -7,7 +7,6 @@
 
 import Foundation
 
-import QuickLook
 import SafariServices
 @testable import StripeConnect
 @_spi(STP) import StripeCore
@@ -20,19 +19,15 @@ class ConnectWebViewTests: XCTestCase {
     private var mockFileManager: MockFileManager!
     var webView: ConnectWebView!
 
-    var canPreviewFile = true
-
     override func setUp() {
         super.setUp()
         mockFileManager = .init()
         mockURLOpener = .init()
-        canPreviewFile = true
         webView = ConnectWebView(frame: .zero,
                                  configuration: .init(),
                                  urlOpener: mockURLOpener,
                                  fileManager: mockFileManager,
-                                 sdkVersion: "1.2.3",
-                                 canPreviewItem: { _ in self.canPreviewFile })
+                                 sdkVersion: "1.2.3")
     }
 
     func testUserAgent() {
@@ -252,32 +247,8 @@ class ConnectWebViewTests: XCTestCase {
         XCTAssertEqual(alertController?.preferredStyle, .alert)
     }
 
-    func testDownloadFinishedShowsPreview() throws {
+    func testDownloadFinishedShowsShareSheet() {
         let mockFileURL = URL(string: "file:///temp/example.csv")!
-
-        var previewController: QLPreviewController?
-        webView.presentPopup = { vc in
-            previewController = vc as? QLPreviewController
-        }
-        webView.downloadedFile = mockFileURL
-
-        webView.downloadDidFinish()
-        XCTAssertNotNil(previewController)
-
-        // Shows 1 item matching the downloaded file
-        XCTAssertEqual(previewController?.dataSource?.numberOfPreviewItems(in: try XCTUnwrap(previewController)), 1)
-        XCTAssertEqual(previewController?.dataSource?.previewController(try XCTUnwrap(previewController), previewItemAt: 0) as? URL, mockFileURL)
-
-        // Dismissing should cleanup downloaded file
-        previewController?.delegate?.previewControllerDidDismiss?(try XCTUnwrap(previewController))
-        XCTAssertNil(webView.downloadedFile)
-        wait(for: [mockFileManager.removeItemExpectation])
-        XCTAssertEqual(mockFileManager.removedItems, [mockFileURL])
-    }
-
-    func testUnsupportedFileTypeDownloadFinishedShowsShareSheet() {
-        let mockFileURL = URL(string: "file:///temp/example.exe")!
-        canPreviewFile = false
 
         var activityVC: UIActivityViewController?
         webView.presentPopup = { vc in


### PR DESCRIPTION
## Summary
- Directly open system share sheet instead of previewing downloaded file
- If the file doesn't exist after it should have downloaded, displays an error message to the user
- Deletes the temp file after the preview or action sheet is closed
- Stubs out some TODOs to add error logging for various edge cases

## Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2827

## Testing
- [x] Manually tested (see video)
- [x] Added unit test coverage


https://github.com/user-attachments/assets/520079a0-4840-4d06-861b-a86bb7646afd

