### PR TITLE
[Connect] Allowlist connections-auth.stripe.com

### DIFF
--- a/StripeConnect/StripeConnect/Source/Internal/StripeConnectConstants.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/StripeConnectConstants.swift
@@ -17,6 +17,7 @@ enum StripeConnectConstants {
     static let allowedHosts: Set<String> = [
         "connect-js.stripe.com",
         "connect.stripe.com",
+        "connections-auth.stripe.com",
     ]
 
     static let connectJSBaseURL = URL(string: "https://connect-js.stripe.com/v1.0/ios_webview.html")!


### PR DESCRIPTION
## Summary
OAuth'ing with Financial connections in a connect component was triggering the SafariVC instead of the embedded popup. Root cause was the domain wasn't allow-listed.

## Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2838

## Testing
TODO
