### PR TITLE
Fix product usage test for flow controller

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -103,9 +103,9 @@ public class PaymentSheet {
         )
     }
 
-    required init(mode: InitializationMode, configuration: Configuration) {
+    required init(mode: InitializationMode, configuration: Configuration, analyticsClient: STPAnalyticsClient = STPAnalyticsClient.sharedClient) {
         AnalyticsHelper.shared.generateSessionID()
-        STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: PaymentSheet.self)
+        analyticsClient.addClass(toProductUsageIfNecessary: PaymentSheet.self)
         self.mode = mode
         self.configuration = configuration
         self.analyticsHelper = PaymentSheetAnalyticsHelper(isCustom: false, configuration: configuration)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -255,9 +255,10 @@ extension PaymentSheet {
         static func create(
             mode: InitializationMode,
             configuration: PaymentSheet.Configuration,
+            analyticsClient: STPAnalyticsClient = STPAnalyticsClient.sharedClient,
             completion: @escaping (Result<PaymentSheet.FlowController, Error>) -> Void
         ) {
-            STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: PaymentSheet.FlowController.self)
+            analyticsClient.addClass(toProductUsageIfNecessary: PaymentSheet.FlowController.self)
             let analyticsHelper = PaymentSheetAnalyticsHelper(isCustom: true, configuration: configuration)
             AnalyticsHelper.shared.generateSessionID()
             PaymentSheetLoader.load(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
@@ -28,9 +28,11 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
         // Clear product usage prior to testing PaymentSheet.FlowController
         STPAnalyticsClient.sharedClient.productUsage = Set()
         XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.isEmpty)
-
-        PaymentSheet.FlowController.create(paymentIntentClientSecret: "", configuration: PaymentSheet.Configuration()) { _ in
+        let expectation = expectation(description: "create")
+        PaymentSheet.FlowController.create(paymentIntentClientSecret: "pi_123_secret_456", configuration: PaymentSheet.Configuration()) { _ in
+            expectation.fulfill()
         }
+        wait(for: [expectation], timeout: 2.0)
         XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.contains("PaymentSheet.FlowController"))
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
@@ -15,26 +15,27 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
     let analyticsClient = STPTestingAnalyticsClient()
 
     func testPaymentSheetAddsUsage() {
-        // Clear product usage prior to testing PaymentSheet
-        STPAnalyticsClient.sharedClient.productUsage = Set()
-        XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.isEmpty)
+        let analyticsClient = STPAnalyticsClient()
+        XCTAssertTrue(analyticsClient.productUsage.isEmpty)
 
         _ = PaymentSheet(
-            paymentIntentClientSecret: "",
-            configuration: PaymentSheet.Configuration()
+            mode: .paymentIntentClientSecret("pi_123_secret_456"),
+            configuration: PaymentSheet.Configuration(),
+            analyticsClient: analyticsClient
         )
-        XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.contains("PaymentSheet"))
+        XCTAssertTrue(analyticsClient.productUsage.contains("PaymentSheet"))
 
         // Clear product usage prior to testing PaymentSheet.FlowController
-        STPAnalyticsClient.sharedClient.productUsage = Set()
-        XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.isEmpty)
-        let expectation = expectation(description: "create")
-        PaymentSheet.FlowController.create(paymentIntentClientSecret: "pi_123_secret_456", configuration: PaymentSheet.Configuration()) { _ in
-            expectation.fulfill()
+        analyticsClient.productUsage = Set()
+        XCTAssertTrue(analyticsClient.productUsage.isEmpty)
+
+        PaymentSheet.FlowController.create(
+            mode: .paymentIntentClientSecret("pi_123_secret_456"),
+            configuration: PaymentSheet.Configuration(),
+            analyticsClient: analyticsClient) { _ in
         }
-        wait(for: [expectation], timeout: 2.0)
-        XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.contains("PaymentSheet.FlowController"))
-    }
+        XCTAssertTrue(analyticsClient.productUsage.contains("PaymentSheet.FlowController"))
+   }
 
     func testPaymentSheetAnalyticPayload() throws {
         // Ensure there is a sessionID

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
@@ -15,21 +15,22 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
     let analyticsClient = STPTestingAnalyticsClient()
 
     func testPaymentSheetAddsUsage() {
+        // Clear product usage prior to testing PaymentSheet
+        STPAnalyticsClient.sharedClient.productUsage = Set()
+        XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.isEmpty)
+
         _ = PaymentSheet(
             paymentIntentClientSecret: "",
             configuration: PaymentSheet.Configuration()
         )
         XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.contains("PaymentSheet"))
 
-        _ = PaymentSheet.FlowController(
-            configuration: PaymentSheet.Configuration(),
-            loadResult: .init(
-                intent: .paymentIntent(STPFixtures.paymentIntent()),
-                elementsSession: .makeBackupElementsSession(with: STPFixtures.paymentIntent()),
-                savedPaymentMethods: [],
-                paymentMethodTypes: [.stripe(.card)]
-            ), analyticsHelper: .init(isCustom: true, configuration: PaymentSheet.Configuration())
-        )
+        // Clear product usage prior to testing PaymentSheet.FlowController
+        STPAnalyticsClient.sharedClient.productUsage = Set()
+        XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.isEmpty)
+
+        PaymentSheet.FlowController.create(paymentIntentClientSecret: "", configuration: PaymentSheet.Configuration()) { _ in
+        }
         XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.contains("PaymentSheet.FlowController"))
     }
 


### PR DESCRIPTION
## Summary
Running this test in isolation was failing due to the movement of where we are setting the static variable.  To remedy this, make the instance injectable on the non-public interface, and utilize the @testable import to call it

## Motivation
Test is failing in isolation.

## Testing
locally

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
