### PR TITLE
Fix finding the `Not now` button in UI tests

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -184,6 +184,6 @@ extension XCUIApplication {
     }
 
     func fc_dismissKeyboard() {
-        toolbars.buttons["Done"].tap()
+        toolbars.buttons["Done"].waitForExistenceAndTap()
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -264,11 +264,7 @@ class CustomerSheetUITest: XCTestCase {
         // "Success" institution is automatically selected because its the first
         app.buttons["connect_accounts_button"].waitForExistenceAndTap(timeout: timeout)
 
-        let notNowButton = app.buttons["Not now"]
-        if notNowButton.waitForExistence(timeout: timeout) {
-            app.toolbars.buttons["Done"].tap() // dismiss keyboard
-            notNowButton.tap()
-        }
+        skipLinkSignup(app)
 
         XCTAssertTrue(app.staticTexts["Success"].waitForExistence(timeout: timeout))
         app.buttons.matching(identifier: "Done").allElementsBoundByIndex.last?.tap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -481,11 +481,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         // "Success" institution is automatically selected because its the first
         app.buttons["connect_accounts_button"].waitForExistenceAndTap(timeout: 10)
 
-        let notNowButton = app.buttons["Not now"]
-        if notNowButton.waitForExistence(timeout: 10) {
-            app.toolbars.buttons["Done"].tap() // dismiss keyboard
-            notNowButton.tap()
-        }
+        skipLinkSignup(app)
 
         app.buttons["Continue"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Add US bank account"].waitForExistence(timeout: 10))

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2433,11 +2433,7 @@ extension PaymentSheetUITestCase {
         // "Success" institution is automatically selected because its the first
         app.buttons["connect_accounts_button"].waitForExistenceAndTap(timeout: 10)
 
-        let notNowButton = app.buttons["Not now"]
-        if notNowButton.waitForExistence(timeout: 10.0) {
-            app.toolbars.buttons["Done"].tap() // dismiss keyboard
-            notNowButton.tap()
-        }
+        skipLinkSignup(app)
 
         XCTAssertTrue(app.staticTexts["Success"].waitForExistence(timeout: 10))
         app.buttons.matching(identifier: "Done").allElementsBoundByIndex.last?.tap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
@@ -274,6 +274,15 @@ extension XCTestCase {
         context.buttons["Done"].tap()
     }
 
+    func skipLinkSignup(_ app: XCUIApplication) {
+        let notNowButton = app.buttons["Not now"]
+        if notNowButton.waitForExistence(timeout: 10.0) {
+            let keyboardCloseButton = app.toolbars.buttons["Done"]
+            keyboardCloseButton.waitForExistenceAndTap() // Dismiss keyboard
+            notNowButton.tap()
+        }
+    }
+
     func waitToDisappear(_ target: Any?) {
         let exists = NSPredicate(format: "exists == 0")
         expectation(for: exists, evaluatedWith: target, handler: nil)


### PR DESCRIPTION
## Summary

Extends on https://github.com/stripe/stripe-ios/pull/4254 to wait for the `Done` toolbar button to be visible before tapping it. This also extracts that logic into a shared function.

## Motivation

Some tests were still failing, this should fix that! https://app.bitrise.io/app/b220f4ba85d134a7/pipelines/fb11ea85-5a35-4c44-a3f0-fdc39f7d8a69?tab=tests

## Testing

N/a

## Changelog

N/a
