### PR TITLE
Fix testLinkCardBrand UI test and bug in payment details API call

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2511,11 +2511,7 @@ extension PaymentSheetUITestCase {
         // "Consent" pane
         app.buttons["Agree and continue"].waitForExistenceAndTap(timeout: 10)
 
-        // "Sign Up" pane
-        let emailTextField = app.textFields["email_text_field"]
-        XCTAssertTrue(emailTextField.waitForExistence(timeout: 10.0), "Failed to find email text field")
-        emailTextField.typeText("\(UUID().uuidString)@uitest.com")
-
+        // "Sign Up" pane. Email will be pre-filled.
         let phoneTextField = app.textFields["phone_text_field"]
         XCTAssertTrue(phoneTextField.waitForExistence(timeout: 10.0), "Failed to find phone text field")
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -1014,7 +1014,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         }
 
         if let billingEmail, !billingEmail.isEmpty {
-            parameters["billing_email_address"] = billingEmail
+            parameters["billing_email_address"] = billingEmail.lowercased()
         }
 
         return post(


### PR DESCRIPTION
## Summary

This fixes a failing UI test, `testLinkCardBrand`. It was expecting to type in an email, but it now gets prefilled from MPE, so that step was failing. 

This UI test also caught a separate bug, where emails containing uppercase characters were causing an error in `/payment_details` API. Example failing request: https://admin.corp.stripe.com/request-log/req_6fKWRSAlsYXzv5

## Motivation

Make CI green!

## Testing

Covered by UI tests

## Changelog

N/a
