### PR TITLE
Fix bad height in playground view for embedded

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/EmbeddedPlaygroundViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EmbeddedPlaygroundViewController.swift
@@ -119,6 +119,7 @@ class EmbeddedPlaygroundViewController: UIViewController {
             scrollView.contentLayoutGuide.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
             scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
             scrollView.contentLayoutGuide.widthAnchor.constraint(equalTo: view.widthAnchor),
+            checkoutButton.heightAnchor.constraint(equalToConstant: 45)
         ])
         paymentOptionView.configure(with: embeddedPaymentElement.paymentOption, showMandate: !configuration.embeddedViewDisplaysMandateText)
     }
@@ -189,6 +190,14 @@ private class EmbeddedPaymentOptionView: UIView {
         return mandateLabel
     }()
 
+    private let verticalStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .vertical
+        stackView.spacing = 12
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
@@ -200,30 +209,24 @@ private class EmbeddedPaymentOptionView: UIView {
     }
 
     private func setupView() {
-        addSubview(titleLabel)
-        addSubview(imageView)
-        addSubview(label)
-        addSubview(mandateTextLabel)
+        let horizontalStackView = UIStackView(arrangedSubviews: [imageView, label])
+        horizontalStackView.axis = .horizontal
+        horizontalStackView.spacing = 12
+        horizontalStackView.alignment = .center
+
+        verticalStackView.addArrangedSubview(titleLabel)
+        verticalStackView.addArrangedSubview(horizontalStackView)
+        verticalStackView.addArrangedSubview(mandateTextLabel)
+
+        addSubview(verticalStackView)
 
         NSLayoutConstraint.activate([
-            titleLabel.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15),
-            titleLabel.topAnchor.constraint(equalTo: self.topAnchor),
-            titleLabel.widthAnchor.constraint(equalTo: self.widthAnchor),
-            titleLabel.heightAnchor.constraint(equalToConstant: 25),
-
-            imageView.leadingAnchor.constraint(equalTo: titleLabel.leadingAnchor),
-            imageView.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
+            verticalStackView.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 15),
+            verticalStackView.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -15),
+            verticalStackView.topAnchor.constraint(equalTo: self.topAnchor, constant: 15),
+            verticalStackView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: -15),
             imageView.widthAnchor.constraint(equalToConstant: 25),
-            imageView.heightAnchor.constraint(equalToConstant: 25),
-
-            label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 12),
-            label.trailingAnchor.constraint(equalTo: self.trailingAnchor),
-            label.topAnchor.constraint(equalTo: self.topAnchor),
-            label.centerYAnchor.constraint(equalTo: imageView.centerYAnchor),
-
-            mandateTextLabel.leadingAnchor.constraint(equalTo: imageView.leadingAnchor),
-            mandateTextLabel.trailingAnchor.constraint(equalTo: self.trailingAnchor, constant: -12),
-            mandateTextLabel.topAnchor.constraint(equalTo: imageView.bottomAnchor, constant: 12),
+            imageView.heightAnchor.constraint(equalToConstant: 25)
         ])
     }
 


### PR DESCRIPTION
## Summary
- Fixes bad height in playground view for payment option
- Sets a height for the checkout button (it looked too short IMO)

![Simulator Screenshot - Snapshot - 2024-10-14 at 14 27 18](https://github.com/user-attachments/assets/e00cdb32-f118-4387-8ab8-68d42966671e)
![Simulator Screenshot - Snapshot - 2024-10-14 at 14 27 20](https://github.com/user-attachments/assets/ecba6f19-8c73-4d81-bcd9-e1bc45648a4a)
![Simulator Screenshot - Snapshot - 2024-10-14 at 14 27 28](https://github.com/user-attachments/assets/d271404c-336c-4f32-ac47-dc472118a107)
![Simulator Screenshot - Snapshot - 2024-10-14 at 14 27 31](https://github.com/user-attachments/assets/9806e7b0-6b20-45d7-82c9-5dc7abf48fcd)
![Simulator Screenshot - Snapshot - 2024-10-14 at 14 27 33](https://github.com/user-attachments/assets/f00e08fa-0736-402d-85c1-590f35e1261f)


## Motivation
- Embedded

## Testing
- Manual

## Changelog
N/A
