### PR TITLE
Fix InstantDebitsUITests - Remove prepane continue button check

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/InstantDebitsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/InstantDebitsUITests.swift
@@ -49,7 +49,6 @@ final class InstantDebitsUITests: XCTestCase {
         XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
         featuredLegacyTestInstitution.tap()
 
-        app.fc_nativePrepaneContinueButton.tap()
         app.fc_nativeConnectAccountsButton.tap()
         app.fc_nativeSuccessDoneButton.tap()
     }


### PR DESCRIPTION
## Summary

With the new test institutions no longer being OAuth, we should no longer wait for a prepane continue button in the UI tests.

## Motivation

https://app.bitrise.io/build/03d84a2c-e631-4b59-ae60-88ae6a9bae1f?tab=log

## Testing

Trust CI ✅ 

## Changelog

N/a