### PR TITLE
Show selection behind sheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -552,7 +552,9 @@ class EmbeddedUITests: PaymentSheetUITestCase {
 
         // Open card and cancel, should reset selection to saved card
         app.buttons["New card"].waitForExistenceAndTap()
-        app.buttons["Close"].waitForExistenceAndTap()
+        let _ = app.buttons["Close"].waitForExistence(timeout: 10)
+        XCTAssertTrue(app.buttons["New card"].isSelected)
+        app.buttons["Close"].tap()
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
         XCTAssertTrue(app.buttons["•••• 4242"].isSelected)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -95,7 +95,7 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         delegate?.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: self)
     }
 
-    func updateSelectionState(isNewSelection: Bool) -> Bool {
+    func updateSelectionState(isNewSelection: Bool) {
         // Deferring notifying delegate until the exit of this function guarantees the new payment option comes from the new instance of `EmbeddedFormViewController`
         defer {
             if isNewSelection {
@@ -109,12 +109,12 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         guard case let .new(paymentMethodType) = embeddedPaymentMethodsView.selection else {
             // This can occur when selection is being reset to nothing selected or to a saved payment method, so don't assert.
             self.formViewController = nil
-            return true
+            return
         }
 
         guard let presentingViewController else {
             stpAssertionFailure("Presenting view controller not found, set EmbeddedPaymentElement.presentingViewController.")
-            return true
+            return
         }
 
         let formViewController = EmbeddedFormViewController(
@@ -132,15 +132,13 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         // Only show forms that require user input
         guard formViewController.collectsUserInput else {
             self.formViewController = nil  // Clear out any previous form view controller to update self._paymentOption
-            return true
+            return
         }
 
         let bottomSheet = bottomSheetController(with: formViewController)
         delegate?.embeddedPaymentElementWillPresent(embeddedPaymentElement: self)
         presentingViewController.presentAsBottomSheet(bottomSheet, appearance: configuration.appearance)
         self.formViewController = formViewController
-        let formHasValidPaymentOption = formViewController.selectedPaymentOption != nil
-        return formHasValidPaymentOption // Show row selected only if payment option is valid
     }
 
     func presentSavedPaymentMethods(selectedSavedPaymentMethod: STPPaymentMethod?) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -14,11 +14,10 @@ import UIKit
 protocol EmbeddedPaymentMethodsViewDelegate: AnyObject {
     func heightDidChange()
     
-    /// Updates the selection state and determines visual feedback
+    /// Updates the selection state
     /// - Parameters:
     ///   - isNewSelection: Indicates if this is a newly selected item
-    /// - Returns: A boolean indicating whether to display a visual selection indicator
-    func updateSelectionState(isNewSelection: Bool) -> Bool
+    func updateSelectionState(isNewSelection: Bool)
     func presentSavedPaymentMethods(selectedSavedPaymentMethod: STPPaymentMethod?)
 }
 
@@ -36,9 +35,9 @@ class EmbeddedPaymentMethodsView: UIView {
         didSet {
             previousSelection = oldValue
             updateMandate()
-            let shouldShowSelection = delegate?.updateSelectionState(isNewSelection: oldValue != selection) ?? true
+            delegate?.updateSelectionState(isNewSelection: oldValue != selection)
             selectionButtonMapping.forEach { (key, button) in
-                button.isSelected = key == selection && shouldShowSelection
+                button.isSelected = key == selection
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
@@ -89,11 +89,10 @@ private class MockEmbeddedPaymentMethodsViewDelegate: EmbeddedPaymentMethodsView
         didCallHeightDidChange = true
     }
 
-    func updateSelectionState(isNewSelection: Bool) -> Bool {
+    func updateSelectionState(isNewSelection: Bool) {
         if isNewSelection {
             didCallSelectionDidUpdate = true
         }
-        return true
     }
 
     func presentSavedPaymentMethods(selectedSavedPaymentMethod: STPPaymentMethod?) {


### PR DESCRIPTION
## Summary
- Based on bug bash feedback and talking with design and product we decided to revert our change from quality review where we do not show the radio selected behind the sheet.
- Now we do show the radio selected behind the sheet.

## Motivation
- Bug bash feedback

## Testing
- Manual
- Updated UI test

## Changelog
N/A
