### PR TITLE
Make UI Tests more stable

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		61FB6BC72C88C8BF00F8E074 /* EmbeddedPlaygroundViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB6BC62C88C8BF00F8E074 /* EmbeddedPlaygroundViewController.swift */; };
 		65D034E37B345C1B64785451 /* StripeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1FD1F5193E4A361EA9E8FED3 /* StripeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6A5CCDA42C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5CCDA32C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift */; };
+		6B03B12F2CDA890700F95A9D /* XCUITest+PaymentSheetTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B03B12E2CDA88F900F95A9D /* XCUITest+PaymentSheetTestUtilities.swift */; };
 		75D1997DA514F6DB82FF1CFC /* StripePaymentSheet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 240DDF52B887E788853A838B /* StripePaymentSheet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		79E8C77C99A25E38F96747F1 /* PaymentSheetTestPlaygroundSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1261A6BDCDB7E81D08F137F0 /* PaymentSheetTestPlaygroundSettings.swift */; };
 		7B89F83982B6D43C3B9E8AD5 /* PaymentSheetTestPlaygroundSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FA7F02B5FFA4FEA1218561A /* PaymentSheetTestPlaygroundSettings.swift */; };
@@ -198,6 +199,7 @@
 		63237DF22FD4600B9D2E8071 /* StripeApplePay.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeApplePay.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6891CC1208EA3F4DE934760E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		6A5CCDA32C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPaymentControllerUITest.swift; sourceTree = "<group>"; };
+		6B03B12E2CDA88F900F95A9D /* XCUITest+PaymentSheetTestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUITest+PaymentSheetTestUtilities.swift"; sourceTree = "<group>"; };
 		6CD01636EA3B4C6F84E9CC86 /* PaymentSheetUITest-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "PaymentSheetUITest-Release.xcconfig"; sourceTree = "<group>"; };
 		6E4F3FA49534E745C5EDC1C0 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		701B8DEF9958B8EDB3C6E25B /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/Main.strings; sourceTree = "<group>"; };
@@ -424,6 +426,7 @@
 				B641A4182C2BA25D00AE654A /* PaymentSheetVerticalUITest.swift */,
 				B6DA0FED2CC97F3D00BF41B7 /* EmbeddedUITest.swift */,
 				36BB679CF53EEF943F0BAAC9 /* XCUITest+Utilities.swift */,
+				6B03B12E2CDA88F900F95A9D /* XCUITest+PaymentSheetTestUtilities.swift */,
 				6A5CCDA32C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift */,
 			);
 			path = PaymentSheetUITest;
@@ -667,6 +670,7 @@
 				2CD71F097C7CD0D9BFC7499D /* PaymentSheetTestPlaygroundSettings.swift in Sources */,
 				540F279CE5B41C122AD1DEF6 /* PaymentSheetUITest.swift in Sources */,
 				6A5CCDA42C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift in Sources */,
