### PR TITLE
[BANKCON-11801] Pass amount, currency, and intent ID to Link signup endpoint

### DIFF
--- a/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
@@ -9,9 +9,25 @@ import Foundation
 
 /// Contains elements session context useful for the Financial Connections SDK.
 @_spi(STP) public struct ElementsSessionContext {
+    @_spi(STP) public enum IntentID {
+        case payment(String)
+        case setup(String)
+    }
+
+    @_spi(STP) public let amount: Int?
+    @_spi(STP) public let currency: String?
+    @_spi(STP) public let intentId: IntentID?
     @_spi(STP) public let linkMode: LinkMode?
 
-    @_spi(STP) public init(linkMode: LinkMode?) {
+    @_spi(STP) public init(
+        amount: Int?,
+        currency: String?,
+        intentId: IntentID?,
+        linkMode: LinkMode?
+    ) {
+        self.amount = amount
+        self.currency = currency
+        self.intentId = intentId
         self.linkMode = linkMode
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -33,19 +33,22 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
     private let clientSecret: String
     private let returnURL: String?
     private let apiClient: FinancialConnectionsAPIClient
+    private let elementsSessionContext: ElementsSessionContext?
 
     init(
         manifest: FinancialConnectionsSessionManifest,
         analyticsClient: FinancialConnectionsAnalyticsClient,
         clientSecret: String,
         returnURL: String?,
-        apiClient: FinancialConnectionsAPIClient
+        apiClient: FinancialConnectionsAPIClient,
+        elementsSessionContext: ElementsSessionContext?
     ) {
         self.manifest = manifest
         self.analyticsClient = analyticsClient
         self.clientSecret = clientSecret
         self.returnURL = returnURL
         self.apiClient = apiClient
+        self.elementsSessionContext = elementsSessionContext
     }
 
     func synchronize() -> Future<FinancialConnectionsLinkLoginPane> {
@@ -74,7 +77,10 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
         apiClient.linkAccountSignUp(
             emailAddress: emailAddress,
             phoneNumber: phoneNumber,
-            country: country
+            country: country,
+            amount: elementsSessionContext?.amount,
+            currency: elementsSessionContext?.currency,
+            intentId: elementsSessionContext?.intentId
         )
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1315,7 +1315,8 @@ private func CreatePaneViewController(
             analyticsClient: dataManager.analyticsClient,
             clientSecret: dataManager.clientSecret,
             returnURL: dataManager.returnURL,
-            apiClient: dataManager.apiClient
+            apiClient: dataManager.apiClient,
+            elementsSessionContext: dataManager.elementsSessionContext
         )
         let linkLoginViewController = LinkLoginViewController(dataSource: linkLoginDataSource)
         linkLoginViewController.delegate = nativeFlowController

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -200,7 +200,10 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
     func linkAccountSignUp(
         emailAddress: String,
         phoneNumber: String,
-        country: String
+        country: String,
+        amount: Int?,
+        currency: String?,
+        intentId: ElementsSessionContext.IntentID?
     ) -> Future<LinkSignUpResponse> {
         return Promise<StripeFinancialConnections.LinkSignUpResponse>()
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -207,9 +207,25 @@ extension PaymentMethodFormViewController {
     private var usBankAccountFormElement: USBankAccountPaymentMethodElement? { form as? USBankAccountPaymentMethodElement }
     private var instantDebitsFormElement: InstantDebitsPaymentMethodElement? { form as? InstantDebitsPaymentMethodElement }
 
-    private var elementsSessionContext: ElementsSessionContext? {
+    private var elementsSessionContext: ElementsSessionContext {
+        let intentId: ElementsSessionContext.IntentID? = {
+            switch intent {
+            case .paymentIntent(let paymentIntent):
+                return .payment(paymentIntent.stripeId)
+            case .setupIntent(let setupIntent):
+                return .setup(setupIntent.stripeID)
+            case .deferredIntent:
+                return nil
+            }
+        }()
+
         let linkMode = elementsSession.linkSettings?.linkMode
-        return ElementsSessionContext(linkMode: linkMode)
+        return ElementsSessionContext(
+            amount: intent.amount,
+            currency: intent.currency,
+            intentId: intentId,
+            linkMode: linkMode
+        )
     }
 
     private var shouldOverridePrimaryButton: Bool {


### PR DESCRIPTION
## Summary

Using the new `ElementsSessionContext`, we can now pass `amount`, `currency`, and `intentId` from payment elements to the Instant Debits Link signup endpoint. This will be used for Link incentives.

## Motivation

[BANKCON-11801](https://jira.corp.stripe.com/browse/BANKCON-11801)

## Testing

Verified API parameters correctly make their way from the payment sheet to the signup endpoint: 

<img width="643" alt="Screenshot 2024-10-09 at 11 08 00 AM" src="https://github.com/user-attachments/assets/d6d04c00-8e37-4da5-98c6-421e07a7cdcf">

## Changelog

N/a
