### PR TITLE
[Connect] Add analytic events (part 1/2)

### DIFF
--- a/Stripe.xcworkspace/contents.xcworkspacedata
+++ b/Stripe.xcworkspace/contents.xcworkspacedata
@@ -78,7 +78,4 @@
          location = "group:IntegrationTester/IntegrationTester.xcodeproj">
       </FileRef>
    </Group>
-   <FileRef
-      location = "group:HTTPStatusError.swift">
-   </FileRef>
 </Workspace>

--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		41542A692C88B6F2004E728E /* JSONEncoder+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41542A682C88B6F2004E728E /* JSONEncoder+extension.swift */; };
 		41542A6B2C88B79E004E728E /* JSONSerialization+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41542A6A2C88B79E004E728E /* JSONSerialization+extension.swift */; };
 		4161C2732C9D0A8A005BD67C /* AccountOnboardingViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4161C2722C9D0A8A005BD67C /* AccountOnboardingViewControllerTests.swift */; };
-		4161C2752C9DB1B9005BD67C /* StripeUICore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4161C2742C9DB1B9005BD67C /* StripeUICore.framework */; };
 		4161C2792C9DB1CE005BD67C /* StripeUICore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4161C2782C9DB1CE005BD67C /* StripeUICore.framework */; };
 		4161C27E2C9DB566005BD67C /* AccountCollectionOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4161C27D2C9DB566005BD67C /* AccountCollectionOptions.swift */; };
 		4161C28C2CA1B54E005BD67C /* OnSetterFunctionCalledMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4161C28B2CA1B54E005BD67C /* OnSetterFunctionCalledMessageHandlerTests.swift */; };
@@ -113,6 +112,8 @@
 		E6660DAB2CDC5702002A7631 /* AuthenticatedWebViewRedirectedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DAA2CDC5702002A7631 /* AuthenticatedWebViewRedirectedEvent.swift */; };
 		E6660DAD2CDC5745002A7631 /* AuthenticatedWebViewCanceledEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DAC2CDC5745002A7631 /* AuthenticatedWebViewCanceledEvent.swift */; };
 		E6660DAF2CDC576F002A7631 /* AuthenticatedWebViewErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DAE2CDC576F002A7631 /* AuthenticatedWebViewErrorEvent.swift */; };
+		E6660DB12CDD8E25002A7631 /* ComponentAnalyticsClient+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DB02CDD8E1B002A7631 /* ComponentAnalyticsClient+Mock.swift */; };
+		E6660DB32CDD8F6E002A7631 /* StripeCoreTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6660DB22CDD8F6E002A7631 /* StripeCoreTestUtils.framework */; };
 		E688AE002CADD8C400951D97 /* NotificationBannerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E688ADFF2CADD8C400951D97 /* NotificationBannerViewControllerTests.swift */; };
 		E688AE032CADE36C00951D97 /* OnNotificationsChangeHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E688AE022CADE36900951D97 /* OnNotificationsChangeHandlerTests.swift */; };
 		E6C5F5F62C9FEE0200861709 /* AccountManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5F5F52C9FEE0200861709 /* AccountManagementViewController.swift */; };
@@ -243,6 +244,8 @@
 		E6660DAA2CDC5702002A7631 /* AuthenticatedWebViewRedirectedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewRedirectedEvent.swift; sourceTree = "<group>"; };
 		E6660DAC2CDC5745002A7631 /* AuthenticatedWebViewCanceledEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewCanceledEvent.swift; sourceTree = "<group>"; };
 		E6660DAE2CDC576F002A7631 /* AuthenticatedWebViewErrorEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewErrorEvent.swift; sourceTree = "<group>"; };
+		E6660DB02CDD8E1B002A7631 /* ComponentAnalyticsClient+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ComponentAnalyticsClient+Mock.swift"; sourceTree = "<group>"; };
+		E6660DB22CDD8F6E002A7631 /* StripeCoreTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeCoreTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E688ADFF2CADD8C400951D97 /* NotificationBannerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationBannerViewControllerTests.swift; sourceTree = "<group>"; };
 		E688AE022CADE36900951D97 /* OnNotificationsChangeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnNotificationsChangeHandlerTests.swift; sourceTree = "<group>"; };
 		E6C5F5F52C9FEE0200861709 /* AccountManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManagementViewController.swift; sourceTree = "<group>"; };
@@ -269,7 +272,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				4161C2752C9DB1B9005BD67C /* StripeUICore.framework in Frameworks */,
+				E6660DB32CDD8F6E002A7631 /* StripeCoreTestUtils.framework in Frameworks */,
 				41D17A4B2C5A73A7007C6EE6 /* StripeConnect.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -479,6 +482,7 @@
 		41A2A5662C5AC5110077FC74 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				E6660DB22CDD8F6E002A7631 /* StripeCoreTestUtils.framework */,
 				4161C2782C9DB1CE005BD67C /* StripeUICore.framework */,
 				4161C2742C9DB1B9005BD67C /* StripeUICore.framework */,
 				41A2A5672C5AC5120077FC74 /* StripeCore.framework */,
@@ -501,6 +505,7 @@
 		41BCCFEE2C8B3C7900797E01 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				E6660DB02CDD8E1B002A7631 /* ComponentAnalyticsClient+Mock.swift */,
 				41BCCFEF2C8B3C8900797E01 /* AppearanceWrapper+Default.swift */,
 				E6F486082C9E8A40000D914F /* ConnectJSURLParamsTests.swift */,
 				41BCCFF22C8B449800797E01 /* TestHelpers.swift */,
@@ -845,6 +850,7 @@
 				410D0FD92C6D1F25009B0E26 /* UpdateConnectInstanceSenderTests.swift in Sources */,
 				E6F486092C9E8A40000D914F /* ConnectJSURLParamsTests.swift in Sources */,
 				416E9E892C76B36F00A0B917 /* PayoutsViewControllerTests.swift in Sources */,
+				E6660DB12CDD8E25002A7631 /* ComponentAnalyticsClient+Mock.swift in Sources */,
 				41814EEB2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift in Sources */,
 				41814EEF2C6BEF2C0014EB5E /* FetchInitParamsMessageHandlerTests.swift in Sources */,
 				41810D692C88C4B100F10EB7 /* AppearanceTests.swift in Sources */,

--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -114,6 +114,7 @@
 		E6660DAF2CDC576F002A7631 /* AuthenticatedWebViewErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DAE2CDC576F002A7631 /* AuthenticatedWebViewErrorEvent.swift */; };
 		E6660DB12CDD8E25002A7631 /* ComponentAnalyticsClient+Mock.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DB02CDD8E1B002A7631 /* ComponentAnalyticsClient+Mock.swift */; };
 		E6660DB32CDD8F6E002A7631 /* StripeCoreTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E6660DB22CDD8F6E002A7631 /* StripeCoreTestUtils.framework */; };
+		E6660DB72CDD99EF002A7631 /* MockComponentAnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DB62CDD99E7002A7631 /* MockComponentAnalyticsClient.swift */; };
 		E688AE002CADD8C400951D97 /* NotificationBannerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E688ADFF2CADD8C400951D97 /* NotificationBannerViewControllerTests.swift */; };
 		E688AE032CADE36C00951D97 /* OnNotificationsChangeHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E688AE022CADE36900951D97 /* OnNotificationsChangeHandlerTests.swift */; };
 		E6C5F5F62C9FEE0200861709 /* AccountManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5F5F52C9FEE0200861709 /* AccountManagementViewController.swift */; };
@@ -246,6 +247,7 @@
 		E6660DAE2CDC576F002A7631 /* AuthenticatedWebViewErrorEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewErrorEvent.swift; sourceTree = "<group>"; };
 		E6660DB02CDD8E1B002A7631 /* ComponentAnalyticsClient+Mock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ComponentAnalyticsClient+Mock.swift"; sourceTree = "<group>"; };
 		E6660DB22CDD8F6E002A7631 /* StripeCoreTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeCoreTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E6660DB62CDD99E7002A7631 /* MockComponentAnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockComponentAnalyticsClient.swift; sourceTree = "<group>"; };
 		E688ADFF2CADD8C400951D97 /* NotificationBannerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationBannerViewControllerTests.swift; sourceTree = "<group>"; };
 		E688AE022CADE36900951D97 /* OnNotificationsChangeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnNotificationsChangeHandlerTests.swift; sourceTree = "<group>"; };
 		E6C5F5F52C9FEE0200861709 /* AccountManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManagementViewController.swift; sourceTree = "<group>"; };
@@ -505,6 +507,7 @@
 		41BCCFEE2C8B3C7900797E01 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				E6660DB62CDD99E7002A7631 /* MockComponentAnalyticsClient.swift */,
 				E6660DB02CDD8E1B002A7631 /* ComponentAnalyticsClient+Mock.swift */,
 				41BCCFEF2C8B3C8900797E01 /* AppearanceWrapper+Default.swift */,
 				E6F486082C9E8A40000D914F /* ConnectJSURLParamsTests.swift */,
@@ -850,6 +853,7 @@
 				410D0FD92C6D1F25009B0E26 /* UpdateConnectInstanceSenderTests.swift in Sources */,
 				E6F486092C9E8A40000D914F /* ConnectJSURLParamsTests.swift in Sources */,
 				416E9E892C76B36F00A0B917 /* PayoutsViewControllerTests.swift in Sources */,
+				E6660DB72CDD99EF002A7631 /* MockComponentAnalyticsClient.swift in Sources */,
 				E6660DB12CDD8E25002A7631 /* ComponentAnalyticsClient+Mock.swift in Sources */,
 				41814EEB2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift in Sources */,
 				41814EEF2C6BEF2C0014EB5E /* FetchInitParamsMessageHandlerTests.swift in Sources */,

--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -95,6 +95,24 @@
 		E65691222CA52D5900E0DB00 /* StripeConnect+Exports.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65691212CA52D5900E0DB00 /* StripeConnect+Exports.swift */; };
 		E65691252CA52F9D00E0DB00 /* NotificationBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65691232CA52F8600E0DB00 /* NotificationBannerViewController.swift */; };
 		E65691272CA533CD00E0DB00 /* OnNotificationsChangeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65691262CA533CD00E0DB00 /* OnNotificationsChangeHandler.swift */; };
+		E6660D8F2CDC418C002A7631 /* ConnectAnalyticEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660D8E2CDC418C002A7631 /* ConnectAnalyticEvent.swift */; };
+		E6660D902CDC418C002A7631 /* ComponentAnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660D8D2CDC418C002A7631 /* ComponentAnalyticsClient.swift */; };
+		E6660D912CDC418C002A7631 /* AnalyticsClientV2+Connect.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660D8C2CDC418C002A7631 /* AnalyticsClientV2+Connect.swift */; };
+		E6660D9A2CDC4194002A7631 /* PageLoadErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660D972CDC4194002A7631 /* PageLoadErrorEvent.swift */; };
+		E6660D9B2CDC4194002A7631 /* ComponentViewedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660D942CDC4194002A7631 /* ComponentViewedEvent.swift */; };
+		E6660D9C2CDC4194002A7631 /* ComponentCreatedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660D922CDC4194002A7631 /* ComponentCreatedEvent.swift */; };
+		E6660D9D2CDC4194002A7631 /* DeserializeMessageErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660D962CDC4194002A7631 /* DeserializeMessageErrorEvent.swift */; };
+		E6660D9E2CDC4194002A7631 /* UnexpectedLoadErrorTypeEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660D982CDC4194002A7631 /* UnexpectedLoadErrorTypeEvent.swift */; };
+		E6660D9F2CDC4194002A7631 /* UnrecognizedSetterEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660D992CDC4194002A7631 /* UnrecognizedSetterEvent.swift */; };
+		E6660DA02CDC4194002A7631 /* ComponentLoadedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660D932CDC4194002A7631 /* ComponentLoadedEvent.swift */; };
+		E6660DA12CDC4194002A7631 /* ComponentWebPageLoadedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660D952CDC4194002A7631 /* ComponentWebPageLoadedEvent.swift */; };
+		E6660DA42CDC4209002A7631 /* URL+extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DA32CDC4209002A7631 /* URL+extension.swift */; };
+		E6660DA52CDC4209002A7631 /* Error+extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DA22CDC4209002A7631 /* Error+extensions.swift */; };
+		E6660DA72CDC42F4002A7631 /* Encodable+Connect.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DA62CDC42F4002A7631 /* Encodable+Connect.swift */; };
+		E6660DA92CDC563C002A7631 /* AuthenticatedWebViewOpenedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DA82CDC563C002A7631 /* AuthenticatedWebViewOpenedEvent.swift */; };
+		E6660DAB2CDC5702002A7631 /* AuthenticatedWebViewRedirectedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DAA2CDC5702002A7631 /* AuthenticatedWebViewRedirectedEvent.swift */; };
+		E6660DAD2CDC5745002A7631 /* AuthenticatedWebViewCanceledEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DAC2CDC5745002A7631 /* AuthenticatedWebViewCanceledEvent.swift */; };
+		E6660DAF2CDC576F002A7631 /* AuthenticatedWebViewErrorEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DAE2CDC576F002A7631 /* AuthenticatedWebViewErrorEvent.swift */; };
 		E688AE002CADD8C400951D97 /* NotificationBannerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E688ADFF2CADD8C400951D97 /* NotificationBannerViewControllerTests.swift */; };
 		E688AE032CADE36C00951D97 /* OnNotificationsChangeHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E688AE022CADE36900951D97 /* OnNotificationsChangeHandlerTests.swift */; };
 		E6C5F5F62C9FEE0200861709 /* AccountManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5F5F52C9FEE0200861709 /* AccountManagementViewController.swift */; };
