### PR TITLE
Temporarily disable Panther E2E test

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2294,7 +2294,8 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         fillLinkAndPay(mode: .checkbox)
     }
 
-    func testLinkCardBrand() {
+    // TODO: Re-enable once #ir-cozy-potential is resolced.
+    func DISABLED_testLinkCardBrand() {
         _testInstantDebits(mode: .payment, useLinkCardBrand: true)
     }
 


### PR DESCRIPTION
## Summary

Temporarily disables the Panther UI test since the feature has been remotely rolled back due to an incident.

## Motivation

Unblock `master` 🤠

## Testing

N/a

## Changelog

N/a