### PR TITLE
[Connect] iPad + landscape bug fixes

### DIFF
--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -85,6 +85,7 @@
 		41D17A6C2C5A7429007C6EE6 /* StripeiOS-Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 41D17A612C5A7429007C6EE6 /* StripeiOS-Release.xcconfig */; };
 		41D17A6D2C5A7429007C6EE6 /* StripeiOS-Shared.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 41D17A622C5A7429007C6EE6 /* StripeiOS-Shared.xcconfig */; };
 		41D17A6E2C5A7429007C6EE6 /* Version.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 41D17A632C5A7429007C6EE6 /* Version.xcconfig */; };
+		E611A7182CE8372800B3F580 /* ActivityViewControllerWithoutPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = E611A7172CE8372500B3F580 /* ActivityViewControllerWithoutPopover.swift */; };
 		E6165CBF2CA7BF2200B76DA5 /* FetchInitComponentPropsMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6165CBE2CA7BF2200B76DA5 /* FetchInitComponentPropsMessageHandler.swift */; };
 		E6165CC12CA7D09900B76DA5 /* FetchInitComponentPropsMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6165CC02CA7D09900B76DA5 /* FetchInitComponentPropsMessageHandlerTests.swift */; };
 		E640C9CC2CBF0C1E009D0C6E /* AuthenticatedWebViewManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = E640C9CB2CBF0C1E009D0C6E /* AuthenticatedWebViewManager.swift */; };
