### PR TITLE
Autoselect the email field when signing up for Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
@@ -154,6 +154,11 @@ extension PayWithLinkViewController {
         override func viewDidAppear(_ animated: Bool) {
             super.viewDidAppear(animated)
             STPAnalyticsClient.sharedClient.logLinkSignupFlowPresented()
+            
+            // If the email field is empty, select it
+            if emailElement.emailAddressString?.isEmpty ?? false {
+                emailElement.beginEditing()
+            }
         }
 
         private func setupBindings() {


### PR DESCRIPTION
## Summary
When the signup view appears, select the email field if it isn't already populated.<

## Testing
In PS Example