### PR TITLE
Link v3: Add support for 2FA Modal and FlowController 

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1967,7 +1967,7 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
 
-    // Tests Native Link, returning user, without SPMs
+    // Tests Native Link with a returning user, 2FA prompt shows first
     func testLinkPaymentSheet_native_enabledSPM_noSPMs_returningLinkUser() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
@@ -1983,8 +1983,31 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         codeField.typeText("000000")
         let pwlController = app.otherElements["Stripe.Link.PayWithLinkViewController"]
         let payButton = pwlController.buttons["Pay $50.99"]
-        _ = payButton.waitForExistence(timeout: 5.0)
-        payButton.tap()
+        _ = payButton.waitForExistenceAndTap()
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
+    }
+
+    // Tests Native Link in Flow Controller with a returning user
+    func testLinkPaymentSheetFC_native_enabledSPM_noSPMs_returningLinkUser() {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.apmsEnabled = .on
+        settings.linkMode = .link_pm
+        settings.uiStyle = .flowController
+        settings.useNativeLink = .on
+        settings.defaultBillingAddress = .on // the email on the default billings details is signed up for Link
+
+        loadPlayground(app, settings)
+
+        app.buttons["Payment method"].waitForExistenceAndTap()
+        app.buttons["Link"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
+        let codeField = app.textViews["Code field"]
+        _ = codeField.waitForExistence(timeout: 5.0)
+        codeField.typeText("000000")
+        let pwlController = app.otherElements["Stripe.Link.PayWithLinkViewController"]
+        let payButton = pwlController.buttons["Pay $50.99"]
+        _ = payButton.waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1967,6 +1967,27 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
 
+    // Tests Native Link, returning user, without SPMs
+    func testLinkPaymentSheet_native_enabledSPM_noSPMs_returningLinkUser() {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.apmsEnabled = .on
+        settings.linkMode = .link_pm
+        settings.useNativeLink = .on
+        settings.defaultBillingAddress = .on // the email on the default billings details is signed up for Link
+
+        loadPlayground(app, settings)
+        app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
+        let codeField = app.textViews["Code field"]
+        _ = codeField.waitForExistence(timeout: 5.0)
+        codeField.typeText("000000")
+        let pwlController = app.otherElements["Stripe.Link.PayWithLinkViewController"]
+        let payButton = pwlController.buttons["Pay $50.99"]
+        _ = payButton.waitForExistence(timeout: 5.0)
+        payButton.tap()
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
+    }
+
     // Tests the #5 flow in PaymentSheet where the merchant enables saved payment methods, buyer has SPMs and first time Link user
     func testLinkPaymentSheet_enabledSPM_hasSPMs_firstTimeLinkUser() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
@@ -2379,7 +2400,7 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
 //        // Allow link.com to sign in
 //        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
 //        springboard.buttons["Continue"].forceTapWhenHittableInTestCase(self)
-//        
+//
 //        let emailField = app.webViews.textFields.firstMatch
 //        emailField.forceTapWhenHittableInTestCase(self)
 //        emailField.typeText("test@example.com")

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		2E4C37C73AD202C8A3DD2E4E /* LoadingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FF291A25EA43D4D100983B /* LoadingViewController.swift */; };
 		2EC9C94DD8D62E4F4EFC8AB8 /* IntentStatusPollerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 990304EF35A0EE37DCE20D5B /* IntentStatusPollerTest.swift */; };
 		311AC53D6C76953E9B70148A /* ConsumerSession+PublishableKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2D61B52BFA201D25E8F6428 /* ConsumerSession+PublishableKey.swift */; };
+		313D00C82CD9972F00A8E6B0 /* PayWithNativeLinkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 313D00C72CD9972F00A8E6B0 /* PayWithNativeLinkController.swift */; };
 		313F5F832B0BE5FD00BD98A9 /* Docs.docc in Sources */ = {isa = PBXBuildFile; fileRef = 313F5F822B0BE5FD00BD98A9 /* Docs.docc */; };
 		3147CEBB2CC07E960067B5E4 /* LinkUtils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEBA2CC07E960067B5E4 /* LinkUtils.swift */; };
 		3147CEC02CC080570067B5E4 /* LinkInMemoryCookieStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEBD2CC080570067B5E4 /* LinkInMemoryCookieStore.swift */; };
@@ -460,6 +461,7 @@
 		2DF75FD35820E7556EC34D15 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2E2B99961C09E31383C9FCE9 /* mt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mt; path = mt.lproj/Localizable.strings; sourceTree = "<group>"; };
 		2E42F31D392C0AED757D6239 /* StripePaymentSheet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripePaymentSheet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		313D00C72CD9972F00A8E6B0 /* PayWithNativeLinkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayWithNativeLinkController.swift; sourceTree = "<group>"; };
 		313F5F822B0BE5FD00BD98A9 /* Docs.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Docs.docc; sourceTree = "<group>"; };
 		3147CEBA2CC07E960067B5E4 /* LinkUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkUtils.swift; sourceTree = "<group>"; };
 		3147CEBC2CC080570067B5E4 /* LinkCookieStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkCookieStore.swift; sourceTree = "<group>"; };
@@ -1546,6 +1548,7 @@
 			children = (
 				52185F7315D3C4089D3465BD /* LinkPaymentController.swift */,
 				B41560E0599A68A84F5C76D2 /* PaymentSheet-LinkConfirmOption.swift */,
+				313D00C72CD9972F00A8E6B0 /* PayWithNativeLinkController.swift */,
 				5DCFBC65AF58423E0E8DD04A /* PayWithLinkController.swift */,
 			);
 			path = Link;
@@ -2141,6 +2144,7 @@
 				3147CECB2CC1BF550067B5E4 /* LinkPaymentMethodPicker-CellContentView.swift in Sources */,
 				3147CECC2CC1BF550067B5E4 /* LinkPaymentMethodPicker-Cell.swift in Sources */,
 				3147CECD2CC1BF550067B5E4 /* LinkPaymentMethodPicker-Header.swift in Sources */,
