### PR TITLE
Configure module READMEs to display on pods page for each pod

### DIFF
--- a/StripeApplePay.podspec
+++ b/StripeApplePay.podspec
@@ -9,6 +9,7 @@ Pod::Spec.new do |s|
                                      'or other size-constrained apps.' 
   s.license                        = { :type => 'MIT', :file => 'LICENSE' } 
   s.homepage                       = 'https://stripe.com/docs/apple-pay' 
+  s.readme                         = 'StripeApplePay/README.md'
   s.authors                        = { 'Stripe' => 'support+github@stripe.com' } 
   s.source                         = { :git => 'https://github.com/stripe/stripe-ios.git', :tag => "#{s.version}" } 
   s.frameworks                     = 'Foundation', 'Security', 'WebKit', 'PassKit', 'Contacts', 'CoreLocation' 

--- a/StripeConnect.podspec
+++ b/StripeConnect.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.summary                        = 'Use Connect embedded components to add connected account dashboard functionality to your app.'
   s.license                        = { type: 'MIT', file: 'LICENSE' }
   s.homepage                       = 'https://docs.stripe.com/connect/get-started-connect-embedded-components'
+  s.readme                         = 'StripeConnect/README.md'
   s.authors                        = { 'Stripe' => 'support+github@stripe.com' }
   s.source                         = { git: 'https://github.com/stripe/stripe-ios.git', tag: "#{s.version}" }
   s.frameworks                     = 'Foundation', 'WebKit', 'UIKit'

--- a/StripeFinancialConnections.podspec
+++ b/StripeFinancialConnections.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
     s.summary                        = 'Securely connect financial accounts to Stripe\'s merchant account.'
     s.license                        = { :type => 'MIT', :file => 'LICENSE' }
     s.homepage                       = 'https://stripe.com/docs/mobile/ios'
+    s.readme                         = 'StripeFinancialConnections/README.md'
     s.authors                        = { 'Stripe' => 'support+github@stripe.com' }
     s.source                         = { :git => 'https://github.com/stripe/stripe-ios.git', :tag => "#{s.version}" }
     s.frameworks                     = 'Foundation', 'WebKit', 'UIKit'

--- a/StripeIdentity.podspec
+++ b/StripeIdentity.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.summary                        = 'Securely capture ID documents and selfies on iOS for use with Stripe\'s Identity API to confirm the identity of global users.'
   s.license                        = { :type => 'MIT', :file => 'LICENSE' }
   s.homepage                       = 'https://stripe.com/identity'
+  s.readme                         = 'StripeIdentity/README.md'
   s.authors                        = { 'Stripe' => 'support+github@stripe.com' }
   s.source                         = { :git => 'https://github.com/stripe/stripe-ios.git', :tag => "#{s.version}" }
   s.frameworks                     = 'Foundation', 'WebKit', 'UIKit'

--- a/StripePaymentSheet.podspec
+++ b/StripePaymentSheet.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.summary                        = "Stripe's prebuilt payment UI."
   s.license                        = { type: 'MIT', file: 'LICENSE' }
   s.homepage                       = 'https://stripe.com/docs/mobile/ios'
+  s.readme                         = 'StripePaymentSheet/README.md'
   s.authors                        = { 'Stripe' => 'support+github@stripe.com' }
   s.source                         = { git: 'https://github.com/stripe/stripe-ios.git', tag: s.version.to_s }
   s.frameworks                     = 'Foundation', 'UIKit'

--- a/StripePayments.podspec
+++ b/StripePayments.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.summary                        = 'Bindings for the Stripe Payments API.'
   s.license                        = { type: 'MIT', file: 'LICENSE' }
   s.homepage                       = 'https://stripe.com/docs/mobile/ios'
+  s.readme                         = 'StripePayments/README.md'
   s.authors                        = { 'Stripe' => 'support+github@stripe.com' }
   s.source                         = { git: 'https://github.com/stripe/stripe-ios.git', tag: s.version.to_s }
   s.frameworks                     = 'Foundation', 'UIKit'

--- a/StripePaymentsUI.podspec
+++ b/StripePaymentsUI.podspec
@@ -8,6 +8,7 @@ Pod::Spec.new do |s|
   s.summary                        = 'UI elements and API bindings for building a custom payment flow using Stripe.'
   s.license                        = { type: 'MIT', file: 'LICENSE' }
   s.homepage                       = 'https://stripe.com/docs/mobile/ios'
+  s.readme                         = 'StripePaymentsUI/README.md'
   s.authors                        = { 'Stripe' => 'support+github@stripe.com' }
   s.source                         = { git: 'https://github.com/stripe/stripe-ios.git', tag: s.version.to_s }
   s.frameworks                     = 'Foundation', 'UIKit'


### PR DESCRIPTION
## Summary
This change updates each SDK podspec to point to the README specific to that SDK.

After releasing the StripeConnect SDK, we noticed that Cocoapods overview displayed the README contents for root directory of the repo, rather than the README contents for Connect. It appears that this is the case for all of our SDKs in this repo:
https://cocoapods.org/pods/StripeConnect
https://cocoapods.org/pods/StripeFinancialConnections
https://cocoapods.org/pods/StripeIdentity
https://cocoapods.org/pods/StripePaymentSheet
https://cocoapods.org/pods/StripePayments
https://cocoapods.org/pods/StripePaymentsUI

## Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-3002

## Testing
Unfortunately, there's no way to test this until the Cocoapods are deployed.

## Changelog
n/a