### PR TITLE
Add initial StripeAttest code

### DIFF
--- a/StripeCore/StripeCore.xcodeproj/project.pbxproj
+++ b/StripeCore/StripeCore.xcodeproj/project.pbxproj
@@ -20,8 +20,13 @@
 		2AA9B01C8A2D2BADC4619629 /* NSCharacterSet+StripeCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC5151C3B6CB4130E9C259A6 /* NSCharacterSet+StripeCore.swift */; };
 		2B98F4F0120888B12EF3B181 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = CFF68ABB8E67E83695FAD8EA /* Localizable.strings */; };
 		2D7A4FDBED7E3FA3D17BBB54 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40A77DE176741B3A542FE890 /* StripeCore.framework */; };
+		310E6B5C2C580C06006A03EC /* StripeAttest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 310E6B5B2C580C06006A03EC /* StripeAttest.swift */; };
 		31AD3BDC2B0C23E40080C800 /* Locale+StripeCore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31AD3BDB2B0C23E40080C800 /* Locale+StripeCore.swift */; };
+		31C5137C2CFE65DB00A429C3 /* StripeAttestTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C5137B2CFE65D600A429C3 /* StripeAttestTest.swift */; };
+		31C5137E2CFE660E00A429C3 /* MockAppAttestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31C5137D2CFE660A00A429C3 /* MockAppAttestService.swift */; };
 		31CDFC302BA372B200B3DD91 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 31CDFC2F2BA372B200B3DD91 /* PrivacyInfo.xcprivacy */; };
+		31DEFE4C2D02C25A00E6E507 /* StripeAttestBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DEFE4B2D02C25A00E6E507 /* StripeAttestBackend.swift */; };
+		31DEFE4E2D02C27000E6E507 /* AppAttestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DEFE4D2D02C27000E6E507 /* AppAttestService.swift */; };
 		330FDCF901D11882D4866DDE /* APIStubbedTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF82F68E8D3A8286FD31DB13 /* APIStubbedTestCase.swift */; };
 		33E1AA9687131A7ECF384848 /* STPSnapshotTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF15BAFA3E58D68668EE6DCC /* STPSnapshotTestCase.swift */; };
 		35931C64F06BEB233A219869 /* NetworkDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = E19F97D1606B517158C7F75A /* NetworkDetector.swift */; };
