### PR TITLE
Revert #4174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### PaymentSheet
+* [Fixed] A bug where PaymentSheet would cause layout issues when nested within certain navigation stacks.
+
 ## 24.0.1 2024-11-18
 ### PaymentSheet
 * [Added] Instant Bank Payments are now available when using deferred intents.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
@@ -69,18 +69,19 @@ class BottomSheetPresentationAnimator: NSObject {
 
     private func animateDismissal(transitionContext: UIViewControllerContextTransitioning) {
         guard
+            let toVC = transitionContext.viewController(forKey: .to),
             let fromVC = transitionContext.viewController(forKey: .from)
         else { return }
 
         // Calls viewWillAppear and viewWillDisappear
-        fromVC.beginAppearanceTransition(false, animated: true)
+        toVC.beginAppearanceTransition(true, animated: true)
 
         Self.animate({
             fromVC.view.frame.origin.y = transitionContext.containerView.frame.height
         }) { didComplete in
             fromVC.view.removeFromSuperview()
             // Calls viewDidAppear and viewDidDisappear
-            fromVC.endAppearanceTransition()
+            toVC.endAppearanceTransition()
             transitionContext.completeTransition(didComplete)
         }
     }


### PR DESCRIPTION
## Summary
- Reverts a changes that causes issues within navigation stacks
- https://github.com/stripe/stripe-ios/pull/4175/

## Motivation
- ir-enter-pioneer

## Testing
- Manual
- Tests to follow as remediation

## Changelog
See diff
