### PR TITLE
[BANKCON-15711] Pass billing details to `/payment_methods` and `/share` endpoints

### DIFF
--- a/StripeCore/StripeCore.xcodeproj/project.pbxproj
+++ b/StripeCore/StripeCore.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		4910B9282C3D8F3F00B030D4 /* Result+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4910B9272C3D8F3F00B030D4 /* Result+Extensions.swift */; };
 		492039932CA47A8600CE2072 /* ElementsSessionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492039922CA47A8600CE2072 /* ElementsSessionContext.swift */; };
 		493B33062CA3015600E3622F /* LinkMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493B33052CA3015600E3622F /* LinkMode.swift */; };
+		49E8CE2A2CD146CE0009DFBB /* KeyedEncodingContainer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E8CE292CD146CE0009DFBB /* KeyedEncodingContainer+Extensions.swift */; };
 		49ECDA412CA340E100F647F0 /* AsyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49ECDA402CA340E100F647F0 /* AsyncTests.swift */; };
 		49F3828D2CC02D43001CE69A /* BillingAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F3828C2CC02D43001CE69A /* BillingAddress.swift */; };
 		4B2FAC57E03D8654A177C408 /* Dictionary+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7727AEEFD2FC880BADDA1872 /* Dictionary+Stripe.swift */; };
@@ -235,6 +236,7 @@
 		493B33052CA3015600E3622F /* LinkMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkMode.swift; sourceTree = "<group>"; };
 		49424775D3233411D9C2473B /* StripeCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeCodable.swift; sourceTree = "<group>"; };
 		49538DBF8457D96707A2DA56 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/Localizable.strings; sourceTree = "<group>"; };
+		49E8CE292CD146CE0009DFBB /* KeyedEncodingContainer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KeyedEncodingContainer+Extensions.swift"; sourceTree = "<group>"; };
 		49ECDA402CA340E100F647F0 /* AsyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncTests.swift; sourceTree = "<group>"; };
 		49F3828C2CC02D43001CE69A /* BillingAddress.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BillingAddress.swift; sourceTree = "<group>"; };
 		4A8030BF88608CA86E295F18 /* Enums+CustomStringConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Enums+CustomStringConvertible.swift"; sourceTree = "<group>"; };
@@ -627,6 +629,7 @@
 				C51179DB520568C246BF3AF0 /* URLEncoder.swift */,
 				B8B76840742D2CAF2931355A /* URLSession+Retry.swift */,
 				4910B9272C3D8F3F00B030D4 /* Result+Extensions.swift */,
+				49E8CE292CD146CE0009DFBB /* KeyedEncodingContainer+Extensions.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1020,6 +1023,7 @@
 				59CA874015261241AC255907 /* FileDownloader.swift in Sources */,
 				45DAE581F74EF7E11C64212B /* InstallMethod.swift in Sources */,
 				096274D0729AA8849FAD103C /* PaymentsSDKVariant.swift in Sources */,
+				49E8CE2A2CD146CE0009DFBB /* KeyedEncodingContainer+Extensions.swift in Sources */,
 				DA5A05459309B9B77ACDD736 /* STPDeviceUtils.swift in Sources */,
 				4910B9282C3D8F3F00B030D4 /* Result+Extensions.swift in Sources */,
 				83790210FFC2DD764C042C8E /* STPDispatchFunctions.swift in Sources */,

--- a/StripeCore/StripeCore/Source/Connections Bindings/BillingAddress.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/BillingAddress.swift
@@ -47,12 +47,12 @@ import Foundation
     // Custom encoder to only encode non-nil & non-empty properties.
     @_spi(STP) public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
