### PR TITLE
Fix issues with concurrent attestations

### DIFF
--- a/StripeCore/StripeCore/Source/Attestation/AppAttestService.swift
+++ b/StripeCore/StripeCore/Source/Attestation/AppAttestService.swift
@@ -7,7 +7,7 @@ import DeviceCheck
 import Foundation
 
 @_spi(STP) public protocol AppAttestService {
-    var isSupported: Bool { get }
+    nonisolated var isSupported: Bool { get }
     func generateKey() async throws -> String
     func generateAssertion(_ keyId: String, clientDataHash: Data) async throws -> Data
     func attestKey(_ keyId: String, clientDataHash: Data) async throws -> Data

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -186,7 +186,7 @@ import UIKit
         if let existingTask = attestationTask {
             return try await existingTask.value
         }
-        
+
         let task = Task<Void, Error> {
             try await _attest()
             let successAnalytic = GenericAnalytic(event: .attestationSucceeded, params: [:])
@@ -203,7 +203,7 @@ import UIKit
         }
     }
     private var attestationTask: Task<Void, Error>?
-    
+
     func _assert() async throws -> Assertion {
         let keyId = try await self.getOrCreateKeyID()
 

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -163,6 +163,9 @@ import UIKit
     }
 
     /// A wrapper for the DCAppAttestService service.
+    /// Marked as nonisolated as it can not be reassigned during the lifetime
+    /// of StripeAttest, and isolation is handled by the AppAttestService itself
+    /// (Either DCAppAttestService or our MockAppAttestService)
     nonisolated let appAttestService: AppAttestService
     /// A network backend for the /challenge and /attest endpoints.
     let appAttestBackend: StripeAttestBackend

--- a/StripeCore/StripeCoreTests/Attestation/MockAppAttestService.swift
+++ b/StripeCore/StripeCoreTests/Attestation/MockAppAttestService.swift
@@ -10,10 +10,10 @@ import DeviceCheck
 @testable @_spi(STP) import StripeCore
 import UIKit
 