@@ -213,9 +218,14 @@
 		2DE48D0086BED21F9E837D0B /* XCTestCase+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Stripe.swift"; sourceTree = "<group>"; };
 		2F1BFF01B1EA57F6EA7BFBF1 /* StripeAPIConfiguration+Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StripeAPIConfiguration+Version.swift"; sourceTree = "<group>"; };
 		303695D2ECDFFCA9C1B68E53 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/Localizable.strings; sourceTree = "<group>"; };
+		310E6B5B2C580C06006A03EC /* StripeAttest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeAttest.swift; sourceTree = "<group>"; };
 		31402722B97FC2D9A3A74E73 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/Localizable.strings; sourceTree = "<group>"; };
 		31AD3BDB2B0C23E40080C800 /* Locale+StripeCore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Locale+StripeCore.swift"; sourceTree = "<group>"; };
+		31C5137B2CFE65D600A429C3 /* StripeAttestTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeAttestTest.swift; sourceTree = "<group>"; };
+		31C5137D2CFE660A00A429C3 /* MockAppAttestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAppAttestService.swift; sourceTree = "<group>"; };
 		31CDFC2F2BA372B200B3DD91 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		31DEFE4B2D02C25A00E6E507 /* StripeAttestBackend.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeAttestBackend.swift; sourceTree = "<group>"; };
+		31DEFE4D2D02C27000E6E507 /* AppAttestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppAttestService.swift; sourceTree = "<group>"; };
 		325E8108336F1178A10D139C /* STPLocalizationUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPLocalizationUtils.swift; sourceTree = "<group>"; };
 		32CB3702691056D3404A8C5F /* StripeAPIConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeAPIConfiguration.swift; sourceTree = "<group>"; };
 		33A34DF206B0980BA1D2258F /* StripeiOS Tests-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS Tests-Release.xcconfig"; sourceTree = "<group>"; };
@@ -430,6 +440,25 @@
 				49ECDA402CA340E100F647F0 /* AsyncTests.swift */,
 			);
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		310E6B5A2C580BFB006A03EC /* Attestation */ = {
+			isa = PBXGroup;
+			children = (
+				310E6B5B2C580C06006A03EC /* StripeAttest.swift */,
+				31DEFE4D2D02C27000E6E507 /* AppAttestService.swift */,
+				31DEFE4B2D02C25A00E6E507 /* StripeAttestBackend.swift */,
+			);
+			path = Attestation;
+			sourceTree = "<group>";
+		};
+		31C5137A2CFE65D000A429C3 /* Attestation */ = {
+			isa = PBXGroup;
+			children = (
+				31C5137B2CFE65D600A429C3 /* StripeAttestTest.swift */,
+				31C5137D2CFE660A00A429C3 /* MockAppAttestService.swift */,
+			);
+			path = Attestation;
 			sourceTree = "<group>";
 		};
 		3A3F265C90373C3EF2F61523 /* Categories */ = {
@@ -659,6 +688,7 @@
 		9EF2F5FC20874E0DD2A5D40C /* StripeCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				31C5137A2CFE65D000A429C3 /* Attestation */,
 				523A1ACB7F366E117F7FE2B4 /* Analytics */,
 				7FD20B12B83EC2F371B71C37 /* API Bindings */,
 				3A3F265C90373C3EF2F61523 /* Categories */,
@@ -673,6 +703,7 @@
 		A42B59A6A0D70019833D6562 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				310E6B5A2C580BFB006A03EC /* Attestation */,
 				66BA4CFF0FEE2E4813FB4D31 /* Analytics */,
 				6D488D8BF0ADC365242F73C8 /* API Bindings */,
 				59A858862FE8D4B90A5D930F /* Categories */,
@@ -960,8 +991,10 @@
 				53D46A03B77577EE21F4B166 /* StripeCodableTest.swift in Sources */,
 				3E9FC2CD06E1D5F6B09872E9 /* AnalyticsClientV2Test.swift in Sources */,
 				84487D8E9B08106C89753536 /* Error_SerializeForLoggingTest.swift in Sources */,
+				31C5137E2CFE660E00A429C3 /* MockAppAttestService.swift in Sources */,
 				0A78AD04075C43A4059C344E /* STPAnalyticsClientTest.swift in Sources */,
 				934CCB00769674F13192A126 /* Dictionary+StripeTests.swift in Sources */,
+				31C5137C2CFE65DB00A429C3 /* StripeAttestTest.swift in Sources */,
 				E6EF91C32CB9DC410082DD1B /* Locale+StripeTests.swift in Sources */,
 				49ECDA412CA340E100F647F0 /* AsyncTests.swift in Sources */,
 				A50CB2ACAC1DCF9539D76F25 /* NSArray+StripeCoreTest.swift in Sources */,
@@ -977,6 +1010,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				31DEFE4C2D02C25A00E6E507 /* StripeAttestBackend.swift in Sources */,
 				87274985CE5E750FA8D34648 /* EmptyResponse.swift in Sources */,
 				6A52ABC06783A90B9E339948 /* StripeFile.swift in Sources */,
 				6A05FB472BCF24370001D128 /* FinancialConnectionsLinkedBank.swift in Sources */,
@@ -1012,6 +1046,7 @@
 				B67F2CA22BAB8B690011E34A /* AnalyticLoggableErrorV2.swift in Sources */,
 				D144C3A657E5C16975CB2191 /* NSError+StripeCore.swift in Sources */,
 				9843D9B7D886C373C7AC71E4 /* NSMutableURLRequest+Stripe.swift in Sources */,
+				310E6B5C2C580C06006A03EC /* StripeAttest.swift in Sources */,
 				9DCBC08C182ED76A962961E7 /* NSURLComponents+Stripe.swift in Sources */,
 				563A42FA383FA9AA5FA4CDCE /* String+StripeCore.swift in Sources */,
 				CA09DC1EC4142701B31F9673 /* UIImage+StripeCore.swift in Sources */,
@@ -1028,6 +1063,7 @@
 				096274D0729AA8849FAD103C /* PaymentsSDKVariant.swift in Sources */,
 				49E8CE2A2CD146CE0009DFBB /* KeyedEncodingContainer+Extensions.swift in Sources */,
 				DA5A05459309B9B77ACDD736 /* STPDeviceUtils.swift in Sources */,
+				31DEFE4E2D02C27000E6E507 /* AppAttestService.swift in Sources */,
 				4910B9282C3D8F3F00B030D4 /* Result+Extensions.swift in Sources */,
 				CB0E9DC82CB9C79E00E083D1 /* LinkBankPaymentMethod.swift in Sources */,
 				83790210FFC2DD764C042C8E /* STPDispatchFunctions.swift in Sources */,

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -24,7 +24,7 @@ import Foundation
 
     // MARK: - Payment Confirmation
     case _3DS2AuthenticationRequestParamsFailed =
-        "stripeios.3ds2_authentication_request_params_failed"
+            "stripeios.3ds2_authentication_request_params_failed"
     case _3DS2AuthenticationAttempt = "stripeios.3ds2_authenticate"
     case _3DS2FrictionlessFlow = "stripeios.3ds2_frictionless_flow"
     case urlRedirectNextAction = "stripeios.url_redirect_next_action"
@@ -293,4 +293,10 @@ import Foundation
 
     // MARK: - Telemetry Client
     case fraudDetectionApiFailure = "fraud_detection_data_repository.api_failure"
+
+    // MARK: - Attestation
+    case attestationFailed = "stripeios.attest.attestation.failed"
+    case attestationSucceeded = "stripeios.attest.attestation.succeeded"
+    case assertionFailed = "stripeios.attest.assertion.failed"
+    case assertionSucceeded = "stripeios.attest.assertion.succeeded"
 }