@@ -207,6 +225,24 @@
 		E65691212CA52D5900E0DB00 /* StripeConnect+Exports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StripeConnect+Exports.swift"; sourceTree = "<group>"; };
 		E65691232CA52F8600E0DB00 /* NotificationBannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationBannerViewController.swift; sourceTree = "<group>"; };
 		E65691262CA533CD00E0DB00 /* OnNotificationsChangeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnNotificationsChangeHandler.swift; sourceTree = "<group>"; };
+		E6660D8C2CDC418C002A7631 /* AnalyticsClientV2+Connect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsClientV2+Connect.swift"; sourceTree = "<group>"; };
+		E6660D8D2CDC418C002A7631 /* ComponentAnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentAnalyticsClient.swift; sourceTree = "<group>"; };
+		E6660D8E2CDC418C002A7631 /* ConnectAnalyticEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectAnalyticEvent.swift; sourceTree = "<group>"; };
+		E6660D922CDC4194002A7631 /* ComponentCreatedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentCreatedEvent.swift; sourceTree = "<group>"; };
+		E6660D932CDC4194002A7631 /* ComponentLoadedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentLoadedEvent.swift; sourceTree = "<group>"; };
+		E6660D942CDC4194002A7631 /* ComponentViewedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentViewedEvent.swift; sourceTree = "<group>"; };
+		E6660D952CDC4194002A7631 /* ComponentWebPageLoadedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentWebPageLoadedEvent.swift; sourceTree = "<group>"; };
+		E6660D962CDC4194002A7631 /* DeserializeMessageErrorEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeserializeMessageErrorEvent.swift; sourceTree = "<group>"; };
+		E6660D972CDC4194002A7631 /* PageLoadErrorEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageLoadErrorEvent.swift; sourceTree = "<group>"; };
+		E6660D982CDC4194002A7631 /* UnexpectedLoadErrorTypeEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnexpectedLoadErrorTypeEvent.swift; sourceTree = "<group>"; };
+		E6660D992CDC4194002A7631 /* UnrecognizedSetterEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnrecognizedSetterEvent.swift; sourceTree = "<group>"; };
+		E6660DA22CDC4209002A7631 /* Error+extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+extensions.swift"; sourceTree = "<group>"; };
+		E6660DA32CDC4209002A7631 /* URL+extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+extension.swift"; sourceTree = "<group>"; };
+		E6660DA62CDC42F4002A7631 /* Encodable+Connect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Encodable+Connect.swift"; sourceTree = "<group>"; };
+		E6660DA82CDC563C002A7631 /* AuthenticatedWebViewOpenedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewOpenedEvent.swift; sourceTree = "<group>"; };
+		E6660DAA2CDC5702002A7631 /* AuthenticatedWebViewRedirectedEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewRedirectedEvent.swift; sourceTree = "<group>"; };
+		E6660DAC2CDC5745002A7631 /* AuthenticatedWebViewCanceledEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewCanceledEvent.swift; sourceTree = "<group>"; };
+		E6660DAE2CDC576F002A7631 /* AuthenticatedWebViewErrorEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewErrorEvent.swift; sourceTree = "<group>"; };
 		E688ADFF2CADD8C400951D97 /* NotificationBannerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationBannerViewControllerTests.swift; sourceTree = "<group>"; };
 		E688AE022CADE36900951D97 /* OnNotificationsChangeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnNotificationsChangeHandlerTests.swift; sourceTree = "<group>"; };
 		E6C5F5F52C9FEE0200861709 /* AccountManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManagementViewController.swift; sourceTree = "<group>"; };
@@ -300,6 +336,7 @@
 		413987C62C63F34B001D375E /* Internal */ = {
 			isa = PBXGroup;
 			children = (
+				E6660D8A2CDC414E002A7631 /* Analytics */,
 				E640C9CD2CBF26C9009D0C6E /* AuthenticatedWebView */,
 				416E9ED02C77F6C100A0B917 /* Extensions */,
 				410D0FE22C6D31C6009B0E26 /* StripeConnectConstants.swift */,
@@ -363,12 +400,15 @@
 		416E9ED02C77F6C100A0B917 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				416E9ED32C77F90600A0B917 /* WKScriptMessage+extension.swift */,
+				E6660DA62CDC42F4002A7631 /* Encodable+Connect.swift */,
+				E6660DA22CDC4209002A7631 /* Error+extensions.swift */,
+				41054E422C989AAD00383C09 /* Font+Extension.swift */,
 				E6D3C8EF2CBE1455003CE967 /* HTTPURLResponse+StripeConnect.swift */,
 				41542A682C88B6F2004E728E /* JSONEncoder+extension.swift */,
 				41542A6A2C88B79E004E728E /* JSONSerialization+extension.swift */,
-				41054E422C989AAD00383C09 /* Font+Extension.swift */,
 				E6EF91C62CBA3BE60082DD1B /* UIViewController+StripeConnect.swift */,
+				E6660DA32CDC4209002A7631 /* URL+extension.swift */,
+				416E9ED32C77F90600A0B917 /* WKScriptMessage+extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -555,6 +595,36 @@
 			path = AuthenticatedWebView;
 			sourceTree = "<group>";
 		};
+		E6660D8A2CDC414E002A7631 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				E6660D8B2CDC4158002A7631 /* Events */,
+				E6660D8C2CDC418C002A7631 /* AnalyticsClientV2+Connect.swift */,
+				E6660D8D2CDC418C002A7631 /* ComponentAnalyticsClient.swift */,
+				E6660D8E2CDC418C002A7631 /* ConnectAnalyticEvent.swift */,
+			);
+			path = Analytics;
+			sourceTree = "<group>";
+		};
+		E6660D8B2CDC4158002A7631 /* Events */ = {
+			isa = PBXGroup;
+			children = (
+				E6660DAC2CDC5745002A7631 /* AuthenticatedWebViewCanceledEvent.swift */,
+				E6660DAE2CDC576F002A7631 /* AuthenticatedWebViewErrorEvent.swift */,
+				E6660DA82CDC563C002A7631 /* AuthenticatedWebViewOpenedEvent.swift */,
+				E6660DAA2CDC5702002A7631 /* AuthenticatedWebViewRedirectedEvent.swift */,
+				E6660D922CDC4194002A7631 /* ComponentCreatedEvent.swift */,
+				E6660D932CDC4194002A7631 /* ComponentLoadedEvent.swift */,
+				E6660D942CDC4194002A7631 /* ComponentViewedEvent.swift */,
+				E6660D952CDC4194002A7631 /* ComponentWebPageLoadedEvent.swift */,
+				E6660D962CDC4194002A7631 /* DeserializeMessageErrorEvent.swift */,
+				E6660D972CDC4194002A7631 /* PageLoadErrorEvent.swift */,
+				E6660D982CDC4194002A7631 /* UnexpectedLoadErrorTypeEvent.swift */,
+				E6660D992CDC4194002A7631 /* UnrecognizedSetterEvent.swift */,
+			);
+			path = Events;
+			sourceTree = "<group>";
+		};
 		E688AE012CADE35300951D97 /* NotificationBanner */ = {
 			isa = PBXGroup;
 			children = (
@@ -717,6 +787,7 @@
 				E65691222CA52D5900E0DB00 /* StripeConnect+Exports.swift in Sources */,
 				E65691252CA52F9D00E0DB00 /* NotificationBannerViewController.swift in Sources */,
 				410D0FE32C6D31C6009B0E26 /* StripeConnectConstants.swift in Sources */,
+				E6660DAD2CDC5745002A7631 /* AuthenticatedWebViewCanceledEvent.swift in Sources */,
 				4186664A2C66AC66003DB62E /* OnSetterFunctionCalledMessageHandler.swift in Sources */,
 				E6D3C8EE2CBE1404003CE967 /* HTTPStatusError.swift in Sources */,
 				413987CC2C63F34B001D375E /* VoidPayload.swift in Sources */,
@@ -734,17 +805,34 @@
 				41810D7A2C8A0AAD00F10EB7 /* CustomFontSource.swift in Sources */,
 				413987CA2C63F34B001D375E /* ScriptMessageHandler.swift in Sources */,
 				416E9E862C76B35E00A0B917 /* PayoutsViewController.swift in Sources */,
+				E6660DA92CDC563C002A7631 /* AuthenticatedWebViewOpenedEvent.swift in Sources */,
 				41542A6B2C88B79E004E728E /* JSONSerialization+extension.swift in Sources */,
 				E6C5F5F62C9FEE0200861709 /* AccountManagementViewController.swift in Sources */,
 				413987C82C63F34B001D375E /* DebugMessageHandler.swift in Sources */,
 				410D0FCC2C6CFFDB009B0E26 /* AccountSessionClaimedMessageHandler.swift in Sources */,
+				E6660DAF2CDC576F002A7631 /* AuthenticatedWebViewErrorEvent.swift in Sources */,
 				41BCCFED2C8B34F600797E01 /* StringCodingKey.swift in Sources */,
 				4186664E2C66ACB3003DB62E /* OnLoadErrorMessageHandler.swift in Sources */,
 				410D0FE52C6D32F0009B0E26 /* ApplicationURLOpener.swift in Sources */,
 				E6F485F82C9E35A5000D914F /* PaymentDetailsViewController.swift in Sources */,
+				E6660D8F2CDC418C002A7631 /* ConnectAnalyticEvent.swift in Sources */,
+				E6660D902CDC418C002A7631 /* ComponentAnalyticsClient.swift in Sources */,
+				E6660D912CDC418C002A7631 /* AnalyticsClientV2+Connect.swift in Sources */,
+				E6660DAB2CDC5702002A7631 /* AuthenticatedWebViewRedirectedEvent.swift in Sources */,
+				E6660D9A2CDC4194002A7631 /* PageLoadErrorEvent.swift in Sources */,
+				E6660D9B2CDC4194002A7631 /* ComponentViewedEvent.swift in Sources */,
+				E6660D9C2CDC4194002A7631 /* ComponentCreatedEvent.swift in Sources */,
+				E6660D9D2CDC4194002A7631 /* DeserializeMessageErrorEvent.swift in Sources */,
+				E6660D9E2CDC4194002A7631 /* UnexpectedLoadErrorTypeEvent.swift in Sources */,
+				E6660D9F2CDC4194002A7631 /* UnrecognizedSetterEvent.swift in Sources */,
+				E6660DA02CDC4194002A7631 /* ComponentLoadedEvent.swift in Sources */,
+				E6660DA12CDC4194002A7631 /* ComponentWebPageLoadedEvent.swift in Sources */,
+				E6660DA72CDC42F4002A7631 /* Encodable+Connect.swift in Sources */,
 				416E9E762C751B0500A0B917 /* EmbeddedComponentManager.swift in Sources */,
 				416E9ECF2C77EAA400A0B917 /* EmbeddedComponentError.swift in Sources */,
 				E640C9CC2CBF0C1E009D0C6E /* AuthenticatedWebViewManager.swift in Sources */,
+				E6660DA42CDC4209002A7631 /* URL+extension.swift in Sources */,
+				E6660DA52CDC4209002A7631 /* Error+extensions.swift in Sources */,
 				410D0FDF2C6D3176009B0E26 /* ConnectWebViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StripeConnect/StripeConnect/Source/Components/AccountManagementViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/AccountManagementViewController.swift
@@ -5,7 +5,6 @@
 //  Created by Mel Ludowise on 9/21/24.
 //
 
-@_spi(STP) import StripeCore
 import UIKit
 
 /**
@@ -30,13 +29,13 @@ public class AccountManagementViewController: UIViewController {
     init(componentManager: EmbeddedComponentManager,
          collectionOptions: AccountCollectionOptions,
          loadContent: Bool,
-         analyticsClient: AnalyticsClientV2Protocol) {
+         analyticsClientFactory: ComponentAnalyticsClientFactory) {
         super.init(nibName: nil, bundle: nil)
         webVC = ConnectComponentWebViewController(
             componentManager: componentManager,
             componentType: .accountManagement,
             loadContent: loadContent,
-            analyticsClient: analyticsClient
+            analyticsClientFactory: analyticsClientFactory
         ) {
             Props(collectionOptions: collectionOptions)
         } didFailLoadWithError: { [weak self] error in

--- a/StripeConnect/StripeConnect/Source/Components/AccountManagementViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/AccountManagementViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Mel Ludowise on 9/21/24.
 //
 
+@_spi(STP) import StripeCore
 import UIKit
 
 /**
@@ -28,12 +29,14 @@ public class AccountManagementViewController: UIViewController {
 
     init(componentManager: EmbeddedComponentManager,
          collectionOptions: AccountCollectionOptions,
-         loadContent: Bool) {
+         loadContent: Bool,
+         analyticsClient: AnalyticsClientV2Protocol) {
         super.init(nibName: nil, bundle: nil)
         webVC = ConnectComponentWebViewController(
             componentManager: componentManager,
             componentType: .accountManagement,
-            loadContent: loadContent
+            loadContent: loadContent,
+            analyticsClient: analyticsClient
         ) {
             Props(collectionOptions: collectionOptions)
         } didFailLoadWithError: { [weak self] error in

--- a/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Chris Mays on 9/17/24.
 //
 
+@_spi(STP) import StripeCore
 import UIKit
 
 /// A view controller representing an account-onboarding component
@@ -38,13 +39,15 @@ public class AccountOnboardingViewController: UIViewController {
 
     init(props: Props,
          componentManager: EmbeddedComponentManager,
-         loadContent: Bool
+         loadContent: Bool,
+         analyticsClient: AnalyticsClientV2Protocol
     ) {
         super.init(nibName: nil, bundle: nil)
         webVC = ConnectComponentWebViewController(
             componentManager: componentManager,
             componentType: .onboarding,
-            loadContent: loadContent
+            loadContent: loadContent,
+            analyticsClient: analyticsClient
         ) {
             props
         } didFailLoadWithError: { [weak self] error in

--- a/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
@@ -5,7 +5,6 @@
 //  Created by Chris Mays on 9/17/24.
 //
 
-@_spi(STP) import StripeCore
 import UIKit
 
 /// A view controller representing an account-onboarding component
@@ -40,14 +39,14 @@ public class AccountOnboardingViewController: UIViewController {
     init(props: Props,
          componentManager: EmbeddedComponentManager,
          loadContent: Bool,
-         analyticsClient: AnalyticsClientV2Protocol
+         analyticsClientFactory: ComponentAnalyticsClientFactory
     ) {
         super.init(nibName: nil, bundle: nil)
         webVC = ConnectComponentWebViewController(
             componentManager: componentManager,
             componentType: .onboarding,
             loadContent: loadContent,
-            analyticsClient: analyticsClient
+            analyticsClientFactory: analyticsClientFactory
         ) {
             props
         } didFailLoadWithError: { [weak self] error in

--- a/StripeConnect/StripeConnect/Source/Components/NotificationBannerViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/NotificationBannerViewController.swift
@@ -5,7 +5,6 @@
 //  Created by Mel Ludowise on 9/25/24.
 //
 
-@_spi(STP) import StripeCore
 import UIKit
 
 @_spi(DashboardOnly)
@@ -27,13 +26,13 @@ public class NotificationBannerViewController: UIViewController {
     init(componentManager: EmbeddedComponentManager,
          collectionOptions: AccountCollectionOptions,
          loadContent: Bool,
-         analyticsClient: AnalyticsClientV2Protocol) {
+         analyticsClientFactory: ComponentAnalyticsClientFactory) {
         super.init(nibName: nil, bundle: nil)
         webVC = ConnectComponentWebViewController(
             componentManager: componentManager,
             componentType: .notificationBanner,
             loadContent: loadContent,
-            analyticsClient: analyticsClient
+            analyticsClientFactory: analyticsClientFactory
         ) {
             Props(collectionOptions: collectionOptions)
         } didFailLoadWithError: { [weak self] error in

--- a/StripeConnect/StripeConnect/Source/Components/NotificationBannerViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/NotificationBannerViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Mel Ludowise on 9/25/24.
 //
 
+@_spi(STP) import StripeCore
 import UIKit
 
 @_spi(DashboardOnly)
@@ -25,12 +26,14 @@ public class NotificationBannerViewController: UIViewController {
 
     init(componentManager: EmbeddedComponentManager,
          collectionOptions: AccountCollectionOptions,
-         loadContent: Bool) {
+         loadContent: Bool,
+         analyticsClient: AnalyticsClientV2Protocol) {
         super.init(nibName: nil, bundle: nil)
         webVC = ConnectComponentWebViewController(
             componentManager: componentManager,
             componentType: .notificationBanner,
-            loadContent: loadContent
+            loadContent: loadContent,
+            analyticsClient: analyticsClient
         ) {
             Props(collectionOptions: collectionOptions)
         } didFailLoadWithError: { [weak self] error in

--- a/StripeConnect/StripeConnect/Source/Components/PaymentDetailsViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/PaymentDetailsViewController.swift
@@ -5,7 +5,6 @@
 //  Created by Mel Ludowise on 8/30/24.
 //
 
-@_spi(STP) import StripeCore
 import UIKit
 
 /**
@@ -20,13 +19,13 @@ public class PaymentDetailsViewController: UIViewController {
 
     init(componentManager: EmbeddedComponentManager,
          loadContent: Bool,
-         analyticsClient: AnalyticsClientV2Protocol) {
+         analyticsClientFactory: ComponentAnalyticsClientFactory) {
         super.init(nibName: nil, bundle: nil)
         webVC = ConnectComponentWebViewController(
             componentManager: componentManager,
             componentType: .paymentDetails,
             loadContent: loadContent,
-            analyticsClient: analyticsClient
+            analyticsClientFactory: analyticsClientFactory
         ) { [weak self] error in
             guard let self else { return }
             delegate?.paymentDetails(self, didFailLoadWithError: error)

--- a/StripeConnect/StripeConnect/Source/Components/PaymentDetailsViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/PaymentDetailsViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Mel Ludowise on 8/30/24.
 //
 
+@_spi(STP) import StripeCore
 import UIKit
 
 /**
@@ -18,12 +19,14 @@ public class PaymentDetailsViewController: UIViewController {
     public weak var delegate: PaymentDetailsViewControllerDelegate?
 
     init(componentManager: EmbeddedComponentManager,
-         loadContent: Bool) {
+         loadContent: Bool,
+         analyticsClient: AnalyticsClientV2Protocol) {
         super.init(nibName: nil, bundle: nil)
         webVC = ConnectComponentWebViewController(
             componentManager: componentManager,
             componentType: .paymentDetails,
-            loadContent: loadContent
+            loadContent: loadContent,
+            analyticsClient: analyticsClient
         ) { [weak self] error in
             guard let self else { return }
             delegate?.paymentDetails(self, didFailLoadWithError: error)

--- a/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
@@ -5,7 +5,6 @@
 //  Created by Chris Mays on 8/21/24.
 //
 
-@_spi(STP) import StripeCore
 import UIKit
 
 /**
@@ -20,13 +19,13 @@ public class PayoutsViewController: UIViewController {
 
     init(componentManager: EmbeddedComponentManager,
          loadContent: Bool,
-         analyticsClient: AnalyticsClientV2Protocol) {
+         analyticsClientFactory: ComponentAnalyticsClientFactory) {
         super.init(nibName: nil, bundle: nil)
         webVC = ConnectComponentWebViewController(
             componentManager: componentManager,
             componentType: .payouts,
             loadContent: loadContent,
-            analyticsClient: analyticsClient
+            analyticsClientFactory: analyticsClientFactory
         ) { [weak self] error in
             guard let self else { return }
             delegate?.payouts(self, didFailLoadWithError: error)

--- a/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Chris Mays on 8/21/24.
 //
 
+@_spi(STP) import StripeCore
 import UIKit
 
 /**
@@ -18,12 +19,14 @@ public class PayoutsViewController: UIViewController {
     public weak var delegate: PayoutsViewControllerDelegate?
 
     init(componentManager: EmbeddedComponentManager,
-         loadContent: Bool) {
+         loadContent: Bool,
+         analyticsClient: AnalyticsClientV2Protocol) {
         super.init(nibName: nil, bundle: nil)
         webVC = ConnectComponentWebViewController(
             componentManager: componentManager,
             componentType: .payouts,
-            loadContent: loadContent
+            loadContent: loadContent,
+            analyticsClient: analyticsClient
         ) { [weak self] error in
             guard let self else { return }
             delegate?.payouts(self, didFailLoadWithError: error)

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
@@ -29,7 +29,10 @@ public class EmbeddedComponentManager {
     var shouldLoadContent: Bool = true
 
     // This should only be used for tests to mock the analytics logger
-    var analyticsClient: AnalyticsClientV2Protocol = AnalyticsClientV2.sharedConnect
+    var analyticsClientFactory: ComponentAnalyticsClientFactory = {
+        ComponentAnalyticsClient(client: AnalyticsClientV2.sharedConnect,
+                                 commonFields: $0)
+    }
 
     /**
      Initializes a StripeConnect instance.
@@ -71,7 +74,7 @@ public class EmbeddedComponentManager {
     public func createPayoutsViewController() -> PayoutsViewController {
         .init(componentManager: self,
               loadContent: shouldLoadContent,
-              analyticsClient: analyticsClient)
+              analyticsClientFactory: analyticsClientFactory)
     }
 
     /**
@@ -102,14 +105,14 @@ public class EmbeddedComponentManager {
             ),
             componentManager: self,
             loadContent: shouldLoadContent,
-            analyticsClient: analyticsClient)
+            analyticsClientFactory: analyticsClientFactory)
        }
 
     @_spi(DashboardOnly)
     public func createPaymentDetailsViewController() -> PaymentDetailsViewController {
         .init(componentManager: self,
               loadContent: shouldLoadContent,
-              analyticsClient: analyticsClient)
+              analyticsClientFactory: analyticsClientFactory)
     }
 
     @_spi(DashboardOnly)
@@ -119,7 +122,7 @@ public class EmbeddedComponentManager {
         .init(componentManager: self,
               collectionOptions: collectionOptions,
               loadContent: shouldLoadContent,
-              analyticsClient: analyticsClient)
+              analyticsClientFactory: analyticsClientFactory)
     }
 
     @_spi(DashboardOnly)
@@ -129,7 +132,7 @@ public class EmbeddedComponentManager {
         .init(componentManager: self,
               collectionOptions: collectionOptions,
               loadContent: shouldLoadContent,
-              analyticsClient: analyticsClient)
+              analyticsClientFactory: analyticsClientFactory)
     }
 
     /// Used to keep reference of all web views associated with this component manager.

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
@@ -6,7 +6,7 @@
 //
 
 import JavaScriptCore
-import StripeCore
+@_spi(STP) import StripeCore
 import UIKit
 
 /// Manages Connect embedded components
@@ -27,6 +27,9 @@ public class EmbeddedComponentManager {
     // This should only be used for tests and determines if webview
     // content should load.
     var shouldLoadContent: Bool = true
+
+    // This should only be used for tests to mock the analytics logger
+    var analyticsClient: AnalyticsClientV2Protocol = AnalyticsClientV2.sharedConnect
 
     /**
      Initializes a StripeConnect instance.
@@ -66,7 +69,9 @@ public class EmbeddedComponentManager {
     /// Creates a payouts component
     /// - Seealso: https://docs.stripe.com/connect/supported-embedded-components/payouts
     public func createPayoutsViewController() -> PayoutsViewController {
-        .init(componentManager: self, loadContent: shouldLoadContent)
+        .init(componentManager: self,
+              loadContent: shouldLoadContent,
+              analyticsClient: analyticsClient)
     }
 
     /**
@@ -96,12 +101,15 @@ public class EmbeddedComponentManager {
                 collectionOptions: collectionOptions
             ),
             componentManager: self,
-            loadContent: shouldLoadContent)
+            loadContent: shouldLoadContent,
+            analyticsClient: analyticsClient)
        }
 
     @_spi(DashboardOnly)
     public func createPaymentDetailsViewController() -> PaymentDetailsViewController {
-        .init(componentManager: self, loadContent: shouldLoadContent)
+        .init(componentManager: self,
+              loadContent: shouldLoadContent,
+              analyticsClient: analyticsClient)
     }
 
     @_spi(DashboardOnly)
@@ -110,7 +118,8 @@ public class EmbeddedComponentManager {
     ) -> AccountManagementViewController {
         .init(componentManager: self,
               collectionOptions: collectionOptions,
-              loadContent: shouldLoadContent)
+              loadContent: shouldLoadContent,
+              analyticsClient: analyticsClient)
     }
 
     @_spi(DashboardOnly)
@@ -119,7 +128,8 @@ public class EmbeddedComponentManager {
     ) -> NotificationBannerViewController {
         .init(componentManager: self,
               collectionOptions: collectionOptions,
-              loadContent: shouldLoadContent)
+              loadContent: shouldLoadContent,
+              analyticsClient: analyticsClient)
     }
 
     /// Used to keep reference of all web views associated with this component manager.

--- a/StripeConnect/StripeConnect/Source/Helpers/ConnectJSURLParams.swift
+++ b/StripeConnect/StripeConnect/Source/Helpers/ConnectJSURLParams.swift
@@ -53,12 +53,8 @@ extension ConnectJSURLParams {
         }
     }
 
-    var url: URL {
-        guard let data = try? JSONEncoder().encode(self),
-              let dict = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            // TODO: MXMOBILE-2491 Log error
-            return StripeConnectConstants.connectJSBaseURL
-        }
+    func url() throws -> URL {
+        let dict = try jsonDictionary(with: .connectEncoder)
 
         // Append as hash params
         return URL(string: "#\(URLEncoder.queryString(from: dict))", relativeTo: StripeConnectConstants.connectJSBaseURL)!

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/AnalyticsClientV2+Connect.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/AnalyticsClientV2+Connect.swift
@@ -1,0 +1,15 @@
+//
+//  AnalyticsClientV2+Connect.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+@_spi(STP) import StripeCore
+
+extension AnalyticsClientV2 {
+    static let sharedConnect = AnalyticsClientV2(
+        clientId: "mobile_connect_sdk",
+        origin: "stripe-connect-ios"
+    )
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/ComponentAnalyticsClient.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/ComponentAnalyticsClient.swift
@@ -1,0 +1,212 @@
+//
+//  ConnectAnalyticsClient.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/1/24.
+//
+
+@_spi(STP) import StripeCore
+
+/// Wraps `AnalyticsClientV2` with some Connect-specific helpers
+@dynamicMemberLookup
+class ComponentAnalyticsClient {
+    struct CommonFields: Encodable {
+        /// The platform's publishable key
+        /// - Note: This will be null when the account is a dashboard account as user keys should never be logged to analytics
+        private(set) var publishableKey: String?
+
+        /// ID of the platform account
+        /// - Note: This is expected to be null unless originating from a dashboard account,
+        ///   otherwise the backend derives this value from the `publishableKey`
+        let platformId: String?
+
+        /// ID of the connected account returned by the `AccountSessionClaimedMessageHandler`
+        var merchantId: String?
+
+        /// Represents if the account is in live mode
+        /// - Note: This is expected to be null unless originating from a dashboard account,
+        ///   otherwise the backend derives this value from the `publishableKey`
+        let livemode: Bool?
+
+        /// The type of component this analytic is originating from
+        let component: ComponentType
+
+        /// A UUID representing a specific component instance.
+        /// All events related to this instance will have the same UUID
+        let componentInstance: UUID
+    }
+
+    let client: AnalyticsClientV2Protocol
+
+    private(set) var commonFields: CommonFields
+
+    /// The `pageViewID` returned from the `PageDidLoadMessageHandler`
+    var pageViewId: String?
+
+    /// Time the page began to load
+    var loadStart: Date?
+
+    /// Time the component was first viewed
+    var componentFirstViewedTime: Date?
+
+    /// If `ComponentWebPageLoadedEvent` was already logged
+    private(set) var loggedPageLoaded = false
+
+    /// If `ComponentLoadedEvent` was already logged
+    private(set) var loggedComponentLoaded = false
+
+    init(client: AnalyticsClientV2Protocol,
+         commonFields: CommonFields) {
+        self.client = client
+        self.commonFields = commonFields
+    }
+
+    subscript<T>(dynamicMember keyPath: WritableKeyPath<CommonFields, T>) -> T {
+        get { commonFields[keyPath: keyPath] }
+        set { commonFields[keyPath: keyPath] = newValue }
+    }
+
+    func log<Event: ConnectAnalyticEvent>(event: Event) {
+        do {
+            var dict = try commonFields.jsonDictionary(with: .analyticsEncoder)
+            let metadataDict = try event.metadata.jsonDictionary(with: .analyticsEncoder)
+            dict["event_metadata"] = metadataDict
+
+            // Also log metadata fields as first-level fields to make it easier
+            // to configure alerting
+            dict.mergeAssertingOnOverwrites(metadataDict)
+
+            client.log(eventName: event.name, parameters: dict)
+        } catch {
+            // We were unable to encode the analytic parameters
+            logClientError(error)
+        }
+    }
+
+    func logComponentViewed(viewedAt: Date) {
+        componentFirstViewedTime = viewedAt
+        log(event: ComponentViewedEvent())
+    }
+
+    func logComponentWebPageLoaded(loadEnd: Date) {
+        guard !loggedPageLoaded, let loadStart else {
+            return
+        }
+
+        log(event: ComponentWebPageLoadedEvent(metadata: .init(
+            timeToLoad: loadEnd.timeIntervalSince(loadStart)
+        )))
+
+        // Prevent the analytic from being logged again in the even the page is reloaded.
+        // This can happen if the app is backgrounded for a long period then foregrounded.
+        loggedPageLoaded = true
+    }
+
+    func logComponentLoaded(loadEnd: Date) {
+        guard !loggedComponentLoaded, let loadStart else {
+            return
+        }
+
+        log(event: ComponentLoadedEvent(metadata: .init(
+            pageViewId: pageViewId,
+            timeToLoad: loadEnd.timeIntervalSince(loadStart),
+            perceivedTimeToLoad: componentFirstViewedTime.map(loadEnd.timeIntervalSince) ?? 0
+        )))
+
+        // Prevent the analytic from being logged again in the even the page is reloaded.
+        // This can happen if the app is backgrounded for a long period then foregrounded.
+        loggedComponentLoaded = true
+    }
+
+    func logUnexpectedLoadErrorType(type: String) {
+        log(event: UnexpectedLoadErrorTypeEvent(metadata: .init(
+            errorType: type,
+            pageViewId: pageViewId
+        )))
+    }
+
+    func logUnexpectedSetterEvent(setter: String) {
+        log(event: UnrecognizedSetterEvent(metadata: .init(
+            setter: setter,
+            pageViewId: pageViewId
+        )))
+    }
+
+    func logDeserializeMessageErrorEvent(message: String, error: Error) {
+        log(event: DeserializeMessageErrorEvent(metadata: .init(
+            message: message,
+            error: error,
+            pageViewId: pageViewId
+        )))
+    }
+
+    func logAuthenticatedWebViewOpenedEvent(id: String) {
+        log(event: AuthenticatedWebViewOpenedEvent(metadata: .init(
+            authenticatedWebViewId: id,
+            pageViewId: pageViewId
+        )))
+    }
+
+    func logAuthenticatedWebViewEventComplete(id: String, redirected: Bool) {
+        if redirected {
+            log(event: AuthenticatedWebViewRedirectedEvent(metadata: .init(
+                authenticatedWebViewId: id,
+                pageViewId: pageViewId
+            )))
+        } else {
+            log(event: AuthenticatedWebViewCanceledEvent(metadata: .init(
+                authenticatedWebViewId: id,
+                pageViewId: pageViewId
+            )))
+        }
+    }
+
+    func logAuthenticatedWebViewEventComplete(id: String, error: Error) {
+        log(event: AuthenticatedWebViewErrorEvent(metadata: .init(
+            authenticatedWebViewId: id,
+            error: error,
+            pageViewId: pageViewId
+        )))
+    }
+
+    /// Catch-all for mobile client-side errors
+    func logClientError(_ error: Error,
+                        file: StaticString = #file,
+                        line: UInt = #line) {
+        client.log(
+            eventName: "client_error",
+            parameters: AnalyticsClientV2.serialize(
+                error: error,
+                filePath: file,
+                line: line
+            )
+        )
+    }
+}
+
+extension ComponentAnalyticsClient.CommonFields {
+    init(apiClient: STPAPIClient,
+         component: ComponentType,
+         componentInstance: UUID = .init()
+    ) {
+        // Reuse logic in ConnectJSURLParams to determine when to use publicKey
+        // platformId + livemode
+        let params = ConnectJSURLParams(component: component, apiClient: apiClient)
+
+        // Ensures a secret key is never logged to analytics in the event
+        // the platform uses a secret key in their app
+        var publicKey = params.publicKey
+        if publicKey != nil {
+            publicKey = apiClient.sanitizedPublishableKey
+        }
+
+        self.init(
+            publishableKey: publicKey,
+            platformId: params.platformIdOverride,
+            merchantId: params.merchantIdOverride,
+            livemode: params.livemodeOverride,
+            component: params.component,
+            componentInstance: componentInstance
+        )
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/ComponentAnalyticsClient.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/ComponentAnalyticsClient.swift
@@ -243,6 +243,8 @@ extension ComponentAnalyticsClient.CommonFields {
         // the platform uses a secret key in their app
         var publicKey = params.publicKey
         if publicKey != nil {
+            // Check for nil so we don't log '[REDACTED_LIVE_KEY]' if we don't
+            // intend to log any key (e.g. for user keys)
             publicKey = apiClient.sanitizedPublishableKey
         }
 

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/ConnectAnalyticEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/ConnectAnalyticEvent.swift
@@ -5,11 +5,13 @@
 //  Created by Mel Ludowise on 10/1/24.
 //
 
+/// Represents an analytics event logged from the Connect SDK
 protocol ConnectAnalyticEvent {
     associatedtype Metadata: Encodable
 
+    /// The `event_name` field of the event
     var name: String { get }
 
-    /// Event-specific metadata
+    /// Event-specific metadata, encoded as a JSON string in the `metadata` field
     var metadata: Metadata { get }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/ConnectAnalyticEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/ConnectAnalyticEvent.swift
@@ -1,0 +1,15 @@
+//
+//  ConnectAnalyticEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/1/24.
+//
+
+protocol ConnectAnalyticEvent {
+    associatedtype Metadata: Encodable
+
+    var name: String { get }
+
+    /// Event-specific metadata
+    var metadata: Metadata { get }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/AuthenticatedWebViewCanceledEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/AuthenticatedWebViewCanceledEvent.swift
@@ -1,0 +1,21 @@
+//
+//  AuthenticatedWebViewCanceledEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 11/6/24.
+//
+
+/// The user closed the authenticated web view before getting redirected back to the app.
+struct AuthenticatedWebViewCanceledEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable {
+        /// ID for the authenticated web view session (sent in `openAuthenticatedWebView` message
+        let authenticatedWebViewId: String
+
+        /// The `pageViewID` from the web view
+        /// - Note: May be null if not yet sent from web
+        let pageViewId: String?
+    }
+
+    let name = "component.authenticated_web.canceled"
+    let metadata: Metadata
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/AuthenticatedWebViewErrorEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/AuthenticatedWebViewErrorEvent.swift
@@ -1,0 +1,30 @@
+//
+//  AuthenticatedWebViewErrorEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 11/6/24.
+//
+
+/// The authenticated web view threw an error and was not successfully redirected back to the app.
+struct AuthenticatedWebViewErrorEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable {
+        /// ID for the authenticated web view session (sent in `openAuthenticatedWebView` message
+        let authenticatedWebViewId: String
+
+        /// The error identifier
+        let error: String
+
+        /// The `pageViewID` from the web view
+        /// - Note: May be null if not yet sent from web
+        let pageViewId: String?
+
+        init(authenticatedWebViewId: String, error: Error, pageViewId: String?) {
+            self.authenticatedWebViewId = authenticatedWebViewId
+            self.error = error.analyticsIdentifier
+            self.pageViewId = pageViewId
+        }
+    }
+
+    let name = "component.authenticated_web.error"
+    let metadata: Metadata
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/AuthenticatedWebViewOpenedEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/AuthenticatedWebViewOpenedEvent.swift
@@ -1,0 +1,21 @@
+//
+//  AuthenticatedWebViewOpenedEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 11/6/24.
+//
+
+/// An authenticated web view was opened
+struct AuthenticatedWebViewOpenedEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable {
+        /// ID for the authenticated web view session (sent in `openAuthenticatedWebView` message
+        let authenticatedWebViewId: String
+
+        /// The `pageViewID` from the web view
+        /// - Note: May be null if not yet sent from web
+        let pageViewId: String?
+    }
+
+    let name = "component.authenticated_web.opened"
+    let metadata: Metadata
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/AuthenticatedWebViewRedirectedEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/AuthenticatedWebViewRedirectedEvent.swift
@@ -1,0 +1,21 @@
+//
+//  AuthenticatedWebViewRedirectedEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 11/6/24.
+//
+
+/// The authenticated web view successfully redirected back to the app
+struct AuthenticatedWebViewRedirectedEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable {
+        /// ID for the authenticated web view session (sent in `openAuthenticatedWebView` message
+        let authenticatedWebViewId: String
+
+        /// The `pageViewID` from the web view
+        /// - Note: May be null if not yet sent from web
+        let pageViewId: String?
+    }
+
+    let name = "component.authenticated_web.redirected"
+    let metadata: Metadata
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/ComponentCreatedEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/ComponentCreatedEvent.swift
@@ -1,0 +1,14 @@
+//
+//  ComponentCreatedEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+/// A component was instantiated via `create{ComponentType}`.
+struct ComponentCreatedEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable { }
+
+    let name = "component.created"
+    let metadata = Metadata()
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/ComponentLoadedEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/ComponentLoadedEvent.swift
@@ -1,0 +1,28 @@
+//
+//  ComponentLoadedEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+/// The component is successfully loaded within the web view.
+/// Triggered from `componentDidLoad` message handler from the web view.
+struct ComponentLoadedEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable {
+        /// The pageViewID from the web view
+        let pageViewId: String?
+
+        /// Elapsed time in seconds it took the component to load
+        /// (starting when the page first began loading).
+        let timeToLoad: TimeInterval
+
+        /// Elapsed time in seconds in took between when the component was
+        /// initially viewed on screen (`component.viewed`) to when the component
+        /// finished loading. This value will be `0` if the component finished
+        /// loading before being viewed on screen.
+        let perceivedTimeToLoad: TimeInterval
+    }
+
+    let name = "component.web.component_loaded"
+    let metadata: Metadata
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/ComponentViewedEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/ComponentViewedEvent.swift
@@ -1,0 +1,14 @@
+//
+//  ComponentViewedEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+/// The component is viewed on screen (`viewDidAppear` lifecycle event)
+struct ComponentViewedEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable { }
+
+    let name = "component.viewed"
+    let metadata = Metadata()
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/ComponentWebPageLoadedEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/ComponentWebPageLoadedEvent.swift
@@ -1,0 +1,18 @@
+//
+//  ComponentWebPageLoadedEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+/// The web page finished loading (`didFinish navigation` event).
+struct ComponentWebPageLoadedEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable {
+        /// Elapsed time in seconds it took the web page to load
+        /// (starting when it first began loading).
+        let timeToLoad: TimeInterval
+    }
+
+    let name = "component.web.page_loaded"
+    let metadata: Metadata
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/DeserializeMessageErrorEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/DeserializeMessageErrorEvent.swift
@@ -1,0 +1,34 @@
+//
+//  DeserializeMessageErrorEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+/// An error occurred deserializing the JSON payload from a web message.
+struct DeserializeMessageErrorEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable {
+        /// The name of the message
+        let message: String
+
+        /// The error identifier
+        let error: String
+
+        /// The error's description, if there is one.
+        let errorDescription: String?
+
+        /// The `pageViewID` from the web view
+        /// - Note: May be null if not yet sent from web
+        let pageViewId: String?
+
+        init(message: String, error: Error, pageViewId: String?) {
+            self.message = message
+            self.error = error.analyticsIdentifier
+            self.errorDescription = (error as NSError).userInfo[NSDebugDescriptionErrorKey] as? String
+            self.pageViewId = pageViewId
+        }
+      }
+
+    let name = "component.web.error.deserialize_message"
+    let metadata: Metadata
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/PageLoadErrorEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/PageLoadErrorEvent.swift
@@ -1,0 +1,34 @@
+//
+//  PageLoadErrorEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+/// The SDK receives a non-200 status code or error loading the web view, other than “Internet connectivity” errors.
+struct PageLoadErrorEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable {
+        /// http status code if the error was a non-200 response
+        let status: Int?
+
+        /// Error identifier for non http status type errors
+        let error: String?
+
+        /// The URL of the page, excluding hashtag params
+        let url: String?
+
+        init(error: Error, url: URL?) {
+            if let statusError = error as? HTTPStatusError {
+                self.status = statusError.errorCode
+                self.error = nil
+            } else {
+                self.status = nil
+                self.error = error.analyticsIdentifier
+            }
+            self.url = url?.absoluteStringRemovingParams
+        }
+    }
+
+    let name = "component.web.error.page_load"
+    let metadata: Metadata
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/UnexpectedLoadErrorTypeEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/UnexpectedLoadErrorTypeEvent.swift
@@ -1,0 +1,21 @@
+//
+//  UnexpectedLoadErrorTypeEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+/// The web view sends an onLoadError that can’t be deserialized by the SDK.
+struct UnexpectedLoadErrorTypeEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable {
+        /// The error `type` property from web
+        let errorType: String
+
+        /// The pageViewID from the web view
+        /// - Note: May be null if not yet sent from web
+        let pageViewId: String?
+    }
+
+    let name = "component.web.warn.unexpected_load_error_type"
+    let metadata: Metadata
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/UnrecognizedSetterEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/UnrecognizedSetterEvent.swift
@@ -1,0 +1,21 @@
+//
+//  UnrecognizedSetterEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+/// If the web view calls `onSetterFunctionCalled` with a `setter` argument the SDK doesn’t know how to handle.
+struct UnrecognizedSetterEvent: ConnectAnalyticEvent {
+    struct Metadata: Encodable {
+        /// The `setter` property sent from web
+        let setter: String
+
+        /// The pageViewID from the web view
+        /// - Note: May be null if not yet sent from web
+        let pageViewId: String?
+    }
+
+    let name = "component.web.warn.unrecognized_setter_function"
+    let metadata: Metadata
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Extensions/Encodable+Connect.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Extensions/Encodable+Connect.swift
@@ -1,0 +1,31 @@
+//
+//  Encodable+Connect.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+private enum JSONSerializationError: Int, Error {
+    /// The encoded object was expected to be a dictionary but turned out to be a single value
+    case expectedDictionary = 0
+}
+
+extension Encodable {
+    /// Encodes to a JSON serialized object with the given encoder and options
+    func jsonObject(
+        with encoder: JSONEncoder,
+        options opt: JSONSerialization.ReadingOptions = []
+    ) throws -> Any {
+        let data = try encoder.encode(self)
+        return try JSONSerialization.jsonObject(with: data, options: .allowFragments)
+    }
+
+    /// Encodes to a JSON dictionary with the given encoder
+    func jsonDictionary(with encoder: JSONEncoder) throws -> [String: Any] {
+        let json = try jsonObject(with: encoder)
+        guard let dict = json as? [String: Any] else {
+            throw JSONSerializationError.expectedDictionary
+        }
+        return dict
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Extensions/Encodable+Connect.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Extensions/Encodable+Connect.swift
@@ -13,8 +13,7 @@ private enum JSONSerializationError: Int, Error {
 extension Encodable {
     /// Encodes to a JSON serialized object with the given encoder and options
     func jsonObject(
-        with encoder: JSONEncoder,
-        options opt: JSONSerialization.ReadingOptions = []
+        with encoder: JSONEncoder
     ) throws -> Any {
         let data = try encoder.encode(self)
         return try JSONSerialization.jsonObject(with: data, options: .allowFragments)

--- a/StripeConnect/StripeConnect/Source/Internal/Extensions/Error+extensions.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Extensions/Error+extensions.swift
@@ -1,0 +1,13 @@
+//
+//  Error+extensions.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+extension Error {
+    var analyticsIdentifier: String {
+        let nsError = self as NSError
+        return "\(nsError.domain):\(nsError.code)"
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Extensions/JSONEncoder+extension.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Extensions/JSONEncoder+extension.swift
@@ -8,10 +8,19 @@
 import Foundation
 
 extension JSONEncoder {
-    static var connectEncoder: JSONEncoder {
+    /// Encoder used for JS Messaging and URL param encoding
+    static let connectEncoder: JSONEncoder = {
         let encoder = JSONEncoder()
         // Ensure keys are sorted for test stability.
         encoder.outputFormatting = .sortedKeys
         return encoder
-    }
+    }()
+
+    /// Encoder used for analytics
+    static let analyticsEncoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.keyEncodingStrategy = .convertToSnakeCase
+        encoder.dateEncodingStrategy = .secondsSince1970
+        return encoder
+    }()
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Extensions/URL+extension.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Extensions/URL+extension.swift
@@ -1,0 +1,20 @@
+//
+//  URL+extension.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 10/4/24.
+//
+
+extension URL {
+    /// Removes query and hashtag params from the absolute URL
+    var absoluteStringRemovingParams: String {
+        // Remove query params
+        var components = URLComponents(url: self, resolvingAgainstBaseURL: true)
+        components?.queryItems = nil
+
+        let absoluteString = components?.url?.absoluteString ?? self.absoluteString
+
+        // Remove hashtag params
+        return absoluteString.split(separator: "#").first.map(String.init) ?? ""
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Extensions/URL+extension.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Extensions/URL+extension.swift
@@ -6,7 +6,8 @@
 //
 
 extension URL {
-    /// Removes query and hashtag params from the absolute URL
+    /// Removes query and hashtag params from the absolute URL.
+    /// - Note: Used for logging sanitized URLs to analytics or to compare URLs without query args
     var absoluteStringRemovingParams: String {
         // Remove query params
         var components = URLComponents(url: self, resolvingAgainstBaseURL: true)

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ApplicationURLOpener.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ApplicationURLOpener.swift
@@ -5,8 +5,18 @@
 //  Created by Chris Mays on 8/14/24.
 //
 
+@_spi(STP) import StripeCore
 import UIKit
 
+/// Error thrown when the system can't open a URL.
+/// Used for analytics logging.
+private struct URLOpenError: Error, AnalyticLoggableErrorV2 {
+    let url: URL
+
+    func analyticLoggableSerializeForLogging() -> [String: Any] {
+        ["url": url.absoluteStringRemovingParams]
+    }
+}
 /// Protocol used to dependency inject `UIApplication.open` for use in tests
 protocol ApplicationURLOpener {
     func canOpenURL(_ url: URL) -> Bool
@@ -26,10 +36,9 @@ extension ApplicationURLOpener {
     typealias OpenCompletionHandler = (Bool) -> Void
     #endif
 
-    func openIfPossible(_ url: URL) {
+    func openIfPossible(_ url: URL) throws {
         guard canOpenURL(url) else {
-            // TODO: MXMOBILE-2491 Log as analytics when url can't be opened.
-            return
+            throw URLOpenError(url: url)
         }
         open(url, options: [:], completionHandler: nil)
     }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ApplicationURLOpener.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ApplicationURLOpener.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// Error thrown when the system can't open a URL.
 /// Used for analytics logging.
-private struct URLOpenError: Error, AnalyticLoggableErrorV2 {
+struct URLOpenError: Error, AnalyticLoggableErrorV2 {
     let url: URL
 
     func analyticLoggableSerializeForLogging() -> [String: Any] {

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
@@ -43,10 +43,10 @@ class ConnectComponentWebViewController: ConnectWebViewController {
         componentManager: EmbeddedComponentManager,
         componentType: ComponentType,
         loadContent: Bool,
+        analyticsClient aClient: AnalyticsClientV2Protocol,
         fetchInitProps: @escaping () -> InitProps,
         didFailLoadWithError: @escaping (Error) -> Void,
         // Should only be overridden for tests
-        analyticsClient aClient: AnalyticsClientV2Protocol = AnalyticsClientV2.sharedConnect,
         notificationCenter: NotificationCenter = NotificationCenter.default,
         webLocale: Locale = Locale.autoupdatingCurrent,
         authenticatedWebViewManager: AuthenticatedWebViewManager = .init()
@@ -113,6 +113,7 @@ class ConnectComponentWebViewController: ConnectWebViewController {
     convenience init(componentManager: EmbeddedComponentManager,
                      componentType: ComponentType,
                      loadContent: Bool,
+                     analyticsClient: AnalyticsClientV2Protocol,
                      didFailLoadWithError: @escaping (Error) -> Void,
                      // Should only be overridden for tests
                      notificationCenter: NotificationCenter = NotificationCenter.default,
@@ -121,6 +122,7 @@ class ConnectComponentWebViewController: ConnectWebViewController {
         self.init(componentManager: componentManager,
                   componentType: componentType,
                   loadContent: loadContent,
+                  analyticsClient: analyticsClient,
                   fetchInitProps: VoidPayload.init,
                   didFailLoadWithError: didFailLoadWithError,
                   notificationCenter: notificationCenter,

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
@@ -43,7 +43,7 @@ class ConnectComponentWebViewController: ConnectWebViewController {
         componentManager: EmbeddedComponentManager,
         componentType: ComponentType,
         loadContent: Bool,
-        analyticsClient aClient: AnalyticsClientV2Protocol,
+        analyticsClientFactory: ComponentAnalyticsClientFactory,
         fetchInitProps: @escaping () -> InitProps,
         didFailLoadWithError: @escaping (Error) -> Void,
         // Should only be overridden for tests
@@ -69,13 +69,10 @@ class ConnectComponentWebViewController: ConnectWebViewController {
 
         super.init(
             configuration: config,
-            analyticsClient: ComponentAnalyticsClient(
-                client: aClient,
-                commonFields: .init(
-                    apiClient: componentManager.apiClient,
-                    component: componentType
-                )
-            )
+            analyticsClient: analyticsClientFactory(.init(
+                apiClient: componentManager.apiClient,
+                component: componentType
+            ))
         )
 
         // Setup views
@@ -113,7 +110,7 @@ class ConnectComponentWebViewController: ConnectWebViewController {
     convenience init(componentManager: EmbeddedComponentManager,
                      componentType: ComponentType,
                      loadContent: Bool,
-                     analyticsClient: AnalyticsClientV2Protocol,
+                     analyticsClientFactory: ComponentAnalyticsClientFactory,
                      didFailLoadWithError: @escaping (Error) -> Void,
                      // Should only be overridden for tests
                      notificationCenter: NotificationCenter = NotificationCenter.default,
@@ -122,7 +119,7 @@ class ConnectComponentWebViewController: ConnectWebViewController {
         self.init(componentManager: componentManager,
                   componentType: componentType,
                   loadContent: loadContent,
-                  analyticsClient: analyticsClient,
+                  analyticsClientFactory: analyticsClientFactory,
                   fetchInitProps: VoidPayload.init,
                   didFailLoadWithError: didFailLoadWithError,
                   notificationCenter: notificationCenter,

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandler.swift
@@ -13,7 +13,10 @@ class AccountSessionClaimedMessageHandler: ScriptMessageHandler<AccountSessionCl
         /// The connected account ID
         let merchantId: String
     }
-    init(didReceiveMessage: @escaping (Payload) -> Void) {
-        super.init(name: "accountSessionClaimed", didReceiveMessage: didReceiveMessage)
+    init(analyticsClient: ComponentAnalyticsClient,
+         didReceiveMessage: @escaping (Payload) -> Void) {
+        super.init(name: "accountSessionClaimed",
+                   analyticsClient: analyticsClient,
+                   didReceiveMessage: didReceiveMessage)
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/DebugMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/DebugMessageHandler.swift
@@ -9,7 +9,10 @@ import Foundation
 
 // Emitted when the SDK should print to the console in debug mode.
 class DebugMessageHandler: ScriptMessageHandler<String> {
-    init(didReceiveMessage: @escaping (String) -> Void = { Swift.debugPrint($0) }) {
-        super.init(name: "debug", didReceiveMessage: didReceiveMessage)
+    init(analyticsClient: ComponentAnalyticsClient,
+         didReceiveMessage: @escaping (String) -> Void = { Swift.debugPrint($0) }) {
+        super.init(name: "debug",
+                   analyticsClient: analyticsClient,
+                   didReceiveMessage: didReceiveMessage)
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandler.swift
@@ -5,30 +5,48 @@
 //  Created by Mel Ludowise on 5/1/24.
 //
 
+@_spi(STP) import StripeCore
 import WebKit
 
 /// Convenience class that conforms to WKScriptMessageHandler and can be instantiated with a closure
 class ScriptMessageHandler<Payload: Decodable>: NSObject, WKScriptMessageHandler {
+    struct UnexpectedMessageNameError: Error, AnalyticLoggableErrorV2 {
+        let actual: String
+        let expected: String
+
+        func analyticLoggableSerializeForLogging() -> [String: Any] {
+            [
+                "actual": actual,
+                "expected": expected,
+            ]
+        }
+    }
+
     let name: String
     let didReceiveMessage: (Payload) -> Void
+    let analyticsClient: ComponentAnalyticsClient
 
     init(name: String,
+         analyticsClient: ComponentAnalyticsClient,
          didReceiveMessage: @escaping (Payload) -> Void) {
         self.name = name
         self.didReceiveMessage = didReceiveMessage
+        self.analyticsClient = analyticsClient
     }
 
     func userContentController(_ userContentController: WKUserContentController,
                                didReceive message: WKScriptMessage) {
         guard message.name == name else {
-            debugPrint("Unexpected message name: \(message.name)")
+            analyticsClient.logClientError(UnexpectedMessageNameError(
+                actual: message.name,
+                expected: name
+            ))
             return
         }
         do {
             didReceiveMessage(try message.toDecodable())
         } catch {
-            // TODO: MXMOBILE-2491 Log as analytics
-            debugPrint("Failed to decode body for message with name: \(message.name) \(error.localizedDescription)")
+            analyticsClient.logDeserializeMessageErrorEvent(message: message.name, error: error)
         }
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandlerWithReply.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandlerWithReply.swift
@@ -32,8 +32,8 @@ class ScriptMessageHandlerWithReply<Payload: Decodable, Response: Encodable>: NS
             let response = try value.jsonObject(with: .connectEncoder)
             return (response, nil)
         } catch {
-            debugPrint("Error processing message: \(error.localizedDescription)")
-            return (nil, error.localizedDescription)
+            debugPrint("Error processing message: \((error as NSError).debugDescription)")
+            return (nil, (error as NSError).debugDescription)
         }
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandlerWithReply.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/Helpers/ScriptMessageHandlerWithReply.swift
@@ -28,16 +28,12 @@ class ScriptMessageHandlerWithReply<Payload: Decodable, Response: Encodable>: NS
         do {
             let payload: Payload = try message.toDecodable()
             let value = try await didReceiveMessage(payload)
-            let responseData = try JSONEncoder.connectEncoder.encode(value)
 
-            guard let response = try? JSONSerialization.jsonObject(with: responseData, options: .allowFragments) else {
-                return (nil, "Failed to encode response")
-            }
-
+            let response = try value.jsonObject(with: .connectEncoder)
             return (response, nil)
         } catch {
-            debugPrint("Error processing message: \((error as NSError).debugDescription)")
-            return (nil, (error as NSError).debugDescription)
+            debugPrint("Error processing message: \(error.localizedDescription)")
+            return (nil, error.localizedDescription)
         }
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandler.swift
@@ -8,10 +8,13 @@
 import Foundation
 
 extension OnLoadErrorMessageHandler.Values.ErrorValue {
-    var connectEmbedError: EmbeddedComponentError {
+    func connectEmbedError(analyticsClient: ComponentAnalyticsClient) -> EmbeddedComponentError {
         // API Error is a catch all so defer to that if we get an unknown type.
-        // TODO(MXMOBILE-2491): Log error analytic if `type` is unrecognized
-        .init(type: .init(rawValue: type) ?? .apiError, description: message)
+        let errorType = EmbeddedComponentError.ErrorType(rawValue: type)
+        if errorType == nil {
+            analyticsClient.logUnexpectedLoadErrorType(type: type)
+        }
+        return .init(type: .init(rawValue: type) ?? .apiError, description: message)
     }
 }
 

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandler.swift
@@ -15,7 +15,10 @@ class OpenAuthenticatedWebViewMessageHandler: ScriptMessageHandler<OpenAuthentic
         /// Unique identifier logged in analytics when the `ASWebAuthenticationSession` is opened or closed.
         let id: String
     }
-    init(didReceiveMessage: @escaping (Payload) -> Void) {
-        super.init(name: "openAuthenticatedWebView", didReceiveMessage: didReceiveMessage)
+    init(analyticsClient: ComponentAnalyticsClient,
+         didReceiveMessage: @escaping (Payload) -> Void) {
+        super.init(name: "openAuthenticatedWebView",
+                   analyticsClient: analyticsClient,
+                   didReceiveMessage: didReceiveMessage)
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/PageDidLoadMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/PageDidLoadMessageHandler.swift
@@ -13,7 +13,10 @@ class PageDidLoadMessageHandler: ScriptMessageHandler<PageDidLoadMessageHandler.
         /// A unique session ID shared with web for analytics logging
         let pageViewId: String
     }
-    init(didReceiveMessage: @escaping (Payload) -> Void) {
-        super.init(name: "pageDidLoad", didReceiveMessage: didReceiveMessage)
+    init(analyticsClient: ComponentAnalyticsClient,
+         didReceiveMessage: @escaping (Payload) -> Void) {
+        super.init(name: "pageDidLoad",
+                   analyticsClient: analyticsClient,
+                   didReceiveMessage: didReceiveMessage)
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/MessageSender.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/MessageSender.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 
+struct MessageSenderError: Error { }
+
 /// Sends a message to the webview by calling a function on `window`
 protocol MessageSender {
     associatedtype Payload: Encodable
@@ -17,11 +19,10 @@ protocol MessageSender {
 }
 
 extension MessageSender {
-    var javascriptMessage: String? {
-        guard let jsonData = try? JSONEncoder.connectEncoder.encode(payload),
-              let jsonString = String(data: jsonData, encoding: .utf8) else {
-            // TODO: MXMOBILE-2491 Log failure to analytics
-            return nil
+    func javascriptMessage() throws -> String {
+        let jsonData = try JSONEncoder.connectEncoder.encode(payload)
+        guard let jsonString = String(data: jsonData, encoding: .utf8) else {
+            throw MessageSenderError()
         }
         return "window.\(name)(\(jsonString));"
     }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/MessageSender.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageSenders/MessageSender.swift
@@ -7,7 +7,10 @@
 
 import Foundation
 
-struct MessageSenderError: Error { }
+private enum MessageSenderError: Int, Error {
+    /// Error encoding the json to utf-8
+    case stringEncoding
+}
 
 /// Sends a message to the webview by calling a function on `window`
 protocol MessageSender {
@@ -22,7 +25,7 @@ extension MessageSender {
     func javascriptMessage() throws -> String {
         let jsonData = try JSONEncoder.connectEncoder.encode(payload)
         guard let jsonString = String(data: jsonData, encoding: .utf8) else {
-            throw MessageSenderError()
+            throw MessageSenderError.stringEncoding
         }
         return "window.\(name)(\(jsonString));"
     }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/PopupWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/PopupWebViewController.swift
@@ -16,12 +16,14 @@ class PopupWebViewController: ConnectWebViewController {
     private var titleObserver: NSKeyValueObservation?
 
     init(configuration: WKWebViewConfiguration,
+         analyticsClient: ComponentAnalyticsClient,
          navigationAction: WKNavigationAction,
          urlOpener: ApplicationURLOpener = UIApplication.shared,
          sdkVersion: String? = StripeAPIConfiguration.STPSDKVersion) {
         super.init(configuration: configuration,
-                        urlOpener: urlOpener,
-                        sdkVersion: sdkVersion)
+                   analyticsClient: analyticsClient,
+                   urlOpener: urlOpener,
+                   sdkVersion: sdkVersion)
         webView.load(navigationAction.request)
 
         // Keep navbar title in sync with web view

--- a/StripeConnect/StripeConnectTests/Components/AccountManagementViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/AccountManagementViewControllerTests.swift
@@ -8,6 +8,7 @@
 import SafariServices
 @_spi(PrivateBetaConnect) @_spi(DashboardOnly) @testable import StripeConnect
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeCoreTestUtils
 import WebKit
 import XCTest
 
@@ -20,6 +21,7 @@ class AccountManagementViewControllerTests: XCTestCase {
         super.setUp()
         STPAPIClient.shared.publishableKey = "pk_test"
         componentManager.shouldLoadContent = false
+        componentManager.analyticsClient = MockAnalyticsClientV2()
     }
 
     @MainActor

--- a/StripeConnect/StripeConnectTests/Components/AccountManagementViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/AccountManagementViewControllerTests.swift
@@ -8,7 +8,6 @@
 import SafariServices
 @_spi(PrivateBetaConnect) @_spi(DashboardOnly) @testable import StripeConnect
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeCoreTestUtils
 import WebKit
 import XCTest
 
@@ -21,7 +20,7 @@ class AccountManagementViewControllerTests: XCTestCase {
         super.setUp()
         STPAPIClient.shared.publishableKey = "pk_test"
         componentManager.shouldLoadContent = false
-        componentManager.analyticsClient = MockAnalyticsClientV2()
+        componentManager.analyticsClientFactory = MockComponentAnalyticsClient.init
     }
 
     @MainActor

--- a/StripeConnect/StripeConnectTests/Components/AccountOnboardingViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/AccountOnboardingViewControllerTests.swift
@@ -8,7 +8,6 @@
 import SafariServices
 @_spi(PrivateBetaConnect) @testable import StripeConnect
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeCoreTestUtils
 import WebKit
 import XCTest
 
@@ -21,7 +20,7 @@ class AccountOnboardingViewControllerTests: XCTestCase {
         super.setUp()
         STPAPIClient.shared.publishableKey = "pk_test"
         componentManager.shouldLoadContent = false
-        componentManager.analyticsClient = MockAnalyticsClientV2()
+        componentManager.analyticsClientFactory = MockComponentAnalyticsClient.init
     }
 
     @MainActor

--- a/StripeConnect/StripeConnectTests/Components/AccountOnboardingViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/AccountOnboardingViewControllerTests.swift
@@ -8,6 +8,7 @@
 import SafariServices
 @_spi(PrivateBetaConnect) @testable import StripeConnect
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeCoreTestUtils
 import WebKit
 import XCTest
 
@@ -20,6 +21,7 @@ class AccountOnboardingViewControllerTests: XCTestCase {
         super.setUp()
         STPAPIClient.shared.publishableKey = "pk_test"
         componentManager.shouldLoadContent = false
+        componentManager.analyticsClient = MockAnalyticsClientV2()
     }
 
     @MainActor

--- a/StripeConnect/StripeConnectTests/Components/NotificationBannerViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/NotificationBannerViewControllerTests.swift
@@ -8,7 +8,6 @@
 import SafariServices
 @_spi(PrivateBetaConnect) @_spi(DashboardOnly) @testable import StripeConnect
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeCoreTestUtils
 import WebKit
 import XCTest
 
@@ -21,7 +20,7 @@ class NotificationBannerViewControllerTests: XCTestCase {
         super.setUp()
         STPAPIClient.shared.publishableKey = "pk_test"
         componentManager.shouldLoadContent = false
-        componentManager.analyticsClient = MockAnalyticsClientV2()
+        componentManager.analyticsClientFactory = MockComponentAnalyticsClient.init
     }
 
     @MainActor

--- a/StripeConnect/StripeConnectTests/Components/NotificationBannerViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/NotificationBannerViewControllerTests.swift
@@ -8,6 +8,7 @@
 import SafariServices
 @_spi(PrivateBetaConnect) @_spi(DashboardOnly) @testable import StripeConnect
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeCoreTestUtils
 import WebKit
 import XCTest
 
@@ -20,6 +21,7 @@ class NotificationBannerViewControllerTests: XCTestCase {
         super.setUp()
         STPAPIClient.shared.publishableKey = "pk_test"
         componentManager.shouldLoadContent = false
+        componentManager.analyticsClient = MockAnalyticsClientV2()
     }
 
     @MainActor

--- a/StripeConnect/StripeConnectTests/Components/PayoutsViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/PayoutsViewControllerTests.swift
@@ -8,7 +8,6 @@
 import SafariServices
 @_spi(PrivateBetaConnect) @testable import StripeConnect
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeCoreTestUtils
 import WebKit
 import XCTest
 
@@ -35,7 +34,7 @@ class PayoutsViewControllerTests: XCTestCase {
         super.setUp()
         STPAPIClient.shared.publishableKey = "pk_test"
         componentManager.shouldLoadContent = false
-        componentManager.analyticsClient = MockAnalyticsClientV2()
+        componentManager.analyticsClientFactory = MockComponentAnalyticsClient.init
     }
 
     @MainActor

--- a/StripeConnect/StripeConnectTests/Components/PayoutsViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/PayoutsViewControllerTests.swift
@@ -8,6 +8,7 @@
 import SafariServices
 @_spi(PrivateBetaConnect) @testable import StripeConnect
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeCoreTestUtils
 import WebKit
 import XCTest
 
@@ -34,6 +35,7 @@ class PayoutsViewControllerTests: XCTestCase {
         super.setUp()
         STPAPIClient.shared.publishableKey = "pk_test"
         componentManager.shouldLoadContent = false
+        componentManager.analyticsClient = MockAnalyticsClientV2()
     }
 
     @MainActor

--- a/StripeConnect/StripeConnectTests/Helpers/ComponentAnalyticsClient+Mock.swift
+++ b/StripeConnect/StripeConnectTests/Helpers/ComponentAnalyticsClient+Mock.swift
@@ -1,0 +1,23 @@
+//
+//  ComponentAnalyticsClient+Mock.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 11/7/24.
+//
+
+@testable import StripeConnect
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeCoreTestUtils
+
+extension ComponentAnalyticsClient {
+    static func mock(
+        _ client: AnalyticsClientV2Protocol = MockAnalyticsClientV2(),
+        _ commonFields: CommonFields = .mock
+    ) -> ComponentAnalyticsClient {
+        .init(client: client, commonFields: commonFields)
+    }
+}
+
+extension ComponentAnalyticsClient.CommonFields {
+    static let mock = ComponentAnalyticsClient.CommonFields(platformId: nil, livemode: nil, component: .onboarding, componentInstance: .init())
+}

--- a/StripeConnect/StripeConnectTests/Helpers/ComponentAnalyticsClient+Mock.swift
+++ b/StripeConnect/StripeConnectTests/Helpers/ComponentAnalyticsClient+Mock.swift
@@ -6,17 +6,6 @@
 //
 
 @testable import StripeConnect
-@_spi(STP) import StripeCore
-@_spi(STP) import StripeCoreTestUtils
-
-extension ComponentAnalyticsClient {
-    static func mock(
-        _ client: AnalyticsClientV2Protocol = MockAnalyticsClientV2(),
-        _ commonFields: CommonFields = .mock
-    ) -> ComponentAnalyticsClient {
-        .init(client: client, commonFields: commonFields)
-    }
-}
 
 extension ComponentAnalyticsClient.CommonFields {
     static let mock = ComponentAnalyticsClient.CommonFields(platformId: nil, livemode: nil, component: .onboarding, componentInstance: .init())

--- a/StripeConnect/StripeConnectTests/Helpers/MockComponentAnalyticsClient.swift
+++ b/StripeConnect/StripeConnectTests/Helpers/MockComponentAnalyticsClient.swift
@@ -1,0 +1,18 @@
+//
+//  MockComponentAnalyticsClient.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 11/7/24.
+//
+
+@testable import StripeConnect
+@_spi(STP) import StripeCoreTestUtils
+import XCTest
+
+class MockComponentAnalyticsClient: ComponentAnalyticsClient {
+    init(commonFields: CommonFields) {
+        super.init(client: MockAnalyticsClientV2(), commonFields: commonFields)
+    }
+
+    // TODO: Add test helpers
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
@@ -9,7 +9,6 @@ import Foundation
 import SafariServices
 @_spi(PrivateBetaConnect) @testable import StripeConnect
 @_spi(STP) import StripeCore
-@_spi(STP) import StripeCoreTestUtils
 @_spi(STP) import StripeUICore
 import WebKit
 import XCTest
@@ -26,7 +25,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { _ in })
 
         try await webVC.webView.evaluateMessageWithReply(name: "fetchClientSecret",
@@ -41,7 +40,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { _ in },
                                                       webLocale: Locale(identifier: "fr_FR"))
 
@@ -56,7 +55,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { _ in },
                                                       webLocale: Locale(identifier: "fr_FR"))
         var appearance = EmbeddedComponentManager.Appearance()
@@ -83,7 +82,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { _ in },
                                                       webLocale: Locale(identifier: "fr_FR"))
 
@@ -103,7 +102,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { _ in },
                                                       webLocale: Locale(identifier: "fr_FR"))
 
@@ -122,7 +121,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { _ in },
                                                       webLocale: Locale(identifier: "fr_FR"))
 
@@ -144,7 +143,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
             componentManager: componentManager,
             componentType: .payouts,
             loadContent: false,
-            analyticsClient: MockAnalyticsClientV2(),
+            analyticsClientFactory: MockComponentAnalyticsClient.init,
             didFailLoadWithError: { _ in },
             notificationCenter: notificationCenter,
             webLocale: Locale(identifier: "fr_FR"))
@@ -165,7 +164,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { _ in },
                                                       webLocale: Locale(identifier: "fr_FR"))
 
@@ -182,7 +181,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { _ in })
         // Mock that loading indicator is animating
         webVC.activityIndicator.startAnimating()
@@ -200,7 +199,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { error = $0 })
         // Mock that loading indicator is animating
         webVC.activityIndicator.startAnimating()
@@ -217,7 +216,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { error = $0 })
         // Mock that loading indicator is animating
         webVC.activityIndicator.startAnimating()
@@ -235,7 +234,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { error = $0 })
         _ = await webVC.webView(webVC.webView, decidePolicyFor: MockNavigationResponse(response: HTTPURLResponse(url: URL(string: "https://connect-js.stripe.com/v1.0/ios_webview.html")!, statusCode: 404, httpVersion: nil, headerFields: nil)!))
         XCTAssertEqual((error as? HTTPStatusError)?.errorCode, 404)
@@ -252,7 +251,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
-                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
                                                       didFailLoadWithError: { _ in },
                                                       authenticatedWebViewManager: authenticatedWebViewManager)
 

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
@@ -9,6 +9,7 @@ import Foundation
 import SafariServices
 @_spi(PrivateBetaConnect) @testable import StripeConnect
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeCoreTestUtils
 @_spi(STP) import StripeUICore
 import WebKit
 import XCTest
@@ -25,6 +26,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
                                                       didFailLoadWithError: { _ in })
 
         try await webVC.webView.evaluateMessageWithReply(name: "fetchClientSecret",
@@ -39,6 +41,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
                                                       didFailLoadWithError: { _ in },
                                                       webLocale: Locale(identifier: "fr_FR"))
 
@@ -53,6 +56,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
                                                       didFailLoadWithError: { _ in },
                                                       webLocale: Locale(identifier: "fr_FR"))
         var appearance = EmbeddedComponentManager.Appearance()
@@ -77,10 +81,11 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let componentManager = componentManagerAssertingOnFetch(appearance: appearance)
 
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
-                                                        componentType: .payouts,
-                                                        loadContent: false,
-                                                        didFailLoadWithError: { _ in },
-                                                        webLocale: Locale(identifier: "fr_FR"))
+                                                      componentType: .payouts,
+                                                      loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
+                                                      didFailLoadWithError: { _ in },
+                                                      webLocale: Locale(identifier: "fr_FR"))
 
         webVC.triggerTraitCollectionChange(style: .dark)
 
@@ -98,6 +103,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
                                                       didFailLoadWithError: { _ in },
                                                       webLocale: Locale(identifier: "fr_FR"))
 
@@ -116,6 +122,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
                                                       didFailLoadWithError: { _ in },
                                                       webLocale: Locale(identifier: "fr_FR"))
 
@@ -137,6 +144,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
             componentManager: componentManager,
             componentType: .payouts,
             loadContent: false,
+            analyticsClient: MockAnalyticsClientV2(),
             didFailLoadWithError: { _ in },
             notificationCenter: notificationCenter,
             webLocale: Locale(identifier: "fr_FR"))
@@ -157,6 +165,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
                                                       didFailLoadWithError: { _ in },
                                                       webLocale: Locale(identifier: "fr_FR"))
 
@@ -173,6 +182,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
                                                       didFailLoadWithError: { _ in })
         // Mock that loading indicator is animating
         webVC.activityIndicator.startAnimating()
@@ -190,6 +200,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
                                                       didFailLoadWithError: { error = $0 })
         // Mock that loading indicator is animating
         webVC.activityIndicator.startAnimating()
@@ -206,6 +217,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
                                                       didFailLoadWithError: { error = $0 })
         // Mock that loading indicator is animating
         webVC.activityIndicator.startAnimating()
@@ -223,8 +235,9 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
                                                       didFailLoadWithError: { error = $0 })
-        _ = await webVC.webView(webVC.webView, decidePolicyFor: MockNavigationResponse(response: HTTPURLResponse(url: URL(string: "https://stripe.com")!, statusCode: 404, httpVersion: nil, headerFields: nil)!))
+        _ = await webVC.webView(webVC.webView, decidePolicyFor: MockNavigationResponse(response: HTTPURLResponse(url: URL(string: "https://connect-js.stripe.com/v1.0/ios_webview.html")!, statusCode: 404, httpVersion: nil, headerFields: nil)!))
         XCTAssertEqual((error as? HTTPStatusError)?.errorCode, 404)
         // Loading indicator should stop
         XCTAssertFalse(webVC.activityIndicator.isAnimating)
@@ -239,6 +252,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .payouts,
                                                       loadContent: false,
+                                                      analyticsClient: MockAnalyticsClientV2(),
                                                       didFailLoadWithError: { _ in },
                                                       authenticatedWebViewManager: authenticatedWebViewManager)
 

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewControllerTests.swift
@@ -24,6 +24,7 @@ class ConnectWebViewControllerTests: XCTestCase {
         mockFileManager = .init()
         mockURLOpener = .init()
         webVC = .init(configuration: .init(),
+                      analyticsClient: .mock(),
                       urlOpener: mockURLOpener,
                       fileManager: mockFileManager,
                       sdkVersion: "1.2.3")
@@ -361,7 +362,7 @@ private class MockFileManager: FileManager {
 }
 
 private class ConnectWebViewControllerTestWrapper: ConnectWebViewController {
-    var presentPopup: (UIViewController) -> Void = {_ in }
+    var presentPopup: (UIViewController) -> Void = { _ in }
 
     override func present(_ viewControllerToPresent: UIViewController, animated flag: Bool, completion: (() -> Void)? = nil) {
         presentPopup(viewControllerToPresent)

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectWebViewControllerTests.swift
@@ -17,14 +17,16 @@ class ConnectWebViewControllerTests: XCTestCase {
 
     private var mockURLOpener: MockURLOpener!
     private var mockFileManager: MockFileManager!
+    private var mockAnalyticsClient: MockComponentAnalyticsClient!
     private var webVC: ConnectWebViewControllerTestWrapper!
 
     override func setUp() {
         super.setUp()
         mockFileManager = .init()
         mockURLOpener = .init()
+        mockAnalyticsClient = .init(commonFields: .mock)
         webVC = .init(configuration: .init(),
-                      analyticsClient: .mock(),
+                      analyticsClient: mockAnalyticsClient,
                       urlOpener: mockURLOpener,
                       fileManager: mockFileManager,
                       sdkVersion: "1.2.3")
@@ -317,7 +319,7 @@ class MockNavigationResponse: WKNavigationResponse {
     }
 }
 
-private class MockURLOpener: ApplicationURLOpener {
+class MockURLOpener: ApplicationURLOpener {
     var canOpenURLOverride: ((_ url: URL) -> Bool)?
     var openURLOverride: ((_ url: URL, _ options: [UIApplication.OpenExternalURLOptionsKey: Any], _ completion: OpenCompletionHandler?) -> Void)?
 

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandlerTests.swift
@@ -13,10 +13,13 @@ class AccountSessionClaimedMessageHandlerTests: ScriptWebTestBase {
         let expectation = self.expectation(description: "Message received")
         let merchantId = "acct_1234"
 
-        webView.addMessageHandler(messageHandler: AccountSessionClaimedMessageHandler(didReceiveMessage: { payload in
-            expectation.fulfill()
-            XCTAssertEqual(payload, .init(merchantId: merchantId))
-        }))
+        webView.addMessageHandler(messageHandler: AccountSessionClaimedMessageHandler(
+            analyticsClient: .mock(),
+            didReceiveMessage: { payload in
+                expectation.fulfill()
+                XCTAssertEqual(payload, .init(merchantId: merchantId))
+            }
+        ))
 
         webView.evaluateAccountSessionClaimed(merchantId: merchantId)
         waitForExpectations(timeout: TestHelpers.defaultTimeout, handler: nil)

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/AccountSessionClaimedMessageHandlerTests.swift
@@ -14,7 +14,7 @@ class AccountSessionClaimedMessageHandlerTests: ScriptWebTestBase {
         let merchantId = "acct_1234"
 
         webView.addMessageHandler(messageHandler: AccountSessionClaimedMessageHandler(
-            analyticsClient: .mock(),
+            analyticsClient: MockComponentAnalyticsClient(commonFields: .mock),
             didReceiveMessage: { payload in
                 expectation.fulfill()
                 XCTAssertEqual(payload, .init(merchantId: merchantId))

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/DebugMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/DebugMessageHandlerTests.swift
@@ -14,7 +14,7 @@ class DebugMessageHandlerTests: ScriptWebTestBase {
         let debugMessage = "test message"
 
         webView.addMessageHandler(messageHandler: DebugMessageHandler(
-            analyticsClient: .mock(),
+            analyticsClient: MockComponentAnalyticsClient(commonFields: .mock),
             didReceiveMessage: { payload in
                 expectation.fulfill()
                 XCTAssertEqual(payload, debugMessage)

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/DebugMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/DebugMessageHandlerTests.swift
@@ -13,10 +13,13 @@ class DebugMessageHandlerTests: ScriptWebTestBase {
         let expectation = self.expectation(description: "Message received")
         let debugMessage = "test message"
 
-        webView.addMessageHandler(messageHandler: DebugMessageHandler(didReceiveMessage: { payload in
-            expectation.fulfill()
-            XCTAssertEqual(payload, debugMessage)
-        }))
+        webView.addMessageHandler(messageHandler: DebugMessageHandler(
+            analyticsClient: .mock(),
+            didReceiveMessage: { payload in
+                expectation.fulfill()
+                XCTAssertEqual(payload, debugMessage)
+            }
+        ))
 
         webView.evaluateDebugMessage(message: debugMessage)
 

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/NotificationBanner/OnNotificationsChangeHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/NotificationBanner/OnNotificationsChangeHandlerTests.swift
@@ -12,7 +12,7 @@ class OnNotificationsChangeHandlerTests: ScriptWebTestBase {
     @MainActor
     func testMessageSend() async throws {
         let expectation = self.expectation(description: "Message received")
-        let messageHandler = OnSetterFunctionCalledMessageHandler()
+        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: .mock())
 
         messageHandler.addHandler(handler: OnNotificationsChangeHandler(didReceiveMessage: { payload in
             expectation.fulfill()

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/NotificationBanner/OnNotificationsChangeHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/NotificationBanner/OnNotificationsChangeHandlerTests.swift
@@ -12,7 +12,7 @@ class OnNotificationsChangeHandlerTests: ScriptWebTestBase {
     @MainActor
     func testMessageSend() async throws {
         let expectation = self.expectation(description: "Message received")
-        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: .mock())
+        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: MockComponentAnalyticsClient(commonFields: .mock))
 
         messageHandler.addHandler(handler: OnNotificationsChangeHandler(didReceiveMessage: { payload in
             expectation.fulfill()

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandlerTests.swift
@@ -12,7 +12,7 @@ class OnLoadErrorMessageHandlerTests: ScriptWebTestBase {
     @MainActor
     func testMessageSend() async throws {
         let expectation = self.expectation(description: "Message received")
-        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: .mock())
+        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: MockComponentAnalyticsClient(commonFields: .mock))
 
         messageHandler.addHandler(handler: OnLoadErrorMessageHandler(didReceiveMessage: { payload in
             expectation.fulfill()

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoadErrorMessageHandlerTests.swift
@@ -12,7 +12,7 @@ class OnLoadErrorMessageHandlerTests: ScriptWebTestBase {
     @MainActor
     func testMessageSend() async throws {
         let expectation = self.expectation(description: "Message received")
-        let messageHandler = OnSetterFunctionCalledMessageHandler()
+        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: .mock())
 
         messageHandler.addHandler(handler: OnLoadErrorMessageHandler(didReceiveMessage: { payload in
             expectation.fulfill()

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoaderStartMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoaderStartMessageHandlerTests.swift
@@ -13,7 +13,7 @@ class OnLoaderStartMessageHandlerTests: ScriptWebTestBase {
     func testMessageSend() async throws {
         let expectation = self.expectation(description: "Message received")
 
-        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: .mock())
+        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: MockComponentAnalyticsClient(commonFields: .mock))
 
         messageHandler.addHandler(handler: OnLoaderStartMessageHandler(didReceiveMessage: { payload in
             expectation.fulfill()

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoaderStartMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnLoaderStartMessageHandlerTests.swift
@@ -13,7 +13,7 @@ class OnLoaderStartMessageHandlerTests: ScriptWebTestBase {
     func testMessageSend() async throws {
         let expectation = self.expectation(description: "Message received")
 
-        let messageHandler = OnSetterFunctionCalledMessageHandler()
+        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: .mock())
 
         messageHandler.addHandler(handler: OnLoaderStartMessageHandler(didReceiveMessage: { payload in
             expectation.fulfill()

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnSetterFunctionCalledMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnSetterFunctionCalledMessageHandlerTests.swift
@@ -12,7 +12,7 @@ class OnSetterFunctionCalledMessageHandlerTests: ScriptWebTestBase {
     func testDeallocation() {
         weak var weakInstance: OnSetterFunctionCalledMessageHandler?
         autoreleasepool {
-            let instance = OnSetterFunctionCalledMessageHandler()
+            let instance = OnSetterFunctionCalledMessageHandler(analyticsClient: .mock())
             weakInstance = instance
             XCTAssertNotNil(weakInstance)
         }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnSetterFunctionCalledMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OnSetterFunctionCalledMessageHandlerTests.swift
@@ -12,7 +12,7 @@ class OnSetterFunctionCalledMessageHandlerTests: ScriptWebTestBase {
     func testDeallocation() {
         weak var weakInstance: OnSetterFunctionCalledMessageHandler?
         autoreleasepool {
-            let instance = OnSetterFunctionCalledMessageHandler(analyticsClient: .mock())
+            let instance = OnSetterFunctionCalledMessageHandler(analyticsClient: MockComponentAnalyticsClient(commonFields: .mock))
             weakInstance = instance
             XCTAssertNotNil(weakInstance)
         }

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/Onboarding/OnExitMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/Onboarding/OnExitMessageHandlerTests.swift
@@ -12,7 +12,7 @@ class OnExitMessageHandlerTests: ScriptWebTestBase {
     @MainActor
     func testMessageSend() async throws {
         let expectation = self.expectation(description: "Message received")
-        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: .mock())
+        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: MockComponentAnalyticsClient(commonFields: .mock))
 
         messageHandler.addHandler(handler: OnExitMessageHandler(didReceiveMessage: {
             expectation.fulfill()

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/Onboarding/OnExitMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/Onboarding/OnExitMessageHandlerTests.swift
@@ -12,7 +12,7 @@ class OnExitMessageHandlerTests: ScriptWebTestBase {
     @MainActor
     func testMessageSend() async throws {
         let expectation = self.expectation(description: "Message received")
-        let messageHandler = OnSetterFunctionCalledMessageHandler()
+        let messageHandler = OnSetterFunctionCalledMessageHandler(analyticsClient: .mock())
 
         messageHandler.addHandler(handler: OnExitMessageHandler(didReceiveMessage: {
             expectation.fulfill()

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandlerTests.swift
@@ -14,7 +14,7 @@ class OpenAuthenticatedWebViewMessageHandlerTests: ScriptWebTestBase {
         let url = "https://dashboard.stripe.com"
         let id = "1234"
         webView.addMessageHandler(messageHandler: OpenAuthenticatedWebViewMessageHandler(
-            analyticsClient: .mock(),
+            analyticsClient: MockComponentAnalyticsClient(commonFields: .mock),
             didReceiveMessage: { payload in
                 expectation.fulfill()
                 XCTAssertEqual(payload, .init(url: URL(string: "https://dashboard.stripe.com")!, id: id))

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/OpenAuthenticatedWebViewMessageHandlerTests.swift
@@ -13,10 +13,13 @@ class OpenAuthenticatedWebViewMessageHandlerTests: ScriptWebTestBase {
         let expectation = self.expectation(description: "Message received")
         let url = "https://dashboard.stripe.com"
         let id = "1234"
-        webView.addMessageHandler(messageHandler: OpenAuthenticatedWebViewMessageHandler(didReceiveMessage: { payload in
-            expectation.fulfill()
-            XCTAssertEqual(payload, .init(url: URL(string: "https://dashboard.stripe.com")!, id: id))
-        }))
+        webView.addMessageHandler(messageHandler: OpenAuthenticatedWebViewMessageHandler(
+            analyticsClient: .mock(),
+            didReceiveMessage: { payload in
+                expectation.fulfill()
+                XCTAssertEqual(payload, .init(url: URL(string: "https://dashboard.stripe.com")!, id: id))
+            }
+        ))
 
         webView.evaluateOpenAuthenticatedWebView(url: url, id: id)
 

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/PageDidLoadMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/PageDidLoadMessageHandlerTests.swift
@@ -14,10 +14,13 @@ class PageDidLoadMessageHandlerTests: ScriptWebTestBase {
 
         let pageViewId = "123"
 
-        webView.addMessageHandler(messageHandler: PageDidLoadMessageHandler(didReceiveMessage: { payload in
-            expectation.fulfill()
-            XCTAssertEqual(payload, .init(pageViewId: pageViewId))
-        }))
+        webView.addMessageHandler(messageHandler: PageDidLoadMessageHandler(
+            analyticsClient: .mock(),
+            didReceiveMessage: { payload in
+                expectation.fulfill()
+                XCTAssertEqual(payload, .init(pageViewId: pageViewId))
+            }
+        ))
 
         webView.evaluatePageDidLoad(pageViewId: pageViewId)
 

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/PageDidLoadMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/PageDidLoadMessageHandlerTests.swift
@@ -15,7 +15,7 @@ class PageDidLoadMessageHandlerTests: ScriptWebTestBase {
         let pageViewId = "123"
 
         webView.addMessageHandler(messageHandler: PageDidLoadMessageHandler(
-            analyticsClient: .mock(),
+            analyticsClient: MockComponentAnalyticsClient(commonFields: .mock),
             didReceiveMessage: { payload in
                 expectation.fulfill()
                 XCTAssertEqual(payload, .init(pageViewId: pageViewId))

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/CallSetterWithSerializableValueSenderTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/CallSetterWithSerializableValueSenderTests.swift
@@ -14,9 +14,9 @@ class CallSetterWithSerializableValueSenderTests: ScriptWebTestBase {
         try validateMessageSent(sender: CallSetterWithSerializableValueSender(payload: .init(setter: "setPayment", value: "pi_1234")))
     }
 
-    func testSenderSignature() {
+    func testSenderSignature() throws {
         XCTAssertEqual(
-            CallSetterWithSerializableValueSender(payload: .init(setter: "setPayment", value: "pi_1234")).javascriptMessage,
+            try CallSetterWithSerializableValueSender(payload: .init(setter: "setPayment", value: "pi_1234")).javascriptMessage(),
             """
             window.callSetterWithSerializableValue({"setter":"setPayment","value":"pi_1234"});
             """

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/ReturnedFromAuthenticatedWebViewSenderTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/ReturnedFromAuthenticatedWebViewSenderTests.swift
@@ -16,7 +16,7 @@ class ReturnedFromAuthenticatedWebViewSenderTests: ScriptWebTestBase {
 
     func testSenderSignature() {
         XCTAssertEqual(
-            ReturnedFromAuthenticatedWebViewSender(payload: .init(url: URL(string: "https://dashboard.stripe.com")!, id: "123")).javascriptMessage,
+            try ReturnedFromAuthenticatedWebViewSender(payload: .init(url: URL(string: "https://dashboard.stripe.com")!, id: "123")).javascriptMessage(),
             """
             window.returnedFromAuthenticatedWebView({"id":"123","url":"https:\\/\\/dashboard.stripe.com"});
             """

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/UpdateConnectInstanceSenderTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/UpdateConnectInstanceSenderTests.swift
@@ -16,7 +16,7 @@ class UpdateConnectInstanceSenderTests: ScriptWebTestBase {
 
     func testSenderSignature() {
         XCTAssertEqual(
-            UpdateConnectInstanceSender(payload: .init(locale: "en", appearance: .default)).javascriptMessage,
+            try UpdateConnectInstanceSender(payload: .init(locale: "en", appearance: .default)).javascriptMessage(),
             """
             window.updateConnectInstance({"appearance":{"variables":{"fontFamily":"-apple-system","fontSizeBase":"16px"}},"locale":"en"});
             """

--- a/StripeConnect/StripeConnectTests/WebView+Tests.swift
+++ b/StripeConnect/StripeConnectTests/WebView+Tests.swift
@@ -115,7 +115,7 @@ extension WKWebView {
     }
 
     func sendMessage<Sender: MessageSender>(sender: Sender) throws {
-        evaluateJavaScript(try XCTUnwrap(sender.javascriptMessage)) { (_, error) in
+        evaluateJavaScript(try sender.javascriptMessage()) { (_, error) in
             if let error {
                 XCTFail("JavaScript execution failed: \(error)")
             }

--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -43,7 +43,7 @@ import UIKit
     /// A publishable key that only contains publishable keys and not secret keys.
     ///
     /// If a secret key is found, returns "[REDACTED_LIVE_KEY]".
-    var sanitizedPublishableKey: String? {
+    @_spi(STP) public var sanitizedPublishableKey: String? {
         guard let publishableKey = publishableKey else {
             return nil
         }

--- a/StripeCore/StripeCore/Source/Analytics/AnalyticsClientV2.swift
+++ b/StripeCore/StripeCore/Source/Analytics/AnalyticsClientV2.swift
@@ -90,7 +90,14 @@ import UIKit
         let payload = payload(withEventName: eventName, parameters: parameters)
 
         #if DEBUG
-            NSLog("LOG ANALYTICS: \(payload)")
+        let jsonString = String(
+            data: try! JSONSerialization.data(
+                withJSONObject: payload,
+                options: [.sortedKeys, .prettyPrinted]
+            ),
+            encoding: .utf8
+        )!
+        NSLog("LOG ANALYTICS: \(jsonString)")
         #endif
 
         guard AnalyticsClientV2.shouldCollectAnalytics else {


### PR DESCRIPTION
## Summary
Adds analytic events matching spec:
https://docs.google.com/document/d/1nzHGofoclzij4nP5n5qgSpYLia-93heStXvt7vOfrkQ/edit?pli=1&tab=t.0#bookmark=id.hbdcbks7wn2n

Also adds catch-all `client_error` to log unexpected client-side errors with their domain and code.

Additional minor changes:
- Only return an HTTPStatusError when the failed URL corresponds to the component page URL. Otherwise we could erroneously return an error if an image asset on the page 404s.
- Updated the debug analytics log statement to pretty-print JSON

## Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2491

## Testing

Adding unit test coverage in #4239 since this PR is already quite large.

### Manual testing

Demonstrates:
* `component.created`
* `component.viewed`
* `component.web.page_loaded`
* `component.web.component_loaded`

https://github.com/user-attachments/assets/f4830aad-c3c2-4bf7-b6e9-6703f8a65a70

Demonstrates the following warnings / errors by invoking them from the Safari console:
* `component.web.error.unexpected_load_error_type`
* `component.web.warn.unrecognized_setter_function`
* `component.web.error.deserialize_message`

https://github.com/user-attachments/assets/46ba2341-1795-4264-947f-05f11990c0ec

Demonstrates the following by invoking the authenticated web view + redirect from the Safari console:
* `component.authenticated_web.opened`
* `component.authenticated_web.canceled`
* `component.authenticated_web.redirected`
* `component.authenticated_web.error`

https://github.com/user-attachments/assets/539a84e7-0df8-4adf-83d7-236fb15cfe44

## Changelog
n/a