### PR TITLE
Fix removal dialog showing incorrect brand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## x.x.x yyyy-yy-yy
 ### PaymentSheet
 * [Fixed] Fixed an issue with the vertical list with 3 or more saved payment methods where tapping outside the screen sometimes drops changes that were made (e.g. removal or update of PMs).
+* [Fixed] Fixed an issue where the dialog when removing a co-branded card may show the incorrect card brand.
 
 ## 24.0.0 2024-11-04
 ### PaymentSheet

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -682,7 +682,7 @@ extension STPPaymentMethod {
     var removalMessage: (title: String, message: String) {
         switch type {
         case .card:
-            let brandString = STPCardBrandUtilities.stringFrom(card?.networks?.preferred?.toCardBrand ?? card?.brand ?? .unknown) ?? ""
+            let brandString = STPCardBrandUtilities.stringFrom(card?.preferredDisplayBrand ?? .unknown) ?? ""
             let last4 = card?.last4 ?? ""
             let formattedMessage = STPLocalizedString(
                 "%1$@ •••• %2$@",

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
@@ -318,4 +318,13 @@ class SavedPaymentOptionsViewControllerTests: XCTestCase {
                                                  analyticsHelper: ._testValue(),
                                                  delegate: nil)
     }
+    
+    // Test case for when the preferred brand of a card is nil that we look at the display brand
+    func testRemovalMessagePreferredBrand_nilPreferredBrand() {
+        let coBrandedCard = STPPaymentMethod._testCardCoBranded(displayBrand: "cartes_bancaires")
+        XCTAssertNil(coBrandedCard.card?.networks?.preferred)
+        let removalMessage = coBrandedCard.removalMessage
+        
+        XCTAssertEqual(removalMessage.message, "Cartes Bancaires •••• 4242")
+    }
 }


### PR DESCRIPTION
## Summary
- When a co-branded card does not have a preferred brand set, we should fall back to the display brand not the brand.

## Motivation
- Bug fix

## Testing
- Manual
- New unit test

## Changelog
See diff