### PR TITLE
Pass through deferred intent type for Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-BaseViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-BaseViewController.swift
@@ -97,7 +97,7 @@ extension PayWithLinkViewController {
         @objc
         func onCloseButtonTapped(_ sender: UIButton) {
             if context.shouldFinishOnClose {
-                coordinator?.finish(withResult: .canceled)
+                coordinator?.finish(withResult: .canceled, deferredIntentConfirmationType: nil)
             } else {
                 coordinator?.cancel()
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -222,7 +222,7 @@ extension PayWithLinkViewController {
 
                     self.coordinator?.confirm(with: self.linkAccount,
                                               paymentDetails: paymentDetails,
-                                              completion: { [weak self] result in
+                                              completion: { [weak self] result, deferredIntentConfirmationType in
                         let state: ConfirmButton.Status
 
                         switch result {
@@ -240,7 +240,7 @@ extension PayWithLinkViewController {
                         #endif
                         self?.confirmButton.update(state: state, animated: true) {
                             if state == .succeeded {
-                                self?.coordinator?.finish(withResult: result)
+                                self?.coordinator?.finish(withResult: result, deferredIntentConfirmationType: deferredIntentConfirmationType)
                             }
                         }
                     })

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -265,14 +265,14 @@ extension PayWithLinkViewController {
             updateErrorLabel(for: nil)
             confirmButton.update(state: .processing)
 
-            coordinator?.confirm(with: linkAccount, paymentDetails: paymentDetails) { [weak self] result in
+            coordinator?.confirm(with: linkAccount, paymentDetails: paymentDetails) { [weak self] result, deferredIntentConfirmationType in
                 switch result {
                 case .completed:
                     #if !os(visionOS)
                     self?.feedbackGenerator.notificationOccurred(.success)
                     #endif
                     self?.confirmButton.update(state: .succeeded, animated: true) {
-                        self?.coordinator?.finish(withResult: result)
+                        self?.coordinator?.finish(withResult: result, deferredIntentConfirmationType: deferredIntentConfirmationType)
                     }
                 case .canceled:
                     self?.confirmButton.update(state: .enabled)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -91,9 +91,9 @@ extension PayWithNativeLinkController: PayWithLinkViewControllerDelegate {
         selfRetainer = nil
     }
 
-    func payWithLinkViewControllerDidFinish(_ payWithLinkViewController: PayWithLinkViewController, result: PaymentSheetResult) {
+    func payWithLinkViewControllerDidFinish(_ payWithLinkViewController: PayWithLinkViewController, result: PaymentSheetResult, deferredIntentConfirmationType: STPAnalyticsClient.DeferredIntentConfirmationType?) {
         payWithLinkViewController.dismiss(animated: true)
-        completion?(result, nil)
+        completion?(result, deferredIntentConfirmationType)
         selfRetainer = nil
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -152,7 +152,8 @@ extension PaymentSheet: PayWithLinkViewControllerDelegate {
 
     func payWithLinkViewControllerDidFinish(
         _ payWithLinkViewController: PayWithLinkViewController,
-        result: PaymentSheetResult
+        result: PaymentSheetResult,
+        deferredIntentConfirmationType: StripeCore.STPAnalyticsClient.DeferredIntentConfirmationType?
     ) {
         completion?(result)
     }


### PR DESCRIPTION
## Summary
Pass through the deferred intent type for Link transactions.

## Motivation
Fixing Link analytics. `deferredIntentConfirmationType` logging is tested in PaymentSheetAnalyticsHelperTest.

## Testing
Manually in PS Example. 