### PR TITLE
Add crypto payment method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 24.0.3 2024-11-22
+### Payments
+* [Added] Support for Crypto bindings.
+
 ## 24.0.2 2024-11-21
 ### PaymentSheet
 * [Fixed] A bug where PaymentSheet would cause layout issues when nested within certain navigation stacks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 24.0.3 2024-11-22
+## x.x.x x-x-x
 ### Payments
 * [Added] Support for Crypto bindings.
 

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples.xcodeproj/project.pbxproj
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		E25C6341B4F787932711D689 /* SofortSourcesExampleViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 58E87A8E1AE06AA97A3310C1 /* SofortSourcesExampleViewController.m */; };
 		E29BEECD69C041C085EFDEA9 /* BlikExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABD4A8C07A1D8B651413DF43 /* BlikExampleViewController.swift */; };
 		E88340F6DFAA14F6772159E7 /* Stripe.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6CA51E7BD0D4D1E0B94075FE /* Stripe.framework */; };
+		F60858F22CEF052100D62278 /* CryptoExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60858F12CEF052100D62278 /* CryptoExampleViewController.swift */; };
 		F635434F095301C541789E1C /* StripePaymentSheet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2ADDFFDCAC5AF682FC6648E8 /* StripePaymentSheet.framework */; };
 /* End PBXBuildFile section */
 
@@ -183,6 +184,7 @@
 		F185553AA1B3E2D0C80B8424 /* SEPADebitExampleViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SEPADebitExampleViewController.h; sourceTree = "<group>"; };
 		F1A0CF82AB6742C41BA5C19C /* WeChatPayExampleViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WeChatPayExampleViewController.m; sourceTree = "<group>"; };
 		F2F0E1A3A75AC9C2C8E9C01B /* OXXOExampleViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OXXOExampleViewController.h; sourceTree = "<group>"; };
+		F60858F12CEF052100D62278 /* CryptoExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoExampleViewController.swift; sourceTree = "<group>"; };
 		F74D08CE9A94C0D55EB3618A /* KlarnaSourcesExampleViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KlarnaSourcesExampleViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -312,6 +314,7 @@
 				CAC3A0312C2F1184007BC888 /* SunbitExampleViewController.swift */,
 				CAC3A0392C2F2AB5007BC888 /* BillieExampleViewController.swift */,
 				CAC80EBA2C333164001E3D0D /* SatispayExampleViewController.swift */,
+				F60858F12CEF052100D62278 /* CryptoExampleViewController.swift */,
 			);
 			path = "Non-Card Payment Examples";
 			sourceTree = "<group>";
@@ -423,6 +426,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				61E1CA232BD6B9DF00A421AE /* MultibancoExampleViewController.swift in Sources */,
+				F60858F22CEF052100D62278 /* CryptoExampleViewController.swift in Sources */,
 				09470488B2A3383D39A9445C /* AUBECSDebitExampleViewController.m in Sources */,
 				11E6BDE8B898A7215AE679F6 /* AffirmExampleViewController.swift in Sources */,
 				2BFF43283D3D33B24CCCB073 /* AfterpayClearpayExampleViewController.swift in Sources */,

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples/BrowseExamplesViewController.m
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples/BrowseExamplesViewController.m
@@ -62,100 +62,100 @@
             cell.textLabel.text = @"WeChat Pay (Sources)";
             break;
         case 3:
-            cell.textLabel.text = @"FPX";
-            break;
-        case 4:
             cell.textLabel.text = @"SEPA Debit";
             break;
-        case 5:
+        case 4:
             cell.textLabel.text = @"iDEAL";
             break;
-        case 6:
+        case 5:
             cell.textLabel.text = @"Alipay";
             break;
-        case 7:
+        case 6:
             cell.textLabel.text = @"Klarna (Sources)";
             break;
-        case 8:
+        case 7:
             cell.textLabel.text = @"Bacs Debit";
             break;
-        case 9:
+        case 8:
             cell.textLabel.text = @"AU BECS Debit";
             break;
-        case 10:
+        case 9:
             cell.textLabel.text = @"giropay";
             break;
-        case 11:
+        case 10:
             cell.textLabel.text = @"Przelewy24";
             break;
-        case 12:
+        case 11:
             cell.textLabel.text = @"Bancontact";
             break;
-        case 13:
+        case 12:
             cell.textLabel.text = @"EPS";
             break;
-        case 14:
+        case 13:
             cell.textLabel.text = @"Sofort (PaymentMethods)";
             break;
-        case 15:
+        case 14:
             cell.textLabel.text = @"GrabPay";
             break;
-        case 16:
+        case 15:
             cell.textLabel.text = @"OXXO";
             break;
-        case 17:
+        case 16:
             cell.textLabel.text = @"Afterpay";
             break;
-        case 18:
+        case 17:
             cell.textLabel.text = @"Boleto";
             break;
-        case 19:
+        case 18:
             cell.textLabel.text = @"Klarna (PaymentMethods)";
             break;
-        case 20:
+        case 19:
             cell.textLabel.text = @"Affirm (PaymentMethods)";
             break;
-        case 21:
+        case 20:
             cell.textLabel.text = @"US Bank Account";
             break;
-        case 22:
+        case 21:
             cell.textLabel.text = @"US Bank Account w/ FinancialConnections";
             break;
-        case 23:
+        case 22:
             cell.textLabel.text = @"Cash App Pay";
             break;
-        case 24:
+        case 23:
             cell.textLabel.text = @"BLIK";
             break;
-        case 25:
+        case 24:
             cell.textLabel.text = @"PayPal";
             break;
