### PR TITLE
Fix test institution name in UI tests

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2428,7 +2428,7 @@ extension PaymentSheetUITestCase {
         vertical: Bool = false,
         useLinkCardBrand: Bool = false
     ) {
-        
+
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.mode = mode
         settings.apmsEnabled = .off
@@ -2481,13 +2481,9 @@ extension PaymentSheetUITestCase {
         linkLoginCtaButton.tap()
 
         // "Institution picker" pane
-        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Test OAuth Institution"]
+        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Payment Success"]
         XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
         featuredLegacyTestInstitution.tap()
-
-        let prepaneContinueButton = app.buttons["prepane_continue_button"]
-        XCTAssertTrue(prepaneContinueButton.waitForExistence(timeout: 60.0), "Failed to open Partner Auth Prepane - \(#function) waiting failed")
-        prepaneContinueButton.tap()
 
         let accountPickerLinkAccountsButton = app.buttons["connect_accounts_button"]
         XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "Failed to open Account Picker pane - \(#function) waiting failed")  // wait for accounts to fetch


### PR DESCRIPTION
## Summary

This fixes some failing UI tests due to test institution name changes. Here are the new Instant Debits test banks:

<img width=40% src="https://github.com/user-attachments/assets/797bc404-d826-4a3c-91d4-db98067662e9">

## Motivation
 Fix master

## Testing

Trust CI!

## Changelog

N/a