### PR TITLE
Update mandate configuration api

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -151,7 +151,7 @@ struct PaymentSheetTestPlayground: View {
                         SettingView(setting: $playgroundController.settings.collectPhone)
                         SettingView(setting: $playgroundController.settings.collectAddress)
                     }
-                    
+
                     if playgroundController.settings.uiStyle == .embedded {
                         Divider()
                         Group {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -161,7 +161,7 @@ struct PaymentSheetTestPlayground: View {
                                 Spacer()
                             }
                             SettingView(setting: $playgroundController.settings.formSheetAction)
-                            SettingView(setting: $playgroundController.settings.hidesMandateText)
+                            SettingView(setting: $playgroundController.settings.embeddedViewDisplaysMandateText)
                         }
                     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -410,13 +410,13 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case on
         case off
     }
-    
+
     enum DisplaysMandateTextEnabled: String, PickerEnum {
         static let enumName: String = "displaysMandateText"
         case on
         case off
     }
-    
+
     enum FormSheetAction: String, PickerEnum {
         static let enumName: String = "formSheetAction"
         case confirm

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -411,8 +411,8 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
     
-    enum HidesMandateTextEnabled: String, PickerEnum {
-        static let enumName: String = "hidesMandateText"
+    enum DisplaysMandateTextEnabled: String, PickerEnum {
+        static let enumName: String = "displaysMandateText"
         case on
         case off
     }
@@ -464,7 +464,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var collectPhone: BillingDetailsPhone
     var collectAddress: BillingDetailsAddress
     var formSheetAction: FormSheetAction
-    var hidesMandateText: HidesMandateTextEnabled
+    var embeddedViewDisplaysMandateText: DisplaysMandateTextEnabled
 
     static func defaultValues() -> PaymentSheetTestPlaygroundSettings {
         return PaymentSheetTestPlaygroundSettings(
@@ -506,7 +506,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             collectPhone: .automatic,
             collectAddress: .automatic,
             formSheetAction: .confirm,
-            hidesMandateText: .off)
+            embeddedViewDisplaysMandateText: .on)
     }
 
     static let nsUserDefaultsKey = "PaymentSheetTestPlaygroundSettings"

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -190,7 +190,7 @@ class PlaygroundController: ObservableObject {
         }()
         
         var configuration = EmbeddedPaymentElement.Configuration(formSheetAction: formSheetAction)
-        configuration.hidesMandateText = settings.hidesMandateText == .on
+        configuration.embeddedViewDisplaysMandateText = settings.embeddedViewDisplaysMandateText == .on
         configuration.externalPaymentMethodConfiguration = externalPaymentMethodConfiguration
         switch settings.externalPaymentMethods {
         case .paypal:

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -188,7 +188,7 @@ class PlaygroundController: ObservableObject {
                 return .continue
             }
         }()
-        
+
         var configuration = EmbeddedPaymentElement.Configuration(formSheetAction: formSheetAction)
         configuration.embeddedViewDisplaysMandateText = settings.embeddedViewDisplaysMandateText == .on
         configuration.externalPaymentMethodConfiguration = externalPaymentMethodConfiguration

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -99,7 +99,7 @@ public class EmbeddedPaymentElement {
             shouldShowApplePay: shouldShowApplePay,
             shouldShowLink: shouldShowLink,
             savedPaymentMethodAccessoryType: savedPaymentMethodAccessoryType,
-            mandateProvider: FormMandateProvider(configuration: configuration,
+            mandateProvider: VerticalListMandateProvider(configuration: configuration,
                                              elementsSession: loadResult.elementsSession,
                                              intent: .deferredIntent(intentConfig: intentConfiguration))
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
@@ -9,142 +9,143 @@
 import UIKit
 
 extension EmbeddedPaymentElement {
-  public struct Configuration {
-    /// If true, allows payment methods that do not move money at the end of the checkout. Defaults to false.
-    /// - Description: Some payment methods can't guarantee you will receive funds from your customer at the end of the checkout because they take time to settle (eg. most bank debits, like SEPA or ACH) or require customer action to complete (e.g. OXXO, Konbini, Boleto). If this is set to true, make sure your integration listens to webhooks for notifications on whether a payment has succeeded or not.
-    /// - Seealso: https://stripe.com/docs/payments/payment-methods#payment-notification
-    public var allowsDelayedPaymentMethods: Bool = false
+    public struct Configuration {
+        /// If true, allows payment methods that do not move money at the end of the checkout. Defaults to false.
+        /// - Description: Some payment methods can't guarantee you will receive funds from your customer at the end of the checkout because they take time to settle (eg. most bank debits, like SEPA or ACH) or require customer action to complete (e.g. OXXO, Konbini, Boleto). If this is set to true, make sure your integration listens to webhooks for notifications on whether a payment has succeeded or not.
+        /// - Seealso: https://stripe.com/docs/payments/payment-methods#payment-notification
+        public var allowsDelayedPaymentMethods: Bool = false
 
-    /// If `true`, allows payment methods that require a shipping address, like Afterpay and Affirm. Defaults to `false`.
-    /// Set this to `true` if you collect shipping addresses and set `Configuration.shippingDetails` or set `shipping` details directly on the PaymentIntent.
-    /// - Note: PaymentSheet considers this property `true` and allows payment methods that require a shipping address if `shipping` details are present on the PaymentIntent when PaymentSheet loads.
-    public var allowsPaymentMethodsRequiringShippingAddress: Bool = false
+        /// If `true`, allows payment methods that require a shipping address, like Afterpay and Affirm. Defaults to `false`.
+        /// Set this to `true` if you collect shipping addresses and set `Configuration.shippingDetails` or set `shipping` details directly on the PaymentIntent.
+        /// - Note: PaymentSheet considers this property `true` and allows payment methods that require a shipping address if `shipping` details are present on the PaymentIntent when PaymentSheet loads.
+        public var allowsPaymentMethodsRequiringShippingAddress: Bool = false
 
-    /// The APIClient instance used to make requests to Stripe
-    public var apiClient: STPAPIClient = STPAPIClient.shared
+        /// The APIClient instance used to make requests to Stripe
+        public var apiClient: STPAPIClient = STPAPIClient.shared
 
-    /// Configuration related to Apple Pay
-    /// If set, PaymentSheet displays Apple Pay as a payment option
-    public var applePay: ApplePayConfiguration?
+        /// Configuration related to Apple Pay
+        /// If set, PaymentSheet displays Apple Pay as a payment option
+        public var applePay: ApplePayConfiguration?
 
-    /// The color of the Buy or Add button. Defaults to `.systemBlue` when `nil`.
-    public var primaryButtonColor: UIColor? {
-      get {
-        return appearance.primaryButton.backgroundColor
-      }
+        /// The color of the Buy or Add button. Defaults to `.systemBlue` when `nil`.
+        public var primaryButtonColor: UIColor? {
+            get {
+                return appearance.primaryButton.backgroundColor
+            }
 
-      set {
-        appearance.primaryButton.backgroundColor = newValue
-      }
+            set {
+                appearance.primaryButton.backgroundColor = newValue
+            }
+        }
+
+        /// The label to use for the primary button.
+        ///
+        /// If not set, Payment Sheet will display suitable default labels
+        /// for payment and setup intents.
+        public var primaryButtonLabel: String?
+
+        private var styleRawValue: Int = 0  // SheetStyle.automatic.rawValue
+        /// The color styling to use for PaymentSheet UI
+        /// Default value is SheetStyle.automatic
+        /// @see SheetStyle
+        public var style: UserInterfaceStyle {  // stored properties can't be marked @available which is why this uses the styleRawValue private var
+            get {
+                return UserInterfaceStyle(rawValue: styleRawValue)!
+            }
+            set {
+                styleRawValue = newValue.rawValue
+            }
+        }
+
+        /// Configuration related to the Stripe Customer
+        /// If set, the customer can select a previously saved payment method within PaymentSheet
+        public var customer: CustomerConfiguration?
+
+        /// Your customer-facing business name.
+        /// The default value is the name of your app, using CFBundleDisplayName or CFBundleName
+        public var merchantDisplayName: String = Bundle.displayName ?? ""
+
+        /// A URL that redirects back to your app that PaymentSheet can use to auto-dismiss
+        /// web views used for additional authentication, e.g. 3DS2
+        public var returnURL: String?
+
+        /// PaymentSheet pre-populates fields with the values provided.
+        /// If `billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod` is `true`, these values will
+        /// be attached to the payment method even if they are not collected by the PaymentSheet UI.
+        public var defaultBillingDetails: BillingDetails = BillingDetails()
+
+        /// PaymentSheet offers users an option to save some payment methods for later use.
+        /// Default value is .automatic
+        /// @see SavePaymentMethodOptInBehavior
+        public var savePaymentMethodOptInBehavior: SavePaymentMethodOptInBehavior = .automatic
+
+        /// Describes the appearance of PaymentSheet
+        public var appearance = PaymentSheet.Appearance.default
+
+        /// A closure that returns the customer's shipping details.
+        /// This is used to display a "Billing address is same as shipping" checkbox if `defaultBillingDetails` is not provided
+        /// If `name` and `line1` are populated, it's also [attached to the PaymentIntent](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping) during payment.
+        public var shippingDetails: () -> AddressViewController.AddressDetails? = { return nil }
+
+        /// The list of preferred networks that should be used to process payments made with a co-branded card.
+        /// This value will only be used if your user hasn't selected a network themselves.
+        public var preferredNetworks: [STPCardBrand]? {
+            didSet {
+                guard let preferredNetworks = preferredNetworks else { return }
+                assert(Set<STPCardBrand>(preferredNetworks).count == preferredNetworks.count,
+                       "preferredNetworks must not contain any duplicate card brands")
+            }
+        }
+
+        /// Override country for test purposes
+        @_spi(STP) public var userOverrideCountry: String?
+
+        /// Describes how billing details should be collected.
+        /// All values default to `automatic`.
+        /// If `never` is used for a required field for the Payment Method used during checkout,
+        /// you **must** provide an appropriate value as part of `defaultBillingDetails`.
+        public var billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration()
+
+        /// Optional configuration to display a custom message when a saved payment method is removed.
+        public var removeSavedPaymentMethodMessage: String?
+
+        /// Configuration for external payment methods.
+        public var externalPaymentMethodConfiguration: ExternalPaymentMethodConfiguration?
+
+        /// By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the customer.
+        /// You can override the default order in which payment methods are displayed in PaymentSheet with a list of payment method types.
+        /// See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid types.  You may also pass external payment methods.
+        /// - Example: ["card", "external_paypal", "klarna"]
+        /// - Note: If you omit payment methods from this list, they’ll be automatically ordered by Stripe after the ones you provide. Invalid payment methods are ignored.
+        public var paymentMethodOrder: [String]?
+
+        /// This is an experimental feature that may be removed at any time.
+        /// If true (the default), the customer can delete all saved payment methods.
+        /// If false, the customer can't delete if they only have one saved payment method remaining.
+        @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) public var allowsRemovalOfLastSavedPaymentMethod = true
+
+        /// The view can display payment methods like “Card” that, when tapped, open a form sheet where customers enter their payment method details. The sheet has a button at the bottom. `FormSheetAction` enumerates the actions the button can perform.
+        public enum FormSheetAction {
+            /// The button says “Pay” or “Setup”. When tapped, we confirm the payment or setup in the form sheet.
+            /// - Parameter completion: Called with the result of the payment or setup.
+            case confirm(
+                completion: (EmbeddedPaymentElementResult) -> Void
+            )
+
+            /// The button says “Continue”. When tapped, the form sheet closes.
+            case `continue`
+        }
+
+        /// The view can display payment methods like “Card” that, when tapped, open a sheet where customers enter their payment method details. The sheet has a button at the bottom. `formSheetAction` controls the action the button performs.
+        public var formSheetAction: FormSheetAction
+
+        /// Controls whether the view displays mandate text at the bottom for payment methods that require it. If set to `false`, your integration must display `PaymentOptionDisplayData.mandateText` to the customer near your “Buy” button to comply with regulations.
+        /// - Note: This doesn't affect mandates displayed in the form sheet.
+        var embeddedViewDisplaysMandateText: Bool = true
+
+        /// Initializes a Configuration with default values
+        public init(formSheetAction: FormSheetAction) {
+            self.formSheetAction = formSheetAction
+        }
     }
-
-    /// The label to use for the primary button.
-    ///
-    /// If not set, Payment Sheet will display suitable default labels
-    /// for payment and setup intents.
-    public var primaryButtonLabel: String?
-
-    private var styleRawValue: Int = 0  // SheetStyle.automatic.rawValue
-    /// The color styling to use for PaymentSheet UI
-    /// Default value is SheetStyle.automatic
-    /// @see SheetStyle
-    public var style: UserInterfaceStyle {  // stored properties can't be marked @available which is why this uses the styleRawValue private var
-      get {
-        return UserInterfaceStyle(rawValue: styleRawValue)!
-      }
-      set {
-        styleRawValue = newValue.rawValue
-      }
-    }
-
-    /// Configuration related to the Stripe Customer
-    /// If set, the customer can select a previously saved payment method within PaymentSheet
-    public var customer: CustomerConfiguration?
-
-    /// Your customer-facing business name.
-    /// The default value is the name of your app, using CFBundleDisplayName or CFBundleName
-    public var merchantDisplayName: String = Bundle.displayName ?? ""
-
-    /// A URL that redirects back to your app that PaymentSheet can use to auto-dismiss
-    /// web views used for additional authentication, e.g. 3DS2
-    public var returnURL: String?
-
-    /// PaymentSheet pre-populates fields with the values provided.
-    /// If `billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod` is `true`, these values will
-    /// be attached to the payment method even if they are not collected by the PaymentSheet UI.
-    public var defaultBillingDetails: BillingDetails = BillingDetails()
-
-    /// PaymentSheet offers users an option to save some payment methods for later use.
-    /// Default value is .automatic
-    /// @see SavePaymentMethodOptInBehavior
-    public var savePaymentMethodOptInBehavior: SavePaymentMethodOptInBehavior = .automatic
-
-    /// Describes the appearance of PaymentSheet
-    public var appearance = PaymentSheet.Appearance.default
-
-    /// A closure that returns the customer's shipping details.
-    /// This is used to display a "Billing address is same as shipping" checkbox if `defaultBillingDetails` is not provided
-    /// If `name` and `line1` are populated, it's also [attached to the PaymentIntent](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-shipping) during payment.
-    public var shippingDetails: () -> AddressViewController.AddressDetails? = { return nil }
-
-    /// The list of preferred networks that should be used to process payments made with a co-branded card.
-    /// This value will only be used if your user hasn't selected a network themselves.
-    public var preferredNetworks: [STPCardBrand]? {
-      didSet {
-        guard let preferredNetworks = preferredNetworks else { return }
-        assert(Set<STPCardBrand>(preferredNetworks).count == preferredNetworks.count,
-               "preferredNetworks must not contain any duplicate card brands")
-      }
-    }
-
-    /// Override country for test purposes
-    @_spi(STP) public var userOverrideCountry: String?
-
-    /// Describes how billing details should be collected.
-    /// All values default to `automatic`.
-    /// If `never` is used for a required field for the Payment Method used during checkout,
-    /// you **must** provide an appropriate value as part of `defaultBillingDetails`.
-    public var billingDetailsCollectionConfiguration = BillingDetailsCollectionConfiguration()
-
-    /// Optional configuration to display a custom message when a saved payment method is removed.
-    public var removeSavedPaymentMethodMessage: String?
-
-    /// Configuration for external payment methods.
-    public var externalPaymentMethodConfiguration: ExternalPaymentMethodConfiguration?
-
-    /// By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the customer.
-    /// You can override the default order in which payment methods are displayed in PaymentSheet with a list of payment method types.
-    /// See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid types.  You may also pass external payment methods.
-    /// - Example: ["card", "external_paypal", "klarna"]
-    /// - Note: If you omit payment methods from this list, they’ll be automatically ordered by Stripe after the ones you provide. Invalid payment methods are ignored.
-    public var paymentMethodOrder: [String]?
-
-    /// This is an experimental feature that may be removed at any time.
-    /// If true (the default), the customer can delete all saved payment methods.
-    /// If false, the customer can't delete if they only have one saved payment method remaining.
-    @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) public var allowsRemovalOfLastSavedPaymentMethod = true
-
-    /// The view can display payment methods like “Card” that, when tapped, open a form sheet where customers enter their payment method details. The sheet has a button at the bottom. `FormSheetAction` enumerates the actions the button can perform.
-    public enum FormSheetAction {
-      /// The button says “Pay” or “Setup”. When tapped, we confirm the payment or setup in the form sheet.
-      /// - Parameter completion: Called with the result of the payment or setup.
-      case confirm(
-        completion: (EmbeddedPaymentElementResult) -> Void
-      )
-
-      /// The button says “Continue”. When tapped, the form sheet closes.
-      case `continue`
-    }
-
-    /// The view can display payment methods like “Card” that, when tapped, open a sheet where customers enter their payment method details. The sheet has a button at the bottom. `formSheetAction` controls the action the button performs.
-    public var formSheetAction: FormSheetAction
-
-    /// Controls whether the view displays mandate text at the bottom for payment methods that require it. If set to `true`, your integration must display `PaymentOptionDisplayData.mandateText` to the customer near your “Buy” button to comply with regulations.
-    public var hidesMandateText: Bool = false
-
-    /// Initializes a Configuration with default values
-    public init(formSheetAction: FormSheetAction) {
-      self.formSheetAction = formSheetAction
-    }
-  }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
@@ -141,7 +141,7 @@ extension EmbeddedPaymentElement {
 
         /// Controls whether the view displays mandate text at the bottom for payment methods that require it. If set to `false`, your integration must display `PaymentOptionDisplayData.mandateText` to the customer near your “Buy” button to comply with regulations.
         /// - Note: This doesn't affect mandates displayed in the form sheet.
-        var embeddedViewDisplaysMandateText: Bool = true
+        public var embeddedViewDisplaysMandateText: Bool = true
 
         /// Initializes a Configuration with default values
         public init(formSheetAction: FormSheetAction) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/MandateTextProvider.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/MandateTextProvider.swift
@@ -14,8 +14,7 @@ protocol MandateTextProvider {
 }
 
 /// A class that can provide the attributed string for a given payment method type and configuration for the vertical list of PMs.
-// TODO: rename to VerticalListFormMandateProvider
-class FormMandateProvider: MandateTextProvider {
+class VerticalListMandateProvider: MandateTextProvider {
     private let configuration: PaymentElementConfiguration
     private let elementsSession: STPElementsSession
     private let intent: Intent
@@ -75,12 +74,11 @@ class FormMandateProvider: MandateTextProvider {
 
         return newMandateText
     }
-    
+
     var shouldDisplayMandateInVerticalList: Bool {
         if let embeddedConfig = configuration as? EmbeddedPaymentElement.Configuration {
             return embeddedConfig.embeddedViewDisplaysMandateText
         }
-
-        return false
+        return true
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/MandateTextProvider.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/MandateTextProvider.swift
@@ -13,7 +13,8 @@ protocol MandateTextProvider {
     func mandate(for paymentMethodType: PaymentSheet.PaymentMethodType?, savedPaymentMethod: STPPaymentMethod?, bottomNoticeAttributedString: NSAttributedString?) -> NSAttributedString?
 }
 
-/// A class that can provide the attributed string for a given payment method type and configuration
+/// A class that can provide the attributed string for a given payment method type and configuration for the vertical list of PMs.
+// TODO: rename to VerticalListFormMandateProvider
 class FormMandateProvider: MandateTextProvider {
     private let configuration: PaymentElementConfiguration
     private let elementsSession: STPElementsSession
@@ -25,14 +26,14 @@ class FormMandateProvider: MandateTextProvider {
         self.intent = intent
     }
 
-    /// Builds the attributed string for a given payment method type
+    /// Builds the attributed string for a given payment method type.
     /// - Parameter paymentMethodType: The payment method type who's mandate should be constructed
     /// - Parameter savedPaymentMethod: The currently selected saved payment method if any
     /// - Parameter bottomNoticeAttributedString: Passing this in just makes this method return it as long as `configuration` doesn't hide mandate text
     /// - Returns: An `NSAttributedString` representing the mandate to be displayed for `paymentMethodType`, returns `nil` if no mandate should be shown
     func mandate(for paymentMethodType: PaymentSheet.PaymentMethodType?, savedPaymentMethod: STPPaymentMethod?, bottomNoticeAttributedString: NSAttributedString? = nil) -> NSAttributedString? {
-        // Merchant will display the mandate
-        guard !configuration.hidesMandateText else {  return nil }
+        // Merchant will display the mandate themselves, return nil.
+        guard shouldDisplayMandateInVerticalList else { return nil }
 
         let newMandateText: NSAttributedString? = {
             guard let paymentMethodType else { return nil }
@@ -74,12 +75,10 @@ class FormMandateProvider: MandateTextProvider {
 
         return newMandateText
     }
-}
-
-extension PaymentElementConfiguration {
-    var hidesMandateText: Bool {
-        if let embeddedConfig = self as? EmbeddedPaymentElement.Configuration {
-            return embeddedConfig.hidesMandateText
+    
+    var shouldDisplayMandateInVerticalList: Bool {
+        if let embeddedConfig = configuration as? EmbeddedPaymentElement.Configuration {
+            return embeddedConfig.embeddedViewDisplaysMandateText
         }
 
         return false

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -257,7 +257,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     }
 
     func updateMandate(animated: Bool = true) {
-        let mandateProvider = FormMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        let mandateProvider = VerticalListMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
         let newMandateText = mandateProvider.mandate(for: selectedPaymentOption?.paymentMethodType,
                                                      savedPaymentMethod: selectedPaymentOption?.savedPaymentMethod,
                                                      bottomNoticeAttributedString: paymentMethodFormViewController?.bottomNoticeAttributedString)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FormMandateProviderTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FormMandateProviderTests.swift
@@ -19,7 +19,7 @@ class FormMandateProviderTests: XCTestCase {
 
     func testFormMandateProvider_WhenConfigurationHidesMandateText_ShouldReturnNil() {
         var embeddedConfiguration = EmbeddedPaymentElement.Configuration(formSheetAction: .continue)
-        embeddedConfiguration.hidesMandateText = true
+        embeddedConfiguration.embeddedViewDisplaysMandateText = false
         embeddedConfiguration.merchantDisplayName = "Test Merchant"
 
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"])
@@ -28,7 +28,7 @@ class FormMandateProviderTests: XCTestCase {
             confirmHandler: { _, _, _ in }
         )
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let formMandateProvider = FormMandateProvider(configuration: embeddedConfiguration, elementsSession: elementsSession, intent: intent)
+        let formMandateProvider = VerticalListMandateProvider(configuration: embeddedConfiguration, elementsSession: elementsSession, intent: intent)
 
         let result = formMandateProvider.mandate(for: .stripe(.card), savedPaymentMethod: nil, bottomNoticeAttributedString: nil)
         XCTAssertNil(result)
@@ -42,7 +42,7 @@ class FormMandateProviderTests: XCTestCase {
             confirmHandler: { _, _, _ in }
         )
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let formMandateProvider = FormMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        let formMandateProvider = VerticalListMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
 
         let result = formMandateProvider.mandate(for: nil, savedPaymentMethod: nil, bottomNoticeAttributedString: nil)
         XCTAssertNil(result)
@@ -58,7 +58,7 @@ class FormMandateProviderTests: XCTestCase {
             confirmHandler: { _, _, _ in }
         )
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let formMandateProvider = FormMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        let formMandateProvider = VerticalListMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
         let paymentMethod: STPPaymentMethod = ._testUSBankAccount()
 
         let result = formMandateProvider.mandate(for: .stripe(.USBankAccount), savedPaymentMethod: paymentMethod, bottomNoticeAttributedString: nil)
@@ -76,7 +76,7 @@ class FormMandateProviderTests: XCTestCase {
             confirmHandler: { _, _, _ in }
         )
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let formMandateProvider = FormMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        let formMandateProvider = VerticalListMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
         let paymentMethod: STPPaymentMethod = ._testSEPA()
 
         let result = formMandateProvider.mandate(for: .stripe(.SEPADebit), savedPaymentMethod: paymentMethod, bottomNoticeAttributedString: nil)
@@ -94,7 +94,7 @@ class FormMandateProviderTests: XCTestCase {
             confirmHandler: { _, _, _ in }
         )
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let formMandateProvider = FormMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        let formMandateProvider = VerticalListMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
         let paymentMethod: STPPaymentMethod = ._testCard()
 
         let result = formMandateProvider.mandate(for: .stripe(.card), savedPaymentMethod: paymentMethod, bottomNoticeAttributedString: nil)
@@ -112,7 +112,7 @@ class FormMandateProviderTests: XCTestCase {
             confirmHandler: { _, _, _ in }
         )
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let formMandateProvider = FormMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        let formMandateProvider = VerticalListMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
         let bottomNoticeAttributedString = NSAttributedString(string: "Test Bottom Notice")
 
         let result = formMandateProvider.mandate(for: .stripe(.USBankAccount), savedPaymentMethod: nil, bottomNoticeAttributedString: bottomNoticeAttributedString)
@@ -129,7 +129,7 @@ class FormMandateProviderTests: XCTestCase {
             confirmHandler: { _, _, _ in }
         )
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let formMandateProvider = FormMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        let formMandateProvider = VerticalListMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
 
         let result = formMandateProvider.mandate(for: .stripe(.cashApp), savedPaymentMethod: nil, bottomNoticeAttributedString: nil)
         let expected = "By continuing, you authorize Test Merchant to debit your Cash App account for this payment and future payments in accordance with Test Merchant\'s terms, until this authorization is revoked. You can change this anytime in your Cash App Settings."
@@ -146,7 +146,7 @@ class FormMandateProviderTests: XCTestCase {
             confirmHandler: { _, _, _ in }
         )
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let formMandateProvider = FormMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        let formMandateProvider = VerticalListMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
 
         let result = formMandateProvider.mandate(for: .stripe(.cashApp), savedPaymentMethod: nil, bottomNoticeAttributedString: nil)
         let expected = "By continuing, you authorize Test Merchant to debit your Cash App account for this payment and future payments in accordance with Test Merchant\'s terms, until this authorization is revoked. You can change this anytime in your Cash App Settings."
@@ -163,7 +163,7 @@ class FormMandateProviderTests: XCTestCase {
             confirmHandler: { _, _, _ in }
         )
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let formMandateProvider = FormMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        let formMandateProvider = VerticalListMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent)
 
         let result = formMandateProvider.mandate(for: .stripe(.cashApp), savedPaymentMethod: nil, bottomNoticeAttributedString: nil)
         XCTAssertNil(result)


### PR DESCRIPTION
## Summary
- Removes `hidesMandateText`, added `embeddedViewDisplaysMandateText` and updated docstring.
- Renames `FormMandateProvider` -> `VerticalListMandateProvider` because the former name implies it provides the mandate for forms e.g. FormFactory would use it to create mandates.  I think this name is more accurate.