### PR TITLE
Disable Link Login CTA during email lookup

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -120,7 +120,7 @@ final class LinkLoginViewController: UIViewController {
 
         let emailAddress = dataSource.manifest.accountholderCustomerEmailAddress ?? dataSource.elementsSessionContext?.prefillDetails?.email
         if let emailAddress, !emailAddress.isEmpty {
-            // Immediately set the button state to loading here to bypass the deboncing by the textfield.
+            // Immediately set the button state to loading here to bypass the debouncing by the textfield.
             footerButton?.isLoading = true
             formView.prefillEmailAddress(emailAddress)
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -120,6 +120,8 @@ final class LinkLoginViewController: UIViewController {
 
         let emailAddress = dataSource.manifest.accountholderCustomerEmailAddress ?? dataSource.elementsSessionContext?.prefillDetails?.email
         if let emailAddress, !emailAddress.isEmpty {
+            // Immediately set the button state to loading here to bypass the deboncing by the textfield.
+            footerButton?.isLoading = true
             formView.prefillEmailAddress(emailAddress)
 
             let phoneNumber = dataSource.manifest.accountholderPhoneNumber ?? dataSource.elementsSessionContext?.prefillDetails?.formattedPhoneNumber
@@ -153,13 +155,15 @@ final class LinkLoginViewController: UIViewController {
 
     private func lookupAccount(with emailAddress: String) {
         formView.emailTextField.showLoadingView(true)
+        footerButton?.isLoading = true
 
         dataSource
             .lookup(emailAddress: emailAddress)
-            .observe { [weak self, weak formView] result in
+            .observe { [weak self, weak formView, weak footerButton] result in
                 formView?.emailTextField.showLoadingView(false)
-                guard let self else { return }
+                footerButton?.isLoading = false
 
+                guard let self else { return }
                 switch result {
                 case .success(let response):
                     if response.exists {


### PR DESCRIPTION
## Summary

This fixes a small bug in the Link Login pane where clicking the `Continue with Link` button too soon (i.e during the `lookup` request) would prematurely call the `signup` endpoint. This now disables that button during the `lookup` request.

## Motivation

🐛 🔨 

## Testing

Before: 

https://github.com/user-attachments/assets/d10a1c41-cdca-4c92-bcbb-482c476227f2

After:

https://github.com/user-attachments/assets/a096586b-6024-46b8-826e-29e443b946de

## Changelog

N/a
