### PR TITLE
[Connect] docs fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,12 @@ The Stripe iOS SDK collects data to help us improve our products and prevent fra
 For help with Apple's App Privacy Details form in App Store Connect, visit [Stripe iOS SDK Privacy Details](https://support.stripe.com/questions/stripe-ios-sdk-privacy-details).
 
 ## Modules
-<!-- Pad `Size` col with &nbsp; to prevent table from shrinking badge images and maintain readability -->
+<!-- 
+  EmergeTools project must be made public before adding to this table:
+  https://www.emergetools.com/settings?tab=app-display-options&cards=public_org_apps
+
+  NOTE: Pad `Size` col with &nbsp; to prevent table from shrinking badge images and maintain readability  
+ -->
 | Module | Description | Size&nbsp;([Download&nbsp;→&nbsp;Install](https://docs.emergetools.com/docs/ios-app-size#download-vs-install-size))&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; |
 |--------|-------------|------|
 | [StripePaymentSheet](StripePaymentSheet) | Stripe's [prebuilt payment UI](https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet). | [![StripePaymentSheet size](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fwww.emergetools.com%2Fapi%2Fv2%2Fpublic_new_build%3FexampleId%3Dcom.stripe.StripePaymentSheetSize%26platform%3Dios%26badgeOption%3Ddownload_and_install_size%26buildType%3Drelease&query=$.badgeMetadata&label=StripePaymentSheet&logo=apple)](https://www.emergetools.com/app/example/ios/com.stripe.StripePaymentSheetSize/release?utm_campaign=badge-data) |

--- a/README.md
+++ b/README.md
@@ -10,26 +10,26 @@
 
 The Stripe iOS SDK makes it quick and easy to build an excellent payment experience in your iOS app. We provide powerful and customizable UI screens and elements that can be used out-of-the-box to collect your users' payment details. We also expose the low-level APIs that power those UIs so that you can build fully custom experiences.
 
-Get started with our [📚 integration guides](https://stripe.com/docs/payments/accept-a-payment?platform=ios) and [example projects](#examples), or [📘 browse the SDK reference](https://stripe.dev/stripe-ios/docs/index.html).
+Get started with our [📚 integration guides](https://stripe.com/docs/payments/accept-a-payment?platform=ios) and [example projects](#Examples), or [📘 browse the SDK reference](https://stripe.dev/stripe-ios/docs/index.html).
 
 > Updating to a newer version of the SDK? See our [migration guide](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md) and [changelog](https://github.com/stripe/stripe-ios/blob/master/CHANGELOG.md).
 
 Table of contents
 =================
-
+<!-- NOTE: Use case-sensitive anchor links for docc compatibility -->
 <!--ts-->
-   * [Features](#features)
-   * [Releases](#releases)
-   * [Requirements](#requirements)
-   * [Getting started](#getting-started)
-      * [Integration](#integration)
-      * [Examples](#examples)
-      * [Building from source](#building-from-source)
-   * [Card scanning](#card-scanning)
-   * [Contributing](#contributing)
-   * [Migrating](#migrating-from-older-versions)
-   * [Code Stye](#code-style)
-   * [Licenses](#licenses)
+   * [Features](#Features)
+   * [Releases](#Releases)
+   * [Requirements](#Requirements)
+   * [Getting started](#Getting-started)
+      * [Integration](#Integration)
+      * [Examples](#Examples)
+      * [Building from source](#Building-from-source)
+   * [Card scanning](#Card-scanning)
+   * [Contributing](#Contributing)
+   * [Migrating](#Migrating-from-older-versions)
+   * [Code Stye](#Code-style)
+   * [Licenses](#Licenses)
 
 <!--te-->
 
@@ -47,7 +47,7 @@ Table of contents
 
 **Stripe API**: [StripePayments](StripePayments/README.md) provides [low-level APIs](https://stripe.dev/stripe-ios/docs/Classes/STPAPIClient.html) that correspond to objects and methods in the Stripe API. You can build your own entirely custom UI on top of this layer, while still taking advantage of utilities like [STPCardValidator](https://stripe.dev/stripe-ios/docs/Classes/STPCardValidator.html) to validate your user’s input.
 
-**Card scanning**: We support card scanning on iOS 13 and higher. See our [Card scanning](#card-scanning) section.
+**Card scanning**: We support card scanning on iOS 13 and higher. See our [Card scanning](#Card-scanning) section.
 
 **App Clips**: The `StripeApplePay` module provides a [lightweight SDK for offering Apple Pay in an App Clip](https://stripe.com/docs/apple-pay#app-clips).
 

--- a/StripeApplePay/README.md
+++ b/StripeApplePay/README.md
@@ -3,15 +3,15 @@
 StripeApplePay is a lightweight Apple Pay SDK intended for building App Clips or other size-constrained apps.
 
 ## Table of contents
-
+<!-- NOTE: Use case-sensitive anchor links for docc compatibility -->
 <!--ts-->
-- [Stripe Apple Pay iOS SDK](#stripe-apple-pay-ios-sdk)
-- [Table of contents](#table-of-contents)
-  - [Requirements](#requirements)
-  - [Getting started](#getting-started)
-    - [Integration](#integration)
-    - [Example](#example)
-  - [Manual linking](#manual-linking)
+- [Stripe Apple Pay iOS SDK](#Stripe-Apple-Pay-iOS-SDK)
+- [Table of contents](#Table-of-contents)
+  - [Requirements](#Requirements)
+  - [Getting started](#Getting-started)
+    - [Integration](#Integration)
+    - [Example](#Example)
+  - [Manual linking](#Manual-linking)
 
 <!--te-->
 

--- a/StripeConnect/README.md
+++ b/StripeConnect/README.md
@@ -7,14 +7,14 @@ Use Connect embedded components to add connected account dashboard functionality
 > Access to the StripeConnect iOS SDK is currently invite only and is limited to only certain connected account types. To request an invitation and get the latest information on supported account types, see our [iOS integration guide](https://docs.stripe.com/connect/get-started-connect-embedded-components?platform=ios).
 
 ## Table of contents
-
+<!-- NOTE: Use case-sensitive anchor links for docc compatibility -->
 <!--ts-->
-* [Supported components](#supported-components)
-* [Requirements](#requirements)
-* [Getting started](#getting-started)
-   * [Integration](#integration)
-   * [Example](#example)
-* [Manual linking](#manual-linking)
+* [Supported components](#Supported-components)
+* [Requirements](#Requirements)
+* [Getting started](#Getting-started)
+   * [Integration](#Integration)
+   * [Example](Example)
+* [Manual linking](#Manual-linking)
 
 <!--te-->
 

--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -95,6 +95,7 @@
 		E65691222CA52D5900E0DB00 /* StripeConnect+Exports.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65691212CA52D5900E0DB00 /* StripeConnect+Exports.swift */; };
 		E65691252CA52F9D00E0DB00 /* NotificationBannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65691232CA52F8600E0DB00 /* NotificationBannerViewController.swift */; };
 		E65691272CA533CD00E0DB00 /* OnNotificationsChangeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E65691262CA533CD00E0DB00 /* OnNotificationsChangeHandler.swift */; };
+		E65A28822D14009000B606F4 /* Docs.docc in Sources */ = {isa = PBXBuildFile; fileRef = E65A28812D14009000B606F4 /* Docs.docc */; };
 		E6660CF92CC2F343002A7631 /* OpenFinancialConnectionsMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660CF82CC2F340002A7631 /* OpenFinancialConnectionsMessageHandlerTests.swift */; };
 		E6660CFB2CC2F438002A7631 /* SetCollectMobileFinancialConnectionsResultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660CFA2CC2F436002A7631 /* SetCollectMobileFinancialConnectionsResultTests.swift */; };
 		E6660CFD2CC2F9A7002A7631 /* FinancialConnectionsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6660CFC2CC2F99C002A7631 /* FinancialConnectionsPresenter.swift */; };
@@ -249,6 +250,7 @@
 		E65691212CA52D5900E0DB00 /* StripeConnect+Exports.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StripeConnect+Exports.swift"; sourceTree = "<group>"; };
 		E65691232CA52F8600E0DB00 /* NotificationBannerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationBannerViewController.swift; sourceTree = "<group>"; };
 		E65691262CA533CD00E0DB00 /* OnNotificationsChangeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnNotificationsChangeHandler.swift; sourceTree = "<group>"; };
+		E65A28812D14009000B606F4 /* Docs.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Docs.docc; sourceTree = "<group>"; };
 		E6660CF82CC2F340002A7631 /* OpenFinancialConnectionsMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenFinancialConnectionsMessageHandlerTests.swift; sourceTree = "<group>"; };
 		E6660CFA2CC2F436002A7631 /* SetCollectMobileFinancialConnectionsResultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetCollectMobileFinancialConnectionsResultTests.swift; sourceTree = "<group>"; };
 		E6660CFC2CC2F99C002A7631 /* FinancialConnectionsPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsPresenter.swift; sourceTree = "<group>"; };
@@ -613,6 +615,7 @@
 		41D17A422C5A73A6007C6EE6 /* StripeConnect */ = {
 			isa = PBXGroup;
 			children = (
+				E65A28812D14009000B606F4 /* Docs.docc */,
 				41A2A5602C5A97130077FC74 /* Source */,
 				41D17A432C5A73A6007C6EE6 /* StripeConnect.h */,
 			);
@@ -875,6 +878,7 @@
 				413987E12C641688001D375E /* PageDidLoadMessageHandler.swift in Sources */,
 				4171B1592C9A5EEC00547F7D /* AccountOnboardingViewController.swift in Sources */,
 				41054E432C989AAD00383C09 /* Font+Extension.swift in Sources */,
+				E65A28822D14009000B606F4 /* Docs.docc in Sources */,
 				E6EF91C72CBA3BED0082DD1B /* UIViewController+StripeConnect.swift in Sources */,
 				E6660DC92CE43BE6002A7631 /* UnexpectedNavigationEvent.swift in Sources */,
 				41542A692C88B6F2004E728E /* JSONEncoder+extension.swift in Sources */,

--- a/StripeConnect/StripeConnect/Docs.docc/StripeConnect.md
+++ b/StripeConnect/StripeConnect/Docs.docc/StripeConnect.md
@@ -1,0 +1,3 @@
+# ``StripeConnect``
+
+Placeholder

--- a/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
@@ -98,7 +98,11 @@ public protocol AccountOnboardingViewControllerDelegate: AnyObject {
 @available(iOS 15, *)
 public extension AccountOnboardingViewControllerDelegate {
     // Add default implementation of delegate methods to make them optional
+
+    @_documentation(visibility: public)
     func accountOnboardingDidExit(_ accountOnboarding: AccountOnboardingViewController) { }
+
+    @_documentation(visibility: public)
     func accountOnboarding(_ accountOnboarding: AccountOnboardingViewController,
                            didFailLoadWithError error: Error) { }
 }

--- a/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
@@ -9,7 +9,7 @@ import UIKit
 
 /// A view controller representing an account-onboarding component
 /// - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
-/// - Seealso: https://docs.stripe.com/connect/supported-embedded-components/account-onboarding
+/// - Seealso: [Account onboarding component documentation](https://docs.stripe.com/connect/supported-embedded-components/account-onboarding?platform=ios)
 @_spi(PrivateBetaConnect)
 @_documentation(visibility: public)
 @available(iOS 15, *)
@@ -34,6 +34,7 @@ public class AccountOnboardingViewController: UIViewController {
     }
 
     /// Delegate that receives callbacks for this component
+    @_documentation(visibility: public)
     public weak var delegate: AccountOnboardingViewControllerDelegate?
 
     private(set) var webVC: ConnectComponentWebViewController!
@@ -79,6 +80,7 @@ public protocol AccountOnboardingViewControllerDelegate: AnyObject {
      The connected account has exited the onboarding process
      - Parameters accountOnboarding: The account onboarding component that the account exited
      */
+    @_documentation(visibility: public)
     func accountOnboardingDidExit(_ accountOnboarding: AccountOnboardingViewController)
 
     /**
@@ -87,6 +89,7 @@ public protocol AccountOnboardingViewControllerDelegate: AnyObject {
        - accountOnboarding: The account onboarding component that errored when loading
        - error: The error that occurred when loading the component
      */
+    @_documentation(visibility: public)
     func accountOnboarding(_ accountOnboarding: AccountOnboardingViewController,
                            didFailLoadWithError error: Error)
 

--- a/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
@@ -8,8 +8,10 @@
 import UIKit
 
 /// A view controller representing an account-onboarding component
+/// - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
 /// - Seealso: https://docs.stripe.com/connect/supported-embedded-components/account-onboarding
 @_spi(PrivateBetaConnect)
+@_documentation(visibility: public)
 @available(iOS 15, *)
 public class AccountOnboardingViewController: UIViewController {
 
@@ -68,7 +70,9 @@ public class AccountOnboardingViewController: UIViewController {
 }
 
 /// Delegate of an `AccountOnboardingViewController`
+/// - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
 @_spi(PrivateBetaConnect)
+@_documentation(visibility: public)
 @available(iOS 15, *)
 public protocol AccountOnboardingViewControllerDelegate: AnyObject {
     /**

--- a/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/AccountOnboardingViewController.swift
@@ -96,6 +96,7 @@ public protocol AccountOnboardingViewControllerDelegate: AnyObject {
 }
 
 @available(iOS 15, *)
+@_documentation(visibility: public)
 public extension AccountOnboardingViewControllerDelegate {
     // Add default implementation of delegate methods to make them optional
 

--- a/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
@@ -9,8 +9,10 @@ import UIKit
 
 /**
  The balance summary, the payout schedule, and a list of payouts for the connected account. It can also allow the user to perform instant or manual payouts.
+ - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
  */
 @_spi(PrivateBetaConnect)
+@_documentation(visibility: public)
 @available(iOS 15, *)
 public class PayoutsViewController: UIViewController {
     private(set) var webVC: ConnectComponentWebViewController!
@@ -40,7 +42,9 @@ public class PayoutsViewController: UIViewController {
 }
 
 /// Delegate of an `PayoutsViewController`
+///  - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
 @_spi(PrivateBetaConnect)
+@_documentation(visibility: public)
 @available(iOS 15, *)
 public protocol PayoutsViewControllerDelegate: AnyObject {
 

--- a/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 /**
  The balance summary, the payout schedule, and a list of payouts for the connected account. It can also allow the user to perform instant or manual payouts.
  - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
+ - Seealso: [Payouts component documentation](https://docs.stripe.com/connect/supported-embedded-components/payouts?platform=ios)
  */
 @_spi(PrivateBetaConnect)
 @_documentation(visibility: public)
@@ -17,6 +18,7 @@ import UIKit
 public class PayoutsViewController: UIViewController {
     private(set) var webVC: ConnectComponentWebViewController!
 
+    @_documentation(visibility: public)
     public weak var delegate: PayoutsViewControllerDelegate?
 
     init(componentManager: EmbeddedComponentManager,
@@ -54,6 +56,7 @@ public protocol PayoutsViewControllerDelegate: AnyObject {
        - payouts: The payouts component that errored when loading
        - error: The error that occurred when loading the component
      */
+    @_documentation(visibility: public)
     func payouts(_ payouts: PayoutsViewController,
                  didFailLoadWithError error: Error)
 

--- a/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
@@ -63,6 +63,7 @@ public protocol PayoutsViewControllerDelegate: AnyObject {
 }
 
 @available(iOS 15, *)
+@_documentation(visibility: public)
 public extension PayoutsViewControllerDelegate {
     // Default implementation to make optional
     @_documentation(visibility: public)

--- a/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
@@ -65,6 +65,7 @@ public protocol PayoutsViewControllerDelegate: AnyObject {
 @available(iOS 15, *)
 public extension PayoutsViewControllerDelegate {
     // Default implementation to make optional
+    @_documentation(visibility: public)
     func payouts(_ payouts: PayoutsViewController,
                  didFailLoadWithError error: Error) { }
 }

--- a/StripeConnect/StripeConnect/Source/CustomFontSource.swift
+++ b/StripeConnect/StripeConnect/Source/CustomFontSource.swift
@@ -12,10 +12,14 @@ import UIKit
 @available(iOS 15, *)
 extension EmbeddedComponentManager {
 
-    /// Use a `CustomFontSource` pass custom fonts embedded in your app's binary when initializing a
-    /// `EmbeddedComponentManager`.
-    /// - Seealso: https://docs.stripe.com/connect/get-started-connect-embedded-components#customize-the-look-of-connect-embedded-components
-    /// - Seealso: https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app
+    /**
+     Use a `CustomFontSource` pass custom fonts embedded in your app's binary when initializing a
+     `EmbeddedComponentManager`.
+     - Seealso:
+       - [Customizing the look of connect embedded components](https://docs.stripe.com/connect/get-started-connect-embedded-components?platform=ios#customize-the-look-of-connect-embedded-components)
+       - [Adding custom fonts to your app](     https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app)
+     */
+    @_documentation(visibility: public)
     public struct CustomFontSource {
         let family: String
         let style: String?
@@ -25,14 +29,15 @@ extension EmbeddedComponentManager {
         /**
          Initializes a CustomFontSource from a base font and its original file URL
          - Parameters:
-         - font: A custom font embedded into your app's binary
-         - fileUrl: The local file URL corresponding to the custom font
-         
+           - font: A custom font embedded into your app's binary
+           - fileUrl: The local file URL corresponding to the custom font
+
          - Note: The font's size does not impact the appearance of the component.
          To adjust the font sizes used in components, use `EmbeddedComponentManager.Appearance`
          
          - Throws: Error if the font couldn't be loaded from the given URL
          */
+        @_documentation(visibility: public)
         public init(font: UIFont, fileUrl: URL) throws {
             guard fileUrl.isFileURL else {
                 throw FontLoadError.notFileURL

--- a/StripeConnect/StripeConnect/Source/CustomFontSource.swift
+++ b/StripeConnect/StripeConnect/Source/CustomFontSource.swift
@@ -15,9 +15,7 @@ extension EmbeddedComponentManager {
     /**
      Use a `CustomFontSource` pass custom fonts embedded in your app's binary when initializing a
      `EmbeddedComponentManager`.
-     - Seealso:
-       - [Customizing the look of connect embedded components](https://docs.stripe.com/connect/get-started-connect-embedded-components?platform=ios#customize-the-look-of-connect-embedded-components)
-       - [Adding custom fonts to your app](     https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app)
+     - Seealso: [Customizing the look of connect embedded components](https://docs.stripe.com/connect/get-started-connect-embedded-components?platform=ios#customize-the-look-of-connect-embedded-components) and [Adding custom fonts to your app](     https://developer.apple.com/documentation/uikit/text_display_and_fonts/adding_a_custom_font_to_your_app)
      */
     @_documentation(visibility: public)
     public struct CustomFontSource {

--- a/StripeConnect/StripeConnect/Source/CustomFontSource.swift
+++ b/StripeConnect/StripeConnect/Source/CustomFontSource.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 @_spi(PrivateBetaConnect)
+@_documentation(visibility: public)
 @available(iOS 15, *)
 extension EmbeddedComponentManager {
 

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
@@ -10,6 +10,7 @@
 import UIKit
 
 @_spi(PrivateBetaConnect)
+@_documentation(visibility: public)
 @available(iOS 15, *)
 extension EmbeddedComponentManager {
     /// Describes the appearance of embedded components.

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
@@ -14,8 +14,10 @@ import UIKit
 @available(iOS 15, *)
 extension EmbeddedComponentManager {
     /// Describes the appearance of embedded components.
-    /// - seealso: https://docs.stripe.com/connect/embedded-appearance-options
+    /// - seealso: [Appearance option documentation](https://docs.stripe.com/connect/embedded-appearance-options)
+    @_documentation(visibility: public)
     public struct Appearance {
+        @_documentation(visibility: public)
         public enum TextTransform {
             /// The text doesn’t have a transform.
             case none
@@ -58,21 +60,26 @@ extension EmbeddedComponentManager {
         }
 
         /// Describes the typography attributes used in embedded components
+        @_documentation(visibility: public)
         public struct Typography {
             /// Describes the font attributes used for a
             /// typography style in embedded components.
+            @_documentation(visibility: public)
             public struct Style {
                 /// The unscaled font size for this typography style.
                 /// The displayed fonts are automatically scaled when the component's size category is updated.
+                @_documentation(visibility: public)
                 public var fontSize: CGFloat?
                 /// The font weight for this typography style.
+                @_documentation(visibility: public)
                 public var weight: UIFont.Weight?
                 /// The text transform for this typography style.
+                @_documentation(visibility: public)
                 public var textTransform: TextTransform?
 
                 /// Creates a `EmbeddedComponentManager.Appearance.Typography.Stylye` with default values
+                @_documentation(visibility: public)
                 public init() {}
-
             }
 
             /// Determines the font family value used throughout embedded components.
@@ -83,77 +90,103 @@ extension EmbeddedComponentManager {
             /// - Note: Custom fonts included in your app's binary must be specified using a
             ///   `CustomFontSource` when initializing the `EmbeddedComponentManager` before
             ///   referencing them in the appearance's `typography.font` property.
+            @_documentation(visibility: public)
             public var font: UIFont?
             /// The unscaled baseline font size set on the embedded component root.
             /// This scales the value of other font size variables and is automatically scaled
             /// when the component's size category is updated.
+            @_documentation(visibility: public)
             public var fontSizeBase: CGFloat? = 16
             /// Describes the font size and weight for the medium body typography.
             /// The `textTransform` property is ignored.
+            @_documentation(visibility: public)
             public var bodyMd: Style = .init()
             /// Describes the font size and weight for the small body typography.
             /// The `textTransform` property is ignored.
+            @_documentation(visibility: public)
             public var bodySm: Style = .init()
             /// Describes the font size and weight for the extra large heading typography.
+            @_documentation(visibility: public)
             public var headingXl: Style = .init()
             /// Describes the font size and weight for the large heading typography.
+            @_documentation(visibility: public)
             public var headingLg: Style = .init()
             /// Describes the font size and weight for the medium heading typography.
+            @_documentation(visibility: public)
             public var headingMd: Style = .init()
             /// Describes the font size and weight for the small heading typography.
+            @_documentation(visibility: public)
             public var headingSm: Style = .init()
             /// Describes the font size and weight for the extra small heading typography.
+            @_documentation(visibility: public)
             public var headingXs: Style = .init()
             /// Describes the font size and weight for the medium label typography.
+            @_documentation(visibility: public)
             public var labelMd: Style = .init()
             /// Describes the font size and weight for the small label typography.
+            @_documentation(visibility: public)
             public var labelSm: Style = .init()
 
             /// Creates a `EmbeddedComponentManager.Appearance.Typography` with default values
+            @_documentation(visibility: public)
             public init() { }
         }
 
         /// Describes the colors used in embedded components.
         /// - Note: If UIColors using dynamicProviders are specified, the appearance will automatically
         ///   update when the component's UITraitCollection is updated (e.g. dark mode)
-        /// - Seealso: https://developer.apple.com/documentation/uikit/appearance_customization/supporting_dark_mode_in_your_interface
+        /// - Seealso: [Supporting Dark Mode in your app](https://developer.apple.com/documentation/uikit/appearance_customization/supporting_dark_mode_in_your_interface)
+        @_documentation(visibility: public)
         public struct Colors {
             /// The primary color used throughout embedded components.
             /// Set this to your primary brand color.
             /// The alpha component is ignored.
+            @_documentation(visibility: public)
             public var primary: UIColor?
             /// The color used for regular text.
+            @_documentation(visibility: public)
             public var text: UIColor?
             /// The color used to indicate errors or destructive actions.
             /// The alpha component is ignored.
+            @_documentation(visibility: public)
             public var danger: UIColor?
             /// The background color for embedded components, including overlays,
             /// tooltips, and popovers. The alpha component is ignored.
+            @_documentation(visibility: public)
             public var background: UIColor?
             /// The color used for secondary text.
+            @_documentation(visibility: public)
             public var secondaryText: UIColor?
             /// The color used for borders throughout the component.
+            @_documentation(visibility: public)
             public var border: UIColor?
             /// The color used for primary actions and links.
             /// The alpha component is ignored.
+            @_documentation(visibility: public)
             public var actionPrimaryText: UIColor?
             /// The color used for secondary actions and links.
             /// The alpha component is ignored.
+            @_documentation(visibility: public)
             public var actionSecondaryText: UIColor?
             /// The background color used when highlighting information,
             /// like the selected row on a table or particular piece of UI.
             /// The alpha component is ignored.
+            @_documentation(visibility: public)
             public var offsetBackground: UIColor?
             /// The background color used for form items.
             /// The alpha component is ignored.
+            @_documentation(visibility: public)
             public var formBackground: UIColor?
             /// The color used to highlight form items when focused.
+            @_documentation(visibility: public)
             public var formHighlightBorder: UIColor?
             /// The color used for to fill in form items like checkboxes,
             /// radio buttons and switches. The alpha component is ignored.
+            @_documentation(visibility: public)
             public var formAccent: UIColor?
 
             /// Creates a `EmbeddedComponentManager.Appearance.Colors` with default values
+            @_documentation(visibility: public)
             public init() {}
 
             /// The computed background color
@@ -181,84 +214,113 @@ extension EmbeddedComponentManager {
         }
 
         /// Describes the appearance of a button type used in embedded components
+        @_documentation(visibility: public)
         public struct Button {
             /// The color used as a background for this button type.
             /// The alpha component is ignored.
+            @_documentation(visibility: public)
             public var colorBackground: UIColor?
             /// The border color used for this button type.
             /// The alpha component is ignored.
+            @_documentation(visibility: public)
             public var colorBorder: UIColor?
             /// The text color used for this button type.
             /// The alpha component is ignored.
+            @_documentation(visibility: public)
             public var colorText: UIColor?
 
             /// Creates a `EmbeddedComponentManager.Appearance.Button` with default values
+            @_documentation(visibility: public)
             public init() { }
         }
 
         /// Describes the appearance of a badge type usied in embedded components.
+        @_documentation(visibility: public)
         public struct Badge {
             /// The background color for this badge type.
             /// The alpha component is ignored.
+            @_documentation(visibility: public)
             public var colorBackground: UIColor?
             /// The border color for this badge type.
+            @_documentation(visibility: public)
             public var colorBorder: UIColor?
             /// The text color for this badge type. The alpha component is ignored.
+            @_documentation(visibility: public)
             public var colorText: UIColor?
 
             /// Creates a `EmbeddedComponentManager.Appearance.Badge` with default values
+            @_documentation(visibility: public)
             public init() {}
         }
 
         /// Describes the corner radius used in embedded components.
+        @_documentation(visibility: public)
         public struct CornerRadius {
             /// The general border radius used in embedded components.
             /// This sets the default corner radius for all components.
+            @_documentation(visibility: public)
             public var base: CGFloat?
             /// The corner radius used for form elements.
+            @_documentation(visibility: public)
             public var form: CGFloat?
             /// The corner radius used for buttons.
+            @_documentation(visibility: public)
             public var button: CGFloat?
             /// The corner radius used for badges.
+            @_documentation(visibility: public)
             public var badge: CGFloat?
             /// The corner radius used for overlays.
+            @_documentation(visibility: public)
             public var overlay: CGFloat?
 
             /// Creates a `EmbeddedComponentManager.Appearance.CornerRadius` with default values
+            @_documentation(visibility: public)
             public init() {}
         }
 
         /// The default appearance
+        @_documentation(visibility: public)
         public static let `default`: Appearance = .init()
 
         /// Describes the appearance of typography used in embedded components.
+        @_documentation(visibility: public)
         public var typography: Typography = .init()
         /// Describes the colors used in embedded components.
+        @_documentation(visibility: public)
         public var colors: Colors = .init()
         /// The base spacing unit that derives all spacing values.
         /// Increase or decrease this value to make your layout more or less spacious.
+        @_documentation(visibility: public)
         public var spacingUnit: CGFloat?
         /// Describes the appearance of the primary button
+        @_documentation(visibility: public)
         public var buttonPrimary: Button  = .init()
         /// Describes the appearance of the secondary button
+        @_documentation(visibility: public)
         public var buttonSecondary: Button  = .init()
         /// Describes the appearance used to represent neutral
         /// state or lack of state in status badges.
+        @_documentation(visibility: public)
         public var badgeNeutral: Badge  = .init()
         /// Describes the appearance used to reinforce a successful
         /// outcome in status badges.
+        @_documentation(visibility: public)
         public var badgeSuccess: Badge  = .init()
         /// Describes the appearance used in status badges to highlight
         /// things that might require action, but are optional to resolve.
+        @_documentation(visibility: public)
         public var badgeWarning: Badge  = .init()
         /// Describes the appearance used in status badges for high-priority,
         /// critical situations that the user must address immediately, and to
         /// indicate failed or unsuccessful outcomes.
+        @_documentation(visibility: public)
         public var badgeDanger: Badge  = .init()
         /// Describes the corner radius used in embedded components.
+        @_documentation(visibility: public)
         public var cornerRadius: CornerRadius = .init()
 
         /// Creates a `EmbeddedComponentManager.Appearance` with default values
+        @_documentation(visibility: public)
         public init() {}
     }
 }

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
@@ -11,8 +11,8 @@ import UIKit
 
 /// Manages Connect embedded components
 /// - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
+/// - Note: Connect embedded components are only available in private preview.
 /// - Seealso: [Step by step integration guide](  https://docs.stripe.com/connect/get-started-connect-embedded-components?platform=ios)
-/// - Note: Connect embedded components are only available in private beta.
 @_spi(PrivateBetaConnect)
 @_documentation(visibility: public)
 @available(iOS 15, *)

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
@@ -12,7 +12,9 @@ import UIKit
 /// Manages Connect embedded components
 /// - Seealso: https://docs.stripe.com/connect/get-started-connect-embedded-components
 /// - Note: Connect embedded components are only available in private beta.
+/// - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
 @_spi(PrivateBetaConnect)
+@_documentation(visibility: public)
 @available(iOS 15, *)
 public class EmbeddedComponentManager {
     let apiClient: STPAPIClient
@@ -33,11 +35,11 @@ public class EmbeddedComponentManager {
         ComponentAnalyticsClient(client: AnalyticsClientV2.sharedConnect,
                                  commonFields: $0)
     }
-    
+
     var baseURL: URL = StripeConnectConstants.connectJSBaseURL
 
-    var publicKeyOverride: String? = nil
-    
+    var publicKeyOverride: String?
+
     @_spi(DashboardOnly)
     public convenience init(apiClient: STPAPIClient = STPAPIClient.shared,
                             appearance: EmbeddedComponentManager.Appearance = .default,
@@ -56,8 +58,7 @@ public class EmbeddedComponentManager {
             baseURL = baseURLOverride
         }
     }
-    
-    
+
     /**
      Initializes an EmbeddedComponentManager instance.
 

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
@@ -10,9 +10,9 @@ import JavaScriptCore
 import UIKit
 
 /// Manages Connect embedded components
-/// - Seealso: https://docs.stripe.com/connect/get-started-connect-embedded-components
-/// - Note: Connect embedded components are only available in private beta.
 /// - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
+/// - Seealso: [Step by step integration guide](  https://docs.stripe.com/connect/get-started-connect-embedded-components?platform=ios)
+/// - Note: Connect embedded components are only available in private beta.
 @_spi(PrivateBetaConnect)
 @_documentation(visibility: public)
 @available(iOS 15, *)
@@ -72,6 +72,7 @@ public class EmbeddedComponentManager {
      delegate access to. This function is also used to retrieve a client secret function to
      refresh the session when it expires.
      */
+    @_documentation(visibility: public)
     public init(apiClient: STPAPIClient = STPAPIClient.shared,
                 appearance: EmbeddedComponentManager.Appearance = .default,
                 fonts: [EmbeddedComponentManager.CustomFontSource] = [],
@@ -86,7 +87,8 @@ public class EmbeddedComponentManager {
     }
 
     /// Updates the appearance of components created from this EmbeddedComponentManager
-    /// - Seealso: https://docs.stripe.com/connect/get-started-connect-embedded-components#customize-the-look-of-connect-embedded-components
+    /// - Seealso: [Customizing the look of Connect embedded components](https://docs.stripe.com/connect/get-started-connect-embedded-components?platform=ios#customize-the-look-of-connect-embedded-components)
+    @_documentation(visibility: public)
     public func update(appearance: Appearance) {
         self.appearance = appearance
         for item in childWebViews.allObjects {
@@ -94,8 +96,9 @@ public class EmbeddedComponentManager {
         }
     }
 
-    /// Creates a payouts component
-    /// - Seealso: https://docs.stripe.com/connect/supported-embedded-components/payouts
+    /// Creates a `PayoutsViewController`
+    /// - Seealso: [Payouts component documentation](https://docs.stripe.com/connect/supported-embedded-components/payouts?platform=ios)
+    @_documentation(visibility: public)
     public func createPayoutsViewController() -> PayoutsViewController {
         .init(componentManager: self,
               loadContent: shouldLoadContent,
@@ -103,24 +106,25 @@ public class EmbeddedComponentManager {
     }
 
     /**
-        Creates an account-onboarding component.
-        - See also: https://docs.stripe.com/connect/supported-embedded-components/account-onboarding
+     Creates an `AccountOnboardingViewController`
+     - Seealso: [Account onboarding component documentation](https://docs.stripe.com/connect/supported-embedded-components/account-onboarding?platform=ios)
 
-        - Parameters:
-          - fullTermsOfServiceUrl: URL to your [full terms of service agreement](https://docs.stripe.com/connect/service-agreement-types#full).
-          - recipientTermsOfServiceUrl: URL to your [recipient terms of service](https://docs.stripe.com/connect/service-agreement-types#recipient) agreement.
-          - privacyPolicyUrl: Absolute URL to your privacy policy.
-          - skipTermsOfServiceCollection: If true, embedded onboarding skips terms of service collection and you must [collect terms acceptance yourself](https://docs.stripe.com/connect/updating-service-agreements#indicating-acceptance).
-          - collectionOptions: Specifies the requirements that Stripe collects from connected accounts
-       */
-       public func createAccountOnboardingViewController(
-           fullTermsOfServiceUrl: URL? = nil,
-           recipientTermsOfServiceUrl: URL? = nil,
-           privacyPolicyUrl: URL? = nil,
-           skipTermsOfServiceCollection: Bool? = nil,
-           collectionOptions: AccountCollectionOptions = .init()
-       ) -> AccountOnboardingViewController {
-           return .init(
+     - Parameters:
+       - fullTermsOfServiceUrl: URL to your [full terms of service agreement](https://docs.stripe.com/connect/service-agreement-types#full).
+       - recipientTermsOfServiceUrl: URL to your [recipient terms of service](https://docs.stripe.com/connect/service-agreement-types#recipient) agreement.
+       - privacyPolicyUrl: Absolute URL to your privacy policy.
+       - skipTermsOfServiceCollection: If true, embedded onboarding skips terms of service collection and you must [collect terms acceptance yourself](https://docs.stripe.com/connect/updating-service-agreements#indicating-acceptance).
+       - collectionOptions: Specifies the requirements that Stripe collects from connected accounts
+     */
+    @_documentation(visibility: public)
+    public func createAccountOnboardingViewController(
+        fullTermsOfServiceUrl: URL? = nil,
+        recipientTermsOfServiceUrl: URL? = nil,
+        privacyPolicyUrl: URL? = nil,
+        skipTermsOfServiceCollection: Bool? = nil,
+        collectionOptions: AccountCollectionOptions = .init()
+    ) -> AccountOnboardingViewController {
+        return .init(
             props: .init(
                 fullTermsOfServiceUrl: fullTermsOfServiceUrl,
                 recipientTermsOfServiceUrl: recipientTermsOfServiceUrl,
@@ -131,7 +135,7 @@ public class EmbeddedComponentManager {
             componentManager: self,
             loadContent: shouldLoadContent,
             analyticsClientFactory: analyticsClientFactory)
-       }
+    }
 
     @_spi(DashboardOnly)
     public func createPaymentDetailsViewController() -> PaymentDetailsViewController {

--- a/StripeConnect/StripeConnect/Source/Helpers/EmbeddedComponentError.swift
+++ b/StripeConnect/StripeConnect/Source/Helpers/EmbeddedComponentError.swift
@@ -8,7 +8,9 @@
 import Foundation
 
 /// An error that can occur loading a Connect embedded component
+/// - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
 @_spi(PrivateBetaConnect)
+@_documentation(visibility: public)
 public struct EmbeddedComponentError: Error, CustomDebugStringConvertible {
     public enum ErrorType: String {
         /// Failure to connect to Stripe's API

--- a/StripeConnect/StripeConnect/Source/Helpers/EmbeddedComponentError.swift
+++ b/StripeConnect/StripeConnect/Source/Helpers/EmbeddedComponentError.swift
@@ -12,6 +12,7 @@ import Foundation
 @_spi(PrivateBetaConnect)
 @_documentation(visibility: public)
 public struct EmbeddedComponentError: Error, CustomDebugStringConvertible {
+    @_documentation(visibility: public)
     public enum ErrorType: String {
         /// Failure to connect to Stripe's API
         case apiConnectionError = "api_connection_error"
@@ -29,11 +30,13 @@ public struct EmbeddedComponentError: Error, CustomDebugStringConvertible {
     }
 
     /// The type of error
+    @_documentation(visibility: public)
     public let type: ErrorType
 
     /// A non localized description of the error.
     let description: String
 
+    @_documentation(visibility: public)
     public var debugDescription: String {
         String("\(type.rawValue): \(description)")
     }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/AppearanceWrapper.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/AppearanceWrapper.swift
@@ -12,8 +12,8 @@ struct AppearanceWrapper: Encodable {
     let appearance: Appearance
     let traitCollection: UITraitCollection
 
-    public func encode(to encoder: Encoder) throws {
-           var container = encoder.container(keyedBy: StringCodingKey.self)
-           try container.encode(appearance.asDictionary(traitCollection: traitCollection), forKey: StringCodingKey("variables"))
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: StringCodingKey.self)
+        try container.encode(appearance.asDictionary(traitCollection: traitCollection), forKey: StringCodingKey("variables"))
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/CustomFontSourceWrapper.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/CustomFontSourceWrapper.swift
@@ -14,7 +14,7 @@ struct CustomFontSourceWrapper: Encodable {
         case family, style, weight, src
     }
 
-    public func encode(to encoder: Encoder) throws {
+    func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
 
         try container.encode(customFontSource.family, forKey: .family)

--- a/StripeConnect/StripeConnect/Source/Models/AccountCollectionOptions.swift
+++ b/StripeConnect/StripeConnect/Source/Models/AccountCollectionOptions.swift
@@ -13,21 +13,26 @@ import Foundation
 @_documentation(visibility: public)
 public struct AccountCollectionOptions: Equatable, Codable {
 
+    @_documentation(visibility: public)
     public enum FieldOption: String, Codable {
         case currentlyDue = "currently_due"
         case eventuallyDue = "eventually_due"
     }
 
+    @_documentation(visibility: public)
     public enum FutureRequirementOption: String, Codable {
         case omit
         case include
     }
 
     /// Customizes collecting `currently_due` or `eventually_due` requirements
+    @_documentation(visibility: public)
     public var fields: FieldOption = .currentlyDue
 
     /// Controls whether to include [future requirements](https://docs.stripe.com/api/accounts/object#account_object-future_requirements)
+    @_documentation(visibility: public)
     public var futureRequirements: FutureRequirementOption = .omit
 
+    @_documentation(visibility: public)
     public init() {}
 }

--- a/StripeConnect/StripeConnect/Source/Models/AccountCollectionOptions.swift
+++ b/StripeConnect/StripeConnect/Source/Models/AccountCollectionOptions.swift
@@ -7,8 +7,10 @@
 
 import Foundation
 
-@_spi(PrivateBetaConnect)
 /// Collection options for account onboarding
+/// - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
+@_spi(PrivateBetaConnect)
+@_documentation(visibility: public)
 public struct AccountCollectionOptions: Equatable, Codable {
 
     public enum FieldOption: String, Codable {

--- a/StripeFinancialConnections/README.md
+++ b/StripeFinancialConnections/README.md
@@ -3,14 +3,14 @@
 Stripe Financial Connections iOS SDK lets your users securely share their financial data by linking their external financial accounts to your business in your iOS app.
 
 ## Table of contents
-
+<!-- NOTE: Use case-sensitive anchor links for docc compatibility -->
 <!--ts-->
-* [Features](#features)
-* [Requirements](#requirements)
-* [Getting started](#getting-started)
-   * [Integration](#integration)
-   * [Example](#example)
-* [Manual linking](#manual-linking)
+* [Features](#Features)
+* [Requirements](#Requirements)
+* [Getting started](#Getting-started)
+   * [Integration](#Integration)
+   * [Example](#Example)
+* [Manual linking](#Manual-linking)
 
 <!--te-->
 

--- a/StripeIdentity/README.md
+++ b/StripeIdentity/README.md
@@ -5,14 +5,14 @@ The Stripe Identity iOS SDK makes it quick and easy to verify your user's identi
 > To get access to the Identity iOS SDK, visit the [Identity Settings](https://dashboard.stripe.com/settings/identity) page and click **Enable**.
 
 ## Table of contents
-
+<!-- NOTE: Use case-sensitive anchor links for docc compatibility -->
 <!--ts-->
-* [Features](#features)
-* [Requirements](#requirements)
-* [Getting started](#getting-started)
-   * [Integration](#integration)
-   * [Example](#example)
-* [Manual linking](#manual-linking)
+* [Features](#Features)
+* [Requirements](#Requirements)
+* [Getting started](#Getting-started)
+   * [Integration](#Integration)
+   * [Example](#Example)
+* [Manual linking](#Manual-linking)
 
 <!--te-->
 

--- a/StripePaymentSheet/README.md
+++ b/StripePaymentSheet/README.md
@@ -3,14 +3,14 @@
 PaymentSheet is a prebuilt UI that combines all the steps required to pay - collecting payment details, billing details, and confirming the payment - into a single sheet that displays on top of your app.
 
 ## Table of contents
-
+<!-- NOTE: Use case-sensitive anchor links for docc compatibility -->
 <!--ts-->
-* [Features](#features)
-* [Requirements](#requirements)
-* [Getting started](#getting-started)
-   * [Integration](#integration)
-   * [Example](#example)
-* [Manual linking](#manual-linking)
+* [Features](#Features)
+* [Requirements](#Requirements)
+* [Getting started](#Getting-started)
+   * [Integration](#Integration)
+   * [Example](#Example)
+* [Manual linking](#Manual-linking)
 
 <!--te-->
 

--- a/StripePayments/README.md
+++ b/StripePayments/README.md
@@ -5,7 +5,7 @@ The StripePayments module contains bindings for the Stripe Payments API.
 If you need to accept card payments, we advise using the [StripePaymentSheet](../StripePaymentSheet/README.md) or [StripePaymentsUI](../StripePaymentsUI/README.md) module. For more information, visit our [integration security guide](https://stripe.com/docs/security/guide).
 
 ## Table of contents
-
+<!-- NOTE: Use case-sensitive anchor links for docc compatibility -->
 <!--ts-->
 * [Requirements](#Requirements)
 * [Getting started](#Getting-started)

--- a/StripePaymentsUI/README.md
+++ b/StripePaymentsUI/README.md
@@ -9,7 +9,7 @@ It contains:
 * [STPAUBECSDebitFormView](https://stripe.dev/stripe-ios/stripepaymentsui/documentation/stripepaymentsui/stpaubecsdebitformview), a UIControl that contains all of the necessary fields and legal text for collecting AU BECS Debit payments.
 
 ## Table of contents
-
+<!-- NOTE: Use case-sensitive anchor links for docc compatibility -->
 <!--ts-->
 * [Requirements](#Requirements)
 * [Getting started](#Getting-started)

--- a/ci_scripts/build_documentation.rb
+++ b/ci_scripts/build_documentation.rb
@@ -197,10 +197,12 @@ def build_index_page(modules, release_version, docs_root_directory)
 
   "''
   # Add the modules to the docc template
-  modules.each do |m|
-    # Load podspec to get module name and summary
-    podspec = Pod::Specification.from_file(File.join_if_safe($ROOT_DIR, m['podspec']))
-    index_content += "**[#{podspec.name}](../../#{m['framework_name'].downcase}/documentation/#{m['framework_name'].downcase})**\n\n#{podspec.summary}\n\n"
+  modules
+    .sort_by { |m| m['framework_name'] }
+    .each do |m|
+      # Load podspec to get module name and summary
+      podspec = Pod::Specification.from_file(File.join_if_safe($ROOT_DIR, m['podspec']))
+      index_content += "**[#{podspec.name}](../../#{m['framework_name'].downcase}/documentation/#{m['framework_name'].downcase})**\n\n#{podspec.summary}\n\n"
   end
 
   File.write(index_path, index_content)
@@ -230,7 +232,7 @@ end
 
 def publish(release_version, docs_root_directory)
   git_publish_dir = Dir.mktmpdir('stripe-docs-git')
-  docs_branchname = "docs-publish/#{release_version}"
+  docs_branchname = "docs-publish/#{release_version}_fix"
   `cp -a "#{$ROOT_DIR}/.git" "#{git_publish_dir}"`
   Dir.chdir(git_publish_dir) do
     `git checkout docs`

--- a/ci_scripts/build_documentation.rb
+++ b/ci_scripts/build_documentation.rb
@@ -217,22 +217,13 @@ def build_index_page(modules, release_version, docs_root_directory)
   # Copy 404 redirect page
   `cp "#{$SCRIPT_DIR}/docs/404.html" "#{docs_root_directory}/docs/404.html"`
 
-  # HACK: Remove all deprecation warnings.
-  # Remove this once DocC is fixed: https://github.com/apple/swift-docc/issues/450
-  js_files = Dir.glob("#{docs_root_directory}/docs/**/*.json")
-  js_files.each do |jsf|
-    content = File.read(jsf)
-    content = content.gsub(/"deprecated":true/, '"deprecated":false')
-    File.open(jsf, 'w') { |file| file.puts content }
-  end
-
   # Clean up the bogus index.html file created by DocC
   File.delete("#{docs_root_directory}/docs/index.html")
 end
 
 def publish(release_version, docs_root_directory)
   git_publish_dir = Dir.mktmpdir('stripe-docs-git')
-  docs_branchname = "docs-publish/#{release_version}_fix"
+  docs_branchname = "docs-publish/#{release_version}"
   `cp -a "#{$ROOT_DIR}/.git" "#{git_publish_dir}"`
   Dir.chdir(git_publish_dir) do
     `git checkout docs`

--- a/modules.yaml
+++ b/modules.yaml
@@ -62,10 +62,6 @@
 #     of the docs for this module. Used as the `--readme` argument to Jazzy.
 #     If omitted, uses Jazzy default (the root directory's README.md file).
 #
-#     NOTE: You must add a placeholder file to the module's project in the 
-#     following location for the README to be included in docs:
-#       [ModuleName]/[ModuleName]/Docs.docc/[ModuleName].md
-#
 #   - include (optional):
 #     An array of modules to be combined with this module, for the purpose of documentation.
 #

--- a/modules.yaml
+++ b/modules.yaml
@@ -62,6 +62,10 @@
 #     of the docs for this module. Used as the `--readme` argument to Jazzy.
 #     If omitted, uses Jazzy default (the root directory's README.md file).
 #
+#     NOTE: You must add a placeholder file to the module's project in the 
+#     following location for the README to be included in docs:
+#       [ModuleName]/[ModuleName]/Docs.docc/[ModuleName].md
+#
 #   - include (optional):
 #     An array of modules to be combined with this module, for the purpose of documentation.
 #


### PR DESCRIPTION
## Summary
- **README is now included in the StripeConnect docs root page**
  Root cause: A placeholder `Docs.docc/StripeConnect.md` file needed to be included in the project. The `build_documentation` script copies the README contents into this file and because docc uses xcodebuild, it can only reference it if it's in the project.

- **Fixed anchor tag links that were using incorrect casing**
  Root cause: docc is case-sensitive when generating anchor tags from headers, so these links didn't work on the docs site on pages that included the README. The change is compatible with Github as it's case-insensitive.

- **Now generating docs for API gated behind `@_spi(ConnectPrivateBeta)`**
  Docc excludes SPI from docs since it's not public, however adding the `@_documentation(visibility: public)` fixes the issue. Unfortunately, this needs to be individually added to every SPI-reference to make it generate to docs, not just the enclosing type.

- **Removed deprecation "hack" from `build_documentation`**
  This was a workaround for the following docc bug, which has since been fixed:
  https://github.com/apple/swift-docc/issues/450

- **Cleaned up docstring references in Connect**
  Various minor fixes to docstrings like formatting the `seealso` sections using Markdoc.

- **Alphabetized modules on root page**

## Motivation
https://jira.corp.stripe.com/browse/MXMOBILE-3003

## Testing
- Applied these changes to the 24.2.0 release tag: https://github.com/stripe/stripe-ios/compare/24.2.0...mludowise/MXMOBILE-3003_docs_readme_base_24.2.0?expand=1
- Ran the `deploy-docs` workflow on that branch: https://app.bitrise.io/build/b7abb0d9-9e19-4705-8550-c12c549b6785
- Pulled the resulting branch locally: https://github.com/stripe/stripe-ios/tree/docs-publish/24.2.0
- Ran `python3 -m http.server 4242` to locally serve the resulting docs site


<img width="1186" alt="image" src="https://github.com/user-attachments/assets/d227f486-91d6-49de-9684-602dd31d9b2d" />
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/62d9f8a8-ec5e-4683-8de4-c7fe67013266" />

## Changelog
n/a
