### PR TITLE
Add clear payment option API

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/EmbeddedPlaygroundViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EmbeddedPlaygroundViewController.swift
@@ -58,14 +58,14 @@ class EmbeddedPlaygroundViewController: UIViewController {
         return checkoutButton
     }()
     
-    private lazy var clearSelectionButton: UIButton = {
+    private lazy var clearPaymentOptionButton: UIButton = {
         let resetButton = UIButton(type: .system)
         resetButton.backgroundColor = .systemGray5
         resetButton.layer.cornerRadius = 5.0
         resetButton.clipsToBounds = true
-        resetButton.setTitle("Clear selection", for: .normal)
+        resetButton.setTitle("Clear payment option", for: .normal)
         resetButton.setTitleColor(.label, for: .normal)
-        resetButton.accessibilityIdentifier = "Clear selection"
+        resetButton.accessibilityIdentifier = "Clear payment option"
         resetButton.translatesAutoresizingMaskIntoConstraints = false
         resetButton.addTarget(self, action: #selector(clearSelection), for: .touchUpInside)
         return resetButton
@@ -143,7 +143,7 @@ class EmbeddedPlaygroundViewController: UIViewController {
             embeddedPaymentElement.view,
             paymentOptionView,
             checkoutButton,
-            clearSelectionButton
+            clearPaymentOptionButton
         ])
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
@@ -164,7 +164,7 @@ class EmbeddedPlaygroundViewController: UIViewController {
             scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
             scrollView.contentLayoutGuide.widthAnchor.constraint(equalTo: view.widthAnchor),
             checkoutButton.heightAnchor.constraint(equalToConstant: 45),
-            clearSelectionButton.heightAnchor.constraint(equalToConstant: 45)
+            clearPaymentOptionButton.heightAnchor.constraint(equalToConstant: 45)
         ])
         paymentOptionView.configure(with: embeddedPaymentElement.paymentOption, showMandate: !configuration.embeddedViewDisplaysMandateText)
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/EmbeddedPlaygroundViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EmbeddedPlaygroundViewController.swift
@@ -229,7 +229,7 @@ class EmbeddedPlaygroundViewController: UIViewController {
     }
 
     @objc func clearSelection() {
-        embeddedPaymentElement?.clearCurrentSelection()
+        embeddedPaymentElement?.clearPaymentOption()
     }
 
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/EmbeddedPlaygroundViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/EmbeddedPlaygroundViewController.swift
@@ -57,6 +57,19 @@ class EmbeddedPlaygroundViewController: UIViewController {
         checkoutButton.addTarget(self, action: #selector(pay), for: .touchUpInside)
         return checkoutButton
     }()
+    
+    private lazy var clearSelectionButton: UIButton = {
+        let resetButton = UIButton(type: .system)
+        resetButton.backgroundColor = .systemGray5
+        resetButton.layer.cornerRadius = 5.0
+        resetButton.clipsToBounds = true
+        resetButton.setTitle("Clear selection", for: .normal)
+        resetButton.setTitleColor(.label, for: .normal)
+        resetButton.accessibilityIdentifier = "Clear selection"
+        resetButton.translatesAutoresizingMaskIntoConstraints = false
+        resetButton.addTarget(self, action: #selector(clearSelection), for: .touchUpInside)
+        return resetButton
+    }()
 
     private let settingsViewContainer = UIStackView()
 
@@ -125,7 +138,13 @@ class EmbeddedPlaygroundViewController: UIViewController {
         view.addSubview(scrollView)
 
         // All our content is in a stack view
-        let stackView = UIStackView(arrangedSubviews: [settingsViewContainer, embeddedPaymentElement.view, paymentOptionView, checkoutButton])
+        let stackView = UIStackView(arrangedSubviews: [
+            settingsViewContainer,
+            embeddedPaymentElement.view,
+            paymentOptionView,
+            checkoutButton,
+            clearSelectionButton
+        ])
         stackView.axis = .vertical
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.isLayoutMarginsRelativeArrangement = true
@@ -145,6 +164,7 @@ class EmbeddedPlaygroundViewController: UIViewController {
             scrollView.contentLayoutGuide.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
             scrollView.contentLayoutGuide.widthAnchor.constraint(equalTo: view.widthAnchor),
             checkoutButton.heightAnchor.constraint(equalToConstant: 45),
+            clearSelectionButton.heightAnchor.constraint(equalToConstant: 45)
         ])
         paymentOptionView.configure(with: embeddedPaymentElement.paymentOption, showMandate: !configuration.embeddedViewDisplaysMandateText)
     }
@@ -206,6 +226,10 @@ class EmbeddedPlaygroundViewController: UIViewController {
                 break
             }
         }
+    }
+
+    @objc func clearSelection() {
+        embeddedPaymentElement?.clearCurrentSelection()
     }
 
 }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -948,6 +948,50 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Submit"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
