### PR TITLE
Pass incentive information to IBP flow

### DIFF
--- a/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
@@ -12,6 +12,14 @@ import Foundation
     @_spi(STP) @frozen public enum IntentID {
         case payment(String)
         case setup(String)
+        case deferred(String)
+        
+        @_spi(STP) public var id: String {
+            switch self {
+            case let .payment(string), let .setup(string), let .deferred(string):
+                return string
+            }
+        }
     }
 
     /// These fields will be used to prefill the Financial Connections Link Login pane.
@@ -42,9 +50,17 @@ import Foundation
     @_spi(STP) public let intentId: IntentID?
     @_spi(STP) public let linkMode: LinkMode?
     @_spi(STP) public let billingDetails: BillingDetails?
+    @_spi(STP) public let eligibleForIncentive: Bool
 
     @_spi(STP) public var billingAddress: BillingAddress? {
         BillingAddress(from: billingDetails)
+    }
+    
+    @_spi(STP) public var incentiveEligibilitySession: IntentID? {
+        guard eligibleForIncentive else {
+            return nil
+        }
+        return intentId
     }
 
     @_spi(STP) public init(
@@ -53,7 +69,8 @@ import Foundation
         prefillDetails: PrefillDetails?,
         intentId: IntentID?,
         linkMode: LinkMode?,
-        billingDetails: BillingDetails?
+        billingDetails: BillingDetails?,
+        eligibleForIncentive: Bool
     ) {
         self.amount = amount
         self.currency = currency
@@ -61,6 +78,7 @@ import Foundation
         self.intentId = intentId
         self.linkMode = linkMode
         self.billingDetails = billingDetails
+        self.eligibleForIncentive = eligibleForIncentive
     }
 }
 

