### PR TITLE
Remove unused `eligibleForNetworking` property

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPaymentAccountResource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPaymentAccountResource.swift
@@ -20,6 +20,5 @@ struct FinancialConnectionsPaymentAccountResource: Decodable {
     let id: String
     let nextPane: FinancialConnectionsSessionManifest.NextPane?
     let microdepositVerificationMethod: MicrodepositVerificationMethod?
-    let eligibleForNetworking: Bool?
     let networkingSuccessful: Bool?
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request removes the unused `eligibleForNetworking` property, which is being removed on [Web and backend](https://git.corp.stripe.com/stripe-internal/pay-server/pull/929759) as well.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
