### PR TITLE
Card Brand Filtering in PAN field and saved PMs

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard1.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard1.xctestplan
@@ -35,6 +35,7 @@
         "PaymentSheetBillingCollectionUICardTests",
         "PaymentSheetBillingCollectionUITestCase",
         "PaymentSheetCVCRecollectionUITests",
+        "PaymentSheetCardBrandFilteringUITests",
         "PaymentSheetCustomerSessionCBCUITests",
         "PaymentSheetCustomerSessionDedupeUITests",
         "PaymentSheetDeferredServerSideUITests",

--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard2.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard2.xctestplan
@@ -38,6 +38,7 @@
         "PaymentSheetBillingCollectionLPMUITests",
         "PaymentSheetBillingCollectionUICardTests",
         "PaymentSheetBillingCollectionUITestCase",
+        "PaymentSheetCardBrandFilteringUITests",
         "PaymentSheetDeferredUIBankAccountTests",
         "PaymentSheetDeferredUITests",
         "PaymentSheetGDPRUITests",

--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard3.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard3.xctestplan
@@ -36,6 +36,7 @@
         "LinkPaymentControllerUITest",
         "PaymentSheetBillingCollectionBankTests",
         "PaymentSheetCVCRecollectionUITests",
+        "PaymentSheetCardBrandFilteringUITests",
         "PaymentSheetCustomerSessionCBCUITests",
         "PaymentSheetCustomerSessionDedupeUITests",
         "PaymentSheetDeferredServerSideUITests",

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -70,6 +70,7 @@ struct CustomerSheetTestPlayground: View {
                         SettingView(setting: $playgroundController.settings.applePay)
                         SettingView(setting: $playgroundController.settings.defaultBillingAddress)
                         SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
+                        SettingView(setting: $playgroundController.settings.cardBrandAcceptance)
                         SettingView(setting: $playgroundController.settings.autoreload)
                         TextField("headerTextForSelectionScreen", text: headerTextForSelectionScreenBinding)
                         SettingView(setting: $playgroundController.settings.allowsRemovalOfLastSavedPaymentMethod)

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -4,7 +4,7 @@
 //
 
 import Combine
-@_spi(STP) @_spi(CustomerSessionBetaAccess) import StripePaymentSheet
+@_spi(STP) @_spi(CustomerSessionBetaAccess) @_spi(CardBrandFilteringBeta) import StripePaymentSheet
 import SwiftUI
 
 class CustomerSheetTestPlaygroundController: ObservableObject {
@@ -139,6 +139,14 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
         configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = settings.attachDefaults == .on
         configuration.preferredNetworks = settings.preferredNetworksEnabled == .on ? [.visa, .cartesBancaires] : nil
         configuration.applePayEnabled = self.applePayEnabled()
+        switch settings.cardBrandAcceptance {
+        case .all:
+            configuration.cardBrandAcceptance = .all
+        case .blockAmEx:
+            configuration.cardBrandAcceptance = .disallowed(brands: [.amex])
+        case .allowVisa:
+            configuration.cardBrandAcceptance = .allowed(brands: [.visa])
+        }
         return configuration
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -135,6 +135,13 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
         }
     }
 
+    enum CardBrandAcceptance: String, PickerEnum {
+        static let enumName: String = "cardBrandAcceptance"
+        case all
+        case blockAmEx
+        case allowVisa
+    }
+
     var customerMode: CustomerMode
     var customerId: String?
     var customerKeyType: CustomerKeyType
@@ -154,6 +161,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     var allowsRemovalOfLastSavedPaymentMethod: AllowsRemovalOfLastSavedPaymentMethod
     var paymentMethodRemove: PaymentMethodRemove
     var paymentMethodAllowRedisplayFilters: PaymentMethodAllowRedisplayFilters
+    var cardBrandAcceptance: CardBrandAcceptance
 
     static func defaultValues() -> CustomerSheetTestPlaygroundSettings {
         return CustomerSheetTestPlaygroundSettings(customerMode: .new,
@@ -173,7 +181,8 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
                                                    preferredNetworksEnabled: .off,
                                                    allowsRemovalOfLastSavedPaymentMethod: .on,
                                                    paymentMethodRemove: .enabled,
-                                                   paymentMethodAllowRedisplayFilters: .always)
+                                                   paymentMethodAllowRedisplayFilters: .always,
+                                                   cardBrandAcceptance: .all)
     }
 
     var base64Data: String {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -39,6 +39,7 @@ struct PaymentSheetTestPlayground: View {
         SettingView(setting: $playgroundController.settings.userOverrideCountry)
         SettingView(setting: $playgroundController.settings.externalPaymentMethods)
         SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
+        SettingView(setting: $playgroundController.settings.cardBrandAcceptance)
         SettingView(setting: $playgroundController.settings.allowsRemovalOfLastSavedPaymentMethod)
         SettingView(setting: $playgroundController.settings.requireCVCRecollection)
         SettingView(setting: $playgroundController.settings.autoreload)
@@ -170,7 +171,7 @@ struct PaymentSheetTestPlayground: View {
                 .environmentObject(playgroundController)
         }.animationUnlessTesting()
     }
-    
+
     var paymentMethodSaveBinding: Binding<PaymentSheetTestPlaygroundSettings.PaymentMethodSave> {
         Binding<PaymentSheetTestPlaygroundSettings.PaymentMethodSave> {
             return playgroundController.settings.paymentMethodSave

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -423,6 +423,13 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case `continue`
     }
 
+    enum CardBrandAcceptance: String, PickerEnum {
+        static let enumName: String = "cardBrandAcceptance"
+        case all
+        case blockAmEx
+        case allowVisa
+    }
+
     var uiStyle: UIStyle
     var layout: Layout
     var mode: Mode
@@ -465,6 +472,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var collectAddress: BillingDetailsAddress
     var formSheetAction: FormSheetAction
     var embeddedViewDisplaysMandateText: DisplaysMandateTextEnabled
+    var cardBrandAcceptance: CardBrandAcceptance
 
     static func defaultValues() -> PaymentSheetTestPlaygroundSettings {
         return PaymentSheetTestPlaygroundSettings(
@@ -506,7 +514,8 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             collectPhone: .automatic,
             collectAddress: .automatic,
             formSheetAction: .confirm,
-            embeddedViewDisplaysMandateText: .on)
+            embeddedViewDisplaysMandateText: .on,
+            cardBrandAcceptance: .all)
     }
 
     static let nsUserDefaultsKey = "PaymentSheetTestPlaygroundSettings"

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -14,7 +14,7 @@ import Contacts
 import PassKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
-@_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(PaymentSheetSkipConfirmation) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(ExperimentalPaymentMethodLayoutAPI) @_spi(EmbeddedPaymentElementPrivateBeta) import StripePaymentSheet
+@_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(PaymentSheetSkipConfirmation) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(ExperimentalPaymentMethodLayoutAPI) @_spi(EmbeddedPaymentElementPrivateBeta) @_spi(CardBrandFilteringBeta) import StripePaymentSheet
 import SwiftUI
 import UIKit
 
@@ -174,6 +174,15 @@ class PlaygroundController: ObservableObject {
         case .automatic:
             configuration.paymentMethodLayout = .automatic
         }
+
+        switch settings.cardBrandAcceptance {
+        case .all:
+            configuration.cardBrandAcceptance = .all
+        case .blockAmEx:
+            configuration.cardBrandAcceptance = .disallowed(brands: [.amex])
+        case .allowVisa:
+            configuration.cardBrandAcceptance = .allowed(brands: [.visa])
+        }
         return configuration
     }
 
@@ -251,6 +260,15 @@ class PlaygroundController: ObservableObject {
         configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = settings.attachDefaults == .on
         configuration.preferredNetworks = settings.preferredNetworksEnabled == .on ? [.visa, .cartesBancaires] : nil
         configuration.allowsRemovalOfLastSavedPaymentMethod = settings.allowsRemovalOfLastSavedPaymentMethod == .on
+
+        switch settings.cardBrandAcceptance {
+        case .all:
+            configuration.cardBrandAcceptance = .all
+        case .blockAmEx:
+            configuration.cardBrandAcceptance = .disallowed(brands: [.amex])
+        case .allowVisa:
+            configuration.cardBrandAcceptance = .allowed(brands: [.visa])
+        }
 
         return configuration
     }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1847,6 +1847,58 @@ class PaymentSheetCVCRecollectionUITests: PaymentSheetUITestCase {
      */
 }
 