--- a/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
@@ -16,8 +16,8 @@ import Foundation
         
         @_spi(STP) public var id: String {
             switch self {
-            case let .payment(string), let .setup(string), let .deferred(string):
-                return string
+            case let .payment(id), let .setup(id), let .deferred(id):
+                return id
             }
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -235,7 +235,7 @@ protocol FinancialConnectionsAPI {
         country: String,
         amount: Int?,
         currency: String?,
-        intentId: ElementsSessionContext.IntentID?
+        incentiveEligibilitySession: ElementsSessionContext.IntentID?
     ) -> Future<LinkSignUpResponse>
 
     func attachLinkConsumerToLinkAccountSession(
@@ -928,7 +928,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         country: String,
         amount: Int?,
         currency: String?,
-        intentId: ElementsSessionContext.IntentID?
+        incentiveEligibilitySession: ElementsSessionContext.IntentID?
     ) -> Future<LinkSignUpResponse> {
         var parameters: [String: Any] = [
             "request_surface": requestSurface,
@@ -947,8 +947,8 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
             parameters["currency"] = currency
         }
 
-        if let intentId {
-            switch intentId {
+        if let incentiveEligibilitySession {
+            switch incentiveEligibilitySession {
             case .payment(let paymentIntentId):
                 parameters["financial_incentive"] = [
                     "payment_intent": paymentIntentId,
@@ -956,6 +956,10 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
             case .setup(let setupIntentId):
                 parameters["financial_incentive"] = [
                     "setup_intent": setupIntentId,
+                ]
+            case .deferred(let elementsSessionId):
+                parameters["financial_incentive"] = [
+                    "elements_session_id": elementsSessionId,
                 ]
             }
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -81,8 +81,7 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
             country: country,
             amount: elementsSessionContext?.amount,
             currency: elementsSessionContext?.currency,
-            // TODO(tillh): Only pass `intentId` when the session is eligible for incentives.
-            intentId: nil
+            incentiveEligibilitySession: elementsSessionContext?.incentiveEligibilitySession
         )
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -159,7 +159,8 @@ extension FinancialConnectionsWebFlowViewController {
             isInstantDebits: manifest.isProductInstantDebits,
             linkMode: elementsSessionContext?.linkMode,
             prefillDetails: elementsSessionContext?.prefillDetails,
-            billingDetails: elementsSessionContext?.billingDetails
+            billingDetails: elementsSessionContext?.billingDetails,
+            incentiveEligibilitySession: elementsSessionContext?.incentiveEligibilitySession
         )
         authSessionManager?
             .start(additionalQueryParameters: additionalQueryParameters)
@@ -450,7 +451,8 @@ extension FinancialConnectionsWebFlowViewController {
         isInstantDebits: Bool,
         linkMode: LinkMode?,
         prefillDetails: ElementsSessionContext.PrefillDetails?,
-        billingDetails: ElementsSessionContext.BillingDetails?
+        billingDetails: ElementsSessionContext.BillingDetails?,
+        incentiveEligibilitySession: ElementsSessionContext.IntentID?
     ) -> String? {
         var parameters: [String] = []
 
@@ -461,6 +463,12 @@ extension FinancialConnectionsWebFlowViewController {
         if isInstantDebits {
             parameters.append("return_payment_method=true")
             parameters.append("expand_payment_method=true")
+            
+            if let incentiveEligibilitySession {
+                parameters.append("instantDebitsIncentive=true")
+                parameters.append("incentiveEligibilitySession=\(incentiveEligibilitySession.id)")
+            }
+            
             if let linkMode {
                 parameters.append("link_mode=\(linkMode.rawValue)")
             }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -203,7 +203,7 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
         country: String,
         amount: Int?,
         currency: String?,
-        intentId: ElementsSessionContext.IntentID?
+        incentiveEligibilitySession: ElementsSessionContext.IntentID?
     ) -> Future<LinkSignUpResponse> {
         return Promise<StripeFinancialConnections.LinkSignUpResponse>()
     }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsWebFlowTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsWebFlowTests.swift
@@ -16,7 +16,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: false,
             linkMode: nil,
             prefillDetails: nil,
-            billingDetails: nil
+            billingDetails: nil,
+            incentiveEligibilitySession: nil
         )
         XCTAssertNil(additionalParameters)
     }
@@ -27,7 +28,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: false,
             linkMode: nil,
             prefillDetails: nil,
-            billingDetails: nil
+            billingDetails: nil,
+            incentiveEligibilitySession: nil
         )
         XCTAssertNil(additionalParameters)
     }
@@ -38,7 +40,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: true,
             linkMode: nil,
             prefillDetails: nil,
-            billingDetails: nil
+            billingDetails: nil,
+            incentiveEligibilitySession: nil
         )
         XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true")
     }
@@ -49,7 +52,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: true,
             linkMode: nil,
             prefillDetails: nil,
-            billingDetails: nil
+            billingDetails: nil,
+            incentiveEligibilitySession: nil
         )
         XCTAssertEqual(additionalParameters, "&return_payment_method=true&expand_payment_method=true")
     }
@@ -60,7 +64,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: false,
             linkMode: .passthrough,
             prefillDetails: nil,
-            billingDetails: nil
+            billingDetails: nil,
+            incentiveEligibilitySession: nil
         )
         XCTAssertNil(additionalParameters)
     }
@@ -71,7 +76,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: true,
             linkMode: .passthrough,
             prefillDetails: nil,
-            billingDetails: nil
+            billingDetails: nil,
+            incentiveEligibilitySession: nil
         )
         XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true&link_mode=PASSTHROUGH")
     }
@@ -82,7 +88,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: true,
             linkMode: .linkCardBrand,
             prefillDetails: nil,
-            billingDetails: nil
+            billingDetails: nil,
+            incentiveEligibilitySession: nil
         )
         XCTAssertEqual(additionalParameters, "&return_payment_method=true&expand_payment_method=true&link_mode=LINK_CARD_BRAND")
     }
@@ -99,7 +106,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: false,
             linkMode: nil,
             prefillDetails: prefillDetails,
