### PR TITLE
Fix `LinkPaymentControllerUITest`, add tests for native & web flow

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -19,7 +19,8 @@ class CustomerSheetUITest: XCTestCase {
 
         app = XCUIApplication()
         app.launchEnvironment = ["UITesting": "true",
-                                 "USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK": "true",
+                                 "FinancialConnectionsSDKAvailable": "true",
+                                 "FinancialConnectionsStubbedResult": "false",
         ]
         app.launch()
     }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
@@ -120,42 +120,12 @@ class LinkPaymentControllerUITest: XCTestCase {
         wait(for: [paymentMethodButtonEnabledExpectation], timeout: 60, enforceOrder: true)
         paymentMethodButton.tap()
 
-        // "Consent" pane
-        app.buttons["Agree and continue"].waitForExistenceAndTap(timeout: timeout)
+        PaymentSheetUITestCase.stepThroughNativeInstantDebitsFlow(app: app, emailPrefilled: false)
 
-        // "Sign Up" pane
-        app.textFields
-            .matching(NSPredicate(format: "label CONTAINS 'Email address'"))
-            .firstMatch
-            .waitForExistenceAndTap(timeout: 10)
-        let email = "linkpaymentcontrolleruitest-\(UUID().uuidString)@example.com"
-        app.typeText(email + XCUIKeyboardKey.return.rawValue)
-        app.textFields["Phone number"].tap()
-        // the `XCUIKeyboardKey.return.rawValue` will automatically
-        // press the "Continue with Link" button to proceed to next
-        // screen
-        app.typeText("4015006000" + XCUIKeyboardKey.return.rawValue)
-
-        app.buttons["link_login.primary_button"].waitForExistenceAndTap(timeout: timeout)
-
-        // "Institution picker" pane
-        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Payment Success"]
-        XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
-        featuredLegacyTestInstitution.tap()
-
-        let accountPickerLinkAccountsButton = app.buttons["connect_accounts_button"]
-        XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "Failed to open Account Picker pane - \(#function) waiting failed")  // wait for accounts to fetch
-        XCTAssert(accountPickerLinkAccountsButton.isEnabled, "no account selected")
-        accountPickerLinkAccountsButton.tap()
-
-        // "Success" pane
-        app.buttons["success_done_button"].waitForExistenceAndTap(timeout: timeout)
+        sleep(3) // wait for modal to disappear before pressing Buy
 
         // Back to "LinkPaymentController"
-        let linkPaymentBuyButton = app.buttons["LinkPaymentBuyButton"]
-        XCTAssertTrue(linkPaymentBuyButton.waitForExistence(timeout: timeout))
-        linkPaymentBuyButton.tap()
-
+        app.buttons["Buy"].waitForExistenceAndTap(timeout: timeout)
         XCTAssert(app.alerts.staticTexts["Your order is confirmed!"].waitForExistence(timeout: timeout))
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
@@ -19,82 +19,143 @@ class LinkPaymentControllerUITest: XCTestCase {
         app = XCUIApplication()
         app.launchEnvironment = ["UITesting": "true"]
     }