-        if let name, !name.isEmpty { try container.encode(name, forKey: .name) }
-        if let line1, !line1.isEmpty { try container.encode(line1, forKey: .line1) }
-        if let line2, !line2.isEmpty { try container.encode(line2, forKey: .line2) }
-        if let city, !city.isEmpty { try container.encode(city, forKey: .city) }
-        if let state, !state.isEmpty { try container.encode(state, forKey: .state) }
-        if let postalCode, !postalCode.isEmpty { try container.encode(postalCode, forKey: .postalCode) }
-        if let countryCode, !countryCode.isEmpty { try container.encode(countryCode, forKey: .countryCode) }
+        try container.encodeIfNotEmpty(name, forKey: .name)
+        try container.encodeIfNotEmpty(line1, forKey: .line1)
+        try container.encodeIfNotEmpty(line2, forKey: .line2)
+        try container.encodeIfNotEmpty(city, forKey: .city)
+        try container.encodeIfNotEmpty(state, forKey: .state)
+        try container.encodeIfNotEmpty(postalCode, forKey: .postalCode)
+        try container.encodeIfNotEmpty(countryCode, forKey: .countryCode)
     }
 }

--- a/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
@@ -59,3 +59,92 @@ import Foundation
         self.billingAddress = billingAddress
     }
 }
+
+@_spi(STP) public extension ElementsSessionContext {
+    /// https://docs.stripe.com/api/payment_methods/create#create_payment_method-billing_details
+    struct BillingDetails: Encodable {
+        struct Address: Encodable {
+            let city: String?
+            let country: String?
+            let line1: String?
+            let line2: String?
+            let postalCode: String?
+            let state: String?
+
+            init?(
+                city: String?,
+                country: String?,
+                line1: String?,
+                line2: String?,
+                postalCode: String?,
+                state: String?
+            ) {
+                guard city != nil || country != nil || line1 != nil || line2 != nil || postalCode != nil || state != nil else {
+                    return nil
+                }
+
+                self.city = city
+                self.country = country
+                self.line1 = line1
+                self.line2 = line2
+                self.postalCode = postalCode
+                self.state = state
+            }
+
+            enum CodingKeys: String, CodingKey {
+                case city
+                case country
+                case line1
+                case line2
+                case postalCode = "postal_code"
+                case state
+            }
+
+            func encode(to encoder: any Encoder) throws {
+                var container: KeyedEncodingContainer<CodingKeys> = encoder.container(keyedBy: CodingKeys.self)
+                try container.encodeIfNotEmpty(self.city, forKey: .city)
+                try container.encodeIfNotEmpty(self.country, forKey: .country)
+                try container.encodeIfNotEmpty(self.line1, forKey: .line1)
+                try container.encodeIfNotEmpty(self.line2, forKey: .line2)
+                try container.encodeIfNotEmpty(self.postalCode, forKey: .postalCode)
+                try container.encodeIfNotEmpty(self.state, forKey: .state)
+            }
+        }
+
+        let name: String?
+        let email: String?
+        let phone: String?
+        let address: Address?
+
+        enum CodingKeys: CodingKey {
+            case name
+            case email
+            case phone
+            case address
+        }
+
+        @_spi(STP) public func encode(to encoder: any Encoder) throws {
+            var container: KeyedEncodingContainer<CodingKeys> = encoder.container(keyedBy: CodingKeys.self)
+            try container.encodeIfNotEmpty(self.name, forKey: .name)
+            try container.encodeIfNotEmpty(self.email, forKey: .email)
+            try container.encodeIfNotEmpty(self.phone, forKey: .phone)
+            try container.encodeIfPresent(self.address, forKey: .address)
+        }
+    }
+
+    var billingDetails: BillingDetails {
+        BillingDetails(
+            name: billingAddress?.name,
+            email: prefillDetails?.email,
+            phone: prefillDetails?.phoneNumber,
+            address: BillingDetails.Address(
+                city: billingAddress?.city,
+                country: billingAddress?.countryCode,
+                line1: billingAddress?.line1,
+                line2: billingAddress?.line2,
+                postalCode: billingAddress?.postalCode,
+                state: billingAddress?.state
+            )
+        )
+    }
+}

