### PR TITLE
Improve console logging for Instant Bank Payments and Panther

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -359,7 +359,12 @@ extension PaymentSheet {
             intent: Intent,
             elementsSession: STPElementsSession
         ) -> PaymentMethodAvailabilityStatus {
-            var primaryRequirementMet: Bool = false
+            // Primary requirement:
+            // - Link is an available payment method.
+            guard elementsSession.orderedPaymentMethodTypes.contains(.link) else {
+                return .notSupported
+            }
+
             var missingRequirements: Set<PaymentMethodTypeRequirement> = []
 
             // Instant Debits is supported when:
@@ -372,14 +377,6 @@ extension PaymentSheet {
 
             if case .missingRequirements(let requirements) = configurationAvailabilityStatus {
                 missingRequirements.formUnion(requirements)
-            }
-
-            // Primary requirement:
-            // - Link is an available payment method.
-            if elementsSession.orderedPaymentMethodTypes.contains(.link) {
-                primaryRequirementMet = true
-            } else {
-                missingRequirements.insert(.unsupported)
             }
 
             // - US Bank Account is *not* an available payment method.
@@ -398,13 +395,7 @@ extension PaymentSheet {
             }
 
             let hasMissingRequirements = !missingRequirements.isEmpty
-            if primaryRequirementMet, hasMissingRequirements {
-                return .missingRequirements(missingRequirements)
-            } else if hasMissingRequirements {
-                return .notSupported
-            }
-
-            return .supported
+            return hasMissingRequirements ? .missingRequirements(missingRequirements) : .supported
         }
 
         /// We support Link Card Brand as a payment method when:
@@ -418,7 +409,12 @@ extension PaymentSheet {
             intent: Intent,
             elementsSession: STPElementsSession
         ) -> PaymentMethodAvailabilityStatus {
-            var primaryRequirementMet: Bool = false
+            // Primary:
+            // - Link Mode is set to Link Card Brand.
+            guard elementsSession.isLinkCardBrand else {
+                return .notSupported
+            }
+
             var missingRequirements: Set<PaymentMethodTypeRequirement> = []
 
             // Instant Debits is supported when:
@@ -431,14 +427,6 @@ extension PaymentSheet {
 
             if case .missingRequirements(let requirements) = configurationAvailabilityStatus {
                 missingRequirements.formUnion(requirements)
-            }
-
-            // Primary:
-            // - Link Mode is set to Link Card Brand.
-            if elementsSession.isLinkCardBrand {
-                primaryRequirementMet = true
-            } else {
-                missingRequirements.insert(.unsupported)
             }
 
             // - Link Funding Sources contains Bank Account.
@@ -457,13 +445,7 @@ extension PaymentSheet {
             }
 
             let hasMissingRequirements = !missingRequirements.isEmpty
-            if primaryRequirementMet, hasMissingRequirements {
-                return .missingRequirements(missingRequirements)
-            } else if hasMissingRequirements {
-                return .notSupported
-            }
-
-            return .supported
+            return hasMissingRequirements ? .missingRequirements(missingRequirements) : .supported
         }
 
         /// Returns whether or not we can show a "☑️ Save for future use" checkbox to the customer

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
@@ -477,13 +477,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .missingRequirements(let requirements) = availability else {
-            XCTFail("Unexpected availability: \(availability)")
-            return
-        }
-
-        XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .instantBankPaymentRequirement(.missingLink))
+        XCTAssertEqual(availability, .notSupported)
     }
 
     func testSupportsInstantBankPayments_unexpectedUsBankAccount() {
@@ -501,13 +495,13 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .primaryRequirementMetButMissingOtherRequirements(_, let requirements) = availability else {
+        guard case .missingRequirements(let requirements) = availability else {
             XCTFail("Unexpected availability: \(availability)")
             return
         }
 
         XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .instantBankPaymentRequirement(.unexpectedUsBankAccount))
+        XCTAssertEqual(requirements.first, .unexpectedUsBankAccount)
     }
 
     func testSupportsInstantBankPayments_linkFundingSourcesMissingBankAccount() {
@@ -525,13 +519,13 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .primaryRequirementMetButMissingOtherRequirements(_, let requirements) = availability else {
+        guard case .missingRequirements(let requirements) = availability else {
             XCTFail("Unexpected availability: \(availability)")
             return
         }
 
         XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .instantBankPaymentRequirement(.linkFundingSourcesMissingBankAccount))
+        XCTAssertEqual(requirements.first, .linkFundingSourcesMissingBankAccount)
     }
 
     func testSupportsInstantBankPayments_invalidEmailCollectionConfiguration() {
@@ -551,13 +545,13 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .primaryRequirementMetButMissingOtherRequirements(_, let requirements) = availability else {
+        guard case .missingRequirements(let requirements) = availability else {
             XCTFail("Unexpected availability: \(availability)")
             return
         }
 
         XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .instantBankPaymentRequirement(.invalidEmailCollectionConfiguration))
+        XCTAssertEqual(requirements.first, .invalidEmailCollectionConfiguration)
     }
 
     func testSupportsInstantBankPayments_multipleMissingNonPrimaryRequirements() {
@@ -577,15 +571,15 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .primaryRequirementMetButMissingOtherRequirements(_, let requirements) = availability else {
+        guard case .missingRequirements(let requirements) = availability else {
             XCTFail("Unexpected availability: \(availability)")
             return
         }
 
         let expectedMissingRequirements: Set<PaymentSheet.PaymentMethodTypeRequirement> = [
-            .instantBankPaymentRequirement(.unexpectedUsBankAccount),
-            .instantBankPaymentRequirement(.linkFundingSourcesMissingBankAccount),
-            .instantBankPaymentRequirement(.invalidEmailCollectionConfiguration),
+            .unexpectedUsBankAccount,
+            .linkFundingSourcesMissingBankAccount,
+            .invalidEmailCollectionConfiguration,
         ]
         XCTAssertEqual(requirements.count, 3)
         XCTAssertEqual(requirements, expectedMissingRequirements)
@@ -608,19 +602,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .missingRequirements(let requirements) = availability else {
-            XCTFail("Unexpected availability: \(availability)")
-            return
-        }
-
-        let expectedMissingRequirements: Set<PaymentSheet.PaymentMethodTypeRequirement> = [
-            .instantBankPaymentRequirement(.missingLink),
-            .instantBankPaymentRequirement(.unexpectedUsBankAccount),
-            .instantBankPaymentRequirement(.linkFundingSourcesMissingBankAccount),
-            .instantBankPaymentRequirement(.invalidEmailCollectionConfiguration),
-        ]
-        XCTAssertEqual(requirements.count, 4)
-        XCTAssertEqual(requirements, expectedMissingRequirements)
+        XCTAssertEqual(availability, .notSupported)
     }
 
     func testSupportsInstantBankPayments_primaryRequirementPresent_debugDescription() {
@@ -639,9 +621,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         )
 
         let expectedDebugDescription = """
-        Link was specified as a payment method, but other requirements were not met for Instant Bank Payments. See https://docs.stripe.com/payments/link/instant-bank-payments
-        Missing requirements:
-        \t* Link funding sources must contain bank account
+        \t* Your account isn't set up to process Instant Bank Payments. Reach out to Stripe support.
         """
         XCTAssertEqual(availability.debugDescription, expectedDebugDescription)
     }
