### PR TITLE
Fix bug in vertical saved PMs list where tapping outside the screen d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * [Fixed] Fixed an issue with FlowController in vertical layout where the payment method could incorrectly be preserved across a call to `update` when it's no longer valid.
 * [Fixed] Fixed a potential deadlock when `paymentOption` is accessed from Swift concurrency.
 * [Fixed] Fixed deferred intent validation to handle cloned payment methods ([#4195](https://github.com/stripe/stripe-ios/issues/4195)
-* [Fixed] Fixed an issue with the vertical list of saved payment methods where tapping outside the screen would drop any changes that were made (e.g. removal or update of PMs).
+* [Fixed] Fixed an issue with the vertical list with 3 or more saved payment methods where tapping outside the screen sometimes drops changes that were made (e.g. removal or update of PMs).
 
 ## 23.32.0 2024-10-21
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,11 @@
 ## 24.0.0 2024-11-04
 ### PaymentSheet
 * [Changed] The default value of `PaymentSheet.Configuration.paymentMethodLayout` has changed from `.horizontal` to `.automatic`. See [MIGRATING.md](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md) for more details.
-
-## X.X.X
-### PaymentSheet
 * [Fixed] Fixed an animation glitch when dismissing PaymentSheet in React Native.
 * [Fixed] Fixed an issue with FlowController in vertical layout where the payment method could incorrectly be preserved across a call to `update` when it's no longer valid.
 * [Fixed] Fixed a potential deadlock when `paymentOption` is accessed from Swift concurrency.
 * [Fixed] Fixed deferred intent validation to handle cloned payment methods ([#4195](https://github.com/stripe/stripe-ios/issues/4195)
+* [Fixed] Fixed an issue with the vertical list of saved payment methods where tapping outside the screen would drop any changes that were made (e.g. removal or update of PMs).
 
 ## 23.32.0 2024-10-21
 ### PaymentSheet

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -337,7 +337,7 @@ class PlaygroundController: ObservableObject {
         case .new:
             return customerId ?? "new"
         case .returning:
-            return "returning"
+            return customerId ?? "returning"
         }
     }
 

--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -363,7 +363,6 @@
 		416E9ED02C77F6C100A0B917 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				E6EF91C62CBA3BE60082DD1B /* UIViewController+StripeConnect.swift */,
 				416E9ED32C77F90600A0B917 /* WKScriptMessage+extension.swift */,
 				E6D3C8EF2CBE1455003CE967 /* HTTPURLResponse+StripeConnect.swift */,
 				41542A682C88B6F2004E728E /* JSONEncoder+extension.swift */,

--- a/StripeConnect/StripeConnect.xcodeproj/xcshareddata/xcschemes/StripeConnect.xcscheme
+++ b/StripeConnect/StripeConnect.xcodeproj/xcshareddata/xcschemes/StripeConnect.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1540"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -194,8 +194,12 @@ extension EmbeddedPaymentElement: VerticalSavedPaymentMethodsViewControllerDeleg
         let accessoryType = getAccessoryButton(
             savedPaymentMethods: latestPaymentMethods
         )
+
+        // If there are still saved payment methods & the saved payment method was previously selected to presenting
+        // the list of saved payment methods, then the embedded view should continue to show it is selected, otherwise unselected.
+        let isSelected: Bool = latestPaymentMethods.count > 0 && embeddedPaymentMethodsView.selection?.isSaved ?? false
         embeddedPaymentMethodsView.updateSavedPaymentMethodRow(savedPaymentMethods.first,
-                                                               isSelected: selectedPaymentMethod != nil,
+                                                               isSelected: isSelected,
                                                                accessoryType: accessoryType)
         presentingViewController?.dismiss(animated: true)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -184,18 +184,19 @@ extension EmbeddedPaymentElement: UpdateCardViewControllerDelegate {
 }
 
 extension EmbeddedPaymentElement: VerticalSavedPaymentMethodsViewControllerDelegate {
-    func didComplete(viewController: VerticalSavedPaymentMethodsViewController,
-                     with selectedPaymentMethod: StripePayments.STPPaymentMethod?,
-                     latestPaymentMethods: [StripePayments.STPPaymentMethod]) {
+    func didComplete(
+        viewController: VerticalSavedPaymentMethodsViewController,
+        with selectedPaymentMethod: STPPaymentMethod?,
+        latestPaymentMethods: [STPPaymentMethod],
+        didTapToDismiss: Bool
+    ) {
         self.savedPaymentMethods = latestPaymentMethods
-        let accessoryType = getAccessoryButton(savedPaymentMethods: latestPaymentMethods)
+        let accessoryType = getAccessoryButton(
+            savedPaymentMethods: latestPaymentMethods
+        )
         embeddedPaymentMethodsView.updateSavedPaymentMethodRow(savedPaymentMethods.first,
                                                                isSelected: selectedPaymentMethod != nil,
                                                                accessoryType: accessoryType)
-        presentingViewController?.dismiss(animated: true)
-    }
-
-    func shouldClose() {
         presentingViewController?.dismiss(animated: true)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -228,7 +228,7 @@ class EmbeddedPaymentMethodsView: UIView {
             }
             // Remove old button & insert new button
             stackView.removeArrangedSubview(previousSavedPaymentMethodButton, animated: false)
-            self.stackView.insertArrangedSubview(updatedSavedPaymentMethodButton, at: viewIndex)
+            stackView.insertArrangedSubview(updatedSavedPaymentMethodButton, at: viewIndex)
 
             // Update instance states
             self.savedPaymentMethodButton = updatedSavedPaymentMethodButton
@@ -238,12 +238,19 @@ class EmbeddedPaymentMethodsView: UIView {
             stackView.removeArrangedSubview(at: separatorIndex, animated: false)
             stackView.removeArrangedSubview(previousSavedPaymentMethodButton, animated: false)
 
-            if case .saved = selection {
+            if selection?.isSaved ?? false {
                 selection = nil
             }
 
             // Update instance states
             self.savedPaymentMethodButton = nil
+        }
+
+        // If there is nothing selected, then update the selection to nil
+        let allRows = stackView.arrangedSubviews.compactMap({ $0 as? RowButton })
+        let allSelectedRows = allRows.filter({ !$0.isHidden && $0.isSelected })
+        if allSelectedRows.first == nil {
+            selection = nil
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -16,15 +16,16 @@ protocol VerticalSavedPaymentMethodsViewControllerDelegate: AnyObject {
     /// Handles the selection of a payment method from the list or the modification of the list such as the removal or update of payment methods.
     ///
     /// - Parameters:
-    ///    - viewController: The `VerticalSavedPaymentMethodsViewController` that completed it's selection
+    ///    - viewController: The `VerticalSavedPaymentMethodsViewController` that completed its selection
     ///    - selectedPaymentMethod: The selected method of payment, if any.
     ///    - latestPaymentMethods: The most recent up-to-date list of payment methods, with the selected (if any) payment method at the front of the list.
-    func didComplete(viewController: VerticalSavedPaymentMethodsViewController,
-                     with selectedPaymentMethod: STPPaymentMethod?,
-                     latestPaymentMethods: [STPPaymentMethod])
-
-    /// Notifies the delegate it should close the entire sheet it is presented in
-    func shouldClose()
+    ///    - didTapToDismiss: Whether or not the customer tapped outside the sheet to dismiss it.
+    func didComplete(
+        viewController: VerticalSavedPaymentMethodsViewController,
+        with selectedPaymentMethod: STPPaymentMethod?,
+        latestPaymentMethods: [STPPaymentMethod],
+        didTapToDismiss: Bool
+    )
 }
 
 /// A view controller that shows a list of saved payment methods in a vertical orientation
@@ -57,7 +58,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
                 // If we are exiting edit mode and there is only one payment method left which can't be removed, select it and dismiss
                 if paymentMethodRows.count == 1, let firstButton = paymentMethodRows.first {
                     firstButton.state = .selected
-                    completeSelection(afterDelay: 0.3)
+                    complete(afterDelay: 0.3)
                 }
             }
         }
@@ -230,20 +231,26 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         paymentMethodRows.removeAll { $0.paymentMethod.stripeId == paymentMethod.stripeId }
         stackView.removeArrangedSubview(button, animated: true)
 
+        // Select the next payment method if nothing is selected anymore
+        // Note: this isn't necessarily the desired behavior, but the next payment method *will* be selected if you cancel out of the sheet at this point, so it's better to be consistent until we change that.
+        if selectedPaymentMethod == nil {
+            paymentMethodRows.first?.state = .selected
+        }
+
         // Update the editing state if needed
         isEditingPaymentMethods = canEdit
 
         // If we deleted the last payment method kick back out to the main screen
         if paymentMethodRows.isEmpty {
-            completeSelection()
+            complete()
         }
     }
 
-    private func completeSelection(afterDelay: TimeInterval = 0.0) {
+    private func complete(didTapToDismiss: Bool = false, afterDelay: TimeInterval = 0.0) {
         // Note this dispatch async gives a brief delay, even when `afterDelay` is 0
         DispatchQueue.main.asyncAfter(deadline: .now() + afterDelay) { [weak self] in
             guard let self = self else { return }
-            // Edge-case: Dismiss `UpdateViewController` if presented, this can occur if `completeSelection` is called before `UpdateViewController` is popped when we remove the last payment method via the `UpdateViewController`
+            // Edge-case: Dismiss `UpdateViewController` if presented, this can occur if `complete` is called before `UpdateViewController` is popped when we remove the last payment method via the `UpdateViewController`
             _ = self.updateViewController?.bottomSheetController?.popContentViewController()
 
             var latestPaymentMethods = self.paymentMethods
@@ -252,7 +259,12 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
                 latestPaymentMethods.remove(selectedPaymentMethod)
                 latestPaymentMethods.insert(selectedPaymentMethod, at: 0)
             }
-            self.delegate?.didComplete(viewController: self, with: self.selectedPaymentMethod, latestPaymentMethods: latestPaymentMethods)
+            self.delegate?.didComplete(
+                viewController: self,
+                with: self.selectedPaymentMethod,
+                latestPaymentMethods: latestPaymentMethods,
+                didTapToDismiss: didTapToDismiss
+            )
         }
     }
 }
@@ -264,7 +276,7 @@ extension VerticalSavedPaymentMethodsViewController: BottomSheetContentViewContr
     }
 
     func didTapOrSwipeToDismiss() {
-        delegate?.shouldClose()
+        complete(didTapToDismiss: true)
     }
 
     var requiresFullScreen: Bool {
@@ -277,14 +289,14 @@ extension VerticalSavedPaymentMethodsViewController: SheetNavigationBarDelegate 
     func sheetNavigationBarDidClose(_ sheetNavigationBar: SheetNavigationBar) {
         // 'back' closed used in:
         //  Embedded
-        completeSelection()
+        complete()
     }
 
     func sheetNavigationBarDidBack(_ sheetNavigationBar: SheetNavigationBar) {
         // 'back' style used in:
         //  PS.Complete & Vertical
         //  PS.FC & Vertical
-        completeSelection()
+        complete()
     }
 }
 
@@ -306,7 +318,7 @@ extension VerticalSavedPaymentMethodsViewController: SavedPaymentMethodRowButton
         self.view.isUserInteractionEnabled = false
         self.navigationBar.isUserInteractionEnabled = false
 
-        self.completeSelection()
+        self.complete()
     }
 
     func didSelectRemoveButton(_ button: SavedPaymentMethodRowButton, with paymentMethod: STPPaymentMethod) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -231,7 +231,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         paymentMethodRows.removeAll { $0.paymentMethod.stripeId == paymentMethod.stripeId }
         stackView.removeArrangedSubview(button, animated: true)
 
-        // Select the next payment method if nothing is selected anymore
+        // Select the first payment method if nothing is selected anymore
         // Note: this isn't necessarily the desired behavior, but the next payment method *will* be selected if you cancel out of the sheet at this point, so it's better to be consistent until we change that.
         if selectedPaymentMethod == nil {
             paymentMethodRows.first?.state = .selected

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -616,9 +616,12 @@ extension PaymentSheetVerticalViewController: BottomSheetContentViewController {
 // MARK: - VerticalSavedPaymentMethodsViewControllerDelegate
 
 extension PaymentSheetVerticalViewController: VerticalSavedPaymentMethodsViewControllerDelegate {
-    func didComplete(viewController: VerticalSavedPaymentMethodsViewController,
-                     with selectedPaymentMethod: STPPaymentMethod?,
-                     latestPaymentMethods: [STPPaymentMethod]) {
+    func didComplete(
+        viewController: VerticalSavedPaymentMethodsViewController,
+        with selectedPaymentMethod: STPPaymentMethod?,
+        latestPaymentMethods: [STPPaymentMethod],
+        didTapToDismiss: Bool
+    ) {
         // Update our list of saved payment methods to be the latest from the manage screen in case of updates/removals
         self.savedPaymentMethods = latestPaymentMethods
         var selection: VerticalPaymentMethodListSelection?
@@ -627,11 +630,12 @@ extension PaymentSheetVerticalViewController: VerticalSavedPaymentMethodsViewCon
         }
         regenerateUI(updatedListSelection: selection)
 
-        _ = viewController.bottomSheetController?.popContentViewController()
-    }
-
-    func shouldClose() {
-        didTapOrSwipeToDismiss()
+        if didTapToDismiss {
+            // Dismiss the entire sheet
+            didCancel()
+        } else {
+            _ = viewController.bottomSheetController?.popContentViewController()
+        }
     }
 }
 


### PR DESCRIPTION
…rops any changes that were made (e.g. remove/update of PMs)

## Summary
Before:

https://github.com/user-attachments/assets/fc8c8b27-eac9-4df0-b5f7-a07fcc6eefa4

After:

2 cards, deleting the selected card and tapping out:

https://github.com/user-attachments/assets/fe86f4d5-f25b-4c72-9929-2700093b9e92

2 cards, deleting the selected card, hitting Done, then tapping out:

https://github.com/user-attachments/assets/64057d0a-68de-43d4-a304-856733fce202

2 cards, deleting the selected card:

https://github.com/user-attachments/assets/20b873b5-f584-4f90-b74c-b00a9b60204a

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3654

## Testing
Manually tested.  Added to UI test but I don't feel great about test coverage in general here.

## Changelog
See changelog