### PR TITLE
Fix Retain Cycles in `CustomerSheet.swift` and `STPCameraView.swift`

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCameraView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCameraView.swift
@@ -36,7 +36,8 @@ class STPCameraView: UIView {
             x: 0, y: 0, width: layer.bounds.size.width, height: layer.bounds.size.height)
         flashLayer?.opacity = 1.0
         CATransaction.commit()
-        DispatchQueue.main.async(execute: {
+        DispatchQueue.main.async(execute: { [weak self] in
+            guard let self = self else { return }
             let fadeAnim = CABasicAnimation(keyPath: "opacity")
             fadeAnim.fromValue = NSNumber(value: 1.0)
             fadeAnim.toValue = NSNumber(value: 0.0)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -3,7 +3,7 @@
 //  StripePaymentSheet
 //
 //
-//  ⚠️🏗 This is feature has not been released yet, and is under construction
+//  ⚠️💧 This is feature has not been released yet, and is under construction
 //  Note: Do not import Stripe using `@_spi(STP)` in production.
 //  Doing so exposes internal functionality which may cause unexpected behavior if used directly.
 //
@@ -133,7 +133,8 @@ public class CustomerSheet {
         STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .customerSheetLoadStarted)
         // Retain self when being presented, it is not guaranteed that CustomerSheet instance
         // will be retained by caller
-        let completion: () -> Void = {
+        let completion: () -> Void = { [weak self] in
+            guard let self = self else { return }
             if let presentingViewController = self.bottomSheetViewController.presentingViewController {
                 // Calling `dismiss()` on the presenting view controller causes
                 // the bottom sheet and any presented view controller by
@@ -162,7 +163,8 @@ public class CustomerSheet {
             return
         }
 
-        customerSheetDataSource.loadPaymentMethodInfo { result in
+        customerSheetDataSource.loadPaymentMethodInfo { [weak self] result in
+            guard let self = self else { return }
             switch result {
             case .success((let savedPaymentMethods, let selectedPaymentMethodOption, let elementsSession)):
                 let merchantSupportedPaymentMethodTypes = customerSheetDataSource.merchantSupportedPaymentMethodTypes(elementsSession: elementsSession)
@@ -202,7 +204,8 @@ public class CustomerSheet {
             loadSpecsPromise.resolve(with: ())
         }
 
-        loadSpecsPromise.observe(on: .main) { _ in
+        loadSpecsPromise.observe(on: .main) { [weak self] _ in
+            guard let self = self else { return }
             let isApplePayEnabled = StripeAPI.deviceSupportsApplePay() && self.configuration.applePayEnabled
             let savedPaymentSheetVC = CustomerSavedPaymentMethodsViewController(savedPaymentMethods: savedPaymentMethods,
                                                                                 selectedPaymentMethodOption: selectedPaymentMethodOption,
@@ -252,14 +255,16 @@ extension CustomerSheet: CustomerSavedPaymentMethodsViewControllerDelegate {
     }
 
     func savedPaymentMethodsViewControllerDidCancel(_ savedPaymentMethodsViewController: CustomerSavedPaymentMethodsViewController, completion _completion: @escaping () -> Void) {
-        savedPaymentMethodsViewController.dismiss(animated: true) {
+        savedPaymentMethodsViewController.dismiss(animated: true) { [weak self] in
+            guard let self = self else { return }
             _completion()
             self.completion?()
         }
     }
 
     func savedPaymentMethodsViewControllerDidFinish(_ savedPaymentMethodsViewController: CustomerSavedPaymentMethodsViewController, completion _completion: @escaping () -> Void) {
-        savedPaymentMethodsViewController.dismiss(animated: true) {
+        savedPaymentMethodsViewController.dismiss(animated: true) { [weak self] in
+            guard let self = self else { return }
             _completion()
             self.completion?()
         }
@@ -268,7 +273,8 @@ extension CustomerSheet: CustomerSavedPaymentMethodsViewControllerDelegate {
 
 extension CustomerSheet: LoadingViewControllerDelegate {
     func shouldDismiss(_ loadingViewController: LoadingViewController) {
-        loadingViewController.dismiss(animated: true) {
+        loadingViewController.dismiss(animated: true) { [weak self] in
+            guard let self = self else { return }
             self.completion?()
         }
     }


### PR DESCRIPTION
## Summary
This pull request resolves retain cycle issues identified in `CustomerSheet.swift` and `STPCameraView.swift` within the `StripePaymentSheet` module. These changes improve memory management by ensuring proper deallocation of resources and preventing memory leaks.

## Motivation
The retain cycles were identified as potential causes of memory leaks, especially during interactions involving the payment sheet and camera preview. To demonstrate the problem:
- In `CustomerSheet.swift`, closures retained strong references to `self`, resulting in retained memory even after the payment flow was complete.
- In `STPCameraView.swift`, the `playSnapshotAnimation` function held a strong reference to `self` inside a `DispatchQueue.main.async` closure, leading to memory retention of the `flashLayer` object.

The changes involve modifying the closure behavior by using `[weak self]`, thus breaking the retain cycles and allowing proper deallocation.

## Testing
- **CustomerSheet.swift**:
  - The `CustomerSheet` presentation and dismissal were tested across different scenarios involving multiple payment methods and cancellation flows.
  - Confirmed that no retain cycles remained, and memory was correctly released after each interaction.

- **STPCameraView.swift**:
  - The `playSnapshotAnimation` functionality was tested on both simulator and real devices to ensure the snapshot effect occurs as intended.
  - Verified that the flash animation did not retain memory unnecessarily, ensuring proper memory release when the view was dismissed.

## Changelog
- `[Fixed]` Retain cycle issues in `CustomerSheet.swift` by adding `[weak self]` to closures.
- `[Fixed]` Retain cycle issues in `STPCameraView.swift` by updating the closure handling in `playSnapshotAnimation`.

### References
- [Automatic Reference Counting (ARC) - Swift Programming Language Guide](https://developer.apple.com/documentation/swift/automatic_reference_counting)
- [Strong Reference Cycles for Closures - Swift Language Guide](https://developer.apple.com/documentation/swift/automatic_reference_counting/avoiding_strong_reference_cycles_for_closures)
