### PR TITLE
Pass billing details to auth flow URL

### DIFF
--- a/StripeCore/StripeCore/Source/Connections Bindings/BillingAddress.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/BillingAddress.swift
@@ -34,6 +34,18 @@ import Foundation
         self.countryCode = countryCode
     }
 
+    @_spi(STP) public init(from billingDetails: ElementsSessionContext.BillingDetails?) {
+        self.init(
+            name: billingDetails?.name,
+            line1: billingDetails?.address?.line1,
+            line2: billingDetails?.address?.line2,
+            city: billingDetails?.address?.city,
+            state: billingDetails?.address?.state,
+            postalCode: billingDetails?.address?.postalCode,
+            countryCode: billingDetails?.address?.country
+        )
+    }
+
     enum CodingKeys: String, CodingKey {
         case name
         case line1 = "line_1"

--- a/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
@@ -41,8 +41,11 @@ import Foundation
     @_spi(STP) public let prefillDetails: PrefillDetails?
     @_spi(STP) public let intentId: IntentID?
     @_spi(STP) public let linkMode: LinkMode?
-    @_spi(STP) public let billingAddress: BillingAddress?
     @_spi(STP) public let billingDetails: BillingDetails?
+
+    @_spi(STP) public var billingAddress: BillingAddress? {
+        BillingAddress(from: billingDetails)
+    }
 
     @_spi(STP) public init(
         amount: Int?,
@@ -50,7 +53,6 @@ import Foundation
         prefillDetails: PrefillDetails?,
         intentId: IntentID?,
         linkMode: LinkMode?,
-        billingAddress: BillingAddress?,
         billingDetails: BillingDetails?
     ) {
         self.amount = amount
@@ -58,7 +60,6 @@ import Foundation
         self.prefillDetails = prefillDetails
         self.intentId = intentId
         self.linkMode = linkMode
-        self.billingAddress = billingAddress
         self.billingDetails = billingDetails
     }
 }
@@ -92,17 +93,6 @@ import Foundation
                 self.line2 = line2
                 self.postalCode = postalCode
                 self.state = state
