### PR TITLE
Don't enable bank accounts in Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -323,7 +323,7 @@ extension STPAPIClient {
         let parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
             "request_surface": "ios_payment_element",
-            "types": ["card", "bank_account"],
+            "types": ["card"],
         ]
 
         post(


### PR DESCRIPTION
## Summary
Disable bank accounts for now when requesting Link PMs.

## Testing
PS Example