### PR TITLE
[Connect] Analytics (3/3) – log analytic when navigating away from component page

### DIFF
--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		E6660DC22CDE7D66002A7631 /* URL+ExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DC12CDE7D56002A7631 /* URL+ExtensionTests.swift */; };
 		E6660DC42CDE7F47002A7631 /* ApplicationURLOpenerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DC32CDE7F41002A7631 /* ApplicationURLOpenerTests.swift */; };
 		E6660DC72CDE8F28002A7631 /* ScriptMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DC62CDE8F28002A7631 /* ScriptMessageHandlerTests.swift */; };
+		E6660DC92CE43BE6002A7631 /* UnexpectedNavigationEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660DC82CE43BDF002A7631 /* UnexpectedNavigationEvent.swift */; };
 		E688AE002CADD8C400951D97 /* NotificationBannerViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E688ADFF2CADD8C400951D97 /* NotificationBannerViewControllerTests.swift */; };
 		E688AE032CADE36C00951D97 /* OnNotificationsChangeHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E688AE022CADE36900951D97 /* OnNotificationsChangeHandlerTests.swift */; };
 		E6C5F5F62C9FEE0200861709 /* AccountManagementViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6C5F5F52C9FEE0200861709 /* AccountManagementViewController.swift */; };
@@ -258,6 +259,7 @@
 		E6660DC12CDE7D56002A7631 /* URL+ExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+ExtensionTests.swift"; sourceTree = "<group>"; };
 		E6660DC32CDE7F41002A7631 /* ApplicationURLOpenerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationURLOpenerTests.swift; sourceTree = "<group>"; };
 		E6660DC62CDE8F28002A7631 /* ScriptMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScriptMessageHandlerTests.swift; sourceTree = "<group>"; };
+		E6660DC82CE43BDF002A7631 /* UnexpectedNavigationEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnexpectedNavigationEvent.swift; sourceTree = "<group>"; };
 		E688ADFF2CADD8C400951D97 /* NotificationBannerViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationBannerViewControllerTests.swift; sourceTree = "<group>"; };
 		E688AE022CADE36900951D97 /* OnNotificationsChangeHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnNotificationsChangeHandlerTests.swift; sourceTree = "<group>"; };
 		E6C5F5F52C9FEE0200861709 /* AccountManagementViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountManagementViewController.swift; sourceTree = "<group>"; };
@@ -642,6 +644,7 @@
 				E6660D962CDC4194002A7631 /* DeserializeMessageErrorEvent.swift */,
 				E6660D972CDC4194002A7631 /* PageLoadErrorEvent.swift */,
 				E6660D982CDC4194002A7631 /* UnexpectedLoadErrorTypeEvent.swift */,
+				E6660DC82CE43BDF002A7631 /* UnexpectedNavigationEvent.swift */,
 				E6660D992CDC4194002A7631 /* UnrecognizedSetterEvent.swift */,
 			);
 			path = Events;
@@ -821,6 +824,7 @@
 				4171B1592C9A5EEC00547F7D /* AccountOnboardingViewController.swift in Sources */,
 				41054E432C989AAD00383C09 /* Font+Extension.swift in Sources */,
 				E6EF91C72CBA3BED0082DD1B /* UIViewController+StripeConnect.swift in Sources */,
+				E6660DC92CE43BE6002A7631 /* UnexpectedNavigationEvent.swift in Sources */,
 				41542A692C88B6F2004E728E /* JSONEncoder+extension.swift in Sources */,
 				416E9E842C76AE0A00A0B917 /* ComponentType.swift in Sources */,
 				410D0FCE2C6D000B009B0E26 /* OpenAuthenticatedWebViewMessageHandler.swift in Sources */,

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/UnexpectedNavigationEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/UnexpectedNavigationEvent.swift
@@ -1,0 +1,21 @@
+//
+//  UnexpectedNavigationEvent.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 11/12/24.
+//
+
+/// The component web page navigated away from the component page to another URL
+struct UnexpectedNavigationEvent: ConnectAnalyticEvent {
+    struct Metadata: Codable, Equatable {
+        let url: String?
+
+        init(url: URL?) {
+            // Sanitize URL for logging
+            self.url = url?.absoluteStringRemovingParams
+        }
+    }
+
+    let name = "component.web.error.unexpected_navigation"
+    let metadata: Metadata
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/UnexpectedNavigationEvent.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Analytics/Events/UnexpectedNavigationEvent.swift
@@ -12,7 +12,8 @@ struct UnexpectedNavigationEvent: ConnectAnalyticEvent {
 
         init(url: URL?) {
             // Sanitize URL for logging
-            self.url = url?.absoluteStringRemovingParams
+            self.url = url?
+                .absoluteStringRemovingParams
         }
     }
 

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
@@ -147,9 +147,14 @@ class ConnectComponentWebViewController: ConnectWebViewController {
 
     // MARK: - ConnectWebViewController
 
-    override func webViewDidFinishNavigation() {
-        super.webViewDidFinishNavigation()
+    override func webViewDidFinishNavigation(to url: URL?) {
+        super.webViewDidFinishNavigation(to: url)
 
+        guard let url,
+              url.absoluteStringRemovingParams == StripeConnectConstants.connectJSBaseURL.absoluteString else {
+            analyticsClient.log(event: UnexpectedNavigationEvent(metadata: .init(url: url)))
+            return
+        }
         analyticsClient.logComponentWebPageLoaded(loadEnd: .now)
     }
 

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebViewController.swift
@@ -97,7 +97,7 @@ class ConnectWebViewController: UIViewController {
         present(alert, animated: true)
     }
 
-    func webViewDidFinishNavigation() {
+    func webViewDidFinishNavigation(to url: URL?) {
         // Override from subclass
     }
 
@@ -211,7 +211,7 @@ extension ConnectWebViewController: WKUIDelegate {
 @available(iOS 15, *)
 extension ConnectWebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        webViewDidFinishNavigation()
+        webViewDidFinishNavigation(to: webView.url)
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) {


### PR DESCRIPTION
## Summary
Adds a `component.web.error.unexpected_navigation` analytic event if the component web page navigates anywhere other than the component wrapper.

## Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2491

Followup from thread: https://github.com/stripe/stripe-ios/pull/4238#discussion_r1838313365

## Testing
Unit tests

## Changelog
n/a