### PR TITLE
Fix issue with bank form in vertical mode

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -474,3 +474,32 @@ extension PaymentElementConfiguration {
         (defaultBillingDetails.email?.isEmpty == false && billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod)
     }
 }
+
+extension PaymentSheet.PaymentMethodType {
+    
+    var isLinkBankPayment: Bool {
+        switch self {
+        case .stripe:
+            return false
+        case .external:
+            return false
+        case .instantDebits:
+            return true
+        case .linkCardBrand:
+            return true
+        }
+    }
+    
+    var isBankPayment: Bool {
+        switch self {
+        case .stripe(let type):
+            return type == .USBankAccount
+        case .external:
+            return false
+        case .instantDebits:
+            return true
+        case .linkCardBrand:
+            return true
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -508,19 +508,3 @@ private extension LinkBankPaymentMethod {
         return STPPaymentMethod.decodedObject(fromAPIResponse: allResponseFields)
     }
 }
-
-private extension PaymentSheet.PaymentMethodType {
-    
-    var isLinkBankPayment: Bool {
-        switch self {
-        case .stripe:
-            return false
-        case .external:
-            return false
-        case .instantDebits:
-            return true
-        case .linkCardBrand:
-            return true
-        }
-    }
-}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -670,7 +670,7 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
             CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(paymentMethod.stripeId), forCustomer: configuration.customer?.id)
         case let .new(paymentMethodType: paymentMethodType):
             let pmFormVC = makeFormVC(paymentMethodType: paymentMethodType)
-            if pmFormVC.form.collectsUserInput {
+            if pmFormVC.form.collectsUserInput || paymentMethodType.isBankPayment {
                 // The payment method form collects user input, display it
                 self.paymentMethodFormViewController = pmFormVC
                 paymentMethodListContentOffsetPercentage = bottomSheetController?.contentOffsetPercentage
@@ -739,6 +739,11 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
     }
 
     private func shouldDisplayForm(for paymentMethodType: PaymentSheet.PaymentMethodType) -> Bool {
+        if paymentMethodType.isBankPayment {
+            // We need to show the form for bank payments (even if we don't collect user input) so that we can launch the auth flow.
+            return true
+        }
+        
         return PaymentSheetFormFactory(
             intent: intent,
             elementsSession: elementsSession,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue with bank forms (ACH, Instant Debits, and Link Card Brand) in vertical mode when email collection (and name collection, for the ACH case) was set to `never`.

This billing details collection configuration results in an empty form, which in vertical mode means “show the pay button instead of the form”. That doesn’t work for any bank payment methods, since they need to “hijack” the primary button to open the bank auth flow.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