@@ -224,6 +225,7 @@
 		41D17A612C5A7429007C6EE6 /* StripeiOS-Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "StripeiOS-Release.xcconfig"; sourceTree = "<group>"; };
 		41D17A622C5A7429007C6EE6 /* StripeiOS-Shared.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "StripeiOS-Shared.xcconfig"; sourceTree = "<group>"; };
 		41D17A632C5A7429007C6EE6 /* Version.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Version.xcconfig; sourceTree = "<group>"; };
+		E611A7172CE8372500B3F580 /* ActivityViewControllerWithoutPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityViewControllerWithoutPopover.swift; sourceTree = "<group>"; };
 		E6165CBE2CA7BF2200B76DA5 /* FetchInitComponentPropsMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchInitComponentPropsMessageHandler.swift; sourceTree = "<group>"; };
 		E6165CC02CA7D09900B76DA5 /* FetchInitComponentPropsMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchInitComponentPropsMessageHandlerTests.swift; sourceTree = "<group>"; };
 		E640C9CB2CBF0C1E009D0C6E /* AuthenticatedWebViewManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticatedWebViewManager.swift; sourceTree = "<group>"; };
@@ -337,6 +339,7 @@
 		413987C42C63F34B001D375E /* Webview */ = {
 			isa = PBXGroup;
 			children = (
+				E611A7172CE8372500B3F580 /* ActivityViewControllerWithoutPopover.swift */,
 				410D0FE42C6D32F0009B0E26 /* ApplicationURLOpener.swift */,
 				410D0FDE2C6D3176009B0E26 /* ConnectWebViewController.swift */,
 				E6D3C8ED2CBE1404003CE967 /* HTTPStatusError.swift */,
@@ -875,6 +878,7 @@
 				E6660D9C2CDC4194002A7631 /* ComponentCreatedEvent.swift in Sources */,
 				E6660D9D2CDC4194002A7631 /* DeserializeMessageErrorEvent.swift in Sources */,
 				E6660D9E2CDC4194002A7631 /* UnexpectedLoadErrorTypeEvent.swift in Sources */,
+				E611A7182CE8372800B3F580 /* ActivityViewControllerWithoutPopover.swift in Sources */,
 				E6660D9F2CDC4194002A7631 /* UnrecognizedSetterEvent.swift in Sources */,
 				E6660DA02CDC4194002A7631 /* ComponentLoadedEvent.swift in Sources */,
 				E6660DA12CDC4194002A7631 /* ComponentWebPageLoadedEvent.swift in Sources */,

--- a/StripeConnect/StripeConnect/Source/Internal/Extensions/UIViewController+StripeConnect.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Extensions/UIViewController+StripeConnect.swift
@@ -5,6 +5,7 @@
 //  Created by Mel Ludowise on 10/11/24.
 //
 
+@_spi(STP) import StripeUICore
 import UIKit
 
 extension UIViewController {
@@ -12,8 +13,7 @@ extension UIViewController {
     func addChildAndPinView(_ child: UIViewController) {
         child.willMove(toParent: self)
         addChild(child)
-        view.addSubview(child.view)
-        child.view.frame = view.bounds
+        view.addAndPinSubview(child.view)
         child.didMove(toParent: self)
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ActivityViewControllerWithoutPopover.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ActivityViewControllerWithoutPopover.swift
@@ -1,0 +1,22 @@
+//
+//  ActivityViewControllerWithoutPopover.swift
+//  StripeConnect
+//
+//  Created by Mel Ludowise on 11/15/24.
+//
+
+import UIKit
+
+/// A `UIActivityViewController` that always uses a `formSheet` modalPresentationStyle.
+/// This prevents the presentation style from getting set to `popup` on iPad.
+class FormSheetActivityViewController: UIActivityViewController {
+    /*
+     Setting `modalPresentationStyle` directly after instantiating a
+     UIActivityViewController doesn't work because UIKit overrides it.
+     So we have to subclass and override `modalPresentationStyle`.
+     */
+    override var modalPresentationStyle: UIModalPresentationStyle {
+        get { .formSheet }
+        set { }
+    }
+}

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebViewController.swift
@@ -131,7 +131,7 @@ private extension ConnectWebViewController {
     func openInAppSafari(url: URL) {
         let safariVC = SFSafariViewController(url: url)
         safariVC.dismissButtonStyle = .done
-        safariVC.modalPresentationStyle = .popover
+        safariVC.modalPresentationStyle = .pageSheet
         present(safariVC, animated: true)
     }
 

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebViewController.swift
@@ -221,7 +221,6 @@ extension ConnectWebViewController: WKNavigationDelegate {
          https://stackoverflow.com/a/59452941/4133371
          */
         webView.setNeedsLayout()
-        webView.layoutSubviews()
         webViewDidFinishNavigation(to: webView.url)
     }
 

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectWebViewController.swift
@@ -211,6 +211,17 @@ extension ConnectWebViewController: WKUIDelegate {
 @available(iOS 15, *)
 extension ConnectWebViewController: WKNavigationDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        /*
+         The web view does not adjust its safe area insets after it finishes loading.
+         This causes a race condition where the horizontal safe area insets are
+         rendered incorrectly in landscape with Face ID devices if the page finishes
+         loading before the view is laid out.
+
+         The fix is to force the web view to redraw after the page finishes loading:
+         https://stackoverflow.com/a/59452941/4133371
+         */
+        webView.setNeedsLayout()
+        webView.layoutSubviews()
         webViewDidFinishNavigation(to: webView.url)
     }
 
@@ -316,7 +327,10 @@ extension ConnectWebViewController {
             return
         }
 
-        let activityViewController = UIActivityViewController(activityItems: [downloadedFile], applicationActivities: nil)
+        // Since downloads can happen async and we don't know where in the webView
+        // the download action was triggered, a popover presentation (default on iPad)
+        // won't look good. Instead, use a `formSheet` presentation style.
+        let activityViewController = FormSheetActivityViewController(activityItems: [downloadedFile], applicationActivities: nil)
         activityViewController.completionWithItemsHandler = { [weak self] _, _, _, _ in
             self?.cleanupDownloadedFile()
         }


### PR DESCRIPTION
## Summary
Fixes the following bugs:
1. Downloading a file crashes on iPad
   - Root cause was the UIActivityViewController attempting to use a popover presentation style with no sourceView set
2. Opening external popups (e.g. onboarding TOS) crashes on iPad
  - Similarly, root case was using popover presentation style with no sourceView set
3. iPad modal layout took up full width and rotating between landscape / portrait didn't re-layout the view
   -  Root cause was not using layout constraints to correctly pin the view to its parent
4. Loading the web view in landscape sometimes didn't render the correct horizontal safe area
   - Root cause is a race condition bug in WKWebView. Fix is to re-layout the view after the web page finishes loading.

## Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-2931

## Testing

#### Downloading files:

iPad:

https://github.com/user-attachments/assets/ab1d09a2-2d0f-4c8a-ab69-5c766daeb196


iPhone (no change):

https://github.com/user-attachments/assets/6a08aa0e-ca15-4450-82f5-daa31d117bbc


#### Opening TOS popup:

iPad:

https://github.com/user-attachments/assets/8d9be4db-ec70-40b1-83f3-ec2a772767a7

iPhone (no change):

https://github.com/user-attachments/assets/077cd2ea-374d-4124-bcd9-4a22d0d1d00f


#### iPad modal layout
| Before | After |
| ------ | ----- |
| <img width="1408" alt="image" src="https://github.com/user-attachments/assets/9140a511-5678-4c12-8e6d-09ea1dfed8ec"> | ![simulator_screenshot_F6644838-495F-41AE-AAFC-450B1CAB20B9](https://github.com/user-attachments/assets/5b5717ec-1d5a-43f2-97e5-82de1a678c9a) |

#### Rotating between portrait and landscape

Before:

https://github.com/user-attachments/assets/4ed9c926-ff8f-49fb-a1a1-c0df631814ff

After:

https://github.com/user-attachments/assets/424c3c89-641d-49e6-927b-5f5394e8b7fa

#### Loading page in landscape on Face ID device
_Note: recorded in simulator with slowed animations to force the page to finish loading before it appears on screen_

Before:

https://github.com/user-attachments/assets/b112cbff-2bf0-443d-a126-3bba5d7cb05e


After:

https://github.com/user-attachments/assets/4edcc53b-c330-49c0-8287-0a8a89d7f209

## Changelog
n/a