### PR TITLE
Add automatic_async to PaymentIntent capture method enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## X.Y.Z
+
+## PaymentSheet
+* [Fixed] Fixed a bug where deferred PaymentIntents would fail to validate when capture_method = automatic_async ([#4329](https://github.com/stripe/stripe-ios/issues/4329))
+
 ## 24.2.0 2024-12-19
 
 ### Connect

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
@@ -6,10 +6,8 @@
 //
 
 import Foundation
-import StripePayments
 @_spi(STP) import StripeCore
-@_spi(STP) import StripePayments
-
+import StripePayments
 struct PaymentSheetDeferredValidator {
     /// Note: We don't validate amount (for any payment method) because there are use cases where the amount can change slightly between PM collection and confirmation.
     static func validate(paymentIntent: STPPaymentIntent,
@@ -68,7 +66,7 @@ struct PaymentSheetDeferredValidator {
             }
             let errorMessage = """
                 \nThere is a mismatch between the payment method ID on your Intent: \(intentPaymentMethod.stripeId) and the payment method passed into the `confirmHandler`: \(paymentMethod.stripeId).
-            
+
                 To resolve this issue, you can:
                 1. Create a new Intent each time before you call the `confirmHandler`, or
                 2. Update the existing Intent with the desired `paymentMethod` before calling the `confirmHandler`.
@@ -141,6 +139,8 @@ private func == (lhs: STPPaymentIntentCaptureMethod, rhs: PaymentSheet.IntentCon
         return rhs == .manual
     case .unknown:
         return false
+    case .automaticAsync:
+        return rhs == .automaticAsync
     @unknown default:
         return false
     }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPPaymentIntent.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPPaymentIntent.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 /// Capture methods for a STPPaymentIntent
+/// - seealso: https://docs.stripe.com/api/payment_intents/object#payment_intent_object-capture_method
 @objc public enum STPPaymentIntentCaptureMethod: Int {
     /// Unknown capture method
     case unknown
@@ -17,6 +18,10 @@ import Foundation
     /// The PaymentIntent must be manually captured once it has the status
     /// `STPPaymentIntentStatusRequiresCapture`
     case manual
+    /// Asynchronously capture funds when the customer authorizes the payment.
+    /// - Note: Recommended over `CaptureMethod.automatic` due to improved latency, but may require additional integration changes.
+    /// - Seealso: https://stripe.com/docs/payments/payment-intents/asynchronous-capture-automatic-async
+    case automaticAsync
 
     /// Parse the string and return the correct `STPPaymentIntentCaptureMethod`,
     /// or `STPPaymentIntentCaptureMethodUnknown` if it's unrecognized by this version of the SDK.
@@ -25,6 +30,7 @@ import Foundation
         let map: [String: STPPaymentIntentCaptureMethod] = [
             "manual": .manual,
             "automatic": .automatic,
+            "automatic_async": .automaticAsync,
         ]
 
         let key = string.lowercased()

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -313,6 +313,8 @@ extension STPPaymentIntentCaptureMethod: CustomStringConvertible {
             return "manual"
         case .unknown:
             return "unknown"
+        case .automaticAsync:
+            return "automaticAsync"
         }
     }
 }


### PR DESCRIPTION
## Motivation
https://github.com/stripe/stripe-ios/issues/4329

## Testing
https://docs.stripe.com/api/payment_intents/object#payment_intent_object-capture_method

## Changelog
See changelog