### PR TITLE
Fix embeddedSettingsView displaying stale values by passing a closure

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -279,6 +279,14 @@ extension View {
     }
 }
 
+struct EmbeddedSettingsView: View {
+    @EnvironmentObject var playgroundController: PlaygroundController
+
+    var body: some View {
+        SettingView(setting: $playgroundController.settings.mode)
+    }
+}
+
 @available(iOS 14.0, *)
 struct PaymentSheetButtons: View {
     @EnvironmentObject var playgroundController: PlaygroundController
@@ -295,7 +303,7 @@ struct PaymentSheetButtons: View {
     // We build the settings view here, rather than in EPVC, so that it can easily update the PI/SI like all other settings and ensure the PI/SI is up to date when it's eventually used at confirm-time
     @ViewBuilder
     var embeddedSettingsView: some View {
-        SettingView(setting: $playgroundController.settings.mode)
+        EmbeddedSettingsView()
     }
 
     var titleAndReloadView: some View {
@@ -400,7 +408,9 @@ struct PaymentSheetButtons: View {
                         HStack {
                             Button {
                                 embeddedIsPresented = true
-                                playgroundController.presentEmbedded(settingsView: embeddedSettingsView)
+                                playgroundController.presentEmbedded(settingsView: {
+                                    embeddedSettingsView.environmentObject(playgroundController)
+                                })
                             } label: {
                                 Text("Present embedded payment element")
                             }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -951,18 +951,16 @@ extension PlaygroundController {
     func makeEmbeddedPaymentElement() {
         embeddedPlaygroundViewController = EmbeddedPlaygroundViewController(
             configuration: embeddedConfiguration,
-            intentConfig: intentConfig
+            intentConfig: intentConfig,
+            playgroundController: self
         )
     }
 
-    func presentEmbedded(settingsView: some View) {
+    func presentEmbedded<SettingsView: View>(settingsView: @escaping () -> SettingsView) {
         guard let embeddedPlaygroundViewController else { return }
 
         // Include settings view
-        let hostingController = UIHostingController(rootView: settingsView)
-        embeddedPlaygroundViewController.addChild(hostingController)
-        hostingController.didMove(toParent: rootViewController)
-        embeddedPlaygroundViewController.setSettingsView(hostingController.view)
+        embeddedPlaygroundViewController.setSettingsView(settingsView)
 
         let closeButton = UIBarButtonItem(barButtonSystemItem: .close, target: self, action: #selector(dismissEmbedded))
         embeddedPlaygroundViewController.navigationItem.leftBarButtonItem = closeButton


### PR DESCRIPTION
## Summary
This PR addresses an issue where embeddedSettingsView in PaymentSheetTestPlayground occasionally shows outdated values because state changes weren't propagating to the embedded SwiftUI view within UIKit. To fix this, we modified the presentEmbedded method to accept a closure that returns a view (@escaping () -> SettingsView) instead of a static view. This change ensures that embeddedSettingsView is re-evaluated whenever it's accessed, allowing it to reflect the latest state updates correctly.

## Motivation
- Embedded

## Testing
-  Manual

## Changelog
N/A
