### PR TITLE
Fix a potential issue with PaymentSheetLoader

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecProvider.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/FormSpec/FormSpecProvider.swift
@@ -24,9 +24,7 @@ class FormSpecProvider {
     fileprivate var formSpecs: [String: FormSpec] = [:]
 
     /// Loading from disk should take place on this serial queue.
-    private lazy var formSpecsUpdateQueue: DispatchQueue = {
-        DispatchQueue(label: "com.stripe.Form.FormSpecProvider", qos: .userInitiated)
-    }()
+    private let formSpecsUpdateQueue = DispatchQueue(label: "com.stripe.Form.FormSpecProvider", qos: .userInitiated)
 
     var isLoaded: Bool {
         return !formSpecs.isEmpty

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -177,14 +177,12 @@ final class PaymentSheetLoader {
     /// Loads miscellaneous singletons
     static func loadMiscellaneousSingletons() async {
         await withCheckedContinuation { continuation in
-            Task {
-                AddressSpecProvider.shared.loadAddressSpecs {
-                    // Load form specs
-                    FormSpecProvider.shared.load { _ in
-                        // Load BSB data
-                        BSBNumberProvider.shared.loadBSBData {
-                            continuation.resume()
-                        }
+            AddressSpecProvider.shared.loadAddressSpecs {
+                // Load form specs
+                FormSpecProvider.shared.load { _ in
+                    // Load BSB data
+                    BSBNumberProvider.shared.loadBSBData {
+                        continuation.resume()
                     }
                 }
             }

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSpecProvider.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSpecProvider.swift
@@ -22,9 +22,7 @@ let addressDataFilename = "localized_address_data"
     public var countries: [String] {
         return addressSpecs.map { $0.key }
     }
-    private lazy var addressSpecsUpdateQueue: DispatchQueue = {
-        DispatchQueue(label: addressDataFilename, qos: .userInitiated)
-    }()
+    private let addressSpecsUpdateQueue: DispatchQueue = DispatchQueue(label: addressDataFilename, qos: .userInitiated)
 
     /// Loads address specs with a completion block
     public func loadAddressSpecs(completion: (() -> Void)? = nil) {

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/BSB/BSBNumberProvider.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/BSB/BSBNumberProvider.swift
@@ -17,9 +17,7 @@ import Foundation
 
     @_spi(STP) public static var shared: BSBNumberProvider = BSBNumberProvider()
     var bsbNumberToNameMapping: [String: String] = [:]
-    private lazy var bsbNumberUpdateQueue: DispatchQueue = {
-        DispatchQueue(label: "com.stripe.BSB.BSBNumberProvider", qos: .userInitiated)
-    }()
+    private let bsbNumberUpdateQueue = DispatchQueue(label: "com.stripe.BSB.BSBNumberProvider", qos: .userInitiated)
 
     public func loadBSBData(completion: (() -> Void)? = nil) {
         bsbNumberUpdateQueue.async {


### PR DESCRIPTION
## Summary
It isn't safe to initialize our singleton's dispatchQueues as a `lazy var`. If this is called twice simultaneously, the two initializations of the `dispatchQueue` will run at the same time and could cause a crash.

Also remove where we split off a new `Task { }` in `loadMiscellaneousSingletons` — it doesn't seem necessary.

## Motivation
Speculative fix for a reported crash in PaymentSheetLoader.

## Testing
Existing tests, ran `loadMiscellaneousSingletons` both concurrently and serially thousands of times.

## Changelog
None