### PR TITLE
Print all requests to console in debug mode

### DIFF
--- a/Stripe/StripeiOSTests/APIRequestTest.swift
+++ b/Stripe/StripeiOSTests/APIRequestTest.swift
@@ -140,6 +140,7 @@ class APIRequestTest: STPNetworkStubbingTestCase {
 
         APIRequest<STPCard>.parseResponse(
             httpURLResponse,
+            method: "GET",
             body: body,
             error: errorParameter
         ) { (object: STPCard?, response, error) in
@@ -173,6 +174,7 @@ class APIRequestTest: STPNetworkStubbingTestCase {
 
         APIRequest<STPCard>.parseResponse(
             httpURLResponse,
+            method: "GET",
             body: body,
             error: errorParameter
         ) { (object: STPCard?, response, error) in
@@ -200,6 +202,7 @@ class APIRequestTest: STPNetworkStubbingTestCase {
 
         APIRequest<STPCard>.parseResponse(
             httpURLResponse,
+            method: "GET",
             body: body,
             error: errorParameter
         ) { (object: STPCard?, response, error) in
@@ -230,6 +233,7 @@ class APIRequestTest: STPNetworkStubbingTestCase {
 
         APIRequest<STPCard>.parseResponse(
             httpURLResponse,
+            method: "GET",
             body: body,
             error: errorParameter
         ) { (object: STPCard?, response, error) in

--- a/StripePayments/StripePayments/Source/Internal/API Bindings/APIRequest.swift
+++ b/StripePayments/StripePayments/Source/Internal/API Bindings/APIRequest.swift
@@ -39,7 +39,7 @@ let JSONKeyObject = "object"
         apiClient.urlSession.stp_performDataTask(
             with: request as URLRequest,
             completionHandler: { body, response, error in
-                self.parseResponse(response, body: body, error: error, completion: completion)
+                self.parseResponse(response, method: "POST", body: body, error: error, completion: completion)
             }
         )
     }
@@ -81,7 +81,7 @@ let JSONKeyObject = "object"
         apiClient.urlSession.stp_performDataTask(
             with: request as URLRequest,
             completionHandler: { body, response, error in
-                self.parseResponse(response, body: body, error: error, completion: completion)
+                self.parseResponse(response, method: "GET", body: body, error: error, completion: completion)
             }
         )
     }
@@ -123,13 +123,14 @@ let JSONKeyObject = "object"
         apiClient.urlSession.stp_performDataTask(
             with: request as URLRequest,
             completionHandler: { body, response, error in
-                self.parseResponse(response, body: body, error: error, completion: completion)
+                self.parseResponse(response, method: "DELETE" ,body: body, error: error, completion: completion)
             }
         )
     }
 
     class func parseResponse(
         _ response: URLResponse?,
+        method: String,
         body: Data?,
         error: Error?,
         completion: @escaping (ResponseType?, HTTPURLResponse?, Error?) -> Void
@@ -190,7 +191,7 @@ let JSONKeyObject = "object"
         if let httpResponse,
            let requestId = httpResponse.value(forHTTPHeaderField: "request-id"),
            let url = httpResponse.value(forKey: "URL") as? URL {
-            print("[Stripe SDK]: Request \(requestId), \(url.relativePath)")
+            print("[Stripe SDK]: \(method) \"\(url.relativePath)\" \(httpResponse.statusCode) \(requestId)")
         }
         #endif
 

--- a/StripePayments/StripePayments/Source/Internal/API Bindings/APIRequest.swift
+++ b/StripePayments/StripePayments/Source/Internal/API Bindings/APIRequest.swift
@@ -189,9 +189,14 @@ let JSONKeyObject = "object"
         if let responseObject = ResponseType.decodedObject(fromAPIResponse: jsonDictionary) {
             safeCompletion(responseObject, nil)
         } else {
-            let error: Error =
-                NSError.stp_error(fromStripeResponse: jsonDictionary, httpResponse: httpResponse)
-                ?? NSError.stp_genericFailedToParseResponseError()
+            let nsError: NSError? = NSError.stp_error(fromStripeResponse: jsonDictionary, httpResponse: httpResponse)
+            let error: Error = nsError ?? NSError.stp_genericFailedToParseResponseError()
+
+            #if DEBUG
+            if let nsError, let requestId = nsError.userInfo[STPError.stripeRequestIDKey] {
+                print("[Stripe SDK]: Failed request \(requestId)")
+            }
+            #endif
             safeCompletion(nil, error)
         }
     }

--- a/StripePayments/StripePayments/Source/Internal/API Bindings/APIRequest.swift
+++ b/StripePayments/StripePayments/Source/Internal/API Bindings/APIRequest.swift
@@ -186,17 +186,20 @@ let JSONKeyObject = "object"
         }
         // END OF STPEmptyStripeResponse HACK
 
+        #if DEBUG
+        if let httpResponse,
+           let requestId = httpResponse.value(forHTTPHeaderField: "request-id"),
+           let url = httpResponse.value(forKey: "URL") as? URL {
+            print("[Stripe SDK]: Request \(requestId), \(url.relativePath)")
+        }
+        #endif
+
         if let responseObject = ResponseType.decodedObject(fromAPIResponse: jsonDictionary) {
             safeCompletion(responseObject, nil)
         } else {
-            let nsError: NSError? = NSError.stp_error(fromStripeResponse: jsonDictionary, httpResponse: httpResponse)
-            let error: Error = nsError ?? NSError.stp_genericFailedToParseResponseError()
-
-            #if DEBUG
-            if let nsError, let requestId = nsError.userInfo[STPError.stripeRequestIDKey] {
-                print("[Stripe SDK]: Failed request \(requestId)")
-            }
-            #endif
+            let error: Error =
+                NSError.stp_error(fromStripeResponse: jsonDictionary, httpResponse: httpResponse)
+                ?? NSError.stp_genericFailedToParseResponseError()
             safeCompletion(nil, error)
         }
     }


### PR DESCRIPTION
## Summary
It's kind of difficult to see when requests are failing. I propose we print requestID to the console so that it's easier to see/debug.

## Motivation
Difficult to view requestId's unless you have a ton of breakpoints in code.

## Testing
Manual testing.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