@@ -662,7 +642,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         )
 
         let expectedDebugDescription = """
-        \t* Specified payment methods must contain link
+        This payment method is not currently supported by PaymentSheet.
         """
         XCTAssertEqual(availability.debugDescription, expectedDebugDescription)
     }
@@ -701,13 +681,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .missingRequirements(let requirements) = availability else {
-            XCTFail("Unexpected availability: \(availability)")
-            return
-        }
-
-        XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .instantBankPaymentRequirement(.unexpectedLinkMode))
+        XCTAssertEqual(availability, .notSupported)
     }
 
     func testSupportsLinkCardIntegration_unexpectedUsBankAccount() {
@@ -725,13 +699,13 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .primaryRequirementMetButMissingOtherRequirements(_, let requirements) = availability else {
+        guard case .missingRequirements(let requirements) = availability else {
             XCTFail("Unexpected availability: \(availability)")
             return
         }
 
         XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .instantBankPaymentRequirement(.unexpectedUsBankAccount))
+        XCTAssertEqual(requirements.first, .unexpectedUsBankAccount)
     }
 
     func testSupportsLinkCardIntegration_linkFundingSourcesMissingBankAccount() {
@@ -749,13 +723,13 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .primaryRequirementMetButMissingOtherRequirements(_, let requirements) = availability else {
+        guard case .missingRequirements(let requirements) = availability else {
             XCTFail("Unexpected availability: \(availability)")
             return
         }
 
         XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .instantBankPaymentRequirement(.linkFundingSourcesMissingBankAccount))
+        XCTAssertEqual(requirements.first, .linkFundingSourcesMissingBankAccount)
     }
 
     func testSupportsLinkCardIntegration_invalidEmailCollectionConfiguration() {
@@ -775,13 +749,13 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .primaryRequirementMetButMissingOtherRequirements(_, let requirements) = availability else {
+        guard case .missingRequirements(let requirements) = availability else {
             XCTFail("Unexpected availability: \(availability)")
             return
         }
 
         XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .instantBankPaymentRequirement(.invalidEmailCollectionConfiguration))
+        XCTAssertEqual(requirements.first, .invalidEmailCollectionConfiguration)
     }
 
     func testSupportsLinkCardIntegration_multipleMissingNonPrimaryRequirements() {
@@ -801,15 +775,15 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .primaryRequirementMetButMissingOtherRequirements(_, let requirements) = availability else {
+        guard case .missingRequirements(let requirements) = availability else {
             XCTFail("Unexpected availability: \(availability)")
             return
         }
 
         let expectedMissingRequirements: Set<PaymentSheet.PaymentMethodTypeRequirement> = [
-            .instantBankPaymentRequirement(.unexpectedUsBankAccount),
-            .instantBankPaymentRequirement(.linkFundingSourcesMissingBankAccount),
-            .instantBankPaymentRequirement(.invalidEmailCollectionConfiguration),
+            .unexpectedUsBankAccount,
+            .linkFundingSourcesMissingBankAccount,
+            .invalidEmailCollectionConfiguration,
         ]
         XCTAssertEqual(requirements.count, 3)
         XCTAssertEqual(requirements, expectedMissingRequirements)
@@ -832,19 +806,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
 
-        guard case .missingRequirements(let requirements) = availability else {
-            XCTFail("Unexpected availability: \(availability)")
-            return
-        }
-
-        let expectedMissingRequirements: Set<PaymentSheet.PaymentMethodTypeRequirement> = [
-            .instantBankPaymentRequirement(.unexpectedLinkMode),
-            .instantBankPaymentRequirement(.unexpectedUsBankAccount),
-            .instantBankPaymentRequirement(.linkFundingSourcesMissingBankAccount),
-            .instantBankPaymentRequirement(.invalidEmailCollectionConfiguration),
-        ]
-        XCTAssertEqual(requirements.count, 4)
-        XCTAssertEqual(requirements, expectedMissingRequirements)
+        XCTAssertEqual(availability, .notSupported)
     }
 
     func testSupportsLinkCardIntegration_primaryRequirementPresent_debugDescription() {
@@ -863,9 +825,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         )
 
         let expectedDebugDescription = """
-        The Link mode was set to Link Card Brand, but other requirements were not met for the Link Card integration. See https://docs.stripe.com/payments/link/link-payment-integrations?link-integrations=link-card-integrations
-        Missing requirements:
-        \t* Link funding sources must contain bank account
+        \t* Your account isn't set up to process Instant Bank Payments. Reach out to Stripe support.
         """
         XCTAssertEqual(availability.debugDescription, expectedDebugDescription)
     }
@@ -886,7 +846,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         )
 
         let expectedDebugDescription = """
-        \t* The Link Mode received is not Link Card Brand
+        This payment method is not currently supported by PaymentSheet.
         """
         XCTAssertEqual(availability.debugDescription, expectedDebugDescription)
     }


### PR DESCRIPTION
## Summary

This adds some console logging to help users debug why they might not be seeing Instant Bank Payment or Link Card Brands as payment methods in MPE. This is the result of feedback from a user who was trying to integrate, and couldn't figure out why these payment methods weren't appearing.

In order to not pollute the logs with unnecessary information, this only logs these events when a "primary condition" is met. Meaning, we suspect the user is trying to add these payment methods, but the other requirements are not met.

## Motivation

Improve debugability (<- new word) of these payment methods

## Testing

<img width="1735" alt="image" src="https://github.com/user-attachments/assets/df101582-872f-4569-99a7-dfbce4135c9c">

## Changelog

N/a
