### PR TITLE
Fix hidden Not now button in UI tests

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -184,9 +184,6 @@ extension XCUIApplication {
     }
 
     func fc_dismissKeyboard() {
-        let returnKey = keyboards.buttons["return"]
-        if returnKey.exists && returnKey.isHittable {
-            returnKey.tap()
-        }
+        toolbars.buttons["Done"].tap()
     }
 }


### PR DESCRIPTION
## Summary

Now that the Networking Link Signup screen prefills the customer email, the `Not now` button is hidden by default in some of our UI tests. This fixes that by first dismissing the keyboard (by tapping the `Done` keyboard toolbar button) before tapping `Not now`:

<img width="688" alt="image" src="https://github.com/user-attachments/assets/36cf3d48-eaec-4736-96d2-f529759cc890">


## Motivation

Fixes CI https://app.bitrise.io/build/a8159376-9ed7-4c67-8f26-76b18bd9b86a?tab=tests

## Testing

CI should pass

## Changelog

N/a