### PR TITLE
Fix setting default payment method in embedded

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -518,6 +518,12 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Checkout"].waitForExistenceAndTap()
         payWithApplePay()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
+        
+        // Apple Pay should be selected by default upon reloading with the same customer
+        app.buttons["Reload"].tap()
+        app.buttons["Present embedded payment element"].waitForExistenceAndTap()
+        XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
+        XCTAssertEqual(app.staticTexts["Payment method"].label, "Apple Pay")
     }
 
     func testLink() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -79,6 +79,7 @@ extension EmbeddedPaymentElement {
             savedPaymentMethodAccessoryType: savedPaymentMethodAccessoryType,
             mandateProvider: mandateProvider,
             shouldShowMandate: configuration.embeddedViewDisplaysMandateText,
+            customer: configuration.customer,
             delegate: delegate
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -24,6 +24,7 @@ class EmbeddedPaymentMethodsView: UIView {
 
     private let appearance: PaymentSheet.Appearance
     private let rowButtonAppearance: PaymentSheet.Appearance
+    private let customer: PaymentSheet.CustomerConfiguration?
     private var previousSelection: Selection?
     private var previousSelectedRowButton: RowButton?
     private var selectedRowButton: RowButton? {
@@ -75,12 +76,14 @@ class EmbeddedPaymentMethodsView: UIView {
         savedPaymentMethodAccessoryType: RowButton.RightAccessoryButton.AccessoryType?,
         mandateProvider: MandateTextProvider,
         shouldShowMandate: Bool = true,
+        customer: PaymentSheet.CustomerConfiguration? = nil,
         delegate: EmbeddedPaymentMethodsViewDelegate? = nil
     ) {
         self.appearance = appearance
         self.mandateProvider = mandateProvider
         self.shouldShowMandate = shouldShowMandate
         self.rowButtonAppearance = appearance.embeddedPaymentElement.row.style.appearanceForStyle(appearance: appearance)
+        self.customer = customer
         self.delegate = delegate
         super.init(frame: .zero)
 
@@ -121,6 +124,7 @@ class EmbeddedPaymentMethodsView: UIView {
             let applePayRowButton = RowButton.makeForApplePay(appearance: rowButtonAppearance,
                                                               isEmbedded: true,
                                                               didTap: { [weak self] rowButton in
+                CustomerPaymentOption.setDefaultPaymentMethod(.applePay, forCustomer: customer?.id)
                 self?.didTap(selectedRowButton: rowButton, selection: selection)
             })
 
@@ -135,6 +139,7 @@ class EmbeddedPaymentMethodsView: UIView {
         if shouldShowLink {
             let selection: Selection = .link
             let linkRowButton = RowButton.makeForLink(appearance: rowButtonAppearance, isEmbedded: true) { [weak self] rowButton in
+                CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: customer?.id)
                 self?.didTap(selectedRowButton: rowButton, selection: selection)
             }
 
@@ -283,6 +288,10 @@ class EmbeddedPaymentMethodsView: UIView {
                                                                            rightAccessoryView: accessoryButton,
                                                                            isEmbedded: true,
                                                                            didTap: { [weak self] rowButton in
+            CustomerPaymentOption.setDefaultPaymentMethod(
+                .stripeId(savedPaymentMethod.stripeId),
+                forCustomer: self?.customer?.id
+            )
            self?.didTap(selectedRowButton: rowButton, selection: selection)
         })
         return savedPaymentMethodButton


### PR DESCRIPTION
## Summary
- When paying with Apple Pay or Link we were not properly setting the customer's default payment method
- We now match what FlowController does by setting it whenever the user taps on saved, Link, or Apple Pay
- https://github.com/stripe/stripe-ios/blob/master/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved%20Payment%20Method%20Screen/SavedPaymentOptionsViewController.swift#L539

## Motivation
- Embedded

## Testing
- Updated a UI test

## Changelog
N/A
