### PR TITLE
Show Bank tab mandate in vertical mode

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -220,6 +220,10 @@ extension STPElementsSession {
         }
         return allowsRemovalOfPaymentMethods
     }
+    
+    var isLinkCardBrand: Bool {
+        linkSettings?.linkMode == .linkCardBrand
+    }
 }
 
 extension STPElementsSession {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/MandateTextProvider.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/MandateTextProvider.swift
@@ -41,6 +41,8 @@ class VerticalListMandateProvider: MandateTextProvider {
                 return USBankAccountPaymentMethodElement.attributedMandateTextSavedPaymentMethod(alignment: .natural, theme: configuration.appearance.asElementsTheme)
             case .stripe(.SEPADebit):
                 return .init(string: String(format: String.Localized.sepa_mandate_text, configuration.merchantDisplayName))
+            case .stripe(.link):
+                return bottomNoticeAttributedString
             default:
                 return nil
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/MandateTextProvider.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/MandateTextProvider.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 @_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
 @_spi(STP) import StripeUICore
 
 protocol MandateTextProvider {
@@ -41,7 +42,9 @@ class VerticalListMandateProvider: MandateTextProvider {
                 return USBankAccountPaymentMethodElement.attributedMandateTextSavedPaymentMethod(alignment: .natural, theme: configuration.appearance.asElementsTheme)
             case .stripe(.SEPADebit):
                 return .init(string: String(format: String.Localized.sepa_mandate_text, configuration.merchantDisplayName))
-            case .stripe(.link):
+            case .stripe(.link): // Instant Debits
+                return bottomNoticeAttributedString
+            case .stripe(.card) where elementsSession.isLinkCardBrand: // Panther
                 return bottomNoticeAttributedString
             default:
                 return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -192,7 +192,7 @@ extension PaymentSheet {
                 elementsSession.linkFundingSources?.contains(.bankAccount) == true &&
                 !elementsSession.orderedPaymentMethodTypes.contains(.USBankAccount) &&
                 (!intent.isDeferredIntent || enableInstantDebitsWithDeferredIntents) &&
-                elementsSession.linkSettings?.linkMode == .linkCardBrand &&
+                elementsSession.isLinkCardBrand &&
                 configuration.isEligibleForBankTab
             }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -254,9 +254,11 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
 
     func updateMandate(animated: Bool = true) {
         let mandateProvider = VerticalListMandateProvider(configuration: configuration, elementsSession: elementsSession, intent: intent, analyticsHelper: analyticsHelper)
-        let newMandateText = mandateProvider.mandate(for: selectedPaymentOption?.paymentMethodType,
-                                                     savedPaymentMethod: selectedPaymentOption?.savedPaymentMethod,
-                                                     bottomNoticeAttributedString: paymentMethodFormViewController?.bottomNoticeAttributedString)
+        let newMandateText = mandateProvider.mandate(
+            for: selectedPaymentOption?.paymentMethodType,
+            savedPaymentMethod: selectedPaymentOption?.savedPaymentMethod,
+            bottomNoticeAttributedString: paymentMethodFormViewController?.bottomNoticeAttributedString
+        )
         animateHeightChange {
             self.mandateView.attributedText = newMandateText
             self.mandateView.setHiddenIfNecessary(newMandateText == nil)


### PR DESCRIPTION
## Summary

The pay by bank mandate was missing in vertical mode. This fixes that!

## Motivation

Alignment between horizontal / vertical mode.

## Testing

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 - 2024-11-14 at 11 05 22](https://github.com/user-attachments/assets/4297754b-7a88-4c45-b4c4-2e8c7dccd683) | ![Simulator Screenshot - iPhone 16 - 2024-11-14 at 11 00 41](https://github.com/user-attachments/assets/14809e53-c3e3-4f5d-bacd-b42913554849) | 

And the `these terms` URL points to: 

<img width=40% src="https://github.com/user-attachments/assets/31dd91b8-5cb5-4b2f-9002-e084f382329f">

## Changelog

N/a
