### PR TITLE
Fix BottomSheetPresentationAnimator issue in RN on iOS 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## X.X.X
+### PaymentSheet
+* [Fixed] Fixed an animation glitch when dismissing PaymentSheet in React Native.
+
+
 ## 23.32.0 2024-10-21
 ### PaymentSheet
 * [Added] Added `PaymentSheet.Configuration.paymentMethodLayout`. Configure the layout of payment methods in the sheet using `paymentMethodLayout` to display them either horizontally, vertically, or let Stripe optimize the layout automatically.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
@@ -69,19 +69,18 @@ class BottomSheetPresentationAnimator: NSObject {
 
     private func animateDismissal(transitionContext: UIViewControllerContextTransitioning) {
         guard
-            let toVC = transitionContext.viewController(forKey: .to),
             let fromVC = transitionContext.viewController(forKey: .from)
         else { return }
 
         // Calls viewWillAppear and viewWillDisappear
-        toVC.beginAppearanceTransition(true, animated: true)
+        fromVC.beginAppearanceTransition(false, animated: true)
 
         Self.animate({
             fromVC.view.frame.origin.y = transitionContext.containerView.frame.height
         }) { didComplete in
             fromVC.view.removeFromSuperview()
             // Calls viewDidAppear and viewDidDisappear
-            toVC.endAppearanceTransition()
+            fromVC.endAppearanceTransition()
             transitionContext.completeTransition(didComplete)
         }
     }


### PR DESCRIPTION
## Summary
Call beginAppearanceTransition on the fromVC, not the toVC. The toVC isn't moving, and calling this on it seems to cause the fromVC's frame to be reset during the transition-out animation.

## Motivation
https://github.com/stripe/stripe-react-native/issues/1723

## Testing
Tested in RN example app and PaymentSheet Example

## Changelog
Will add