### PR TITLE
Fix MLModel loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
+## X.X.X 
 ### PaymentSheet, CustomerSheet
 * [Changed] Changed the edit and remove saved payment method flow so that tapping 'Edit' displays an icon that leads to a new update payment method screen that displays payment method details for card (last 4 digits of card number, cvc and expiry date fields), US Bank account (name, email, last 4 digits of bank acocunt), and SEPA debit (name, email, last 4 digits of IBAN).
+
+### Identity
+* [Fixed] Fixes an error with selfie verification.
 
 ## 24.1.2 2024-12-05
 ### PaymentSheet

--- a/Example/IdentityVerification Example/IdentityVerification Example.xcodeproj/project.pbxproj
+++ b/Example/IdentityVerification Example/IdentityVerification Example.xcodeproj/project.pbxproj
@@ -475,7 +475,7 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				INFOPLIST_FILE = "IdentityVerification Example/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.IdentityVerification-Example79";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.IdentityVerification-Example";
 				PRODUCT_NAME = IdentityVerificationExample;
 				SDKROOT = iphoneos;
 			};
@@ -487,7 +487,7 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				INFOPLIST_FILE = "IdentityVerification Example/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.IdentityVerification-Example79";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.IdentityVerification-Example";
 				PRODUCT_NAME = IdentityVerificationExample;
 				SDKROOT = iphoneos;
 			};

--- a/Example/IdentityVerification Example/IdentityVerification Example.xcodeproj/project.pbxproj
+++ b/Example/IdentityVerification Example/IdentityVerification Example.xcodeproj/project.pbxproj
@@ -475,7 +475,7 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				INFOPLIST_FILE = "IdentityVerification Example/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.IdentityVerification-Example";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.IdentityVerification-Example79";
 				PRODUCT_NAME = IdentityVerificationExample;
 				SDKROOT = iphoneos;
 			};
@@ -487,7 +487,7 @@
 			buildSettings = {
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				INFOPLIST_FILE = "IdentityVerification Example/Info.plist";
-				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.IdentityVerification-Example";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.IdentityVerification-Example79";
 				PRODUCT_NAME = IdentityVerificationExample;
 				SDKROOT = iphoneos;
 			};


### PR DESCRIPTION
## Summary
This code changed behavior after https://github.com/stripe/stripe-ios/pull/3869: It's now running some work on the main thread which should run on a background thread (such as call to compile the model), and the temporary files sometimes fall out of scope before they can be compiled. We'll move these calls to the loadPromiseCacheQueue. It also feels brittle for `downloadFileTemporarily` to rely on the `downloadTask`'s file sticking around, so we'll make it explicit by moving it to a temporary directory.

## Motivation
Fix an issue with using StripeIdentity in SDKs after https://github.com/stripe/stripe-ios/pull/3869 landed.

## Testing
In Identity Example.

## Changelog
Will add