+				6B03B12F2CDA890700F95A9D /* XCUITest+PaymentSheetTestUtilities.swift in Sources */,
 				EE0FA73AAB80863583C69D70 /* XCUITest+Utilities.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -98,9 +98,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
 
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-
-        XCTAssertTrue(app.buttons["•••• 1001"].waitForExistence(timeout: 3.0))
-        XCTAssertFalse(app.buttons["•••• 4242"].waitForExistence(timeout: 3.0))
+        ensureSPMSelection("•••• 1001", insteadOf: "•••• 4242")
 
         // Switch from 1001 to 4242
         app.buttons["View more"].waitForExistenceAndTap()
@@ -132,9 +130,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
 
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-
-        XCTAssertTrue(app.buttons["••••6789"].waitForExistence(timeout: 3.0))
-        XCTAssertFalse(app.buttons["•••• 4242"].waitForExistence(timeout: 3.0))
+        ensureSPMSelection("••••6789", insteadOf: "•••• 4242")
 
         // Switch from 6789 (Bank account) to 4242
         app.buttons["View more"].waitForExistenceAndTap()
@@ -172,5 +168,22 @@ class EmbeddedUITests: PaymentSheetUITestCase {
 
         let alert = app.alerts[alertTitle]
         alert.buttons[buttonToTap].tap()
+    }
+
+    // Returning customers have two payment methods in a non-deterministic order.
+    // Ensure state of payment method of label1 is selected prior to starting tests.
+    func ensureSPMSelection(_ label1: String, insteadOf label2: String) {
+        if app.buttons[label1].waitForExistence(timeout: 3.0) {
+            XCTAssertFalse(app.buttons[label2].waitForExistence(timeout: 3.0))
+            return
+        }
+        guard app.buttons[label2].waitForExistence(timeout: 3.0) else {
+            XCTFail("Unable to find either \(label1) or \(label2)")
+            return
+        }
+        app.buttons["View more"].waitForExistenceAndTap(timeout: 3.0)
+        app.buttons[label1].waitForExistenceAndTap(timeout: 3.0)
+        XCTAssertTrue(app.buttons[label1].waitForExistence(timeout: 3.0))
+
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+PaymentSheetTestUtilities.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+PaymentSheetTestUtilities.swift
@@ -1,0 +1,74 @@
+//
+//  XCUITest+PaymentSheetTestUtilities.swift
+//  PaymentSheet Example
+//
+
+import XCTest
+
+extension XCTestCase {
+    func reload(_ app: XCUIApplication, settings: PaymentSheetTestPlaygroundSettings) {
+        app.buttons["Reload"].waitForExistenceAndTap(timeout: 10)
+        waitForReload(app, settings: settings)
+    }
+
+    func waitForReload(_ app: XCUIApplication, settings: PaymentSheetTestPlaygroundSettings) {
+        switch settings.uiStyle {
+        case .paymentSheet:
+            let presentButton = app.buttons["Present PaymentSheet"]
+            expectation(
+                for: NSPredicate(format: "enabled == true"),
+                evaluatedWith: presentButton,
+                handler: nil
+            )
+        case .flowController:
+            let confirm = app.buttons["Confirm"]
+            expectation(
+                for: NSPredicate(format: "enabled == true"),
+                evaluatedWith: confirm,
+                handler: nil
+            )
+        case .embedded:
+            let confirm = app.buttons["Present embedded payment element"]
+            expectation(
+                for: NSPredicate(format: "enabled == true"),
+                evaluatedWith: confirm,
+                handler: nil
+            )
+        }
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    func loadPlayground(_ app: XCUIApplication, _ settings: PaymentSheetTestPlaygroundSettings) {
+        if #available(iOS 15.0, *) {
+            // Doesn't work on 16.4. Seems like a bug, can't see any confirmation that this works online.
+            //   var urlComponents = URLComponents(string: "stripe-paymentsheet-example://playground")!
+            //   urlComponents.query = settings.base64Data
+            //   app.open(urlComponents.url!)
+            // This should work, but we get an "Open in 'PaymentSheet Example'" consent dialog the first time we run it.
+            // And while the dialog is appearing, `open()` doesn't return, so we can't install an interruption handler or anything to handle it.
+            //   XCUIDevice.shared.system.open(urlComponents.url!)
+            app.launchEnvironment = app.launchEnvironment.merging(["STP_PLAYGROUND_DATA": settings.base64Data]) { (_, new) in new }
+            app.launch()
+        } else {
+            XCTFail("This test is only supported on iOS 15.0 or later.")
+        }
+        waitForReload(app, settings: settings)
+    }
+    func waitForReload(_ app: XCUIApplication, settings: CustomerSheetTestPlaygroundSettings) {
+        let paymentMethodButton = app.buttons["Payment method"]
+        expectation(
+            for: NSPredicate(format: "enabled == true"),
+            evaluatedWith: paymentMethodButton,
+            handler: nil
+        )
+        waitForExpectations(timeout: 10, handler: nil)
+    }
+    func loadPlayground(_ app: XCUIApplication, _ settings: CustomerSheetTestPlaygroundSettings) {
+        if #available(iOS 15.0, *) {
+            app.launchEnvironment = app.launchEnvironment.merging(["STP_CUSTOMERSHEET_PLAYGROUND_DATA": settings.base64Data]) { (_, new) in new }
+            app.launch()
+        } else {
+            XCTFail("This test is only supported on iOS 15.0 or later.")
+        }
+        waitForReload(app, settings: settings)
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
@@ -24,6 +24,13 @@ extension XCUIElement {
         }
     }
 
+    func scrollToAndTap(in app: XCUIApplication) {
+        while !self.exists {
+            app.swipeUp()
+        }
+        self.tap()
+    }
+
     func forceTapWhenHittableInTestCase(_ testCase: XCTestCase) {
         let predicate = NSPredicate(format: "hittable == true")
         testCase.expectation(for: predicate, evaluatedWith: self, handler: nil)
@@ -277,71 +284,5 @@ extension XCTestCase {
         let elementExistsPredicate = NSPredicate(format: "count == %d", count)
         expectation(for: elementExistsPredicate, evaluatedWith: target, handler: nil)
         waitForExpectations(timeout: 10.0, handler: nil)
-    }
-
-    func reload(_ app: XCUIApplication, settings: PaymentSheetTestPlaygroundSettings) {
-        app.buttons["Reload"].waitForExistenceAndTap(timeout: 10)
-        waitForReload(app, settings: settings)
-    }
-
-    func waitForReload(_ app: XCUIApplication, settings: PaymentSheetTestPlaygroundSettings) {
-        switch settings.uiStyle {
-        case .paymentSheet:
-            let presentButton = app.buttons["Present PaymentSheet"]
-            expectation(
-                for: NSPredicate(format: "enabled == true"),
-                evaluatedWith: presentButton,
-                handler: nil
-            )
-        case .flowController:
-            let confirm = app.buttons["Confirm"]
-            expectation(
-                for: NSPredicate(format: "enabled == true"),
-                evaluatedWith: confirm,
-                handler: nil
-            )
-        case .embedded:
-            let confirm = app.buttons["Present embedded payment element"]
-            expectation(
-                for: NSPredicate(format: "enabled == true"),
-                evaluatedWith: confirm,
-                handler: nil
-            )
-        }
-        waitForExpectations(timeout: 10, handler: nil)
-    }
-    func loadPlayground(_ app: XCUIApplication, _ settings: PaymentSheetTestPlaygroundSettings) {
-        if #available(iOS 15.0, *) {
-            // Doesn't work on 16.4. Seems like a bug, can't see any confirmation that this works online.
-            //   var urlComponents = URLComponents(string: "stripe-paymentsheet-example://playground")!
-            //   urlComponents.query = settings.base64Data
-            //   app.open(urlComponents.url!)
-            // This should work, but we get an "Open in 'PaymentSheet Example'" consent dialog the first time we run it.
-            // And while the dialog is appearing, `open()` doesn't return, so we can't install an interruption handler or anything to handle it.
-            //   XCUIDevice.shared.system.open(urlComponents.url!)
-            app.launchEnvironment = app.launchEnvironment.merging(["STP_PLAYGROUND_DATA": settings.base64Data]) { (_, new) in new }
-            app.launch()
-        } else {
-            XCTFail("This test is only supported on iOS 15.0 or later.")
-        }
-        waitForReload(app, settings: settings)
-    }
-    func waitForReload(_ app: XCUIApplication, settings: CustomerSheetTestPlaygroundSettings) {
-        let paymentMethodButton = app.buttons["Payment method"]
-        expectation(
-            for: NSPredicate(format: "enabled == true"),
-            evaluatedWith: paymentMethodButton,
-            handler: nil
-        )
-        waitForExpectations(timeout: 10, handler: nil)
-    }
-    func loadPlayground(_ app: XCUIApplication, _ settings: CustomerSheetTestPlaygroundSettings) {
-        if #available(iOS 15.0, *) {
-            app.launchEnvironment = app.launchEnvironment.merging(["STP_CUSTOMERSHEET_PLAYGROUND_DATA": settings.base64Data]) { (_, new) in new }
-            app.launch()
-        } else {
-            XCTFail("This test is only supported on iOS 15.0 or later.")
-        }
-        waitForReload(app, settings: settings)
     }
 }

--- a/Testers/IntegrationTester/IntegrationTester.xcodeproj/project.pbxproj
+++ b/Testers/IntegrationTester/IntegrationTester.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		61DB7CADBEC4D02E824EBCCB /* StripeApplePay.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 071CB368DEE3801C0ECF1755 /* StripeApplePay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6453D2766DC5C04D49617E98 /* Stripe.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CA7414BE30CD6E4778C3982F /* Stripe.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		666B3478C24A96635D50189B /* Stripe.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CA7414BE30CD6E4778C3982F /* Stripe.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6B03B12D2CDA87A900F95A9D /* XCUITest+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B03B12C2CDA87A900F95A9D /* XCUITest+Utilities.swift */; };
 		738352333BC65C77F28CCD6E /* Stripe.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA7414BE30CD6E4778C3982F /* Stripe.framework */; };
 		7D6A6F51B50CB5043BEE3454 /* CardSetupIntentsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F38BCBD16314976A7ABFB7D /* CardSetupIntentsView.swift */; };
 		867577501F923D56CA61E0B7 /* PaymentButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD40F16C3CE95FEA4DC72EE1 /* PaymentButton.swift */; };