+class PaymentSheetCardBrandFilteringUITests: PaymentSheetUITestCase {
+    func testPaymentSheet_disallowedBrands() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.cardBrandAcceptance = .blockAmEx
+        loadPlayground(app, settings)
+
+        app.buttons["Present PaymentSheet"].tap()
+
+        let numberField = app.textFields["Card number"]
+        numberField.forceTapWhenHittableInTestCase(self)
+        app.typeText("3712")
+
+        // Text should show that we cannot process American Express
+        XCTAssertTrue(app.staticTexts["American Express is not accepted"].waitForExistence(timeout: 5.0))
+
+        numberField.clearText()
+
+        // Try and pay with a Visa
+        try fillCardData(app)
+
+        app.buttons["Pay $50.99"].tap()
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
+
+    func testPaymentSheet_allowedBrands() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.cardBrandAcceptance = .allowVisa
+        loadPlayground(app, settings)
+
+        app.buttons["Present PaymentSheet"].tap()
+
+        let numberField = app.textFields["Card number"]
+        numberField.forceTapWhenHittableInTestCase(self)
+        app.typeText("3712")
+
+        // Text should show that we cannot process American Express
+        XCTAssertTrue(app.staticTexts["American Express is not accepted"].waitForExistence(timeout: 5.0))
+
+        numberField.clearText()
+
+        // Try and pay with a Visa
+        try fillCardData(app)
+
+        app.buttons["Pay $50.99"].tap()
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
+}
+
 // MARK: - Link
 class PaymentSheetLinkUITests: PaymentSheetUITestCase {
     // MARK: PaymentSheet Link inline signup

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -216,6 +216,7 @@ import Foundation
     case paymentSheetUpdateCardBrand = "mc_update_card"
     case paymentSheetUpdateCardBrandFailed = "mc_update_card_failed"
     case paymentSheetClosesEditScreen = "mc_cancel_edit_screen"
+    case paymentSheetDisallowedCardBrand = "mc_disallowed_card_brand"
 
     // MARK: - CustomerSheet card brand choice
     case customerSheetDisplayCardBrandDropdownIndicator = "cs_display_cbc_dropdown"

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -120,6 +120,8 @@
 		619AF0852BF56C5E00D1C981 /* PaymentMethodRowButtonSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619AF0842BF56C5E00D1C981 /* PaymentMethodRowButtonSnapshotTests.swift */; };
 		619AF08A2BF56FC000D1C981 /* VerticalSavedPaymentMethodsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 619AF0882BF56F9100D1C981 /* VerticalSavedPaymentMethodsViewControllerTests.swift */; };
 		61C0D3B8C63EB4558AB74A7E /* StripePayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5A1C7CFA5C9C1A8A73CFA1C0 /* StripePayments.framework */; };
+		61C87E1B2CB818ED001B7DA9 /* CardBrandFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C87E1A2CB818ED001B7DA9 /* CardBrandFilter.swift */; };
+		61C87E1E2CB81FAD001B7DA9 /* CardBrandFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C87E1C2CB81F9B001B7DA9 /* CardBrandFilterTests.swift */; };
 		61CB0BD02BED985100E24A4C /* VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CBE6672BED97EE005F7FEB /* VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift */; };
 		61CBE6662BED9749005F7FEB /* VerticalSavedPaymentMethodsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CBE6652BED9749005F7FEB /* VerticalSavedPaymentMethodsViewController.swift */; };
 		61D842892CADE4B9009D2D51 /* PaymentElementConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D842882CADE4B9009D2D51 /* PaymentElementConfiguration.swift */; };
@@ -478,6 +480,8 @@
 		6198AA6D2BED1C5A00F39D3E /* SavedPaymentMethodRowButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPaymentMethodRowButton.swift; sourceTree = "<group>"; };
 		619AF0842BF56C5E00D1C981 /* PaymentMethodRowButtonSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodRowButtonSnapshotTests.swift; sourceTree = "<group>"; };
 		619AF0882BF56F9100D1C981 /* VerticalSavedPaymentMethodsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerticalSavedPaymentMethodsViewControllerTests.swift; sourceTree = "<group>"; };
+		61C87E1A2CB818ED001B7DA9 /* CardBrandFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBrandFilter.swift; sourceTree = "<group>"; };
+		61C87E1C2CB81F9B001B7DA9 /* CardBrandFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBrandFilterTests.swift; sourceTree = "<group>"; };
 		61CBE6652BED9749005F7FEB /* VerticalSavedPaymentMethodsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalSavedPaymentMethodsViewController.swift; sourceTree = "<group>"; };
 		61CBE6672BED97EE005F7FEB /* VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		61D842882CADE4B9009D2D51 /* PaymentElementConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentElementConfiguration.swift; sourceTree = "<group>"; };
@@ -859,6 +863,7 @@
 				446E3BBF316178C04343B193 /* STPApplePayContext+PaymentSheet.swift */,
 				2C59FD8C17CA1D740BCAFA4D /* STPPaymentIntentShippingDetailsParams+PaymentSheet.swift */,
 				61D842882CADE4B9009D2D51 /* PaymentElementConfiguration.swift */,
+				61C87E1A2CB818ED001B7DA9 /* CardBrandFilter.swift */,
 			);
 			path = PaymentSheet;
 			sourceTree = "<group>";
@@ -1451,6 +1456,7 @@
 				0901281208BEB220D0B491A8 /* PaymentSheetLinkAccountTests.swift */,
 				492B254E43F3BB9F9CEAEA06 /* PaymentSheetLoaderStubbedTest.swift */,
 				C90A2636C2A577AF36FB793B /* PaymentSheetLoaderTest.swift */,
+				61C87E1C2CB81F9B001B7DA9 /* CardBrandFilterTests.swift */,
 				C47D00B9DE812D0801B4E33F /* PaymentSheetLPMConfirmFlowTests.swift */,
 				D926018024823367971A8907 /* PaymentSheetPaymentMethodTypeTest.swift */,
 				7E2803AA0D975AF78D787757 /* PaymentSheetSnapshotTests.swift */,
@@ -1720,6 +1726,7 @@
 				ABC3A7CF6D5B21D0C9684A09 /* LinkPopupURLParserTests.swift in Sources */,
 				F94F6A157CEB937896B682D4 /* LinkURLGeneratorTests.swift in Sources */,
 				10A336F0F2331F22F1A0AC1B /* LinkStubs.swift in Sources */,
+				61C87E1E2CB81FAD001B7DA9 /* CardBrandFilterTests.swift in Sources */,
 				316B33122B5F171C0008D2E5 /* UserDefaults+StripePaymentSheetTest.swift in Sources */,
 				D77514C28C9A031908E99CA1 /* PaymentMethodMessagingViewFunctionalTest.swift in Sources */,
 				D14478CFCABDF7455DA7472A /* PaymentMethodMessagingViewSnapshotTests.swift in Sources */,
@@ -1799,6 +1806,7 @@
 				EB190E908B567CD90D5B0645 /* STPImageLibrary.swift in Sources */,
 				6180A5C72C824377009D1536 /* RadioButton.swift in Sources */,
 				6180A5C12C8222A9009D1536 /* EmbeddedPaymentMethodsView.swift in Sources */,