-//
-//    func testInstantDebitsOnlyLinkPaymentController() {
-//        app.launch()
-//
-//        // PaymentSheet Example
-//        app.staticTexts["LinkPaymentController"].tap()
-//
-//        // LinkPaymentController
-//        let paymentMethodButton = app.buttons["SelectPaymentMethodButton"]
-//        let paymentMethodButtonEnabledExpectation = expectation(
-//            for: NSPredicate(format: "enabled == true"),
-//            evaluatedWith: paymentMethodButton
-//        )
-//        wait(for: [paymentMethodButtonEnabledExpectation], timeout: 60, enforceOrder: true)
-//        paymentMethodButton.tap()
-//
-//        // "Consent" pane
-//        app.buttons["Agree and continue"].waitForExistenceAndTap(timeout: timeout)
-//
-//        // "Sign Up" pane
-//        app.textFields
-//            .matching(NSPredicate(format: "label CONTAINS 'Email address'"))
-//            .firstMatch
-//            .waitForExistenceAndTap(timeout: 10)
-//        let email = "linkpaymentcontrolleruitest-\(UUID().uuidString)@example.com"
-//        app.typeText(email + XCUIKeyboardKey.return.rawValue)
-//        app.textFields["Phone number"].tap()
-//        // the `XCUIKeyboardKey.return.rawValue` will automatically
-//        // press the "Continue with Link" button to proceed to next
-//        // screen
-//        app.typeText("4015006000" + XCUIKeyboardKey.return.rawValue)
-//
-//        // "Institution Picker" pane
-//        let searchTextField = app.textFields
-//            .matching(NSPredicate(format: "label CONTAINS 'Search'"))
-//            .firstMatch
-//        searchTextField.waitForExistenceAndTap(timeout: 10)
-//        app.typeText("Test Institution" + XCUIKeyboardKey.return.rawValue)
-//        searchTextField
-//            .coordinate(
-//                withNormalizedOffset: CGVector(
-//                    dx: 0.5,
-//                    // bottom of search text field
-//                    dy: 1.0
-//                )
-//            )
-//        // at this point, we searched "Test Institution"
-//        // and the only search result is "Test Institution,"
-//        // so here we guess that 80 pixels below search bar
-//        // there will be a "Test Institution"
-//        //
-//        // we do this "guess" because every other method of
-//        // selecting the institution did not work on iOS 17
-//            .withOffset(CGVector(dx: 0, dy: 80))
-//            .tap()
-//
-//        // "Account Picker" pane
-//        _ = app.staticTexts["Select account"].waitForExistence(timeout: 10)
-//        app.buttons["Connect account"].tap()
-//
-//        // "Success" pane
-//        XCTAssert(app.staticTexts["Your account was connected."].waitForExistence(timeout: 10))
-//        // XCUITest had problems tapping the Done button in success pane,
-//        // so here we tap the Done button by estimating coordinates
-//        app.coordinate(
-//            // this locates the middle of the bottom of the app
-//            withNormalizedOffset: CGVector(dx: 0.5, dy: 1.0)
-//        )
-//        // we then navigate from the bottom to the "Done" button
-//            .withOffset(CGVector(dx: 0, dy: -130))
-//            .tap()
-//
-//        sleep(3) // wait for modal to disappear before pressing Buy
-//
-//        // Back to "LinkPaymentController"
-//        app.buttons["Buy"].waitForExistenceAndTap(timeout: timeout)
-//        XCTAssert(app.alerts.staticTexts["Your order is confirmed!"].waitForExistence(timeout: timeout))
-//    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        app.launchEnvironment = [:]
+    }
+
+    func testWebInstantDebitsOnlyLinkPaymentController() {
+        app.launchEnvironment["FinancialConnectionsSDKAvailable"] = "false"
+        app.launch()
+
+        // PaymentSheet Example
+        app.staticTexts["LinkPaymentController"].tap()
+
+        // LinkPaymentController
+        let paymentMethodButton = app.buttons["SelectPaymentMethodButton"]
+        let paymentMethodButtonEnabledExpectation = expectation(
+            for: NSPredicate(format: "enabled == true"),
+            evaluatedWith: paymentMethodButton
+        )
+        wait(for: [paymentMethodButtonEnabledExpectation], timeout: 60, enforceOrder: true)
+        paymentMethodButton.tap()
+
+        // "Consent" pane
+        app.buttons["Agree and continue"].waitForExistenceAndTap(timeout: timeout)
+
+        // "Sign Up" pane
+        app.textFields
+            .matching(NSPredicate(format: "label CONTAINS 'Email address'"))
+            .firstMatch
+            .waitForExistenceAndTap(timeout: 10)
+        let email = "linkpaymentcontrolleruitest-\(UUID().uuidString)@example.com"
+        app.typeText(email + XCUIKeyboardKey.return.rawValue)
+        app.textFields["Phone number"].tap()
+        // the `XCUIKeyboardKey.return.rawValue` will automatically
+        // press the "Continue with Link" button to proceed to next
+        // screen
+        app.typeText("4015006000" + XCUIKeyboardKey.return.rawValue)
+
+        // "Institution Picker" pane
+        let searchTextField = app.textFields
+            .matching(NSPredicate(format: "label CONTAINS 'Search'"))
+            .firstMatch
+        searchTextField.waitForExistenceAndTap(timeout: 10)
+        app.typeText("Test Institution" + XCUIKeyboardKey.return.rawValue)
+        searchTextField
+            .coordinate(
+                withNormalizedOffset: CGVector(
+                    dx: 0.5,
+                    // bottom of search text field
+                    dy: 1.0
+                )
+            )
+        // at this point, we searched "Test Institution"
+        // and the only search result is "Test Institution,"
+        // so here we guess that 80 pixels below search bar
+        // there will be a "Test Institution"
+        //
+        // we do this "guess" because every other method of
+        // selecting the institution did not work on iOS 17
+            .withOffset(CGVector(dx: 0, dy: 80))
+            .tap()
+
+        // "Account Picker" pane
+        _ = app.staticTexts["Select account"].waitForExistence(timeout: 10)
+        app.buttons["Connect account"].tap()
+
+        // "Success" pane
+        XCTAssert(app.staticTexts["Your account was connected."].waitForExistence(timeout: 10))
+        // XCUITest had problems tapping the Done button in success pane,
+        // so here we tap the Done button by estimating coordinates
+        app.coordinate(
+            // this locates the middle of the bottom of the app
+            withNormalizedOffset: CGVector(dx: 0.5, dy: 1.0)
+        )
+        // we then navigate from the bottom to the "Done" button
+        .withOffset(CGVector(dx: 0, dy: -130))
+        .tap()
+
+        sleep(3) // wait for modal to disappear before pressing Buy
+
+        // Back to "LinkPaymentController"
+        app.buttons["Buy"].waitForExistenceAndTap(timeout: timeout)
+        XCTAssert(app.alerts.staticTexts["Your order is confirmed!"].waitForExistence(timeout: timeout))
+    }
+
+    func testNativeInstantDebitsOnlyLinkPaymentController() {
+        app.launchEnvironment["FinancialConnectionsSDKAvailable"] = "true"
+        app.launch()
+
+        // PaymentSheet Example
+        app.staticTexts["LinkPaymentController"].tap()
+
+        // LinkPaymentController
+        let paymentMethodButton = app.buttons["SelectPaymentMethodButton"]
+        let paymentMethodButtonEnabledExpectation = expectation(
+            for: NSPredicate(format: "enabled == true"),
+            evaluatedWith: paymentMethodButton
+        )
+        wait(for: [paymentMethodButtonEnabledExpectation], timeout: 60, enforceOrder: true)
+        paymentMethodButton.tap()
+
+        // "Consent" pane
+        app.buttons["Agree and continue"].waitForExistenceAndTap(timeout: timeout)
+
+        // "Sign Up" pane
+        app.textFields
+            .matching(NSPredicate(format: "label CONTAINS 'Email address'"))
+            .firstMatch
+            .waitForExistenceAndTap(timeout: 10)
+        let email = "linkpaymentcontrolleruitest-\(UUID().uuidString)@example.com"
+        app.typeText(email + XCUIKeyboardKey.return.rawValue)
+        app.textFields["Phone number"].tap()
+        // the `XCUIKeyboardKey.return.rawValue` will automatically
+        // press the "Continue with Link" button to proceed to next
+        // screen
+        app.typeText("4015006000" + XCUIKeyboardKey.return.rawValue)
+
+        app.buttons["link_login.primary_button"].waitForExistenceAndTap(timeout: timeout)
+
+        // "Institution picker" pane
+        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Payment Success"]
+        XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
+        featuredLegacyTestInstitution.tap()
+
+        let accountPickerLinkAccountsButton = app.buttons["connect_accounts_button"]
+        XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "Failed to open Account Picker pane - \(#function) waiting failed")  // wait for accounts to fetch
+        XCTAssert(accountPickerLinkAccountsButton.isEnabled, "no account selected")
+        accountPickerLinkAccountsButton.tap()
+
+        // "Success" pane
+        app.buttons["success_done_button"].waitForExistenceAndTap(timeout: timeout)
+
+        // Back to "LinkPaymentController"
+        let linkPaymentBuyButton = app.buttons["LinkPaymentBuyButton"]
+        XCTAssertTrue(linkPaymentBuyButton.waitForExistence(timeout: timeout))
+        linkPaymentBuyButton.tap()
+
+        XCTAssert(app.alerts.staticTexts["Your order is confirmed!"].waitForExistence(timeout: timeout))
+    }
 }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
