### PR TITLE
Add local feature flag for attaching billing details to bank payments

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -143,6 +143,7 @@ struct PaymentSheetTestPlayground: View {
                                 .font(.headline)
                             Spacer()
                         }
+                        SettingView(setting: $playgroundController.settings.attachBillingDetailsToBankPayment)
                         SettingView(setting: $playgroundController.settings.attachDefaults)
                         SettingView(setting: $playgroundController.settings.collectName)
                         SettingView(setting: $playgroundController.settings.collectEmail)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -253,6 +253,13 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case GB
     }
 
+    enum AttachBillingDetailsToBankPayment: String, PickerEnum {
+        static var enumName: String { "Attach to bank payment" }
+
+        case on
+        case off
+    }
+
     enum BillingDetailsAttachDefaults: String, PickerEnum {
         static var enumName: String { "Attach defaults" }
 
@@ -460,6 +467,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var requireCVCRecollection: RequireCVCRecollectionEnabled
     var allowsRemovalOfLastSavedPaymentMethod: AllowsRemovalOfLastSavedPaymentMethodEnabled
 
+    var attachBillingDetailsToBankPayment: AttachBillingDetailsToBankPayment
     var attachDefaults: BillingDetailsAttachDefaults
     var collectName: BillingDetailsName
     var collectEmail: BillingDetailsEmail
@@ -503,6 +511,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             preferredNetworksEnabled: .off,
             requireCVCRecollection: .off,
             allowsRemovalOfLastSavedPaymentMethod: .on,
+            attachBillingDetailsToBankPayment: .off,
             attachDefaults: .off,
             collectName: .automatic,
             collectEmail: .automatic,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -438,6 +438,10 @@ class PlaygroundController: ObservableObject {
             } else {
                 self.ambiguousViewTimer?.invalidate()
             }
+
+            // Hack to access playground setting value via UserDefaults from the Financial Connections SDK.
+            let attachBillingDetailsToBankPayment = newValue.attachBillingDetailsToBankPayment == .on
+            UserDefaults.standard.set(attachBillingDetailsToBankPayment, forKey: "FINANCIAL_CONNECTIONS_ATTACH_BILLING_DETAILS_TO_BANK_PAYMENT")
         }.store(in: &subscribers)
 
         // Listen for analytics

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -79,12 +79,12 @@ final class FinancialConnectionsAPIClient {
         return promise
     }
 