+				61C87E1B2CB818ED001B7DA9 /* CardBrandFilter.swift in Sources */,
 				610EAAF02C0F5D9400124AB2 /* FormHeaderView.swift in Sources */,
 				40806EF506CB719299FC90CC /* STPLocalizedString.swift in Sources */,
 				71132CE036C3EE0655ECD2DB /* STPStringUtils.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -351,6 +351,8 @@ extension PaymentSheet.Configuration {
         payload["billing_details_collection_configuration"] = billingDetailsCollectionConfiguration.analyticPayload
         payload["preferred_networks"] = preferredNetworks?.map({ STPCardBrandUtilities.apiValue(from: $0) }).joined(separator: ", ")
         payload["payment_method_layout"] = paymentMethodLayout.description
+        payload["card_brand_acceptance"] = cardBrandAcceptance != .all
+
         return payload
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CardBrandFilter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CardBrandFilter.swift
@@ -1,0 +1,82 @@
+//
+//  CardBrandFilter.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 10/10/24.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+struct CardBrandFilter {
+
+    static let `default`: CardBrandFilter = .init(cardBrandAcceptance: .all)
+
+    private let cardBrandAcceptance: PaymentSheet.CardBrandAcceptance
+
+    init(cardBrandAcceptance: PaymentSheet.CardBrandAcceptance) {
+        self.cardBrandAcceptance = cardBrandAcceptance
+    }
+
+    /// Determines if a merchant can accept a card brand based on `cardBrandAcceptance`
+    /// - Parameter cardBrand: The `STPCardBrand` to determine if acceptance
+    /// - Returns: Returns true if this merchant can accept this card brand, false otherwise
+    func isAccepted(cardBrand: STPCardBrand) -> Bool {
+        switch cardBrandAcceptance {
+        case .all:
+            return true
+        case .allowed(let allowedCardBrands):
+            // If a merchant has specified a list of brands to allow, block unknown brands
+            guard let brandCategory = cardBrand.asBrandCategory else {
+                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetDisallowedCardBrand,
+                                                                     params: ["brand": STPCardBrandUtilities.apiValue(from: cardBrand)])
+                return false
+            }
+
+            if !allowedCardBrands.contains(brandCategory) {
+                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetDisallowedCardBrand,
+                                                                     params: ["brand": STPCardBrandUtilities.apiValue(from: cardBrand)])
+                return false
+            }
+        case .disallowed(let disallowedBrands):
+            if let brandCategory = cardBrand.asBrandCategory, disallowedBrands.contains(brandCategory) {
+                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetDisallowedCardBrand,
+                                                                     params: ["brand": STPCardBrandUtilities.apiValue(from: cardBrand)])
+                return false
+            }
+        }
+
+        return true
+    }
+}
+
+extension STPCardBrand {
+    var asBrandCategory: PaymentSheet.CardBrandAcceptance.BrandCategory? {
+        switch self {
+        case .visa:
+            return .visa
+        case .amex:
+            return .amex
+        case .mastercard:
+            return .mastercard
+        case .discover, .JCB, .dinersClub, .unionPay:
+            return .discover
+        case .cartesBancaires, .unknown:
+            return nil
+        @unknown default:
+            return nil
+        }
+    }
+}
+
+extension PaymentElementConfiguration {
+    var cardBrandFilter: CardBrandFilter {
+        .init(cardBrandAcceptance: cardBrandAcceptance)
+    }
+}
+
+extension CustomerSheet.Configuration {
+    var cardBrandFilter: CardBrandFilter {
+        .init(cardBrandAcceptance: cardBrandAcceptance)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CardBrandFilter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CardBrandFilter.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-@_spi(STP) import StripeCore
 
 struct CardBrandFilter {
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CardBrandFilter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CardBrandFilter.swift
@@ -28,20 +28,14 @@ struct CardBrandFilter {
         case .allowed(let allowedCardBrands):
             // If a merchant has specified a list of brands to allow, block unknown brands
             guard let brandCategory = cardBrand.asBrandCategory else {
-                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetDisallowedCardBrand,
-                                                                     params: ["brand": STPCardBrandUtilities.apiValue(from: cardBrand)])
                 return false
             }
 
             if !allowedCardBrands.contains(brandCategory) {
-                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetDisallowedCardBrand,
-                                                                     params: ["brand": STPCardBrandUtilities.apiValue(from: cardBrand)])
                 return false
             }
         case .disallowed(let disallowedBrands):
             if let brandCategory = cardBrand.asBrandCategory, disallowedBrands.contains(brandCategory) {
-                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetDisallowedCardBrand,
-                                                                     params: ["brand": STPCardBrandUtilities.apiValue(from: cardBrand)])
                 return false
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -436,7 +436,8 @@ extension CustomerSavedPaymentMethodsCollectionViewController: PaymentOptionCell
                                               appearance: appearance,
                                               hostedSurface: .customerSheet,
                                               canRemoveCard: configuration.paymentMethodRemove && (savedPaymentMethods.count > 1 || configuration.allowsRemovalOfLastSavedPaymentMethod),
-                                              isTestMode: configuration.isTestMode)
+                                              isTestMode: configuration.isTestMode,
+                                              cardBrandFilter: savedPaymentMethodsConfiguration.cardBrandFilter)
         editVc.delegate = self
         self.bottomSheetController?.pushContentViewController(editVc)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -74,6 +74,13 @@ extension CustomerSheet {
         /// If false, the customer can't delete if they only have one saved payment method remaining.
         @_spi(STP) public var allowsRemovalOfLastSavedPaymentMethod = true
 
+        /// By default, CustomerSheet will accept all supported cards by Stripe.
+        /// You can specify card brands CustomerSheet should block disallow or allow payment for by providing an array of those card brands.
+        /// Note: For Apple Pay, the list of supported card brands is determined by combining `StripeAPI.supportedPKPaymentNetworks()` with `StripeAPI.additionalEnabledApplePayNetworks` and then applying the `cardBrandAcceptance` filter. This filtered list is then assigned to `PKPaymentRequest.supportedNetworks`, ensuring that only the allowed card brands are available for Apple Pay transactions. Any `PKPaymentNetwork` that does not correspond to a `BrandCategory` will be blocked if you have specified an allow list, or will not be blocked if you have specified a disallow list.
+        /// Note: This is only a client-side solution.
+        /// Note: Card brand filtering is not currently supported by Link.
+        @_spi(CardBrandFilteringBeta) public var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = .all
+
         public init () {
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
@@ -36,6 +36,7 @@ final class CardSectionElement: ContainerElement {
     }()
     let cardSection: SectionElement
     let analyticsHelper: PaymentSheetAnalyticsHelper
+    let cardBrandFilter: CardBrandFilter
 
     struct DefaultValues {
         internal init(name: String? = nil, pan: String? = nil, cvc: String? = nil, expiry: String? = nil) {
@@ -68,11 +69,13 @@ final class CardSectionElement: ContainerElement {
         cardBrandChoiceEligible: Bool = false,
         hostedSurface: HostedSurface,
         theme: ElementsAppearance = .default,
-        analyticsHelper: PaymentSheetAnalyticsHelper
+        analyticsHelper: PaymentSheetAnalyticsHelper,
+        cardBrandFilter: CardBrandFilter = .default
     ) {
         self.hostedSurface = hostedSurface
         self.theme = theme
         self.analyticsHelper = analyticsHelper
+        self.cardBrandFilter = cardBrandFilter
         let nameElement = collectName
             ? PaymentMethodElementWrapper(
                 TextFieldElement.NameConfiguration(
@@ -94,7 +97,7 @@ final class CardSectionElement: ContainerElement {
             }
         }
         let panElement = PaymentMethodElementWrapper(TextFieldElement.PANConfiguration(defaultValue: defaultValues.pan,
-                                                                                       cardBrandDropDown: cardBrandDropDown?.element), theme: theme) { field, params in
+                                                                                       cardBrandDropDown: cardBrandDropDown?.element, cardFilter: cardBrandFilter), theme: theme) { field, params in
             cardParams(for: params).number = field.text
             return params
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
@@ -36,7 +36,6 @@ final class CardSectionElement: ContainerElement {
     }()
     let cardSection: SectionElement
     let analyticsHelper: PaymentSheetAnalyticsHelper
-    let cardBrandFilter: CardBrandFilter
 
     struct DefaultValues {
         internal init(name: String? = nil, pan: String? = nil, cvc: String? = nil, expiry: String? = nil) {
@@ -75,7 +74,6 @@ final class CardSectionElement: ContainerElement {
         self.hostedSurface = hostedSurface
         self.theme = theme
         self.analyticsHelper = analyticsHelper
-        self.cardBrandFilter = cardBrandFilter
         let nameElement = collectName
             ? PaymentMethodElementWrapper(
                 TextFieldElement.NameConfiguration(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
@@ -109,8 +109,11 @@ extension TextFieldElement {
                 case .invalidBrand, .invalidLuhn:
                     return String.Localized.your_card_number_is_invalid
                 case .disallowedBrand(let brand):
-                    let cardBrandDisplayName =  STPCardBrandUtilities.stringFrom(brand) ?? "This card brand"
-                    return .localizedStringWithFormat(.Localized.brand_not_allowed, cardBrandDisplayName)
+                    if let cardBrandDisplayName = STPCardBrandUtilities.stringFrom(brand) {
+                        return .localizedStringWithFormat(.Localized.brand_not_allowed, cardBrandDisplayName)
+                    }
+                    
+                    return .Localized.generic_brand_not_allowed
                 }
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
@@ -109,19 +109,8 @@ extension TextFieldElement {
                 case .invalidBrand, .invalidLuhn:
                     return String.Localized.your_card_number_is_invalid
                 case .disallowedBrand(let brand):
-                    let isEnglishLocale: Bool = {
-                        if let languageCode = Locale.current.languageCode {
-                            return languageCode.starts(with: "en")
-                        }
-                        return false
-                    }()
-
-                    if isEnglishLocale, let cardBrandDisplayName = STPCardBrandUtilities.stringFrom(brand) {
-                        // This string won't localize well, so just hardcode it for English and use a generic message for other languages.
-                        return "\(cardBrandDisplayName) is not accepted"
-                    } else {
-                        return .Localized.selected_brand_not_allowed
-                    }
+                    let cardBrandDisplayName =  STPCardBrandUtilities.stringFrom(brand) ?? "This card brand"
+                    return .localizedStringWithFormat(.Localized.brand_not_allowed, cardBrandDisplayName)
                 }
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
@@ -109,7 +109,7 @@ extension TextFieldElement {
                 case .invalidBrand, .invalidLuhn:
                     return String.Localized.your_card_number_is_invalid
                 case .disallowedBrand(let brand):
-                    if let cardBrandDisplayName = STPCardBrandUtilities.stringFrom(brand) {
+                    if let cardBrandDisplayName = STPCardBrandUtilities.stringFrom(brand), brand != .unknown {
                         return .localizedStringWithFormat(.Localized.brand_not_allowed, cardBrandDisplayName)
                     }
                     

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
@@ -109,8 +109,19 @@ extension TextFieldElement {
                 case .invalidBrand, .invalidLuhn:
                     return String.Localized.your_card_number_is_invalid
                 case .disallowedBrand(let brand):
-                    let cardBrandDisplayName =  STPCardBrandUtilities.stringFrom(brand) ?? "This card brand"
-                    return .localizedStringWithFormat(.Localized.brand_not_allowed, cardBrandDisplayName)
+                    let isEnglishLocale: Bool = {
+                        if let languageCode = Locale.current.languageCode {
+                            return languageCode.starts(with: "en")
+                        }
+                        return false
+                    }()
+
+                    if isEnglishLocale, let cardBrandDisplayName = STPCardBrandUtilities.stringFrom(brand) {
+                        // This string won't localize well, so just hardcode it for English and use a generic message for other languages.
+                        return "\(cardBrandDisplayName) is not accepted"
+                    } else {
+                        return .Localized.selected_brand_not_allowed
+                    }
                 }
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
@@ -124,6 +124,13 @@ extension EmbeddedPaymentElement {
         /// If false, the customer can't delete if they only have one saved payment method remaining.
         @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) public var allowsRemovalOfLastSavedPaymentMethod = true
 
+        /// By default, the embedded payment element will accept all supported cards by Stripe.
+        /// You can specify card brands the embedded payment element should block disallow or allow payment for by providing an array of those card brands.
+        /// Note: For Apple Pay, the list of supported card brands is determined by combining `StripeAPI.supportedPKPaymentNetworks()` with `StripeAPI.additionalEnabledApplePayNetworks` and then applying the `cardBrandAcceptance` filter. This filtered list is then assigned to `PKPaymentRequest.supportedNetworks`, ensuring that only the allowed card brands are available for Apple Pay transactions. Any `PKPaymentNetwork` that does not correspond to a `BrandCategory` will be blocked if you have specified an allow list, or will not be blocked if you have specified a disallow list.
+        /// Note: This is only a client-side solution.
+        /// Note: Card brand filtering is not currently supported by Link.
+        @_spi(CardBrandFilteringBeta) public var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = .all
+
         /// The view can display payment methods like “Card” that, when tapped, open a form sheet where customers enter their payment method details. The sheet has a button at the bottom. `FormSheetAction` enumerates the actions the button can perform.
         public enum FormSheetAction {
             /// The button says “Pay” or “Setup”. When tapped, we confirm the payment or setup in the form sheet.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentElementConfiguration.swift
@@ -34,6 +34,7 @@ protocol PaymentElementConfiguration: PaymentMethodRequirementProvider {
     var externalPaymentMethodConfiguration: PaymentSheet.ExternalPaymentMethodConfiguration? { get set }
     var paymentMethodOrder: [String]? { get set }
     var allowsRemovalOfLastSavedPaymentMethod: Bool { get set }
+    var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance { get set }
 }
 
 extension PaymentElementConfiguration {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -195,6 +195,13 @@ extension PaymentSheet {
         /// The layout of payment methods in PaymentSheet. Defaults to `.horizontal`.
         /// - Seealso: `PaymentSheet.PaymentMethodLayout` for the list of available layouts.
         @_spi(ExperimentalPaymentMethodLayoutAPI) public var paymentMethodLayout: PaymentMethodLayout = .horizontal
+
+        /// By default, PaymentSheet will accept all supported cards by Stripe.
+        /// You can specify card brands PaymentSheet should block disallow or allow payment for by providing an array of those card brands.
+        /// Note: For Apple Pay, the list of supported card brands is determined by combining `StripeAPI.supportedPKPaymentNetworks()` with `StripeAPI.additionalEnabledApplePayNetworks` and then applying the `cardBrandAcceptance` filter. This filtered list is then assigned to `PKPaymentRequest.supportedNetworks`, ensuring that only the allowed card brands are available for Apple Pay transactions. Any `PKPaymentNetwork` that does not correspond to a `BrandCategory` will be blocked if you have specified an allow list, or will not be blocked if you have specified a disallow list.
+        /// Note: This is only a client-side solution.
+        /// Note: Card brand filtering is not currently supported by Link.
+        @_spi(CardBrandFilteringBeta) public var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = .all
     }
 
     /// Defines the layout orientations available for displaying payment methods in PaymentSheet.
@@ -517,5 +524,33 @@ extension PaymentSheet.CustomerConfiguration {
         case .customerSession:
             return elementsSession?.customer?.customerSession.apiKey
         }
+    }
+}
+
+@_spi(CardBrandFilteringBeta) extension PaymentSheet {
+    /// Options to block certain card brands on the client
+    public enum CardBrandAcceptance: Equatable {
+
+        /// Card brand categories that can be allowed or disallowed
+        public enum BrandCategory: Equatable  {
+            /// Visa branded cards
+            case visa
+            /// Mastercard branded cards
+            case mastercard
+            /// Amex branded cards
+            case amex
+            /// Discover branded cards.
+            /// - Note: Encompasses all of Discover Global Network (Discover, Diners, JCB, UnionPay, Elo)
+            case discover
+        }
+
+        /// Accept all card brands supported by Stripe
+        case all
+        /// Accept only the card brands specified in the associated value
+        /// - Note: Any card brands that do not map to a `BrandCategory` will be blocked when using an allow list.
+        case allowed(brands: [BrandCategory])
+        /// Accept all card brands supported by Stripe except for those specified in the associated value
+        /// - Note: Any card brands that do not map to a `BrandCategory` will be accepted when using a disallow list.
+        case disallowed(brands: [BrandCategory])
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -58,7 +58,8 @@ extension PaymentSheetFormFactory {
             cardBrandChoiceEligible: cardBrandChoiceEligible,
             hostedSurface: .init(config: configuration),
             theme: theme,
-            analyticsHelper: analyticsHelper
+            analyticsHelper: analyticsHelper,
+            cardBrandFilter: configuration.cardBrandFilter
         )
 
         let billingAddressSection: PaymentMethodElementWrapper<AddressSectionElement>? = {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -93,4 +93,13 @@ enum PaymentSheetFormFactoryConfig {
             return config.isUsingBillingAddressCollection()
         }
     }
+
+    var cardBrandFilter: CardBrandFilter {
+        switch self {
+        case .paymentSheet(let config):
+            return config.cardBrandFilter
+        case .customerSheet(let config):
+            return config.cardBrandFilter
+        }
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -318,7 +318,11 @@ final class PaymentSheetLoader {
             }
         }
 
-        return savedPaymentMethods
+        // Hide any saved cards whose brands are not allowed
+        return savedPaymentMethods.filter {
+            guard let cardBrand = $0.card?.brand else { return true }
+            return configuration.cardBrandFilter.isAccepted(cardBrand: cardBrand)
+        }
     }
 
     static func fetchSavedPaymentMethodsUsingApiClient(configuration: PaymentElementConfiguration) async throws -> [STPPaymentMethod] {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -560,7 +560,8 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
                                               appearance: appearance,
                                               hostedSurface: .paymentSheet,
                                               canRemoveCard: configuration.allowsRemovalOfPaymentMethods && (savedPaymentMethods.count > 1 || configuration.allowsRemovalOfLastSavedPaymentMethod),
-                                              isTestMode: configuration.isTestMode)
+                                              isTestMode: configuration.isTestMode,
+                                              cardBrandFilter: paymentSheetConfiguration.cardBrandFilter)
         editVc.delegate = self
         self.bottomSheetController?.pushContentViewController(editVc)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -310,7 +310,8 @@ extension VerticalSavedPaymentMethodsViewController: SavedPaymentMethodRowButton
                                                             appearance: configuration.appearance,
                                                             hostedSurface: .paymentSheet,
                                                             canRemoveCard: canRemovePaymentMethods,
-                                                            isTestMode: configuration.apiClient.isTestmode)
+                                                            isTestMode: configuration.apiClient.isTestmode,
+                                                            cardBrandFilter: configuration.cardBrandFilter)
 
         updateViewController.delegate = self
         self.updateViewController = updateViewController

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -569,7 +569,8 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                                                                 appearance: configuration.appearance,
                                                                 hostedSurface: .paymentSheet,
                                                                 canRemoveCard: configuration.allowsRemovalOfLastSavedPaymentMethod && elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
-                                                                isTestMode: configuration.apiClient.isTestmode)
+                                                                isTestMode: configuration.apiClient.isTestmode,
+                                                                cardBrandFilter: configuration.cardBrandFilter)
             updateViewController.delegate = self
             bottomSheetController?.pushContentViewController(updateViewController)
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdateCardViewController.swift
@@ -27,6 +27,7 @@ final class UpdateCardViewController: UIViewController {
     private let isTestMode: Bool
     private let hostedSurface: HostedSurface
     private let canRemoveCard: Bool
+    private let cardBrandFilter: CardBrandFilter
 
     private var latestError: Error? {
         didSet {
@@ -91,7 +92,7 @@ final class UpdateCardViewController: UIViewController {
 
     // MARK: Elements
     private lazy var panElement: TextFieldElement = {
-        return TextFieldElement.LastFourConfiguration(lastFour: paymentMethod.card?.last4 ?? "", cardBrandDropDown: cardBrandDropDown).makeElement(theme: appearance.asElementsTheme)
+        return TextFieldElement.LastFourConfiguration(lastFour: paymentMethod.card?.last4 ?? "", cardBrandDropDown: cardBrandDropDown, cardFilter: cardBrandFilter).makeElement(theme: appearance.asElementsTheme)
     }()
 
     private lazy var cardBrandDropDown: DropdownFieldElement = {
@@ -136,13 +137,15 @@ final class UpdateCardViewController: UIViewController {
          appearance: PaymentSheet.Appearance,
          hostedSurface: HostedSurface,
          canRemoveCard: Bool,
-         isTestMode: Bool) {
+         isTestMode: Bool,
+         cardBrandFilter: CardBrandFilter = .default) {
         self.paymentMethod = paymentMethod
         self.removeSavedPaymentMethodMessage = removeSavedPaymentMethodMessage
         self.appearance = appearance
         self.hostedSurface = hostedSurface
         self.isTestMode = isTestMode
         self.canRemoveCard = canRemoveCard
+        self.cardBrandFilter = cardBrandFilter
 
         super.init(nibName: nil, bundle: nil)
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CardBrandFilterTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CardBrandFilterTests.swift
@@ -75,15 +75,4 @@ class CardBrandFilterTests: XCTestCase {
             XCTAssertTrue(filter.isAccepted(cardBrand: brand), "Brand \(brand) without category should be accepted.")
         }
     }
-
-    func testIsAccepted_disallowedBrandsAnalytic() {
-        let disallowedBrands: [PaymentSheet.CardBrandAcceptance.BrandCategory] = [.amex]
-        let filter = CardBrandFilter(cardBrandAcceptance: .disallowed(brands: disallowedBrands))
-
-        XCTAssertFalse(filter.isAccepted(cardBrand: .amex))
-
-        XCTAssertEqual(STPAnalyticsClient.sharedClient._testLogHistory.count, 1)
-        XCTAssertEqual(STPAnalyticsClient.sharedClient._testLogHistory.first?["event"] as? String, "mc_disallowed_card_brand")
-        XCTAssertEqual(STPAnalyticsClient.sharedClient._testLogHistory.first?["brand"] as? String, "american_express")
-    }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CardBrandFilterTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CardBrandFilterTests.swift
@@ -1,0 +1,89 @@
+//
+//  CardBrandFilterTests.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 10/10/24.
+//
+
+import XCTest
+@testable @_spi(CardBrandFilteringBeta) import StripePaymentSheet
+@_spi(STP) import StripeCore
+
+class CardBrandFilterTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        STPAnalyticsClient.sharedClient._testLogHistory = []
+    }
+
+    func testIsAccepted_allBrandsAccepted() {
+        let filter = CardBrandFilter(cardBrandAcceptance: .all)
+
+        for brand in STPCardBrand.allCases {
+            XCTAssertTrue(filter.isAccepted(cardBrand: brand), "Brand \(brand) should be accepted when all brands are accepted.")
+        }
+    }
+
+    func testIsAccepted_allowedBrands() {
+        let allowedBrands: [PaymentSheet.CardBrandAcceptance.BrandCategory] = [.visa, .mastercard]
+        let filter = CardBrandFilter(cardBrandAcceptance: .allowed(brands: allowedBrands))
+
+        for brand in STPCardBrand.allCases {
+            let isExpectedToBeAccepted: Bool
+            if let brandCategory = brand.asBrandCategory {
+                isExpectedToBeAccepted = allowedBrands.contains(brandCategory)
+            } else {
+                // Brands without a category should not be accepted
+                isExpectedToBeAccepted = false
+            }
+            let isAccepted = filter.isAccepted(cardBrand: brand)
+            XCTAssertEqual(isAccepted, isExpectedToBeAccepted, "Brand \(brand) acceptance mismatch. Expected \(isExpectedToBeAccepted), got \(isAccepted).")
+        }
+    }
+
+    func testIsAccepted_disallowedBrands() {
+        let disallowedBrands: [PaymentSheet.CardBrandAcceptance.BrandCategory] = [.amex, .discover]
+        let filter = CardBrandFilter(cardBrandAcceptance: .disallowed(brands: disallowedBrands))
+
+        for brand in STPCardBrand.allCases {
+            let isExpectedToBeAccepted: Bool
+            if let brandCategory = brand.asBrandCategory {
+                isExpectedToBeAccepted = !disallowedBrands.contains(brandCategory)
+            } else {
+                // Brands without a category should be accepted
+                isExpectedToBeAccepted = true
+            }
+            let isAccepted = filter.isAccepted(cardBrand: brand)
+            XCTAssertEqual(isAccepted, isExpectedToBeAccepted, "Brand \(brand) acceptance mismatch. Expected \(isExpectedToBeAccepted), got \(isAccepted).")
+        }
+    }
+
+    func testIsAccepted_unknownBrandCategory() {
+        let allowedBrands: [PaymentSheet.CardBrandAcceptance.BrandCategory] = [.visa]
+        let filter = CardBrandFilter(cardBrandAcceptance: .allowed(brands: allowedBrands))
+
+        for brand in STPCardBrand.allCases where brand.asBrandCategory == nil {
+            XCTAssertFalse(filter.isAccepted(cardBrand: brand), "Brand \(brand) without category should be accepted.")
+        }
+    }
+
+    func testIsAccepted_allowsBrandWithNilCategory_whenDisallowed() {
+        let disallowedBrands: [PaymentSheet.CardBrandAcceptance.BrandCategory] = [.visa]
+        let filter = CardBrandFilter(cardBrandAcceptance: .disallowed(brands: disallowedBrands))
+
+        for brand in STPCardBrand.allCases where brand.asBrandCategory == nil {
+            XCTAssertTrue(filter.isAccepted(cardBrand: brand), "Brand \(brand) without category should be accepted.")
+        }
+    }
+
+    func testIsAccepted_disallowedBrandsAnalytic() {
+        let disallowedBrands: [PaymentSheet.CardBrandAcceptance.BrandCategory] = [.amex]
+        let filter = CardBrandFilter(cardBrandAcceptance: .disallowed(brands: disallowedBrands))
+
+        XCTAssertFalse(filter.isAccepted(cardBrand: .amex))
+
+        XCTAssertEqual(STPAnalyticsClient.sharedClient._testLogHistory.count, 1)
+        XCTAssertEqual(STPAnalyticsClient.sharedClient._testLogHistory.first?["event"] as? String, "mc_disallowed_card_brand")
+        XCTAssertEqual(STPAnalyticsClient.sharedClient._testLogHistory.first?["brand"] as? String, "american_express")
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -8,7 +8,7 @@
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripeCoreTestUtils
 @testable@_spi(STP) import StripePayments
-@testable @_spi(STP) import StripePaymentSheet
+@testable @_spi(STP) @_spi(CardBrandFilteringBeta) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsTestUtils
 @testable@_spi(STP) import StripeUICore
 import XCTest
@@ -318,6 +318,50 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
             }
         }
         await fulfillment(of: [expectation], timeout: STPTestingNetworkRequestTimeout)
+    }
+
+    func testPaymentSheetLoadFiltersCardBrandAcceptance() async throws {
+        let apiClient = STPAPIClient(publishableKey: STPTestingJPPublishableKey)
+        var configuration = PaymentSheet.Configuration()
+        configuration.apiClient = apiClient
+        configuration.cardBrandAcceptance = .disallowed(brands: [.visa])
+
+        // A hardcoded test Customer
+        let testCustomerID = "cus_OtOGvD0ZVacBoj"
+
+        // Create a new EK for the Customer
+        let customerAndEphemeralKey = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(customerID: testCustomerID, merchantCountry: "jp")
+        configuration.customer = .init(id: testCustomerID, ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret)
+
+        // This is a Visa saved card:
+        let savedCard = "card_1O5upWIq2LmpyICo9tQmU9xY"
+
+        // Check that the test Customer has the expected cards
+        let checkCustomerExpectation = expectation(description: "Check test customer")
+        apiClient.listPaymentMethods(forCustomer: testCustomerID, using: customerAndEphemeralKey.ephemeralKeySecret) { paymentMethods, _ in
+            XCTAssertEqual(paymentMethods?.last?.stripeId, savedCard)
+            checkCustomerExpectation.fulfill()
+        }
+        await fulfillment(of: [checkCustomerExpectation])
+
+        // Load PaymentSheet...
+        let loadExpectation = XCTestExpectation(description: "Load PaymentSheet")
+        let confirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandler = {_, _, _ in
+            XCTFail("Confirm handler shouldn't be called.")
+        }
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "JPY"), confirmHandler: confirmHandler)
+        PaymentSheetLoader.load(mode: .deferredIntent(intentConfig), configuration: configuration, analyticsHelper: .init(isCustom: false, configuration: configuration), integrationShape: .complete) { result in
+            loadExpectation.fulfill()
+            switch result {
+            case .success(let loadResult):
+                // ...check that it filters out the saved Visa card
+                XCTAssertTrue(loadResult.savedPaymentMethods.isEmpty)
+
+            case .failure:
+                XCTFail()
+            }
+        }
+        await fulfillment(of: [loadExpectation], timeout: STPTestingNetworkRequestTimeout)
     }
 
     func testLoadPerformance() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/TextFieldElement+CardTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/TextFieldElement+CardTest.swift
@@ -10,7 +10,7 @@ import XCTest
 
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripePayments
-@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP)@_spi(CardBrandFilteringBeta) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsTestUtils
 @testable@_spi(STP) import StripePaymentsUI
 @testable@_spi(STP) import StripeUICore
@@ -332,6 +332,39 @@ class TextFieldElementCardTest: STPNetworkStubbingTestCase {
             XCTAssertTrue(
                 actual == expected,
                 "Input \"\(text)\": expected \(expected) but got \(actual!)"
+            )
+        }
+    }
+
+    func testPANValidation_cardBrandFiltering() throws {
+        typealias Error = TextFieldElement.PANConfiguration.Error
+        let testcases: [String: ElementValidationState] = [
+            // Valid (luhn-passing) PANs
+            "4012888888881881": .valid,
+            "2223000010089800": .invalid(error: Error.disallowedBrand(brand: .mastercard), shouldDisplay: true),  // mastercard
+            "3530111333300000": .valid,
+            "4242424242424242": .valid,  // visa
+            "4000056655665556": .valid,  // visa (debit)
+            "5555555555554444": .invalid(error: Error.disallowedBrand(brand: .mastercard), shouldDisplay: true),  // mastercard
+            "2223003122003222": .invalid(error: Error.disallowedBrand(brand: .mastercard), shouldDisplay: true),  // mastercard (2-series)
+            "5200828282828210": .invalid(error: Error.disallowedBrand(brand: .mastercard), shouldDisplay: true),  // mastercard (debit)
+            "5105105105105100": .invalid(error: Error.disallowedBrand(brand: .mastercard), shouldDisplay: true),  // mastercard (prepaid)
+            "378282246310005": .invalid(error: Error.disallowedBrand(brand: .amex), shouldDisplay: true),  // amex
+            "371449635398431": .invalid(error: Error.disallowedBrand(brand: .amex), shouldDisplay: true),  // amex
+            "6011111111111117": .valid,  // discover
+            "6011000990139424": .valid,  // discover
+            "3056930009020004": .valid,  // diners club
+            "36227206271667": .valid,  // diners club (14 digit)
+            "3566002020360505": .valid,  // jcb
+            "6200000000000005": .valid,  // cup
+        ]
+
+        let configuration = TextFieldElement.PANConfiguration(cardFilter: .init(cardBrandAcceptance: .disallowed(brands: [.amex, .mastercard])))
+        for (text, expected) in testcases {
+            let actual = configuration.simulateValidationState(text)
+            XCTAssertTrue(
+                actual == expected,
+                "Input \"\(text)\": expected \(expected) but got \(actual)"
             )
         }
     }

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0000_post_create_ephemeral_key.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_ephemeral_key$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=mGo3nof4GlqEcAADYuHA2QPYcD1Myt%2FgPmxZzQ6pwIvkuHW6Zo%2FjKqkhWsz4vcpNSaQgotlmNSyC3q9HyDK8pcP8EXuLkzkvkEt8w%2Fr9Tqdz0yWAaSQsn0nJeXllyabe76q7kJYB5RlfVEMtQR89F4gXgnQh87%2F6PeP3UamjadBaoNd4ogr%2FwiRM9gp%2FnNXbsk9M5v0CtGdlVrboXswCSKrBf%2FTfIqVBY%2BgGUORF0SM%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 34ae114f63811378a970058f7c3b0d42;o=1
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Thu, 10 Oct 2024 14:40:39 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 149
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"ephemeral_key_secret":"ek_test_YWNjdF8xTnBJWVJJcTJMbXB5SUNvLEV3NTVIQnJaZEpHSVQ3ZnpZYjVBa3JNcWlaSkxCT1E_00Axfn9W7S","customer":"cus_OtOGvD0ZVacBoj"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0001_get_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0001_get_v1_payment_methods.tail
@@ -1,0 +1,135 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_methods\?customer=cus_OtOGvD0ZVacBoj&type=card$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_9yi73qj9p9lIKZ
+Content-Length: 2583
+Vary: Origin
+Date: Thu, 10 Oct 2024 14:40:40 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "has_more" : false,
+  "object" : "list",
+  "data" : [
+    {
+      "object" : "payment_method",
+      "id" : "pm_1O5bTlIq2LmpyICoB8eZH4BJ",
+      "billing_details" : {
+        "email" : null,
+        "phone" : null,
+        "name" : "Apple Pay",
+        "address" : {
+          "state" : "CA",
+          "country" : "US",
+          "line2" : null,
+          "city" : "Oyster Point",
+          "line1" : "1",
+          "postal_code" : null
+        }
+      },
+      "card" : {
+        "fingerprint" : "H5ytsQoN2pwNyAbE",
+        "last4" : "4242",
+        "funding" : "credit",
+        "generated_from" : null,
+        "networks" : {
+          "available" : [
+            "visa"
+          ],
+          "preferred" : null
+        },
+        "brand" : "visa",
+        "checks" : {
+          "address_postal_code_check" : null,
+          "cvc_check" : null,
+          "address_line1_check" : null
+        },
+        "three_d_secure_usage" : {
+          "supported" : true
+        },
+        "wallet" : {
+          "type" : "apple_pay",
+          "apple_pay" : {
+            "type" : "apple_pay"
+          },
+          "dynamic_last4" : "4242"
+        },
+        "display_brand" : "visa",
+        "exp_month" : 12,
+        "exp_year" : 2042,
+        "country" : "US"
+      },
+      "livemode" : false,
+      "created" : 1698357158,
+      "allow_redisplay" : "unspecified",
+      "type" : "card",
+      "customer" : "cus_OtOGvD0ZVacBoj"
+    },
+    {
+      "object" : "payment_method",
+      "id" : "card_1O5upWIq2LmpyICo9tQmU9xY",
+      "billing_details" : {
+        "email" : null,
+        "phone" : null,
+        "name" : "Not Apple Pay",
+        "address" : {
+          "state" : null,
+          "country" : null,
+          "line2" : null,
+          "city" : null,
+          "line1" : null,
+          "postal_code" : null
+        }
+      },
+      "card" : {
+        "fingerprint" : "H5ytsQoN2pwNyAbE",
+        "last4" : "4242",
+        "funding" : "credit",
+        "generated_from" : null,
+        "networks" : {
+          "available" : [
+            "visa"
+          ],
+          "preferred" : null
+        },
+        "brand" : "visa",
+        "checks" : {
+          "address_postal_code_check" : null,
+          "cvc_check" : null,
+          "address_line1_check" : null
+        },
+        "three_d_secure_usage" : {
+          "supported" : true
+        },
+        "wallet" : null,
+        "display_brand" : "visa",
+        "exp_month" : 4,
+        "exp_year" : 2042,
+        "country" : "US"
+      },
+      "livemode" : false,
+      "created" : 1698431542,
+      "type" : "card",
+      "customer" : "cus_OtOGvD0ZVacBoj"
+    }
+  ],
+  "url" : "\/v1\/payment_methods"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0002_get_v1_elements_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0002_get_v1_elements_sessions.tail
@@ -1,0 +1,332 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?deferred_intent%5Bamount%5D=1000&deferred_intent%5Bcapture_method%5D=automatic&deferred_intent%5Bcurrency%5D=JPY&deferred_intent%5Bmode%5D=payment&key=pk_test_51NpIYRIq2LmpyICoBLPaTxfWFW4I34pnWuBjKXf8CgOlVih7Ni6oDfPRHGTzBEnpsrHiPvqP2UyydilqY66BWp8N00mQCJ1PU5&locale=en-US&type=deferred_intent$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Felements%2Fsessions; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=ocs-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=ocs-bapi-srv"}],"include_subdomains":true}
+request-id: req_3kCqmKIPCJMySG
+Content-Length: 13217
+Vary: Origin
+Date: Thu, 10 Oct 2024 14:40:40 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "payment_method_preference" : {
+    "country_code" : "US",
+    "object" : "payment_method_preference",
+    "type" : "deferred_intent",
+    "ordered_payment_method_types" : [
+      "card",
+      "link",
+      "konbini"
+    ]
+  },
+  "capability_enabled_card_networks" : [
+    "cartes_bancaires"
+  ],
+  "flags" : {
+    "elements_enable_external_payment_method_wallets_india" : false,
+    "elements_enable_external_payment_method_check" : false,
+    "elements_enable_external_payment_method_fonix" : false,
+    "elements_enable_external_payment_method_au_pay" : false,
+    "elements_enable_invalid_country_for_pm_error" : true,
+    "elements_enable_external_payment_method_ebt_snap" : false,
+    "elements_enable_external_payment_method_v_pay" : false,
+    "elements_enable_link_in_passthrough_ece" : true,
+    "elements_enable_passive_hcaptcha_in_payment_method_creation" : true,
+    "legacy_confirmation_tokens" : false,
+    "elements_enable_external_payment_method_swish" : false,
+    "elements_enable_external_payment_method_online_banking_poland" : false,
+    "elements_enable_read_allow_redisplay" : true,
+    "elements_enable_card_brand_choice_payment_element_spm" : true,
+    "elements_enable_external_payment_method_divido" : false,
+    "elements_enable_external_payment_method_tng" : false,
+    "elements_enable_express_checkout_button_demo_pay" : false,
+    "elements_enable_external_payment_method_tabby" : false,
+    "elements_enable_mx_card_installments" : false,
+    "elements_disable_link_global_holdback_lookup" : false,
+    "elements_enable_external_payment_method_bpay" : false,
+    "elements_enable_external_payment_method_laybuy" : false,
+    "elements_enable_external_payment_method_bluecode" : false,
+    "elements_enable_external_payment_method_grabpay_later" : false,
+    "elements_disable_klarna_ece_crossborder_validation" : false,
+    "elements_disable_payment_element_card_country_zip_validations" : false,
+    "elements_enable_external_payment_method_billie" : false,
+    "elements_enable_external_payment_method_postfinance" : false,
+    "elements_enable_external_payment_method_scalapay" : false,
+    "elements_enable_external_payment_method_famipay" : false,
+    "elements_enable_save_for_future_payments_pre_check" : false,
+    "show_swish_redirect_and_qr_code_auth_flows" : true,
+    "elements_enable_external_payment_method_online_banking_finland" : false,
+    "elements_enable_external_payment_method_nexi_pay" : false,
+    "elements_enable_external_payment_method_pay_easy" : false,
+    "elements_enable_external_payment_method_sequra" : false,
+    "elements_spm_set_as_default" : false,
+    "payment_element_link_modal_preload_killswitch" : false,
+    "elements_enable_external_payment_method_paidy" : false,
+    "elements_enable_write_allow_redisplay" : true,
+    "elements_enable_external_payment_method_online_banking_thailand" : false,
+    "elements_enable_external_payment_method_momo" : false,
+    "elements_enable_external_payment_method_payrexx" : false,
+    "elements_appearance_payment_accordion_overrides" : false,
+    "elements_enable_cb_apple_pay_for_connect_platforms" : true,
+    "link_purchase_protections_rollout" : false,
+    "elements_enable_external_payment_method_walley" : false,
+    "elements_enable_external_payment_method_mb_way" : false,
+    "elements_enable_external_payment_method_rabbitline_pay" : false,
+    "disable_cbc_in_link_popup" : false,
+    "elements_enable_external_payment_method_gopay" : false,
+    "elements_enable_mobilepay" : false,
+    "elements_enable_external_payment_method_knet" : false,
+    "elements_enable_external_payment_method_pledg" : false,
+    "elements_enable_klarna_unified_offer" : true,
+    "elements_enable_external_payment_method_postepay" : false,
+    "elements_enable_19_digit_pans" : false,
+    "elements_enable_external_payment_method_aplazo" : false,
+    "elements_enable_external_payment_method_dapp" : false,
+    "elements_enable_external_payment_method_atone" : false,
+    "elements_enable_external_payment_method_dankort" : false,
+    "elements_enable_external_payment_method_fawry" : false,
+    "elements_enable_external_payment_method_payconiq" : false,
+    "elements_enable_external_payment_method_vipps" : false,
+    "elements_enable_external_payment_method_paysafecard" : false,
+    "elements_enable_external_payment_method_eftpos_australia" : false,
+    "elements_enable_external_payment_method_wechat_mobile" : false,
+    "elements_spm_messages" : false,
+    "elements_enable_external_payment_method_azupay" : false,
+    "ece_apple_pay_payment_request_passthrough" : false,
+    "elements_enable_external_payment_method_online_banking_czech_republic" : false,
+    "elements_enable_external_payment_method_aplazame" : false,
+    "elements_enable_external_payment_method_rakuten_pay" : false,
+    "paypal_express_checkout_recurring_support" : false,
+    "elements_enable_external_payment_method_paypo" : false,
+    "elements_enable_external_payment_method_netbanking" : false,
+    "elements_enable_external_payment_method_pix_international" : false,
+    "elements_enable_external_payment_method_poli" : false,
+    "elements_enable_external_payment_method_kriya" : false,
+    "financial_connections_enable_deferred_intent_flow" : true,
+    "elements_enable_external_payment_method_hands_in" : false,
+    "elements_enable_external_payment_method_younitedpay" : false,
+    "elements_enable_br_card_installments" : false,
+    "elements_enable_external_payment_method_atome" : false,
+    "elements_enable_external_payment_method_mercado_pago" : false,
+    "elements_enable_external_payment_method_amazon_pay" : false,
+    "elements_enable_external_payment_method_line_pay" : false,
+    "elements_enable_external_payment_method_paytm" : false,
+    "elements_enable_external_payment_method_catch" : false,
+    "elements_enable_external_payment_method_skrill" : false,
+    "elements_enable_external_payment_method_paypay" : false,
+    "elements_enable_klarna_express_checkout" : false,
+    "elements_enable_external_payment_method_ratepay" : false,
+    "elements_enable_external_payment_method_sezzle" : false,
+    "elements_enable_external_payment_method_bankaxept" : false,
+    "elements_enable_external_payment_method_satispay" : false,
+    "elements_enable_external_payment_method_dbarai" : false,
+    "elements_enable_external_payment_method_titres_restaurant" : false,
+    "elements_link_global_holdback_rollout" : false,
+    "elements_enable_external_payment_method_coinbase_pay" : false,
+    "elements_enable_external_payment_method_trustly" : false,
+    "elements_enable_external_payment_method_kbc" : false,
+    "elements_enable_external_payment_method_bizum" : false,
+    "elements_enable_external_payment_method_gcash" : false,
+    "elements_enable_card_brand_choice_payment_element_link" : true,
+    "elements_enable_external_payment_method_payit" : false,
+    "elements_enable_blik" : true,
+    "elements_enable_south_korea_market_underlying_pms" : false,
+    "elements_enable_external_payment_method_girocard" : false,
+    "elements_enable_external_payment_method_oney" : false,
+    "elements_enable_external_payment_method_humm" : false,
+    "elements_enable_external_payment_method_iwocapay" : false,
+    "elements_enable_external_payment_method_benefit" : false,
+    "elements_enable_external_payment_method_twint" : false,
+    "link_enable_card_brand_choice" : true,
+    "elements_enable_external_payment_method_paybright" : false,
+    "elements_enable_link_spm" : true,
+    "elements_spm_max_visible_payment_methods" : false,
+    "elements_disable_link_email_otp" : false,
+    "cbc_in_link_popup" : true,
+    "elements_enable_external_payment_method_picpay" : false,
+    "elements_enable_external_payment_method_planpay" : false,
+    "elements_enable_external_payment_method_samsung_pay" : false,
+    "elements_enable_external_payment_method_truelayer" : false,
+    "elements_enable_link_in_ece_personalization" : false,
+    "elements_enable_passive_captcha" : true,
+    "elements_disable_paypal_express" : false,
+    "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+    "elements_enable_external_payment_method_alipay_mobile" : false,
+    "elements_enable_external_payment_method_merpay" : false,
+    "elements_enable_external_payment_method_payu" : false,
+    "elements_disable_express_checkout_button_amazon_pay" : false,
+    "elements_enable_external_payment_method_venmo" : false,
+    "link_set_active_field_true" : true,
+    "elements_enable_external_payment_method_mondu" : false,
+    "elements_enable_external_payment_method_paydirekt" : false,
+    "elements_stop_move_focus_to_first_errored_field" : true,
+    "elements_enable_external_payment_method_online_banking_slovakia" : false,
+    "elements_enable_external_payment_method_interac" : false,
+    "link_new_learn_more_modal_enabled" : true,
+    "use_link_views" : false,
+    "elements_enable_external_payment_method_mybank" : false
+  },
+  "merchant_logo_url" : null,
+  "session_id" : "elements_session_1L3AWkCPaVX",
+  "account_id" : "acct_1NpIYRIq2LmpyICo",
+  "merchant_id" : "acct_1NpIYRIq2LmpyICo",
+  "merchant_currency" : "jpy",
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping_address_settings" : {
+    "autocomplete_allowed" : true
+  },
+  "external_payment_method_data" : null,
+  "meta_pay_signed_container_context" : null,
+  "apple_pay_preference" : "enabled",
+  "lpm_promotions" : null,
+  "merchant_country" : "JP",
+  "google_pay_preference" : "enabled",
+  "paypal_express_config" : {
+    "client_id" : null,
+    "paypal_merchant_id" : null
+  },
+  "experiments_data" : {
+    "arb_id" : "a1cfedea-781c-4277-b295-449dbd243aeb",
+    "experiment_metadata" : {
+      "seed" : "530e80543638e9c96ec5901d23cd77ca9e374988f0f8b03a5a98369a01a977b9"
+    },
+    "experiment_assignments" : {
+      "default_values_prefill_holdback" : "control",
+      "ocs_buyer_xp_elements_lpm_holdback" : "control",
+      "link_popup_webview_option_ios" : "control",
+      "elements_merchant_ui_api_srv" : "control"
+    }
+  },
+  "legacy_customer" : null,
+  "link_settings" : {
+    "link_enable_webauthn_for_link_popup" : true,
+    "link_no_code_default_values_recall" : true,
+    "link_payment_session_context" : {
+      "bank_account_permissions" : [
+
+      ],
+      "bank_account_verification_method" : null
+    },
+    "link_consumer_incentive" : null,
+    "link_default_opt_in" : "FULL",
+    "link_elements_pageload_sign_up_disabled" : false,
+    "link_crypto_onramp_bank_upsell" : false,
+    "link_funding_sources" : [
+      "CARD"
+    ],
+    "link_disabled_reasons" : {
+      "payment_element_payment_method_mode" : [
+
+      ],
+      "payment_element_passthrough_mode" : [
+        "automatic_payment_methods_enabled",
+        "includes_link_in_payment_method_types"
+      ]
+    },
+    "link_supported_payment_methods" : [
+      "CARD"
+    ],
+    "link_elements_is_crypto_onramp" : false,
+    "link_payment_element_disabled_by_targeting" : false,
+    "link_popup_webview_option" : "shared",
+    "link_targeting_results" : {
+      "payment_element_passthrough_mode" : null
+    },
+    "link_disable_email_otp" : false,
+    "link_local_storage_login_enabled" : true,
+    "link_enable_instant_debits_in_testmode" : false,
+    "link_global_holdback_on" : false,
+    "link_session_storage_login_enabled" : true,
+    "link_payment_element_enable_webauthn_login" : true,
+    "link_authenticated_change_event_enabled" : false,
+    "link_bank_onboarding_enabled" : false,
+    "link_hcaptcha_rqdata" : null,
+    "link_m2_default_integration_enabled" : true,
+    "link_financial_incentives_experiment_enabled" : false,
+    "link_passthrough_mode_enabled" : false,
+    "link_no_code_default_values_identification" : true,
+    "link_enable_email_otp_for_link_popup" : true,
+    "link_pay_button_element_enabled" : true,
+    "link_crypto_onramp_elements_logout_disabled" : false,
+    "link_mode" : "LINK_PAYMENT_METHOD",
+    "link_no_code_default_values_usage" : true,
+    "link_hcaptcha_site_key" : "20000000-ffff-ffff-ffff-000000000002",
+    "link_crypto_onramp_force_cvc_reverification" : false,
+    "link_email_verification_login_enabled" : false,
+    "link_only_for_payment_method_types_enabled" : false,
+    "link_bank_incentives_enabled" : false,
+    "link_pm_killswitch_on_in_elements" : false
+  },
+  "passive_captcha" : {
+    "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+    "rqdata" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "prefill_selectors" : {
+    "default_values" : {
+      "email" : [
+
+      ],
+      "merchant_provides_default_values_on_update" : true
+    }
+  },
+  "unactivated_payment_method_types" : [
+    "link",
+    "konbini"
+  ],
+  "unverified_payment_methods_on_domain" : [
+    "apple_pay"
+  ],
+  "order" : null,
+  "link_purchase_protections_data" : {
+    "type" : null,
+    "is_eligible" : false
+  },
+  "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1NpIYRIq2LmpyICo\/",
+  "customer" : null,
+  "klarna_express_config" : {
+    "klarna_mid" : null
+  },
+  "business_name" : "Mobile Japan Test Merchant",
+  "ordered_payment_method_types_and_wallets" : [
+    "card",
+    "link",
+    "apple_pay",
+    "konbini",
+    "google_pay"
+  ],
+  "customer_error" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0003_get_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0003_get_v1_payment_methods.tail
@@ -1,0 +1,35 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_methods\?customer=cus_OtOGvD0ZVacBoj&limit=100&type=us_bank_account$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_DcF5tazfLJhXtd
+Content-Length: 89
+Vary: Origin
+Date: Thu, 10 Oct 2024 14:40:40 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "has_more" : false,
+  "object" : "list",
+  "data" : [
+
+  ],
+  "url" : "\/v1\/payment_methods"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0004_get_v1_customers_cus_OtOGvD0ZVacBoj.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0004_get_v1_customers_cus_OtOGvD0ZVacBoj.tail
@@ -1,0 +1,37 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/customers\/cus_OtOGvD0ZVacBoj\?$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fcustomers%2F%3Acustomer; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=accounts-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=accounts-bapi-srv"}],"include_subdomains":true}
+request-id: req_twSniONksApMan
+Content-Length: 215
+Vary: Origin
+Date: Thu, 10 Oct 2024 14:40:40 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "object" : "customer",
+  "id" : "cus_OtOGvD0ZVacBoj",
+  "livemode" : false,
+  "created" : 1698357141,
+  "email" : null,
+  "default_source" : "card_1O5upWIq2LmpyICo9tQmU9xY",
+  "description" : null,
+  "shipping" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0005_get_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0005_get_v1_payment_methods.tail
@@ -1,0 +1,35 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_methods\?customer=cus_OtOGvD0ZVacBoj&limit=100&type=sepa_debit$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_anZsixpVwqH7GP
+Content-Length: 89
+Vary: Origin
+Date: Thu, 10 Oct 2024 14:40:41 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "has_more" : false,
+  "object" : "list",
+  "data" : [
+
+  ],
+  "url" : "\/v1\/payment_methods"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0006_get_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0006_get_v1_payment_methods.tail
@@ -1,0 +1,135 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_methods\?customer=cus_OtOGvD0ZVacBoj&limit=100&type=card$
+200
+application/json
+access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
+request-id: req_dPTAWPgMPqXk1f
+Content-Length: 2583
+Vary: Origin
+Date: Thu, 10 Oct 2024 14:40:41 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+
+{
+  "has_more" : false,
+  "object" : "list",
+  "data" : [
+    {
+      "object" : "payment_method",
+      "id" : "pm_1O5bTlIq2LmpyICoB8eZH4BJ",
+      "billing_details" : {
+        "email" : null,
+        "phone" : null,
+        "name" : "Apple Pay",
+        "address" : {
+          "state" : "CA",
+          "country" : "US",
+          "line2" : null,
+          "city" : "Oyster Point",
+          "line1" : "1",
+          "postal_code" : null
+        }
+      },
+      "card" : {
+        "fingerprint" : "H5ytsQoN2pwNyAbE",
+        "last4" : "4242",
+        "funding" : "credit",
+        "generated_from" : null,
+        "networks" : {
+          "available" : [
+            "visa"
+          ],
+          "preferred" : null
+        },
+        "brand" : "visa",
+        "checks" : {
+          "address_postal_code_check" : null,
+          "cvc_check" : null,
+          "address_line1_check" : null
+        },
+        "three_d_secure_usage" : {
+          "supported" : true
+        },
+        "wallet" : {
+          "type" : "apple_pay",
+          "apple_pay" : {
+            "type" : "apple_pay"
+          },
+          "dynamic_last4" : "4242"
+        },
+        "display_brand" : "visa",
+        "exp_month" : 12,
+        "exp_year" : 2042,
+        "country" : "US"
+      },
+      "livemode" : false,
+      "created" : 1698357158,
+      "allow_redisplay" : "unspecified",
+      "type" : "card",
+      "customer" : "cus_OtOGvD0ZVacBoj"
+    },
+    {
+      "object" : "payment_method",
+      "id" : "card_1O5upWIq2LmpyICo9tQmU9xY",
+      "billing_details" : {
+        "email" : null,
+        "phone" : null,
+        "name" : "Not Apple Pay",
+        "address" : {
+          "state" : null,
+          "country" : null,
+          "line2" : null,
+          "city" : null,
+          "line1" : null,
+          "postal_code" : null
+        }
+      },
+      "card" : {
+        "fingerprint" : "H5ytsQoN2pwNyAbE",
+        "last4" : "4242",
+        "funding" : "credit",
+        "generated_from" : null,
+        "networks" : {
+          "available" : [
+            "visa"
+          ],
+          "preferred" : null
+        },
+        "brand" : "visa",
+        "checks" : {
+          "address_postal_code_check" : null,
+          "cvc_check" : null,
+          "address_line1_check" : null
+        },
+        "three_d_secure_usage" : {
+          "supported" : true
+        },
+        "wallet" : null,
+        "display_brand" : "visa",
+        "exp_month" : 4,
+        "exp_year" : 2042,
+        "country" : "US"
+      },
+      "livemode" : false,
+      "created" : 1698431542,
+      "type" : "card",
+      "customer" : "cus_OtOGvD0ZVacBoj"
+    }
+  ],
+  "url" : "\/v1\/payment_methods"
+}

--- a/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/en.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Details of a saved card. '{card brand} ending in {last 4}' e.g. 'VISA ending in 4242' */
 "%1$@ ending in %2$@" = "%1$@ ending in %2$@";
 
