### PR TITLE
Disable embedded after a successful confirmation

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -318,6 +318,9 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
 extension EmbeddedPaymentElement {
 
     func _confirm() async -> (result: PaymentSheetResult, deferredIntentConfirmationType: STPAnalyticsClient.DeferredIntentConfirmationType?) {
+        guard !hasConfirmedIntent else {
+            return (.failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent), STPAnalyticsClient.DeferredIntentConfirmationType.none)
+        }
         // Wait for the last update to finish and fail if didn't succeed. A failure means the view is out of sync with the intent and could e.g. not be showing a required mandate.
         if let latestUpdateTask {
             switch await latestUpdateTask.value {
@@ -377,6 +380,13 @@ extension EmbeddedPaymentElement {
         analyticsHelper.logPayment(paymentOption: paymentOption,
                                    result: result,
                                    deferredIntentConfirmationType: deferredIntentConfirmationType)
+        
+        // If the confirmation was successful, disable user interaction
+        if case .completed = result {
+            hasConfirmedIntent = true
+            containerView.isUserInteractionEnabled = false
+        }
+        
         return (result, deferredIntentConfirmationType)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -104,6 +104,11 @@ public final class EmbeddedPaymentElement {
     public func update(
         intentConfiguration: IntentConfiguration
     ) async -> UpdateResult {
+        // Do not process any update calls if we have already successfully confirmed an intent
+        guard !hasConfirmedIntent else {
+            return .failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent)
+        }
+        
         embeddedPaymentMethodsView.isUserInteractionEnabled = false
         // Cancel the old task and let it finish so that merchants receive update results in order
         latestUpdateTask?.cancel()
@@ -192,6 +197,9 @@ public final class EmbeddedPaymentElement {
     
     /// Sets the currently selected payment option to `nil`.
     public func clearPaymentOption() {
+        // If a payment has been successfully completed, we don't allow clearing the payment option.
+        guard !hasConfirmedIntent else { return }
+        
         // Early exit for a nil payment option, don't notify delegate since no change in payment option can occur
         guard paymentOption != nil else { return }
         
@@ -219,6 +227,8 @@ public final class EmbeddedPaymentElement {
     internal var savedPaymentMethods: [STPPaymentMethod]
     internal private(set) var formCache: PaymentMethodFormCache = .init()
     internal var formViewController: EmbeddedFormViewController?
+    /// Indicates if a payment has been successfully completed.
+    internal var hasConfirmedIntent = false
 #if DEBUG
     internal var _test_paymentOption: PaymentOption? // for testing only
 #endif

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -56,6 +56,7 @@ public enum PaymentSheetError: Error, LocalizedError {
 
     // MARK: - Confirmation errors
     case unexpectedNewPaymentMethod
+    case embeddedPaymentElementAlreadyConfirmedIntent
 
     public var errorDescription: String? {
         return NSError.stp_unexpectedErrorMessage()
@@ -126,6 +127,8 @@ extension PaymentSheetError: CustomDebugStringConvertible {
                 return "New payment method should not have been created yet"
             case .intentConfigurationValidationFailed(message: let message):
                 return message
+            case .embeddedPaymentElementAlreadyConfirmedIntent:
+                return "This instance of EmbeddedPaymentElement has already confirmed an intent successfully. Create a new instance of EmbeddedPaymentElement to confirm a new intent."
             }
         }()
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -446,7 +446,7 @@ extension EmbeddedPaymentMethodsView {
     }
 }
 
-extension PaymentSheetResult: @retroactive Equatable {
+extension PaymentSheetResult: Equatable {
     public static func == (lhs: StripePaymentSheet.PaymentSheetResult, rhs: StripePaymentSheet.PaymentSheetResult) -> Bool {
         switch (lhs, rhs) {
         case (.completed, .completed): return true

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -327,6 +327,92 @@ class EmbeddedPaymentElementTest: XCTestCase {
         XCTAssertFalse(delegateDidUpdatePaymentOptionCalled)
         XCTAssertFalse(delegateDidUpdateHeightCalled)
     }
+    
+    func testConfirmThenUpdateFails() async throws {
+        // Given an EmbeddedPaymentElement that can confirm
+        let sut = try await EmbeddedPaymentElement.create(intentConfiguration: paymentIntentConfigWithConfirmHandler, configuration: configuration)
+        sut.presentingViewController = UIViewController()
+        sut.view.autosizeHeight(width: 320)
+
+        // Create test confirmParams with valid card details
+        let confirmParams = IntentConfirmParams(type: .stripe(.card))
+        confirmParams.paymentMethodParams.card = STPPaymentMethodCardParams()
+        confirmParams.paymentMethodParams.card?.number = "4242424242424242"
+        confirmParams.paymentMethodParams.card?.expMonth = NSNumber(value: 12)
+        confirmParams.paymentMethodParams.card?.expYear = NSNumber(value: Calendar.current.component(.year, from: Date()) + 5)
+        confirmParams.paymentMethodParams.card?.cvc = "123"
+        confirmParams.setDefaultBillingDetailsIfNecessary(for: sut.configuration)
+        
+        // Inject the test payment option and confirm the payment successfully
+        sut._test_paymentOption = .new(confirmParams: confirmParams)
+        let confirmResult = await sut.confirm()
+        XCTAssertEqual(confirmResult, .completed)
+
+        // Now that the payment is confirmed, attempting to update should fail
+        let updateResult = await sut.update(intentConfiguration: paymentIntentConfig2)
+        guard case let .failed(error) = updateResult else {
+            XCTFail("Expected the update to fail after confirming the intent.")
+            return
+        }
+        
+        XCTAssertEqual((error as! PaymentSheetError).debugDescription, PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent.debugDescription)
+    }
+
+    func testConfirmThenClearPaymentOptionDoesNothing() async throws {
+        // Given an EmbeddedPaymentElement that can confirm
+        let sut = try await EmbeddedPaymentElement.create(intentConfiguration: paymentIntentConfigWithConfirmHandler, configuration: configuration)
+        sut.presentingViewController = UIViewController()
+        sut.view.autosizeHeight(width: 320)
+
+        // Create test confirmParams with valid card details
+        let confirmParams = IntentConfirmParams(type: .stripe(.card))
+        confirmParams.paymentMethodParams.card = STPPaymentMethodCardParams()
+        confirmParams.paymentMethodParams.card?.number = "4242424242424242"
+        confirmParams.paymentMethodParams.card?.expMonth = NSNumber(value: 12)
+        confirmParams.paymentMethodParams.card?.expYear = NSNumber(value: Calendar.current.component(.year, from: Date()) + 5)
+        confirmParams.paymentMethodParams.card?.cvc = "123"
+        confirmParams.setDefaultBillingDetailsIfNecessary(for: sut.configuration)
+        
+        // Inject the test payment option and confirm the payment successfully
+        sut._test_paymentOption = .new(confirmParams: confirmParams)
+        let confirmResult = await sut.confirm()
+        XCTAssertEqual(confirmResult, .completed)
+
+        // Once confirmed, attempting to clear the payment option should do nothing
+        let previousPaymentOption = sut.paymentOption
+        sut.clearPaymentOption()
+        XCTAssertEqual(sut.paymentOption, previousPaymentOption, "Clearing payment option after confirmation should have no effect.")
+    }
+
+    func testConfirmTwiceFails() async throws {
+        // Given an EmbeddedPaymentElement that can confirm
+        let sut = try await EmbeddedPaymentElement.create(intentConfiguration: paymentIntentConfigWithConfirmHandler, configuration: configuration)
+        sut.presentingViewController = UIViewController()
+        sut.view.autosizeHeight(width: 320)
+
+        // Create test confirmParams with valid card details
+        let confirmParams = IntentConfirmParams(type: .stripe(.card))
+        confirmParams.paymentMethodParams.card = STPPaymentMethodCardParams()
+        confirmParams.paymentMethodParams.card?.number = "4242424242424242"
+        confirmParams.paymentMethodParams.card?.expMonth = NSNumber(value: 12)
+        confirmParams.paymentMethodParams.card?.expYear = NSNumber(value: Calendar.current.component(.year, from: Date()) + 5)
+        confirmParams.paymentMethodParams.card?.cvc = "123"
+        confirmParams.setDefaultBillingDetailsIfNecessary(for: sut.configuration)
+        
+        // Inject the test payment option and confirm the payment successfully once
+        sut._test_paymentOption = .new(confirmParams: confirmParams)
+        let firstConfirmResult = await sut.confirm()
+        XCTAssertEqual(firstConfirmResult, .completed)
+        
+        // Attempting to confirm again should fail
+        let secondConfirmResult = await sut.confirm()
+        guard case let .failed(error) = secondConfirmResult else {
+            XCTFail("Expected second confirm to fail after the intent has already been confirmed.")
+            return
+        }
+        XCTAssertEqual((error as! PaymentSheetError).debugDescription, PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent.debugDescription)
+    }
+
 }
 
 extension EmbeddedPaymentElementTest: EmbeddedPaymentElementDelegate {
@@ -357,5 +443,16 @@ extension EmbeddedPaymentMethodsView {
 
     func getRowButton(accessibilityIdentifier: String) -> RowButton {
         return rowButtons.first { $0.accessibilityIdentifier == accessibilityIdentifier }!
+    }
+}
+
+extension PaymentSheetResult: @retroactive Equatable {
+    public static func == (lhs: StripePaymentSheet.PaymentSheetResult, rhs: StripePaymentSheet.PaymentSheetResult) -> Bool {
+        switch (lhs, rhs) {
+        case (.completed, .completed): return true
+        case let (.failed(lhsError), .failed(rhsError)): return lhsError.nonGenericDescription == rhsError.nonGenericDescription
+        case (.canceled, .canceled): return true
+        default: return false
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Essentially "bricks" the embedded payment element after a successful confirmation to prevent double charging or showing forms post confirmation.

From the bug bash:

> "If you re-open the element after confirming, you get this greyed-out version of the card field. And you can still hit "Pay" and have it spin and show a green checkmark."



## Motivation
- Bug bash

## Testing
- Manually broke our playground to test this
- Added some unit tests

## Changelog
N/A
