### PR TITLE
Don't send Link signup failure logs if Link is already disabled

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
@@ -205,9 +205,11 @@ final class LinkInlineSignupViewModel {
 
         if linkAccount?.isRegistered ?? false {
             // User already has a Link account, they can't sign up
-            STPAnalyticsClient.sharedClient.logLinkSignupFailureAccountExists()
-            // Don't bother them again
-            UserDefaults.standard.markLinkAsUsed()
+            if !UserDefaults.standard.customerHasUsedLink {
+                STPAnalyticsClient.sharedClient.logLinkSignupFailureAccountExists()
+                // Don't bother them again
+                UserDefaults.standard.markLinkAsUsed()
+            }
             return .continueWithoutLink
         }
 


### PR DESCRIPTION
## Summary
Once we log 'logLinkSignupFailureAccountExists', we won't show the field again. We should only take this action once, instead of every time we check the field's `action`.

## Motivation
Avoid spurious logging.

## Testing
Confirmed in PS Example

## Changelog
None