### PR TITLE
Move FC SDK build failures to Customer UX bots slack channel

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -210,6 +210,11 @@ workflows:
         - webhook_url_on_error: $WEBHOOK_SLACK_CUX_BOTS
     - slack@3:
         is_always_run: true
+        inputs:
+        - webhook_url: $WEBHOOK_SLACK_CONNECTIONS_MOBILE
+        - webhook_url_on_error: $WEBHOOK_SLACK_CONNECTIONS_MOBILE
+    - slack@3:
+        is_always_run: true
         run_if: .IsBuildFailed
         inputs:
         - webhook_url: $SLACK_KGAIDIS_TESTING_WEBHOOK_URL


### PR DESCRIPTION
## Summary

This moves the Financial Connections build failures to the #connections-customer-ux-bots slack channel, as well as Kris's test channel. 

## Motivation

Better visibility on test failures. 

## Testing

N/a

## Changelog

N/a
