### PR TITLE
[CONSUMERBANK-528] Handle invalid phone numbers in Link signup more gracefully

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -179,6 +179,7 @@ final class LinkLoginViewController: UIViewController {
                         }
                     } else {
                         formView?.showAndEditPhoneNumberFieldIfNeeded()
+                        setContinueWithLinkButtonDisabledState()
                     }
                 case .failure(let error):
                     self.delegate?.linkLoginViewController(self, didReceiveTerminalError: error)
@@ -210,7 +211,21 @@ final class LinkLoginViewController: UIViewController {
             case .success(let response):
                 self.delegate?.linkLoginViewController(self, signedUpAttachedAndSynchronized: response)
             case .failure(let error):
-                self.delegate?.linkLoginViewController(self, didReceiveTerminalError: error)
+                func completeWithTerminalError() {
+                    self.delegate?.linkLoginViewController(self, didReceiveTerminalError: error)
+                }
+
+                guard let stripeError = error as? StripeError, case .apiError(let stripeAPIError) = stripeError else {
+                    return completeWithTerminalError()
+                }
+
+                // Hack to determine if the error is related to the phone number.
+                // If so, show a generic error message under the phone textfield.
+                if let errorMessage = stripeAPIError.message, errorMessage.contains("phone") {
+                    formView.phoneTextField.setErrorText(PhoneTextField.LocalizedStrings.invalidPhoneNumber)
+                } else {
+                    completeWithTerminalError()
+                }
             }
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/LinkSignupFormView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/LinkSignupFormView.swift
@@ -194,6 +194,7 @@ extension LinkSignupFormView: PhoneTextFieldDelegate {
         _ phoneTextField: PhoneTextField,
         didChangePhoneNumber phoneNumber: PhoneNumber?
     ) {
+        phoneTextField.clearErrorText()
         delegate?.linkSignupFormViewDidUpdateFields(self)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneTextField.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/PhoneTextField.swift
@@ -19,9 +19,21 @@ protocol PhoneTextFieldDelegate: AnyObject {
 
 final class PhoneTextField: UIView {
 
+    enum LocalizedStrings {
+        static let textfieldPlaceholder = STPLocalizedString(
+            "Phone number",
+            "The title of a user-input-field that appears when a user is signing up to Link (a payment service). It instructs user to type a phone number."
+        )
+
+        static let invalidPhoneNumber = STPLocalizedString(
+            "Your mobile phone number is invalid.",
+            "An error message that instructs the user to keep typing their phone number in a user-input field."
+        )
+    }
+
     fileprivate lazy var textField: RoundedTextField = {
         let textField = RoundedTextField(
-            placeholder: STPLocalizedString("Phone number", "The title of a user-input-field that appears when a user is signing up to Link (a payment service). It instructs user to type a phone number."),
+            placeholder: LocalizedStrings.textfieldPlaceholder,
             showDoneToolbar: true,
             theme: theme
         )
@@ -158,12 +170,20 @@ final class PhoneTextField: UIView {
                 if text.isEmpty {
                     // no error message if empty
                 } else {
-                    textField.errorText = STPLocalizedString("Your mobile phone number is incomplete.", "An error message that instructs the user to keep typing their phone number in a user-input field.")
+                    textField.errorText = LocalizedStrings.invalidPhoneNumber
                 }
             }
         }
 
         delegate?.phoneTextField(self, didChangePhoneNumber: phoneNumber)
+    }
+
+    func setErrorText(_ errorMessage: String) {
+        textField.errorText = errorMessage
+    }
+
+    func clearErrorText() {
+        textField.errorText = nil
     }
 }
 


### PR DESCRIPTION
## Summary

This updates the Link Login pane to more gracefully handle errors related to the phone number. Previously, we had very little input validation on the phone textfield, and any API errors related to an improperly formatted phone number would lead to the terminal error pane. This attempts to catch phone number related API errors, and present them under the phone textfield.

## Motivation

[CONSUMERBANK-528](https://jira.corp.stripe.com/browse/CONSUMERBANK-528)

## Testing

https://github.com/user-attachments/assets/6d038299-6abd-410a-8095-27fe18b0f9c4

## Changelog

N/a
