### PR TITLE
Fix incorrect `PaymentOptionDisplayData` for Link card brand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### PaymentSheet
+* [Fixed] Fixed an issue where FlowController returned incorrect `PaymentOptionDisplayData` for Link card brand transactions.
+
 ## 24.1.1 2024-12-02
 ### PaymentSheet
 * [Fixed] Fixed an animation glitch when dismissing PaymentSheet in React Native.

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2461,6 +2461,10 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
     func testLinkCardBrand() {
         _testInstantDebits(mode: .payment, useLinkCardBrand: true)
     }
+    
+    func testLinkCardBrand_flowController() {
+        _testInstantDebits(mode: .payment, useLinkCardBrand: true, uiStyle: .flowController)
+    }
 
     // MARK: Link test helpers
 
@@ -2689,11 +2693,12 @@ extension PaymentSheetUITestCase {
     func _testInstantDebits(
         mode: PaymentSheetTestPlaygroundSettings.Mode,
         vertical: Bool = false,
-        useLinkCardBrand: Bool = false
+        useLinkCardBrand: Bool = false,
+        uiStyle: PaymentSheetTestPlaygroundSettings.UIStyle = .paymentSheet
     ) {
-
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.mode = mode
+        settings.uiStyle = uiStyle
         settings.apmsEnabled = .off
         settings.supportedPaymentMethods = useLinkCardBrand ? "card" : "card,link"
         if vertical {
@@ -2701,7 +2706,13 @@ extension PaymentSheetUITestCase {
         }
 
         loadPlayground(app, settings)
-        app.buttons["Present PaymentSheet"].tap()
+        
+        if uiStyle == .flowController {
+            app.buttons["Apple Pay, apple_pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
+            app.buttons["+ Add"].waitForExistenceAndTap()
+        } else {
+            app.buttons["Present PaymentSheet"].tap()
+        }
 
         // Select "Bank"
         if vertical {
@@ -2722,7 +2733,17 @@ extension PaymentSheetUITestCase {
         Self.stepThroughNativeInstantDebitsFlow(app: app)
 
         // Back to Payment Sheet
-        app.buttons[mode == .setup ? "Set up" : "Pay $50.99"].waitForExistenceAndTap(timeout: 10)
+        switch uiStyle {
+        case .paymentSheet:
+            app.buttons[mode == .setup ? "Set up" : "Pay $50.99"].waitForExistenceAndTap(timeout: 10)
+        case .flowController, .embedded:
+            // Give time for the dismiss animation
+            sleep(2)
+            app.buttons["Continue"].waitForExistenceAndTap(timeout: 10)
+            XCTAssertTrue(app.staticTexts["•••• 6789"].waitForExistence(timeout: 10))
+            app.buttons["Confirm"].waitForExistenceAndTap(timeout: 10)
+        }
+        
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
@@ -44,6 +44,13 @@ extension STPPaymentMethod {
         default:
             return nil
         }
-
+    }
+    
+    func paymentOptionLabel(confirmParams: IntentConfirmParams?) -> String {
+        if let instantDebitsLinkedBank = confirmParams?.instantDebitsLinkedBank {
+            return "•••• \(instantDebitsLinkedBank.last4 ?? "")"
+        } else {
+            return paymentSheetLabel
+        }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -484,13 +484,9 @@ extension PaymentSheet.PaymentMethodType {
     
     var isLinkBankPayment: Bool {
         switch self {
-        case .stripe:
+        case .stripe, .external:
             return false
-        case .external:
-            return false
-        case .instantDebits:
-            return true
-        case .linkCardBrand:
+        case .instantDebits, .linkCardBrand:
             return true
         }
     }
@@ -501,9 +497,7 @@ extension PaymentSheet.PaymentMethodType {
             return type == .USBankAccount
         case .external:
             return false
-        case .instantDebits:
-            return true
-        case .linkCardBrand:
+        case .instantDebits, .linkCardBrand:
             return true
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -21,8 +21,12 @@ extension PaymentOption {
         switch self {
         case .applePay:
             return Image.apple_pay_mark.makeImage().withRenderingMode(.alwaysOriginal)
-        case .saved(let paymentMethod, _):
-            return paymentMethod.makeIcon()
+        case .saved(let paymentMethod, let paymentOption):
+            if let linkedBank = paymentOption?.instantDebitsLinkedBank {
+                return PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: linkedBank.bankName))
+            } else {
+                return paymentMethod.makeIcon()
+            }
         case .new(let confirmParams):
             return confirmParams.makeIcon(updateImageHandler: updateImageHandler)
         case .link:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -115,8 +115,8 @@ extension PaymentSheet {
                     label = String.Localized.apple_pay
                     paymentMethodType = "apple_pay"
                     billingDetails = nil
-                case .saved(let paymentMethod, _):
-                    label = paymentMethod.paymentSheetLabel
+                case .saved(let paymentMethod, let confirmParams):
+                    label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams)
                     paymentMethodType = paymentMethod.type.identifier
                     billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
                 case .new(let confirmParams):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -61,7 +61,7 @@ class PaymentMethodFormViewController: UIViewController {
                 guard let paymentMethod = params.instantDebitsLinkedBank?.paymentMethod.decode() else {
                     return nil
                 }
-                return .saved(paymentMethod: paymentMethod, confirmParams: nil)
+                return .saved(paymentMethod: paymentMethod, confirmParams: params)
             }
 
             return .new(confirmParams: params)


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the `PaymentOptionDisplayData` showed incorrect information for payments with Link card brand.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

Updated the UI test to validate the displayed data.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

[Fixed] Fixed an issue where FlowController showed incorrect `PaymentOptionDisplayData` for Link card brand.