+				313D00C82CD9972F00A8E6B0 /* PayWithNativeLinkController.swift in Sources */,
 				3147CECE2CC1BF550067B5E4 /* LinkPaymentMethodPicker-RadioButton.swift in Sources */,
 				3147CECF2CC1BF550067B5E4 /* LinkPaymentMethodPicker-AddButton.swift in Sources */,
 				FB653AA92B68F73344835A50 /* Intent.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewModel.swift
@@ -133,14 +133,14 @@ extension PayWithLinkViewController {
 
         private let accountLookupDebouncer = OperationDebouncer(debounceTime: LinkUI.accountLookupDebounceTime)
 
-        private let configuration: PaymentSheet.Configuration
+        private let configuration: PaymentElementConfiguration
 
         private let country: String?
 
         // MARK: Initializer
 
         init(
-            configuration: PaymentSheet.Configuration,
+            configuration: PaymentElementConfiguration,
             accountService: LinkAccountServiceProtocol,
             linkAccount: PaymentSheetLinkAccount?,
             country: String?

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
@@ -24,7 +24,7 @@ extension PayWithLinkViewController {
         weak var delegate: UpdatePaymentViewControllerDelegate?
         let linkAccount: PaymentSheetLinkAccount
         let intent: Intent
-        var configuration: PaymentSheet.Configuration
+        var configuration: PaymentElementConfiguration
         let paymentMethod: ConsumerPaymentDetails
 
         private let titleLabel: UILabel = {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -63,7 +63,7 @@ final class PayWithLinkViewController: UINavigationController {
     final class Context {
         let intent: Intent
         let elementsSession: STPElementsSession
-        let configuration: PaymentSheet.Configuration
+        let configuration: PaymentElementConfiguration
         let shouldOfferApplePay: Bool
         let shouldFinishOnClose: Bool
         let callToAction: ConfirmButton.CallToActionType
@@ -82,7 +82,7 @@ final class PayWithLinkViewController: UINavigationController {
         init(
             intent: Intent,
             elementsSession: STPElementsSession,
-            configuration: PaymentSheet.Configuration,
+            configuration: PaymentElementConfiguration,
             shouldOfferApplePay: Bool,
             shouldFinishOnClose: Bool,
             callToAction: ConfirmButton.CallToActionType?,
@@ -119,7 +119,7 @@ final class PayWithLinkViewController: UINavigationController {
     convenience init(
         intent: Intent,
         elementsSession: STPElementsSession,
-        configuration: PaymentSheet.Configuration,
+        configuration: PaymentElementConfiguration,
         shouldOfferApplePay: Bool = false,
         shouldFinishOnClose: Bool = false,
         callToAction: ConfirmButton.CallToActionType? = nil,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkCardEditElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkCardEditElement.swift
@@ -47,7 +47,7 @@ final class LinkCardEditElement: Element {
 
     let paymentMethod: ConsumerPaymentDetails
 
-    let configuration: PaymentSheet.Configuration
+    let configuration: PaymentElementConfiguration
 
     let theme: ElementsAppearance = LinkUI.appearance.asElementsTheme
 
@@ -177,7 +177,7 @@ final class LinkCardEditElement: Element {
         )
     }()
 
-    init(paymentMethod: ConsumerPaymentDetails, configuration: PaymentSheet.Configuration) {
+    init(paymentMethod: ConsumerPaymentDetails, configuration: PaymentElementConfiguration) {
         self.paymentMethod = paymentMethod
         self.configuration = configuration
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -39,14 +39,11 @@ extension STPElementsSession {
     }
     
     func shouldShowLink2FABeforePaymentSheet(for linkAccount: PaymentSheetLinkAccount, configuration: PaymentSheet.Configuration) -> Bool {
-        if configuration.forceNativeLinkEnabled &&
-           self.supportsLink &&
-            linkAccount.sessionState == .requiresVerification &&
-            !linkAccount.hasStartedSMSVerification &&
-           self.linkSettings?.suppress2FAModal != true {
-            return true
-        }
-        return false
+        return configuration.forceNativeLinkEnabled &&
+        self.supportsLink &&
+        linkAccount.sessionState == .requiresVerification &&
+        !linkAccount.hasStartedSMSVerification &&
+        self.linkSettings?.suppress2FAModal != true
     }
 
     func countryCode(overrideCountry: String?) -> String? {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -37,7 +37,7 @@ extension STPElementsSession {
     var linkPopupWebviewOption: LinkSettings.PopupWebviewOption {
         linkSettings?.popupWebviewOption ?? .shared
     }
-    
+
     func shouldShowLink2FABeforePaymentSheet(for linkAccount: PaymentSheetLinkAccount, configuration: PaymentSheet.Configuration) -> Bool {
         return configuration.forceNativeLinkEnabled &&
         self.supportsLink &&

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -37,6 +37,17 @@ extension STPElementsSession {
     var linkPopupWebviewOption: LinkSettings.PopupWebviewOption {
         linkSettings?.popupWebviewOption ?? .shared
     }
+    
+    func shouldShowLink2FABeforePaymentSheet(for linkAccount: PaymentSheetLinkAccount, configuration: PaymentSheet.Configuration) -> Bool {
+        if configuration.forceEnableNativeLink &&
+           self.supportsLink &&
+            linkAccount.sessionState == .requiresVerification &&
+            !linkAccount.hasStartedSMSVerification &&
+           self.linkSettings?.suppress2FAModal != true {
+            return true
+        }
+        return false
+    }
 
     func countryCode(overrideCountry: String?) -> String? {
 #if DEBUG

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -39,7 +39,7 @@ extension STPElementsSession {
     }
     
     func shouldShowLink2FABeforePaymentSheet(for linkAccount: PaymentSheetLinkAccount, configuration: PaymentSheet.Configuration) -> Bool {
-        if configuration.forceEnableNativeLink &&
+        if configuration.forceNativeLinkEnabled &&
            self.supportsLink &&
             linkAccount.sessionState == .requiresVerification &&
             !linkAccount.hasStartedSMSVerification &&

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -99,7 +99,7 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
                 delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: self)
             }
         }
-        
+
         guard case let .new(paymentMethodType) = embeddedPaymentMethodsView.selection else {
             // This can occur when selection is being reset to nothing selected or to a saved payment method, so don't assert.
             self.formViewController = nil
@@ -200,7 +200,7 @@ extension EmbeddedPaymentElement: UpdateCardViewControllerDelegate {
                                                                accessoryType: accessoryType)
         presentingViewController?.dismiss(animated: true)
     }
-    
+
     func didDismiss(viewController: UpdateCardViewController) {
         presentingViewController?.dismiss(animated: true)
     }
@@ -276,7 +276,7 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
             completion(result, deferredIntentConfirmationType)
         }
     }
-    
+
     func embeddedFormViewControllerDidCompleteConfirmation(_ embeddedFormViewController: EmbeddedFormViewController, result: PaymentSheetResult) {
         embeddedFormViewController.dismiss(animated: true) {
             if case let .confirm(completion) = self.configuration.formSheetAction {
@@ -284,7 +284,7 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
             }
         }
     }
-    
+
     func embeddedFormViewControllerDidCancel(_ embeddedFormViewController: EmbeddedFormViewController) {
         if embeddedFormViewController.selectedPaymentOption == nil {
             self.formViewController = nil
@@ -292,16 +292,16 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
         }
         embeddedFormViewController.dismiss(animated: true)
     }
-    
+
     func embeddedFormViewControllerShouldClose(_ embeddedFormViewController: EmbeddedFormViewController) {
         embeddedFormViewController.dismiss(animated: true)
         delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: self)
     }
-    
+
 }
 
 extension EmbeddedPaymentElement {
-    
+
     func _confirm() async -> (result: PaymentSheetResult, deferredIntentConfirmationType: STPAnalyticsClient.DeferredIntentConfirmationType?) {
         // Wait for the last update to finish and fail if didn't succeed. A failure means the view is out of sync with the intent and could e.g. not be showing a required mandate.
         if let latestUpdateTask {
@@ -360,7 +360,7 @@ extension EmbeddedPaymentElement {
             analyticsHelper: analyticsHelper
         )
     }
-    
+
     func bottomSheetController(with viewController: BottomSheetContentViewController) -> BottomSheetViewController {
         return BottomSheetViewController(contentViewController: viewController,
                                          appearance: configuration.appearance,
@@ -371,23 +371,22 @@ extension EmbeddedPaymentElement {
     }
 }
 
-
 // TODO(porter) When we use Xcode 16 on CI do this instead of `STPAuthenticationContextWrapper`
 // @retroactive is not supported in Xcode 15
-//extension UIViewController: @retroactive STPAuthenticationContext {
+// extension UIViewController: @retroactive STPAuthenticationContext {
 //    public func authenticationPresentingViewController() -> UIViewController {
 //        return self
 //    }
-//}
+// }
 
 final class STPAuthenticationContextWrapper: UIViewController {
     let _presentingViewController: UIViewController
-    
+
     init(presentingViewController: UIViewController) {
         self._presentingViewController = presentingViewController
         super.init(nibName: nil, bundle: nil)
     }
-    
+
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -356,7 +356,8 @@ extension EmbeddedPaymentElement {
             elementsSession: elementsSession,
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
-            integrationShape: .embedded
+            integrationShape: .embedded,
+            analyticsHelper: analyticsHelper
         )
     }
     

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
@@ -153,6 +153,9 @@ extension EmbeddedPaymentElement {
         /// Controls whether to filter out wallet payment methods from the saved payment method list.
         @_spi(DashboardOnly) public var disableWalletPaymentMethodFiltering: Bool = false
 
+        internal var linkPaymentMethodsOnly: Bool = false
+        @_spi(STP) public var forceNativeLinkEnabled: Bool = false
+
         /// Initializes a Configuration with default values
         public init(formSheetAction: FormSheetAction) {
             self.formSheetAction = formSheetAction

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
@@ -25,12 +25,14 @@ final class PayWithLinkController {
     let intent: Intent
     let elementsSession: STPElementsSession
     let configuration: PaymentElementConfiguration
+    let analyticsHelper: PaymentSheetAnalyticsHelper
 
-    init(intent: Intent, elementsSession: STPElementsSession, configuration: PaymentElementConfiguration) {
+    init(intent: Intent, elementsSession: STPElementsSession, configuration: PaymentElementConfiguration, analyticsHelper: PaymentSheetAnalyticsHelper) {
         self.intent = intent
         self.elementsSession = elementsSession
         self.configuration = configuration
         self.paymentHandler = .init(apiClient: configuration.apiClient)
+        self.analyticsHelper = analyticsHelper
     }
 
     func present(
@@ -64,7 +66,8 @@ extension PayWithLinkController: PayWithLinkWebControllerDelegate {
             elementsSession: elementsSession,
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
-            integrationShape: .complete
+            integrationShape: .complete,
+            analyticsHelper: analyticsHelper
         ) { result, deferredIntentConfirmationType in
             self.completion?(result, deferredIntentConfirmationType)
             self.selfRetainer = nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -1,0 +1,106 @@
+//
+//  PayWithLinkController.swift
+//  StripePaymentSheet
+//
+//  Created by Ramon Torres on 7/18/22.
+//  Copyright © 2022 Stripe, Inc. All rights reserved.
+//
+
+@_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
+import UIKit
+
+/// Standalone Link controller
+@available(iOSApplicationExtension, unavailable)
+@available(macCatalystApplicationExtension, unavailable)
+final class PayWithNativeLinkController {
+
+    typealias CompletionBlock = PaymentSheetResultCompletionBlock
+
+    private let paymentHandler: STPPaymentHandler
+
+    private var completion: PaymentSheetResultCompletionBlock?
+
+    private var selfRetainer: PayWithNativeLinkController?
+
+    let intent: Intent
+    let elementsSession: STPElementsSession
+    let configuration: PaymentSheet.Configuration
+    let analyticsHelper: PaymentSheetAnalyticsHelper
+
+    init(intent: Intent, elementsSession: STPElementsSession, configuration: PaymentSheet.Configuration, analyticsHelper: PaymentSheetAnalyticsHelper) {
+        self.intent = intent
+        self.elementsSession = elementsSession
+        self.configuration = configuration
+        self.analyticsHelper = analyticsHelper
+        self.paymentHandler = .init(apiClient: configuration.apiClient)
+    }
+
+    func present(on viewController: UIViewController, completion: @escaping CompletionBlock) {
+        guard
+            let keyWindow = UIApplication.shared.windows.first(where: { $0.isKeyWindow }),
+            let presentedViewController = keyWindow.findTopMostPresentedViewController()
+        else {
+            assertionFailure("No key window with view controller found")
+            return
+        }
+
+        present(from: presentedViewController, completion: completion)
+    }
+
+    func present(
+        from presentingController: UIViewController,
+        completion: @escaping PaymentSheetResultCompletionBlock
+    ) {
+        // Similarly to `PKPaymentAuthorizationController`, `LinkController` should retain
+        // itself while presented.
+        self.selfRetainer = self
+        self.completion = completion
+
+        let payWithLinkViewController = PayWithLinkViewController(intent: intent,
+                                                                  elementsSession: elementsSession, configuration: configuration, analyticsHelper: analyticsHelper)
+        payWithLinkViewController.payWithLinkDelegate = self
+        payWithLinkViewController.modalPresentationStyle = UIDevice.current.userInterfaceIdiom == .pad
+            ? .formSheet
+            : .overFullScreen
+
+        presentingController.present(payWithLinkViewController, animated: true)
+    }
+
+}
+
+@available(iOSApplicationExtension, unavailable)
+@available(macCatalystApplicationExtension, unavailable)
+extension PayWithNativeLinkController: PayWithLinkViewControllerDelegate {
+
+    func payWithLinkViewControllerDidConfirm(
+        _ payWithLinkViewController: PayWithLinkViewController,
+        intent: Intent,
+        elementsSession: STPElementsSession,
+        with paymentOption: PaymentOption,
+        completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
+    ) {
+        PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: payWithLinkViewController,
+            intent: intent,
+            elementsSession: elementsSession,
+            paymentOption: paymentOption,
+            paymentHandler: paymentHandler,
+            completion: completion
+        )
+    }
+
+    func payWithLinkViewControllerDidCancel(_ payWithLinkViewController: PayWithLinkViewController) {
+        payWithLinkViewController.dismiss(animated: true)
+//        completion?(.canceled)
+        selfRetainer = nil
+    }
+
+    func payWithLinkViewControllerDidFinish(_ payWithLinkViewController: PayWithLinkViewController, result: PaymentSheetResult) {
+        payWithLinkViewController.dismiss(animated: true)
+//        completion?(result)
+        selfRetainer = nil
+    }
+
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -38,15 +38,7 @@ final class PayWithNativeLinkController {
     }
 
     func present(on viewController: UIViewController, completion: @escaping CompletionBlock) {
-        guard
-            let keyWindow = UIApplication.shared.windows.first(where: { $0.isKeyWindow }),
-            let presentedViewController = keyWindow.findTopMostPresentedViewController()
-        else {
-            stpAssertionFailure("No key window with view controller found")
-            return
-        }
-
-        present(from: presentedViewController, completion: completion)
+        present(from: viewController, completion: completion)
     }
 
     func present(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripeUICore
 import UIKit

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -25,10 +25,10 @@ final class PayWithNativeLinkController {
 
     let intent: Intent
     let elementsSession: STPElementsSession
-    let configuration: PaymentSheet.Configuration
+    let configuration: PaymentElementConfiguration
     let analyticsHelper: PaymentSheetAnalyticsHelper
 
-    init(intent: Intent, elementsSession: STPElementsSession, configuration: PaymentSheet.Configuration, analyticsHelper: PaymentSheetAnalyticsHelper) {
+    init(intent: Intent, elementsSession: STPElementsSession, configuration: PaymentElementConfiguration, analyticsHelper: PaymentSheetAnalyticsHelper) {
         self.intent = intent
         self.elementsSession = elementsSession
         self.configuration = configuration
@@ -87,19 +87,20 @@ extension PayWithNativeLinkController: PayWithLinkViewControllerDelegate {
             elementsSession: elementsSession,
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
+            analyticsHelper: analyticsHelper,
             completion: completion
         )
     }
 
     func payWithLinkViewControllerDidCancel(_ payWithLinkViewController: PayWithLinkViewController) {
         payWithLinkViewController.dismiss(animated: true)
-//        completion?(.canceled)
+        completion?(.canceled, nil)
         selfRetainer = nil
     }
 
     func payWithLinkViewControllerDidFinish(_ payWithLinkViewController: PayWithLinkViewController, result: PaymentSheetResult) {
         payWithLinkViewController.dismiss(animated: true)
-//        completion?(result)
+        completion?(result, nil)
         selfRetainer = nil
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -41,7 +41,7 @@ final class PayWithNativeLinkController {
             let keyWindow = UIApplication.shared.windows.first(where: { $0.isKeyWindow }),
             let presentedViewController = keyWindow.findTopMostPresentedViewController()
         else {
-            assertionFailure("No key window with view controller found")
+            stpAssertionFailure("No key window with view controller found")
             return
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -51,7 +51,7 @@ class AddPaymentMethodViewController: UIViewController {
 
     private let intent: Intent
     private let elementsSession: STPElementsSession
-    private let configuration: PaymentSheet.Configuration
+    private let configuration: PaymentElementConfiguration
     private let formCache: PaymentMethodFormCache
     private let analyticsHelper: PaymentSheetAnalyticsHelper
     var previousCustomerInput: IntentConfirmParams?
@@ -90,7 +90,7 @@ class AddPaymentMethodViewController: UIViewController {
     required init(
         intent: Intent,
         elementsSession: STPElementsSession,
-        configuration: PaymentSheet.Configuration,
+        configuration: PaymentElementConfiguration,
         previousCustomerInput: IntentConfirmParams? = nil,
         paymentMethodTypes: [PaymentSheet.PaymentMethodType],
         formCache: PaymentMethodFormCache,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentElementConfiguration.swift
@@ -37,6 +37,8 @@ protocol PaymentElementConfiguration: PaymentMethodRequirementProvider {
     var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance { get set }
     var analyticPayload: [String: Any] { get }
     var disableWalletPaymentMethodFiltering: Bool { get set }
+    var linkPaymentMethodsOnly: Bool { get set }
+    var forceNativeLinkEnabled: Bool { get set }
 }
 
 extension PaymentElementConfiguration {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -42,6 +42,7 @@ extension PaymentSheet {
         paymentHandler: STPPaymentHandler,
         integrationShape: IntegrationShape = .complete,
         paymentMethodID: String? = nil,
+        analyticsHelper: PaymentSheetAnalyticsHelper,
         completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
     ) {
         // Perform PaymentSheet-specific local actions before confirming.
@@ -59,7 +60,7 @@ extension PaymentSheet {
                                                 confirmAction: {
                 // If confirmed, dismiss the MandateView and complete the transaction:
                 authenticationContext.authenticationPresentingViewController().dismiss(animated: true)
-                confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: nil, paymentHandler: paymentHandler, completion: completion)
+                confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: nil, paymentHandler: paymentHandler, analyticsHelper: analyticsHelper, completion: completion)
             }, cancelAction: {
                 // Dismiss the MandateView and return to PaymentSheet
                 authenticationContext.authenticationPresentingViewController().dismiss(animated: true)
@@ -88,7 +89,7 @@ extension PaymentSheet {
                 configuration: configuration,
                 onCompletion: { vc, intentConfirmParams in
                     vc.dismiss(animated: true)
-                    confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: intentConfirmParams, paymentHandler: paymentHandler, completion: completion)
+                    confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: intentConfirmParams, paymentHandler: paymentHandler, analyticsHelper: analyticsHelper, completion: completion)
                 },
                 onCancel: { vc in
                     vc.dismiss(animated: true)
@@ -107,7 +108,7 @@ extension PaymentSheet {
             presentingViewController.presentAsBottomSheet(bottomSheetVC, appearance: configuration.appearance)
         } else {
             // MARK: - No local actions
-            confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: nil, paymentHandler: paymentHandler, completion: completion)
+            confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: nil, paymentHandler: paymentHandler, analyticsHelper: analyticsHelper, completion: completion)
         }
     }
     
@@ -119,6 +120,7 @@ extension PaymentSheet {
         paymentOption: PaymentOption,
         paymentHandler: STPPaymentHandler,
         integrationShape: IntegrationShape = .complete,
+        analyticsHelper: PaymentSheetAnalyticsHelper,
         paymentMethodID: String? = nil
     ) async -> (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) {
         await withCheckedContinuation { continuation in
@@ -131,7 +133,8 @@ extension PaymentSheet {
                     paymentOption: paymentOption,
                     paymentHandler: paymentHandler,
                     integrationShape: integrationShape,
-                    paymentMethodID: paymentMethodID
+                    paymentMethodID: paymentMethodID,
+                    analyticsHelper: analyticsHelper
                 ) { result, deferredType in
                     continuation.resume(returning: (result, deferredType))
                 }
@@ -149,6 +152,7 @@ extension PaymentSheet {
         paymentHandler: STPPaymentHandler,
         isFlowController: Bool = false,
         paymentMethodID: String? = nil,
+        analyticsHelper: PaymentSheetAnalyticsHelper,
         completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
     ) {
         // Translates a STPPaymentHandler result to a PaymentResult
@@ -461,11 +465,11 @@ extension PaymentSheet {
 
             switch confirmOption {
             case .wallet:
-                if configuration.forceEnableNativeLink {
-//                    let linkController = PayWithNativeLinkController(intent: intent, configuration: configuration)
-//                    linkController.present(on: authenticationContext.authenticationPresentingViewController(), completion: completion)
+                if configuration.forceNativeLinkEnabled {
+                    let linkController = PayWithNativeLinkController(intent: intent, elementsSession: elementsSession, configuration: configuration, analyticsHelper: analyticsHelper)
+                    linkController.present(on: authenticationContext.authenticationPresentingViewController(), completion: completion)
                 } else {
-                    let linkController = PayWithLinkController(intent: intent, elementsSession: elementsSession, configuration: configuration)
+                    let linkController = PayWithLinkController(intent: intent, elementsSession: elementsSession, configuration: configuration, analyticsHelper: analyticsHelper)
                     linkController.present(from: authenticationContext.authenticationPresentingViewController(),
                                            completion: completion)
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -31,7 +31,7 @@ extension PaymentSheet {
             }
         }
     }
-    
+
     /// Confirms a PaymentIntent with the given PaymentOption and returns a PaymentResult
     static func confirm(
         configuration: PaymentElementConfiguration,
@@ -111,7 +111,7 @@ extension PaymentSheet {
             confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: nil, paymentHandler: paymentHandler, analyticsHelper: analyticsHelper, completion: completion)
         }
     }
-    
+
     static func confirm(
         configuration: PaymentElementConfiguration,
         authenticationContext: STPAuthenticationContext,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -461,9 +461,14 @@ extension PaymentSheet {
 
             switch confirmOption {
             case .wallet:
-                let linkController = PayWithLinkController(intent: intent, elementsSession: elementsSession, configuration: configuration)
-                linkController.present(from: authenticationContext.authenticationPresentingViewController(),
-                                       completion: completion)
+                if configuration.forceEnableNativeLink {
+//                    let linkController = PayWithNativeLinkController(intent: intent, configuration: configuration)
+//                    linkController.present(on: authenticationContext.authenticationPresentingViewController(), completion: completion)
+                } else {
+                    let linkController = PayWithLinkController(intent: intent, elementsSession: elementsSession, configuration: configuration)
+                    linkController.present(from: authenticationContext.authenticationPresentingViewController(),
+                                           completion: completion)
+                }
             case .signUp(let linkAccount, let phoneNumber, let consentAction, let legalName, let intentConfirmParams):
                 linkAccount.signUp(with: phoneNumber, legalName: legalName, consentAction: consentAction) { result in
                     UserDefaults.standard.markLinkAsUsed()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -133,7 +133,8 @@ extension PaymentSheet: PayWithLinkViewControllerDelegate {
             elementsSession: elementsSession,
             paymentOption: paymentOption,
             paymentHandler: self.paymentHandler,
-            integrationShape: .complete)
+            integrationShape: .complete,
+            analyticsHelper: analyticsHelper)
         { result, confirmationType in
             if case let .failed(error) = result {
                 self.mostRecentError = error

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -188,7 +188,7 @@ public class PaymentSheet {
                             }
                         case .canceled:
                             presentPaymentSheet()
-                        case .failed(_):
+                        case .failed:
                             // Error is logged within LinkVerificationViewController
                             presentPaymentSheet()
                         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -182,7 +182,7 @@ public class PaymentSheet {
                     verificationController.present(from: self.bottomSheetViewController) { result in
                         switch result {
                         case .completed:
-                            self.presentPayWithNativeLinkController(from: self.bottomSheetViewController, intent: loadResult.intent, elementsSession: loadResult.elementsSession, shouldOfferApplePay: true, shouldFinishOnClose: false) {
+                            self.presentPayWithNativeLinkController(from: self.bottomSheetViewController, intent: loadResult.intent, elementsSession: loadResult.elementsSession, shouldOfferApplePay: self.configuration.isApplePayEnabled, shouldFinishOnClose: false) {
                                 // To prevent a flash of PaymentSheet content, don't present it until after the LinkController presentation animation has completed
                                 presentPaymentSheet()
                             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -280,7 +280,8 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
                 elementsSession: paymentSheetViewController.elementsSession,
                 paymentOption: paymentOption,
                 paymentHandler: self.paymentHandler,
-                integrationShape: .complete
+                integrationShape: .complete,
+                analyticsHelper: self.analyticsHelper
             ) { result, deferredIntentConfirmationType in
                 if case let .failed(error) = result {
                     self.mostRecentError = error

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -327,7 +327,21 @@ extension PaymentSheet {
                 self.isPresented = true
             }
 
-            showPaymentOptions()
+            if let linkAccount = LinkAccountContext.shared.account,
+               elementsSession.shouldShowLink2FABeforePaymentSheet(for: linkAccount, configuration: self.configuration) {
+                let verificationController = LinkVerificationController(mode: .inlineLogin, linkAccount: linkAccount)
+                verificationController.present(from: presentingViewController) { [weak self] result in
+                    switch result {
+                    case .completed:
+                        self?.viewController.selectLink()
+                        completion?()
+                    case .canceled, .failed(_):
+                        showPaymentOptions()
+                    }
+                }
+            } else {
+                showPaymentOptions()
+            }
         }
 
         /// Completes the payment or setup.
@@ -581,4 +595,5 @@ internal protocol FlowControllerViewControllerProtocol: BottomSheetContentViewCo
     /// Note that, unlike selectedPaymentOption, this is non-nil even if the PM form is invalid.
     var selectedPaymentMethodType: PaymentSheet.PaymentMethodType? { get }
     var flowControllerDelegate: FlowControllerViewControllerDelegate? { get set }
+    func selectLink()
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -327,21 +327,7 @@ extension PaymentSheet {
                 self.isPresented = true
             }
 
-            if let linkAccount = LinkAccountContext.shared.account,
-               elementsSession.shouldShowLink2FABeforePaymentSheet(for: linkAccount, configuration: self.configuration) {
-                let verificationController = LinkVerificationController(mode: .inlineLogin, linkAccount: linkAccount)
-                verificationController.present(from: presentingViewController) { [weak self] result in
-                    switch result {
-                    case .completed:
-                        self?.viewController.selectLink()
-                        completion?()
-                    case .canceled, .failed(_):
-                        showPaymentOptions()
-                    }
-                }
-            } else {
-                showPaymentOptions()
-            }
+            showPaymentOptions()
         }
 
         /// Completes the payment or setup.
@@ -407,7 +393,8 @@ extension PaymentSheet {
                     elementsSession: elementsSession,
                     paymentOption: paymentOption,
                     paymentHandler: paymentHandler,
-                    integrationShape: .flowController
+                    integrationShape: .flowController,
+                    analyticsHelper: analyticsHelper
                 ) { [analyticsHelper, configuration] result, deferredIntentConfirmationType in
                     analyticsHelper.logPayment(
                         paymentOption: paymentOption,
@@ -595,5 +582,4 @@ internal protocol FlowControllerViewControllerProtocol: BottomSheetContentViewCo
     /// Note that, unlike selectedPaymentOption, this is non-nil even if the PM form is invalid.
     var selectedPaymentMethodType: PaymentSheet.PaymentMethodType? { get }
     var flowControllerDelegate: FlowControllerViewControllerDelegate? { get set }
-    func selectLink()
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -463,17 +463,6 @@ class SavedPaymentOptionsViewController: UIViewController {
         let defaultSelectedIndex = viewModels.firstIndex(where: { $0 == defaultPaymentMethod }) ?? defaultIndex
         return (defaultSelectedIndex, viewModels)
     }
-
-    func selectLink() {
-        guard configuration.showLink else {
-            stpAssertionFailure()
-            return
-        }
-
-        CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: configuration.customerID)
-        selectedViewModelIndex = viewModels.firstIndex(where: { $0 == .link })
-        collectionView.selectItem(at: selectedIndexPath, animated: false, scrollPosition: .centeredHorizontally)
-    }
 }
 
 // MARK: - UICollectionView

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -86,6 +86,10 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
     private let isLinkEnabled: Bool
     private var isHackyLinkButtonSelected: Bool = false
 
+    func selectLink() {
+        savedPaymentOptionsViewController.selectLink()
+    }
+    
     private lazy var savedPaymentMethodManager: SavedPaymentMethodManager = {
         return SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession)
     }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -85,7 +85,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
     private let isApplePayEnabled: Bool
     private let isLinkEnabled: Bool
     private var isHackyLinkButtonSelected: Bool = false
-    
+
     private lazy var savedPaymentMethodManager: SavedPaymentMethodManager = {
         return SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession)
     }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -85,10 +85,6 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
     private let isApplePayEnabled: Bool
     private let isLinkEnabled: Bool
     private var isHackyLinkButtonSelected: Bool = false
-
-    func selectLink() {
-        savedPaymentOptionsViewController.selectLink()
-    }
     
     private lazy var savedPaymentMethodManager: SavedPaymentMethodManager = {
         return SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -105,10 +105,6 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession)
     }()
 
-    func selectLink() {
-        //TODO(link): Vertical FlowController
-    }
-    
     // MARK: - UI properties
 
     lazy var navigationBar: SheetNavigationBar = {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -105,6 +105,10 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession)
     }()
 
+    func selectLink() {
+        //TODO(link): Vertical FlowController
+    }
+    
     // MARK: - UI properties
 
     lazy var navigationBar: SheetNavigationBar = {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -197,10 +197,6 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
         self.view.backgroundColor = configuration.appearance.colors.background
     }
 
-    func selectLink() {
-        savedPaymentOptionsViewController.selectLink()
-    }
-
     // MARK: UIViewController Methods
 
     override func viewDidLoad() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkCardEditElementSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkCardEditElementSnapshotTests.swift
@@ -69,7 +69,7 @@ extension LinkCardEditElementSnapshotTests {
             isDefault: isDefault
         )
 
-        return LinkCardEditElement(paymentMethod: paymentMethod, configuration: .init())
+        return LinkCardEditElement(paymentMethod: paymentMethod, configuration: PaymentSheet.Configuration())
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
@@ -136,7 +136,7 @@ extension PayWithLinkViewController_WalletViewModelTests {
             context: .init(
                 intent: .paymentIntent(paymentIntent),
                 elementsSession: elementsSession,
-                configuration: .init(),
+                configuration: PaymentSheet.Configuration(),
                 shouldOfferApplePay: false,
                 shouldFinishOnClose: false,
                 callToAction: nil,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -99,7 +99,8 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
                             intent: loadResult.intent,
                             elementsSession: loadResult.elementsSession,
                             paymentOption: self.newCardPaymentOption,
-                            paymentHandler: self.paymentHandler
+                            paymentHandler: self.paymentHandler,
+                            analyticsHelper: ._testValue()
                         ) { result, _ in
                             switch result {
                             case .completed:
@@ -186,7 +187,8 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
                                      intent: .deferredIntent(intentConfig: intentConfig),
                                      elementsSession: loadResult.elementsSession,
                                      paymentOption: self.newCardPaymentOption,
-                                     paymentHandler: self.paymentHandler) { result, _ in
+                                     paymentHandler: self.paymentHandler,
+                                     analyticsHelper: ._testValue()) { result, _ in
                     switch result {
                     case .completed:
                         confirmExpectation.fulfill()
@@ -253,7 +255,8 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
                                      intent: .deferredIntent(intentConfig: intentConfig),
                                      elementsSession: loadResult.elementsSession,
                                      paymentOption: self.newCardPaymentOption,
-                                     paymentHandler: self.paymentHandler) { result, _ in
+                                     paymentHandler: self.paymentHandler,
+                                     analyticsHelper: ._testValue()) { result, _ in
                     switch result {
                     case .completed:
                         confirmExpectation.fulfill()
@@ -304,7 +307,8 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
                     intent: loadResult.intent,
                     elementsSession: loadResult.elementsSession,
                     paymentOption: .saved(paymentMethod: .init(stripeId: "pm_card_visa", type: .card), confirmParams: nil),
-                    paymentHandler: self.paymentHandler
+                    paymentHandler: self.paymentHandler,
+                    analyticsHelper: ._testValue()
                 ) { result, _ in
                     switch result {
                     case .completed:
@@ -563,7 +567,8 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
             intent: intent,
             elementsSession: ._testCardValue(),
             paymentOption: inputPaymentOption,
-            paymentHandler: self.paymentHandler
+            paymentHandler: self.paymentHandler,
+            analyticsHelper: ._testValue()
         ) { result, _ in
             XCTAssertTrue(Thread.isMainThread)
             switch (result, expectedResult) {
@@ -624,7 +629,8 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
             intent: .deferredIntent(intentConfig: intentConfig),
             elementsSession: ._testCardValue(),
             paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
-            paymentHandler: paymentHandler
+            paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue()
         ) { result, _ in
             e.fulfill()
             guard case let .failed(error) = result else {
@@ -654,7 +660,8 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
             intent: .deferredIntent(intentConfig: intentConfig),
             elementsSession: ._testCardValue(),
             paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
-            paymentHandler: paymentHandler
+            paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue()
         ) { result, _ in
             e.fulfill()
             // The result is completed, even though the IntentConfiguration and PaymentIntent amounts are not the same
@@ -682,7 +689,8 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
             intent: .deferredIntent(intentConfig: intentConfig),
             elementsSession: ._testCardValue(),
             paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
-            paymentHandler: paymentHandler
+            paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue()
         ) { result, _ in
             e.fulfill()
             guard case let .failed(error) = result else {
@@ -712,7 +720,8 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
             intent: .deferredIntent(intentConfig: intentConfig),
             elementsSession: ._testCardValue(),
             paymentOption: .new(confirmParams: self.valid_card_checkbox_selected),
-            paymentHandler: paymentHandler
+            paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue()
         ) { result, _ in
             e.fulfill()
             // The result is completed, even though the IntentConfiguration and SetupIntent setup_future_usage values are not the same
@@ -1145,7 +1154,8 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
             intent: intent,
             elementsSession: elementsSession,
             paymentOption: paymentOption,
-            paymentHandler: paymentHandler
+            paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue()
         ) { _, deferredConfirmationType in
             // ...should set the newly saved PM as the default
             let defaultPM = CustomerPaymentOption.defaultPaymentMethod(for: configuration.customer?.id)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+DashboardConfirmParamsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+DashboardConfirmParamsTest.swift
@@ -144,6 +144,7 @@ final class PaymentSheet_ConfirmParamsTest: APIStubbedTestCase {
             elementsSession: .emptyElementsSession,
             paymentOption: .saved(paymentMethod: MockParams.cardPaymentMethod, confirmParams: nil),
             paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue(),
             completion: { _, _ in
                 exp.fulfill()
             }
@@ -169,6 +170,7 @@ final class PaymentSheet_ConfirmParamsTest: APIStubbedTestCase {
             elementsSession: .emptyElementsSession,
             paymentOption: .new(confirmParams: MockParams.intentConfirmParams),
             paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue(),
             completion: { _, _ in
                 exp.fulfill()
             }
@@ -198,6 +200,7 @@ final class PaymentSheet_ConfirmParamsTest: APIStubbedTestCase {
             elementsSession: .emptyElementsSession,
             paymentOption: .new(confirmParams: intentConfirmParams),
             paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue(),
             completion: { _, _ in
                 exp.fulfill()
             }
@@ -224,6 +227,7 @@ final class PaymentSheet_ConfirmParamsTest: APIStubbedTestCase {
             elementsSession: .emptyElementsSession,
             paymentOption: .saved(paymentMethod: MockParams.cardPaymentMethod, confirmParams: nil),
             paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue(),
             completion: { _, _ in
                 exp.fulfill()
             }
@@ -249,6 +253,7 @@ final class PaymentSheet_ConfirmParamsTest: APIStubbedTestCase {
             elementsSession: .emptyElementsSession,
             paymentOption: .new(confirmParams: MockParams.intentConfirmParams),
             paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue(),
             completion: { _, _ in
                 exp.fulfill()
             }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetExternalPaymentMethodTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetExternalPaymentMethodTests.swift
@@ -45,7 +45,8 @@ final class PaymentSheetExternalPaymentMethodTests: XCTestCase {
             intent: intent,
             elementsSession: ._testCardValue(),
             paymentOption: .external(paymentMethod: ._testPayPalValue(), billingDetails: .init()),
-            paymentHandler: .shared()
+            paymentHandler: .shared(),
+            analyticsHelper: ._testValue()
         ) { result, analyticsConfirmType in
             e.fulfill()
             guard case .completed = result else {
@@ -106,7 +107,8 @@ final class PaymentSheetExternalPaymentMethodTests: XCTestCase {
             intent: intent,
             elementsSession: ._testCardValue(),
             paymentOption: .external(paymentMethod: ._testPayPalValue(), billingDetails: intentConfirmParams.paymentMethodParams.nonnil_billingDetails),
-            paymentHandler: .shared()
+            paymentHandler: .shared(),
+            analyticsHelper: ._testValue()
         ) { _, _ in }
         await fulfillment(of: [externalConfirmHandlerCalled], timeout: 5)
     }
@@ -129,7 +131,8 @@ final class PaymentSheetExternalPaymentMethodTests: XCTestCase {
                 intent: intent,
                 elementsSession: ._testCardValue(),
                 paymentOption: .external(paymentMethod: ._testPayPalValue(), billingDetails: .init()),
-                paymentHandler: .shared()
+                paymentHandler: .shared(),
+                analyticsHelper: ._testValue()
             ) { result, analyticsConfirmType in
                 e.fulfill()
                 XCTAssertEqual(analyticsConfirmType, nil)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetGDPRConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetGDPRConfirmFlowTests.swift
@@ -410,7 +410,8 @@ final class PaymentSheet_GDPR_ConfirmFlowTests: STPNetworkStubbingTestCase {
             intent: intent,
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: intentConfirmParams),
-            paymentHandler: paymentHandler
+            paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue()
         ) { result, _  in
             switch result {
             case .failed(error: let error):

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -361,7 +361,8 @@ final class PaymentSheet_LPM_ConfirmFlowTests: STPNetworkStubbingTestCase {
                     intent: intent,
                     elementsSession: ._testValue(intent: intent),
                     paymentOption: .saved(paymentMethod: savedSepaPM, confirmParams: nil),
-                    paymentHandler: paymentHandler
+                    paymentHandler: paymentHandler,
+                    analyticsHelper: ._testValue()
                 ) { result, _  in
                     e.fulfill()
                     switch result {
@@ -681,7 +682,8 @@ extension PaymentSheet_LPM_ConfirmFlowTests {
                 intent: intent,
                 elementsSession: ._testValue(intent: intent),
                 paymentOption: .new(confirmParams: intentConfirmParams),
-                paymentHandler: paymentHandler
+                paymentHandler: paymentHandler,
+                analyticsHelper: ._testValue()
             ) { result, _  in
                 switch result {
                 case .failed(error: let error):

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
@@ -26,6 +26,7 @@ import Foundation
     @_spi(STP) public let popupWebviewOption: PopupWebviewOption?
     @_spi(STP) public let passthroughModeEnabled: Bool?
     @_spi(STP) public let disableSignup: Bool?
+    @_spi(STP) public let suppress2FAModal: Bool?
     @_spi(STP) public let linkMode: LinkMode?
     @_spi(STP) public let linkFlags: [String: Bool]?
 
@@ -36,6 +37,7 @@ import Foundation
         popupWebviewOption: PopupWebviewOption?,
         passthroughModeEnabled: Bool?,
         disableSignup: Bool?,
+        suppress2FAModal: Bool?,
         linkMode: LinkMode?,
         linkFlags: [String: Bool]?,
         allResponseFields: [AnyHashable: Any]
@@ -44,6 +46,7 @@ import Foundation
         self.popupWebviewOption = popupWebviewOption
         self.passthroughModeEnabled = passthroughModeEnabled
         self.disableSignup = disableSignup
+        self.suppress2FAModal = suppress2FAModal
         self.linkMode = linkMode
         self.linkFlags = linkFlags
         self.allResponseFields = allResponseFields
@@ -65,6 +68,7 @@ import Foundation
         let webviewOption = PopupWebviewOption(rawValue: response["link_popup_webview_option"] as? String ?? "")
         let passthroughModeEnabled = response["link_passthrough_mode_enabled"] as? Bool ?? false
         let disableSignup = response["link_mobile_disable_signup"] as? Bool ?? false
+        let suppress2FAModal = response["link_mobile_suppress_2fa_modal"] as? Bool ?? false
         let linkMode = (response["link_mode"] as? String).flatMap { LinkMode(rawValue: $0) }
 
         // Collect the flags for the URL generator
@@ -79,6 +83,7 @@ import Foundation
             popupWebviewOption: webviewOption,
             passthroughModeEnabled: passthroughModeEnabled,
             disableSignup: disableSignup,
+            suppress2FAModal: suppress2FAModal,
             linkMode: linkMode,
             linkFlags: linkFlags,
             allResponseFields: response


### PR DESCRIPTION
## Summary
* Show the 2FA modal before showing the list of payment methods. Allow this to be disabled by a server-side flag.
* Enable Link in FlowController by bringing back the PayWithNativeLinkController. This can be used separately to confirm a Link payment.
* We pass through the AnalyticsHelper from PaymentSheet when using it.

## Motivation
Enabling FlowController in Link v3.

## Testing
PaymentSheet Example, will add end-to-end tests

## Changelog
None yet