@@ -385,7 +385,10 @@ class PaymentSheetStandardLPMUITwoTests: PaymentSheetStandardLPMUICase {
     }
 
     func testUSBankAccountPaymentMethod() throws {
-        app.launchEnvironment = app.launchEnvironment.merging(["USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK": "false"]) { (_, new) in new }
+        app.launchEnvironment = app.launchEnvironment.merging([
+            "FinancialConnectionsSDKAvailable": "true",
+            "FinancialConnectionsStubbedResult": "true",
+        ]) { (_, new) in new }
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
         settings.apmsEnabled = .off

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -36,8 +36,9 @@ class PaymentSheetUITestCase: XCTestCase {
         app = XCUIApplication()
         app.launchEnvironment = [
             "UITesting": "true",
-            // This makes the Financial Connections SDK trigger the (testmode) production flow instead of a stub. See FinancialConnectionsSDKAvailability.isUnitTestOrUITest.
-            "USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK": "true",
+            // This makes the Financial Connections SDK trigger the (testmode) production flow instead of a stub. See `FinancialConnectionsSDKAvailability`.
+            "FinancialConnectionsSDKAvailable": "true",
+            "FinancialConnectionsStubbedResult": "false",
         ]
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2508,40 +2508,7 @@ extension PaymentSheetUITestCase {
         XCTAssertTrue(continueButton.isEnabled)
         continueButton.tap()
 
-        // "Consent" pane
-        app.buttons["Agree and continue"].waitForExistenceAndTap(timeout: 10)
-
-        // "Sign Up" pane. Email will be pre-filled.
-        let phoneTextField = app.textFields["phone_text_field"]
-        XCTAssertTrue(phoneTextField.waitForExistence(timeout: 10.0), "Failed to find phone text field")
-
-        let countryCodeSelector = app.otherElements["phone_country_code_selector"]
-        XCTAssertTrue(countryCodeSelector.waitForExistence(timeout: 10.0), "Failed to find phone text field")
-        countryCodeSelector.tap()
-        app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States (+1)")
-        app.toolbars.buttons["Done"].tap()
-
-        phoneTextField.tap()
-        phoneTextField.typeText("4015006000")
-
-        let linkLoginCtaButton = app.buttons["link_login.primary_button"]
-        XCTAssertTrue(linkLoginCtaButton.waitForExistence(timeout: 10.0))
-        linkLoginCtaButton.tap()
-
-        // "Institution picker" pane
-        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Payment Success"]
-        XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
-        featuredLegacyTestInstitution.tap()
-
-        let accountPickerLinkAccountsButton = app.buttons["connect_accounts_button"]
-        XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "Failed to open Account Picker pane - \(#function) waiting failed")  // wait for accounts to fetch
-        XCTAssert(accountPickerLinkAccountsButton.isEnabled, "no account selected")
-        accountPickerLinkAccountsButton.tap()
-
-        // "Success" pane
-        let successDoneButton = app.buttons["success_done_button"]
-        XCTAssertTrue(successDoneButton.waitForExistence(timeout: 120.0), "Failed to open Success pane - \(#function) waiting failed")  // wait for accounts to link
-        successDoneButton.tap()
+        Self.stepThroughNativeInstantDebitsFlow(app: app)
 
         // Back to Payment Sheet
         app.buttons[mode == .setup ? "Set up" : "Pay $50.99"].waitForExistenceAndTap(timeout: 10)
@@ -2667,5 +2634,51 @@ extension PaymentSheetUITestCase {
         app.buttons[confirmButtonText].tap()
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+    }
+
+    static func stepThroughNativeInstantDebitsFlow(app: XCUIApplication, emailPrefilled: Bool = true) {
+        // "Consent" pane
+        app.buttons["Agree and continue"].waitForExistenceAndTap(timeout: 10)
+
+        // "Sign Up" pane
+        if !emailPrefilled {
+            app.textFields
+                .matching(NSPredicate(format: "label CONTAINS 'Email address'"))
+                .firstMatch
+                .waitForExistenceAndTap(timeout: 10)
+            let email = "linkpaymentcontrolleruitest-\(UUID().uuidString)@example.com"
+            app.typeText(email + XCUIKeyboardKey.return.rawValue)
+        }
+
+        let phoneTextField = app.textFields["phone_text_field"]
+        XCTAssertTrue(phoneTextField.waitForExistence(timeout: 10.0), "Failed to find phone text field")
+
+        let countryCodeSelector = app.otherElements["phone_country_code_selector"]
+        XCTAssertTrue(countryCodeSelector.waitForExistence(timeout: 10.0), "Failed to find phone text field")
+        countryCodeSelector.tap()
+        app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States (+1)")
+        app.toolbars.buttons["Done"].tap()
+
+        phoneTextField.tap()
+        phoneTextField.typeText("4015006000")
+
+        let linkLoginCtaButton = app.buttons["link_login.primary_button"]
+        XCTAssertTrue(linkLoginCtaButton.waitForExistence(timeout: 10.0))
+        linkLoginCtaButton.tap()
+
+        // "Institution picker" pane
+        let featuredLegacyTestInstitution = app.tables.cells.staticTexts["Payment Success"]
+        XCTAssertTrue(featuredLegacyTestInstitution.waitForExistence(timeout: 60.0))
+        featuredLegacyTestInstitution.tap()
+
+        let accountPickerLinkAccountsButton = app.buttons["connect_accounts_button"]
+        XCTAssertTrue(accountPickerLinkAccountsButton.waitForExistence(timeout: 120.0), "Failed to open Account Picker pane - \(#function) waiting failed")  // wait for accounts to fetch
+        XCTAssert(accountPickerLinkAccountsButton.isEnabled, "no account selected")
+        accountPickerLinkAccountsButton.tap()
+
+        // "Success" pane
+        let successDoneButton = app.buttons["success_done_button"]
+        XCTAssertTrue(successDoneButton.waitForExistence(timeout: 120.0), "Failed to open Success pane - \(#function) waiting failed")  // wait for accounts to link
+        successDoneButton.tap()
     }
 }

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -32,10 +32,6 @@ import UIKit
         #endif
     }()
 
