### PR TITLE
[Instant Debits] Renames Instant Debits institution on UI tests.

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/InstantDebitsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/InstantDebitsUITests.swift
@@ -45,7 +45,7 @@ final class InstantDebitsUITests: XCTestCase {
         XCTAssertTrue(linkLoginCtaButton.waitForExistence(timeout: 10.0))
         linkLoginCtaButton.tap()
 
-        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Test OAuth Institution"]
+        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Payment Success"]
         XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
         featuredLegacyTestInstitution.tap()
 


### PR DESCRIPTION
## Summary
Renames Instant Debits institution on UI tests.

## Motivation
https://not-a-startup.pagerduty.com/incidents/Q2TQG2YSE9HUCD