@@ -140,6 +141,7 @@
 		5C5DC0E1E38C522B304FEB27 /* IntegrationTester-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "IntegrationTester-Debug.xcconfig"; sourceTree = "<group>"; };
 		5D44356934CDF4E4A102B02C /* PaymentsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsModels.swift; sourceTree = "<group>"; };
 		5F38BCBD16314976A7ABFB7D /* CardSetupIntentsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardSetupIntentsView.swift; sourceTree = "<group>"; };
+		6B03B12C2CDA87A900F95A9D /* XCUITest+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUITest+Utilities.swift"; sourceTree = "<group>"; };
 		6FA9771F3CDF6A69DA0D1FE9 /* ApplePayModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayModel.swift; sourceTree = "<group>"; };
 		7DBEDD99632BE5929ECA574B /* BackendModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackendModel.swift; sourceTree = "<group>"; };
 		813249BFF59CA231C04D1F85 /* CardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
@@ -206,6 +208,7 @@
 			isa = PBXGroup;
 			children = (
 				56DEA9E4BED67D35CD2FA1B9 /* Info.plist */,
+				6B03B12C2CDA87A900F95A9D /* XCUITest+Utilities.swift */,
 				1093AE24530AED2074A1348F /* IntegrationTesterUITests.swift */,
 			);
 			path = IntegrationTesterUITests;