-        case 26:
+        case 25:
             cell.textLabel.text = @"RevolutPay";
             break;
-        case 27:
+        case 26:
             cell.textLabel.text = @"Swish";
             break;
-        case 28:
+        case 27:
             cell.textLabel.text = @"Amazon Pay";
             break;
-        case 29:
+        case 28:
             cell.textLabel.text = @"Alma";
             break;
-        case 30:
+        case 29:
             cell.textLabel.text = @"Multibanco";
             break;
-        case 31:
+        case 30:
             cell.textLabel.text = @"MobilePay";
             break;
-        case 32:
+        case 31:
             cell.textLabel.text = @"Sunbit";
             break;
-        case 33:
+        case 32:
             cell.textLabel.text = @"Billie";
             break;
-        case 34:
+        case 33:
             cell.textLabel.text = @"Satispay";
+            break;
+        case 34:
+            cell.textLabel.text = @"Crypto";
             break;
     }
     return cell;
@@ -371,6 +371,12 @@
         }
         case 33: {
             SatispayExampleViewController *exampleVC = [SatispayExampleViewController new];
+            exampleVC.delegate = self;
+            viewController = exampleVC;
+            break;
+        }
+        case 34: {
+            CryptoExampleViewController *exampleVC = [CryptoExampleViewController new];
             exampleVC.delegate = self;
             viewController = exampleVC;
             break;

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples/CryptoExampleViewController.swift
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples/CryptoExampleViewController.swift
@@ -1,0 +1,116 @@
+//
+//  CryptoExampleViewController.swift
+//  Non-Card Payment Examples
+//
+//  Created by Eric Zhang on 11/20/24.
+//
+
+import Stripe
+import UIKit
+
+class CryptoExampleViewController: UIViewController {
+    @objc weak var delegate: ExampleViewControllerDelegate?
+    var inProgress: Bool = false {
+        didSet {
+            navigationController?.navigationBar.isUserInteractionEnabled = !inProgress
+            payButton.isEnabled = !inProgress
+            inProgress
+                ? activityIndicatorView.startAnimating() : activityIndicatorView.stopAnimating()
+        }
+    }
+
+    // UI
+    lazy var activityIndicatorView = {
+        return UIActivityIndicatorView(style: .gray)
+    }()
+    lazy var payButton: UIButton = {
+        let button = UIButton(type: .roundedRect)
+        button.setTitle("Pay with Crypto", for: .normal)
+        button.addTarget(self, action: #selector(didTapPayButton), for: .touchUpInside)
+        return button
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = .white
+        title = "Crypto"
+        [payButton, activityIndicatorView].forEach { subview in
+            view.addSubview(subview)
+            subview.translatesAutoresizingMaskIntoConstraints = false
+        }
+
+        let constraints = [
+            payButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            payButton.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+
+            activityIndicatorView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            activityIndicatorView.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+        ]
+        NSLayoutConstraint.activate(constraints)
+    }
+
+    @objc func didTapPayButton() {
+        guard STPAPIClient.shared.publishableKey != nil else {
+            delegate?.exampleViewController(
+                self,
+                didFinishWithMessage: "Please set a Stripe Publishable Key in Constants.m"
+            )
+            return
+        }
+        inProgress = true
+        pay()
+    }
+}
+
+// MARK: - Crypto
+extension CryptoExampleViewController {
+    @objc func pay() {
+        // 1. Create an Crypto PaymentIntent
+        MyAPIClient.shared().createPaymentIntent(
+            completion: { (_, clientSecret, error) in
+                guard let clientSecret = clientSecret else {
+                    self.delegate?.exampleViewController(self, didFinishWithError: error)
+                    return
+                }
+
+                // 2. Confirm the payment and redirect the user to Crypto
+                let paymentIntentParams = STPPaymentIntentParams(clientSecret: clientSecret)
+                paymentIntentParams.paymentMethodParams = STPPaymentMethodParams(
+                    crypto: STPPaymentMethodCryptoParams(),
+                    billingDetails: nil,
+                    metadata: nil
+                )
+                paymentIntentParams.returnURL = "payments-example://safepay/"
+
+                STPPaymentHandler.shared().confirmPayment(
+                    paymentIntentParams,
+                    with: self
+                ) { (status, _, error) in
+                    switch status {
+                    case .canceled:
+                        self.delegate?.exampleViewController(
+                            self,
+                            didFinishWithMessage: "Cancelled"
+                        )
+                    case .failed:
+                        self.delegate?.exampleViewController(self, didFinishWithError: error)
+                    case .succeeded:
+                        self.delegate?.exampleViewController(
+                            self,
+                            didFinishWithMessage: "Payment successfully created."
+                        )
+                    @unknown default:
+                        fatalError()
+                    }
+                }
+            },
+            additionalParameters: "supported_payment_methods=crypto"
+        )
+    }
+}
+
+extension CryptoExampleViewController: STPAuthenticationContext {
+    func authenticationPresentingViewController() -> UIViewController {
+        self
+    }
+}

--- a/Stripe/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe/Stripe.xcodeproj/project.pbxproj
@@ -300,6 +300,8 @@
 		F49D9C4030829D13A6EB45BE /* MockFiles in Resources */ = {isa = PBXBuildFile; fileRef = FE2DED6ABA7407C17C1391B6 /* MockFiles */; };
 		F550D4EB3DCFE03D6FC8F023 /* STPIntentActionPayNowDisplayQrCodeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A517686D4D12691351311CA /* STPIntentActionPayNowDisplayQrCodeTest.swift */; };
 		F5CC4F320D09A06F0B21ABE6 /* STPPaymentMethodAffirmTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F0DF2ED9232A7CC51F5FCB1 /* STPPaymentMethodAffirmTests.swift */; };
