### PR TITLE
Fix always allowing manual entry on `terminal_error` pane

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/TerminalError/TerminalErrorViewController.swift
@@ -39,7 +39,7 @@ final class TerminalErrorViewController: UIViewController {
         navigationItem.hidesBackButton = true
 
         let terminalErrorView = TerminalErrorView(
-            allowManualEntry: true,
+            allowManualEntry: allowManualEntry,
             theme: theme,
             didSelectManualEntry: { [weak self] in
                 guard let self = self else { return }


### PR DESCRIPTION
## Summary

Fixes a small bug in the `TerminalErrorViewController` where we would always allow manual entry. It now correctly reflects `manifest.allowManualEntry`.

https://github.com/stripe/stripe-ios/blob/d5e0616335fbacce6da02eb9594d1bd7a7e2505a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift#L1519-L1523

## Motivation

Correctness

## Testing

N/a

## Changelog

N/a
