### PR TITLE
Default Embedded formSheetAction property as `.continue`

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleEmbeddedElementCheckoutViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleEmbeddedElementCheckoutViewController.swift
@@ -260,11 +260,10 @@ class ExampleEmbeddedElementCheckoutViewController: UIViewController {
             self.computedTotals = ComputedTotals(subtotal: subtotal, tax: tax, total: total)
 
             // MARK: - Create a EmbeddedPaymentElement instance
-            var configuration = EmbeddedPaymentElement.Configuration(
-                formSheetAction: .confirm(completion: { [weak self] result in
-                    self?.handlePaymentResult(result)
-                })
-            )
+            var configuration = EmbeddedPaymentElement.Configuration()
+            configuration.formSheetAction = .confirm(completion: { [weak self] result in
+                self?.handlePaymentResult(result)
+            })
             // This example displays the buy button in a screen that is separate from screen that displays the embedded view, so we disable the mandate text in the embedded view and show it near our buy button.
             configuration.embeddedViewDisplaysMandateText = false
             configuration.merchantDisplayName = "Example, Inc."

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -200,7 +200,8 @@ class PlaygroundController: ObservableObject {
             }
         }()
 
-        var configuration = EmbeddedPaymentElement.Configuration(formSheetAction: formSheetAction)
+        var configuration = EmbeddedPaymentElement.Configuration()
+        configuration.formSheetAction = formSheetAction
         configuration.embeddedViewDisplaysMandateText = settings.embeddedViewDisplaysMandateText == .on
         configuration.externalPaymentMethodConfiguration = externalPaymentMethodConfiguration
         switch settings.externalPaymentMethods {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
@@ -144,12 +144,12 @@ extension EmbeddedPaymentElement {
                 completion: (EmbeddedPaymentElementResult) -> Void
             )
 
-            /// The button says “Continue”. When tapped, the form sheet closes.
+            /// The button says “Continue”. When tapped, the form sheet closes. The customer can confirm payment or setup back in your app.
             case `continue`
         }
 
         /// The view can display payment methods like “Card” that, when tapped, open a sheet where customers enter their payment method details. The sheet has a button at the bottom. `formSheetAction` controls the action the button performs.
-        public var formSheetAction: FormSheetAction
+        public var formSheetAction: FormSheetAction = .continue
 
         /// Controls whether the view displays mandate text at the bottom for payment methods that require it. If set to `false`, your integration must display `PaymentOptionDisplayData.mandateText` to the customer near your “Buy” button to comply with regulations.
         /// - Note: This doesn't affect mandates displayed in the form sheet.
