### PR TITLE
Update AUBecs minlen 4, maxlen 9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ### PaymentSheet
 * [Fixed] Fixed an issue with the vertical list with 3 or more saved payment methods where tapping outside the screen sometimes drops changes that were made (e.g. removal or update of PMs).
 * [Fixed] Fixed an issue where the dialog when removing a co-branded card may show the incorrect card brand.
+* [Fixed] Fixed issue preventing users to enter in 4 digit account numbers for AU Becs.
 
 ## 24.0.0 2024-11-04
 ### PaymentSheet

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+AccountFactory.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+AccountFactory.swift
@@ -56,10 +56,11 @@ import UIKit
                                                             String.Localized.incompleteAccountNumber)
             let label = String.Localized.accountNumber
             let disallowedCharacters: CharacterSet = .stp_invertedAsciiDigit
-            let numberOfDigitsRequired = 9
+            let minimumNumberOfDigits = 4
+            let maximumNumberofDigits = 9
 
             func maxLength(for text: String) -> Int {
-                return numberOfDigitsRequired
+                return maximumNumberofDigits
             }
             let defaultValue: String?
 
@@ -67,7 +68,7 @@ import UIKit
                 if text.isEmpty {
                     return isOptional ? .valid : .invalid(Error.empty)
                 }
-                return text.count == numberOfDigitsRequired ? .valid : .invalid(AUBECSAccountNumberConfiguration.incompleteError)
+                return text.count >= minimumNumberOfDigits && text.count <= maximumNumberofDigits ? .valid : .invalid(AUBECSAccountNumberConfiguration.incompleteError)
             }
 
             func keyboardProperties(for text: String) -> TextFieldElement.KeyboardProperties {

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/TestFieldElement+AccountFactoryTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/TestFieldElement+AccountFactoryTest.swift
@@ -37,6 +37,11 @@ class TextFieldElementAccountFactoryTest: XCTestCase {
     func testAUBECSAccountNumberConfiguration_validAccountNumber() {
         let bsb = TextFieldElement.Account.AUBECSAccountNumberConfiguration(defaultValue: nil)
 
+        bsb.test(text: "1234", isOptional: false, matches: .valid)
+        bsb.test(text: "12345", isOptional: false, matches: .valid)
+        bsb.test(text: "123456", isOptional: false, matches: .valid)
+        bsb.test(text: "1234567", isOptional: false, matches: .valid)
+        bsb.test(text: "12345678", isOptional: false, matches: .valid)
         bsb.test(text: "000123456", isOptional: false, matches: .valid)
     }
 
@@ -52,11 +57,6 @@ class TextFieldElementAccountFactoryTest: XCTestCase {
         bsb.test(text: "0", isOptional: false, matches: .invalid(TextFieldElement.Account.AUBECSAccountNumberConfiguration.incompleteError))
         bsb.test(text: "00", isOptional: false, matches: .invalid(TextFieldElement.Account.AUBECSAccountNumberConfiguration.incompleteError))
         bsb.test(text: "000", isOptional: false, matches: .invalid(TextFieldElement.Account.AUBECSAccountNumberConfiguration.incompleteError))
-        bsb.test(text: "0001", isOptional: false, matches: .invalid(TextFieldElement.Account.AUBECSAccountNumberConfiguration.incompleteError))
-        bsb.test(text: "00012", isOptional: false, matches: .invalid(TextFieldElement.Account.AUBECSAccountNumberConfiguration.incompleteError))
-        bsb.test(text: "000123", isOptional: false, matches: .invalid(TextFieldElement.Account.AUBECSAccountNumberConfiguration.incompleteError))
-        bsb.test(text: "0001234", isOptional: false, matches: .invalid(TextFieldElement.Account.AUBECSAccountNumberConfiguration.incompleteError))
-        bsb.test(text: "00012345", isOptional: false, matches: .invalid(TextFieldElement.Account.AUBECSAccountNumberConfiguration.incompleteError))
     }
 
 }


### PR DESCRIPTION
## Summary
Mirrors change introduced here:
https://github.com/stripe/stripe-android/pull/9576

## Motivation
Au Becs can have a minimum of 5 digits (4 for Cuscal (BSB prefix 80)) however the SDK only allows for an account number with 9 digits. This PR allows for 4-5 digit account numbers for Becs.

## Testing
Updated unit tests