--- a/StripeCore/StripeCore/Source/Attestation/AppAttestService.swift
+++ b/StripeCore/StripeCore/Source/Attestation/AppAttestService.swift
@@ -1,0 +1,53 @@
+//
+//  AppAttestService.swift
+//  StripeCore
+//
+
+import DeviceCheck
+import Foundation
+
+@_spi(STP) public protocol AppAttestService {
+    var isSupported: Bool { get }
+    func generateKey() async throws -> String
+    func generateAssertion(_ keyId: String, clientDataHash: Data) async throws -> Data
+    func attestKey(_ keyId: String, clientDataHash: Data) async throws -> Data
+}
+
+@_spi(STP) public class AppleAppAttestService: AppAttestService {
+    @_spi(STP) public static var shared = AppleAppAttestService()
+
+    // No one should initialize this directly, it's a wrapper around a system singleton
+    private init() { }
+
+    @_spi(STP) public var isSupported: Bool {
+        if #available(iOS 14.0, *) {
+            return DCAppAttestService.shared.isSupported
+        } else {
+            return false
+        }
+    }
+
+    @_spi(STP) public func generateKey() async throws -> String {
+        guard #available(iOS 14.0, *) else {
+            stpAssertionFailure()
+            throw StripeAttest.AttestationError.attestationNotSupported
+        }
+        return try await DCAppAttestService.shared.generateKey()
+    }
+
+    @_spi(STP) public func generateAssertion(_ keyId: String, clientDataHash: Data) async throws -> Data {
+        guard #available(iOS 14.0, *) else {
+            stpAssertionFailure()
+            throw StripeAttest.AttestationError.attestationNotSupported
+        }
+        return try await DCAppAttestService.shared.generateAssertion(keyId, clientDataHash: clientDataHash)
+    }
+
+    @_spi(STP) public func attestKey(_ keyId: String, clientDataHash: Data) async throws -> Data {
+        guard #available(iOS 14.0, *) else {
+            stpAssertionFailure()
+            throw StripeAttest.AttestationError.attestationNotSupported
+        }
+        return try await DCAppAttestService.shared.attestKey(keyId, clientDataHash: clientDataHash)
+    }
+}

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -9,18 +9,11 @@ import Foundation
 import UIKit
 
 @_spi(STP) public class StripeAttest {
-    /// A wrapper for the DCAppAttestService service.
-    @_spi(STP) public var appAttestService: AppAttestService
-    /// A network backend for the /challenge and /attest endpoints.
-    @_spi(STP) public var appAttestBackend: StripeAttestBackend
-
-    /// Initialize a new StripeAttest object.
-    @_spi(STP) public init(appAttestService: AppAttestService = AppleAppAttestService.shared, appAttestBackend: StripeAttestBackend = StripeAPIAttestationBackend(apiClient: STPAPIClient.shared)) {
-        self.appAttestService = appAttestService
-        self.appAttestBackend = appAttestBackend
+    /// Initialize a new StripeAttest object with the specified STPAPIClient.
+    @_spi(STP) public convenience init(apiClient: STPAPIClient = .shared) {
+        self.init(appAttestService: AppleAppAttestService.shared,
+                  appAttestBackend: StripeAPIAttestationBackend(apiClient: apiClient))
     }
-
-    // MARK: - Public functions
 
     /// Sign an assertion.
     /// Will create and attest a new device key if needed.
@@ -74,6 +67,8 @@ import UIKit
         case invalidChallengeData
     }
 
+    // MARK: - Internal
+
     // MARK: - Device-local settings
     private enum DefaultsKeys: String {
         /// The ID of the attestation key stored in the keychain.
@@ -111,7 +106,15 @@ import UIKit
         }
     }
 
