### PR TITLE
Fix issue with sending empty encoded parameters

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -79,12 +79,12 @@ final class FinancialConnectionsAPIClient {
         return promise
     }
 
-    static func encodeAsParameters(_ value: any Encodable) throws -> [String: Any] {
+    static func encodeAsParameters(_ value: any Encodable) throws -> [String: Any]? {
         let jsonData = try JSONEncoder().encode(value)
         let jsonObject = try JSONSerialization.jsonObject(with: jsonData)
 
         if let dictionary = jsonObject as? [String: Any] {
-            return dictionary
+            return dictionary.isEmpty ? nil : dictionary
         } else {
             throw EncodingError.cannotCastToDictionary
         }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
@@ -53,6 +53,13 @@ class FinancialConnectionsAPIClientTests: XCTestCase {
         XCTAssertNil(apiClient.consumerPublishableKeyProvider(canUseConsumerKey: false))
     }
 
+    func testEmptyBillingAddressEncodedAsParameters() throws {
+        let billingAddress = BillingAddress()
+        let encodedBillingAddress = try FinancialConnectionsAPIClient.encodeAsParameters(billingAddress)
+        
+        XCTAssertNil(encodedBillingAddress)
+    }
+
     func testBillingAddressEncodedAsParameters() throws {
         let billingAddress = BillingAddress(
             name: "Bobby Tables",
@@ -65,13 +72,13 @@ class FinancialConnectionsAPIClientTests: XCTestCase {
         )
         let encodedBillingAddress = try FinancialConnectionsAPIClient.encodeAsParameters(billingAddress)
 
-        XCTAssertEqual(encodedBillingAddress["name"] as? String, "Bobby Tables")
-        XCTAssertEqual(encodedBillingAddress["line_1"] as? String, "123 Fake St")
-        XCTAssertNil(encodedBillingAddress["line_2"])
-        XCTAssertEqual(encodedBillingAddress["locality"] as? String, "Utopia")
-        XCTAssertEqual(encodedBillingAddress["administrative_area"] as? String, "CA")
-        XCTAssertEqual(encodedBillingAddress["postal_code"] as? String, "90210")
-        XCTAssertEqual(encodedBillingAddress["country_code"] as? String, "US")
+        XCTAssertEqual(encodedBillingAddress?["name"] as? String, "Bobby Tables")
+        XCTAssertEqual(encodedBillingAddress?["line_1"] as? String, "123 Fake St")
+        XCTAssertNil(encodedBillingAddress?["line_2"])
+        XCTAssertEqual(encodedBillingAddress?["locality"] as? String, "Utopia")
+        XCTAssertEqual(encodedBillingAddress?["administrative_area"] as? String, "CA")
+        XCTAssertEqual(encodedBillingAddress?["postal_code"] as? String, "90210")
+        XCTAssertEqual(encodedBillingAddress?["country_code"] as? String, "US")
     }
 
     func testBillingAddressEncodedAsParametersNonNilLine2() throws {
@@ -86,12 +93,12 @@ class FinancialConnectionsAPIClientTests: XCTestCase {
         )
         let encodedBillingAddress = try FinancialConnectionsAPIClient.encodeAsParameters(billingAddress)
 
-        XCTAssertEqual(encodedBillingAddress["name"] as? String, "Bobby Tables")
-        XCTAssertEqual(encodedBillingAddress["line_1"] as? String, "123 Fake St")
-        XCTAssertNil(encodedBillingAddress["line_2"])
-        XCTAssertEqual(encodedBillingAddress["locality"] as? String, "Utopia")
-        XCTAssertEqual(encodedBillingAddress["administrative_area"] as? String, "CA")
-        XCTAssertEqual(encodedBillingAddress["postal_code"] as? String, "90210")
-        XCTAssertEqual(encodedBillingAddress["country_code"] as? String, "US")
+        XCTAssertEqual(encodedBillingAddress?["name"] as? String, "Bobby Tables")
+        XCTAssertEqual(encodedBillingAddress?["line_1"] as? String, "123 Fake St")
+        XCTAssertNil(encodedBillingAddress?["line_2"])
+        XCTAssertEqual(encodedBillingAddress?["locality"] as? String, "Utopia")
+        XCTAssertEqual(encodedBillingAddress?["administrative_area"] as? String, "CA")
+        XCTAssertEqual(encodedBillingAddress?["postal_code"] as? String, "90210")
+        XCTAssertEqual(encodedBillingAddress?["country_code"] as? String, "US")
     }
 }


### PR DESCRIPTION
## Summary

This fixes an issue in the `FinancialConnectionsAPIClient` where we were sending `[:]` when all the values were `nil` or empty.

## Motivation

🐛 🔨 

## Testing

Unit tests added

## Changelog

N/a