### PR TITLE
Pass `link_mode` to LAS creation

### DIFF
--- a/Stripe/StripeiOSTests/STPAPIClient+LinkAccountSessionTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClient+LinkAccountSessionTest.swift
@@ -13,7 +13,13 @@ final class STPAPIClient_LinkAccountSessionTest: XCTestCase {
     func testCreateLinkAccountSessionForDeferredIntent() {
         let e = expectation(description: "create link account session")
         let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
-        apiClient.createLinkAccountSessionForDeferredIntent(sessionId: "mobile_test_\(UUID().uuidString)", amount: nil, currency: nil, onBehalfOf: nil) { linkAccountSession, error in
+        apiClient.createLinkAccountSessionForDeferredIntent(
+            sessionId: "mobile_test_\(UUID().uuidString)",
+            amount: nil,
+            currency: nil,
+            onBehalfOf: nil,
+            linkMode: nil
+        ) { linkAccountSession, error in
             XCTAssertNil(error)
             XCTAssertNotNil(linkAccountSession)
             e.fulfill()

--- a/Stripe/StripeiOSTests/STPAPIClientStubbedTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClientStubbedTest.swift
@@ -93,7 +93,8 @@ class STPAPIClientStubbedTest: APIStubbedTestCase {
             clientSecret: "si_client_secret_123",
             paymentMethodType: .USBankAccount,
             customerName: "Test Tester",
-            customerEmailAddress: "test@example.com"
+            customerEmailAddress: "test@example.com",
+            linkMode: nil
         ) { intent, _ in
             guard let intent = intent else {
                 XCTFail("Intent was null")
@@ -163,7 +164,8 @@ class STPAPIClientStubbedTest: APIStubbedTestCase {
             clientSecret: "si_client_secret_123",
             paymentMethodType: .USBankAccount,
             customerName: "Test Tester",
-            customerEmailAddress: "test@example.com"
+            customerEmailAddress: "test@example.com",
+            linkMode: nil
         ) { intent, _ in
             guard let intent = intent else {
                 XCTFail("Intent was null")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -147,7 +147,7 @@ import UIKit
                                                    paymentMethodType: .link,
                                                    customerName: configuration.defaultBillingDetails.name,
                                                    customerEmailAddress: configuration.defaultBillingDetails.email,
-                                                   linkMode: .linkPaymentMethod,
+                                                   linkMode: nil,
                                                    additionalParameters: parameters) { [weak self] linkAccountSession, error in
                     self?.generateManifest(continuation: continuation, error: error, emailAddress: self?.configuration.defaultBillingDetails.email, linkAccountSession: linkAccountSession)
                 }
@@ -161,7 +161,7 @@ import UIKit
                                                    paymentMethodType: .link,
                                                    customerName: configuration.defaultBillingDetails.name,
                                                    customerEmailAddress: configuration.defaultBillingDetails.email,
-                                                   linkMode: .linkPaymentMethod,
+                                                   linkMode: nil,
                                                    additionalParameters: parameters) { [weak self] linkAccountSession, error in
                     self?.generateManifest(continuation: continuation, error: error, emailAddress: self?.configuration.defaultBillingDetails.email, linkAccountSession: linkAccountSession)
                 }
@@ -182,7 +182,7 @@ import UIKit
                         amount: amount,
                         currency: currency,
                         onBehalfOf: intentConfiguration.onBehalfOf,
-                        linkMode: .linkPaymentMethod,
+                        linkMode: nil,
                         additionalParameters: ["product": "instant_debits"]
                     ) { [weak self] linkAccountSession, error in
                         self?.generateManifest(continuation: continuation, error: error, emailAddress: self?.configuration.defaultBillingDetails.email, linkAccountSession: linkAccountSession)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -147,7 +147,8 @@ import UIKit
                                                    paymentMethodType: .link,
                                                    customerName: configuration.defaultBillingDetails.name,
                                                    customerEmailAddress: configuration.defaultBillingDetails.email,
-                                                   additionalParameteres: parameters) { [weak self] linkAccountSession, error in
+                                                   linkMode: .linkPaymentMethod,
+                                                   additionalParameters: parameters) { [weak self] linkAccountSession, error in
                     self?.generateManifest(continuation: continuation, error: error, emailAddress: self?.configuration.defaultBillingDetails.email, linkAccountSession: linkAccountSession)
                 }
             case .setupIntentClientSecret(let clientSecret):
@@ -160,7 +161,8 @@ import UIKit
                                                    paymentMethodType: .link,
                                                    customerName: configuration.defaultBillingDetails.name,
                                                    customerEmailAddress: configuration.defaultBillingDetails.email,
-                                                   additionalParameteres: parameters) { [weak self] linkAccountSession, error in
+                                                   linkMode: .linkPaymentMethod,
+                                                   additionalParameters: parameters) { [weak self] linkAccountSession, error in
                     self?.generateManifest(continuation: continuation, error: error, emailAddress: self?.configuration.defaultBillingDetails.email, linkAccountSession: linkAccountSession)
                 }
             case .deferredIntent(let intentConfiguration):
@@ -180,6 +182,7 @@ import UIKit
                         amount: amount,
                         currency: currency,
                         onBehalfOf: intentConfiguration.onBehalfOf,
+                        linkMode: .linkPaymentMethod,
                         additionalParameters: ["product": "instant_debits"]
                     ) { [weak self] linkAccountSession, error in
                         self?.generateManifest(continuation: continuation, error: error, emailAddress: self?.configuration.defaultBillingDetails.email, linkAccountSession: linkAccountSession)

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
@@ -24,7 +24,8 @@ public extension STPAPIClient {
         paymentMethodType: STPPaymentMethodType,
         customerName: String?,
         customerEmailAddress: String?,
-        additionalParameteres: [String: Any] = [:],
+        linkMode: LinkMode?,
+        additionalParameters: [String: Any] = [:],
         completion: @escaping STPLinkAccountSessionBlock
     ) {
         let endpoint: String = "setup_intents/\(setupIntentID)/link_account_sessions"
@@ -34,7 +35,8 @@ public extension STPAPIClient {
             paymentMethodType: paymentMethodType,
             customerName: customerName,
             customerEmailAddress: customerEmailAddress,
-            additionalParameteres: additionalParameteres,
+            linkMode: linkMode,
+            additionalParameters: additionalParameters,
             completion: completion
         )
     }
@@ -45,7 +47,8 @@ public extension STPAPIClient {
         paymentMethodType: STPPaymentMethodType,
         customerName: String?,
         customerEmailAddress: String?,
-        additionalParameteres: [String: Any] = [:],
+        linkMode: LinkMode?,
+        additionalParameters: [String: Any] = [:],
         completion: @escaping STPLinkAccountSessionBlock
     ) {
         let endpoint: String = "payment_intents/\(paymentIntentID)/link_account_sessions"
@@ -55,7 +58,8 @@ public extension STPAPIClient {
             paymentMethodType: paymentMethodType,
             customerName: customerName,
             customerEmailAddress: customerEmailAddress,
-            additionalParameteres: additionalParameteres,
+            linkMode: linkMode,
+            additionalParameters: additionalParameters,
             completion: completion
         )
     }
@@ -65,6 +69,7 @@ public extension STPAPIClient {
         amount: Int?,
         currency: String?,
         onBehalfOf: String?,
+        linkMode: LinkMode?,
         additionalParameters: [String: Any] = [:],
         completion: @escaping STPLinkAccountSessionBlock
     ) {
@@ -75,6 +80,7 @@ public extension STPAPIClient {
         parameters["amount"] = amount
         parameters["currency"] = currency
         parameters["on_behalf_of"] = onBehalfOf
+        parameters["link_mode"] = linkMode?.rawValue ?? "LINK_DISABLED"
         APIRequest<LinkAccountSession>.post(
             with: self,
             endpoint: endpoint,
@@ -91,10 +97,11 @@ public extension STPAPIClient {
         paymentMethodType: STPPaymentMethodType,
         customerName: String?,
         customerEmailAddress: String?,
-        additionalParameteres: [String: Any],
+        linkMode: LinkMode?,
+        additionalParameters: [String: Any],
         completion: @escaping STPLinkAccountSessionBlock
     ) {
-        var parameters = additionalParameteres
+        var parameters = additionalParameters
         parameters["client_secret"] = clientSecret
 
         if let paymentMethodType = STPPaymentMethod.string(from: paymentMethodType) {
@@ -106,6 +113,8 @@ public extension STPAPIClient {
         if let customerEmailAddress = customerEmailAddress {
             parameters["payment_method_data[billing_details][email]"] = customerEmailAddress
         }
+        
+        parameters["link_mode"] = linkMode?.rawValue ?? "LINK_DISABLED"
 
         APIRequest<LinkAccountSession>.post(
             with: self,

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+LinkAccountSession.swift
@@ -80,7 +80,12 @@ public extension STPAPIClient {
         parameters["amount"] = amount
         parameters["currency"] = currency
         parameters["on_behalf_of"] = onBehalfOf
-        parameters["link_mode"] = linkMode?.rawValue ?? "LINK_DISABLED"
+        
+        let hostedSurface = parameters["hosted_surface"]
+        if hostedSurface != nil {
+            parameters["link_mode"] = linkMode?.rawValue ?? "LINK_DISABLED"
+        }
+        
         APIRequest<LinkAccountSession>.post(
             with: self,
             endpoint: endpoint,
@@ -114,7 +119,10 @@ public extension STPAPIClient {
             parameters["payment_method_data[billing_details][email]"] = customerEmailAddress
         }
         
-        parameters["link_mode"] = linkMode?.rawValue ?? "LINK_DISABLED"
+        let hostedSurface = parameters["hosted_surface"]
+        if hostedSurface != nil {
+            parameters["link_mode"] = linkMode?.rawValue ?? "LINK_DISABLED"
+        }
 
         APIRequest<LinkAccountSession>.post(
             with: self,

--- a/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
@@ -271,7 +271,8 @@ public class STPBankAccountCollector: NSObject {
             paymentMethodType: params.paymentMethodParams.type,
             customerName: params.paymentMethodParams.billingDetails?.name,
             customerEmailAddress: params.paymentMethodParams.billingDetails?.email,
-            additionalParameteres: additionalParameters,
+            linkMode: elementsSessionContext?.linkMode,
+            additionalParameters: additionalParameters,
             completion: linkAccountSessionCallback
         )
     }
@@ -527,7 +528,8 @@ public class STPBankAccountCollector: NSObject {
             paymentMethodType: params.paymentMethodParams.type,
             customerName: params.paymentMethodParams.billingDetails?.name,
             customerEmailAddress: params.paymentMethodParams.billingDetails?.email,
-            additionalParameteres: additionalParameters,
+            linkMode: elementsSessionContext?.linkMode,
+            additionalParameters: additionalParameters,
             completion: linkAccountSessionCallback
         )
     }
@@ -591,6 +593,7 @@ public class STPBankAccountCollector: NSObject {
             amount: amount,
             currency: currency,
             onBehalfOf: onBehalfOf,
+            linkMode: elementsSessionContext?.linkMode,
             additionalParameters: additionalParameters
         ) { linkAccountSession, error in
             if let error {

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0000_post_create_setup_intent.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0000_post_create_setup_intent.tail
@@ -4,15 +4,15 @@ https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_setup_intent
 text/html
 Content-Type: text/html;charset=utf-8
 Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-Set-Cookie: rack.session=1oCyAYvdPwS688kusmHG0EBx%2FrV10iNG%2BIInjznSUAgp5KCznSOct2HblVAkagVTcwpK7cxbTQqXpTbnrH9qjI%2FzZUyLBUnMF%2BYxDcZiq4JVQ%2ByZ4aeG5w3htLC3vG2dI0M65%2F43rlVv1%2FpBp1kc7M1fVUTpahUhO7pHuVWZXI8YBWPsVDH4wOJ1pQRSmrKgPDkkKGoryzHVG9%2FdJ1fqFZZhssul5cvzVP8V11UwlW0%3D; path=/
+Set-Cookie: rack.session=kMbSP24EoX14A3Doj0J84duO0NhBAPSCvnf59dcbxW5oABW%2FG55pMUlPQe2fuao22NRY2eR8SPPLhFiHWDnNvJBTbWklobwQxMfau3kpZTKyQ48EK1PAb8%2BC%2FNpv6i6KXwCY9ggmv%2B83K2YkfDhMPph7qnd4On06cobCC83ueHQeKtpx1JER2Vw%2FFw30rPHOWkK9PVr7arILzssXmNh9eaYbIMWTpZNFt3FcCPas3Hc%3D; path=/
 Server: Google Frontend
-x-cloud-trace-context: 2e93b9ade9308b655c0cc127fc3bdfd1
+x-cloud-trace-context: 507e1e7a9ca39dea4c7aa56b43c8bd88;o=1
 Via: 1.1 google
 x-xss-protection: 1; mode=block
-Date: Wed, 31 Jul 2024 02:13:13 GMT
+Date: Wed, 16 Oct 2024 18:31:01 GMT
 x-robots-tag: noindex, nofollow
 Content-Length: 157
 x-content-type-options: nosniff
 x-frame-options: SAMEORIGIN
 
-{"intent":"seti_1PiS2PFY0qyl6XeWUpOO5bwC","secret":"seti_1PiS2PFY0qyl6XeWUpOO5bwC_secret_QZbELNf9k2u6CuPsjpWEA6vcTEesCD6","status":"requires_payment_method"}
+{"intent":"seti_1QAbztFY0qyl6XeWSwepK8jr","secret":"seti_1QAbztFY0qyl6XeWSwepK8jr_secret_R2hOSpH9lTW0FDhshSOCzPRo8rCBfkD","status":"requires_payment_method"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0001_get_v1_setup_intents_seti_1QAbztFY0qyl6XeWSwepK8jr.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0001_get_v1_setup_intents_seti_1QAbztFY0qyl6XeWSwepK8jr.tail
@@ -1,22 +1,23 @@
 GET
-https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1PiS2OFY0qyl6XeWfFtnj0kz\?client_secret=seti_1PiS2OFY0qyl6XeWfFtnj0kz_secret_QZbEHYhiYvbBxXlvE8DXyH6BhLS3PFf$
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1QAbztFY0qyl6XeWSwepK8jr\?client_secret=seti_1QAbztFY0qyl6XeWSwepK8jr_secret_R2hOSpH9lTW0FDhshSOCzPRo8rCBfkD$
 200
 application/json
-access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
 content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
 Server: nginx
 Cache-Control: no-cache, no-store
 reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+x-wc: A
 Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 cross-origin-opener-policy-report-only: same-origin; report-to="coop"
 Access-Control-Allow-Origin: *
 x-stripe-routing-context-priority-tier: api-testmode
 x-stripe-priority-routing-enabled: true
 report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
-request-id: req_W6eHcreEXjIEDm
+request-id: req_5nVBeSCSHTFwil
 Content-Length: 651
 Vary: Origin
-Date: Wed, 31 Jul 2024 02:13:12 GMT
+Date: Wed, 16 Oct 2024 18:31:02 GMT
 stripe-version: 2020-08-27
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
@@ -25,7 +26,7 @@ Content-Type: application/json
 x-content-type-options: nosniff
 
 {
-  "id" : "seti_1PiS2OFY0qyl6XeWfFtnj0kz",
+  "id" : "seti_1QAbztFY0qyl6XeWSwepK8jr",
   "description" : null,
   "next_action" : null,
   "status" : "requires_payment_method",
@@ -38,8 +39,8 @@ x-content-type-options: nosniff
   ],
   "object" : "setup_intent",
   "last_setup_error" : null,
-  "created" : 1722391992,
-  "client_secret" : "seti_1PiS2OFY0qyl6XeWfFtnj0kz_secret_QZbEHYhiYvbBxXlvE8DXyH6BhLS3PFf",
+  "created" : 1729103461,
+  "client_secret" : "seti_1QAbztFY0qyl6XeWSwepK8jr_secret_R2hOSpH9lTW0FDhshSOCzPRo8rCBfkD",
   "automatic_payment_methods" : null,
   "cancellation_reason" : null,
   "payment_method_options" : {

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0002_post_v1_setup_intents_seti_1QAbztFY0qyl6XeWSwepK8jr_link_account_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccount/0002_post_v1_setup_intents_seti_1QAbztFY0qyl6XeWSwepK8jr_link_account_sessions.tail
@@ -1,32 +1,33 @@
 POST
-https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1PiS2OFY0qyl6XeWfFtnj0kz\/link_account_sessions$
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1QAbztFY0qyl6XeWSwepK8jr\/link_account_sessions$
 200
 application/json
-access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
 content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent%2Flink_account_sessions; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
 Server: nginx
 Cache-Control: no-cache, no-store
-reporting-endpoints: coop="https://q.stripe.com/coop-report?s=mono-bapi-srv"
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=lpm-bapi-srv"
+x-wc: A
 Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 cross-origin-opener-policy-report-only: same-origin; report-to="coop"
 Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
-report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=mono-bapi-srv"}],"include_subdomains":true}
-request-id: req_pIAeWLuzJZTTiW
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=lpm-bapi-srv"}],"include_subdomains":true}
+request-id: req_xBrz9UIomatKW7
 x-stripe-routing-context-priority-tier: api-testmode
-Content-Length: 491
+Content-Length: 531
 Vary: Origin
-Date: Wed, 31 Jul 2024 02:13:13 GMT
-original-request: req_pIAeWLuzJZTTiW
+Date: Wed, 16 Oct 2024 18:31:02 GMT
+original-request: req_xBrz9UIomatKW7
 stripe-version: 2020-08-27
-idempotency-key: 03454f6a-476a-49ed-a9f2-768767caa32e
+idempotency-key: 1835b3a2-61bd-436c-8422-5f4282a6e1f3
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
 Content-Type: application/json
 x-content-type-options: nosniff
-X-Stripe-Mock-Request: client_secret=seti_1PiS2OFY0qyl6XeWfFtnj0kz_secret_QZbEHYhiYvbBxXlvE8DXyH6BhLS3PFf&hosted_surface=payment_element&payment_method_data%5Bbilling_details%5D%5Bemail%5D=test%40example\.com&payment_method_data%5Bbilling_details%5D%5Bname%5D=John%20Doe&payment_method_data%5Btype%5D=us_bank_account
+X-Stripe-Mock-Request: client_secret=seti_1QAbztFY0qyl6XeWSwepK8jr_secret_R2hOSpH9lTW0FDhshSOCzPRo8rCBfkD&hosted_surface=payment_element&link_mode=LINK_DISABLED&payment_method_data%5Bbilling_details%5D%5Bemail%5D=test%40example\.com&payment_method_data%5Bbilling_details%5D%5Bname%5D=John%20Doe&payment_method_data%5Btype%5D=us_bank_account
 
 {
   "object" : "link_account_session",
@@ -37,7 +38,7 @@ X-Stripe-Mock-Request: client_secret=seti_1PiS2OFY0qyl6XeWfFtnj0kz_secret_QZbEHY
       "savings"
     ]
   },
-  "id" : "fcsess_1PiS2PFY0qyl6XeWSR26ucad",
+  "id" : "fcsess_1QAbzuFY0qyl6XeWKijAh6q4",
   "livemode" : false,
   "prefetch" : [
 
@@ -49,9 +50,9 @@ X-Stripe-Mock-Request: client_secret=seti_1PiS2OFY0qyl6XeWfFtnj0kz_secret_QZbEHY
 
     ],
     "total_count" : 0,
-    "url" : "\/v1\/linked_accounts"
+    "url" : "\/v1\/linked_accounts?session=fcsess_1QAbzuFY0qyl6XeWKijAh6q4"
   },
-  "client_secret" : "fcsess_client_secret_wuSJALAfBwUapRl6dd6OCpsX",
+  "client_secret" : "fcsess_client_secret_tGXvM4Bg6tqC1FlOXPLOWGDA",
   "permissions" : [
     "payment_method"
   ]

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0000_post_create_setup_intent.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0000_post_create_setup_intent.tail
@@ -4,15 +4,15 @@ https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_setup_intent
 text/html
 Content-Type: text/html;charset=utf-8
 Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-Set-Cookie: rack.session=xKJR1qTrj5gRFnMZAFEvW6YNfkiiXJQTPDLj9YB4G5aGhlkYTtvRT5Od1upAhDia8F3gsPiW8JWPPMaF44ZJKj%2FbOn%2BJ1BfR5mMXCv3XQchyFsAPRBfUTihkuyaBSVVhInWGqN5CnEAbOaOgmfpitYwumxOaZq%2BQDwmqG8OWS9I%2FSejpXymJM2t0fJVn1M%2FIKUkVOeUIlqUx5DJOj%2BUsyx%2F1AS2%2F3K5lSYNoRLUassM%3D; path=/
+Set-Cookie: rack.session=BNPYA5kiUgXXtmiVbpAFGUNLInLkSzv7Is%2BqNj9z%2B52bfTi7LyvTiBf0J5T4PtR8jio73ScDsvAfRYDJCxWqeGNhcR5PqNxUHKgfvE%2FnfaVNvAW8PXkaF4R3bHoAPO8R%2FqkE0FU8mj3NvBpyNvLyb2mUdx%2FpFKuj7W1Kda2EkVskf7FxPS75dN5n6gWAs%2BOIAvX8cowom3qjj1c4bb1QUHyedmiLkwphAieMByWdIsY%3D; path=/
 Server: Google Frontend
-x-cloud-trace-context: 187a62250c3640830a2db90144953368
+x-cloud-trace-context: 4d82c81053bbcc136b4149fa3caad951;o=1
 Via: 1.1 google
 x-xss-protection: 1; mode=block
-Date: Wed, 31 Jul 2024 02:13:12 GMT
+Date: Wed, 16 Oct 2024 17:11:41 GMT
 x-robots-tag: noindex, nofollow
 Content-Length: 157
 x-content-type-options: nosniff
 x-frame-options: SAMEORIGIN
 
-{"intent":"seti_1PiS2OFY0qyl6XeWfFtnj0kz","secret":"seti_1PiS2OFY0qyl6XeWfFtnj0kz_secret_QZbEHYhiYvbBxXlvE8DXyH6BhLS3PFf","status":"requires_payment_method"}
+{"intent":"seti_1QAal7FY0qyl6XeWmpU3uZvt","secret":"seti_1QAal7FY0qyl6XeWmpU3uZvt_secret_R2g7P4UwG2D372G9nm6uUC2XVjlnZNI","status":"requires_payment_method"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0001_get_v1_setup_intents_seti_1QAal7FY0qyl6XeWmpU3uZvt.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0001_get_v1_setup_intents_seti_1QAal7FY0qyl6XeWmpU3uZvt.tail
@@ -1,22 +1,23 @@
 GET
-https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1PiS2PFY0qyl6XeWUpOO5bwC\?client_secret=seti_1PiS2PFY0qyl6XeWUpOO5bwC_secret_QZbELNf9k2u6CuPsjpWEA6vcTEesCD6$
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1QAal7FY0qyl6XeWmpU3uZvt\?client_secret=seti_1QAal7FY0qyl6XeWmpU3uZvt_secret_R2g7P4UwG2D372G9nm6uUC2XVjlnZNI$
 200
 application/json
-access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
 content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
 Server: nginx
 Cache-Control: no-cache, no-store
 reporting-endpoints: coop="https://q.stripe.com/coop-report?s=payins-bapi-srv"
+x-wc: A
 Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 cross-origin-opener-policy-report-only: same-origin; report-to="coop"
 Access-Control-Allow-Origin: *
 x-stripe-routing-context-priority-tier: api-testmode
 x-stripe-priority-routing-enabled: true
 report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=payins-bapi-srv"}],"include_subdomains":true}
-request-id: req_ogRqBaXPGWUcgi
+request-id: req_mBT1iOLCg8OeGy
 Content-Length: 651
 Vary: Origin
-Date: Wed, 31 Jul 2024 02:13:13 GMT
+Date: Wed, 16 Oct 2024 17:11:42 GMT
 stripe-version: 2020-08-27
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
@@ -25,7 +26,7 @@ Content-Type: application/json
 x-content-type-options: nosniff
 
 {
-  "id" : "seti_1PiS2PFY0qyl6XeWUpOO5bwC",
+  "id" : "seti_1QAal7FY0qyl6XeWmpU3uZvt",
   "description" : null,
   "next_action" : null,
   "status" : "requires_payment_method",
@@ -38,8 +39,8 @@ x-content-type-options: nosniff
   ],
   "object" : "setup_intent",
   "last_setup_error" : null,
-  "created" : 1722391993,
-  "client_secret" : "seti_1PiS2PFY0qyl6XeWUpOO5bwC_secret_QZbELNf9k2u6CuPsjpWEA6vcTEesCD6",
+  "created" : 1729098701,
+  "client_secret" : "seti_1QAal7FY0qyl6XeWmpU3uZvt_secret_R2g7P4UwG2D372G9nm6uUC2XVjlnZNI",
   "automatic_payment_methods" : null,
   "cancellation_reason" : null,
   "payment_method_options" : {

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0002_post_v1_setup_intents_seti_1QAal7FY0qyl6XeWmpU3uZvt_link_account_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CustomerSheetConfirmFlowTests/testUSBankAccountAttachDefaults/0002_post_v1_setup_intents_seti_1QAal7FY0qyl6XeWmpU3uZvt_link_account_sessions.tail
@@ -1,32 +1,33 @@
 POST
-https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1PiS2PFY0qyl6XeWUpOO5bwC\/link_account_sessions$
+https:\/\/api\.stripe\.com\/v1\/setup_intents\/seti_1QAal7FY0qyl6XeWmpU3uZvt\/link_account_sessions$
 200
 application/json
-access-control-allow-methods: GET,HEAD,PUT,PATCH,POST,DELETE
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
 content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fsetup_intents%2F%3Aintent%2Flink_account_sessions; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
 Server: nginx
 Cache-Control: no-cache, no-store
-reporting-endpoints: coop="https://q.stripe.com/coop-report?s=mono-bapi-srv"
+reporting-endpoints: coop="https://q.stripe.com/coop-report?s=lpm-bapi-srv"
+x-wc: A
 Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 cross-origin-opener-policy-report-only: same-origin; report-to="coop"
 Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
-report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=mono-bapi-srv"}],"include_subdomains":true}
-request-id: req_Wvr3MJhgDrcsPi
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report?s=lpm-bapi-srv"}],"include_subdomains":true}
+request-id: req_gDesS7f5C15PW8
 x-stripe-routing-context-priority-tier: api-testmode
-Content-Length: 491
+Content-Length: 531
 Vary: Origin
-Date: Wed, 31 Jul 2024 02:13:14 GMT
-original-request: req_Wvr3MJhgDrcsPi
+Date: Wed, 16 Oct 2024 17:11:42 GMT
+original-request: req_gDesS7f5C15PW8
 stripe-version: 2020-08-27
-idempotency-key: 9c124802-6d8f-4ec4-bb94-fc0074fcc302
+idempotency-key: 541871ac-a8ee-4edd-a8dd-87b1bb8e73df
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
 Content-Type: application/json
 x-content-type-options: nosniff
-X-Stripe-Mock-Request: client_secret=seti_1PiS2PFY0qyl6XeWUpOO5bwC_secret_QZbELNf9k2u6CuPsjpWEA6vcTEesCD6&hosted_surface=payment_element&payment_method_data%5Bbilling_details%5D%5Bemail%5D=test%40example\.com&payment_method_data%5Bbilling_details%5D%5Bname%5D=John%20Doe&payment_method_data%5Btype%5D=us_bank_account
+X-Stripe-Mock-Request: client_secret=seti_1QAal7FY0qyl6XeWmpU3uZvt_secret_R2g7P4UwG2D372G9nm6uUC2XVjlnZNI&hosted_surface=payment_element&link_mode=LINK_DISABLED&payment_method_data%5Bbilling_details%5D%5Bemail%5D=test%40example\.com&payment_method_data%5Bbilling_details%5D%5Bname%5D=John%20Doe&payment_method_data%5Btype%5D=us_bank_account
 
 {
   "object" : "link_account_session",
@@ -37,7 +38,7 @@ X-Stripe-Mock-Request: client_secret=seti_1PiS2PFY0qyl6XeWUpOO5bwC_secret_QZbELN
       "savings"
     ]
   },
-  "id" : "fcsess_1PiS2QFY0qyl6XeWwsQkrnbu",
+  "id" : "fcsess_1QAal8FY0qyl6XeWofUBOUTR",
   "livemode" : false,
   "prefetch" : [
 
@@ -49,9 +50,9 @@ X-Stripe-Mock-Request: client_secret=seti_1PiS2PFY0qyl6XeWUpOO5bwC_secret_QZbELN
 
     ],
     "total_count" : 0,
-    "url" : "\/v1\/linked_accounts"
+    "url" : "\/v1\/linked_accounts?session=fcsess_1QAal8FY0qyl6XeWofUBOUTR"
   },
-  "client_secret" : "fcsess_client_secret_T3HsqUzEbAdeBHQx1xtqrfl8",
+  "client_secret" : "fcsess_client_secret_NvhYqIW6cdPN0mjYyZxBpx8C",
   "permissions" : [
     "payment_method"
   ]


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request adds a `link_mode` field to the LAS creation request. If Link is not enabled, we send `LINK_DISABLED` just like Web does.

(cc @selinafeng-stripe)

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[BANKCON-15655](https://jira.corp.stripe.com/browse/BANKCON-15655)

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