+/* String to inform a user that specific card brands are not accepted. E.g. American Express is not accepted */
+"%1$@ is not accepted" = "%1$@ is not accepted";
+
 /* Address line 2 placeholder for billing address form. */
 "Address line 2 (optional)" = "Address line 2 (optional)";
 
@@ -63,9 +66,6 @@
 
 /* Error string displayed to user when they enter in an invalid BSB number. */
 "The BSB you entered is invalid." = "The BSB you entered is invalid.";
-
-/* String to inform a user that specific card brands are not accepted. */
-"The selected brand is not allowed" = "The selected brand is not allowed";
 
 /* Error when the user hasn't allowed the current app to access the camera when scanning a payment card. 'Settings' is the localized name of the iOS Settings app. */
 "To scan your card, allow camera access in Settings." = "To scan your card, allow camera access in Settings.";

--- a/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/en.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Details of a saved card. '{card brand} ending in {last 4}' e.g. 'VISA ending in 4242' */
 "%1$@ ending in %2$@" = "%1$@ ending in %2$@";
 
+/* String to inform a user that specific card brands are not accepted. E.g. American Express is not accepted */
+"%1$@ is not accepted" = "%1$@ is not accepted";
+
 /* Address line 2 placeholder for billing address form. */
 "Address line 2 (optional)" = "Address line 2 (optional)";
 

