### PR TITLE
Warm up emulator before ui tests start

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -627,7 +627,7 @@ workflows:
     steps:
     - script@1:
         inputs:
-        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2&gt;&amp;1 | grep "iPhone 12 mini,OS=16.4" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
+        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
         title: Warm up emulator (iPhone 12 mini, OS=16.4)
     - xcode-test@4:
         inputs:
@@ -649,7 +649,7 @@ workflows:
     steps:
     - script@1:
         inputs:
-        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2&gt;&amp;1 | grep "iPhone 12 mini,OS=16.4" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
+        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
         title: Warm up emulator (iPhone 12 mini, OS=16.4)    
     - xcode-test@4:
         inputs:
@@ -671,7 +671,7 @@ workflows:
     steps:
     - script@1:
         inputs:
-        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2&gt;&amp;1 | grep "iPhone 12 mini,OS=16.4" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
+        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
         title: Warm up emulator (iPhone 12 mini, OS=16.4)      
     - xcode-test@4:
         inputs:
@@ -693,7 +693,7 @@ workflows:
     steps:
     - script@1:
         inputs:
-        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2&gt;&amp;1 | grep "iPhone 12 mini,OS=16.4" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
+        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
         title: Warm up emulator (iPhone 12 mini, OS=16.4)    
     - xcode-test@4:
         inputs:
@@ -715,7 +715,7 @@ workflows:
     steps:
     - script@1:
         inputs:
-        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2&gt;&amp;1 | grep "iPhone 12 mini,OS=16.4" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
+        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
         title: Warm up emulator (iPhone 12 mini, OS=16.4)    
     - xcode-test@4:
         inputs:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -625,6 +625,10 @@ workflows:
         machine_type_id: g2.mac.large        
   ui-tests-1:
     steps:
+    - script@1:
+        inputs:
+        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2&gt;&amp;1 | grep "iPhone 12 mini,OS=16.4" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
+        title: Warm up emulator (iPhone 12 mini, OS=16.4)
     - xcode-test@4:
         inputs:
         - destination: $DEFAULT_TEST_DEVICE
@@ -643,6 +647,10 @@ workflows:
         machine_type_id: g2.mac.large
   ui-tests-2:
     steps:
+    - script@1:
+        inputs:
+        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2&gt;&amp;1 | grep "iPhone 12 mini,OS=16.4" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
+        title: Warm up emulator (iPhone 12 mini, OS=16.4)    
     - xcode-test@4:
         inputs:
         - destination: $DEFAULT_TEST_DEVICE
@@ -661,6 +669,10 @@ workflows:
         machine_type_id: g2.mac.large
   ui-tests-3:
     steps:
+    - script@1:
+        inputs:
+        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2&gt;&amp;1 | grep "iPhone 12 mini,OS=16.4" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
+        title: Warm up emulator (iPhone 12 mini, OS=16.4)      
     - xcode-test@4:
         inputs:
         - destination: $DEFAULT_TEST_DEVICE
@@ -679,6 +691,10 @@ workflows:
         machine_type_id: g2.mac.large
   ui-tests-4:
     steps:
+    - script@1:
+        inputs:
+        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2&gt;&amp;1 | grep "iPhone 12 mini,OS=16.4" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
+        title: Warm up emulator (iPhone 12 mini, OS=16.4)    
     - xcode-test@4:
         inputs:
         - destination: $DEFAULT_TEST_DEVICE
@@ -697,6 +713,10 @@ workflows:
         machine_type_id: g2.mac.large
   ui-tests-5:
     steps:
+    - script@1:
+        inputs:
+        - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2&gt;&amp;1 | grep "iPhone 12 mini,OS=16.4" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
+        title: Warm up emulator (iPhone 12 mini, OS=16.4)    
     - xcode-test@4:
         inputs:
         - destination: $DEFAULT_TEST_DEVICE


### PR DESCRIPTION
## Summary
Warm up emulator before ui tests start. Reached out to support, and using their suggestion to warm up the emulator prior to running UI tests.

## Motivation
Intermittently seeing:
```
Failed to establish communication with the test runner. (Underlying Error: Error retrieving daemon unix domain socket from simulator, failed after 30 attempts.; getenv error: Error Domain=com.apple.CoreSimulator.SimError Code=405 "Unable to getenv("TESTMANAGERD_SIM_SOCK") while not booting or booted.  Current state: Shutdown" UserInfo={NSLocalizedDescription=Unable to getenv("TESTMANAGERD_SIM_SOCK") while not booting or booted.  Current state: Shutdown})
```

## Testing
Running through CI

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
