### PR TITLE
[Connect] Use appearance to compute loading indicator color

### DIFF
--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
@@ -155,11 +155,14 @@ extension EmbeddedComponentManager {
             /// Creates a `EmbeddedComponentManager.Appearance.Colors` with default values
             public init() {}
 
+            /// The computed background color
             var resolvedBackground: UIColor {
+                // Defaults to white if none is set
                 background ?? .white
             }
 
-            var loadingColor: UIColor {
+            /// The computed loading indicator color
+            var loadingIndicatorColor: UIColor {
                 .init { traitCollection in
                     let background = resolvedBackground.resolvedColor(with: traitCollection)
 

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
@@ -6,6 +6,7 @@
 //
 
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
 import UIKit
 
 @_spi(PrivateBetaConnect)
@@ -153,6 +154,26 @@ extension EmbeddedComponentManager {
 
             /// Creates a `EmbeddedComponentManager.Appearance.Colors` with default values
             public init() {}
+
+            var resolvedBackground: UIColor {
+                background ?? .white
+            }
+
+            var loadingColor: UIColor {
+                .init { traitCollection in
+                    let background = resolvedBackground.resolvedColor(with: traitCollection)
+
+                    // Use the secondary text color if it was set
+                    if let secondaryText {
+                        return secondaryText
+                            .resolvedColor(with: traitCollection)
+                            .adjustedForContrast(with: background)
+                    }
+
+                    // Lighten or darken the background to get enough contrast
+                    return background.adjustedForContrast(with: background)
+                }
+            }
         }
 
         /// Describes the appearance of a button type used in embedded components

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebView.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebView.swift
@@ -194,6 +194,6 @@ private extension ConnectComponentWebView {
     func updateColors(appearance: Appearance) {
         backgroundColor = appearance.colors.background
         isOpaque = backgroundColor == nil
-        activityIndicator.tintColor = appearance.colors.loadingColor
+        activityIndicator.tintColor = appearance.colors.loadingIndicatorColor
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebView.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebView.swift
@@ -32,7 +32,6 @@ class ConnectComponentWebView: ConnectWebView {
     let activityIndicator: ActivityIndicator = {
         let activityIndicator = ActivityIndicator()
         activityIndicator.hidesWhenStopped = true
-        activityIndicator.tintColor = .gray
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
         return activityIndicator
     }()
@@ -195,5 +194,6 @@ private extension ConnectComponentWebView {
     func updateColors(appearance: Appearance) {
         backgroundColor = appearance.colors.background
         isOpaque = backgroundColor == nil
+        activityIndicator.tintColor = appearance.colors.loadingColor
     }
 }

--- a/StripeUICore/StripeUICore.xcodeproj/xcshareddata/xcschemes/StripeUICore.xcscheme
+++ b/StripeUICore/StripeUICore.xcodeproj/xcshareddata/xcschemes/StripeUICore.xcscheme
@@ -36,13 +36,6 @@
             ReferencedContainer = "container:StripeUICore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "FB_REFERENCE_IMAGE_DIR"
-            value = "$(SRCROOT)/../Tests/ReferenceImages"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -55,6 +48,15 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "FB_REFERENCE_IMAGE_DIR"
+            value = "$(SRCROOT)/../Tests/ReferenceImages"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/StripeUICore/StripeUICore.xcodeproj/xcshareddata/xcschemes/StripeUICore.xcscheme
+++ b/StripeUICore/StripeUICore.xcodeproj/xcshareddata/xcschemes/StripeUICore.xcscheme
@@ -36,6 +36,13 @@
             ReferencedContainer = "container:StripeUICore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "FB_REFERENCE_IMAGE_DIR"
+            value = "$(SRCROOT)/../Tests/ReferenceImages"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,15 +55,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <CommandLineArguments>
-      </CommandLineArguments>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "FB_REFERENCE_IMAGE_DIR"
-            value = "$(SRCROOT)/../Tests/ReferenceImages"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/StripeUICore/StripeUICore/Source/Categories/UIColor+StripeUICore.swift
+++ b/StripeUICore/StripeUICore/Source/Categories/UIColor+StripeUICore.swift
@@ -103,6 +103,36 @@ import UIKit
         return contrastRatioToWhite > contrastRatioToBlack ? .white : .black
     }
 
+    /// Adjust color for minimum contrast with a given background color
+    ///
+    /// # Reference
+    ///
+    /// [WCAG 2.1 Contrast Minimum](https://www.w3.org/WAI/WCAG21/Understanding/contrast-minimum.html#dfn-contrast-ratio)
+    /// - Parameters:
+    ///   - backgroundColor: The background color with which to get minimum contrast
+    ///   - minimumRatio: The minimum contrast ratio (defaults to WGAG minimum ratio of 4.5)
+    func adjustedForContrast(with backgroundColor: UIColor, minimumRatio: CGFloat = 4.5) -> UIColor {
+        var adjustedColor = self
+
+        let shouldLighten = backgroundColor.luminance < 0.5
+
+        // Adjust the brightness until we reach the minimum contrast ratio
+        // or as much contrast ratio as possible (black or white)
+        while adjustedColor.contrastRatio(to: backgroundColor) < minimumRatio
+                && ((shouldLighten && adjustedColor.brightness < 1)
+                    || (!shouldLighten && adjustedColor.brightness > 0)) {
+            if shouldLighten {
+                // If the background color dark, go lighter
+                adjustedColor = adjustedColor.lighten(by: 0.1)
+            } else {
+                // If the background color light, go darker
+                adjustedColor = adjustedColor.darken(by: 0.1)
+            }
+        }
+
+        return adjustedColor
+    }
+
     /// Returns this color in a "disabled" state by reducing the alpha by 60%
     var disabledColor: UIColor {
         let (_, _, _, alpha) = rgba
@@ -126,6 +156,12 @@ import UIKit
         getRed(&red, green: &green, blue: &blue, alpha: &alpha)
 
         return (red, green, blue, alpha)
+    }
+
+    var brightness: CGFloat {
+        var brightness: CGFloat = 0
+        getHue(nil, saturation: nil, brightness: &brightness, alpha: nil)
+        return brightness
     }
 
     var perceivedBrightness: CGFloat {

--- a/StripeUICore/StripeUICoreTests/Unit/Categories/UIColor+StripeUICoreTests.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Categories/UIColor+StripeUICoreTests.swift
@@ -219,4 +219,44 @@ final class UIColorStripeUICoreTests: XCTestCase {
         XCTAssertEqual(b, 0, accuracy: eps)
         XCTAssertEqual(a, 0.6, accuracy: eps)
     }
+
+    func testAdjustedForContrastDoesNotInfiniteLoop() {
+        let midGray = UIColor(white: 0.5, alpha: 1.0)
+
+        // The maximum contrast ratio to mid-gray is 5.28, ensure that this
+        // returns a color with the maximum contrast ratio that can be achieved
+        let color = midGray.adjustedForContrast(with: midGray, minimumRatio: 5.5)
+        XCTAssertLessThan(color.contrastRatio(to: midGray), 5.5)
+        XCTAssertColorsEqual(color, .white)
+    }
+
+    func testAdjustedForContrastMaximums() {
+        // Tests that
+        let whiteContrast = UIColor.white.adjustedForContrast(with: .white)
+        XCTAssertColorsNotEqual(whiteContrast, .white)
+
+        let blackContrast = UIColor.black.adjustedForContrast(with: .black)
+        XCTAssertColorsNotEqual(blackContrast, .black)
+    }
+}
+
+private extension UIColorStripeUICoreTests {
+    func XCTAssertColorsNotEqual(_ a: UIColor, _ b: UIColor, line: UInt = #line) {
+        XCTAssert(!UIColor.equivalent(a, b), "\"\(a.rgba)\" is equal to \"\(b.rgba)\"", line: line)
+    }
+    func XCTAssertColorsEqual(_ a: UIColor, _ b: UIColor, line: UInt = #line) {
+        XCTAssert(UIColor.equivalent(a, b), "\"\(a.rgba)\" is not equal to \"\(b.rgba)\"", line: line)
+    }
+}
+
+extension UIColor {
+    static func equivalent(_ lhs: UIColor, _ rhs: UIColor) -> Bool {
+        let left = lhs.rgba
+        let right = rhs.rgba
+
+        return left.red == right.red
+        && left.green == right.green
+        && left.blue == right.blue
+        && left.alpha == right.alpha
+    }
 }


### PR DESCRIPTION
## Summary
Updates the loading indicator color to match the web view more closely using:
- Secondary text color, if one has been set
- A contrasting color with the background

The color is not exactly the same as web, but it's pretty close.

## Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2812

## Testing

https://github.com/user-attachments/assets/e9782eb6-3e21-4b89-85f3-d55454f27cd3