--- a/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/en.lproj/Localizable.strings
@@ -4,9 +4,6 @@
 /* Details of a saved card. '{card brand} ending in {last 4}' e.g. 'VISA ending in 4242' */
 "%1$@ ending in %2$@" = "%1$@ ending in %2$@";
 
-/* String to inform a user that specific card brands are not accepted. E.g. American Express is not accepted */
-"%1$@ is not accepted" = "%1$@ is not accepted";
-
 /* Address line 2 placeholder for billing address form. */
 "Address line 2 (optional)" = "Address line 2 (optional)";
 
@@ -66,6 +63,9 @@
 
 /* Error string displayed to user when they enter in an invalid BSB number. */
 "The BSB you entered is invalid." = "The BSB you entered is invalid.";
+
+/* String to inform a user that specific card brands are not accepted. */
+"The selected brand is not allowed" = "The selected brand is not allowed";
 
 /* Error when the user hasn't allowed the current app to access the camera when scanning a payment card. 'Settings' is the localized name of the iOS Settings app. */
 "To scan your card, allow camera access in Settings." = "To scan your card, allow camera access in Settings.";

--- a/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/en.lproj/Localizable.strings
@@ -67,6 +67,9 @@
 /* Error string displayed to user when they enter in an invalid BSB number. */
 "The BSB you entered is invalid." = "The BSB you entered is invalid.";
 