-            }
-
-            @_spi(STP) public init?(from billingAddress: BillingAddress?) {
-                self.init(
-                    city: billingAddress?.city,
-                    country: billingAddress?.countryCode,
-                    line1: billingAddress?.line1,
-                    line2: billingAddress?.line2,
-                    postalCode: billingAddress?.postalCode,
-                    state: billingAddress?.state
-                )
             }
 
             enum CodingKeys: String, CodingKey {

--- a/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
@@ -42,6 +42,7 @@ import Foundation
     @_spi(STP) public let intentId: IntentID?
     @_spi(STP) public let linkMode: LinkMode?
     @_spi(STP) public let billingAddress: BillingAddress?
+    @_spi(STP) public let billingDetails: BillingDetails?
 
     @_spi(STP) public init(
         amount: Int?,
@@ -49,7 +50,8 @@ import Foundation
         prefillDetails: PrefillDetails?,
         intentId: IntentID?,
         linkMode: LinkMode?,
-        billingAddress: BillingAddress?
+        billingAddress: BillingAddress?,
+        billingDetails: BillingDetails?
     ) {
         self.amount = amount
         self.currency = currency
@@ -57,21 +59,22 @@ import Foundation
         self.intentId = intentId
         self.linkMode = linkMode
         self.billingAddress = billingAddress
+        self.billingDetails = billingDetails
     }
 }
 
 @_spi(STP) public extension ElementsSessionContext {
     /// https://docs.stripe.com/api/payment_methods/create#create_payment_method-billing_details
     struct BillingDetails: Encodable {
-        struct Address: Encodable {
-            let city: String?
-            let country: String?
-            let line1: String?
-            let line2: String?
-            let postalCode: String?
-            let state: String?
+        @_spi(STP) public struct Address: Encodable {
+            @_spi(STP) public let city: String?
+            @_spi(STP) public let country: String?
+            @_spi(STP) public let line1: String?
+            @_spi(STP) public let line2: String?
+            @_spi(STP) public let postalCode: String?
+            @_spi(STP) public let state: String?
 
-            init?(
+            @_spi(STP) public init?(
                 city: String?,
                 country: String?,
                 line1: String?,
@@ -91,6 +94,17 @@ import Foundation
                 self.state = state
             }
 
+            @_spi(STP) public init?(from billingAddress: BillingAddress?) {
+                self.init(
+                    city: billingAddress?.city,
+                    country: billingAddress?.countryCode,
+                    line1: billingAddress?.line1,
+                    line2: billingAddress?.line2,
+                    postalCode: billingAddress?.postalCode,
+                    state: billingAddress?.state
+                )
+            }
+
             enum CodingKeys: String, CodingKey {
                 case city
                 case country
@@ -100,7 +114,7 @@ import Foundation
                 case state
             }
 
-            func encode(to encoder: any Encoder) throws {
+            @_spi(STP) public func encode(to encoder: any Encoder) throws {
                 var container: KeyedEncodingContainer<CodingKeys> = encoder.container(keyedBy: CodingKeys.self)
                 try container.encodeIfNotEmpty(self.city, forKey: .city)
                 try container.encodeIfNotEmpty(self.country, forKey: .country)
@@ -111,10 +125,17 @@ import Foundation
             }
         }
 
-        let name: String?
-        let email: String?
-        let phone: String?
-        let address: Address?
+        @_spi(STP) public let name: String?
+        @_spi(STP) public let email: String?
+        @_spi(STP) public let phone: String?
+        @_spi(STP) public let address: Address?
+
+        @_spi(STP) public init(name: String?, email: String?, phone: String?, address: Address?) {
+            self.name = name
+            self.email = email
+            self.phone = phone
+            self.address = address
+        }
 
         enum CodingKeys: CodingKey {
             case name
@@ -130,21 +151,5 @@ import Foundation
             try container.encodeIfNotEmpty(self.phone, forKey: .phone)
             try container.encodeIfPresent(self.address, forKey: .address)
         }
-    }
-
-    var billingDetails: BillingDetails {
-        BillingDetails(
-            name: billingAddress?.name,
-            email: prefillDetails?.email,
-            phone: prefillDetails?.formattedPhoneNumber,
-            address: BillingDetails.Address(
-                city: billingAddress?.city,
-                country: billingAddress?.countryCode,
-                line1: billingAddress?.line1,
-                line2: billingAddress?.line2,
-                postalCode: billingAddress?.postalCode,
-                state: billingAddress?.state
-            )
-        )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -510,8 +510,8 @@ extension NativeFlowController {
         var bankAccountDetails: BankAccountDetails?
         let elementsSessionContext = dataManager.elementsSessionContext
         let linkMode = elementsSessionContext?.linkMode
-        let email = elementsSessionContext?.prefillDetails?.email ?? dataManager.consumerSession?.emailAddress
-        let phone = elementsSessionContext?.prefillDetails?.formattedPhoneNumber
+        let email = elementsSessionContext?.billingDetails?.email ?? dataManager.consumerSession?.emailAddress
+        let phone = elementsSessionContext?.billingDetails?.phone
         dataManager.createPaymentDetails(
             consumerSessionClientSecret: consumerSession.clientSecret,
             bankAccountId: bankAccountId,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/AuthenticationSessionManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/AuthenticationSessionManager.swift
@@ -35,7 +35,7 @@ final class AuthenticationSessionManager: NSObject {
 
     // MARK: - Public
 
-    func start(additionalQueryParameters: String) -> Promise<AuthenticationSessionManager.Result> {
+    func start(additionalQueryParameters: String?) -> Promise<AuthenticationSessionManager.Result> {
         let promise = Promise<AuthenticationSessionManager.Result>()
 
         guard let hostedAuthUrl = manifest.hostedAuthUrl else {
@@ -43,7 +43,8 @@ final class AuthenticationSessionManager: NSObject {
             return promise
         }
 
-        let urlString = hostedAuthUrl + additionalQueryParameters
+        let queryParameters = additionalQueryParameters ?? ""
+        let urlString = hostedAuthUrl + queryParameters
 
         guard let url = URL(string: urlString) else {
             promise.reject(with: FinancialConnectionsSheetError.unknown(debugDescription: "Malformed hosted auth URL"))

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -443,6 +443,38 @@ extension FinancialConnectionsWebFlowViewController {
             if let linkMode = linkMode {
                 parameters.append("link_mode=\(linkMode.rawValue)")
             }
+
+            if let billingDetails = billingDetails {
+                if let name = billingDetails.name, !name.isEmpty {
+                    parameters.append("billingDetails[name]=\(name)")
+                }
+                if let email = billingDetails.email, !email.isEmpty {
+                    parameters.append("billingDetails[email]=\(email)")
+                }
+                if let phone = billingDetails.phone, !phone.isEmpty {
+                    parameters.append("billingDetails[phone]=\(phone)")
+                }
+                if let address = billingDetails.address {
+                    if let city = address.city, !city.isEmpty {
+                        parameters.append("billingDetails[address][city]=\(city)")
+                    }
+                    if let country = address.country, !country.isEmpty {
+                        parameters.append("billingDetails[address][country]=\(country)")
+                    }
+                    if let line1 = address.line1, !line1.isEmpty {
+                        parameters.append("billingDetails[address][line1]=\(line1)")
+                    }
+                    if let line2 = address.line2, !line2.isEmpty {
+                        parameters.append("billingDetails[address][line2]=\(line2)")
+                    }
+                    if let postalCode = address.postalCode, !postalCode.isEmpty {
+                        parameters.append("billingDetails[address][postal_code]=\(postalCode)")
+                    }
+                    if let state = address.state, !state.isEmpty {
+                        parameters.append("billingDetails[address][state]=\(state)")
+                    }
+                }
+            }
         }
 
         if let prefillDetails = prefillDetails {
@@ -457,39 +489,8 @@ extension FinancialConnectionsWebFlowViewController {
             }
         }
 
-        if let billingDetails = billingDetails {
-            if let name = billingDetails.name, !name.isEmpty {
-                parameters.append("billingDetails[name]=\(name)")
-            }
-            if let email = billingDetails.email, !email.isEmpty {
-                parameters.append("billingDetails[email]=\(email)")
-            }
-            if let phone = billingDetails.phone, !phone.isEmpty {
-                parameters.append("billingDetails[phone]=\(phone)")
-            }
-            if let address = billingDetails.address {
-                if let city = address.city, !city.isEmpty {
-                    parameters.append("billingDetails[address][city]=\(city)")
-                }
-                if let country = address.country, !country.isEmpty {
-                    parameters.append("billingDetails[address][country]=\(country)")
-                }
-                if let line1 = address.line1, !line1.isEmpty {
-                    parameters.append("billingDetails[address][line1]=\(line1)")
-                }
-                if let line2 = address.line2, !line2.isEmpty {
-                    parameters.append("billingDetails[address][line2]=\(line2)")
-                }
-                if let postalCode = address.postalCode, !postalCode.isEmpty {
-                    parameters.append("billingDetails[address][postal_code]=\(postalCode)")
-                }
-                if let state = address.state, !state.isEmpty {
-                    parameters.append("billingDetails[address][state]=\(state)")
-                }
-            }
-        }
-
         // Join all values with an &, and URL encode.
+        // We encode these parameters since they will be appended to the auth flow URL.
         guard let result = parameters.joined(separator: "&").addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) else {
             return nil
         }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsWebFlowTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsWebFlowTests.swift
@@ -188,12 +188,12 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
         )
         let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: nil,
-            isInstantDebits: false,
+            isInstantDebits: true,
             linkMode: nil,
             prefillDetails: nil,
             billingDetails: billingDetails
         )
-        XCTAssertEqual(additionalParameters, "&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON")
+        XCTAssertEqual(additionalParameters, "&return_payment_method=true&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON")
     }
 
     func test_additionalParameters_fullBillingDetails_fullPrefillDetails_instantDebits_passthroughLinkMode() {
@@ -223,6 +223,6 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             prefillDetails: prefillDetails,
             billingDetails: billingDetails
         )
-        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&link_mode=PASSTHROUGH&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON")
+        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&link_mode=PASSTHROUGH&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsWebFlowTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsWebFlowTests.swift
@@ -11,71 +11,78 @@ import XCTest
 
 final class FinancialConnectionsWebFlowTests: XCTestCase {
     func test_noAdditionalParameters_empty() {
-        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: nil,
             isInstantDebits: false,
             linkMode: nil,
-            prefillDetails: nil
+            prefillDetails: nil,
+            billingDetails: nil
         )
-        XCTAssertEqual(additionalParameters, "")
+        XCTAssertNil(additionalParameters)
     }
 
     func test_someAdditionalParameters_notInstantDebits_noLinkMode() {
-        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: "",
             isInstantDebits: false,
             linkMode: nil,
-            prefillDetails: nil
+            prefillDetails: nil,
+            billingDetails: nil
         )
-        XCTAssertEqual(additionalParameters, "")
+        XCTAssertNil(additionalParameters)
     }
 
     func test_someAdditionalParameters_instantDebits_noLinkMode() {
-        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: "&testmode=true",
             isInstantDebits: true,
             linkMode: nil,
-            prefillDetails: nil
+            prefillDetails: nil,
+            billingDetails: nil
         )
         XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true")
     }
 
     func test_additionalParameters_instantDebits_noLinkMode() {
-        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: "",
             isInstantDebits: true,
             linkMode: nil,
-            prefillDetails: nil
+            prefillDetails: nil,
+            billingDetails: nil
         )
         XCTAssertEqual(additionalParameters, "&return_payment_method=true")
     }
 
     func test_additionalParameters_notInstantDebits_someLinkMode() {
-        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: "",
             isInstantDebits: false,
             linkMode: .passthrough,
-            prefillDetails: nil
+            prefillDetails: nil,
+            billingDetails: nil
         )
-        XCTAssertEqual(additionalParameters, "")
+        XCTAssertNil(additionalParameters)
     }
 
     func test_someAdditionalParameters_instantDebits_passthroughLinkMode() {
-        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: "&testmode=true",
             isInstantDebits: true,
             linkMode: .passthrough,
-            prefillDetails: nil
+            prefillDetails: nil,
+            billingDetails: nil
         )
         XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&link_mode=PASSTHROUGH")
     }
 
     func test_additionalParameters_instantDebits_linkCardBrandLinkMode() {
-        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: "",
             isInstantDebits: true,
             linkMode: .linkCardBrand,
-            prefillDetails: nil
+            prefillDetails: nil,
+            billingDetails: nil
         )
         XCTAssertEqual(additionalParameters, "&return_payment_method=true&link_mode=LINK_CARD_BRAND")
     }
@@ -87,13 +94,14 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             unformattedPhoneNumber: nil,
             countryCode: nil
         )
-        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: nil,
             isInstantDebits: false,
             linkMode: nil,
-            prefillDetails: prefillDetails
+            prefillDetails: prefillDetails,
+            billingDetails: nil
         )
