### PR TITLE
Fix when selecting a saved payment method

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -408,7 +408,8 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["View more"].waitForExistenceAndTap())
         XCTAssertTrue(app.buttons["•••• 4242"].waitForExistenceAndTap())
         
-        // Card should now be selected
+        // Verify we have dismissed the saved payment method view and have the correct card selected
+        XCTAssertTrue(app.buttons["View more"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["•••• 4242"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
     }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -410,7 +410,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["•••• 4242"].waitForExistenceAndTap())
         
         // Verify we have dismissed the saved payment method view and have the correct card selected
-        XCTAssertTrue(app.buttons["View more"].waitForExistence(timeout: 10))
+        XCTAssertFalse(app.staticTexts["Select payment method"].waitForExistence(timeout: 2))
         XCTAssertTrue(app.staticTexts["•••• 4242"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -406,12 +406,31 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         
         // Select a saved card
         XCTAssertTrue(app.buttons["View more"].waitForExistenceAndTap())
+        XCTAssertTrue(app.staticTexts["Select payment method"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["•••• 4242"].waitForExistenceAndTap())
         
         // Verify we have dismissed the saved payment method view and have the correct card selected
         XCTAssertTrue(app.buttons["View more"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.staticTexts["•••• 4242"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
+        
+        // Select Cash App Pay again
+        app.buttons["Cash App Pay"].waitForExistenceAndTap()
+        XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Checkout"].isEnabled)
+        
+        // Delete one payment method so we only have one left, we should not auto select the last remaining saved PM
+        XCTAssertTrue(app.buttons["View more"].waitForExistenceAndTap())
+        XCTAssertTrue(app.buttons["Edit"].waitForExistenceAndTap())
+        XCTAssertTrue(app.buttons["CircularButton.Remove"].firstMatch.waitForExistenceAndTap())
+        dismissAlertView(alertBody: "Visa •••• 4242", alertTitle: "Remove card?", buttonToTap: "Remove")
+        XCTAssertTrue(app.buttons["Done"].waitForExistenceAndTap())
+        
+        // Verify we show the bank account in the saved PM row
+        XCTAssertTrue(app.buttons["Edit"].waitForExistence(timeout: 10))
+        XCTAssertFalse(app.buttons["••••6789"].isSelected)
+        XCTAssertTrue(app.buttons["Cash App Pay"].isSelected)
+        XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
     }
 
     func testSelection() {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -345,7 +345,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         let bank6789Button = app.buttons["••••6789"]
         let applePayButton = app.buttons["Apple Pay"]
 
-        // Ensure card bankacct is selected, and apple pay is not.
+        // Ensure card bank acct. is selected, and apple pay is not.
         XCTAssertTrue(bank6789Button.waitForExistence(timeout: 3.0))
         XCTAssertTrue(bank6789Button.isSelected)
         XCTAssertTrue(applePayButton.waitForExistence(timeout: 3.0))

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -362,7 +362,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(applePayButton.isSelected)
         XCTAssertFalse(bank6789Button.isSelected)
 
-        // Remove bankacct while it isn't selected
+        // Remove bank acct. while it isn't selected
         app.buttons["View more"].waitForExistenceAndTap()
         app.buttons["Edit"].waitForExistenceAndTap()
         app.buttons["CircularButton.Remove"].firstMatch.waitForExistenceAndTap()
@@ -388,6 +388,29 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Checkout"].waitForExistenceAndTap()
         payWithApplePay()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
+    }
+    
+    func testSelection_savedPaymentMethod() {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.uiStyle = .embedded
+        settings.customerMode = .returning
+        settings.applePayEnabled = .on
+        
+        loadPlayground(app, settings)
+        app.buttons["Present embedded payment element"].waitForExistenceAndTap()
+        
+        // Select Cash App Pay
+        app.buttons["Cash App Pay"].waitForExistenceAndTap()
+        XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Checkout"].isEnabled)
+        
+        // Select a saved card
+        XCTAssertTrue(app.buttons["View more"].waitForExistenceAndTap())
+        XCTAssertTrue(app.buttons["•••• 4242"].waitForExistenceAndTap())
+        
+        // Card should now be selected
+        XCTAssertTrue(app.staticTexts["•••• 4242"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Checkout"].isEnabled)
     }
 
     func testSelection() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -228,8 +228,13 @@ extension EmbeddedPaymentElement: VerticalSavedPaymentMethodsViewControllerDeleg
             savedPaymentMethods: latestPaymentMethods
         )
 
+        // Select the selected payment method if we selected a payment method and have more than one saved PM
+        // Or if there are still saved payment methods & the saved payment method was previously selected to presenting
+        // the list of saved payment methods, then the embedded view should continue to show it is selected, otherwise unselected.
+        let isSelected = (latestPaymentMethods.count > 1 && selectedPaymentMethod != nil) ||
+        (embeddedPaymentMethodsView.selection?.isSaved ?? false && latestPaymentMethods.count > 0)
         embeddedPaymentMethodsView.updateSavedPaymentMethodRow(savedPaymentMethods.first,
-                                                               isSelected: selectedPaymentMethod != nil,
+                                                               isSelected: isSelected,
                                                                accessoryType: accessoryType)
         presentingViewController?.dismiss(animated: true)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -228,9 +228,9 @@ extension EmbeddedPaymentElement: VerticalSavedPaymentMethodsViewControllerDeleg
             savedPaymentMethods: latestPaymentMethods
         )
 
-        // Select the selected payment method if we selected a payment method and have more than one saved PM
-        // Or if there are still saved payment methods & the saved payment method was previously selected to presenting
-        // the list of saved payment methods, then the embedded view should continue to show it is selected, otherwise unselected.
+        // Select the *saved payment method if we selected a payment method
+        // or
+        // there are still saved payment methods & the saved payment method was previously selected to presenting
         let isSelected = (latestPaymentMethods.count > 1 && selectedPaymentMethod != nil) ||
         (embeddedPaymentMethodsView.selection?.isSaved ?? false && latestPaymentMethods.count > 0)
         embeddedPaymentMethodsView.updateSavedPaymentMethodRow(savedPaymentMethods.first,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -228,11 +228,8 @@ extension EmbeddedPaymentElement: VerticalSavedPaymentMethodsViewControllerDeleg
             savedPaymentMethods: latestPaymentMethods
         )
 
-        // If there are still saved payment methods & the saved payment method was previously selected to presenting
-        // the list of saved payment methods, then the embedded view should continue to show it is selected, otherwise unselected.
-        let isSelected: Bool = latestPaymentMethods.count > 0 && embeddedPaymentMethodsView.selection?.isSaved ?? false
         embeddedPaymentMethodsView.updateSavedPaymentMethodRow(savedPaymentMethods.first,
-                                                               isSelected: isSelected,
+                                                               isSelected: selectedPaymentMethod != nil,
                                                                accessoryType: accessoryType)
         presentingViewController?.dismiss(animated: true)
     }


### PR DESCRIPTION
## Summary
- When we would have something other than the saved payment method selected, then hit "View more" and select a payment method it would not be selected.
- The selected saved payment method should become the payment option to match the behavior of vertical mode and not require users to tap the saved payment method twice.
- I don't believe there to be any scenario where the saved payment method view controller completes with a selected payment method that we would not want it to be selected.

### Before
https://github.com/user-attachments/assets/31081f58-cedb-4003-a161-8bea4154b876



## Motivation
- Bug fix

## Testing
- Manual
- New UI test

## Changelog
N/A
