### PR TITLE
Fix issue where multiple accounts are selected for single select

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -185,7 +185,13 @@ final class AccountPickerViewController: UIViewController {
                     // AND `authSession.skipAccountSelection` is true
                     let skipAccountSelection = (accountsPayload.skipAccountSelection ?? self.dataSource.authSession.skipAccountSelection ?? false)
                     if skipAccountSelection {
-                        self.dataSource.updateSelectedAccounts(accounts)
+                        if self.dataSource.manifest.singleAccount {
+                            if let firstEnabledAccount = accounts.first(where: \.allowSelectionNonOptional) {
+                                self.dataSource.updateSelectedAccounts([firstEnabledAccount])
+                            }
+                        } else {
+                            self.dataSource.updateSelectedAccounts(accounts)
+                        }
                         self.didSelectLinkAccounts(isSkipAccountSelection: true)
                     } else if
                         self.dataSource.manifest.singleAccount,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -185,12 +185,20 @@ final class AccountPickerViewController: UIViewController {
                     // AND `authSession.skipAccountSelection` is true
                     let skipAccountSelection = (accountsPayload.skipAccountSelection ?? self.dataSource.authSession.skipAccountSelection ?? false)
                     if skipAccountSelection {
+                        let selectableAccounts = accounts.filter(\.allowSelectionNonOptional)
                         if self.dataSource.manifest.singleAccount {
-                            if let firstEnabledAccount = accounts.first(where: \.allowSelectionNonOptional) {
+                            if let firstEnabledAccount = selectableAccounts.first {
                                 self.dataSource.updateSelectedAccounts([firstEnabledAccount])
+                            } else {
+                                self.showNoEligibleAccountsErrorView(
+                                    numberOfIneligibleAccounts: accounts.count,
+                                    error: FinancialConnectionsSheetError.unknown(
+                                        debugDescription: "No eligible accounts found"
+                                    )
+                                )
                             }
                         } else {
-                            self.dataSource.updateSelectedAccounts(accounts)
+                            self.dataSource.updateSelectedAccounts(selectableAccounts)
                         }
                         self.didSelectLinkAccounts(isSkipAccountSelection: true)
                     } else if
@@ -234,26 +242,10 @@ final class AccountPickerViewController: UIViewController {
                         // show "AccountLoadErrorView."
                         numberOfIneligibleAccounts > 0
                     {
-                        let errorView = AccountPickerNoAccountEligibleErrorView(
-                            institution: self.dataSource.institution,
-                            bussinessName: self.businessName,
-                            institutionSkipAccountSelection: self.dataSource.authSession.institutionSkipAccountSelection
-                                ?? false,
+                        self.showNoEligibleAccountsErrorView(
                             numberOfIneligibleAccounts: numberOfIneligibleAccounts,
-                            paymentMethodType: self.dataSource.manifest.paymentMethodType ?? .usBankAccount,
-                            theme: self.dataSource.manifest.theme,
-                            didSelectAnotherBank: self.didSelectAnotherBank
+                            error: error
                         )
-                        // the user will never enter this instance of `AccountPickerViewController`
-                        // again...they can only choose manual entry or go through "ResetFlow"
-                        self.showErrorView(errorView)
-                        self.dataSource
-                            .analyticsClient
-                            .logExpectedError(
-                                error,
-                                errorName: "AccountNoneEligibleForPaymentMethodError",
-                                pane: .accountPicker
-                            )
                     } else {
                         // if we didn't get that specific error back, we don't know what's wrong. could the be
                         // aggregator, could be Stripe.
@@ -262,6 +254,29 @@ final class AccountPickerViewController: UIViewController {
                 }
                 retreivingAccountsLoadingView.removeFromSuperview()
             }
+    }
+
+    private func showNoEligibleAccountsErrorView(numberOfIneligibleAccounts: Int, error: Error) {
+        let errorView = AccountPickerNoAccountEligibleErrorView(
+            institution: self.dataSource.institution,
+            bussinessName: self.businessName,
+            institutionSkipAccountSelection: self.dataSource.authSession.institutionSkipAccountSelection
+                ?? false,
+            numberOfIneligibleAccounts: numberOfIneligibleAccounts,
+            paymentMethodType: self.dataSource.manifest.paymentMethodType ?? .usBankAccount,
+            theme: self.dataSource.manifest.theme,
+            didSelectAnotherBank: self.didSelectAnotherBank
+        )
+        // the user will never enter this instance of `AccountPickerViewController`
+        // again...they can only choose manual entry or go through "ResetFlow"
+        self.showErrorView(errorView)
+        self.dataSource
+            .analyticsClient
+            .logExpectedError(
+                error,
+                errorName: "AccountNoneEligibleForPaymentMethodError",
+                pane: .accountPicker
+            )
     }
 
     private func displayAccounts(


### PR DESCRIPTION
## Summary

This fixes an issue in the account picker pane where multiple account could be selected when both `skipAccountSelection` and `manifest.singleAccount` is `true`. Instead, we select the first selectable account. 

## Motivation

Fixes bug reported by Doordash.

## Testing

Manual testing via latest Testflight build on this branch. @carlosmuvi-stripe confirmed this fixes the issue!

## Changelog

N/a