+		F60858F62CEF058200D62278 /* STPPaymentMethodCryptoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60858F52CEF058200D62278 /* STPPaymentMethodCryptoTests.swift */; };
+		F60858F82CEF058F00D62278 /* STPPaymentMethodCryptoParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60858F72CEF058F00D62278 /* STPPaymentMethodCryptoParamsTests.swift */; };
 		F729E784CFFC1F79EF5F2ABE /* STPPaymentIntentLastPaymentErrorTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C7B8DACB0A7294BC235E3BC /* STPPaymentIntentLastPaymentErrorTest.swift */; };
 		F86F2DF6E46EFABE23AD5D27 /* STPApplePayContextDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E452877E5D11120B1E28A6E7 /* STPApplePayContextDelegate.swift */; };
 		F975CE029DF30419B8DB0D8F /* STPNumericStringValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA36705DED9164663A98B6A /* STPNumericStringValidatorTests.swift */; };
@@ -667,6 +669,8 @@
 		F44327A2B2C9483F52EE343B /* STPFormViewSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPFormViewSnapshotTests.swift; sourceTree = "<group>"; };
 		F4E5416F6AE8BED88980D6F8 /* STPPaymentMethodBancontactTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodBancontactTests.swift; sourceTree = "<group>"; };
 		F546088BA4F763334CFD3D34 /* STPImageLibraryTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPImageLibraryTest.swift; sourceTree = "<group>"; };
+		F60858F52CEF058200D62278 /* STPPaymentMethodCryptoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodCryptoTests.swift; sourceTree = "<group>"; };
+		F60858F72CEF058F00D62278 /* STPPaymentMethodCryptoParamsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodCryptoParamsTests.swift; sourceTree = "<group>"; };
 		F6558C62376C2397030BD4A6 /* STPPaymentMethodPrzelewy24Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodPrzelewy24Tests.swift; sourceTree = "<group>"; };
 		F7385193226663A5B79E69ED /* STPFloatingPlaceholderTextFieldSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPFloatingPlaceholderTextFieldSnapshotTests.swift; sourceTree = "<group>"; };
 		FC30E6129279F14506219E98 /* STPPaymentHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentHandlerTests.swift; sourceTree = "<group>"; };
@@ -1111,6 +1115,8 @@
 				CAC3A0332C2F176A007BC888 /* STPPaymentMethodSunbitTests.swift */,
 				CAC3A03D2C2F2CD8007BC888 /* STPPaymentMethodBillieTests.swift */,
 				CAC80EBE2C33339D001E3D0D /* STPPaymentMethodSatispayTests.swift */,
+				F60858F52CEF058200D62278 /* STPPaymentMethodCryptoTests.swift */,
+				F60858F72CEF058F00D62278 /* STPPaymentMethodCryptoParamsTests.swift */,
 			);
 			path = StripeiOSTests;
 			sourceTree = "<group>";
@@ -1523,6 +1529,7 @@
 				4935C8B3ECFBAD947E694934 /* STPIntentActionTypeTest.swift in Sources */,
 				8F0326E98C74EB62E34B9FEA /* STPIntentActionWeChatPayRedirectToAppTest.swift in Sources */,
 				9FB20E559379F468070C7B50 /* STPLabeledFormTextFieldViewSnapshotTests.swift in Sources */,
+				F60858F62CEF058200D62278 /* STPPaymentMethodCryptoTests.swift in Sources */,
 				A22D548084E7DE1FE5ABE8E7 /* STPLabeledMultiFormTextFieldViewSnapshotTests.swift in Sources */,
 				331924F0801287BAD413FDCB /* STPMandateCustomerAcceptanceParamsTest.swift in Sources */,
 				781EC0163AC001C6A66045B6 /* STPMandateDataParamsTest.swift in Sources */,
@@ -1539,6 +1546,7 @@
 				A30CD9DA2CCC2DFE00EA22D3 /* STPAPIClientTest.swift in Sources */,
 				FEF2E0DAC862FF42B814AFCA /* STPPaymentHandlerFunctionalTest.m in Sources */,
 				8F5AF9D3566B8DBCA5AB5188 /* STPPaymentHandlerFunctionalTest.swift in Sources */,
+				F60858F82CEF058F00D62278 /* STPPaymentMethodCryptoParamsTests.swift in Sources */,
 				194154708E1A9E013DCE2C72 /* STPPaymentHandlerStubbedMockedFilesTests.swift in Sources */,
 				2A528B7B2579E5F977797822 /* STPPaymentHandlerTests.swift in Sources */,
 				1BC4044802EE7D3E2643DC84 /* STPPaymentIntentEnumsTest.swift in Sources */,

--- a/Stripe/StripeiOSTests/STPPaymentIntentFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentIntentFunctionalTest.swift
@@ -1330,6 +1330,57 @@ class STPPaymentIntentFunctionalTest: STPNetworkStubbingTestCase {
         waitForExpectations(timeout: STPTestingNetworkRequestTimeout, handler: nil)
     }
 