+/* String to inform a user that specific card brands are not accepted. */
+"The selected brand is not allowed" = "The selected brand is not allowed";
+
 /* Error when the user hasn't allowed the current app to access the camera when scanning a payment card. 'Settings' is the localized name of the iOS Settings app. */
 "To scan your card, allow camera access in Settings." = "To scan your card, allow camera access in Settings.";
 

--- a/StripePaymentsUI/StripePaymentsUI/Source/Helpers/String+Localized.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Helpers/String+Localized.swift
@@ -127,10 +127,10 @@ extension String.Localized {
         )
     }
 
-    @_spi(STP) public static var brand_not_allowed: String {
+    @_spi(STP) public static var selected_brand_not_allowed: String {
         STPLocalizedString(
-            "%1$@ is not accepted",
-            "String to inform a user that specific card brands are not accepted. E.g. American Express is not accepted"
+            "The selected brand is not allowed",
+            "String to inform a user that specific card brands are not accepted."
         )
     }
 }

--- a/StripePaymentsUI/StripePaymentsUI/Source/Helpers/String+Localized.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Helpers/String+Localized.swift
@@ -127,10 +127,10 @@ extension String.Localized {
         )
     }
 
-    @_spi(STP) public static var selected_brand_not_allowed: String {
+    @_spi(STP) public static var brand_not_allowed: String {
         STPLocalizedString(
-            "The selected brand is not allowed",
-            "String to inform a user that specific card brands are not accepted."
+            "%1$@ is not accepted",
+            "String to inform a user that specific card brands are not accepted. E.g. American Express is not accepted"
         )
     }
 }

