### PR TITLE
[BANKCON-15981] Success pane: "Almost there" copy for microdeposits

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -825,6 +825,10 @@ extension NativeFlowController: ManualEntryViewControllerDelegate {
         dataManager.accountNumberLast4 = accountNumberLast4
 
         if dataManager.manifest.manualEntryUsesMicrodeposits {
+            dataManager.customSuccessPaneCaption = STPLocalizedString(
+                "Almost there",
+                "The title of the success screen that appears when a user manually entered their bank account information."
+            )
             dataManager.customSuccessPaneSubCaption = String(
                 format: STPLocalizedString(
                     "You can expect micro-deposits to account ••••%@ in 1-2 days and an email with further instructions.",


### PR DESCRIPTION
## Summary

Updates success pane title copy to reflect delay in time for microdeposits verification.

## Motivation

[BANKCON-15981](https://jira.corp.stripe.com/browse/BANKCON-15981)

## Testing

<img width = 50% src="https://github.com/user-attachments/assets/cf70d95a-abbb-4384-90cc-e4687a479686">

## Changelog

N/a
