### PR TITLE
Fix FlowController vertical update edge case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## X.X.X
 ### PaymentSheet
 * [Fixed] Fixed an animation glitch when dismissing PaymentSheet in React Native.
+* [Fixed] Fixed an issue with FlowController in vertical layout where the payment method could incorrectly be preserved across a call to `update` when it's no longer valid.
 
 
 ## 23.32.0 2024-10-21

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
@@ -42,7 +42,6 @@ class VerticalPaymentMethodListViewController: UIViewController {
         amount: Int?,
         delegate: VerticalPaymentMethodListViewControllerDelegate
     ) {
-        self.currentSelection = initialSelection
         self.delegate = delegate
         self.appearance = appearance
         self.delegate = delegate


### PR DESCRIPTION
## Summary
Fix FlowController vertical mode preserving payment method during update if it has no form and is no longer in the list after the update. 

## Testing
See test

## Changelog
See changelog