+    // MARK: - Crypto
+
+    func testConfirmPaymentIntentWithCrypto() {
+        var clientSecret: String?
+        let createExpectation = self.expectation(description: "Create PaymentIntent.")
+        STPTestingAPIClient.shared.createPaymentIntent(
+            withParams: [
+                "payment_method_types": ["crypto"],
+                "currency": "usd",
+                "amount": NSNumber(value: 100),
+            ],
+            account: "us"
+        ) { createdClientSecret, creationError in
+            XCTAssertNotNil(createdClientSecret)
+            XCTAssertNil(creationError)
+            createExpectation.fulfill()
+            clientSecret = createdClientSecret
+        }
+        waitForExpectations(timeout: STPTestingNetworkRequestTimeout, handler: nil)
+        XCTAssertNotNil(clientSecret)
+
+        let client = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let expectation = self.expectation(description: "Payment Intent confirm")
+
+        let paymentIntentParams = STPPaymentIntentParams(clientSecret: clientSecret!)
+        paymentIntentParams.paymentMethodParams = STPPaymentMethodParams(
+            crypto: STPPaymentMethodCryptoParams(),
+            billingDetails: nil,
+            metadata: [
+                "test_key": "test_value",
+            ]
+        )
+
+        let options = STPConfirmPaymentMethodOptions()
+        paymentIntentParams.paymentMethodOptions = options
+        paymentIntentParams.returnURL = "example-app-scheme://unused"
+        client.confirmPaymentIntent(with: paymentIntentParams) { paymentIntent, error in
+            XCTAssertNil(error, "With valid key + secret, should be able to confirm the intent")
+            XCTAssertNotNil(paymentIntent)
+            XCTAssertEqual(paymentIntent?.stripeId, paymentIntentParams.stripeId)
+            XCTAssertFalse(paymentIntent!.livemode)
+            XCTAssertNotNil(paymentIntent?.paymentMethodId)
+
+            XCTAssertEqual(paymentIntent?.status, .requiresAction)
+            XCTAssertEqual(paymentIntent!.nextAction?.type, .redirectToURL)
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: STPTestingNetworkRequestTimeout, handler: nil)
+    }
+
     // MARK: - Multibanco
 
     func testConfirmPaymentIntentWithMultibanco() throws {

--- a/Stripe/StripeiOSTests/STPPaymentMethodCryptoParamsTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodCryptoParamsTests.swift
@@ -1,0 +1,44 @@
+//
+//  STPPaymentMethodCryptoParamsTests.swift
+//  StripeiOSTests
+//
+//  Created by Eric Zhang on 11/20/24.
+//
+
+import Foundation
+import StripeCoreTestUtils
+
+@testable@_spi(STP) import Stripe
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripePayments
+@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripePaymentsUI
+
+class STPPaymentMethodCryptoParamsTests: XCTestCase {
+
+    func testCreateCryptoPaymentMethod() throws {
+        let cryptoParams = STPPaymentMethodCryptoParams()
+
+        let params = STPPaymentMethodParams(
+            crypto: cryptoParams,
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        let exp = expectation(description: "Payment Method Crypto create")
+
+        let client = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        client.createPaymentMethod(with: params) {
+            (paymentMethod: STPPaymentMethod?, error: Error?) in
+            exp.fulfill()
+
+            XCTAssertNil(error)
+            XCTAssertNotNil(paymentMethod, "Payment method should be populated")
+            XCTAssertEqual(paymentMethod?.type, .crypto, "Incorrect PaymentMethod type")
+            XCTAssertNotNil(paymentMethod?.crypto, "The `crypto` property must be populated")
+        }
+
+        self.waitForExpectations(timeout: STPTestingNetworkRequestTimeout)
+    }
+
+}

--- a/Stripe/StripeiOSTests/STPPaymentMethodCryptoTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodCryptoTests.swift
@@ -1,0 +1,17 @@
+//
+//  STPPaymentMethodCryptoTests.swift
+//  StripeiOSTests
+//
+//  Created by Eric Zhang on 11/20/24.
+//
+
+@testable import Stripe
+import StripeCoreTestUtils
+import XCTest
+
+class STPPaymentMethodCryptoTests: XCTestCase {
+    func testObjectDecoding() {
+        let crypto = STPPaymentMethodCrypto.decodedObject(fromAPIResponse: STPTestUtils.jsonNamed("CryptoPaymentMethod") as? [AnyHashable: Any])
+        XCTAssertNotNil(crypto, "Failed to decode JSON")
+    }
+}

--- a/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
@@ -323,6 +323,20 @@ class STPPaymentMethodFunctionalTest: STPNetworkStubbingTestCase {
         waitForExpectations(timeout: 5, handler: nil)
     }
 
+    func testCreateCryptoPaymentMethod() {
+        let client = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let params = STPPaymentMethodParams(crypto: STPPaymentMethodCryptoParams(), billingDetails: nil, metadata: nil)
+        let expectation = self.expectation(description: "Payment Method create")
+        client.createPaymentMethod(with: params) { paymentMethod, error in
+            XCTAssertNil(error)
+            XCTAssertNotNil(paymentMethod)
+            XCTAssertEqual(paymentMethod?.type, .crypto)
+            XCTAssertNotNil(paymentMethod?.crypto, "The `crypto` property must be populated")
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5, handler: nil)
+    }
+
     func testCreateMultibancoPaymentMethod() {
         let client = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
         let billingDetails = STPPaymentMethodBillingDetails()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -289,7 +289,7 @@ extension PaymentSheet {
                         return []
                     case .alipay, .EPS, .FPX, .giropay, .grabPay, .netBanking, .payPal, .przelewy24, .klarna,
                             .bancontact, .iDEAL, .cashApp, .affirm, .zip, .revolutPay, .amazonPay, .alma,
-                            .mobilePay, .swish, .twint, .sunbit, .billie, .satispay, .crypto:
+                            .mobilePay, .swish, .twint, .sunbit, .billie, .satispay:
                         return [.returnURL]
                     case .USBankAccount:
                         return [
@@ -302,7 +302,7 @@ extension PaymentSheet {
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
                     case .afterpayClearpay:
                         return [.returnURL, .shippingAddress]
-                    case .link, .unknown:
+                    case .link, .unknown, .crypto:
                         return [.unsupported]
                     @unknown default:
                         return [.unsupported]

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -276,7 +276,7 @@ extension PaymentSheet {
                     case .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .giropay, .przelewy24, .EPS,
                         .netBanking, .OXXO, .afterpayClearpay, .UPI, .link, .affirm, .paynow, .zip, .alma,
                         .mobilePay, .unknown, .alipay, .konbini, .promptPay, .swish, .twint, .multibanco,
-                        .sunbit, .billie, .satispay:
+                        .sunbit, .billie, .satispay, .crypto:
                         return [.unsupportedForSetup]
                     @unknown default:
                         return [.unsupportedForSetup]
@@ -289,7 +289,7 @@ extension PaymentSheet {
                         return []
                     case .alipay, .EPS, .FPX, .giropay, .grabPay, .netBanking, .payPal, .przelewy24, .klarna,
                             .bancontact, .iDEAL, .cashApp, .affirm, .zip, .revolutPay, .amazonPay, .alma,
-                            .mobilePay, .swish, .twint, .sunbit, .billie, .satispay:
+                            .mobilePay, .swish, .twint, .sunbit, .billie, .satispay, .crypto:
                         return [.returnURL]
                     case .USBankAccount:
                         return [
@@ -451,7 +451,7 @@ extension STPPaymentMethodParams {
             } else {
                 return "FPX"
             }
-        case .paynow, .zip, .amazonPay, .alma, .mobilePay, .konbini, .promptPay, .swish, .sunbit, .billie, .satispay, .iDEAL, .SEPADebit, .bacsDebit, .AUBECSDebit, .giropay, .przelewy24, .EPS, .bancontact, .netBanking, .OXXO, .sofort, .UPI, .grabPay, .payPal, .afterpayClearpay, .blik, .weChatPay, .boleto, .link, .klarna, .affirm, .USBankAccount, .cashApp, .revolutPay, .twint, .multibanco, .alipay, .cardPresent:
+        case .paynow, .zip, .amazonPay, .alma, .mobilePay, .konbini, .promptPay, .swish, .sunbit, .billie, .satispay, .crypto, .iDEAL, .SEPADebit, .bacsDebit, .AUBECSDebit, .giropay, .przelewy24, .EPS, .bancontact, .netBanking, .OXXO, .sofort, .UPI, .grabPay, .payPal, .afterpayClearpay, .blik, .weChatPay, .boleto, .link, .klarna, .affirm, .USBankAccount, .cashApp, .revolutPay, .twint, .multibanco, .alipay, .cardPresent:
             // Use the label already defined in STPPaymentMethodType; the params object for these types don't contain additional information that affect the display label (like cards do)
             return type.displayName
         case .unknown:

--- a/StripePayments/StripePayments.xcodeproj/project.pbxproj
+++ b/StripePayments/StripePayments.xcodeproj/project.pbxproj
@@ -272,6 +272,8 @@
 		F34C04E0C2A142C8CC05D902 /* STPPaymentMethodUPIParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0105DFAE5504CD3A1AAE89B5 /* STPPaymentMethodUPIParams.swift */; };
 		F5A6F7E73ECEC80D3351002A /* STPCardParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFA6071616ABA9D79DB6AE6A /* STPCardParams.swift */; };
 		F5C6780CF3A62BF6818D695D /* STPFormEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F7F214A072869D24123AAD3 /* STPFormEncoder.swift */; };
+		F60858EA2CEF040400D62278 /* STPPaymentMethodCryptoParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60858E92CEF040400D62278 /* STPPaymentMethodCryptoParams.swift */; };
+		F60858EE2CEF046500D62278 /* STPPaymentMethodCrypto.swift in Sources */ = {isa = PBXBuildFile; fileRef = F60858ED2CEF046500D62278 /* STPPaymentMethodCrypto.swift */; };
 		F7FCB1AB78C57461C2B07A0C /* STPPaymentMethodOXXO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DCAF9C6479868993596880A /* STPPaymentMethodOXXO.swift */; };
 		F86AF35CBA2995BFC5544D32 /* STPRadarSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 674DAF7E5982F1BCEA40B010 /* STPRadarSession.swift */; };
 		FB33420154165650EAD32165 /* STPAPIClient+PaymentsCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53E191CAFF05C311F8660273 /* STPAPIClient+PaymentsCore.swift */; };
@@ -683,6 +685,8 @@
 		F3299145C8B3D2382AE58911 /* STPSourceEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPSourceEnums.swift; sourceTree = "<group>"; };
 		F4E97EEB6FFF42428F389A23 /* STPAnalyticsClient+StripePayments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPAnalyticsClient+StripePayments.swift"; sourceTree = "<group>"; };
 		F582CA101C67145B68AEF8F2 /* STPSourceVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPSourceVerification.swift; sourceTree = "<group>"; };
+		F60858E92CEF040400D62278 /* STPPaymentMethodCryptoParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodCryptoParams.swift; sourceTree = "<group>"; };
+		F60858ED2CEF046500D62278 /* STPPaymentMethodCrypto.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodCrypto.swift; sourceTree = "<group>"; };
 		F609CFD0BA68E23080585BFF /* STPSourceCardDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPSourceCardDetails.swift; sourceTree = "<group>"; };
 		F87DC370A768081815E2FDE9 /* STPMandateOnlineParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPMandateOnlineParams.swift; sourceTree = "<group>"; };
 		F8A038F1551529DED40E01B5 /* NSString+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSString+Stripe.swift"; sourceTree = "<group>"; };
@@ -1301,6 +1305,8 @@
 				CAB989BE2C5877FE00DF9851 /* STPPaymentMethodBillie.swift */,
 				CAC80EC22C333646001E3D0D /* STPPaymentMethodSatispay.swift */,
 				CAC80EC42C33368E001E3D0D /* STPPaymentMethodSatispayParams.swift */,
+				F60858ED2CEF046500D62278 /* STPPaymentMethodCrypto.swift */,
+				F60858E92CEF040400D62278 /* STPPaymentMethodCryptoParams.swift */,
 			);
 			path = Types;
 			sourceTree = "<group>";
@@ -1733,6 +1739,7 @@
 				63200203FD7EFE05901CB191 /* STPPaymentMethodLink.swift in Sources */,
 				E9DE9FDAF4C3B73E387EFCF7 /* STPPaymentMethodLinkParams.swift in Sources */,
 				CCB5BAB2A22D94DE02938573 /* STPPaymentMethodMobilePayParams.swift in Sources */,
+				F60858EE2CEF046500D62278 /* STPPaymentMethodCrypto.swift in Sources */,
 				9CBE7C1776C15DA13861ED70 /* STPPaymentMethodNetBanking.swift in Sources */,
 				D0F6FFED5BE9947097990BE6 /* STPPaymentMethodNetBankingParams.swift in Sources */,
 				F7FCB1AB78C57461C2B07A0C /* STPPaymentMethodOXXO.swift in Sources */,
@@ -1854,6 +1861,7 @@
 				B472CF82B4F1CE69F308DC68 /* Analytic+Payments.swift in Sources */,
 				8021C790E703EE5BF74DD2C5 /* STPAnalyticsClient+Payments.swift in Sources */,
 				6541526D2141523AF9567D55 /* NSArray+Stripe.swift in Sources */,
+				F60858EA2CEF040400D62278 /* STPPaymentMethodCryptoParams.swift in Sources */,
 				CAC80EC52C33368E001E3D0D /* STPPaymentMethodSatispayParams.swift in Sources */,
 				9893D9DC84A0AB2AA2230555 /* NSDecimalNumber+Stripe_Currency.swift in Sources */,
 				84DF21A5711A6CB12B2EDBCA /* NSDictionary+Stripe.swift in Sources */,

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
@@ -92,6 +92,8 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
     @objc private(set) public var billie: STPPaymentMethodBillie?
     /// If this is a Satispay PaymentMethod (i.e. `self.type == STPPaymentMethodTypeSatispay`), this contains additional details.
     @objc private(set) public var satispay: STPPaymentMethodSatispay?
+    /// If this is a Crypto PaymentMethod (i.e. `self.type == STPPaymentMethodTypeCrypto`), this contains additional details.
+    @objc private(set) public var crypto: STPPaymentMethodCrypto?
     /// If this is a Multibanco PaymentMethod (i.e. `self.type == STPPaymentMethodTypeMultibanco`), this contains additional details.
     @objc private(set) public var multibanco: STPPaymentMethodMultibanco?
     /// If this is a MobilePay PaymentMethod (i.e. `self.type == STPPaymentMethodTypeMobilePay`), this contains additional details.
@@ -163,6 +165,7 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
             "sunbit = \(String(describing: sunbit))",
             "billie = \(String(describing: billie))",
             "satispay = \(String(describing: satispay))",
+            "crypto = \(String(describing: crypto))",
             "multibanco = \(String(describing: multibanco))",
             "mobilePay = \(String(describing: mobilePay))",
             "liveMode = \(liveMode ? "YES" : "NO")",
@@ -350,6 +353,9 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
         )
         paymentMethod.satispay = STPPaymentMethodSatispay.decodedObject(
             fromAPIResponse: dict.stp_dictionary(forKey: "satispay")
+        )
+        paymentMethod.crypto = STPPaymentMethodCrypto.decodedObject(
+            fromAPIResponse: dict.stp_dictionary(forKey: "crypto")
         )
         paymentMethod.multibanco = STPPaymentMethodMultibanco.decodedObject(
             fromAPIResponse: dict.stp_dictionary(forKey: "multibanco")

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -82,6 +82,8 @@ import Foundation
     case billie
     /// A Satispay payment method
     case satispay
+    /// A Crypto payment method
+    case crypto
     /// A MobilePay payment method
     case mobilePay
     /// A Konbini payment method
@@ -174,6 +176,8 @@ import Foundation
             return "Billie"
         case .satispay:
             return "Satispay"
+        case .crypto:
+            return "Crypto"
         case .mobilePay:
             return "MobilePay"
         case .konbini:
@@ -269,6 +273,8 @@ import Foundation
             return "billie"
         case .satispay:
             return "satispay"
+        case .crypto:
+            return "crypto"
         case .mobilePay:
             return "mobilepay"
         case .konbini:

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -106,6 +106,8 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
     @objc public var billie: STPPaymentMethodBillieParams?
     /// If this is a Satispay PaymentMethod, this contains additional details.
     @objc public var satispay: STPPaymentMethodSatispayParams?
+    /// If this is a Crypto PaymentMethod, this contains additional details.
+    @objc public var crypto: STPPaymentMethodCryptoParams?
     /// If this is a Multibanco PaymentMethod, this contains additional details.
     @objc public var multibanco: STPPaymentMethodMultibancoParams?
 
@@ -704,6 +706,24 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
         self.metadata = metadata
     }
 
