### PR TITLE
Remove extra CY country code mapping

### DIFF
--- a/StripeUICore/StripeUICore/Source/Validators/PhoneNumber.swift
+++ b/StripeUICore/StripeUICore/Source/Validators/PhoneNumber.swift
@@ -343,7 +343,6 @@ import UIKit
             Metadata(prefix: "+509", regionCode: "HT", pattern: "## ## ####"),
             Metadata(prefix: "+51", regionCode: "PE", pattern: "### ### ###"),
             Metadata(prefix: "+52", regionCode: "MX", pattern: "### ### ####"),
-            Metadata(prefix: "+537", regionCode: "CY", pattern: ""),
             Metadata(prefix: "+54", regionCode: "AR", pattern: "## ##-####-####"),
             Metadata(prefix: "+55", regionCode: "BR", pattern: "## #####-####"),
             Metadata(prefix: "+56", regionCode: "CL", pattern: "# #### ####"),


### PR DESCRIPTION
# Summary
<!-- Simple summary of what was changed. -->
This was incorrect. See https://en.wikipedia.org/wiki/Telephone_numbers_in_Cyprus

# Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3773