--- a/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
@@ -136,7 +136,7 @@ import Foundation
         BillingDetails(
             name: billingAddress?.name,
             email: prefillDetails?.email,
-            phone: prefillDetails?.phoneNumber,
+            phone: prefillDetails?.formattedPhoneNumber,
             address: BillingDetails.Address(
                 city: billingAddress?.city,
                 country: billingAddress?.countryCode,

--- a/StripeCore/StripeCore/Source/Helpers/KeyedEncodingContainer+Extensions.swift
+++ b/StripeCore/StripeCore/Source/Helpers/KeyedEncodingContainer+Extensions.swift
@@ -1,0 +1,15 @@
+//
+//  KeyedEncodingContainer+Extensions.swift
+//  StripeCore
+//
+//  Created by Mat Schmid on 2024-10-29.
+//
+
+import Foundation
+
+@_spi(STP) public extension KeyedEncodingContainer {
+    mutating func encodeIfNotEmpty(_ value: String?, forKey key: K) throws {
+        guard let value, !value.isEmpty else { return }
+        try encode(value, forKey: key)
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -510,7 +510,8 @@ extension NativeFlowController {
         var bankAccountDetails: BankAccountDetails?
         let elementsSessionContext = dataManager.elementsSessionContext
         let linkMode = elementsSessionContext?.linkMode
-        let email = dataManager.consumerSession?.emailAddress
+        let email = elementsSessionContext?.prefillDetails?.email ?? dataManager.consumerSession?.emailAddress
+        let phone = elementsSessionContext?.prefillDetails?.phoneNumber
         dataManager.createPaymentDetails(
             consumerSessionClientSecret: consumerSession.clientSecret,
             bankAccountId: bankAccountId,
@@ -529,13 +530,16 @@ extension NativeFlowController {
                 return self.dataManager.apiClient.sharePaymentDetails(
                     consumerSessionClientSecret: consumerSession.clientSecret,
                     paymentDetailsId: paymentDetails.redactedPaymentDetails.id,
-                    expectedPaymentMethodType: linkMode.expectedPaymentMethodType
+                    expectedPaymentMethodType: linkMode.expectedPaymentMethodType,
+                    billingEmail: email,
+                    billingPhone: phone
                 )
                 .transformed { $0 as PaymentMethodIDProvider }
             } else {
-                return self.dataManager.createPaymentMethod(
+                return self.dataManager.apiClient.paymentMethods(
                     consumerSessionClientSecret: consumerSession.clientSecret,
-                    paymentDetailsId: paymentDetails.redactedPaymentDetails.id
+                    paymentDetailsId: paymentDetails.redactedPaymentDetails.id,
+                    billingDetails: elementsSessionContext?.billingDetails
                 )
                 .transformed { $0 as PaymentMethodIDProvider }
             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -511,7 +511,7 @@ extension NativeFlowController {
         let elementsSessionContext = dataManager.elementsSessionContext
         let linkMode = elementsSessionContext?.linkMode
         let email = elementsSessionContext?.prefillDetails?.email ?? dataManager.consumerSession?.emailAddress
-        let phone = elementsSessionContext?.prefillDetails?.phoneNumber
+        let phone = elementsSessionContext?.prefillDetails?.formattedPhoneNumber
         dataManager.createPaymentDetails(
             consumerSessionClientSecret: consumerSession.clientSecret,
             bankAccountId: bankAccountId,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -42,10 +42,6 @@ protocol NativeFlowDataManager: AnyObject {
         billingAddress: BillingAddress?,
         billingEmail: String?
     ) -> Future<FinancialConnectionsPaymentDetails>
-    func createPaymentMethod(
-        consumerSessionClientSecret: String,
-        paymentDetailsId: String
-    ) -> Future<FinancialConnectionsPaymentMethod>
     func resetState(withNewManifest newManifest: FinancialConnectionsSessionManifest)
     func completeFinancialConnectionsSession(terminalError: String?) -> Future<StripeAPI.FinancialConnectionsSession>
 }
@@ -151,16 +147,6 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
             bankAccountId: bankAccountId,
             billingAddress: billingAddress,
             billingEmail: billingEmail
-        )
-    }
-
-    func createPaymentMethod(
-        consumerSessionClientSecret: String,
-        paymentDetailsId: String
-    ) -> Future<FinancialConnectionsPaymentMethod> {
-        apiClient.paymentMethods(
-            consumerSessionClientSecret: consumerSessionClientSecret,
-            paymentDetailsId: paymentDetailsId
         )
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -224,11 +224,21 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
         Promise<StripeFinancialConnections.FinancialConnectionsPaymentDetails>()
     }
 
-    func sharePaymentDetails(consumerSessionClientSecret: String, paymentDetailsId: String, expectedPaymentMethodType: String) -> Future<FinancialConnectionsSharePaymentDetails> {
+    func sharePaymentDetails(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String,
+        expectedPaymentMethodType: String,
+        billingEmail: String?,
+        billingPhone: String?
+    ) -> Future<FinancialConnectionsSharePaymentDetails> {
         Promise<StripeFinancialConnections.FinancialConnectionsSharePaymentDetails>()
     }
 
-    func paymentMethods(consumerSessionClientSecret: String, paymentDetailsId: String) -> StripeCore.Future<StripeFinancialConnections.FinancialConnectionsPaymentMethod> {
+    func paymentMethods(
+        consumerSessionClientSecret: String,
+        paymentDetailsId: String,
+        billingDetails: ElementsSessionContext.BillingDetails?
+    ) -> StripeCore.Future<StripeFinancialConnections.FinancialConnectionsPaymentMethod> {
         Promise<StripeFinancialConnections.FinancialConnectionsPaymentMethod>()
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -164,8 +164,6 @@ extension PaymentSheet {
                 recommendedStripePaymentMethodTypes.map { PaymentMethodType.stripe($0) }
                 // External Payment Methods
                 + elementsSession.externalPaymentMethods.map { PaymentMethodType.external($0) }
-            
-            let hasIneligibleConfiguration = configuration.billingDetailsCollectionConfiguration.email == .never && configuration.defaultBillingDetails.email?.isEmpty != false
 
             // We should manually add Instant Debits as a payment method when:
             // - Link is an available payment method.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -164,6 +164,8 @@ extension PaymentSheet {
                 recommendedStripePaymentMethodTypes.map { PaymentMethodType.stripe($0) }
                 // External Payment Methods
                 + elementsSession.externalPaymentMethods.map { PaymentMethodType.external($0) }
+            
+            let hasIneligibleConfiguration = configuration.billingDetailsCollectionConfiguration.email == .never && configuration.defaultBillingDetails.email?.isEmpty != false
 
             // We should manually add Instant Debits as a payment method when:
             // - Link is an available payment method.


### PR DESCRIPTION
## Summary

This passes the following billing details to the create payment method endpoints:

- `/share` ([Source](https://git.corp.stripe.com/stripe-internal/pay-server/blob/ce01ba417b09b994ab52f518cd5c272380a52973/lib/consumer/api/methods/payment_details/share_payment_details.rb#L45-L52)):
    - `billing_email`
    - `billing_phone`
- `/payment_methods` ([Source](https://docs.stripe.com/api/payment_methods/create#create_payment_method-billing_details)):
    - `name`
    - `email`
    - `phone`
    - `address`
        - `city`
        - `country`
        - `line1`
        - `line2`
        - `postal_code`
        - `state`

## Motivation

[BANKCON-15711](https://jira.corp.stripe.com/browse/BANKCON-15711)

## Testing

Verified all the billing details are correctly applied to payment intents for the Instant Debits & Panther flows:

Example Instant Debits payment intent: https://admin.corp.stripe.com/payment_intent/pi_3QFJMcLu5o3P18Zp0le2qPNP
Example Panther payment intent: https://admin.corp.stripe.com/payment_intent/pi_3QFJKYLu5o3P18Zp1aglRfbM

## Changelog

N/a