-        XCTAssertEqual(additionalParameters, "")
+        XCTAssertNil(additionalParameters)
     }
 
     func test_additionalParameters_prefilledEmail() {
@@ -103,13 +111,14 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             unformattedPhoneNumber: nil,
             countryCode: nil
         )
-        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: nil,
             isInstantDebits: false,
             linkMode: nil,
-            prefillDetails: prefillDetails
+            prefillDetails: prefillDetails,
+            billingDetails: nil
         )
-        XCTAssertEqual(additionalParameters, "&email=test@example.com")
+        XCTAssertEqual(additionalParameters, "&email=test%40example.com")
     }
 
     func test_additionalParameters_fullPrefillDetails() {
@@ -119,13 +128,14 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             unformattedPhoneNumber: "1234567890",
             countryCode: "US"
         )
-        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: nil,
             isInstantDebits: false,
             linkMode: nil,
-            prefillDetails: prefillDetails
+            prefillDetails: prefillDetails,
+            billingDetails: nil
         )
-        XCTAssertEqual(additionalParameters, "&email=test@example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
+        XCTAssertEqual(additionalParameters, "&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
     }
 
     func test_additionalParameters_fullPrefillDetails_instantDebits_passthroughLinkMode() {
@@ -135,12 +145,84 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             unformattedPhoneNumber: "1234567890",
             countryCode: "US"
         )
-        let additionalParameters = FinancialConnectionsWebFlowViewController.updateAdditionalParameters(
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: "&testmode=true",
             isInstantDebits: true,
             linkMode: .passthrough,
-            prefillDetails: prefillDetails
+            prefillDetails: prefillDetails,
+            billingDetails: nil
         )
-        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&link_mode=PASSTHROUGH&email=test@example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
+        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&link_mode=PASSTHROUGH&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
+    }
+
+    func test_additionalParameters_emptyBillingDetails() {
+        let billingDetails = ElementsSessionContext.BillingDetails(
+            name: nil,
+            email: nil,
+            phone: nil,
+            address: nil
+        )
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
+            startingAdditionalParameters: nil,
+            isInstantDebits: false,
+            linkMode: nil,
+            prefillDetails: nil,
+            billingDetails: billingDetails
+        )
+        XCTAssertNil(additionalParameters)
+    }
+
+    func test_additionalParameters_billingDetails() {
+        let billingDetails = ElementsSessionContext.BillingDetails(
+            name: "Foo Bar",
+            email: "foo@bar.com",
+            phone: "+1 (123) 456-7890",
+            address: ElementsSessionContext.BillingDetails.Address(
+                city: "Toronto",
+                country: "CA",
+                line1: "123 Main St",
+                line2: "",
+                postalCode: "A0B 1C2",
+                state: "ON"
+            )
+        )
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
+            startingAdditionalParameters: nil,
+            isInstantDebits: false,
+            linkMode: nil,
+            prefillDetails: nil,
+            billingDetails: billingDetails
+        )
+        XCTAssertEqual(additionalParameters, "&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON")
+    }
+
+    func test_additionalParameters_fullBillingDetails_fullPrefillDetails_instantDebits_passthroughLinkMode() {
+        let prefillDetails = ElementsSessionContext.PrefillDetails(
+            email: "test@example.com",
+            formattedPhoneNumber: "+1 (123) 456-7890",
+            unformattedPhoneNumber: "1234567890",
+            countryCode: "US"
+        )
+        let billingDetails = ElementsSessionContext.BillingDetails(
+            name: "Foo Bar",
+            email: "foo@bar.com",
+            phone: "+1 (123) 456-7890",
+            address: ElementsSessionContext.BillingDetails.Address(
+                city: "Toronto",
+                country: "CA",
+                line1: "123 Main St",
+                line2: nil,
+                postalCode: "A0B 1C2",
+                state: "ON"
+            )
+        )
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
+            startingAdditionalParameters: "&testmode=true",
+            isInstantDebits: true,
+            linkMode: .passthrough,
+            prefillDetails: prefillDetails,
+            billingDetails: billingDetails
+        )
+        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&link_mode=PASSTHROUGH&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON")
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -111,15 +111,21 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
         return configuration.defaultBillingDetails.address
     }
 
