### PR TITLE
[BANKCON-16077] Pass email and phone number to web FC auth flow URL for prefill

### DIFF
--- a/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
@@ -15,13 +15,24 @@ import Foundation
     }
 
     /// These fields will be used to prefill the Financial Connections Link Login pane.
+    /// An unformatted phone number + country code will be passed to the web flow,
+    /// and a formatted phone number will be passed to the native flow.
     @_spi(STP) public struct PrefillDetails {
         @_spi(STP) public let email: String?
-        @_spi(STP) public let phoneNumber: String?
+        @_spi(STP) public let formattedPhoneNumber: String?
+        @_spi(STP) public let unformattedPhoneNumber: String?
+        @_spi(STP) public let countryCode: String?
 
-        @_spi(STP) public init(email: String?, phoneNumber: String?) {
+        @_spi(STP) public init(
+            email: String?,
+            formattedPhoneNumber: String?,
+            unformattedPhoneNumber: String?,
+            countryCode: String?
+        ) {
             self.email = email
-            self.phoneNumber = phoneNumber
+            self.formattedPhoneNumber = formattedPhoneNumber
+            self.unformattedPhoneNumber = unformattedPhoneNumber
+            self.countryCode = countryCode
         }
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -122,7 +122,7 @@ final class LinkLoginViewController: UIViewController {
         if let emailAddress, !emailAddress.isEmpty {
             formView.prefillEmailAddress(emailAddress)
 
-            let phoneNumber = dataSource.manifest.accountholderPhoneNumber ?? dataSource.elementsSessionContext?.prefillDetails?.phoneNumber
+            let phoneNumber = dataSource.manifest.accountholderPhoneNumber ?? dataSource.elementsSessionContext?.prefillDetails?.formattedPhoneNumber
             formView.prefillPhoneNumber(phoneNumber)
         } else {
             // Slightly delay opening the keyboard to avoid a janky animation.

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -156,7 +156,8 @@ extension FinancialConnectionsWebFlowViewController {
         let additionalQueryParameters = Self.updateAdditionalParameters(
             startingAdditionalParameters: additionalQueryParameters,
             isInstantDebits: manifest.isProductInstantDebits,
-            linkMode: elementsSessionContext?.linkMode
+            linkMode: elementsSessionContext?.linkMode,
+            prefillDetails: elementsSessionContext?.prefillDetails
         )
         authSessionManager?
             .start(additionalQueryParameters: additionalQueryParameters)
@@ -426,13 +427,25 @@ extension FinancialConnectionsWebFlowViewController {
     static func updateAdditionalParameters(
         startingAdditionalParameters: String?,
         isInstantDebits: Bool,
-        linkMode: LinkMode?
+        linkMode: LinkMode?,
+        prefillDetails: ElementsSessionContext.PrefillDetails?
     ) -> String {
         var additionalQueryParameters = startingAdditionalParameters ?? ""
         if isInstantDebits {
             additionalQueryParameters = additionalQueryParameters + "&return_payment_method=true"
             if let linkMode {
                 additionalQueryParameters = additionalQueryParameters + "&link_mode=\(linkMode.rawValue)"
+            }
+        }
+        if let prefillDetails {
+            if let email = prefillDetails.email {
+                additionalQueryParameters = additionalQueryParameters + "&email=\(email)"
+            }
+            if let phoneNumber = prefillDetails.unformattedPhoneNumber {
+                additionalQueryParameters = additionalQueryParameters + "&linkMobilePhone=\(phoneNumber)"
+            }
+            if let countryCode = prefillDetails.countryCode {
+                additionalQueryParameters = additionalQueryParameters + "&linkMobilePhoneCountry=\(countryCode)"
             }
         }
         return additionalQueryParameters

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsWebFlowTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsWebFlowTests.swift
@@ -11,65 +11,136 @@ import XCTest
 
 final class FinancialConnectionsWebFlowTests: XCTestCase {
     func test_noAdditionalParameters_empty() {
-        let additionalParamers = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
             startingAdditionalParameters: nil,
             isInstantDebits: false,
-            linkMode: nil
+            linkMode: nil,
+            prefillDetails: nil
         )
-        XCTAssertEqual(additionalParamers, "")
+        XCTAssertEqual(additionalParameters, "")
     }
 
     func test_someAdditionalParameters_notInstantDebits_noLinkMode() {
-        let additionalParamers = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
             startingAdditionalParameters: "",
             isInstantDebits: false,
-            linkMode: nil
+            linkMode: nil,
+            prefillDetails: nil
         )
-        XCTAssertEqual(additionalParamers, "")
+        XCTAssertEqual(additionalParameters, "")
     }
 
     func test_someAdditionalParameters_instantDebits_noLinkMode() {
-        let additionalParamers = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
             startingAdditionalParameters: "&testmode=true",
             isInstantDebits: true,
-            linkMode: nil
+            linkMode: nil,
+            prefillDetails: nil
         )
-        XCTAssertEqual(additionalParamers, "&testmode=true&return_payment_method=true")
+        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true")
     }
 
     func test_additionalParameters_instantDebits_noLinkMode() {
-        let additionalParamers = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
             startingAdditionalParameters: "",
             isInstantDebits: true,
-            linkMode: nil
+            linkMode: nil,
+            prefillDetails: nil
         )
-        XCTAssertEqual(additionalParamers, "&return_payment_method=true")
+        XCTAssertEqual(additionalParameters, "&return_payment_method=true")
     }
 
     func test_additionalParameters_notInstantDebits_someLinkMode() {
-        let additionalParamers = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
             startingAdditionalParameters: "",
             isInstantDebits: false,
-            linkMode: .passthrough
+            linkMode: .passthrough,
+            prefillDetails: nil
         )
-        XCTAssertEqual(additionalParamers, "")
+        XCTAssertEqual(additionalParameters, "")
     }
 
     func test_someAdditionalParameters_instantDebits_passthroughLinkMode() {
-        let additionalParamers = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
             startingAdditionalParameters: "&testmode=true",
             isInstantDebits: true,
-            linkMode: .passthrough
+            linkMode: .passthrough,
+            prefillDetails: nil
         )
-        XCTAssertEqual(additionalParamers, "&testmode=true&return_payment_method=true&link_mode=PASSTHROUGH")
+        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&link_mode=PASSTHROUGH")
     }
 
     func test_additionalParameters_instantDebits_linkCardBrandLinkMode() {
-        let additionalParamers = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
             startingAdditionalParameters: "",
             isInstantDebits: true,
-            linkMode: .linkCardBrand
+            linkMode: .linkCardBrand,
+            prefillDetails: nil
         )
-        XCTAssertEqual(additionalParamers, "&return_payment_method=true&link_mode=LINK_CARD_BRAND")
+        XCTAssertEqual(additionalParameters, "&return_payment_method=true&link_mode=LINK_CARD_BRAND")
+    }
+
+    func test_additionalParameters_emptyPrefillDetails() {
+        let prefillDetails = ElementsSessionContext.PrefillDetails(
+            email: nil,
+            formattedPhoneNumber: nil,
+            unformattedPhoneNumber: nil,
+            countryCode: nil
+        )
+        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+            startingAdditionalParameters: nil,
+            isInstantDebits: false,
+            linkMode: nil,
+            prefillDetails: prefillDetails
+        )
+        XCTAssertEqual(additionalParameters, "")
+    }
+
+    func test_additionalParameters_prefilledEmail() {
+        let prefillDetails = ElementsSessionContext.PrefillDetails(
+            email: "test@example.com",
+            formattedPhoneNumber: nil,
+            unformattedPhoneNumber: nil,
+            countryCode: nil
+        )
+        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+            startingAdditionalParameters: nil,
+            isInstantDebits: false,
+            linkMode: nil,
+            prefillDetails: prefillDetails
+        )
+        XCTAssertEqual(additionalParameters, "&email=test@example.com")
+    }
+
+    func test_additionalParameters_fullPrefillDetails() {
+        let prefillDetails = ElementsSessionContext.PrefillDetails(
+            email: "test@example.com",
+            formattedPhoneNumber: "+1 (123) 456-7890",
+            unformattedPhoneNumber: "1234567890",
+            countryCode: "US"
+        )
+        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+            startingAdditionalParameters: nil,
+            isInstantDebits: false,
+            linkMode: nil,
+            prefillDetails: prefillDetails
+        )
+        XCTAssertEqual(additionalParameters, "&email=test@example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
+    }
+
+    func test_additionalParameters_fullPrefillDetails_instantDebits_passthroughLinkMode() {
+        let prefillDetails = ElementsSessionContext.PrefillDetails(
+            email: "test@example.com",
+            formattedPhoneNumber: "+1 (123) 456-7890",
+            unformattedPhoneNumber: "1234567890",
+            countryCode: "US"
+        )
+        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+            startingAdditionalParameters: "&testmode=true",
+            isInstantDebits: true,
+            linkMode: .passthrough,
+            prefillDetails: prefillDetails
+        )
+        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&link_mode=PASSTHROUGH&email=test@example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -219,9 +219,16 @@ extension PaymentMethodFormViewController {
             }
         }()
 