-    // MARK: - Internal
+    init(appAttestService: AppAttestService = AppleAppAttestService.shared, appAttestBackend: StripeAttestBackend = StripeAPIAttestationBackend(apiClient: STPAPIClient.shared)) {
+        self.appAttestService = appAttestService
+        self.appAttestBackend = appAttestBackend
+    }
+
+    /// A wrapper for the DCAppAttestService service.
+    var appAttestService: AppAttestService
+    /// A network backend for the /challenge and /attest endpoints.
+    var appAttestBackend: StripeAttestBackend
 
     /// The minimum time between key generation attempts.
     /// This is a safeguard against generating keys too often, as each key generation

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -1,0 +1,276 @@
+//
+//  StripeAttest.swift
+//  StripeCore
+//
+//  Created by David Estes on 7/29/24.
+//
+
+import CryptoKit
+import DeviceCheck
+import Foundation
+import UIKit
+
+@_spi(STP) public class StripeAttest {
+    /// A wrapper for the DCAppAttestService service.
+    @_spi(STP) public var appAttestService: AppAttestService
+    /// A network backend for the /challenge and /attest endpoints.
+    @_spi(STP) public var appAttestBackend: StripeAttestBackend
+
+    /// Initialize a new StripeAttest object.
+    @_spi(STP) public init(appAttestService: AppAttestService = AppleAppAttestService.shared, appAttestBackend: StripeAttestBackend = StripeAPIAttestationBackend(apiClient: STPAPIClient.shared)) {
+        self.appAttestService = appAttestService
+        self.appAttestBackend = appAttestBackend
+    }
+
+    // MARK: - Public functions
+
+    /// Sign an assertion using the current device key.
+    @_spi(STP) public func assert() async throws -> Assertion {
+        do {
+            let assertion = try await _assert()
+            let successAnalytic = GenericAnalytic(event: .assertionSucceeded, params: [:])
+            STPAnalyticsClient.sharedClient.log(analytic: successAnalytic)
+            return assertion
+        } catch {
+            let errorAnalytic = ErrorAnalytic(event: .assertionFailed, error: error)
+            STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
+            throw error
+        }
+    }
+
+    // MARK: Public structs
+
+    /// Contains the signed data and various information used to sign the request.
+    @_spi(STP) public struct Assertion {
+        /// The signed assertion data.
+        @_spi(STP) public var assertionData: Data
+        /// The `identifierForVendor` for the current app/device pair.
+        @_spi(STP) public var deviceID: String
+        /// The App ID (not fully qualified, it's missing the Team ID prefix)
+        @_spi(STP) public var appID: String
+        /// The key ID
+        @_spi(STP) public var keyID: String
+
+        /// A convenience function to return the fields used in an asserted request.
+        @_spi(STP) public var requestFields: [String: String] {
+            return [ "deviceId": deviceID,
+                     "appID": appID,
+                     "keyID": keyID,
+                     "assertionData": assertionData.base64EncodedString(), ]
+        }
+    }
+
+    @_spi(STP) public enum AttestationError: Error {
+        /// Attestation is not supported on this device.
+        case attestationNotSupported
+        /// Device ID is unavailable.
+        case noDeviceID
+        /// App ID is unavailable.
+        case noAppID
+        /// Retried assertion, but it failed.
+        case secondAssertionFailureAfterRetryingAttestation
+        /// Can't generate any more keys today.
+        case keygenRateLimitExceeded
+        /// The challenge couldn't be converted to UTF-8 data.
+        case invalidChallengeData
+    }
+
+    // MARK: - Device-local settings
+    private enum DefaultsKeys: String {
+        /// The ID of the attestation key stored in the keychain.
+        case keyID = "STPAttestKeyID"
+        /// The last date we generated an attestation key, used for rate limiting.
+        case lastGeneratedDate = "STPAttestKeyLastGenerated"
+        /// Whether the current keyID key has been attested successfully.
+        case successfullyAttested = "STPAttestKeySuccessfullyAttested"
+    }
+
+    private static var keyID: String? {
+        get {
+            UserDefaults.standard.string(forKey: DefaultsKeys.keyID.rawValue)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: DefaultsKeys.keyID.rawValue)
+        }
+    }
+
+    private static var successfullyAttested: Bool {
+        get {
+            UserDefaults.standard.bool(forKey: DefaultsKeys.successfullyAttested.rawValue)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: DefaultsKeys.successfullyAttested.rawValue)
+        }
+    }
+
+    private static var lastGeneratedDate: Date? {
+        get {
+            UserDefaults.standard.object(forKey: DefaultsKeys.lastGeneratedDate.rawValue) as? Date
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: DefaultsKeys.lastGeneratedDate.rawValue)
+        }
+    }
+
+    // MARK: - Internal
+
+    /// The minimum time between key generation attempts.
+    /// This is a safeguard against generating keys too often, as each key generation
+    /// permanently increases a counter for the device/app pair.
+    /// We expect each device/app pair to generate one key *ever*.
+    /// If this rate limit is being hit, something is wrong.
+    private static let minDurationBetweenKeyGenerationAttempts: TimeInterval = 60 * 60 * 24 // 24 hours
+
+    /// Attest the current device key. Only perform this once per device key.
+    /// You should not call this directly, it'll be called automatically during assert.
+    /// Returns nothing on success, throws on failure.
+    func attest() async throws {
+        do {
+            try await _attest()
+            let successAnalytic = GenericAnalytic(event: .attestationSucceeded, params: [:])
+            STPAnalyticsClient.sharedClient.log(analytic: successAnalytic)
+        } catch {
+            let errorAnalytic = ErrorAnalytic(event: .attestationFailed, error: error)
+            STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
+            throw error
+        }
+    }
+
+    func _assert() async throws -> Assertion {
+        let keyId = try await self.getOrCreateKeyID()
+
+        if !Self.successfullyAttested {
+            // We haven't attested yet, so do that first.
+            try await self.attest()
+        }
+
+        let challenge = try await getChallenge()
+
+        let deviceId = try getDeviceID()
+        let appId = try getAppID()
+
+        let assertion = try await generateAssertion(keyId: keyId, challenge: challenge)
+        return Assertion(assertionData: assertion, deviceID: deviceId, appID: appId, keyID: keyId)
+    }
+
+    func _attest() async throws {
+        let keyId = try await self.getOrCreateKeyID()
+        let challenge = try await getChallenge()
+        guard let challengeData = challenge.data(using: .utf8) else {
+            throw AttestationError.invalidChallengeData
+        }
+        let hash = Data(SHA256.hash(data: challengeData))
+
+        do {
+            let attestation = try await appAttestService.attestKey(keyId, clientDataHash: hash)
+            print(attestation)
+            guard let deviceId = await UIDevice.current.identifierForVendor?.uuidString,
+            let appId = Bundle.main.bundleIdentifier else {
+                // Error, could not get appID/deviceID
+                return
+            }
+            try await appAttestBackend.attest(appId: appId, deviceId: deviceId, keyId: keyId, attestation: attestation)
+        } catch {
+            // If error is DCErrorInvalidKey (3) and the domain is DCErrorDomain,
+            // we need to generate a new key as the key has already been attested or is otherwise corrupt.
+            let error = error as NSError
+            if error.domain == DCErrorDomain && error.code == DCError.invalidKey.rawValue {
+                resetKey()
+            }
+            // For other errors, just report them as an analytic and throw. We'll want to retry attestation with the same key.
+            throw error
+        }
+        // Store the successful attestation
+        Self.successfullyAttested = true
+    }
+
+    /// Returns the device's current key ID, creating one if needed.
+    /// Throw an error if the device doesn't support attestation, or if key generation fails.
+    private func getOrCreateKeyID() async throws -> String {
+        guard appAttestService.isSupported else {
+            throw AttestationError.attestationNotSupported
+        }
+        if let keyId = Self.keyID {
+            return keyId
+        }
+        // If we don't have a key, generate one.
+        return try await self.createKeyIfAllowed()
+    }
+
+    @_spi(STP) public func resetKey() {
+        Self.keyID = nil
+        Self.successfullyAttested = false
+    }
+
+    private func createKeyIfAllowed() async throws -> String {
+        // Perform key generation and attestation.
+        // It's dangerous to call this, as it increments a permanent counter for the device.
+        // First, make sure we the last time we called this is more than 24 hours away from now.
+        // (Either in the future or the past, who knows what people are doing with their clocks)
+        if let lastGenerated = StripeAttest.lastGeneratedDate, abs(lastGenerated.timeIntervalSinceNow) < Self.minDurationBetweenKeyGenerationAttempts {
+            throw AttestationError.keygenRateLimitExceeded
+        }
+        let keyId = try await appAttestService.generateKey()
+        // Save the last time we generated a key, the Key ID, and that the key is not attested.
+        Self.lastGeneratedDate = Date()
+        Self.keyID = keyId
+        Self.successfullyAttested = false
+        return keyId
+    }
+
+    func getAppID() throws -> String {
+        if let appID = Bundle.main.bundleIdentifier {
+            return appID
+        }
+        throw AttestationError.noAppID
+    }
+
+    func getDeviceID() throws -> String {
+        if let deviceID = UIDevice.current.identifierForVendor?.uuidString {
+            return deviceID
+        }
+        throw AttestationError.noDeviceID
+    }
+
+    /// Get a challenge from the backend.
+    func getChallenge() async throws -> String {
+        let keyID = try await self.getOrCreateKeyID()
+        return try await appAttestBackend.getChallenge(appId: getAppID(), deviceId: getDeviceID(), keyId: keyID)
+    }
+
+    /// Generate the assertion data from a key and challenge.
+    private func generateAssertion(keyId: String, challenge: String, retryIfNeeded: Bool = true) async throws -> Data {
+        // We're just signing the challenge for now.
+        // The expected format is the SHA256 hash of the JSON-encoded dictionary.
+        let assertionDictionary = [ "challenge": challenge ]
+        let assertionData = try JSONSerialization.data(withJSONObject: assertionDictionary,
+                                                       // Sort our keys: It's important that the JSON is
+                                                       // the same on the backend and frontend!
+                                                       options: [.sortedKeys])
+        let assertionDataHash = Data(SHA256.hash(data: assertionData))
+        do {
+            return try await appAttestService.generateAssertion(keyId, clientDataHash: assertionDataHash)
+        } catch {
+            // If error is DCErrorInvalidKey (3) and the domain is DCErrorDomain,
+            // then the key is either unattested or corrupted.
+            let error = error as NSError
+            if error.domain == DCErrorDomain && error.code == DCError.invalidKey.rawValue {
+                // We'll try to attest again, maybe our initial attestation was unsuccessful?
+                // `DCError.invalidKey` could mean a lot of things, unfortunately.
+                // If this doesn't work, then in `attest()` we'll deem the key to be corrupted
+                // and throw it out.
+                try await attest()
+                // Once we've successfully re-attested, we'll try one more time to do the assertion.
+                if retryIfNeeded {
+                    return try await generateAssertion(keyId: keyId, challenge: challenge, retryIfNeeded: false)
+                } else {
+                    // If it *still* fails, something is super broken.
+                    // Give up for now, we'll try again tomorrow.
+                    throw AttestationError.secondAssertionFailureAfterRetryingAttestation
+                }
+            }
+            // For other errors, we'll want to retry attestation later with the same key.
+            throw error
+        }
+    }
+}

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -160,7 +160,7 @@ import UIKit
 
     func _attest() async throws {
         // It's dangerous to attest, as it increments a permanent counter for the device.
-        // First, make sure we the last time we called this is more than 24 hours away from now.
+        // First, make sure the last time we called this is more than 24 hours away from now.
         // (Either in the future or the past, who knows what people are doing with their clocks)
         if let lastGenerated = StripeAttest.lastAttestedDate, abs(lastGenerated.timeIntervalSinceNow) < Self.minDurationBetweenKeyGenerationAttempts {
             throw AttestationError.attestationRateLimitExceeded

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -61,8 +61,8 @@ import UIKit
         case noAppID
         /// Retried assertion, but it failed.
         case secondAssertionFailureAfterRetryingAttestation
-        /// Can't generate any more keys today.
-        case keygenRateLimitExceeded
+        /// Can't attest any more keys today.
+        case attestationRateLimitExceeded
         /// The challenge couldn't be converted to UTF-8 data.
         case invalidChallengeData
     }
@@ -163,7 +163,7 @@ import UIKit
         // First, make sure we the last time we called this is more than 24 hours away from now.
         // (Either in the future or the past, who knows what people are doing with their clocks)
         if let lastGenerated = StripeAttest.lastAttestedDate, abs(lastGenerated.timeIntervalSinceNow) < Self.minDurationBetweenKeyGenerationAttempts {
-            throw AttestationError.keygenRateLimitExceeded
+            throw AttestationError.attestationRateLimitExceeded
         }
 
         let keyId = try await self.getOrCreateKeyID()

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -241,7 +241,7 @@ import UIKit
     }
 
     /// Generate the assertion data from a key and challenge.