-            billingDetails: nil
+            billingDetails: nil,
+            incentiveEligibilitySession: nil
         )
         XCTAssertNil(additionalParameters)
     }
@@ -116,7 +124,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: false,
             linkMode: nil,
             prefillDetails: prefillDetails,
-            billingDetails: nil
+            billingDetails: nil,
+            incentiveEligibilitySession: nil
         )
         XCTAssertEqual(additionalParameters, "&email=test%40example.com")
     }
@@ -133,7 +142,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: false,
             linkMode: nil,
             prefillDetails: prefillDetails,
-            billingDetails: nil
+            billingDetails: nil,
+            incentiveEligibilitySession: nil
         )
         XCTAssertEqual(additionalParameters, "&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
     }
@@ -150,7 +160,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: true,
             linkMode: .passthrough,
             prefillDetails: prefillDetails,
-            billingDetails: nil
+            billingDetails: nil,
+            incentiveEligibilitySession: nil
         )
         XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true&link_mode=PASSTHROUGH&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
     }
@@ -167,7 +178,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: false,
             linkMode: nil,
             prefillDetails: nil,
-            billingDetails: billingDetails
+            billingDetails: billingDetails,
+            incentiveEligibilitySession: nil
         )
         XCTAssertNil(additionalParameters)
     }
@@ -191,9 +203,25 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: true,
             linkMode: nil,
             prefillDetails: nil,
-            billingDetails: billingDetails
+            billingDetails: billingDetails,
+            incentiveEligibilitySession: nil
         )
         XCTAssertEqual(additionalParameters, "&return_payment_method=true&expand_payment_method=true&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON")
+    }
+    
+    func test_additionalParameters_incentiveEligible() {
+        let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
+            startingAdditionalParameters: nil,
+            isInstantDebits: true,
+            linkMode: nil,
+            prefillDetails: nil,
+            billingDetails: nil,
+            incentiveEligibilitySession: .payment("pi_123")
+        )
+        XCTAssertEqual(
+            additionalParameters,
+            "&return_payment_method=true&expand_payment_method=true&instantDebitsIncentive=true&incentiveEligibilitySession=pi_123"
+        )
     }
 
     func test_additionalParameters_fullBillingDetails_fullPrefillDetails_instantDebits_passthroughLinkMode() {
@@ -221,7 +249,8 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             isInstantDebits: true,
             linkMode: .passthrough,
             prefillDetails: prefillDetails,
-            billingDetails: billingDetails
+            billingDetails: billingDetails,
+            incentiveEligibilitySession: nil
         )
         XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true&link_mode=PASSTHROUGH&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -320,7 +320,8 @@ import UIKit
             prefillDetails: makePrefillDetails(),
             intentId: nil,
             linkMode: nil,
-            billingDetails: billingDetails
+            billingDetails: billingDetails,
+            eligibleForIncentive: false
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -32,6 +32,7 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     private var linkedBank: InstantDebitsLinkedBank?
     private let theme: ElementsAppearance
     var presentingViewControllerDelegate: PresentingViewControllerDelegate?
+    var incentive: PaymentMethodIncentive?
 
     var delegate: ElementDelegate?
     var view: UIView {
@@ -190,6 +191,7 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
 
         self.linkedBank = nil
         self.linkedBankInfoSectionElement.view.isHidden = true
+        self.incentive = incentive
         self.theme = theme
         
         let promoDisclaimerElement = incentive.flatMap {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -270,7 +270,8 @@ extension PaymentMethodFormViewController {
             prefillDetails: prefillDetails,
             intentId: intentId,
             linkMode: linkMode,
-            billingDetails: billingDetails
+            billingDetails: billingDetails,
+            eligibleForIncentive: instantDebitsFormElement?.incentive != nil
         )
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request passes the incentive information into the Instant Bank Payments flow. We set an `incentiveEligibilitySession` if the session is eligible, or `nil` otherwise.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[CONSUMERBANK-569](https://jira.corp.stripe.com/browse/CONSUMERBANK-569)

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