+    
+    func testClearCurrentSelection() {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .returning
+        settings.mode = .payment
+        settings.integrationType = .deferred_csc
+        settings.uiStyle = .embedded
+        settings.formSheetAction = .continue
+
+        loadPlayground(app, settings)
+        app.buttons["Present embedded payment element"].waitForExistenceAndTap()
+
+        // As a returning customer, a saved payment method should be automatically selected.
+        // Verify that a payment method (e.g. "•••• 4242") is displayed right away.
+        let paymentMethodLabel = app.staticTexts["Payment method"]
+        XCTAssertTrue(paymentMethodLabel.waitForExistence(timeout: 10))
+        let initiallySelectedPM = paymentMethodLabel.label
+        XCTAssertTrue(initiallySelectedPM.contains("••••"), "Expected a saved card to be selected, but got: \(initiallySelectedPM)")
+
+        // Clear the selection
+        let clearButton = app.buttons["Clear selection"]
+        XCTAssertTrue(clearButton.waitForExistence(timeout: 10))
+        clearButton.tap()
+
+        // After clearing, there should be no "Payment method" label.
+        XCTAssertFalse(paymentMethodLabel.exists)
+
+        // Now select a different payment method, "Cash App Pay"
+        let cashAppPayButton = app.buttons["Cash App Pay"]
+        XCTAssertTrue(cashAppPayButton.waitForExistence(timeout: 10))
+        cashAppPayButton.tap()
+
+        // Verify that "Cash App Pay" is now selected and displayed
+        XCTAssertTrue(paymentMethodLabel.waitForExistence(timeout: 10))
+        XCTAssertEqual(paymentMethodLabel.label, "Cash App Pay")
+        XCTAssertTrue(cashAppPayButton.isSelected)
+        
+        // Clear selection again
+        clearButton.tap()
+
+        // Verify that no payment method is selected after the second reset
+        XCTAssertFalse(paymentMethodLabel.exists)
+        XCTAssertFalse(cashAppPayButton.isSelected)
+    }
 
     func dismissAlertView(alertBody: String, alertTitle: String, buttonToTap: String) {
         let alertText = app.staticTexts[alertBody]

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -949,7 +949,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
     
-    func testClearCurrentSelection() {
+    func testClearPaymentOption() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .returning
         settings.mode = .payment

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -968,7 +968,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(initiallySelectedPM.contains("••••"), "Expected a saved card to be selected, but got: \(initiallySelectedPM)")
 
         // Clear the selection
-        let clearButton = app.buttons["Clear selection"]
+        let clearButton = app.buttons["Clear payment option"]
         XCTAssertTrue(clearButton.waitForExistence(timeout: 10))
         clearButton.tap()
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -191,7 +191,7 @@ public final class EmbeddedPaymentElement {
     }
     
     /// Sets the currently selected payment option to `nil`.
-    public func clearCurrentSelection() {
+    public func clearPaymentOption() {
         // Early exit for a nil payment option, don't notify delegate since no change in payment option can occur
         guard paymentOption != nil else { return }
         

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -189,6 +189,24 @@ public final class EmbeddedPaymentElement {
     public func confirm() async -> EmbeddedPaymentElementResult {        
         return await _confirm().result
     }
+    
+    /// Sets the currently selected payment option to `nil`.
+    public func clearCurrentSelection() {
+        // Early exit for a nil payment option, don't notify delegate since no change in payment option can occur
+        guard paymentOption != nil else { return }
+        
+        // Clear out the form controller to clear any payment option
+        formViewController = nil
+        
+        // Reset the selection on the `embeddedPaymentMethodsView`
+        embeddedPaymentMethodsView.resetSelection()
+        
+        // Clear the testable payment option (only populated during unit testing)
+        _test_paymentOption = nil
+        
+        // Notify the delegate that the payment option has changed
+        delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: self)
+    }
 
     // MARK: - Internal
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -221,6 +221,10 @@ class EmbeddedPaymentMethodsView: UIView {
     func resetSelectionToLastSelection() {
         self.selection = previousSelection
     }
+    
+    func resetSelection() {
+        selection = nil
+    }
 
     // MARK: Tap handling
     func didTap(selection: Selection) {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -274,6 +274,59 @@ class EmbeddedPaymentElementTest: XCTestCase {
             XCTFail("Expected confirm to fail, but it was canceled")
         }
     }
+    
+    func testClearCurrentSelectionAfterSelection() async throws {
+        // Given a EmbeddedPaymentElement instance...
+        let sut = try await EmbeddedPaymentElement.create(intentConfiguration: paymentIntentConfig, configuration: configuration)
+        sut.delegate = self
+        sut.presentingViewController = UIViewController()
+        sut.view.autosizeHeight(width: 320)
+
+        // Initially, no paymentOption should be selected
+        XCTAssertNil(sut.paymentOption)
+
+        // Select the "Card" payment method
+        sut.embeddedPaymentMethodsView.didTap(selection: .new(paymentMethodType: .stripe(.cashApp)))
+        // The delegate should have been notified
+        XCTAssertTrue(delegateDidUpdatePaymentOptionCalled)
+        XCTAssertNotNil(sut.paymentOption)
+
+        // Reset flags
+        delegateDidUpdatePaymentOptionCalled = false
+        delegateDidUpdateHeightCalled = false
+
+        // Reset the selection
+        sut.clearCurrentSelection()
+
+        // The paymentOption should now be nil after reset
+        XCTAssertNil(sut.paymentOption)
+
+        // The delegate should have been notified again after reset
+        XCTAssertTrue(delegateDidUpdatePaymentOptionCalled)
+    }
+
+    func testClearCurrentSelectionWhenNoSelection() async throws {
+        // Given a EmbeddedPaymentElement instance...
+        let sut = try await EmbeddedPaymentElement.create(intentConfiguration: paymentIntentConfig, configuration: configuration)
+        sut.delegate = self
+        sut.presentingViewController = UIViewController()
+        sut.view.autosizeHeight(width: 320)
+
+        // Initially, no paymentOption should be selected
+        XCTAssertNil(sut.paymentOption)
+
+        // Reset flags
+        delegateDidUpdatePaymentOptionCalled = false
+        delegateDidUpdateHeightCalled = false
+
+        // Call reset when no selection is made
+        sut.clearCurrentSelection()
+
+        // Confirm that paymentOption is still nil and no delegate calls were made
+        XCTAssertNil(sut.paymentOption)
+        XCTAssertFalse(delegateDidUpdatePaymentOptionCalled)
+        XCTAssertFalse(delegateDidUpdateHeightCalled)
+    }
 }
 
 extension EmbeddedPaymentElementTest: EmbeddedPaymentElementDelegate {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -275,7 +275,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
         }
     }
     
-    func testClearCurrentSelectionAfterSelection() async throws {
+    func testClearPaymentOptionAfterSelection() async throws {
         // Given a EmbeddedPaymentElement instance...
         let sut = try await EmbeddedPaymentElement.create(intentConfiguration: paymentIntentConfig, configuration: configuration)
         sut.delegate = self
@@ -296,7 +296,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
         delegateDidUpdateHeightCalled = false
 
         // Reset the selection
-        sut.clearCurrentSelection()
+        sut.clearPaymentOption()
 
         // The paymentOption should now be nil after reset
         XCTAssertNil(sut.paymentOption)
@@ -305,7 +305,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
         XCTAssertTrue(delegateDidUpdatePaymentOptionCalled)
     }
 
-    func testClearCurrentSelectionWhenNoSelection() async throws {
+    func testClearPaymentOptionWhenNoSelection() async throws {
         // Given a EmbeddedPaymentElement instance...
         let sut = try await EmbeddedPaymentElement.create(intentConfiguration: paymentIntentConfig, configuration: configuration)
         sut.delegate = self
@@ -320,7 +320,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
         delegateDidUpdateHeightCalled = false
 
         // Call reset when no selection is made
-        sut.clearCurrentSelection()
+        sut.clearPaymentOption()
 
         // Confirm that paymentOption is still nil and no delegate calls were made
         XCTAssertNil(sut.paymentOption)


### PR DESCRIPTION
## Summary
- Adds a clearPaymentOption API to embedded. This resets the current payment option to nil.
- API review has been updated.
- Updates playground to allow clearing the payment option

## Motivation
- https://stripe.slack.com/archives/C058XM768SE/p1733429552581069

## Testing
- Manual
- New UI tests
- New unit tests

## Changelog
N/A