@@ -161,8 +161,6 @@ extension EmbeddedPaymentElement {
         internal var linkPaymentMethodsOnly: Bool = false
 
         /// Initializes a Configuration with default values
-        public init(formSheetAction: FormSheetAction) {
-            self.formSheetAction = formSheetAction
-        }
+        public init() {}
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedFormViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedFormViewControllerSnapshotTests.swift
@@ -73,11 +73,8 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
     // MARK: - Tests
 
     func testDisplayCard_confirmFormSheetAction() {
-        let configuration = EmbeddedPaymentElement.Configuration(
-            formSheetAction: .confirm(completion: { _ in
-                // no-op
-            })
-        )
+        var configuration = EmbeddedPaymentElement.Configuration()
+        configuration.formSheetAction = .confirm(completion: { _ in })
         let sut = makeEmbeddedFormViewController(
             configuration: configuration,
             paymentMethodType: .card
@@ -86,9 +83,7 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
     }
 
     func testDisplayCard_continueFormSheetAction() {
-        let configuration = EmbeddedPaymentElement.Configuration(
-            formSheetAction: .continue
-        )
+        var configuration = EmbeddedPaymentElement.Configuration()
         let sut = makeEmbeddedFormViewController(
             configuration: configuration,
             paymentMethodType: .card
@@ -102,11 +97,8 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
                 return "Mock error description"
             }
         }
-        let configuration = EmbeddedPaymentElement.Configuration(
-            formSheetAction: .confirm(completion: { _ in
-                // no-op
-            })
-        )
+        var configuration = EmbeddedPaymentElement.Configuration()
+        configuration.formSheetAction = .confirm(completion: { _ in })
         let sut = makeEmbeddedFormViewController(
             configuration: configuration,
             paymentMethodType: .card
@@ -116,11 +108,8 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
     }
 
     func testRestoresPreviousCustomerInput() {
-        let configuration = EmbeddedPaymentElement.Configuration(
-            formSheetAction: .confirm(completion: { _ in
-                // no-op
-            })
-        )
+        var configuration = EmbeddedPaymentElement.Configuration()
+        configuration.formSheetAction = .confirm(completion: { _ in })
         let previousPaymentOption = PaymentOption.new(
             confirmParams: IntentConfirmParams(
                 params: ._testValidCardValue(),
@@ -136,11 +125,8 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
     }
 
     func testDisabledState() {
-        let configuration = EmbeddedPaymentElement.Configuration(
-            formSheetAction: .confirm(completion: { _ in
-                // no-op
-            })
-        )
+        var configuration = EmbeddedPaymentElement.Configuration()
+        configuration.formSheetAction = .confirm(completion: { _ in })
         let sut = makeEmbeddedFormViewController(
             configuration: configuration,
             paymentMethodType: .card
@@ -150,11 +136,8 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
     }
 
     func testBillingCollectionConfiguration() {
-        var configuration = EmbeddedPaymentElement.Configuration(
-            formSheetAction: .confirm(completion: { _ in
-                // no-op
-            })
-        )
+        var configuration = EmbeddedPaymentElement.Configuration()
+        configuration.formSheetAction = .confirm(completion: { _ in })
         configuration.billingDetailsCollectionConfiguration = .init(name: .always, phone: .always)
         let sut = makeEmbeddedFormViewController(
             configuration: configuration,
@@ -164,11 +147,8 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
     }
 
     func testMandateView() {
-        let configuration = EmbeddedPaymentElement.Configuration(
-            formSheetAction: .confirm(completion: { _ in
-                // no-op
-            })
-        )
+        var configuration = EmbeddedPaymentElement.Configuration()
+        configuration.formSheetAction = .confirm(completion: { _ in })
         let sut = makeEmbeddedFormViewController(
             configuration: configuration,
             paymentMethodType: .SEPADebit
@@ -177,18 +157,15 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
         sut.updateMandate()
         verify(sut)
     }
-    
+
     func testDisplaysErrorAndMandate() {
         struct MockError: LocalizedError {
             var errorDescription: String? {
                 return "Mock error description"
             }
         }
-        let configuration = EmbeddedPaymentElement.Configuration(
-            formSheetAction: .confirm(completion: { _ in
-                // no-op
-            })
-        )
+        var configuration = EmbeddedPaymentElement.Configuration()
+        configuration.formSheetAction = .confirm(completion: { _ in })
         let sut = makeEmbeddedFormViewController(
             configuration: configuration,
             paymentMethodType: .SEPADebit

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FormMandateProviderTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FormMandateProviderTests.swift
@@ -18,7 +18,7 @@ class FormMandateProviderTests: XCTestCase {
     }
 
     func testFormMandateProvider_WhenConfigurationHidesMandateText_ShouldReturnNil() {
-        var embeddedConfiguration = EmbeddedPaymentElement.Configuration(formSheetAction: .continue)
+        var embeddedConfiguration = EmbeddedPaymentElement.Configuration()
         embeddedConfiguration.embeddedViewDisplaysMandateText = false
         embeddedConfiguration.merchantDisplayName = "Test Merchant"
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
@@ -35,7 +35,7 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
         STPAnalyticsClient.sharedClient.productUsage = Set()
         XCTAssertTrue(STPAnalyticsClient.sharedClient.productUsage.isEmpty)
         let e = expectation(description: "callback")
-        EmbeddedPaymentElement.create(intentConfiguration: intentConfig, configuration: EmbeddedPaymentElement.Configuration(formSheetAction: .continue)) { _ in
+        EmbeddedPaymentElement.create(intentConfiguration: intentConfig, configuration: EmbeddedPaymentElement.Configuration()) { _ in
             e.fulfill()
         }
         wait(for: [e], timeout: 1.0)
@@ -377,7 +377,7 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
             config.customer = customer
             return config
         case .embedded:
-            var config = EmbeddedPaymentElement.Configuration(formSheetAction: .continue)
+            var config = EmbeddedPaymentElement.Configuration()
             config.applePay = applePay
             config.customer = customer
             return config

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -29,7 +29,7 @@ public extension PaymentSheet.Configuration {
 public extension EmbeddedPaymentElement.Configuration {
     /// Provides a Configuration that allows all pm types available
     static func _testValue_MostPermissive(isApplePayEnabled: Bool = true) -> Self {
-        var configuration = EmbeddedPaymentElement.Configuration(formSheetAction: .continue)
+        var configuration = EmbeddedPaymentElement.Configuration()
         configuration.returnURL = "https://foo.com"
         configuration.allowsDelayedPaymentMethods = true
         configuration.allowsPaymentMethodsRequiringShippingAddress = true


### PR DESCRIPTION
https://stripe.slack.com/archives/C0353FPANQ0/p1734643574432679?thread_ts=1727303418.476899&cid=C0353FPANQ0


## Testing
Relying on existing tests

## Changelog
Feature not yet released