-class MockAppAttestService: AppAttestService {
+actor MockAppAttestService: AppAttestService {
     @_spi(STP) public static var shared = MockAppAttestService()
 
-    @_spi(STP) public var isSupported: Bool {
+    @_spi(STP) public nonisolated var isSupported: Bool {
         if #available(iOS 14.0, *) {
             return true
         } else {
@@ -25,6 +25,22 @@ class MockAppAttestService: AppAttestService {
     var shouldFailAssertionWithError: Error?
     var shouldFailAttestationWithError: Error?
     var attestationUsingDevelopmentEnvironment: Bool = false
+    
+    func setShouldFailKeygenWithError(_ error: Error?) async {
+        shouldFailKeygenWithError = error
+    }
+    
+    func setShouldFailAssertionWithError(_ error: Error?) async {
+        shouldFailAssertionWithError = error
+    }
+    
+    func setShouldFailAttestationWithError(_ error: Error?) async {
+        shouldFailAttestationWithError = error
+    }
+    
+    func setAttestationUsingDevelopmentEnvironment(_ value: Bool) async {
+        attestationUsingDevelopmentEnvironment = value
+    }
 
     var keys: [String: FakeKey] = [:]
 
@@ -71,7 +87,7 @@ class MockAppAttestService: AppAttestService {
         return try JSONSerialization.data(withJSONObject: attestation)
     }
 
-    @_spi(STP) public func attestationDataIsDevelopmentEnvironment(_ data: Data) -> Bool {
+    @_spi(STP) public nonisolated func attestationDataIsDevelopmentEnvironment(_ data: Data) -> Bool {
         let decodedKey = try! JSONSerialization.jsonObject(with: data) as! [String: Any]
         return decodedKey["isDevelopmentEnvironment"] as! Bool
     }

--- a/StripeCore/StripeCoreTests/Attestation/MockAppAttestService.swift
+++ b/StripeCore/StripeCoreTests/Attestation/MockAppAttestService.swift
@@ -25,19 +25,19 @@ actor MockAppAttestService: AppAttestService {
     var shouldFailAssertionWithError: Error?
     var shouldFailAttestationWithError: Error?
     var attestationUsingDevelopmentEnvironment: Bool = false
-    
+
     func setShouldFailKeygenWithError(_ error: Error?) async {
         shouldFailKeygenWithError = error
     }
-    
+
     func setShouldFailAssertionWithError(_ error: Error?) async {
         shouldFailAssertionWithError = error
     }
-    
+
     func setShouldFailAttestationWithError(_ error: Error?) async {
         shouldFailAttestationWithError = error
     }
-    
+
     func setAttestationUsingDevelopmentEnvironment(_ value: Bool) async {
         attestationUsingDevelopmentEnvironment = value
     }

--- a/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
+++ b/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
@@ -18,9 +18,14 @@ class StripeAttestTest: XCTestCase {
         self.mockAttestService = MockAppAttestService()
         self.stripeAttest = StripeAttest(appAttestService: mockAttestService, appAttestBackend: mockAttestBackend, apiClient: apiClient)
 
+        let expectation = self.expectation(description: "Wait for setup")
         // Reset storage
-        UserDefaults.standard.removeObject(forKey: self.stripeAttest.defaultsKeyForSetting(.lastAttestedDate))
-        stripeAttest.resetKey()
+        Task { @MainActor in
+            await UserDefaults.standard.removeObject(forKey: self.stripeAttest.defaultsKeyForSetting(.lastAttestedDate))
+            await stripeAttest.resetKey()
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 5)
     }
 
     func testAppAttestService() async {
@@ -39,7 +44,7 @@ class StripeAttestTest: XCTestCase {
         try! await stripeAttest.attest()
         let invalidKeyError = NSError(domain: DCErrorDomain, code: DCError.invalidKey.rawValue, userInfo: nil)
         // But fail the assertion, causing the key to be reset
-        mockAttestService.shouldFailAssertionWithError = invalidKeyError
+        await mockAttestService.setShouldFailAssertionWithError(invalidKeyError)
         do {
             _ = try await stripeAttest.assert()
             XCTFail("Should not succeed")
@@ -51,11 +56,11 @@ class StripeAttestTest: XCTestCase {
 
     func testCanAttestAsMuchAsNeededInDev() async {
         // Create and attest a key in the dev environment
-        mockAttestService.attestationUsingDevelopmentEnvironment = true
+        await mockAttestService.setAttestationUsingDevelopmentEnvironment(true)
         try! await stripeAttest.attest()
         let invalidKeyError = NSError(domain: DCErrorDomain, code: DCError.invalidKey.rawValue, userInfo: nil)
         // But fail the assertion, which will cause us to try to re-attest the key
-        mockAttestService.shouldFailAssertionWithError = invalidKeyError
+        await mockAttestService.setShouldFailAssertionWithError(invalidKeyError)
         do {
             _ = try await stripeAttest.assert()
             XCTFail("Should not succeed")
@@ -74,10 +79,10 @@ class StripeAttestTest: XCTestCase {
             // Create and attest a key
             try! await stripeAttest.attest()
             // But it's an old key, so we'll be allowed to attest a new one
-            UserDefaults.standard.set(Date.distantPast, forKey: self.stripeAttest.defaultsKeyForSetting(.lastAttestedDate))
+            await UserDefaults.standard.set(Date.distantPast, forKey: self.stripeAttest.defaultsKeyForSetting(.lastAttestedDate))
             // Always fail the assertions and don't remember attestations:
             let invalidKeyError = NSError(domain: DCErrorDomain, code: DCError.invalidKey.rawValue, userInfo: nil)
-            mockAttestService.shouldFailAssertionWithError = invalidKeyError
+            await mockAttestService.setShouldFailAssertionWithError(invalidKeyError)
 
             _ = try await stripeAttest.assert()
             XCTFail("Should not succeed")
@@ -108,5 +113,17 @@ class StripeAttestTest: XCTestCase {
         mockAttestService.shouldFailAssertionWithError = invalidKeyError
         let assertion = try! await stripeAttest.assert()
         XCTAssertEqual(assertion.keyID, "TestKeyID")
+    }
+    
+    func testConcurrentAssertionsAndAttestations() async {
+        let iterations = 500
+        try! await withThrowingTaskGroup(of: Void.self) { group in
+            for _ in 0..<iterations {
+                group.addTask {
+                    try await self.stripeAttest.assert()
+                }
+            }
+            try await group.waitForAll()
+        }
     }
 }

--- a/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
+++ b/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
@@ -92,7 +92,7 @@ class StripeAttestTest: XCTestCase {
     }
 
     func testNoPublishableKey() async {
-        stripeAttest.apiClient.publishableKey = nil
+        await stripeAttest.apiClient.publishableKey = nil
         do {
             // Create and attest a key
             try await stripeAttest.attest()
@@ -104,17 +104,17 @@ class StripeAttestTest: XCTestCase {
 
     func testAssertionsNotRequiredInTestMode() async {
         // Configure a test merchant PK:
-        stripeAttest.apiClient.publishableKey = "pk_test_abc123"
+        await stripeAttest.apiClient.publishableKey = "pk_test_abc123"
         // And reset the last attestation date:
-        UserDefaults.standard.removeObject(forKey: self.stripeAttest.defaultsKeyForSetting(.lastAttestedDate))
+        await UserDefaults.standard.removeObject(forKey: self.stripeAttest.defaultsKeyForSetting(.lastAttestedDate))
         // Fail the assertion, which will cause us to try to re-attest the key, but then the
         // assertions still won't work, so we'll send the testmode data instead.
         let invalidKeyError = NSError(domain: DCErrorDomain, code: DCError.invalidKey.rawValue, userInfo: nil)
-        mockAttestService.shouldFailAssertionWithError = invalidKeyError
+        await mockAttestService.setShouldFailAssertionWithError(invalidKeyError)
         let assertion = try! await stripeAttest.assert()
         XCTAssertEqual(assertion.keyID, "TestKeyID")
     }
-    
+
     func testConcurrentAssertionsAndAttestations() async {
         let iterations = 500
         try! await withThrowingTaskGroup(of: Void.self) { group in

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -56,13 +56,15 @@ extension STPAPIClient {
                 parameters: parameters,
                 ephemeralKeySecret: publishableKey
             ) { (result: Result<ConsumerSession.LookupResponse, Error>) in
-                // If there's an assertion error, send it to StripeAttest
-                if useMobileEndpoints,
-                   case .failure(let error) = result,
-                   Self.isLinkAssertionError(error: error) {
-                    StripeAttest(apiClient: self).receivedAssertionError(error)
+                Task { @MainActor in
+                    // If there's an assertion error, send it to StripeAttest
+                    if useMobileEndpoints,
+                       case .failure(let error) = result,
+                       Self.isLinkAssertionError(error: error) {
+                        await StripeAttest(apiClient: self).receivedAssertionError(error)
+                    }
+                    completion(result)
                 }
-                completion(result)
             }
         }
     }
@@ -115,14 +117,16 @@ extension STPAPIClient {
                 resource: useMobileEndpoints ? modernEndpoint : legacyEndpoint,
                 parameters: parameters
             ) { (result: Result<ConsumerSession.SessionWithPublishableKey, Error>) in
-                // If there's an assertion error, send it to StripeAttest
-                if useMobileEndpoints,
-                   case .failure(let error) = result,
-                   Self.isLinkAssertionError(error: error) {
-                    StripeAttest(apiClient: self).receivedAssertionError(error)
-                }
+                Task { @MainActor in
+                    // If there's an assertion error, send it to StripeAttest
+                    if useMobileEndpoints,
+                       case .failure(let error) = result,
+                       Self.isLinkAssertionError(error: error) {
+                        await StripeAttest(apiClient: self).receivedAssertionError(error)
+                    }
 
-                completion(result)
+                    completion(result)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
I realized that some of this code is unsafe if run concurrently, so I:
* Adopted actors to protect stored properties in StripeAttest and the MockAppAttestService
* Used a stored `Task` to only allow one simultaneous attestation to occur

Now we can kick off as many simultaneous `assert()` requests as we'd like, and they all seem to complete without issues.

Note that I marked the appAttestService as `nonisolated` in order to access the `isSupported` boolean synchronously. I _think_ this is fine (DCAppAttestService appears to be set up to handle this correctly), but this is our first use of actors in the SDK, so let me know if it seems odd!

## Motivation
Fixing concurrency-related crashes and unexpected behavior

## Testing
Added a test, tested attestation on device

## Changelog
None