--- a/StripePaymentsUI/StripePaymentsUI/Source/Helpers/String+Localized.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Helpers/String+Localized.swift
@@ -126,6 +126,13 @@ extension String.Localized {
             "String to describe an invalid year in expiry date."
         )
     }
+
+    @_spi(STP) public static var brand_not_allowed: String {
+        STPLocalizedString(
+            "%1$@ is not accepted",
+            "String to inform a user that specific card brands are not accepted. E.g. American Express is not accepted"
+        )
+    }
 }
 
 @_spi(STP) public struct StripeSharedStrings {

--- a/StripePaymentsUI/StripePaymentsUI/Source/Helpers/String+Localized.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Helpers/String+Localized.swift
@@ -133,6 +133,13 @@ extension String.Localized {
             "String to inform a user that specific card brands are not accepted. E.g. American Express is not accepted"
         )
     }
+    
+    @_spi(STP) public static var generic_brand_not_allowed: String {
+        STPLocalizedString(
+            "The selected brand is not allowed",
+            "String to inform a user that specific card brands are not accepted."
+        )
+    }
 }
 
 @_spi(STP) public struct StripeSharedStrings {


### PR DESCRIPTION
## Summary
- Adds the CBF public API to PaymentSheet and CustomerSheet under SPI
- Adds unit and UI tests
- Updates playground with a CBF toggle
- Filters cards in the card text field based on brand
- Hides saved payment methods of cards with disallowed brands

In a future PR:
- Filter card networks in Apple Pay
- Filter card brands in CBC dropdown

### Blocking AmEx then paying with Visa

https://github.com/user-attachments/assets/ccafb592-337a-48cd-af12-729705d455da



## Motivation
https://docs.google.com/document/d/1DD7mncHsHbMtU_jqr_TnaLL8ltjO61pPmdOAlJXxYHY/edit

## Testing
- Manual
- Unit tests
- UI tests

## Changelog
N/A for now