### PR TITLE
Add support for payment_method_remove_last for ps & cs

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -51,6 +51,7 @@ struct CustomerSheetTestPlayground: View {
                                     Spacer()
                                 }
                                 SettingPickerView(setting: $playgroundController.settings.paymentMethodRemove)
+                                SettingPickerView(setting: $playgroundController.settings.paymentMethodRemoveLast)
                                 SettingPickerView(setting: $playgroundController.settings.paymentMethodAllowRedisplayFilters)
                             }
                         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -327,6 +327,7 @@ class CustomerSheetBackend {
                      "customer_key_type": settings.customerKeyType.rawValue,
                      "merchant_country_code": settings.merchantCountryCode.rawValue,
                      "customer_session_payment_method_remove": settings.paymentMethodRemove.rawValue,
+                     "customer_session_payment_method_remove_last": settings.paymentMethodRemoveLast.rawValue,
         ] as [String: Any]
 
         if let allowRedisplayValue = settings.paymentMethodAllowRedisplayFilters.arrayValue() {

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -176,7 +176,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     var paymentMethodAllowRedisplayFilters: PaymentMethodAllowRedisplayFilters
     var cardBrandAcceptance: CardBrandAcceptance
     var alternateUpdatePaymentMethodNavigation: AlternateUpdatePaymentMethodNavigation
-    
+
     static func defaultValues() -> CustomerSheetTestPlaygroundSettings {
         return CustomerSheetTestPlaygroundSettings(customerMode: .new,
                                                    customerId: nil,

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -110,6 +110,12 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
         case enabled
         case disabled
     }
+    enum PaymentMethodRemoveLast: String, PickerEnum {
+        static let enumName: String = "PaymentMethodRemoveLast"
+
+        case enabled
+        case disabled
+    }
     enum PaymentMethodAllowRedisplayFilters: String, PickerEnum {
         static var enumName: String { "PaymentMethodRedisplayFilters" }
 
@@ -166,6 +172,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     var preferredNetworksEnabled: PreferredNetworksEnabled
     var allowsRemovalOfLastSavedPaymentMethod: AllowsRemovalOfLastSavedPaymentMethod
     var paymentMethodRemove: PaymentMethodRemove
+    var paymentMethodRemoveLast: PaymentMethodRemoveLast
     var paymentMethodAllowRedisplayFilters: PaymentMethodAllowRedisplayFilters
     var cardBrandAcceptance: CardBrandAcceptance
     var alternateUpdatePaymentMethodNavigation: AlternateUpdatePaymentMethodNavigation
@@ -188,6 +195,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
                                                    preferredNetworksEnabled: .off,
                                                    allowsRemovalOfLastSavedPaymentMethod: .on,
                                                    paymentMethodRemove: .enabled,
+                                                   paymentMethodRemoveLast: .enabled,
                                                    paymentMethodAllowRedisplayFilters: .always,
                                                    cardBrandAcceptance: .all,
                                                    alternateUpdatePaymentMethodNavigation: .off)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -115,6 +115,7 @@ struct PaymentSheetTestPlayground: View {
                                     SettingPickerView(setting: $playgroundController.settings.allowRedisplayOverride)
                                 }
                                 SettingPickerView(setting: $playgroundController.settings.paymentMethodRemove)
+                                SettingPickerView(setting: $playgroundController.settings.paymentMethodRemoveLast)
                                 SettingPickerView(setting: paymentMethodRedisplayBinding)
                                 if playgroundController.settings.paymentMethodRedisplay == .enabled {
                                     SettingPickerView(setting: $playgroundController.settings.paymentMethodAllowRedisplayFilters)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -198,6 +198,12 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case enabled
         case disabled
     }
+    enum PaymentMethodRemoveLast: String, PickerEnum {
+        static var enumName: String { "PaymentMethodRemoveLast" }
+
+        case enabled
+        case disabled
+    }
     enum PaymentMethodRedisplay: String, PickerEnum {
         static var enumName: String { "PaymentMethodRedisplay" }
 
@@ -463,6 +469,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var paymentMethodSave: PaymentMethodSave
     var allowRedisplayOverride: AllowRedisplayOverride
     var paymentMethodRemove: PaymentMethodRemove
+    var paymentMethodRemoveLast: PaymentMethodRemoveLast
     var paymentMethodRedisplay: PaymentMethodRedisplay
     var paymentMethodAllowRedisplayFilters: PaymentMethodAllowRedisplayFilters
     var defaultBillingAddress: DefaultBillingAddress
@@ -510,6 +517,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             paymentMethodSave: .enabled,
             allowRedisplayOverride: .notSet,
             paymentMethodRemove: .enabled,
+            paymentMethodRemoveLast: .enabled,
             paymentMethodRedisplay: .enabled,
             paymentMethodAllowRedisplayFilters: .always,
             defaultBillingAddress: .off,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -619,6 +619,7 @@ extension PlaygroundController {
             "customer_session_component_name": "mobile_payment_element",
             "customer_session_payment_method_save": settings.paymentMethodSave.rawValue,
             "customer_session_payment_method_remove": settings.paymentMethodRemove.rawValue,
+            "customer_session_payment_method_remove_last": settings.paymentMethodRemoveLast.rawValue,
             "customer_session_payment_method_redisplay": settings.paymentMethodRedisplay.rawValue,
             //            "set_shipping_address": true // Uncomment to make server vend PI with shipping address populated
         ] as [String: Any]

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -441,7 +441,7 @@ class PlaygroundController: ObservableObject {
             } else {
                 self.ambiguousViewTimer?.invalidate()
             }
-            
+
             // Hack to enable incentives in Instant Debits
             let enableInstantDebitsIncentives = newValue.instantDebitsIncentives == .on
             UserDefaults.standard.set(enableInstantDebitsIncentives, forKey: "FINANCIAL_CONNECTIONS_INSTANT_DEBITS_INCENTIVES")

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -504,7 +504,7 @@ class CustomerSheetUITest: XCTestCase {
         app.buttons["Done"].waitForExistenceAndTap()
     }
     // MARK: - allowsRemovalOfLastSavedPaymentMethod
-    func testRemoveLastSavedPaymentMethod() throws {
+    func testRemoveLastSavedPaymentMethod_clientConfig() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.merchantCountryCode = .FR
         settings.customerMode = .new
@@ -514,7 +514,23 @@ class CustomerSheetUITest: XCTestCase {
             app,
             settings
         )
-
+        try _testRemoveLastSavedPaymentMethod()
+    }
+    func testRemoveLastSavedPaymentMethod_customerSession() throws {
+        var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
+        settings.merchantCountryCode = .FR
+        settings.customerMode = .new
+        settings.applePay = .on
+        settings.allowsRemovalOfLastSavedPaymentMethod = .on
+        settings.customerKeyType = .customerSession
+        settings.paymentMethodRemoveLast = .disabled
+        loadPlayground(
+            app,
+            settings
+        )
+        try _testRemoveLastSavedPaymentMethod()
+    }
+    func _testRemoveLastSavedPaymentMethod() throws {
         // Save a card
         app.staticTexts["None"].waitForExistenceAndTap()
         app.buttons["+ Add"].waitForExistenceAndTap()
@@ -527,7 +543,7 @@ class CustomerSheetUITest: XCTestCase {
 
         // Add another PM
         app.buttons["+ Add"].waitForExistenceAndTap()
-        try! fillCardData(app, postalEnabled: true)
+        try! fillCardData(app, cardNumber: "5555555555554444", postalEnabled: true)
         app.buttons["Save"].tap()
         XCTAssertTrue(app.buttons["Confirm"].waitForExistence(timeout: timeout))
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -555,6 +555,9 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertNotNil(scroll(collectionView: app.collectionViews.firstMatch, toFindButtonWithId: "CircularButton.Remove")?.tap())
         XCTAssertTrue(app.alerts.buttons["Remove"].waitForExistenceAndTap())
 
+        // Sleep for 1 second to ensure animation has been completed
+        sleep(1)
+
         // Should be kicked out of edit mode now that we have one saved PM
         XCTAssertFalse(app.staticTexts["Done"].waitForExistence(timeout: 1)) // "Done" button is gone - we are not in edit mode
         XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1)) // "Edit" button is gone - we can't edit

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1364,12 +1364,7 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
 
         app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
 
-        try! fillCardData(app)
-        if shouldTapSaveCheckbox {
-            let saveThisAccountToggle = app.switches["Save payment details to Example, Inc. for future purchases"]
-            XCTAssertFalse(saveThisAccountToggle.isSelected)
-            saveThisAccountToggle.tap()
-        }
+        try! fillCardData(app, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
 
         // Complete payment
         app.buttons["Pay $50.99"].tap()
@@ -1385,12 +1380,8 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
 
         // Add another PM
         app.buttons["+ Add"].waitForExistenceAndTap()
-        try! fillCardData(app, cardNumber: "5555555555554444")
-        if shouldTapSaveCheckbox {
-            let saveThisAccountToggle = app.switches["Save payment details to Example, Inc. for future purchases"]
-            XCTAssertFalse(saveThisAccountToggle.isSelected)
-            saveThisAccountToggle.tap()
-        }
+        try! fillCardData(app, cardNumber: "5555555555554444", tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
+
         app.buttons["Pay $50.99"].tap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
@@ -1451,12 +1442,7 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         app.buttons["Apple Pay, apple_pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
         app.buttons["+ Add"].waitForExistenceAndTap()
 
-        try! fillCardData(app)
-        if shouldTapSaveCheckbox {
-            let saveThisAccountToggle = app.switches["Save payment details to Example, Inc. for future purchases"]
-            XCTAssertFalse(saveThisAccountToggle.isSelected)
-            saveThisAccountToggle.tap()
-        }
+        try! fillCardData(app, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
 
         // Complete payment
         app.buttons["Continue"].tap()
@@ -1478,12 +1464,7 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
 
         // Add another PM
         app.buttons["+ Add"].waitForExistenceAndTap()
-        try! fillCardData(app, cardNumber: "5555555555554444")
-        if shouldTapSaveCheckbox {
-            let saveThisAccountToggle = app.switches["Save payment details to Example, Inc. for future purchases"]
-            XCTAssertFalse(saveThisAccountToggle.isSelected)
-            saveThisAccountToggle.tap()
-        }
+        try! fillCardData(app, cardNumber: "5555555555554444", tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
 
         app.buttons["Continue"].tap()
         app.buttons["Confirm"].tap()
@@ -1631,12 +1612,7 @@ class PaymentSheetCustomerSessionCBCUITests: PaymentSheetUITestCase {
 
         app.buttons["Payment method"].waitForExistenceAndTap()
         app.buttons["+ Add"].waitForExistenceAndTap()
-        try fillCardData(app)
-
-        // toggle save this card on
-        let saveThisCardToggle = app.switches["Save payment details to Example, Inc. for future purchases"]
-        saveThisCardToggle.tap()
-        XCTAssertTrue(saveThisCardToggle.isSelected)
+        try fillCardData(app, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
 
         app.buttons["Continue"].tap()
         app.buttons["Confirm"].tap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1339,7 +1339,7 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.linkMode = .link_pm
         settings.allowsRemovalOfLastSavedPaymentMethod = .off
 
-        try _testRemoveLastSavedPaymentMethodPaymentSheet(settings: settings, shouldTapSaveCheckbox: false)
+        try _testRemoveLastSavedPaymentMethodPaymentSheet(settings: settings)
     }
     func testRemoveLastSavedPaymentMethodPaymentSheet() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
@@ -1357,14 +1357,14 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.paymentMethodSave = .enabled
         settings.allowsRemovalOfLastSavedPaymentMethod = .on
 
-        try _testRemoveLastSavedPaymentMethodPaymentSheet(settings: settings, shouldTapSaveCheckbox: true)
+        try _testRemoveLastSavedPaymentMethodPaymentSheet(settings: settings, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
     }
-    func _testRemoveLastSavedPaymentMethodPaymentSheet(settings: PaymentSheetTestPlaygroundSettings, shouldTapSaveCheckbox: Bool) throws {
+    func _testRemoveLastSavedPaymentMethodPaymentSheet(settings: PaymentSheetTestPlaygroundSettings, tapCheckboxWithText: String? = nil) throws {
         loadPlayground(app, settings)
 
         app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
 
-        try! fillCardData(app, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
+        try! fillCardData(app, tapCheckboxWithText: tapCheckboxWithText)
 
         // Complete payment
         app.buttons["Pay $50.99"].tap()
@@ -1380,7 +1380,7 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
 
         // Add another PM
         app.buttons["+ Add"].waitForExistenceAndTap()
-        try! fillCardData(app, cardNumber: "5555555555554444", tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
+        try! fillCardData(app, cardNumber: "5555555555554444", tapCheckboxWithText: tapCheckboxWithText)
 
         app.buttons["Pay $50.99"].tap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
@@ -1417,7 +1417,7 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.allowsRemovalOfLastSavedPaymentMethod = .off
         loadPlayground(app, settings)
 
-        try _testRemoveLastSavedPaymentMethodFlowController(settings: settings, shouldTapSaveCheckbox: false)
+        try _testRemoveLastSavedPaymentMethodFlowController(settings: settings)
     }
     func test_RemoveLastSavedPaymentMethodFlowController_customerSession() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
@@ -1435,14 +1435,14 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.allowsRemovalOfLastSavedPaymentMethod = .on
         loadPlayground(app, settings)
 
-        try _testRemoveLastSavedPaymentMethodFlowController(settings: settings, shouldTapSaveCheckbox: true)
+        try _testRemoveLastSavedPaymentMethodFlowController(settings: settings, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
     }
 
-    func _testRemoveLastSavedPaymentMethodFlowController(settings: PaymentSheetTestPlaygroundSettings, shouldTapSaveCheckbox: Bool) throws {
+    func _testRemoveLastSavedPaymentMethodFlowController(settings: PaymentSheetTestPlaygroundSettings, tapCheckboxWithText: String? = nil) throws {
         app.buttons["Apple Pay, apple_pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
         app.buttons["+ Add"].waitForExistenceAndTap()
 
-        try! fillCardData(app, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
+        try! fillCardData(app, tapCheckboxWithText: tapCheckboxWithText)
 
         // Complete payment
         app.buttons["Continue"].tap()
@@ -1464,7 +1464,7 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
 
         // Add another PM
         app.buttons["+ Add"].waitForExistenceAndTap()
-        try! fillCardData(app, cardNumber: "5555555555554444", tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
+        try! fillCardData(app, cardNumber: "5555555555554444", tapCheckboxWithText: tapCheckboxWithText)
 
         app.buttons["Continue"].tap()
         app.buttons["Confirm"].tap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
@@ -190,7 +190,8 @@ extension XCTestCase {
     func fillCardData(_ app: XCUIApplication,
                       container: XCUIElement? = nil,
                       cardNumber: String? = nil,
-                      postalEnabled: Bool = true) throws {
+                      postalEnabled: Bool = true,
+                      tapCheckboxWithText checkboxText: String? = nil) throws {
         let context = container ?? app
 
         let numberField = context.textFields["Card number"]
@@ -200,6 +201,12 @@ extension XCTestCase {
         app.typeText("123") // CVC
         if postalEnabled {
             app.typeText("12345") // Postal
+        }
+        if let checkboxText {
+            let saveThisAccountToggle = app.switches[checkboxText]
+            XCTAssertFalse(saveThisAccountToggle.isSelected)
+            saveThisAccountToggle.tap()
+            XCTAssertTrue(saveThisAccountToggle.isSelected)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
@@ -41,6 +41,10 @@ struct CustomerSession: Equatable, Hashable {
                   let paymentMethodRemove = mobilePaymentElementFeaturesDict["payment_method_remove"] as? String else {
                 return nil
             }
+            var paymentMethodRemoveLastValue: String = "enabled"
+            if let paymentMethodRemoveLast = mobilePaymentElementFeaturesDict["payment_method_remove_last"] as? String {
+                paymentMethodRemoveLastValue = paymentMethodRemoveLast
+            }
 
             var allowRedisplayOverrideValue: STPPaymentMethodAllowRedisplay?
             if let allowRedisplayOverride = mobilePaymentElementFeaturesDict["payment_method_save_allow_redisplay_override"] as? String {
@@ -50,6 +54,7 @@ struct CustomerSession: Equatable, Hashable {
             mobilePaymentElementComponent = MobilePaymentElementComponent(enabled: true,
                                                                           features: MobilePaymentElementComponentFeature(paymentMethodSave: paymentMethodSave == "enabled",
                                                                                                                          paymentMethodRemove: paymentMethodRemove == "enabled",
+                                                                                                                         paymentMethodRemoveLast: paymentMethodRemoveLastValue == "enabled",
                                                                                                                          paymentMethodSaveAllowRedisplayOverride: allowRedisplayOverrideValue))
         } else {
             mobilePaymentElementComponent = MobilePaymentElementComponent(enabled: false, features: nil)
@@ -87,6 +92,7 @@ struct MobilePaymentElementComponent: Equatable, Hashable {
 struct MobilePaymentElementComponentFeature: Equatable, Hashable {
     let paymentMethodSave: Bool
     let paymentMethodRemove: Bool
+    let paymentMethodRemoveLast: Bool
     let paymentMethodSaveAllowRedisplayOverride: STPPaymentMethodAllowRedisplay?
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
@@ -41,10 +41,7 @@ struct CustomerSession: Equatable, Hashable {
                   let paymentMethodRemove = mobilePaymentElementFeaturesDict["payment_method_remove"] as? String else {
                 return nil
             }
-            var paymentMethodRemoveLastValue: String = "enabled"
-            if let paymentMethodRemoveLast = mobilePaymentElementFeaturesDict["payment_method_remove_last"] as? String {
-                paymentMethodRemoveLastValue = paymentMethodRemoveLast
-            }
+            let paymentMethodRemoveLast = mobilePaymentElementFeaturesDict["payment_method_remove_last"] as? String ?? "enabled"
 
             var allowRedisplayOverrideValue: STPPaymentMethodAllowRedisplay?
             if let allowRedisplayOverride = mobilePaymentElementFeaturesDict["payment_method_save_allow_redisplay_override"] as? String {
@@ -54,7 +51,7 @@ struct CustomerSession: Equatable, Hashable {
             mobilePaymentElementComponent = MobilePaymentElementComponent(enabled: true,
                                                                           features: MobilePaymentElementComponentFeature(paymentMethodSave: paymentMethodSave == "enabled",
                                                                                                                          paymentMethodRemove: paymentMethodRemove == "enabled",
-                                                                                                                         paymentMethodRemoveLast: paymentMethodRemoveLastValue == "enabled",
+                                                                                                                         paymentMethodRemoveLast: paymentMethodRemoveLast == "enabled",
                                                                                                                          paymentMethodSaveAllowRedisplayOverride: allowRedisplayOverrideValue))
         } else {
             mobilePaymentElementComponent = MobilePaymentElementComponent(enabled: false, features: nil)
@@ -66,14 +63,11 @@ struct CustomerSession: Equatable, Hashable {
                   let paymentMethodRemove = customerSheetFeaturesDict["payment_method_remove"] as? String else {
                 return nil
             }
+            let paymentMethodRemoveLast = customerSheetFeaturesDict["payment_method_remove_last"] as? String ?? "enabled"
 
-            var paymentMethodRemoveLastValue: String = "enabled"
-            if let paymentMethodRemoveLast = customerSheetFeaturesDict["payment_method_remove_last"] as? String {
-                paymentMethodRemoveLastValue = paymentMethodRemoveLast
-            }
             customerSheetComponent = CustomerSheetComponent(enabled: true,
                                                             features: CustomerSheetComponentFeature(paymentMethodRemove: paymentMethodRemove == "enabled",
-                                                                                                    paymentMethodRemoveLast: paymentMethodRemoveLastValue == "enabled"))
+                                                                                                    paymentMethodRemoveLast: paymentMethodRemoveLast == "enabled"))
         } else {
             customerSheetComponent = CustomerSheetComponent(enabled: false, features: nil)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
@@ -66,8 +66,14 @@ struct CustomerSession: Equatable, Hashable {
                   let paymentMethodRemove = customerSheetFeaturesDict["payment_method_remove"] as? String else {
                 return nil
             }
+
+            var paymentMethodRemoveLastValue: String = "enabled"
+            if let paymentMethodRemoveLast = customerSheetFeaturesDict["payment_method_remove_last"] as? String {
+                paymentMethodRemoveLastValue = paymentMethodRemoveLast
+            }
             customerSheetComponent = CustomerSheetComponent(enabled: true,
-                                                          features: CustomerSheetComponentFeature(paymentMethodRemove: paymentMethodRemove == "enabled"))
+                                                            features: CustomerSheetComponentFeature(paymentMethodRemove: paymentMethodRemove == "enabled",
+                                                                                                    paymentMethodRemoveLast: paymentMethodRemoveLastValue == "enabled"))
         } else {
             customerSheetComponent = CustomerSheetComponent(enabled: false, features: nil)
         }
@@ -103,4 +109,5 @@ struct CustomerSheetComponent: Equatable, Hashable {
 
 struct CustomerSheetComponentFeature: Equatable, Hashable {
     let paymentMethodRemove: Bool
+    let paymentMethodRemoveLast: Bool
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -224,6 +224,9 @@ extension STPElementsSession {
         }
         return allowsRemovalOfPaymentMethods
     }
+    var allowsRemovalOfLastPaymentMethodForCustomerSheet: Bool {
+        return customer?.customerSession.customerSheetComponent.features?.paymentMethodRemoveLast ?? true
+    }
 
     var isLinkCardBrand: Bool {
         linkSettings?.linkMode == .linkCardBrand

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -25,7 +25,7 @@ final class STPElementsSession: NSObject {
 
     /// Link-specific settings for this ElementsSession.
     let linkSettings: LinkSettings?
-    
+
     /// Flags for this ElementsSession.
     let flags: [String: Bool]
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -207,8 +207,7 @@ extension STPElementsSession {
         }
         return allowsRemovalOfPaymentMethods
     }
-
-    var allowsRemovalOfLastPaymentMethodForPaymentSheet: Bool {
+    var paymentMethodRemoveLastForPaymentSheet: Bool {
         return customer?.customerSession.mobilePaymentElementComponent.features?.paymentMethodRemoveLast ?? true
     }
 
@@ -224,7 +223,7 @@ extension STPElementsSession {
         }
         return allowsRemovalOfPaymentMethods
     }
-    var allowsRemovalOfLastPaymentMethodForCustomerSheet: Bool {
+    var paymentMethodRemoveLastForCustomerSheet: Bool {
         return customer?.customerSession.customerSheetComponent.features?.paymentMethodRemoveLast ?? true
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -208,6 +208,10 @@ extension STPElementsSession {
         return allowsRemovalOfPaymentMethods
     }
 
+    var allowsRemovalOfLastPaymentMethodForPaymentSheet: Bool {
+        return customer?.customerSession.mobilePaymentElementComponent.features?.paymentMethodRemoveLast ?? true
+    }
+
     func allowsRemovalOfPaymentMethodsForCustomerSheet() -> Bool {
         var allowsRemovalOfPaymentMethods = false
         if let customerSession = customer?.customerSession {
@@ -220,7 +224,7 @@ extension STPElementsSession {
         }
         return allowsRemovalOfPaymentMethods
     }
-    
+
     var isLinkCardBrand: Bool {
         linkSettings?.linkMode == .linkCardBrand
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -34,7 +34,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
     let configuration: CustomerSheet.Configuration
     let customerSheetDataSource: CustomerSheetDataSource
     let paymentMethodRemove: Bool
-    let paymentMethodRemoveLast: Bool
+    let allowsRemovalOfLastSavedPaymentMethod: Bool
     let cbcEligible: Bool
 
     // MARK: - Writable Properties
@@ -102,7 +102,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
             savedPaymentMethodsConfiguration: self.configuration,
             configuration: .init(
                 showApplePay: showApplePay,
-                allowsRemovalOfLastSavedPaymentMethod: (configuration.allowsRemovalOfLastSavedPaymentMethod || paymentMethodRemoveLast),
+                allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
                 paymentMethodRemove: paymentMethodRemove,
                 isTestMode: configuration.apiClient.isTestmode,
                 alternateUpdatePaymentMethodNavigation: configuration.alternateUpdatePaymentMethodNavigation
@@ -147,7 +147,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         customerSheetDataSource: CustomerSheetDataSource,
         isApplePayEnabled: Bool,
         paymentMethodRemove: Bool,
-        paymentMethodRemoveLast: Bool,
+        allowsRemovalOfLastSavedPaymentMethod: Bool,
         cbcEligible: Bool,
         csCompletion: CustomerSheet.CustomerSheetCompletion?,
         delegate: CustomerSavedPaymentMethodsViewControllerDelegate
@@ -159,7 +159,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         self.customerSheetDataSource = customerSheetDataSource
         self.isApplePayEnabled = isApplePayEnabled
         self.paymentMethodRemove = paymentMethodRemove
-        self.paymentMethodRemoveLast = paymentMethodRemoveLast
+        self.allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod
         self.cbcEligible = cbcEligible
         self.csCompletion = csCompletion
         self.delegate = delegate
@@ -656,7 +656,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
             savedPaymentMethodsConfiguration: self.configuration,
             configuration: .init(
                 showApplePay: isApplePayEnabled,
-                allowsRemovalOfLastSavedPaymentMethod: (configuration.allowsRemovalOfLastSavedPaymentMethod || paymentMethodRemoveLast),
+                allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
                 paymentMethodRemove: paymentMethodRemove,
                 isTestMode: configuration.apiClient.isTestmode,
                 alternateUpdatePaymentMethodNavigation: configuration.alternateUpdatePaymentMethodNavigation

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -34,6 +34,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
     let configuration: CustomerSheet.Configuration
     let customerSheetDataSource: CustomerSheetDataSource
     let paymentMethodRemove: Bool
+    let paymentMethodRemoveLast: Bool
     let cbcEligible: Bool
 
     // MARK: - Writable Properties
@@ -101,7 +102,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
             savedPaymentMethodsConfiguration: self.configuration,
             configuration: .init(
                 showApplePay: showApplePay,
-                allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod,
+                allowsRemovalOfLastSavedPaymentMethod: (configuration.allowsRemovalOfLastSavedPaymentMethod || paymentMethodRemoveLast),
                 paymentMethodRemove: paymentMethodRemove,
                 isTestMode: configuration.apiClient.isTestmode,
                 alternateUpdatePaymentMethodNavigation: configuration.alternateUpdatePaymentMethodNavigation
@@ -146,6 +147,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         customerSheetDataSource: CustomerSheetDataSource,
         isApplePayEnabled: Bool,
         paymentMethodRemove: Bool,
+        paymentMethodRemoveLast: Bool,
         cbcEligible: Bool,
         csCompletion: CustomerSheet.CustomerSheetCompletion?,
         delegate: CustomerSavedPaymentMethodsViewControllerDelegate
@@ -157,6 +159,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         self.customerSheetDataSource = customerSheetDataSource
         self.isApplePayEnabled = isApplePayEnabled
         self.paymentMethodRemove = paymentMethodRemove
+        self.paymentMethodRemoveLast = paymentMethodRemoveLast
         self.cbcEligible = cbcEligible
         self.csCompletion = csCompletion
         self.delegate = delegate
@@ -653,7 +656,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
             savedPaymentMethodsConfiguration: self.configuration,
             configuration: .init(
                 showApplePay: isApplePayEnabled,
-                allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod,
+                allowsRemovalOfLastSavedPaymentMethod: (configuration.allowsRemovalOfLastSavedPaymentMethod || paymentMethodRemoveLast),
                 paymentMethodRemove: paymentMethodRemove,
                 isTestMode: configuration.apiClient.isTestmode,
                 alternateUpdatePaymentMethodNavigation: configuration.alternateUpdatePaymentMethodNavigation

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -247,7 +247,7 @@ extension CustomerSheet {
             return false
         } else {
             // Merchant is using client side default, so defer to CustomerSession's value
-            return elementsSession.customer?.customerSession.mobilePaymentElementComponent.features?.paymentMethodRemoveLast ?? true
+            return elementsSession.paymentMethodRemoveLastForCustomerSheet
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -242,11 +242,11 @@ public class CustomerSheet {
 
 extension CustomerSheet {
     static func allowsRemovalOfLastPaymentMethod(elementsSession: STPElementsSession, configuration: CustomerSheet.Configuration) -> Bool {
-        // Merchant has set local configuration to "false"
         if !configuration.allowsRemovalOfLastSavedPaymentMethod {
+            // Merchant has set local configuration to false, so honor it.
             return false
         } else {
-            // Defer to CustomerSession if local configuration == true
+            // Merchant is using client side default, so defer to CustomerSession's value
             return elementsSession.customer?.customerSession.mobilePaymentElementComponent.features?.paymentMethodRemoveLast ?? true
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -167,12 +167,14 @@ public class CustomerSheet {
             case .success((let savedPaymentMethods, let selectedPaymentMethodOption, let elementsSession)):
                 let merchantSupportedPaymentMethodTypes = customerSheetDataSource.merchantSupportedPaymentMethodTypes(elementsSession: elementsSession)
                 let paymentMethodRemove = customerSheetDataSource.paymentMethodRemove(elementsSession: elementsSession)
+                let paymentMethodRemoveLast = customerSheetDataSource.paymentMethodRemoveLast(elementsSession: elementsSession)
                 self.present(from: presentingViewController,
                              savedPaymentMethods: savedPaymentMethods,
                              selectedPaymentMethodOption: selectedPaymentMethodOption,
                              merchantSupportedPaymentMethodTypes: merchantSupportedPaymentMethodTypes,
                              customerSheetDataSource: customerSheetDataSource,
                              paymentMethodRemove: paymentMethodRemove,
+                             paymentMethodRemoveLast: paymentMethodRemoveLast,
                              cbcEligible: elementsSession.cardBrandChoice?.eligible ?? false)
                 STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .customerSheetLoadSucceeded,
                                                                      duration: Date().timeIntervalSince(loadingStartDate))
@@ -196,6 +198,7 @@ public class CustomerSheet {
                  merchantSupportedPaymentMethodTypes: [STPPaymentMethodType],
                  customerSheetDataSource: CustomerSheetDataSource,
                  paymentMethodRemove: Bool,
+                 paymentMethodRemoveLast: Bool,
                  cbcEligible: Bool) {
         let loadSpecsPromise = Promise<Void>()
         AddressSpecProvider.shared.loadAddressSpecs {
@@ -211,6 +214,7 @@ public class CustomerSheet {
                                                                                 customerSheetDataSource: customerSheetDataSource,
                                                                                 isApplePayEnabled: isApplePayEnabled,
                                                                                 paymentMethodRemove: paymentMethodRemove,
+                                                                                paymentMethodRemoveLast: paymentMethodRemoveLast,
                                                                                 cbcEligible: cbcEligible,
                                                                                 csCompletion: self.csCompletion,
                                                                                 delegate: self)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
@@ -203,7 +203,7 @@ extension CustomerSheetDataSource {
         case .customerAdapter:
             return true
         case .customerSession:
-            return elementsSession.allowsRemovalOfLastPaymentMethodForCustomerSheet
+            return elementsSession.customer?.customerSession.customerSheetComponent.features?.paymentMethodRemoveLast ?? true
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
@@ -198,4 +198,12 @@ extension CustomerSheetDataSource {
             return elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
         }
     }
+    func paymentMethodRemoveLast(elementsSession: STPElementsSession) -> Bool {
+        switch dataSource {
+        case .customerAdapter:
+            return true
+        case .customerSession:
+            return elementsSession.allowsRemovalOfLastPaymentMethodForCustomerSheet
+        }
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
@@ -198,12 +198,4 @@ extension CustomerSheetDataSource {
             return elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
         }
     }
-    func paymentMethodRemoveLast(elementsSession: STPElementsSession) -> Bool {
-        switch dataSource {
-        case .customerAdapter:
-            return true
-        case .customerSession:
-            return elementsSession.paymentMethodRemoveLastForCustomerSheet
-        }
-    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
@@ -203,7 +203,7 @@ extension CustomerSheetDataSource {
         case .customerAdapter:
             return true
         case .customerSession:
-            return elementsSession.customer?.customerSession.customerSheetComponent.features?.paymentMethodRemoveLast ?? true
+            return elementsSession.paymentMethodRemoveLastForCustomerSheet
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -205,7 +205,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
                 merchantDisplayName: configuration.merchantDisplayName,
                 isCVCRecollectionEnabled: false,
                 isTestMode: configuration.apiClient.isTestmode,
-                allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod,
+                allowsRemovalOfLastSavedPaymentMethod: (configuration.allowsRemovalOfLastSavedPaymentMethod || elementsSession.allowsRemovalOfLastPaymentMethodForPaymentSheet),
                 allowsRemovalOfPaymentMethods: elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                 alternateUpdatePaymentMethodNavigation: configuration.alternateUpdatePaymentMethodNavigation
             ),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -205,7 +205,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
                 merchantDisplayName: configuration.merchantDisplayName,
                 isCVCRecollectionEnabled: false,
                 isTestMode: configuration.apiClient.isTestmode,
-                allowsRemovalOfLastSavedPaymentMethod: (configuration.allowsRemovalOfLastSavedPaymentMethod || elementsSession.allowsRemovalOfLastPaymentMethodForPaymentSheet),
+                allowsRemovalOfLastSavedPaymentMethod: PaymentSheetViewController.allowsRemovalOfLastPaymentMethod(elementsSession: elementsSession, configuration: configuration),
                 allowsRemovalOfPaymentMethods: elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                 alternateUpdatePaymentMethodNavigation: configuration.alternateUpdatePaymentMethodNavigation
             ),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -173,7 +173,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                 merchantDisplayName: configuration.merchantDisplayName,
                 isCVCRecollectionEnabled: isCVCRecollectionEnabled,
                 isTestMode: configuration.apiClient.isTestmode,
-                allowsRemovalOfLastSavedPaymentMethod: (configuration.allowsRemovalOfLastSavedPaymentMethod || elementsSession.allowsRemovalOfLastPaymentMethodForPaymentSheet),
+                allowsRemovalOfLastSavedPaymentMethod: PaymentSheetViewController.allowsRemovalOfLastPaymentMethod(elementsSession: elementsSession, configuration: configuration),
                 allowsRemovalOfPaymentMethods: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                 alternateUpdatePaymentMethodNavigation: configuration.alternateUpdatePaymentMethodNavigation
             ),
@@ -486,6 +486,18 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                     }
                 }
             }
+        }
+    }
+}
+// MARK: - Helpers
+extension PaymentSheetViewController {
+    static func allowsRemovalOfLastPaymentMethod(elementsSession: STPElementsSession, configuration: PaymentSheet.Configuration) -> Bool {
+        // Merchant has set local configuration to "false"
+        if !configuration.allowsRemovalOfLastSavedPaymentMethod {
+            return false
+        } else {
+            // Defer to CustomerSession if local configuration == true
+            return elementsSession.paymentMethodRemoveLastForPaymentSheet
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -173,7 +173,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                 merchantDisplayName: configuration.merchantDisplayName,
                 isCVCRecollectionEnabled: isCVCRecollectionEnabled,
                 isTestMode: configuration.apiClient.isTestmode,
-                allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod,
+                allowsRemovalOfLastSavedPaymentMethod: (configuration.allowsRemovalOfLastSavedPaymentMethod || elementsSession.allowsRemovalOfLastPaymentMethodForPaymentSheet),
                 allowsRemovalOfPaymentMethods: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                 alternateUpdatePaymentMethodNavigation: configuration.alternateUpdatePaymentMethodNavigation
             ),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -492,11 +492,11 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
 // MARK: - Helpers
 extension PaymentSheetViewController {
     static func allowsRemovalOfLastPaymentMethod(elementsSession: STPElementsSession, configuration: PaymentSheet.Configuration) -> Bool {
-        // Merchant has set local configuration to "false"
         if !configuration.allowsRemovalOfLastSavedPaymentMethod {
+            // Merchant has set local configuration to false, so honor it.
             return false
         } else {
-            // Defer to CustomerSession if local configuration == true
+            // Merchant is using client side default, so defer to CustomerSession's value
             return elementsSession.paymentMethodRemoveLastForPaymentSheet
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfirmParamsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfirmParamsTest.swift
@@ -41,7 +41,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .selected
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodSaveAllowRedisplayOverride: nil),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil),
                                               isSettingUp: true)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -50,7 +50,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .deselected
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodSaveAllowRedisplayOverride: nil),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil),
                                               isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -62,7 +62,7 @@ class IntentConfirmParamsTest: XCTestCase {
 
         // The backend will prevent allowRedisplayValue from being set, when paymentMethodSave is set to enabled
         // but our code should be defensive enough to ensure allowRedisplayOverride does not override the value
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodSaveAllowRedisplayOverride: .always),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .always),
                                               isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -72,7 +72,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .hidden
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodSaveAllowRedisplayOverride: nil),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil),
                                               isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -82,7 +82,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .hidden
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodSaveAllowRedisplayOverride: .always),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .always),
                                               isSettingUp: true)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -91,7 +91,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .hidden
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodSaveAllowRedisplayOverride: .limited),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .limited),
                                               isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -100,7 +100,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .hidden
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodSaveAllowRedisplayOverride: .unspecified),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .unspecified),
                                               isSettingUp: true)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -110,7 +110,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .deselected
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodSaveAllowRedisplayOverride: nil),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil),
                                               isSettingUp: false)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -119,7 +119,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .selected
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodSaveAllowRedisplayOverride: nil),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil),
                                               isSettingUp: false)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -127,7 +127,7 @@ class IntentConfirmParamsTest: XCTestCase {
     func testSetAllowRedisplay_PI_saveDisabled_hidden() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodSaveAllowRedisplayOverride: nil),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil),
                                               isSettingUp: false)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -136,7 +136,7 @@ class IntentConfirmParamsTest: XCTestCase {
     func testSetAllowRedisplay_PI_saveDisabled_hidden_doesNotOverride() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodSaveAllowRedisplayOverride: .limited),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .limited),
                                               isSettingUp: false)
 
         // Ensure that allowRedisplayOverride doesn't override: (hidden checkbox and not attached to customer)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -141,7 +141,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
 
         XCTAssertTrue(allowsRemoval)
-        XCTAssertTrue(elementsSession.allowsRemovalOfLastPaymentMethodForPaymentSheet)
+        XCTAssertTrue(elementsSession.paymentMethodRemoveLastForPaymentSheet)
         XCTAssertEqual(.paymentSheetWithCustomerSessionPaymentMethodSaveEnabled, savePaymentMethodConsentBehavior)
     }
     func testSPMConsentAndRemoval_pmsD_pmrE() {
@@ -222,7 +222,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
 
         XCTAssertTrue(allowsRemoval)
-        XCTAssertTrue(elementsSession.allowsRemovalOfLastPaymentMethodForPaymentSheet)
+        XCTAssertTrue(elementsSession.paymentMethodRemoveLastForPaymentSheet)
     }
     func testPaymentMethodRemoveLast_disabled() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
@@ -242,7 +242,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
 
         XCTAssertTrue(allowsRemoval)
-        XCTAssertFalse(elementsSession.allowsRemovalOfLastPaymentMethodForPaymentSheet)
+        XCTAssertFalse(elementsSession.paymentMethodRemoveLastForPaymentSheet)
     }
     func testSPMConsentAndRemoval_invalidComponent() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
@@ -304,7 +304,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
 
         XCTAssertFalse(allowsRemoval)
-        XCTAssertTrue(elementsSession.allowsRemovalOfLastPaymentMethodForCustomerSheet)
+        XCTAssertTrue(elementsSession.paymentMethodRemoveLastForCustomerSheet)
     }
     func testAllowsRemovalOfPaymentMethodsForCustomerSheet_removeLast_enabled() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
@@ -322,7 +322,7 @@ class STPElementsSessionTest: XCTestCase {
 
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
         XCTAssertTrue(allowsRemoval)
-        XCTAssertTrue(elementsSession.allowsRemovalOfLastPaymentMethodForCustomerSheet)
+        XCTAssertTrue(elementsSession.paymentMethodRemoveLastForCustomerSheet)
     }
     func testAllowsRemovalOfPaymentMethodsForCustomerSheet_removeLast_disabled() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
@@ -340,6 +340,6 @@ class STPElementsSessionTest: XCTestCase {
 
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
         XCTAssertTrue(allowsRemoval)
-        XCTAssertFalse(elementsSession.allowsRemovalOfLastPaymentMethodForCustomerSheet)
+        XCTAssertFalse(elementsSession.paymentMethodRemoveLastForCustomerSheet)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -211,7 +211,7 @@ class STPElementsSessionTest: XCTestCase {
                                                                     "enabled": true,
                                                                     "features": ["payment_method_save": "enabled",
                                                                                  "payment_method_remove": "enabled",
-                                                                                 "payment_method_remove_last": "enabled"
+                                                                                 "payment_method_remove_last": "enabled",
                                                                                 ],
                                                                 ],
                                                                 "customer_sheet": [
@@ -231,7 +231,7 @@ class STPElementsSessionTest: XCTestCase {
                                                                     "enabled": true,
                                                                     "features": ["payment_method_save": "enabled",
                                                                                  "payment_method_remove": "enabled",
-                                                                                 "payment_method_remove_last": "disabled"
+                                                                                 "payment_method_remove_last": "disabled",
                                                                                 ],
                                                                 ],
                                                                 "customer_sheet": [

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -141,6 +141,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
 
         XCTAssertTrue(allowsRemoval)
+        XCTAssertTrue(elementsSession.allowsRemovalOfLastPaymentMethodForPaymentSheet)
         XCTAssertEqual(.paymentSheetWithCustomerSessionPaymentMethodSaveEnabled, savePaymentMethodConsentBehavior)
     }
     func testSPMConsentAndRemoval_pmsD_pmrE() {
@@ -202,6 +203,46 @@ class STPElementsSessionTest: XCTestCase {
 
         XCTAssertFalse(allowsRemoval)
         XCTAssertEqual(.paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, savePaymentMethodConsentBehavior)
+    }
+    func testPaymentMethodRemoveLast_enabled() {
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
+                                                            customerSessionData: [
+                                                                "mobile_payment_element": [
+                                                                    "enabled": true,
+                                                                    "features": ["payment_method_save": "enabled",
+                                                                                 "payment_method_remove": "enabled",
+                                                                                 "payment_method_remove_last": "enabled"
+                                                                                ],
+                                                                ],
+                                                                "customer_sheet": [
+                                                                    "enabled": false
+                                                                ],
+                                                            ])
+
+        let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
+
+        XCTAssertTrue(allowsRemoval)
+        XCTAssertTrue(elementsSession.allowsRemovalOfLastPaymentMethodForPaymentSheet)
+    }
+    func testPaymentMethodRemoveLast_disabled() {
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
+                                                            customerSessionData: [
+                                                                "mobile_payment_element": [
+                                                                    "enabled": true,
+                                                                    "features": ["payment_method_save": "enabled",
+                                                                                 "payment_method_remove": "enabled",
+                                                                                 "payment_method_remove_last": "disabled"
+                                                                                ],
+                                                                ],
+                                                                "customer_sheet": [
+                                                                    "enabled": false
+                                                                ],
+                                                            ])
+
+        let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
+
+        XCTAssertTrue(allowsRemoval)
+        XCTAssertFalse(elementsSession.allowsRemovalOfLastPaymentMethodForPaymentSheet)
     }
     func testSPMConsentAndRemoval_invalidComponent() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -304,5 +304,42 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
 
         XCTAssertFalse(allowsRemoval)
+        XCTAssertTrue(elementsSession.allowsRemovalOfLastPaymentMethodForCustomerSheet)
+    }
+    func testAllowsRemovalOfPaymentMethodsForCustomerSheet_removeLast_enabled() {
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
+                                                            customerSessionData: [
+                                                                "mobile_payment_element": [
+                                                                    "enabled": false
+                                                                ],
+                                                                "customer_sheet": [
+                                                                    "enabled": true,
+                                                                    "features": ["payment_method_remove": "enabled",
+                                                                                 "payment_method_remove_last": "enabled",
+                                                                                ],
+                                                                ],
+                                                            ])
+
+        let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
+        XCTAssertTrue(allowsRemoval)
+        XCTAssertTrue(elementsSession.allowsRemovalOfLastPaymentMethodForCustomerSheet)
+    }
+    func testAllowsRemovalOfPaymentMethodsForCustomerSheet_removeLast_disabled() {
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
+                                                            customerSessionData: [
+                                                                "mobile_payment_element": [
+                                                                    "enabled": false
+                                                                ],
+                                                                "customer_sheet": [
+                                                                    "enabled": true,
+                                                                    "features": ["payment_method_remove": "enabled",
+                                                                                 "payment_method_remove_last": "disabled",
+                                                                                ],
+                                                                ],
+                                                              ])
+
+        let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
+        XCTAssertTrue(allowsRemoval)
+        XCTAssertFalse(elementsSession.allowsRemovalOfLastPaymentMethodForCustomerSheet)
     }
 }


### PR DESCRIPTION
## Summary
Adds support for `payment_method_remove_last` on CustomerSessions

## Motivation
New feature on CustomerSessions

## Testing
Added unit tests, but will add UI tests once backend changes are deployed

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
