### PR TITLE
Fix loading strings when "Show non-localized strings" is enabled

### DIFF
--- a/StripeCore/StripeCore/Source/Localization/STPLocalizationUtils.swift
+++ b/StripeCore/StripeCore/Source/Localization/STPLocalizationUtils.swift
@@ -37,7 +37,7 @@ import Foundation
         return false
     }
 
-    static let UnknownString = "STPStringNotFound"
+    static let UnknownString = "STPSTRINGNOTFOUND"
 
     public class func localizedStripeString(
         forKey key: String,


### PR DESCRIPTION
## Summary
If the current locale isn't supported by the Stripe framework, we allow users to override our localizations by checking for the string in their main bundle. This involves a hack of checking for a default value of "STPStringNotFound". If we find that default value, we assume the user hasn't implemented this string, so we return the best available string in the Stripe framework.

But if the "Show non-localized strings" debug setting is enabled, all non-localized strings will be in uppercase, so the string returned will just be "STPSTRINGNOTFOUND", and we won't correctly fall back to the Stripe framework's string, so the user will see "STPSTRINGNOTFOUND".

To work around this, we'll always use the uppercase STPSTRINGNOTFOUND string.