+        let defaultPhoneNumber = configuration.defaultBillingDetails.phone
+        let defaultUnformattedPhoneNumber: String? = {
+            guard let defaultPhoneNumber else { return nil }
+            return PhoneNumber.fromE164(defaultPhoneNumber)?.number
+        }()
         let prefillDetails = ElementsSessionContext.PrefillDetails(
             email: instantDebitsFormElement?.email ?? configuration.defaultBillingDetails.name,
-            phoneNumber: instantDebitsFormElement?.phone ?? configuration.defaultBillingDetails.phone
+            formattedPhoneNumber: instantDebitsFormElement?.phone ?? defaultPhoneNumber,
+            unformattedPhoneNumber: instantDebitsFormElement?.phoneElement?.phoneNumber?.number ?? defaultUnformattedPhoneNumber,
+            countryCode: instantDebitsFormElement?.phoneElement?.selectedCountryCode
         )
         let linkMode = elementsSession.linkSettings?.linkMode
         return ElementsSessionContext(


### PR DESCRIPTION
## Summary

This passes the email and phone number entered in the MPE Bank tab to the FC auth flow URL. This will prefill those details into the Link login.

For the web flow, we need to pass the unformatted phone number + country code as separate params, but for the native flow we can pass the formatted number.

> [!NOTE]  
> There is currently a bug where the country code is not being applied from the value provided as a URL param. This is being fixed now: https://git.corp.stripe.com/stripe-internal/pay-server/pull/930617

## Motivation

BANKCON-16077

## Testing

Web flow:

https://github.com/user-attachments/assets/cff7fc7a-1fdb-4500-806b-8062fba0141a

Native flow:

https://github.com/user-attachments/assets/16145a30-0d97-4ed3-a884-d78d99366e47

## Changelog

N/a