-    static func encodeAsParameters(_ value: any Encodable) throws -> [String: Any] {
+    static func encodeAsParameters(_ value: any Encodable) throws -> [String: Any]? {
         let jsonData = try JSONEncoder().encode(value)
         let jsonObject = try JSONSerialization.jsonObject(with: jsonData)
 
         if let dictionary = jsonObject as? [String: Any] {
-            return dictionary
+            return dictionary.isEmpty ? nil : dictionary
         } else {
             throw EncodingError.cannotCastToDictionary
         }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
@@ -53,6 +53,13 @@ class FinancialConnectionsAPIClientTests: XCTestCase {
         XCTAssertNil(apiClient.consumerPublishableKeyProvider(canUseConsumerKey: false))
     }
 
+    func testEmptyBillingAddressEncodedAsParameters() throws {
+        let billingAddress = BillingAddress()
+        let encodedBillingAddress = try FinancialConnectionsAPIClient.encodeAsParameters(billingAddress)
+
+        XCTAssertNil(encodedBillingAddress)
+    }
+
     func testBillingAddressEncodedAsParameters() throws {
         let billingAddress = BillingAddress(
             name: "Bobby Tables",
@@ -65,13 +72,13 @@ class FinancialConnectionsAPIClientTests: XCTestCase {
         )
         let encodedBillingAddress = try FinancialConnectionsAPIClient.encodeAsParameters(billingAddress)
 
-        XCTAssertEqual(encodedBillingAddress["name"] as? String, "Bobby Tables")
-        XCTAssertEqual(encodedBillingAddress["line_1"] as? String, "123 Fake St")
-        XCTAssertNil(encodedBillingAddress["line_2"])
-        XCTAssertEqual(encodedBillingAddress["locality"] as? String, "Utopia")
-        XCTAssertEqual(encodedBillingAddress["administrative_area"] as? String, "CA")
-        XCTAssertEqual(encodedBillingAddress["postal_code"] as? String, "90210")
-        XCTAssertEqual(encodedBillingAddress["country_code"] as? String, "US")
+        XCTAssertEqual(encodedBillingAddress?["name"] as? String, "Bobby Tables")
+        XCTAssertEqual(encodedBillingAddress?["line_1"] as? String, "123 Fake St")
+        XCTAssertNil(encodedBillingAddress?["line_2"])
+        XCTAssertEqual(encodedBillingAddress?["locality"] as? String, "Utopia")
+        XCTAssertEqual(encodedBillingAddress?["administrative_area"] as? String, "CA")
+        XCTAssertEqual(encodedBillingAddress?["postal_code"] as? String, "90210")
+        XCTAssertEqual(encodedBillingAddress?["country_code"] as? String, "US")
     }
 
     func testBillingAddressEncodedAsParametersNonNilLine2() throws {
@@ -86,12 +93,12 @@ class FinancialConnectionsAPIClientTests: XCTestCase {
         )
         let encodedBillingAddress = try FinancialConnectionsAPIClient.encodeAsParameters(billingAddress)
 
-        XCTAssertEqual(encodedBillingAddress["name"] as? String, "Bobby Tables")
-        XCTAssertEqual(encodedBillingAddress["line_1"] as? String, "123 Fake St")
-        XCTAssertNil(encodedBillingAddress["line_2"])
-        XCTAssertEqual(encodedBillingAddress["locality"] as? String, "Utopia")
-        XCTAssertEqual(encodedBillingAddress["administrative_area"] as? String, "CA")
-        XCTAssertEqual(encodedBillingAddress["postal_code"] as? String, "90210")
-        XCTAssertEqual(encodedBillingAddress["country_code"] as? String, "US")
+        XCTAssertEqual(encodedBillingAddress?["name"] as? String, "Bobby Tables")
+        XCTAssertEqual(encodedBillingAddress?["line_1"] as? String, "123 Fake St")
+        XCTAssertNil(encodedBillingAddress?["line_2"])
+        XCTAssertEqual(encodedBillingAddress?["locality"] as? String, "Utopia")
+        XCTAssertEqual(encodedBillingAddress?["administrative_area"] as? String, "CA")
+        XCTAssertEqual(encodedBillingAddress?["postal_code"] as? String, "90210")
+        XCTAssertEqual(encodedBillingAddress?["country_code"] as? String, "US")
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -231,7 +231,13 @@ extension PaymentMethodFormViewController {
             countryCode: instantDebitsFormElement?.phoneElement?.selectedCountryCode
         )
         let linkMode = elementsSession.linkSettings?.linkMode
-        let billingDetails = instantDebitsFormElement?.billingDetails
+        let billingDetails: ElementsSessionContext.BillingDetails? = {
+            // Only attach billing details to bank payment if the feature flag is enabled.
+            guard UserDefaults.standard.bool(forKey: "FINANCIAL_CONNECTIONS_ATTACH_BILLING_DETAILS_TO_BANK_PAYMENT") else {
+                return nil
+            }
+            return instantDebitsFormElement?.billingDetails
+        }()
 
         return ElementsSessionContext(
             amount: intent.amount,


### PR DESCRIPTION
## Summary

We want to hold off on attaching billing details to instant bank payments until the work has been properly bug bashed. This guards that logic behind a toggle in the PaymentSheet Example app `Attach to bank payment`.

## Motivation

Hold of on GA'ing billing details changes

## Testing

https://github.com/user-attachments/assets/aed13bd5-b46d-45ab-be38-9c77e84965c9

## Changelog

N/a