### PR TITLE
Add Link warmup pane for deferred intents

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentDataSource.swift
@@ -25,7 +25,7 @@ protocol ConsentDataSource: AnyObject {
 struct ConsentAcquiredResult {
     var manifest: FinancialConnectionsSessionManifest
     var consumerSession: ConsumerSessionData? = nil
-    var publishableKey: String? = nil
+    var consumerPublishableKey: String? = nil
     
     var nextPane: FinancialConnectionsSessionManifest.NextPane {
         // If we have a consumer session, then provide the returning-user experience
@@ -87,7 +87,7 @@ final class ConsentDataSourceImplementation: ConsentDataSource {
                     let result = ConsentAcquiredResult(
                         manifest: manifest,
                         consumerSession: response.consumerSession,
-                        publishableKey: response.publishableKey
+                        consumerPublishableKey: response.publishableKey
                     )
                     promise.resolve(with: result)
                 case .failure:

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentDataSource.swift
@@ -24,9 +24,9 @@ protocol ConsentDataSource: AnyObject {
 
 struct ConsentAcquiredResult {
     var manifest: FinancialConnectionsSessionManifest
-    var consumerSession: ConsumerSessionData? = nil
-    var consumerPublishableKey: String? = nil
-    
+    var consumerSession: ConsumerSessionData?
+    var consumerPublishableKey: String?
+
     var nextPane: FinancialConnectionsSessionManifest.NextPane {
         // If we have a consumer session, then provide the returning-user experience
         consumerSession != nil ? .networkingLinkLoginWarmup : manifest.nextPane
@@ -42,7 +42,7 @@ final class ConsentDataSourceImplementation: ConsentDataSource {
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
     private let elementsSessionContext: ElementsSessionContext?
-    
+
     var email: String? {
         elementsSessionContext?.prefillDetails?.email
     }
@@ -99,7 +99,7 @@ final class ConsentDataSourceImplementation: ConsentDataSource {
             return promise
         }
     }
-    
+
     func completeAssertionIfNeeded(
         possibleError: Error?,
         api: FinancialConnectionsAPIClientLogger.API

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentDataSource.swift
@@ -9,12 +9,28 @@ import Foundation
 @_spi(STP) import StripeCore
 
 protocol ConsentDataSource: AnyObject {
+    var email: String? { get }
     var manifest: FinancialConnectionsSessionManifest { get }
     var consent: FinancialConnectionsConsent { get }
     var merchantLogo: [String]? { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
 
-    func markConsentAcquired() -> Promise<FinancialConnectionsSessionManifest>
+    func markConsentAcquired() -> Future<ConsentAcquiredResult>
+    func completeAssertionIfNeeded(
+        possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API
+    ) -> Error?
+}
+
+struct ConsentAcquiredResult {
+    var manifest: FinancialConnectionsSessionManifest
+    var consumerSession: ConsumerSessionData? = nil
+    var publishableKey: String? = nil
+    
+    var nextPane: FinancialConnectionsSessionManifest.NextPane {
+        // If we have a consumer session, then provide the returning-user experience
+        consumerSession != nil ? .networkingLinkLoginWarmup : manifest.nextPane
+    }
 }
 
 final class ConsentDataSourceImplementation: ConsentDataSource {
@@ -25,6 +41,11 @@ final class ConsentDataSourceImplementation: ConsentDataSource {
     private let apiClient: any FinancialConnectionsAPI
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
+    private let elementsSessionContext: ElementsSessionContext?
+    
+    var email: String? {
+        elementsSessionContext?.prefillDetails?.email
+    }
 
     init(
         manifest: FinancialConnectionsSessionManifest,
@@ -32,7 +53,8 @@ final class ConsentDataSourceImplementation: ConsentDataSource {
         merchantLogo: [String]?,
         apiClient: any FinancialConnectionsAPI,
         clientSecret: String,
-        analyticsClient: FinancialConnectionsAnalyticsClient
+        analyticsClient: FinancialConnectionsAnalyticsClient,
+        elementsSessionContext: ElementsSessionContext?
     ) {
         self.manifest = manifest
         self.consent = consent
@@ -40,9 +62,59 @@ final class ConsentDataSourceImplementation: ConsentDataSource {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
+        self.elementsSessionContext = elementsSessionContext
     }
 
-    func markConsentAcquired() -> Promise<FinancialConnectionsSessionManifest> {
-        return apiClient.markConsentAcquired(clientSecret: clientSecret)
+    func markConsentAcquired() -> Future<ConsentAcquiredResult> {
+        return apiClient.markConsentAcquired(clientSecret: clientSecret).chained { [weak self] manifest in
+            guard let self, manifest.shouldLookupConsumerSession, let email else {
+                let result = ConsentAcquiredResult(manifest: manifest)
+                return Promise(value: result)
+            }
+
+            let promise = Promise<ConsentAcquiredResult>()
+
+            apiClient.consumerSessionLookup(
+                emailAddress: email,
+                clientSecret: clientSecret,
+                sessionId: manifest.id,
+                emailSource: .customerObject,
+                useMobileEndpoints: manifest.verified,
+                pane: .consent
+            ).observe { lookupResult in
+                switch lookupResult {
+                case .success(let response):
+                    let result = ConsentAcquiredResult(
+                        manifest: manifest,
+                        consumerSession: response.consumerSession,
+                        publishableKey: response.publishableKey
+                    )
+                    promise.resolve(with: result)
+                case .failure:
+                    let result = ConsentAcquiredResult(manifest: manifest)
+                    promise.resolve(with: result)
+                }
+            }
+
+            return promise
+        }
+    }
+    
+    func completeAssertionIfNeeded(
+        possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API
+    ) -> Error? {
+        guard manifest.verified else { return nil }
+        return apiClient.completeAssertion(
+            possibleError: possibleError,
+            api: api,
+            pane: .linkLogin
+        )
+    }
+}
+
+private extension FinancialConnectionsSessionManifest {
+    var shouldLookupConsumerSession: Bool {
+        isLinkWithStripe == true && accountholderCustomerEmailAddress == nil
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -157,12 +157,12 @@ class ConsentViewController: UIViewController {
                         possibleError: error,
                         api: .consumerSessionLookup
                     )
-                    
+
                     if attestationError != nil {
                         let prefillDetails = WebPrefillDetails(email: dataSource.email)
                         self.delegate?.consentViewControllerDidFailAttestationVerdict(self, prefillDetails: prefillDetails)
                     }
-                    
+
                     // we display no errors on failure
                     self.dataSource
                         .analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -19,7 +19,11 @@ protocol ConsentViewControllerDelegate: AnyObject {
     )
     func consentViewController(
         _ viewController: ConsentViewController,
-        didConsentWithManifest manifest: FinancialConnectionsSessionManifest
+        didConsentWithResult result: ConsentAcquiredResult
+    )
+    func consentViewControllerDidFailAttestationVerdict(
+        _ viewController: ConsentViewController,
+        prefillDetails: WebPrefillDetails
     )
 }
 
@@ -146,9 +150,19 @@ class ConsentViewController: UIViewController {
             .observe(on: .main) { [weak self] result in
                 guard let self = self else { return }
                 switch result {
-                case .success(let manifest):
-                    self.delegate?.consentViewController(self, didConsentWithManifest: manifest)
+                case .success(let result):
+                    self.delegate?.consentViewController(self, didConsentWithResult: result)
                 case .failure(let error):
+                    let attestationError = self.dataSource.completeAssertionIfNeeded(
+                        possibleError: error,
+                        api: .consumerSessionLookup
+                    )
+                    
+                    if attestationError != nil {
+                        let prefillDetails = WebPrefillDetails(email: dataSource.email)
+                        self.delegate?.consentViewControllerDidFailAttestationVerdict(self, prefillDetails: prefillDetails)
+                    }
+                    
                     // we display no errors on failure
                     self.dataSource
                         .analyticsClient

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -729,7 +729,7 @@ extension NativeFlowController: ConsentViewControllerDelegate {
             pushPane(nextPane, parameters: parameters, animated: true)
         }
     }
-    
+
     func consentViewControllerDidFailAttestationVerdict(
         _ viewController: ConsentViewController,
         prefillDetails: WebPrefillDetails

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -705,7 +705,7 @@ extension NativeFlowController: ConsentViewControllerDelegate {
 
         dataManager.manifest = result.manifest
         dataManager.consumerSession = result.consumerSession
-        dataManager.consumerPublishableKey = result.publishableKey
+        dataManager.consumerPublishableKey = result.consumerPublishableKey
 
         let nextPane = result.nextPane
         if nextPane == .networkingLinkLoginWarmup {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
@@ -12,6 +12,7 @@ protocol NetworkingLinkLoginWarmupDataSource: AnyObject {
     var manifest: FinancialConnectionsSessionManifest { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var email: String? { get }
+    var hasConsumerSession: Bool { get }
 
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse>
     func disableNetworking() -> Future<FinancialConnectionsSessionManifest>
@@ -32,6 +33,10 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
 
     var email: String? {
         manifest.accountholderCustomerEmailAddress ?? elementsSessionContext?.prefillDetails?.email
+    }
+    
+    var hasConsumerSession: Bool {
+        apiClient.consumerSession != nil && apiClient.consumerPublishableKey != nil
     }
 
     init(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
@@ -34,7 +34,7 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
     var email: String? {
         manifest.accountholderCustomerEmailAddress ?? elementsSessionContext?.prefillDetails?.email
     }
-    
+
     var hasConsumerSession: Bool {
         apiClient.consumerSession != nil && apiClient.consumerPublishableKey != nil
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -120,7 +120,7 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
             eventName: "click.continue",
             pane: .networkingLinkLoginWarmup
         )
-        
+
         if dataSource.hasConsumerSession {
             // We already have a consumer session, so let's us this one directly
             delegate?.networkingLinkLoginWarmupViewControllerDidSelectContinue(self)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -14,8 +14,11 @@ typealias NetworkingLinkLoginWarmupFooterView = (footerView: UIView?, primaryBut
 
 protocol NetworkingLinkLoginWarmupViewControllerDelegate: AnyObject {
     func networkingLinkLoginWarmupViewControllerDidSelectContinue(
+        _ viewController: NetworkingLinkLoginWarmupViewController
+    )
+    func networkingLinkLoginWarmupViewControllerDidFindConsumerSession(
         _ viewController: NetworkingLinkLoginWarmupViewController,
-        withSession consumerSession: ConsumerSessionData,
+        consumerSession: ConsumerSessionData,
         consumerPublishableKey: String
     )
     func networkingLinkLoginWarmupViewControllerDidSelectCancel(
@@ -117,7 +120,17 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
             eventName: "click.continue",
             pane: .networkingLinkLoginWarmup
         )
+        
+        if dataSource.hasConsumerSession {
+            // We already have a consumer session, so let's us this one directly
+            delegate?.networkingLinkLoginWarmupViewControllerDidSelectContinue(self)
+        } else {
+            // Otherwise, look it up so that we have it for the next pane
+            lookupConsumerSessionAndContinue()
+        }
+    }
 
+    private func lookupConsumerSessionAndContinue() {
         warmupFooterView.primaryButton?.isLoading = true
 
         dataSource
@@ -141,11 +154,12 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
                 switch result {
                 case .success(let response):
                     if let consumerSession = response.consumerSession, let publishableKey = response.publishableKey {
-                        self.delegate?.networkingLinkLoginWarmupViewControllerDidSelectContinue(
+                        self.delegate?.networkingLinkLoginWarmupViewControllerDidFindConsumerSession(
                             self,
-                            withSession: consumerSession,
+                            consumerSession: consumerSession,
                             consumerPublishableKey: publishableKey
                         )
+                        self.delegate?.networkingLinkLoginWarmupViewControllerDidSelectContinue(self)
                     } else {
                         let error = FinancialConnectionsSheetError.unknown(
                             debugDescription: "Unexpected consumer lookup response without consumer session or publishable key"


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request improves the returning-user experience for IBP consumers when the flow is opened for deferred intents. With those, we don’t have a populated `accountholderCustomerEmailAddress`, so we need to manually look for a consumer account after the user accepts on the consent pane.

It also updates the warmup pane to only lookup a consumer session if there isn’t one yet.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
