### PR TITLE
Add MPE integration to Connections demo app

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -31,16 +31,16 @@ final class PlaygroundConfiguration {
         }
     }
 
-    // MARK: - Experience
+    // MARK: - Integration Type
 
-    enum Experience: String, CaseIterable, Identifiable, Hashable {
-        case financialConnections = "financial_connections"
-        case instantDebits = "instant_debits"
+    enum IntegrationType: String, CaseIterable, Identifiable, Hashable {
+        case standalone = "standalone"
+        case paymentElement = "payment_element"
 
         var displayName: String {
             switch self {
-            case .financialConnections: "Financial Connections"
-            case .instantDebits: "Instant Debits"
+            case .standalone: "Standalone"
+            case .paymentElement: "Payment Element"
             }
         }
 
@@ -49,15 +49,61 @@ final class PlaygroundConfiguration {
         }
     }
 
+    private static let integrationTypeKey = "integration_type"
+
+    var integrationType: IntegrationType {
+        get {
+            if
+                let integrationTypeString = configurationStore[Self.integrationTypeKey] as? String,
+                let integrationType = IntegrationType(rawValue: integrationTypeString)
+            {
+                return integrationType
+            } else {
+                return .standalone
+            }
+        }
+        set {
+            configurationStore[Self.integrationTypeKey] = newValue.rawValue
+        }
+    }
+
+    // MARK: - Experience
+
+    enum Experience: String, CaseIterable, Identifiable, Hashable {
+        case financialConnections = "financial_connections"
+        case instantBankPayment = "instant_debits"
+        case linkCardBrand = "link_card_brand"
+
+        var displayName: String {
+            switch self {
+            case .financialConnections: "Financial Connections"
+            case .instantBankPayment: "Instant Bank Payment"
+            case .linkCardBrand: "Link Card Brand"
+            }
+        }
+
+        var id: String {
+            return rawValue
+        }
+
+        var paymentMethods: String {
+            switch self {
+            case .financialConnections: return "['card', 'link', 'us_bank_account']"
+            case .instantBankPayment: return "['card', 'link']"
+            case .linkCardBrand: return "['card']"
+            }
+        }
+    }
+
     private static let experienceKey = "experience"
 
     var experience: Experience {
         get {
             if
-                let sdkTypeString = configurationStore[Self.experienceKey] as? String,
-                let sdkType = Experience(rawValue: sdkTypeString)
+                let experienceString = configurationStore[Self.experienceKey] as? String,
+                let experience = Experience(rawValue: experienceString)
             {
-                return sdkType
+                return experience
             } else {
                 return .financialConnections
             }

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
@@ -17,17 +17,32 @@ struct PlaygroundView: View {
         ZStack {
             VStack {
                 Form {
-                    Section(header: Text("Experience")) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Picker("Select Experience", selection: viewModel.experience) {
-                                ForEach(PlaygroundConfiguration.Experience.allCases) {
-                                    Text($0.displayName)
-                                        .tag($0)
-                                }
+                    Section(header: Text("Integration Type")) {
+                        Picker("Integration Type", selection: viewModel.integrationType) {
+                            ForEach(PlaygroundConfiguration.IntegrationType.allCases) {
+                                Text($0.displayName)
+                                    .tag($0)
                             }
-                            .pickerStyle(.segmented)
+                        }
+                        .pickerStyle(.segmented)
+                    }
+
+                    Picker("Experience", selection: viewModel.experience) {
+                        ForEach(PlaygroundConfiguration.Experience.allCases) {
+                            Text($0.displayName)
+                                .tag($0)
+                        }
+
+                        if viewModel.integrationType.wrappedValue == .standalone && viewModel.experience.wrappedValue == .linkCardBrand {
+                            Text("'Link Card Brand' in the standalone integration will launch the Instant Bank Payment flow.")
+                                .font(.caption)
+                                .italic()
+                        } else if viewModel.integrationType.wrappedValue == .paymentElement {
+                            Text("Payment methods requested will be: `\(viewModel.experience.wrappedValue.paymentMethods)`")
+                                .font(.caption)
                         }
                     }
+                    .pickerStyle(.inline)
 
                     Section(header: Text("Select SDK Type")) {
                         VStack(alignment: .leading, spacing: 4) {


### PR DESCRIPTION
## Summary

This adds an MPE integration in our Financial Connections example app, along with 3 different experiences: 

1. Financial Connections: Payment methods: `['card', 'link', 'us_bank_account']`
2. Instant Bank Payments: Payment methods: `['card', 'link']`
3. Link Card Brand: Payment methods: `['card']`
    a. Note: Using the Link Card Brand experience with the standalone integration will simply launch the IBP flow. 

As part of this, I also updated our Glitch server (`financial-connections-playground-ios`) with a `/create_payment_intent` endpoint.

## Motivation

Provide a more standard integration option right in the FC example app, rather than always using the Payment Sheet example app.

## Testing

Running through the integrations / experiences: 

https://github.com/user-attachments/assets/dad909c0-0279-4334-b559-34e217809f20

And setting the SDK type to `web` still works with the payment sheet:

https://github.com/user-attachments/assets/39efb9d8-4079-4274-b36f-15c5f2836b08

## Changelog

N/a