### PR TITLE
Retain FlowController during presentation

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -307,9 +307,12 @@ extension PaymentSheet {
                 return
             }
 
-            if let completion = completion {
-                presentPaymentOptionsCompletion = completion
+            // Overwrite completion closure to retain self until called
+            let wrappedCompletion: () -> Void = {
+                completion?()
+                self.presentPaymentOptionsCompletion = nil
             }
+            presentPaymentOptionsCompletion = wrappedCompletion
 
             let showPaymentOptions: () -> Void = { [weak self] in
                 guard let self = self else { return }


### PR DESCRIPTION
## Summary
Retain the FlowController while PaymentSheet is displayed.

## Motivation
Workaround for an issue where FlowController is presented without being retained. This is generally an integration issue, but the result is confusing (PaymentSheet is visible, but the controller itself is deallocated, so it isn't possible to interact with it).

See also: https://github.com/stripe/stripe-ios/issues/4299

## Testing
Existing tests, tried calling `presentPaymentMethods` without retaining FC.

## Changelog
Not significant enough for Changelog