### PR TITLE
Selecting a new saved payment method bug fix

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -414,22 +414,26 @@ class EmbeddedUITests: PaymentSheetUITestCase {
 
         // Should auto select a saved payment method
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
+        XCTAssertTrue(app.buttons["•••• 4242"].isSelected)
 
         // Open card and cancel, should reset selection to saved card
         app.buttons["New card"].waitForExistenceAndTap()
         app.buttons["Close"].waitForExistenceAndTap()
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
+        XCTAssertTrue(app.buttons["•••• 4242"].isSelected)
 
         // Select Cash App Pay
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Cash App Pay"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
         // Open card and cancel, should reset back to Cash App Pay
         app.buttons["New card"].waitForExistenceAndTap()
         app.buttons["Close"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Cash App Pay"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
         // Try to fill a card
@@ -440,6 +444,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Continue"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4444")
+        XCTAssertTrue(app.buttons["•••• 4444"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
         // Tapping on card again should present the form filled out
@@ -450,18 +455,21 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Close"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4444")
+        XCTAssertTrue(app.buttons["•••• 4444"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
-        // Select and cancel out a form PM to ensure that the 4242 card is still selected
+        // Select and cancel out a form PM to ensure that the 4444 card is still selected
         app.buttons["Klarna"].waitForExistenceAndTap()
         app.buttons["Close"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4444")
+        XCTAssertTrue(app.buttons["•••• 4444"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
         // Select a no-form PM such as Cash App Pay
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Cash App Pay"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
         // Fill out US Bank Acct.
@@ -488,11 +496,13 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Continue"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "••••6789")
+        XCTAssertTrue(app.buttons["US bank account"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
         // Confirm with the saved card
         app.buttons["•••• 4242"].waitForExistenceAndTap()
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
+        XCTAssertTrue(app.buttons["•••• 4242"].isSelected)
         app.swipeUp() // scroll to see the checkout button
         XCTAssertTrue(app.buttons["Checkout"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -444,7 +444,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Continue"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4444")
-        XCTAssertTrue(app.buttons["•••• 4444"].isSelected)
+        XCTAssertTrue(app.buttons["New card"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
         // Tapping on card again should present the form filled out
@@ -455,7 +455,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Close"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4444")
-        XCTAssertTrue(app.buttons["•••• 4444"].isSelected)
+        XCTAssertTrue(app.buttons["New card"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
         // Select and cancel out a form PM to ensure that the 4444 card is still selected
@@ -463,7 +463,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Close"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4444")
-        XCTAssertTrue(app.buttons["•••• 4444"].isSelected)
+        XCTAssertTrue(app.buttons["New card"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
         // Select a no-form PM such as Cash App Pay

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -220,6 +220,7 @@ class EmbeddedPaymentMethodsView: UIView {
                                      isSelected: Bool,
                                      accessoryType: RowButton.RightAccessoryButton.AccessoryType?) {
         guard let previousSavedPaymentMethodButton = self.savedPaymentMethodButton,
+              let previousSelection = selectionButtonMapping.first(where: { $0.value == previousSavedPaymentMethodButton })?.key,
               let viewIndex = stackView.arrangedSubviews.firstIndex(of: previousSavedPaymentMethodButton) else {
             stpAssertionFailure("""
             This function should never be called when there isn't already a saved PM row because there's no way for Embedded
@@ -229,9 +230,7 @@ class EmbeddedPaymentMethodsView: UIView {
         }
         
         // Remove old mapping from selectionButtonMapping
-        if let previousSelection = selectionButtonMapping.first(where: { $0.value == previousSavedPaymentMethodButton })?.key {
-            selectionButtonMapping.removeValue(forKey: previousSelection)
-        }
+        selectionButtonMapping.removeValue(forKey: previousSelection)
 
         if let savedPaymentMethod {
             // Replace saved payment method button at same index

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -100,7 +100,7 @@ class EmbeddedPaymentMethodsView: UIView {
                 shouldAnimateOnPress: true,
                 isEmbedded: true,
                 didTap: { [weak self] rowButton in
-                    self?.didTap(selectedRowButton: rowButton, selection: selection)
+                    self?.didTap(selection: selection)
                 }
             )
             if initialSelection == selection {
@@ -116,7 +116,7 @@ class EmbeddedPaymentMethodsView: UIView {
                                                               isEmbedded: true,
                                                               didTap: { [weak self] rowButton in
                 CustomerPaymentOption.setDefaultPaymentMethod(.applePay, forCustomer: customer?.id)
-                self?.didTap(selectedRowButton: rowButton, selection: selection)
+                self?.didTap(selection: selection)
             })
 
             if initialSelection == selection {
@@ -130,7 +130,7 @@ class EmbeddedPaymentMethodsView: UIView {
             let selection: Selection = .link
             let linkRowButton = RowButton.makeForLink(appearance: rowButtonAppearance, isEmbedded: true) { [weak self] rowButton in
                 CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: customer?.id)
-                self?.didTap(selectedRowButton: rowButton, selection: selection)
+                self?.didTap(selection: selection)
             }
 
             if initialSelection == selection {
@@ -151,7 +151,7 @@ class EmbeddedPaymentMethodsView: UIView {
                 shouldAnimateOnPress: true,
                 isEmbedded: true,
                 didTap: { [weak self] rowButton in
-                    self?.didTap(selectedRowButton: rowButton, selection: selection)
+                    self?.didTap(selection: selection)
                 }
             )
             if initialSelection == selection {
@@ -208,7 +208,7 @@ class EmbeddedPaymentMethodsView: UIView {
     }
 
     // MARK: Tap handling
-    func didTap(selectedRowButton: RowButton, selection: Selection) {
+    func didTap(selection: Selection) {
         self.selection = selection
     }
 
@@ -287,7 +287,7 @@ class EmbeddedPaymentMethodsView: UIView {
                 .stripeId(savedPaymentMethod.stripeId),
                 forCustomer: self?.customer?.id
             )
-           self?.didTap(selectedRowButton: rowButton, selection: selection)
+           self?.didTap(selection: selection)
         })
         return savedPaymentMethodButton
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
@@ -210,7 +210,7 @@ protocol VerticalPaymentMethodListViewControllerDelegate: AnyObject {
 }
 
 // MARK: - VerticalPaymentMethodListSelection
-enum VerticalPaymentMethodListSelection: Equatable {
+enum VerticalPaymentMethodListSelection: Equatable, Hashable {
     case new(paymentMethodType: PaymentSheet.PaymentMethodType)
     case saved(paymentMethod: STPPaymentMethod)
     case applePay
@@ -228,6 +228,21 @@ enum VerticalPaymentMethodListSelection: Equatable {
             return lhsPM.stripeId == rhsPM.stripeId && lhsPM.calculateCardBrandToDisplay() == rhsPM.calculateCardBrandToDisplay()
         default:
             return false
+        }
+    }
+    
+    func hash(into hasher: inout Hasher) {
+        switch self {
+        case .new(let paymentMethodType):
+            hasher.combine(0)
+            hasher.combine(paymentMethodType.identifier)
+        case .saved(let paymentMethod):
+            hasher.combine(1)
+            hasher.combine(paymentMethod.stripeId)
+        case .applePay:
+            hasher.combine(2)
+        case .link:
+            hasher.combine(3)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -58,7 +58,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
         sut.view.autosizeHeight(width: 320)
         // ...with cash app selected...
         let cashAppPayRowButton = sut.embeddedPaymentMethodsView.getRowButton(accessibilityIdentifier: "Cash App Pay")
-        sut.embeddedPaymentMethodsView.didTap(selectedRowButton: cashAppPayRowButton, selection: .new(paymentMethodType: .stripe(.cashApp)))
+        sut.embeddedPaymentMethodsView.didTap(selection: .new(paymentMethodType: .stripe(.cashApp)))
         delegateDidUpdatePaymentOptionCalled = false // This gets set to true when we select cash app ^
         XCTAssertNil(sut.paymentOption?.mandateText)
         // ...its intent should match the initial intent config...

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
@@ -209,7 +209,7 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
 
         // Simulate tapping the last button
         if let rowButton = embeddedView.stackView.arrangedSubviews.last(where: { $0 is RowButton }) as? RowButton {
-            embeddedView.didTap(selectedRowButton: rowButton, selection: .new(paymentMethodType: .stripe(.cashApp)))
+            embeddedView.didTap(selection: .new(paymentMethodType: .stripe(.cashApp)))
         }
 
         verify(embeddedView)
@@ -431,7 +431,7 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
 
         // Simulate tapping the last button
         if let rowButton = embeddedView.stackView.arrangedSubviews.last(where: { $0 is RowButton }) as? RowButton {
-            embeddedView.didTap(selectedRowButton: rowButton, selection: .new(paymentMethodType: .stripe(.cashApp)))
+            embeddedView.didTap(selection: .new(paymentMethodType: .stripe(.cashApp)))
         }
 
         verify(embeddedView)
@@ -454,7 +454,7 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
 
         // Simulate tapping the last button
         if let rowButton = embeddedView.stackView.arrangedSubviews.last(where: { $0 is RowButton }) as? RowButton {
-            embeddedView.didTap(selectedRowButton: rowButton, selection: .new(paymentMethodType: .stripe(.cashApp)))
+            embeddedView.didTap(selection: .new(paymentMethodType: .stripe(.cashApp)))
         }
 
         verify(embeddedView)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
@@ -52,28 +52,28 @@ final class EmbeddedPaymentMethodsViewTests: XCTestCase {
         XCTAssertNil(embeddedView.selection)
 
         // Simulate tapping Cash App and verify delegate is called
-        embeddedView.didTap(selectedRowButton: rowButtons[1], selection: .new(paymentMethodType: .stripe(.cashApp)))
+        embeddedView.didTap(selection: .new(paymentMethodType: .stripe(.cashApp)))
         XCTAssertTrue(mockDelegate.didCallHeightDidChange, "didCallHeightDidChange should be called when selection changes to show a mandate")
         XCTAssertTrue(mockDelegate.didCallSelectionDidUpdate, "selectionDidUpdate should be called when selection changes")
         XCTAssertEqual(embeddedView.selection, .new(paymentMethodType: .stripe(.cashApp)), "Cash App Pay should be the current selection")
         mockDelegate.reset()
 
         // Simulate tapping Klarna and verify delegate is called
-        embeddedView.didTap(selectedRowButton: rowButtons[2], selection: .new(paymentMethodType: .stripe(.klarna)))
+        embeddedView.didTap(selection: .new(paymentMethodType: .stripe(.klarna)))
         XCTAssertTrue(mockDelegate.didCallHeightDidChange, "didCallHeightDidChange should be called when selection changes to show a different sized mandate")
         XCTAssertTrue(mockDelegate.didCallSelectionDidUpdate, "selectionDidUpdate should be called when selection changes")
         XCTAssertEqual(embeddedView.selection, .new(paymentMethodType: .stripe(.klarna)), "Klarna should be the current selection")
         mockDelegate.reset()
 
         // Simulate tapping PayPal and verify delegate is called
-        embeddedView.didTap(selectedRowButton: rowButtons[3], selection: .new(paymentMethodType: .stripe(.payPal)))
+        embeddedView.didTap(selection: .new(paymentMethodType: .stripe(.payPal)))
         XCTAssertTrue(mockDelegate.didCallHeightDidChange, "didCallHeightDidChange should be called when selection changes to show a different sized mandate")
         XCTAssertTrue(mockDelegate.didCallSelectionDidUpdate, "selectionDidUpdate should be called when selection changes")
         XCTAssertEqual(embeddedView.selection, .new(paymentMethodType: .stripe(.payPal)), "PayPal should be the current selection")
         mockDelegate.reset()
 
         // Simulate tapping PayPal again (same selection) and verify delegate is NOT called
-        embeddedView.didTap(selectedRowButton: rowButtons[3], selection: .new(paymentMethodType: .stripe(.payPal)))
+        embeddedView.didTap(selection: .new(paymentMethodType: .stripe(.payPal)))
         XCTAssertFalse(mockDelegate.didCallHeightDidChange, "didCallHeightDidChange should not be called when the same selection is selected again")
         XCTAssertFalse(mockDelegate.didCallSelectionDidUpdate, "selectionDidUpdate should not be called when the same selection is selected again")
         XCTAssertEqual(embeddedView.selection, .new(paymentMethodType: .stripe(.payPal)), "PayPal should still be the current selection")


### PR DESCRIPTION
## Summary
- If you would select a saved payment method by opening the manage screen (tapping "View more"), then tap new card, then dismiss the card form the row but the previously selected payment method would not be selected.
- This was due to `updateSavedPaymentMethodRow` updating the selection before the saved payment method button.
- This PR improves the selection logic making it less bug prone by keeping a map of selections to row buttons
- We also improve the selection UI tests

## Motivation
- Embedded

## Testing
- Manual
- Improved existing tests

## Changelog
N/A