-    private func generateAssertion(keyId: String, challenge: String, retryIfNeeded: Bool = true) async throws -> Data {
+    private func generateAssertion(keyId: String, challenge: String, retryAfterReattestingIfNeeded: Bool = true) async throws -> Data {
         // We're just signing the challenge for now.
         // The expected format is the SHA256 hash of the JSON-encoded dictionary.
         let assertionDictionary = [ "challenge": challenge ]
@@ -257,14 +257,14 @@ import UIKit
             // then the key is either unattested or corrupted.
             let error = error as NSError
             if error.domain == DCErrorDomain && error.code == DCError.invalidKey.rawValue {
-                if retryIfNeeded {
+                if retryAfterReattestingIfNeeded {
                     // We'll try to attest again, maybe our initial attestation was unsuccessful?
                     // `DCError.invalidKey` could mean a lot of things, unfortunately.
                     // If this doesn't work, then in `attest()` we'll deem the key to be corrupted
                     // and throw it out.
                     try await attest()
                     // Once we've successfully re-attested, we'll try one more time to do the assertion.
-                    return try await generateAssertion(keyId: keyId, challenge: challenge, retryIfNeeded: false)
+                    return try await generateAssertion(keyId: keyId, challenge: challenge, retryAfterReattestingIfNeeded: false)
                 } else {
                     // If it *still* fails, something is super broken.
                     // Give up for now, we'll try again tomorrow.

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -172,6 +172,8 @@ import UIKit
         do {
             let attestation = try await appAttestService.attestKey(keyId, clientDataHash: hash)
             try await appAttestBackend.attest(appId: appId, deviceId: deviceId, keyId: keyId, attestation: attestation)
+            // Store the successful attestation
+            Self.successfullyAttested = true
         } catch {
             // If error is DCErrorInvalidKey (3) and the domain is DCErrorDomain,
             // we need to generate a new key as the key has already been attested or is otherwise corrupt.
@@ -182,8 +184,6 @@ import UIKit
             // For other errors, just report them as an analytic and throw. We'll want to retry attestation with the same key.
             throw error
         }
-        // Store the successful attestation
-        Self.successfullyAttested = true
     }
 
     /// Returns the device's current key ID, creating one if needed.

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -166,13 +166,11 @@ import UIKit
         }
         let hash = Data(SHA256.hash(data: challengeData))
 
+        let deviceId = try getDeviceID()
+        let appId = try getAppID()
+
         do {
             let attestation = try await appAttestService.attestKey(keyId, clientDataHash: hash)
-            guard let deviceId = await UIDevice.current.identifierForVendor?.uuidString,
-            let appId = Bundle.main.bundleIdentifier else {
-                // Error, could not get appID/deviceID
-                return
-            }
             try await appAttestBackend.attest(appId: appId, deviceId: deviceId, keyId: keyId, attestation: attestation)
         } catch {
             // If error is DCErrorInvalidKey (3) and the domain is DCErrorDomain,

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -2,8 +2,6 @@
 //  StripeAttest.swift
 //  StripeCore
 //
-//  Created by David Estes on 7/29/24.
-//
 
 import CryptoKit
 import DeviceCheck
@@ -24,7 +22,8 @@ import UIKit
 
     // MARK: - Public functions
 
-    /// Sign an assertion using the current device key.
+    /// Sign an assertion.
+    /// Will create and attest a new device key if needed.
     @_spi(STP) public func assert() async throws -> Assertion {
         do {
             let assertion = try await _assert()

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttestBackend.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttestBackend.swift
@@ -1,0 +1,28 @@
+//
+//  StripeAttestBackend.swift
+//  StripeCore
+//
+
+import Foundation
+
+@_spi(STP) public protocol StripeAttestBackend {
+    func getChallenge(appId: String, deviceId: String, keyId: String) async throws -> String
+    func attest(appId: String, deviceId: String, keyId: String, attestation: Data) async throws
+}
+
+@_spi(STP) public class StripeAPIAttestationBackend: StripeAttestBackend {
+    let apiClient: STPAPIClient
+
+    @_spi(STP) public init(apiClient: STPAPIClient) {
+        self.apiClient = apiClient
+    }
+
+    public func attest(appId: String, deviceId: String, keyId: String, attestation: Data) async throws {
+        stpAssertionFailure("Not implemented")
+    }
+
+    public func getChallenge(appId: String, deviceId: String, keyId: String) async throws -> String {
+        stpAssertionFailure("Not implemented")
+        return ""
+    }
+}

--- a/StripeCore/StripeCoreTests/Attestation/MockAppAttestService.swift
+++ b/StripeCore/StripeCoreTests/Attestation/MockAppAttestService.swift
@@ -1,0 +1,133 @@
+//
+//  MockAppAttestService.swift
+//  StripeCore
+//
+//  Created by David Estes on 12/2/24.
+//
+
+import CryptoKit
+import DeviceCheck
+@_spi(STP) import StripeCore
+import UIKit
+
+class MockAppAttestService: AppAttestService {
+    @_spi(STP) public static var shared = MockAppAttestService()
+
+    @_spi(STP) public var isSupported: Bool {
+        if #available(iOS 14.0, *) {
+            return true
+        } else {
+            return false
+        }
+    }
+
+    var shouldFailKeygenWithError: Error?
+    var shouldFailAssertionWithError: Error?
+    var shouldFailAttestationWithError: Error?
+
+    var keys: [String: FakeKey] = [:]
+
+    struct FakeKey: Codable {
+        var id: String = UUID().uuidString
+        var counter: Int = 0
+    }
+
+    @_spi(STP) public func generateKey() async throws -> String {
+        if let error = shouldFailKeygenWithError {
+            throw error
+        }
+        let key = FakeKey()
+        keys[key.id] = key
+        return key.id
+    }
+
+    @_spi(STP) public func generateAssertion(_ keyId: String, clientDataHash: Data) async throws -> Data {
+        guard var key = keys[keyId] else {
+            // Throw the same error that the real service would throw
+            throw NSError(domain: DCErrorDomain, code: DCError.invalidKey.rawValue, userInfo: nil)
+        }
+        if let error = shouldFailAssertionWithError {
+            throw error
+        }
+        key.counter += 1
+        keys[key.id] = key
+        // Our fake assertion is the keyID glommed onto the clientDataHash
+        return key.id.data(using: .utf8)! + clientDataHash
+    }
+
+    @_spi(STP) public func attestKey(_ keyId: String, clientDataHash: Data) async throws -> Data {
+        guard var key = keys[keyId] else {
+            // Throw the same error that the real service would throw
+            throw NSError(domain: DCErrorDomain, code: DCError.invalidKey.rawValue, userInfo: nil)
+        }
+        if let error = shouldFailAttestationWithError {
+            throw error
+        }
+        key.counter += 1
+        keys[key.id] = key
+        // Generate a fake attestion
+        let attestation = ["keyID": key.id, "counter": key.counter, "clientDataHash": clientDataHash.base64EncodedString()] as [String: Any]
+        return try JSONSerialization.data(withJSONObject: attestation)
+    }
+
+}
+
+@_spi(STP) public class MockAttestBackend: StripeAttestBackend {
+    var storedChallenge: String?
+
+    public func attest(appId: String, deviceId: String, keyId: String, attestation: Data) async throws {
+        // Decode the attestation data (it's a JSON dictionary)
+        let attestationDict = try JSONSerialization.jsonObject(with: attestation) as! [String: Any]
+
+        // Confirm the challenge exists in our challenge list
+        guard let challenge = storedChallenge else {
+            // No challenge available, throw an error
+            throw NSError(domain: "com.stripe.internal-error", code: 403, userInfo: ["error": "No challenge available"])
+        }
+
+        // Confirm the Key ID is correct
+        let hash = Data(SHA256.hash(data: challenge.data(using: .utf8)!)).base64EncodedString()
+        guard hash == attestationDict["clientDataHash"] as? String else {
+            // Hash is incorrect, throw an error
+            throw NSError(domain: "com.stripe.internal-error", code: 403, userInfo: ["error": "Incorrect hash"])
+        }
+
+        // Remove the challenge
+        storedChallenge = nil
+    }
+
+    public func assertionTest(assertion: StripeAttest.Assertion) async throws {
+        guard let challenge = storedChallenge else {
+            // No challenge available, throw an error
+            throw NSError(domain: "com.stripe.internal-error", code: 403, userInfo: ["error": "No challenge available"])
+        }
+
+        let request = assertion.requestFields
+        let requestFieldsToHash = [ "challenge": challenge ]
+        let clientDataToHash = try JSONSerialization.data(withJSONObject: requestFieldsToHash)
+        print(String(data: clientDataToHash, encoding: .utf8)!)
+        let clientDataHash = Data(SHA256.hash(data: clientDataToHash))
+
+        // Our fake assertion is the keyID glommed onto the clientDataHash
+        let expectedAssertionData = assertion.keyID.data(using: .utf8)! + clientDataHash
+        guard expectedAssertionData == assertion.assertionData else {
+            throw NSError(domain: "com.stripe.internal-error", code: 403, userInfo: ["error": "Assertion data does not match expected data"])
+        }
+        // Clean up the challenge
+        storedChallenge = nil
+    }
+
+    public func getChallenge(appId: String, deviceId: String, keyId: String) async throws -> String {
+        // Confirm the AppID and DeviceID are correct
+        let currentDeviceId = await UIDevice.current.identifierForVendor!.uuidString
+
+        guard appId == Bundle.main.bundleIdentifier && deviceId == currentDeviceId else {
+            throw NSError(domain: "com.stripe.internal-error", code: 403, userInfo: ["error": "Device ID or Bundle ID incorrect"])
+        }
+
+        // Generate a random challenge:
+        let challenge = UUID().uuidString.data(using: .utf8)!.base64EncodedString()
+        storedChallenge = challenge
+        return challenge
+    }
+}

--- a/StripeCore/StripeCoreTests/Attestation/MockAppAttestService.swift
+++ b/StripeCore/StripeCoreTests/Attestation/MockAppAttestService.swift
@@ -102,7 +102,6 @@ class MockAppAttestService: AppAttestService {
             throw NSError(domain: "com.stripe.internal-error", code: 403, userInfo: ["error": "No challenge available"])
         }
 
-        let request = assertion.requestFields
         let requestFieldsToHash = [ "challenge": challenge ]
         let clientDataToHash = try JSONSerialization.data(withJSONObject: requestFieldsToHash)
         print(String(data: clientDataToHash, encoding: .utf8)!)

--- a/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
+++ b/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
@@ -15,7 +15,7 @@ class StripeAttestTest: XCTestCase {
     override func setUp() {
         self.mockAttestBackend = MockAttestBackend()
         self.mockAttestService = MockAppAttestService()
-        self.stripeAttest = StripeAttest(appAttestService: mockAttestService, appAttestBackend: mockAttestBackend)
+        self.stripeAttest = StripeAttest(appAttestService: mockAttestService, appAttestBackend: mockAttestBackend, apiClient: .shared)
 
         // Reset storage
         UserDefaults.standard.removeObject(forKey: "STPAttestKeyLastGenerated")

--- a/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
+++ b/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
@@ -44,7 +44,7 @@ class StripeAttestTest: XCTestCase {
             XCTFail("Should not succeed")
         } catch {
             // Should get a rate limiting error when we try to generate the second key:
-            XCTAssertEqual(error as! StripeAttest.AttestationError, StripeAttest.AttestationError.keygenRateLimitExceeded)
+            XCTAssertEqual(error as! StripeAttest.AttestationError, StripeAttest.AttestationError.attestationRateLimitExceeded)
         }
     }
 

--- a/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
+++ b/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
@@ -1,0 +1,79 @@
+//
+//  StripeAttestTest.swift
+//  StripeCore
+//
+
+import DeviceCheck
+@testable @_spi(STP) import StripeCore
+import XCTest
+
+class StripeAttestTest: XCTestCase {
+    var mockAttestService: MockAppAttestService!
+    var mockAttestBackend: MockAttestBackend!
+    var stripeAttest: StripeAttest!
+
+    override func setUp() {
+        self.mockAttestBackend = MockAttestBackend()
+        self.mockAttestService = MockAppAttestService()
+        self.stripeAttest = StripeAttest(appAttestService: mockAttestService, appAttestBackend: mockAttestBackend)
+
+        // Reset storage
+        UserDefaults.standard.removeObject(forKey: "STPAttestKeyLastGenerated")
+        stripeAttest.resetKey()
+    }
+
+    func testAppAttestService() async {
+        try! await stripeAttest.attest()
+        let assertionResponse = try! await stripeAttest.assert()
+        try! await self.mockAttestBackend.assertionTest(assertion: assertionResponse)
+    }
+
+    func testCanAssertWithoutAttestation() async {
+        let assertionResponse = try! await stripeAttest.assert()
+        try! await self.mockAttestBackend.assertionTest(assertion: assertionResponse)
+    }
+
+    func testCanOnlyGenerateOncePerDay() async {
+        // Create and attest a key
+        try! await stripeAttest.attest()
+        let invalidKeyError = NSError(domain: DCErrorDomain, code: DCError.invalidKey.rawValue, userInfo: nil)
+        // But fail the assertion, causing the key to be reset, and have the second attestation fail too:
+        mockAttestService.shouldFailAssertionWithError = invalidKeyError
+        mockAttestService.shouldFailAttestationWithError = invalidKeyError
+        do {
+            _ = try await stripeAttest.assert()
+            XCTFail("Should not succeed")
+        } catch {
+            XCTAssertEqual(error as NSError, invalidKeyError)
+        }
+
+        // Fix the errors:
+        mockAttestService.shouldFailAssertionWithError = nil
+        mockAttestService.shouldFailAttestationWithError = nil
+        // Now try again:
+        do {
+            try await stripeAttest.attest()
+            XCTFail("Should not succeed")
+        } catch {
+            // Should get a rate limiting error
+            XCTAssertEqual(error as! StripeAttest.AttestationError, StripeAttest.AttestationError.keygenRateLimitExceeded)
+        }
+    }
+
+    func testAssertionGivesUpAfterMultipleTries() async {
+        do {
+            // Create and attest a key
+            try! await stripeAttest.attest()
+            // But it's an old key, so we'll be allowed to generate a new one
+            UserDefaults.standard.set(Date.distantPast, forKey: "STPAttestKeyLastGenerated")
+            // Always fail the assertions:
+            let invalidKeyError = NSError(domain: DCErrorDomain, code: DCError.invalidKey.rawValue, userInfo: nil)
+            mockAttestService.shouldFailAssertionWithError = invalidKeyError
+
+            _ = try await stripeAttest.assert()
+            XCTFail("Should not succeed")
+        } catch {
+            XCTAssertEqual(error as! StripeAttest.AttestationError, StripeAttest.AttestationError.secondAssertionFailureAfterRetryingAttestation)
+        }
+    }
+}

--- a/modules.yaml
+++ b/modules.yaml
@@ -155,8 +155,8 @@ modules:
     output: docs/stripeapplepay
     readme: StripeApplePay/README.md
   size_report:
-    max_compressed_size: 500
-    max_uncompressed_size: 1200
+    max_compressed_size: 700
+    max_uncompressed_size: 1700
     max_incremental_uncompressed_size: 100
 
 - podspec: StripeCardScan.podspec


### PR DESCRIPTION
## Summary
Adds StripeAttest, a class for implementing basic App Attestation against the Stripe API.

## Motivation
Enabling basic App Attestation support in the SDK.

## Testing
Added unit tests and additional tests for a few edge cases.

## Changelog
Not user-visible.