### PR TITLE
Fix issue with extracting payment method from redirect URL

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -307,7 +307,13 @@ private extension URL {
             return nil
         }
         
-        return try? JSONDecoder().decode(LinkBankPaymentMethod.self, from: data)
+        let result: Result<LinkBankPaymentMethod, Error> = STPAPIClient.decodeResponse(
+            data: data,
+            error: nil,
+            response: nil
+        )
+        
+        return try? result.get()
     }
     
     func extractValue(forKey key: String) -> String? {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the expanded `PaymentMethod` returned from the web flow of Instant Bank Payments wasn’t correctly decoded, leaving the form in a blocked state.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