-    static let isUnitOrUITest: Bool = {
-        isUnitTest || isUITest
-    }()
-
     // Return true for unit tests, the value of `FinancialConnectionsSDKAvailable` for UI tests,
     // and whether or not the Financial Connections SDK is available otherwise.
     @_spi(STP) public static var isFinancialConnectionsSDKAvailable: Bool {
@@ -51,7 +47,7 @@ import UIKit
 
     static func financialConnections() -> FinancialConnectionsSDKInterface? {
         let financialConnectionsStubbedResult = ProcessInfo.processInfo.environment["FinancialConnectionsStubbedResult"] == "true"
-        if isUnitOrUITest, financialConnectionsStubbedResult {
+        if isUnitTest || (isUITest && financialConnectionsStubbedResult) {
             return StubbedConnectionsSDKInterface()
         }
 

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -26,9 +26,10 @@ import UIKit
     }()
 
     @_spi(STP) public static var isFinancialConnectionsSDKAvailable: Bool {
-        // return true for tests
+        // return true for tests, unless overridden by `FinancialConnectionsSDKAvailable`.
         if isUnitOrUITest {
-            return true
+            let financialConnectionsSDKAvailable = ProcessInfo.processInfo.environment["FinancialConnectionsSDKAvailable"] == "true"
+            return financialConnectionsSDKAvailable
         }
         return FinancialConnectionsSDKClass != nil
     }

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -16,21 +16,37 @@ import UIKit
         NSClassFromString("StripeFinancialConnections.FinancialConnectionsSDKImplementation")
         as? FinancialConnectionsSDKInterface.Type
 
-    static let isUnitOrUITest: Bool = {
+    static let isUnitTest: Bool = {
         #if targetEnvironment(simulator)
-        return NSClassFromString("XCTest") != nil || ProcessInfo.processInfo.environment["UITesting"] != nil
+        return NSClassFromString("XCTest") != nil
         #else
             return false
         #endif
     }()
 
+    static let isUITest: Bool = {
+        #if targetEnvironment(simulator)
+        return ProcessInfo.processInfo.environment["UITesting"] != nil
+        #else
+            return false
+        #endif
+    }()
+
+    static let isUnitOrUITest: Bool = {
+        isUnitTest || isUITest
+    }()
+
+    // Return true for unit tests, the value of `FinancialConnectionsSDKAvailable` for UI tests,
+    // and whether or not the Financial Connections SDK is available otherwise.
     @_spi(STP) public static var isFinancialConnectionsSDKAvailable: Bool {
-        // return true for tests, unless overridden by `FinancialConnectionsSDKAvailable`.
-        if isUnitOrUITest {
+        if isUnitTest {
+            return true
+        } else if isUITest {
             let financialConnectionsSDKAvailable = ProcessInfo.processInfo.environment["FinancialConnectionsSDKAvailable"] == "true"
             return financialConnectionsSDKAvailable
+        } else {
+            return FinancialConnectionsSDKClass != nil
         }
-        return FinancialConnectionsSDKClass != nil
     }
 
     static func financialConnections() -> FinancialConnectionsSDKInterface? {

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -18,27 +18,24 @@ import UIKit
 
     static let isUnitOrUITest: Bool = {
         #if targetEnvironment(simulator)
-        let useProductionSDK = ProcessInfo.processInfo.environment["USE_PRODUCTION_FINANCIAL_CONNECTIONS_SDK"] == "true"
-        return !useProductionSDK && (NSClassFromString("XCTest") != nil || ProcessInfo.processInfo.environment["UITesting"] != nil)
+        return NSClassFromString("XCTest") != nil || ProcessInfo.processInfo.environment["UITesting"] != nil
         #else
             return false
         #endif
     }()
 
-    static let financialConnectionsSDKAvailableOverride: Bool = {
-        ProcessInfo.processInfo.environment["FinancialConnectionsSDKAvailable"] == "true"
-    }()
-
     @_spi(STP) public static var isFinancialConnectionsSDKAvailable: Bool {
         // return true for tests, unless overridden by `FinancialConnectionsSDKAvailable`.
         if isUnitOrUITest {
-            return financialConnectionsSDKAvailableOverride
+            let financialConnectionsSDKAvailable = ProcessInfo.processInfo.environment["FinancialConnectionsSDKAvailable"] == "true"
+            return financialConnectionsSDKAvailable
         }
         return FinancialConnectionsSDKClass != nil
     }
 
     static func financialConnections() -> FinancialConnectionsSDKInterface? {
-        if isUnitOrUITest, !financialConnectionsSDKAvailableOverride {
+        let financialConnectionsStubbedResult = ProcessInfo.processInfo.environment["FinancialConnectionsStubbedResult"] == "true"
+        if isUnitOrUITest, financialConnectionsStubbedResult {
             return StubbedConnectionsSDKInterface()
         }
 

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -25,17 +25,20 @@ import UIKit
         #endif
     }()
 
+    static let financialConnectionsSDKAvailableOverride: Bool = {
+        ProcessInfo.processInfo.environment["FinancialConnectionsSDKAvailable"] == "true"
+    }()
+
     @_spi(STP) public static var isFinancialConnectionsSDKAvailable: Bool {
         // return true for tests, unless overridden by `FinancialConnectionsSDKAvailable`.
         if isUnitOrUITest {
-            let financialConnectionsSDKAvailable = ProcessInfo.processInfo.environment["FinancialConnectionsSDKAvailable"] == "true"
-            return financialConnectionsSDKAvailable
+            return financialConnectionsSDKAvailableOverride
         }
         return FinancialConnectionsSDKClass != nil
     }
 
     static func financialConnections() -> FinancialConnectionsSDKInterface? {
-        if isUnitOrUITest {
+        if isUnitOrUITest, !financialConnectionsSDKAvailableOverride {
             return StubbedConnectionsSDKInterface()
         }
 


### PR DESCRIPTION
## Summary

This fixes the recently disabled `LinkPaymentControllerUITest`, which were failing since we switched to using the native instant debits flow. It now has a test for the web flow, and a test for the native flow.

## Motivation

Restores a disabled test

## Testing

✅

## Changelog

N/a