### PR TITLE
[BANKCON-16076] Prefill email and phone in native ACH flow

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -266,7 +266,7 @@ class CustomerSheetUITest: XCTestCase {
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: timeout) {
-            app.typeText(XCUIKeyboardKey.return.rawValue) // dismiss keyboard
+            app.toolbars.buttons["Done"].tap() // dismiss keyboard
             notNowButton.tap()
         }
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -17,7 +17,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.formSheetAction = .continue
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         // Entering a card w/ deferred PaymentIntent...
         app.buttons["Card"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Add card"].waitForExistence(timeout: 10))
@@ -27,14 +27,14 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Continue"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
-        
+
         // ...and *updating* to a SetupIntent...
         app.buttons.matching(identifier: "Setup").element(boundBy: 1).waitForExistenceAndTap()
         // ...(wait for it to finish updating)...
         XCTAssertTrue(app.buttons["Reload"].waitForExistence(timeout: 10))
         // ...should cause Card to no longer be the selected payment method.
         XCTAssertFalse(app.staticTexts["Payment method"].exists)
-        
+
         // ....Tapping card should show the card form with details preserved
         app.buttons["Card"].waitForExistenceAndTap()
         // ...thus the Continue button should be enabled
@@ -49,7 +49,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         // ...card entered for setup should be preserved after update
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
-        
+
         // ...selecting Alipay w/ deferred PaymentIntent...
         app.buttons["Alipay"].waitForExistenceAndTap()
         XCTAssertEqual(app.staticTexts["Payment method"].label, "Alipay")
@@ -59,12 +59,12 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Reload"].waitForExistence(timeout: 10))
         // ...should cause Alipay to no longer be the selected payment method, since it is not valid for setup.
         XCTAssertFalse(app.staticTexts["Payment method"].exists)
-        
+
         // ...go back into deferred PaymentIntent mode
         app.buttons.matching(identifier: "Payment").element(boundBy: 1).waitForExistenceAndTap()
         // ...(wait for it to finish updating)...
         XCTAssertTrue(app.buttons["Reload"].waitForExistence(timeout: 10))
-        //...selecting Cash App Pay w/ deferred PaymentIntent...
+        // ...selecting Cash App Pay w/ deferred PaymentIntent...
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
         XCTAssertEqual(app.staticTexts["Payment method"].label, "Cash App Pay")
         // ...and *updating* to a SetupIntent...
@@ -73,12 +73,12 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Reload"].waitForExistence(timeout: 10))
         // ...should cause Cash App Pay to be the selected payment method, since it is valid for setup.
         XCTAssertEqual(app.staticTexts["Payment method"].label, "Cash App Pay")
-        
+
         // ...go back into deferred PaymentIntent mode
         app.buttons.matching(identifier: "Payment").element(boundBy: 1).waitForExistenceAndTap()
         // ...(wait for it to finish updating)...
         XCTAssertTrue(app.buttons["Reload"].waitForExistence(timeout: 10))
-        //...selecting Klarna w/ deferred PaymentIntent...
+        // ...selecting Klarna w/ deferred PaymentIntent...
         app.buttons["Klarna"].waitForExistenceAndTap()
         // ...fill out the form for Klarna
         let emailField = app.textFields["Email"]
@@ -101,7 +101,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Reload"].waitForExistence(timeout: 10))
         // ... Klarna should still be selected
         XCTAssertEqual(app.staticTexts["Payment method"].label, "Klarna")
-        
+
         // Confirm the Klarna payment
         XCTAssertTrue(app.buttons["Checkout"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
@@ -187,7 +187,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertFalse(app.images["stp_card_visa"].waitForExistence(timeout: 3))
         XCTAssertFalse(app.images["stp_card_cartes_bancaires"].waitForExistence(timeout: 3))
         XCTAssertTrue(applePayButton.isSelected)
-        
+
         app.buttons["Checkout"].waitForExistenceAndTap()
         payWithApplePay()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
@@ -272,7 +272,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
 
         XCTAssertTrue(app.buttons["•••• 4242"].waitForExistence(timeout: 3.0))
         XCTAssertFalse(app.buttons["•••• 1001"].waitForExistence(timeout: 3.0))
-        
+
         // Finish confirming the payment
         app.buttons["Checkout"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
@@ -384,12 +384,12 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertFalse(card4242Button.waitForExistence(timeout: 3.0))
         XCTAssertTrue(applePayButton.waitForExistence(timeout: 3.0))
         XCTAssertTrue(applePayButton.isSelected)
-        
+
         app.buttons["Checkout"].waitForExistenceAndTap()
         payWithApplePay()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
     }
-    
+
     func testSelection() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.mode = .paymentWithSetup
@@ -398,7 +398,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.formSheetAction = .continue
         settings.customerMode = .new
         loadPlayground(app, settings)
-        
+
         // Start by saving a new card
         app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
         try! fillCardData(app, postalEnabled: true)
@@ -406,32 +406,32 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         // Complete payment
         app.buttons["Pay $50.99"].tap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
-        
+
         // Switch to embedded mode kicks off a reload
         app.buttons["embedded"].waitForExistenceAndTap(timeout: 5)
         app.buttons["Payment"].waitForExistenceAndTap(timeout: 5)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         // Should auto select a saved payment method
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
-        
+
         // Open card and cancel, should reset selection to saved card
         app.buttons["New card"].waitForExistenceAndTap()
         app.buttons["Close"].waitForExistenceAndTap()
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
-        
+
         // Select Cash App Pay
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-        
+
         // Open card and cancel, should reset back to Cash App Pay
         app.buttons["New card"].waitForExistenceAndTap()
         app.buttons["Close"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-        
+
         // Try to fill a card
         app.buttons["New card"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Add new card"].waitForExistence(timeout: 10))
@@ -441,7 +441,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4444")
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-        
+
         // Tapping on card again should present the form filled out
         app.buttons["New card"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Add new card"].waitForExistence(timeout: 10))
@@ -458,12 +458,12 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4444")
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-        
+
         // Select a no-form PM such as Cash App Pay
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-        
+
         // Fill out US Bank Acct.
         app.buttons["US bank account"].waitForExistenceAndTap()
         // Fill out name and email fields
@@ -483,7 +483,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: 10) {
-            app.typeText(XCUIKeyboardKey.return.rawValue) // dismiss keyboard
+            app.toolbars.buttons["Done"].tap() // dismiss keyboard
             notNowButton.tap()
         }
 
@@ -493,7 +493,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "••••6789")
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-        
+
         // Confirm with the saved card
         app.buttons["•••• 4242"].waitForExistenceAndTap()
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
@@ -503,7 +503,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Checkout"].tap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 20))
     }
-    
+
     func testApplePay() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
@@ -513,13 +513,13 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.formSheetAction = .continue
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         app.buttons["Apple Pay"].waitForExistenceAndTap()
         app.buttons["Checkout"].waitForExistenceAndTap()
         payWithApplePay()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
     }
-    
+
     func testLink() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
@@ -529,7 +529,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.formSheetAction = .continue
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         app.buttons["Link"].waitForExistenceAndTap()
         app.buttons["Checkout"].waitForExistenceAndTap()
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2435,7 +2435,7 @@ extension PaymentSheetUITestCase {
 
         let notNowButton = app.buttons["Not now"]
         if notNowButton.waitForExistence(timeout: 10.0) {
-            app.typeText(XCUIKeyboardKey.return.rawValue) // dismiss keyboard
+            app.toolbars.buttons["Done"].tap() // dismiss keyboard
             notNowButton.tap()
         }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1355,7 +1355,8 @@ private func CreatePaneViewController(
             returnURL: dataManager.returnURL,
             apiClient: dataManager.apiClient,
             clientSecret: dataManager.clientSecret,
-            analyticsClient: dataManager.analyticsClient
+            analyticsClient: dataManager.analyticsClient,
+            elementsSessionContext: dataManager.elementsSessionContext
         )
         let networkingLinkSignupViewController = NetworkingLinkSignupViewController(
             dataSource: networkingLinkSignupDataSource

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -10,6 +10,7 @@ import Foundation
 
 protocol NetworkingLinkSignupDataSource: AnyObject {
     var manifest: FinancialConnectionsSessionManifest { get }
+    var elementsSessionContext: ElementsSessionContext? { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
 
     func synchronize() -> Future<FinancialConnectionsNetworkingLinkSignup>
@@ -24,6 +25,7 @@ protocol NetworkingLinkSignupDataSource: AnyObject {
 final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDataSource {
 
     let manifest: FinancialConnectionsSessionManifest
+    let elementsSessionContext: ElementsSessionContext?
     private let selectedAccounts: [FinancialConnectionsPartnerAccount]?
     private let returnURL: String?
     private let apiClient: FinancialConnectionsAPIClient
@@ -36,7 +38,8 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
         returnURL: String?,
         apiClient: FinancialConnectionsAPIClient,
         clientSecret: String,
-        analyticsClient: FinancialConnectionsAnalyticsClient
+        analyticsClient: FinancialConnectionsAnalyticsClient,
+        elementsSessionContext: ElementsSessionContext?
     ) {
         self.manifest = manifest
         self.selectedAccounts = selectedAccounts
@@ -44,6 +47,7 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
+        self.elementsSessionContext = elementsSessionContext
     }
 
     func synchronize() -> Future<FinancialConnectionsNetworkingLinkSignup> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -165,11 +165,17 @@ final class NetworkingLinkSignupViewController: UIViewController {
         paneLayoutView.scrollView.keyboardDismissMode = .onDrag
         #endif
 
-        let emailAddress = dataSource.manifest.accountholderCustomerEmailAddress
+        let emailAddress = dataSource.manifest.accountholderCustomerEmailAddress ?? dataSource.elementsSessionContext?.prefillDetails?.email
         if let emailAddress, !emailAddress.isEmpty {
             formView.prefillEmailAddress(emailAddress)
+
+            let phoneNumber = dataSource.manifest.accountholderPhoneNumber ?? dataSource.elementsSessionContext?.prefillDetails?.formattedPhoneNumber
+            formView.prefillPhoneNumber(phoneNumber)
         } else {
-            formView.beginEditingEmailAddressField()
+            // Slightly delay opening the keyboard to avoid a janky animation.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { [weak self] in
+                self?.formView.beginEditingEmailAddressField()
+            }
         }
 
         assert(self.footerView != nil, "footer view should be initialized as part of displaying content")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/USBankAccountPaymentMethodElement.swift
@@ -30,6 +30,7 @@ final class USBankAccountPaymentMethodElement: ContainerElement {
         }
     }
 
+    let phoneElement: PhoneNumberElement?
     private(set) var mandateString: NSMutableAttributedString?
     private let configuration: PaymentSheetFormFactoryConfig
     private let merchantName: String
@@ -82,10 +83,10 @@ final class USBankAccountPaymentMethodElement: ContainerElement {
     init(
         configuration: PaymentSheetFormFactoryConfig,
         titleElement: StaticElement,
-        nameElement: PaymentMethodElement?,
-        emailElement: PaymentMethodElement?,
-        phoneElement: PaymentMethodElement?,
-        addressElement: PaymentMethodElement?,
+        nameElement: PaymentMethodElementWrapper<TextFieldElement>?,
+        emailElement: PaymentMethodElementWrapper<TextFieldElement>?,
+        phoneElement: PaymentMethodElementWrapper<PhoneNumberElement>?,
+        addressElement: PaymentMethodElementWrapper<AddressSectionElement>?,
         checkboxElement: PaymentMethodElement?,
         savingAccount: BoolReference,
         merchantName: String,
@@ -104,6 +105,8 @@ final class USBankAccountPaymentMethodElement: ContainerElement {
             (collectingName || hasDefaultName) && (collectingEmail || hasDefaultEmail),
             "If name or email are not collected, they must be provided through defaults"
         )
+
+        self.phoneElement = phoneElement?.element
 
         self.configuration = configuration
         self.linkedBank = initialLinkedBank

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -54,7 +54,7 @@ class PaymentMethodFormViewController: UIViewController {
             if case .external(let paymentMethod) = paymentMethodType {
                 return .external(paymentMethod: paymentMethod, billingDetails: params.paymentMethodParams.nonnil_billingDetails)
             }
-            
+
             if paymentMethodType.isLinkBankPayment {
                 // We create the final payment method in the bank auth flow, therefore treating
                 // the Link Bank Payment result like a saved payment option.
@@ -63,7 +63,7 @@ class PaymentMethodFormViewController: UIViewController {
                 }
                 return .saved(paymentMethod: paymentMethod, confirmParams: nil)
             }
-            
+
             return .new(confirmParams: params)
         }
         return nil
@@ -216,6 +216,28 @@ extension PaymentMethodFormViewController {
     private var usBankAccountFormElement: USBankAccountPaymentMethodElement? { form as? USBankAccountPaymentMethodElement }
     private var instantDebitsFormElement: InstantDebitsPaymentMethodElement? { form as? InstantDebitsPaymentMethodElement }
 
+    private var bankTabEmail: String? {
+        switch paymentMethodType {
+        case .stripe(.USBankAccount):
+            return usBankAccountFormElement?.email
+        case .instantDebits, .linkCardBrand:
+            return instantDebitsFormElement?.email
+        default:
+            return nil
+        }
+    }
+
+    private var bankTabPhoneElement: PhoneNumberElement? {
+        switch paymentMethodType {
+        case .stripe(.USBankAccount):
+            return usBankAccountFormElement?.phoneElement
+        case .instantDebits, .linkCardBrand:
+            return instantDebitsFormElement?.phoneElement
+        default:
+            return nil
+        }
+    }
+
     private var elementsSessionContext: ElementsSessionContext {
         let intentId: ElementsSessionContext.IntentID? = {
             switch intent {
@@ -234,10 +256,10 @@ extension PaymentMethodFormViewController {
             return PhoneNumber.fromE164(defaultPhoneNumber)?.number
         }()
         let prefillDetails = ElementsSessionContext.PrefillDetails(
-            email: instantDebitsFormElement?.email ?? configuration.defaultBillingDetails.email,
-            formattedPhoneNumber: instantDebitsFormElement?.phone ?? defaultPhoneNumber,
-            unformattedPhoneNumber: instantDebitsFormElement?.phoneElement?.phoneNumber?.number ?? defaultUnformattedPhoneNumber,
-            countryCode: instantDebitsFormElement?.phoneElement?.selectedCountryCode
+            email: bankTabEmail ?? configuration.defaultBillingDetails.email,
+            formattedPhoneNumber: bankTabPhoneElement?.phoneNumber?.string(as: .e164) ?? defaultPhoneNumber,
+            unformattedPhoneNumber: bankTabPhoneElement?.phoneNumber?.number ?? defaultUnformattedPhoneNumber,
+            countryCode: bankTabPhoneElement?.selectedCountryCode
         )
         let linkMode = elementsSession.linkSettings?.linkMode
         let billingDetails = instantDebitsFormElement?.billingDetails
@@ -444,14 +466,14 @@ extension PaymentMethodFormViewController {
             "product": "instant_debits",
             "hosted_surface": "payment_element",
         ]
-        
+
         switch intent {
         case .paymentIntent, .setupIntent:
             additionalParameters["attach_required"] = true
         case .deferredIntent:
             break
         }
-        
+
         switch intent {
         case .paymentIntent(let paymentIntent):
             client.collectBankAccountForPayment(
@@ -506,5 +528,21 @@ private extension LinkBankPaymentMethod {
 
     func decode() -> STPPaymentMethod? {
         return STPPaymentMethod.decodedObject(fromAPIResponse: allResponseFields)
+    }
+}
+
+private extension PaymentSheet.PaymentMethodType {
+
+    var isLinkBankPayment: Bool {
+        switch self {
+        case .stripe:
+            return false
+        case .external:
+            return false
+        case .instantDebits:
+            return true
+        case .linkCardBrand:
+            return true
+        }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -530,19 +530,3 @@ private extension LinkBankPaymentMethod {
         return STPPaymentMethod.decodedObject(fromAPIResponse: allResponseFields)
     }
 }
-
-private extension PaymentSheet.PaymentMethodType {
-
-    var isLinkBankPayment: Bool {
-        switch self {
-        case .stripe:
-            return false
-        case .external:
-            return false
-        case .instantDebits:
-            return true
-        case .linkCardBrand:
-            return true
-        }
-    }
-}


### PR DESCRIPTION
## Summary

This updates `ElementsSessionContext.PrefillDetails` to also take email / phone values from the US Bank (ACH) tab. It also updates the Networking Link Signup pane accordingly.

## Motivation

[BANKCON-16076](https://jira.corp.stripe.com/browse/BANKCON-16076)

## Testing

Prefill for native ACH:

https://github.com/user-attachments/assets/1e893776-0df6-4ddd-a0fd-546ade006a7b

Prefill for Instant Debits still works:

https://github.com/user-attachments/assets/63d78ebb-44fe-4c9c-a443-c4df6ed7cec3

## Changelog

N/a