@@ -475,6 +478,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				925B06A1984163D9A1DE2A1E /* IntegrationTesterUITests.swift in Sources */,
+				6B03B12D2CDA87A900F95A9D /* XCUITest+Utilities.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
@@ -217,10 +217,10 @@ class IntegrationTesterUIPMTests: IntegrationTesterUITests {
 
         // Klarna uses ASWebAuthenticationSession, tap continue to allow the web view to open:
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        springboard.buttons["Continue"].tap()
+        springboard.buttons["Continue"].waitForExistenceAndTap(timeout: 3)
 
         // This is where we'd fill out Klarna's forms, but we'll just cancel for now
-        app.buttons["Cancel"].tap()
+        app.buttons["Cancel"].waitForExistenceAndTap(timeout: 3)
 
         let statusView = app.staticTexts["Payment status view"]
         XCTAssertTrue(statusView.waitForExistence(timeout: 10.0))
@@ -403,25 +403,5 @@ class IntegrationTesterUITests: XCTestCase {
         let statusView = app.staticTexts["Payment status view"]
         XCTAssertTrue(statusView.waitForExistence(timeout: 10.0))
         XCTAssertNotNil(statusView.label.range(of: "Payment complete"))
-    }
-}
-
-// There seems to be an issue with our SwiftUI buttons - XCTest fails to scroll to the button's position.
-// Work around this by targeting a coordinate inside the button.
-// https://stackoverflow.com/questions/33422681/xcode-ui-test-ui-testing-failure-failed-to-scroll-to-visible-by-ax-action
-extension XCUIElement {
-    func forceTapElement() {
-        // Tap the middle of the element.
-        // (Sometimes the edges of rounded buttons aren't tappable in certain web elements.)
-        let coordinate: XCUICoordinate = self.coordinate(
-            withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
-        coordinate.tap()
-    }
-
-    func scrollToAndTap(in app: XCUIApplication) {
-        while !self.exists {
-            app.swipeUp()
-        }
-        self.tap()
     }
 }

--- a/Testers/IntegrationTester/IntegrationTesterUITests/XCUITest+Utilities.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/XCUITest+Utilities.swift
@@ -1,0 +1,1 @@
+../../../Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift


### PR DESCRIPTION
## Summary
1. Returning customers in our playground backend results in some nondeterministic behavior.

The change involves creating a new customer and attaching two payment methods (card and us bank account) to that customer. The order of these payment methods is non-deterministic, so UI tests can’t assume that the order of the payment methods.

2. Integration tests also seem to be sporadically failing w/ klarna. Refactored code to take advantage of the XCUIElement extensions by adding a symlink then creating another extension.

## Motivation
Make UI tests more stable

## Testing
Ran tests locally

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
