### PR TITLE
[BANKCON-15710] Support requested billing address fields in Instant Debits bank tab

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -164,8 +164,6 @@ extension PaymentSheet {
                 recommendedStripePaymentMethodTypes.map { PaymentMethodType.stripe($0) }
                 // External Payment Methods
                 + elementsSession.externalPaymentMethods.map { PaymentMethodType.external($0) }
-            
-            let hasIneligibleConfiguration = configuration.billingDetailsCollectionConfiguration.email == .never && configuration.defaultBillingDetails.email?.isEmpty != false
 
             // We should manually add Instant Debits as a payment method when:
             // - Link is an available payment method.
@@ -178,7 +176,7 @@ extension PaymentSheet {
                 !elementsSession.orderedPaymentMethodTypes.contains(.USBankAccount) &&
                 !intent.isDeferredIntent &&
                 elementsSession.linkFundingSources?.contains(.bankAccount) == true &&
-                !hasIneligibleConfiguration
+                configuration.isEligibleForBankTab
             }
 
             // We should manually add Link Card Brand as a payment method when:
@@ -192,7 +190,7 @@ extension PaymentSheet {
                 !elementsSession.orderedPaymentMethodTypes.contains(.USBankAccount) &&
                 !intent.isDeferredIntent &&
                 elementsSession.linkSettings?.linkMode == .linkCardBrand &&
-                !hasIneligibleConfiguration
+                configuration.isEligibleForBankTab
             }
 
             if eligibleForInstantDebits {
@@ -455,5 +453,12 @@ extension STPPaymentMethodParams {
         default:
             return label
         }
+    }
+}
+
+extension PaymentElementConfiguration {
+    var isEligibleForBankTab: Bool {
+        billingDetailsCollectionConfiguration.email != .never ||
+        defaultBillingDetails.email?.isEmpty == false
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -459,6 +459,6 @@ extension STPPaymentMethodParams {
 extension PaymentElementConfiguration {
     var isEligibleForBankTab: Bool {
         billingDetailsCollectionConfiguration.email != .never ||
-        defaultBillingDetails.email?.isEmpty == false
+        (defaultBillingDetails.email?.isEmpty == false && billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -644,19 +644,30 @@ extension PaymentSheetFormFactory {
     }
 
     func makeInstantDebits() -> PaymentMethodElement {
+        let titleElement: StaticElement? = if case .paymentSheet = configuration {
+            makeSectionTitleLabelWith(text: Self.PayByBankDescriptionText)
+        } else {
+            nil
+        }
+
+        let nameElement = configuration.billingDetailsCollectionConfiguration.name == .always ? makeName() : nil
+        let phoneElement = configuration.billingDetailsCollectionConfiguration.phone == .always ? makePhone() : nil
+        let addressElement = configuration.billingDetailsCollectionConfiguration.address == .full
+            ? makeBillingAddressSection(collectionMode: .all(), countries: nil)
+            : nil
+
+        // An email is required, so only hide the email field iff:
+        // The configuration specifies never collecting email, and a default (non-empty) email is provided.
+        let shouldHideEmailField = configuration.billingDetailsCollectionConfiguration.email == .never && configuration.defaultBillingDetails.email?.isEmpty == false
+        let emailElement = shouldHideEmailField ? nil : makeEmail()
+
         return InstantDebitsPaymentMethodElement(
             configuration: configuration,
-            titleElement: {
-                switch configuration {
-                case .customerSheet:
-                    return nil // customer sheet is not supported
-                case .paymentSheet:
-                    return makeSectionTitleLabelWith(
-                        text: Self.PayByBankDescriptionText
-                    )
-                }
-            }(),
-            emailElement: makeEmail(),
+            titleElement: titleElement,
+            nameElement: nameElement,
+            emailElement: emailElement,
+            phoneElement: phoneElement,
+            addressElement: addressElement,
             theme: theme
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -643,22 +643,24 @@ extension PaymentSheetFormFactory {
         return StaticElement(view: label)
     }
 
-    func makeInstantDebits() -> PaymentMethodElement {
+    func makeInstantDebits(countries: [String]? = nil) -> PaymentMethodElement {
         let titleElement: StaticElement? = if case .paymentSheet = configuration {
             makeSectionTitleLabelWith(text: Self.PayByBankDescriptionText)
         } else {
             nil
         }
 
-        let nameElement = configuration.billingDetailsCollectionConfiguration.name == .always ? makeName() : nil
-        let phoneElement = configuration.billingDetailsCollectionConfiguration.phone == .always ? makePhone() : nil
-        let addressElement = configuration.billingDetailsCollectionConfiguration.address == .full
-            ? makeBillingAddressSection(collectionMode: .all(), countries: nil)
+        let billingConfiguration = configuration.billingDetailsCollectionConfiguration
+        let nameElement = billingConfiguration.name == .always ? makeName() : nil
+        let phoneElement = billingConfiguration.phone == .always ? makePhone() : nil
+        let addressElement = billingConfiguration.address == .full
+        ? makeBillingAddressSection(collectionMode: .all(), countries: countries)
             : nil
 
         // An email is required, so only hide the email field iff:
         // The configuration specifies never collecting email, and a default (non-empty) email is provided.
-        let shouldHideEmailField = configuration.billingDetailsCollectionConfiguration.email == .never && configuration.defaultBillingDetails.email?.isEmpty == false
+        let shouldHideEmailField = billingConfiguration.email == .never &&
+            configuration.defaultBillingDetails.email?.isEmpty == false
         let emailElement = shouldHideEmailField ? nil : makeEmail()
 
         return InstantDebitsPaymentMethodElement(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -19,11 +19,15 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     private let configuration: PaymentSheetFormFactoryConfig
     private let formElement: FormElement
 
+    private let nameElement: TextFieldElement?
+    private let emailElement: TextFieldElement?
+    private let phoneElement: PhoneNumberElement?
+    private let addressElement: AddressSectionElement?
+
     private var linkedBankElements: [Element] {
         return [linkedBankInfoSectionElement]
     }
     private let linkedBankInfoSectionElement: SectionElement
-    private let emailElement: TextFieldElement
     private let linkedBankInfoView: BankAccountInfoView
     private var linkedBank: InstantDebitsLinkedBank?
     private let theme: ElementsAppearance
@@ -64,17 +68,83 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
         }
     }
 
-    var enableCTA: Bool {
-        return STPEmailAddressValidator.stringIsValidEmailAddress(email)
+    var name: String? {
+        nameElement?.text ?? defaultName
     }
-    var email: String {
-        return emailElement.text
+
+    var defaultName: String? {
+        configuration.defaultBillingDetails.name
+    }
+
+    var email: String? {
+        emailElement?.text ?? defaultEmail
+    }
+
+    var defaultEmail: String? {
+        configuration.defaultBillingDetails.email
+    }
+
+    var phone: String? {
+        phoneElement?.phoneNumber?.string(as: .e164) ?? defaultPhone
+    }
+
+    var defaultPhone: String? {
+        configuration.defaultBillingDetails.phone
+    }
+
+    var address: PaymentSheet.Address {
+        PaymentSheet.Address(
+            city: addressElement?.city?.text,
+            country: addressElement?.selectedCountryCode,
+            line1: addressElement?.line1?.text,
+            line2: addressElement?.line2?.text,
+            postalCode: addressElement?.postalCode?.text,
+            state: addressElement?.state?.rawData
+        )
+    }
+
+    var enableCTA: Bool {
+        let nameValid: Bool = {
+            // If the name field isn't shown, we treat the name as valid.
+            guard nameElement != nil else { return true }
+            // Otherwise, check if the name field is not empty.
+            return name?.isEmpty == false
+        }()
+
+        let emailValid: Bool = {
+            if emailElement != nil {
+                // If the email field is shown, make sure we have a valid email.
+                return STPEmailAddressValidator.stringIsValidEmailAddress(email)
+            } else {
+                // Otherwise, make sure the default email provided is not empty.
+                return defaultEmail?.isEmpty == false
+            }
+        }()
+
+        let phoneValid: Bool = {
+            // If the phone field isn't shown, we treat the phone number as valid.
+            guard phoneElement != nil else { return true }
+            // Otherwise, check if the phone field is not empty.
+            return phone?.isEmpty == false
+        }()
+
+        let addressValid: Bool = {
+            // If the address section isn't shown, we treat the address as valid.
+            guard addressElement != nil else { return true }
+            // If the address section is shown, the address is valid if all fields (except line2) are not empty.
+            return address.isValid
+        }()
+
+        return nameValid && emailValid && phoneValid && addressValid
     }
 
     init(
         configuration: PaymentSheetFormFactoryConfig,
         titleElement: StaticElement?,
-        emailElement: PaymentMethodElementWrapper<TextFieldElement>,
+        nameElement: PaymentMethodElementWrapper<TextFieldElement>?,
+        emailElement: PaymentMethodElementWrapper<TextFieldElement>?,
+        phoneElement: PaymentMethodElementWrapper<PhoneNumberElement>?,
+        addressElement: PaymentMethodElementWrapper<AddressSectionElement>?,
         theme: ElementsAppearance = .default
     ) {
         self.configuration = configuration
@@ -84,14 +154,22 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
             elements: [StaticElement(view: linkedBankInfoView)],
             theme: theme
         )
-        self.emailElement = emailElement.element
+
+        self.nameElement = nameElement?.element
+        self.emailElement = emailElement?.element
+        self.phoneElement = phoneElement?.element
+        self.addressElement = addressElement?.element
+
         self.linkedBank = nil
         self.linkedBankInfoSectionElement.view.isHidden = true
         self.theme = theme
 
         let allElements: [Element?] = [
             titleElement,
+            nameElement,
             emailElement,
+            phoneElement,
+            addressElement,
             linkedBankInfoSectionElement,
         ]
         let autoSectioningElements = allElements.compactMap { $0 }
@@ -202,5 +280,15 @@ extension InstantDebitsPaymentMethodElement: ElementDelegate {
 
     func continueToNextField(element: Element) {
         self.delegate?.continueToNextField(element: element)
+    }
+}
+
+private extension PaymentSheet.Address {
+    var isValid: Bool {
+        city?.isEmpty == false &&
+        country?.isEmpty == false &&
+        line1?.isEmpty == false &&
+        postalCode?.isEmpty == false &&
+        state?.isEmpty == false
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -73,7 +73,8 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     }
 
     var defaultName: String? {
-        configuration.defaultBillingDetails.name
+        guard configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod else { return nil }
+        return configuration.defaultBillingDetails.name
     }
 
     var email: String? {
@@ -81,7 +82,8 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     }
 
     var defaultEmail: String? {
-        configuration.defaultBillingDetails.email
+        guard configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod else { return nil }
+        return configuration.defaultBillingDetails.email
     }
 
     var phone: String? {
@@ -89,7 +91,8 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     }
 
     var defaultPhone: String? {
-        configuration.defaultBillingDetails.phone
+        guard configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod else { return nil }
+        return configuration.defaultBillingDetails.phone
     }
 
     var address: PaymentSheet.Address {
@@ -104,7 +107,8 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     }
 
     var defaultAddress: PaymentSheet.Address? {
-        configuration.defaultBillingDetails.address
+        guard configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod else { return nil }
+        return configuration.defaultBillingDetails.address
     }
 
     var enableCTA: Bool {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -19,10 +19,10 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     private let configuration: PaymentSheetFormFactoryConfig
     private let formElement: FormElement
 
-    private let nameElement: TextFieldElement?
-    private let emailElement: TextFieldElement?
-    private let phoneElement: PhoneNumberElement?
-    private let addressElement: AddressSectionElement?
+    let nameElement: TextFieldElement?
+    let emailElement: TextFieldElement?
+    let phoneElement: PhoneNumberElement?
+    let addressElement: AddressSectionElement?
 
     private var linkedBankElements: [Element] {
         return [linkedBankInfoSectionElement]
@@ -101,6 +101,10 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
             postalCode: addressElement?.postalCode?.text,
             state: addressElement?.state?.rawData
         )
+    }
+
+    var defaultAddress: PaymentSheet.Address? {
+        configuration.defaultBillingDetails.address
     }
 
     var enableCTA: Bool {
@@ -284,6 +288,7 @@ extension InstantDebitsPaymentMethodElement: ElementDelegate {
 }
 
 private extension PaymentSheet.Address {
+    /// An address is valid if all fields except `line2` are not empty.
     var isValid: Bool {
         city?.isEmpty == false &&
         country?.isEmpty == false &&

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -1699,7 +1699,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertNil(instantDebitsSection.addressElement)
     }
 
-    func testMakeInstantDebits_defaultValues() {
+    func testMakeInstantDebits_defaultValues_attachDefaultsOff() {
         let defaultAddress = PaymentSheet.Address(
             city: "San Francisco",
             country: "CA",
@@ -1714,6 +1714,40 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         configuration.defaultBillingDetails.email = "foo@bar.com"
         configuration.defaultBillingDetails.phone = "+12345678900"
         configuration.defaultBillingDetails.address = defaultAddress
+        configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = false
+
+        let factory = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            configuration: .paymentSheet(configuration),
+            paymentMethod: .stripe(.card)
+        )
+        guard let instantDebitsSection = factory.makeInstantDebits(countries: ["US"]) as? InstantDebitsPaymentMethodElement else {
+            return XCTFail("Expected InstantDebitsPaymentMethodElement from factory")
+        }
+
+        XCTAssertNil(instantDebitsSection.defaultName)
+        XCTAssertNil(instantDebitsSection.defaultEmail)
+        XCTAssertNil(instantDebitsSection.defaultPhone)
+        XCTAssertNil(instantDebitsSection.defaultAddress)
+    }
+
+    func testMakeInstantDebits_defaultValues_attachDefaultsOn() {
+        let defaultAddress = PaymentSheet.Address(
+            city: "San Francisco",
+            country: "CA",
+            line1: "510 Townsend St.",
+            line2: "Line 2",
+            postalCode: "94102",
+            state: "CA"
+        )
+
+        var configuration = PaymentSheet.Configuration()
+        configuration.defaultBillingDetails.name = "Foo Bar"
+        configuration.defaultBillingDetails.email = "foo@bar.com"
+        configuration.defaultBillingDetails.phone = "+12345678900"
+        configuration.defaultBillingDetails.address = defaultAddress
+        configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = true
 
         let factory = PaymentSheetFormFactory(
             intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
@@ -1751,6 +1785,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         configuration.billingDetailsCollectionConfiguration.email = .always
         configuration.billingDetailsCollectionConfiguration.phone = .always
         configuration.billingDetailsCollectionConfiguration.address = .full
+        configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = true
 
         configuration.defaultBillingDetails.name = "Foo Bar"
         configuration.defaultBillingDetails.email = "foo@bar.com"
@@ -1876,6 +1911,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         noDefaultsConfiguration.billingDetailsCollectionConfiguration.email = .never
         noDefaultsConfiguration.billingDetailsCollectionConfiguration.phone = .never
         noDefaultsConfiguration.billingDetailsCollectionConfiguration.address = .never
+        noDefaultsConfiguration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = true
 
         let noDefaultsFacotry = PaymentSheetFormFactory(
             intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
@@ -1894,6 +1930,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         defaultEmailConfiguration.billingDetailsCollectionConfiguration.email = .never
         defaultEmailConfiguration.billingDetailsCollectionConfiguration.phone = .never
         defaultEmailConfiguration.billingDetailsCollectionConfiguration.address = .never
+        defaultEmailConfiguration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = true
         defaultEmailConfiguration.defaultBillingDetails.email = "foo@bar.com"
 
         let defaultEmailFacotry = PaymentSheetFormFactory(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -1598,6 +1598,317 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertTrue(cardForm_si.getMandateElement() != nil)
     }
 
+    // MARK: Instant Debits
+
+    func testMakeInstantDebits_configuration_automatic() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .automatic
+        configuration.billingDetailsCollectionConfiguration.email = .automatic
+        configuration.billingDetailsCollectionConfiguration.phone = .automatic
+        configuration.billingDetailsCollectionConfiguration.address = .automatic
+
+        let factory = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            configuration: .paymentSheet(configuration),
+            paymentMethod: .stripe(.card)
+        )
+        guard let instantDebitsSection = factory.makeInstantDebits(countries: ["US"]) as? InstantDebitsPaymentMethodElement else {
+            return XCTFail("Expected InstantDebitsPaymentMethodElement from factory")
+        }
+
+        // All form elements should be nil except for email.
+        XCTAssertNil(instantDebitsSection.nameElement)
+        XCTAssertNotNil(instantDebitsSection.emailElement)
+        XCTAssertNil(instantDebitsSection.phoneElement)
+        XCTAssertNil(instantDebitsSection.addressElement)
+    }
+
+    func testMakeInstantDebits_configuration_alwaysOrFull() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .always
+        configuration.billingDetailsCollectionConfiguration.email = .always
+        configuration.billingDetailsCollectionConfiguration.phone = .always
+        configuration.billingDetailsCollectionConfiguration.address = .full
+
+        let factory = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            configuration: .paymentSheet(configuration),
+            paymentMethod: .stripe(.card)
+        )
+        guard let instantDebitsSection = factory.makeInstantDebits(countries: ["US"]) as? InstantDebitsPaymentMethodElement else {
+            return XCTFail("Expected InstantDebitsPaymentMethodElement from factory")
+        }
+
+        // All form elements should not be nil.
+        XCTAssertNotNil(instantDebitsSection.nameElement)
+        XCTAssertNotNil(instantDebitsSection.emailElement)
+        XCTAssertNotNil(instantDebitsSection.phoneElement)
+        XCTAssertNotNil(instantDebitsSection.addressElement)
+    }
+
+    func testMakeInstantDebits_configuration_never() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .never
+        configuration.billingDetailsCollectionConfiguration.email = .never
+        configuration.billingDetailsCollectionConfiguration.phone = .never
+        configuration.billingDetailsCollectionConfiguration.address = .never
+
+        let factory = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            configuration: .paymentSheet(configuration),
+            paymentMethod: .stripe(.card)
+        )
+        guard let instantDebitsSection = factory.makeInstantDebits(countries: ["US"]) as? InstantDebitsPaymentMethodElement else {
+            return XCTFail("Expected InstantDebitsPaymentMethodElement from factory")
+        }
+
+        // All form elements should be nil except for email.
+        // This is because a default email was not provided.
+        XCTAssertNil(instantDebitsSection.nameElement)
+        XCTAssertNotNil(instantDebitsSection.emailElement)
+        XCTAssertNil(instantDebitsSection.phoneElement)
+        XCTAssertNil(instantDebitsSection.addressElement)
+    }
+
+    func testMakeInstantDebits_configuration_never_withDefaultEmail() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .never
+        configuration.billingDetailsCollectionConfiguration.email = .never
+        configuration.billingDetailsCollectionConfiguration.phone = .never
+        configuration.billingDetailsCollectionConfiguration.address = .never
+
+        configuration.defaultBillingDetails.email = "foo@bar.com"
+
+        let factory = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            configuration: .paymentSheet(configuration),
+            paymentMethod: .stripe(.card)
+        )
+        guard let instantDebitsSection = factory.makeInstantDebits(countries: ["US"]) as? InstantDebitsPaymentMethodElement else {
+            return XCTFail("Expected InstantDebitsPaymentMethodElement from factory")
+        }
+
+        // All form elements should be nil.
+        XCTAssertNil(instantDebitsSection.nameElement)
+        XCTAssertNil(instantDebitsSection.emailElement)
+        XCTAssertNil(instantDebitsSection.phoneElement)
+        XCTAssertNil(instantDebitsSection.addressElement)
+    }
+
+    func testMakeInstantDebits_defaultValues() {
+        let defaultAddress = PaymentSheet.Address(
+            city: "San Francisco",
+            country: "CA",
+            line1: "510 Townsend St.",
+            line2: "Line 2",
+            postalCode: "94102",
+            state: "CA"
+        )
+
+        var configuration = PaymentSheet.Configuration()
+        configuration.defaultBillingDetails.name = "Foo Bar"
+        configuration.defaultBillingDetails.email = "foo@bar.com"
+        configuration.defaultBillingDetails.phone = "+12345678900"
+        configuration.defaultBillingDetails.address = defaultAddress
+
+        let factory = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            configuration: .paymentSheet(configuration),
+            paymentMethod: .stripe(.card)
+        )
+        guard let instantDebitsSection = factory.makeInstantDebits(countries: ["US"]) as? InstantDebitsPaymentMethodElement else {
+            return XCTFail("Expected InstantDebitsPaymentMethodElement from factory")
+        }
+
+        XCTAssertEqual(instantDebitsSection.name, "Foo Bar")
+        XCTAssertEqual(instantDebitsSection.defaultName, "Foo Bar")
+        XCTAssertEqual(instantDebitsSection.email, "foo@bar.com")
+        XCTAssertEqual(instantDebitsSection.defaultEmail, "foo@bar.com")
+        XCTAssertEqual(instantDebitsSection.phone, "+12345678900")
+        XCTAssertEqual(instantDebitsSection.defaultPhone, "+12345678900")
+        // Unlike the other fields, the `address` will not fallback to the default.
+        XCTAssertEqual(instantDebitsSection.address, PaymentSheet.Address())
+        XCTAssertEqual(instantDebitsSection.defaultAddress, defaultAddress)
+    }
+
+    func testMakeInstantDebits_customValues() {
+        let defaultAddress = PaymentSheet.Address(
+            city: "San Francisco",
+            country: "US",
+            line1: "510 Townsend St.",
+            line2: "Line 2",
+            postalCode: "94102",
+            state: "CA"
+        )
+
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .always
+        configuration.billingDetailsCollectionConfiguration.email = .always
+        configuration.billingDetailsCollectionConfiguration.phone = .always
+        configuration.billingDetailsCollectionConfiguration.address = .full
+
+        configuration.defaultBillingDetails.name = "Foo Bar"
+        configuration.defaultBillingDetails.email = "foo@bar.com"
+        configuration.defaultBillingDetails.phone = "+12345678900"
+        configuration.defaultBillingDetails.address = defaultAddress
+
+        let factory = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            configuration: .paymentSheet(configuration),
+            paymentMethod: .stripe(.card)
+        )
+        guard let instantDebitsSection = factory.makeInstantDebits(countries: ["US"]) as? InstantDebitsPaymentMethodElement else {
+            return XCTFail("Expected InstantDebitsPaymentMethodElement from factory")
+        }
+
+        instantDebitsSection.nameElement?.setText("Bar Foo")
+        instantDebitsSection.emailElement?.setText("bar@foo.com")
+        instantDebitsSection.phoneElement?.textFieldElement.setText("+10987654321")
+
+        instantDebitsSection.addressElement?.city?.setText(defaultAddress.city!)
+        instantDebitsSection.addressElement?.country.select(index: 0) // "US"
+        instantDebitsSection.addressElement?.line1?.setText(defaultAddress.line1!)
+        instantDebitsSection.addressElement?.line2?.setText(defaultAddress.line2!)
+        instantDebitsSection.addressElement?.postalCode?.setText(defaultAddress.postalCode!)
+        instantDebitsSection.addressElement?.state?.setRawData(defaultAddress.state!)
+
+        XCTAssertEqual(instantDebitsSection.name, "Bar Foo")
+        XCTAssertEqual(instantDebitsSection.defaultName, "Foo Bar")
+        XCTAssertEqual(instantDebitsSection.email, "bar@foo.com")
+        XCTAssertEqual(instantDebitsSection.defaultEmail, "foo@bar.com")
+        XCTAssertEqual(instantDebitsSection.phone, "+110987654321")
+        XCTAssertEqual(instantDebitsSection.defaultPhone, "+12345678900")
+        XCTAssertEqual(instantDebitsSection.address, defaultAddress)
+        XCTAssertEqual(instantDebitsSection.defaultAddress, defaultAddress)
+    }
+
+    func testMakeInstantDebits_enableCta_automatic() {
+        var configuration = PaymentSheet.Configuration()
+        // Only email is required here.
+        configuration.billingDetailsCollectionConfiguration.name = .automatic
+        configuration.billingDetailsCollectionConfiguration.email = .automatic
+        configuration.billingDetailsCollectionConfiguration.phone = .automatic
+        configuration.billingDetailsCollectionConfiguration.address = .automatic
+
+        let factory = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            configuration: .paymentSheet(configuration),
+            paymentMethod: .stripe(.card)
+        )
+        guard let instantDebitsSection = factory.makeInstantDebits(countries: ["US"]) as? InstantDebitsPaymentMethodElement else {
+            return XCTFail("Expected InstantDebitsPaymentMethodElement from factory")
+        }
+
+        // No email
+        XCTAssertFalse(instantDebitsSection.enableCTA)
+
+        // Set an invalid email
+        instantDebitsSection.emailElement?.setText("gibberish")
+        XCTAssertFalse(instantDebitsSection.enableCTA)
+
+        // Set a valid email
+        instantDebitsSection.emailElement?.setText("foo@bar.com")
+        XCTAssertTrue(instantDebitsSection.enableCTA)
+    }
+
+    func testMakeInstantDebits_enableCta_alwaysOrFull() {
+        let defaultAddress = PaymentSheet.Address(
+            city: "San Francisco",
+            country: "US",
+            line1: "510 Townsend St.",
+            line2: "Line 2",
+            postalCode: "94102",
+            state: "CA"
+        )
+
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .always
+        configuration.billingDetailsCollectionConfiguration.email = .always
+        configuration.billingDetailsCollectionConfiguration.phone = .always
+        configuration.billingDetailsCollectionConfiguration.address = .full
+
+        let factory = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            configuration: .paymentSheet(configuration),
+            paymentMethod: .stripe(.card)
+        )
+        guard let instantDebitsSection = factory.makeInstantDebits(countries: ["US"]) as? InstantDebitsPaymentMethodElement else {
+            return XCTFail("Expected InstantDebitsPaymentMethodElement from factory")
+        }
+
+        // No fields set
+        XCTAssertFalse(instantDebitsSection.enableCTA)
+
+        // Set a name
+        instantDebitsSection.nameElement?.setText("Foo Bar")
+        XCTAssertFalse(instantDebitsSection.enableCTA)
+
+        // Set a valid email
+        instantDebitsSection.emailElement?.setText("foo@bar.com")
+        XCTAssertFalse(instantDebitsSection.enableCTA)
+
+        // Set a phone number
+        instantDebitsSection.phoneElement?.textFieldElement.setText("+12345678900")
+        XCTAssertFalse(instantDebitsSection.enableCTA)
+
+        // Set a valid address
+        instantDebitsSection.addressElement?.city?.setText(defaultAddress.city!)
+        instantDebitsSection.addressElement?.country.select(index: 0) // "US"
+        instantDebitsSection.addressElement?.line1?.setText(defaultAddress.line1!)
+        instantDebitsSection.addressElement?.postalCode?.setText(defaultAddress.postalCode!)
+        instantDebitsSection.addressElement?.state?.setRawData(defaultAddress.state!)
+
+        // CTA will now be enabled
+        XCTAssertTrue(instantDebitsSection.enableCTA)
+    }
+
+    func testMakeInstantDebits_enableCta_never() {
+        var noDefaultsConfiguration = PaymentSheet.Configuration()
+        noDefaultsConfiguration.billingDetailsCollectionConfiguration.name = .never
+        noDefaultsConfiguration.billingDetailsCollectionConfiguration.email = .never
+        noDefaultsConfiguration.billingDetailsCollectionConfiguration.phone = .never
+        noDefaultsConfiguration.billingDetailsCollectionConfiguration.address = .never
+
+        let noDefaultsFacotry = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            configuration: .paymentSheet(noDefaultsConfiguration),
+            paymentMethod: .stripe(.card)
+        )
+        guard let noDefaultsInstantDebitsSection = noDefaultsFacotry.makeInstantDebits(countries: ["US"]) as? InstantDebitsPaymentMethodElement else {
+            return XCTFail("Expected InstantDebitsPaymentMethodElement from factory")
+        }
+
+        XCTAssertFalse(noDefaultsInstantDebitsSection.enableCTA)
+
+        var defaultEmailConfiguration = PaymentSheet.Configuration()
+        defaultEmailConfiguration.billingDetailsCollectionConfiguration.name = .never
+        defaultEmailConfiguration.billingDetailsCollectionConfiguration.email = .never
+        defaultEmailConfiguration.billingDetailsCollectionConfiguration.phone = .never
+        defaultEmailConfiguration.billingDetailsCollectionConfiguration.address = .never
+        defaultEmailConfiguration.defaultBillingDetails.email = "foo@bar.com"
+
+        let defaultEmailFacotry = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            configuration: .paymentSheet(defaultEmailConfiguration),
+            paymentMethod: .stripe(.card)
+        )
+        guard let defaultEmailInstantDebitsSection = defaultEmailFacotry.makeInstantDebits(countries: ["US"]) as? InstantDebitsPaymentMethodElement else {
+            return XCTFail("Expected InstantDebitsPaymentMethodElement from factory")
+        }
+
+        XCTAssertTrue(defaultEmailInstantDebitsSection.enableCTA)
+    }
+
     // MARK: - Previous Customer Input tests
 
     // Covers:

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
@@ -424,6 +424,25 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         XCTAssertEqual(types, [.stripe(.card), .linkCardBrand])
     }
 
+    func testPaymentMethodTypesLinkCardBrand_noDefaults() {
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.email = .never
+        configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = false
+        configuration.defaultBillingDetails.email = nil
+        let types = PaymentSheet.PaymentMethodType.filteredPaymentMethodTypes(
+            from: intent,
+            elementsSession: ._testValue(
+                intent: intent,
+                linkMode: .linkCardBrand,
+                linkFundingSources: [.card, .bankAccount]
+            ),
+            configuration: configuration
+        )
+        // This configuration should not show the bank tab.
+        XCTAssertEqual(types, [.stripe(.card)])
+    }
+
     // MARK: Other
 
     func testUnknownPMTypeIsUnsupported() {


### PR DESCRIPTION
## Summary

This adds the `name`, `phoneNumber`, and `address` fields / sections in the MPE Bank tab, if they are included as part of the merchant configuration. The email field will always be shown, even when the configuration specifies to never collect an email, if no email is provided in the default billing details.

## Motivation

https://jira.corp.stripe.com/browse/BANKCON-15710

## Testing

Plenty of unit tests, and some manual testing:

| Configuration | Screenshot |
|--------|--------|
| Automatic | <img width=50% src="https://github.com/user-attachments/assets/991a31bc-8b73-47b7-a613-60471eb45d75"> |
| Always or Full | <img width=50% src="https://github.com/user-attachments/assets/f3c5a258-d957-42f4-b73c-1e1bc422a188"> |
| Never, no defaults | <img width=50% src="https://github.com/user-attachments/assets/991a31bc-8b73-47b7-a613-60471eb45d75"> |
| Never, default email | <img width=50% src="https://github.com/user-attachments/assets/76483838-a1bb-45f6-bd77-fdcc7040fa59"> | 

## Changelog

N/a
