### PR TITLE
Hide autogenerated *.tail files by default in PR diffs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.tail linguist-generated=true


### PR DESCRIPTION
.
![CleanShot 2024-10-14 at 18 07 50@2x](https://github.com/user-attachments/assets/c2dcb1b8-5fbb-4e7f-8c91-69ee79111531)