+    /// Creates params for a Crypto PaymentMethod.
+    /// - Parameters:
+    ///   - crypto:              An object containing additional Crypto details.
+    ///   - billingDetails:      An object containing the user's billing details.
+    ///   - metadata:            Additional information to attach to the PaymentMethod.
+    @objc
+    public convenience init(
+        crypto: STPPaymentMethodCryptoParams,
+        billingDetails: STPPaymentMethodBillingDetails?,
+        metadata: [String: String]?
+    ) {
+        self.init()
+        self.type = .crypto
+        self.crypto = crypto
+        self.billingDetails = billingDetails
+        self.metadata = metadata
+    }
+
     /// Creates params for an Multibanco PaymentMethod.
     /// - Parameters:
     ///   - multibanco:          An object containing additional Multibanco details.
@@ -792,6 +812,8 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             self.billie = STPPaymentMethodBillieParams()
         case .satispay:
             self.satispay = STPPaymentMethodSatispayParams()
+        case .crypto:
+            self.crypto = STPPaymentMethodCryptoParams()
         case .multibanco:
             self.multibanco = STPPaymentMethodMultibancoParams()
         case .paynow, .zip, .mobilePay, .konbini, .promptPay, .twint:
@@ -857,6 +879,7 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             NSStringFromSelector(#selector(getter: sunbit)): "sunbit",
             NSStringFromSelector(#selector(getter: billie)): "billie",
             NSStringFromSelector(#selector(getter: satispay)): "satispay",
+            NSStringFromSelector(#selector(getter: crypto)): "crypto",
             NSStringFromSelector(#selector(getter: multibanco)): "multibanco",
             NSStringFromSelector(#selector(getter: link)): "link",
             NSStringFromSelector(#selector(getter: metadata)): "metadata",
@@ -1333,6 +1356,8 @@ extension STPPaymentMethodParams {
             billie = STPPaymentMethodBillieParams()
         case .satispay:
             satispay = STPPaymentMethodSatispayParams()
+        case .crypto:
+            crypto = STPPaymentMethodCryptoParams()
         case .multibanco:
             multibanco = STPPaymentMethodMultibancoParams()
         case .cardPresent, .paynow, .zip, .konbini, .promptPay, .twint:

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodCrypto.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodCrypto.swift
@@ -1,0 +1,41 @@
+//
+//  STPPaymentMethodCrypto.swift
+//  StripePayments
+//
+//  Created by Eric Zhang on 11/20/24.
+//
+
+import Foundation
+
+/// The Crypto Payment Method.
+/// - seealso: https://docs.stripe.com/crypto/pay-with-crypto
+public class STPPaymentMethodCrypto: NSObject {
+    /// :nodoc:
+    @objc private(set) public var allResponseFields: [AnyHashable: Any] = [:]
+
+    // MARK: - Description
+    /// :nodoc:
+    @objc public override var description: String {
+        let props = [
+            // Object
+            String(format: "%@: %p", NSStringFromClass(STPPaymentMethodCrypto.self), self)
+        ]
+
+        return "<\(props.joined(separator: "; "))>"
+    }
+
+    // MARK: - STPAPIResponseDecodeable
+    @objc
+    /// :nodoc:
+    public class func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
+        guard let response = response else {
+            return nil
+        }
+
+        return self.init(dictionary: response)
+    }
+
+    required init?(dictionary dict: [AnyHashable: Any]) {
+        super.init()
+    }
+}

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodCryptoParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodCryptoParams.swift
@@ -1,0 +1,24 @@
+//
+//  STPPaymentMethodCryptoParams.swift
+//  StripePayments
+//
+//  Created by Eric Zhang on 11/20/24.
+//
+
+import Foundation
+
+/// An object representing parameters used to create a Crypto Payment Method
+public class STPPaymentMethodCryptoParams: NSObject, STPFormEncodable {
+    @objc public var additionalAPIParameters: [AnyHashable: Any] = [:]
+
+    // MARK: - STPFormEncodable
+    @objc
+    public class func rootObjectName() -> String? {
+        return "crypto"
+    }
+
+    @objc
+    public class func propertyNamesToFormFieldNamesMapping() -> [String: String] {
+        return [:]
+    }
+}

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -523,7 +523,7 @@ extension STPPaymentMethodType: CustomStringConvertible {
             return "swish"
         case .twint:
             return "TWINT"
-        case .paynow, .zip, .revolutPay, .mobilePay, .amazonPay, .alma, .konbini, .promptPay, .sunbit, .billie, .satispay:
+        case .paynow, .zip, .revolutPay, .mobilePay, .amazonPay, .alma, .konbini, .promptPay, .sunbit, .billie, .satispay, .crypto:
             // `description` is the value used when this type is converted to a string for debugging purposes, just use the display name.
             return displayName
         case .multibanco:

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -735,6 +735,7 @@ public class STPPaymentHandler: NSObject {
             .sunbit,
             .billie,
             .satispay,
+            .crypto,
             .konbini,
             .promptPay,
             .swish,

--- a/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CryptoPaymentMethod.json
+++ b/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CryptoPaymentMethod.json
@@ -1,0 +1,24 @@
+{
+    "id": "pm_1QO42LFY0qyl6XeWuK9FjZq5",
+    "object": "payment_method",
+    "allow_redisplay": "unspecified",
+    "billing_details": {
+      "address": {
+        "city": null,
+        "country": null,
+        "line1": null,
+        "line2": null,
+        "postal_code": null,
+        "state": null
+      },
+      "email": null,
+      "name": null,
+      "phone": null
+    },
+    "created": 1732309509,
+    "crypto": {},
+    "customer": null,
+    "livemode": false,
+    "metadata": {},
+    "type": "crypto"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPPaymentIntentFunctionalTest/testConfirmPaymentIntentWithCrypto/0000_post_create_payment_intent.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPPaymentIntentFunctionalTest/testConfirmPaymentIntentWithCrypto/0000_post_create_payment_intent.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_payment_intent$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=CedNxsigcEwUINzVWfdh0TKipI4aE2UMxz8iI0EeMMuHm72SkuYGPG0I9vKCQUVkN9jm633NmpDLEZvObjC9O0CbCFucYWARdlQiZOZzjzCm4PQicqJ05Btn903Inlo%2F1TVwXoFtybgpft%2FYw9Pe6zPNXxnHGidGJVnJ6ZDBNtnFFaijW2%2FvfaFWNa3uM%2FWs07%2FGmQPREtosRF1jnIWKUE%2BKvfv9Kj3hd%2FxRLzro59U%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: fc39f7625804b2320c560d367044f15f;o=1
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Thu, 21 Nov 2024 22:17:31 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 147
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"intent":"pi_3QNigpFY0qyl6XeW0hHlAmk2","secret":"pi_3QNigpFY0qyl6XeW0hHlAmk2_secret_And197hbBohPSmyW8s9VJi86h","status":"requires_payment_method"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPPaymentIntentFunctionalTest/testConfirmPaymentIntentWithCrypto/0001_post_v1_payment_intents_pi_3QNigpFY0qyl6XeW0hHlAmk2_confirm.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPPaymentIntentFunctionalTest/testConfirmPaymentIntentWithCrypto/0001_post_v1_payment_intents_pi_3QNigpFY0qyl6XeW0hHlAmk2_confirm.tail
@@ -1,0 +1,75 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_intents\/pi_3QNigpFY0qyl6XeW0hHlAmk2\/confirm$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_intents%2F%3Aintent%2Fconfirm; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}
+request-id: req_6M9r3Cb82vtM93
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 1140
+Vary: Origin
+Date: Thu, 21 Nov 2024 22:17:36 GMT
+original-request: req_6M9r3Cb82vtM93
+stripe-version: 2020-08-27
+idempotency-key: 0ffb131d-6a63-4664-9734-751337347ea6
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+X-Stripe-Mock-Request: client_secret=pi_3QNigpFY0qyl6XeW0hHlAmk2_secret_And197hbBohPSmyW8s9VJi86h&payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[metadata]\[test_key]=test_value&payment_method_data\[payment_user_agent]=.*&payment_method_data\[type]=crypto&return_url=example-app-scheme%3A\/\/unused
+
+{
+  "payment_method_configuration_details" : null,
+  "canceled_at" : null,
+  "source" : null,
+  "amount" : 100,
+  "capture_method" : "automatic",
+  "livemode" : false,
+  "shipping" : null,
+  "status" : "requires_action",
+  "object" : "payment_intent",
+  "currency" : "usd",
+  "last_payment_error" : null,
+  "amount_subtotal" : 100,
+  "automatic_payment_methods" : null,
+  "cancellation_reason" : null,
+  "next_action" : {
+    "type" : "redirect_to_url",
+    "redirect_to_url" : {
+      "return_url" : "example-app-scheme:\/\/unused",
+      "url" : "https:\/\/pm-redirects.stripe.com\/authorize\/acct_1G6m1pFY0qyl6XeW\/pa_nonce_RGFB8PslpY1GVcOrt4qAPHK88TTrJL8"
+    }
+  },
+  "total_details" : {
+    "amount_discount" : 0,
+    "amount_tax" : 0
+  },
+  "payment_method" : "pm_1QNigpFY0qyl6XeWDpW2ZD5Y",
+  "client_secret" : "pi_3QNigpFY0qyl6XeW0hHlAmk2_secret_And197hbBohPSmyW8s9VJi86h",
+  "id" : "pi_3QNigpFY0qyl6XeW0hHlAmk2",
+  "confirmation_method" : "automatic",
+  "amount_details" : {
+    "tip" : {
+
+    }
+  },
+  "processing" : null,
+  "receipt_email" : null,
+  "payment_method_types" : [
+    "crypto"
+  ],
+  "setup_future_usage" : null,
+  "created" : 1732227451,
+  "description" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPPaymentMethodFunctionalTest/testCreateCryptoPaymentMethod/0000_post_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPPaymentMethodFunctionalTest/testCreateCryptoPaymentMethod/0000_post_v1_payment_methods.tail
@@ -1,0 +1,56 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_methods$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: report-uri https://q.stripe.com/csp-report?p=v1%2Fpayment_methods; block-all-mixed-content; default-src 'none'; base-uri 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report"
+x-wc: A
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}
+request-id: req_gaAnTguxIFGJWF
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 448
+Vary: Origin
+Date: Thu, 21 Nov 2024 22:23:20 GMT
+original-request: req_gaAnTguxIFGJWF
+stripe-version: 2020-08-27
+idempotency-key: 891d3387-37e8-4ac5-aeb3-aac7cd5d7d22
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+x-content-type-options: nosniff
+X-Stripe-Mock-Request: allow_redisplay=unspecified&payment_user_agent=.*&type=crypto
+
+{
+  "object" : "payment_method",
+  "crypto" : {
+
+  },
+  "id" : "pm_1QNimSFY0qyl6XeWhTt9lkIP",
+  "billing_details" : {
+    "email" : null,
+    "phone" : null,
+    "name" : null,
+    "address" : {
+      "state" : null,
+      "country" : null,
+      "line2" : null,
+      "city" : null,
+      "line1" : null,
+      "postal_code" : null
+    }
+  },
+  "livemode" : false,
+  "created" : 1732227800,
+  "allow_redisplay" : "unspecified",
+  "type" : "crypto",
+  "customer" : null
+}


### PR DESCRIPTION
## Summary
- Add `crypto` payment method bindings + tests

## Motivation
Add `crypto` payment method support

## Testing
Added tests + tested with Basic Non-Card Payment Examples project

## Changelog
See diff