-    var billingAddress: BillingAddress {
-        BillingAddress(
-            name: name,
+    var billingDetails: ElementsSessionContext.BillingDetails {
+        let billingAddress = ElementsSessionContext.BillingDetails.Address(
+            city: address.city,
+            country: address.country,
             line1: address.line1,
             line2: address.line2,
-            city: address.city,
-            state: address.state,
             postalCode: address.postalCode,
-            countryCode: address.country
+            state: address.state
+        )
+
+        return ElementsSessionContext.BillingDetails(
+            name: name,
+            email: email,
+            phone: phone,
+            address: billingAddress
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -225,7 +225,7 @@ extension PaymentMethodFormViewController {
             return PhoneNumber.fromE164(defaultPhoneNumber)?.number
         }()
         let prefillDetails = ElementsSessionContext.PrefillDetails(
-            email: instantDebitsFormElement?.email ?? configuration.defaultBillingDetails.name,
+            email: instantDebitsFormElement?.email ?? configuration.defaultBillingDetails.email,
             formattedPhoneNumber: instantDebitsFormElement?.phone ?? defaultPhoneNumber,
             unformattedPhoneNumber: instantDebitsFormElement?.phoneElement?.phoneNumber?.number ?? defaultUnformattedPhoneNumber,
             countryCode: instantDebitsFormElement?.phoneElement?.selectedCountryCode
@@ -240,13 +240,21 @@ extension PaymentMethodFormViewController {
                 return nil
             }
         }()
+
+        let billingDetails = ElementsSessionContext.BillingDetails(
+            name: instantDebitsFormElement?.name,
+            email: instantDebitsFormElement?.email,
+            phone: instantDebitsFormElement?.phone,
+            address: ElementsSessionContext.BillingDetails.Address(from: billingAddress)
+        )
         return ElementsSessionContext(
             amount: intent.amount,
             currency: intent.currency,
             prefillDetails: prefillDetails,
             intentId: intentId,
             linkMode: linkMode,
-            billingAddress: billingAddress
+            billingAddress: billingAddress,
+            billingDetails: billingDetails
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -231,29 +231,14 @@ extension PaymentMethodFormViewController {
             countryCode: instantDebitsFormElement?.phoneElement?.selectedCountryCode
         )
         let linkMode = elementsSession.linkSettings?.linkMode
-        let billingAddress: BillingAddress? = {
-            if configuration.billingDetailsCollectionConfiguration.address == .full {
-                return instantDebitsFormElement?.billingAddress
-            } else if configuration.billingDetailsCollectionConfiguration.name == .always {
-                return BillingAddress(name: instantDebitsFormElement?.name)
-            } else {
-                return nil
-            }
-        }()
+        let billingDetails = instantDebitsFormElement?.billingDetails
 
-        let billingDetails = ElementsSessionContext.BillingDetails(
-            name: instantDebitsFormElement?.name,
-            email: instantDebitsFormElement?.email,
-            phone: instantDebitsFormElement?.phone,
-            address: ElementsSessionContext.BillingDetails.Address(from: billingAddress)
-        )
         return ElementsSessionContext(
             amount: intent.amount,
             currency: intent.currency,
             prefillDetails: prefillDetails,
             intentId: intentId,
             linkMode: linkMode,
-            billingAddress: billingAddress,
             billingDetails: billingDetails
         )
     }


### PR DESCRIPTION
## Summary

In order to populate billing details on a payment method created in the web auth flow, we need to pass in all the billing details to the auth flow URL. We now pass the following query params to the auth flow URL: 

- `billingDetails[name]`
- `billingDetails[address][city]`
- `billingDetails[address][country]`
- `billingDetails[address][line1]`
- `billingDetails[address][line2]`
- `billingDetails[address][postal_code]`
- `billingDetails[address][state]`

## Motivation

Fix web auth flow billing details

## Testing

Unit tests and manual testing:

<img width="1660" alt="Screenshot 2024-10-30 at 2 10 46 PM" src="https://github.com/user-attachments/assets/d74c4425-7222-444f-b2da-6c915eab887e">

## Changelog

N/a