### PR TITLE
Fix bug when paying by Link in vertical payment sheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -154,9 +154,9 @@ extension PaymentSheet: PayWithLinkViewControllerDelegate {
         completion?(result)
     }
 
-    private func findPaymentSheetViewController() -> PaymentSheetViewController? {
+    private func findPaymentSheetViewController() -> PaymentSheetViewControllerProtocol? {
         for vc in bottomSheetViewController.contentStack {
-            if let paymentSheetVC = vc as? PaymentSheetViewController {
+            if let paymentSheetVC = vc as? PaymentSheetViewControllerProtocol {
                 return paymentSheetVC
             }
         }


### PR DESCRIPTION
## Summary

This fixes a bug in the vertical payment sheet controller when paying with Link. An assertion failure was thrown when trying to find the payment sheet controller. This updates that logic to also look for the `PaymentSheetVerticalViewController`, and have the function return an `PaymentSheetViewControllerProtocol` instead of the `PaymentSheetViewController` itself.

## Motivation

🐛 🔨 

## Testing

Before:

<img width="1592" alt="Screenshot 2024-11-14 at 11 15 55 AM" src="https://github.com/user-attachments/assets/623566e2-e99c-4644-9697-f77ece2f62e7">

After:

https://github.com/user-attachments/assets/2bde22bf-4618-4492-ad82-a22219e740a4

## Changelog

N/a