### PR TITLE
Cancel taps when the user scrolls

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -263,8 +263,6 @@ class RowButton: UIView {
         // Add tap gesture
         let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
         gestureRecognizer.delegate = self
-//        gestureRecognizer.requiresExclusiveTouchType = true
-        gestureRecognizer.cancelsTouchesInView = true
         shadowRoundedRect.addGestureRecognizer(gestureRecognizer)
 
         // Add long press gesture if we should animate on press

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -263,6 +263,8 @@ class RowButton: UIView {
         // Add tap gesture
         let gestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(handleTap))
         gestureRecognizer.delegate = self
+//        gestureRecognizer.requiresExclusiveTouchType = true
+        gestureRecognizer.cancelsTouchesInView = true
         shadowRoundedRect.addGestureRecognizer(gestureRecognizer)
 
         // Add long press gesture if we should animate on press
@@ -395,6 +397,19 @@ extension RowButton: UIGestureRecognizerDelegate {
         }
         
         return true
+    }
+    
+    func gestureRecognizer(
+        _ gestureRecognizer: UIGestureRecognizer,
+        shouldRequireFailureOf otherGestureRecognizer: UIGestureRecognizer
+    ) -> Bool {
+        // If the scroll view’s pan gesture begins, we want to fail the button’s tap,
+        // so the user can scroll without accidentally tapping.
+        if otherGestureRecognizer is UIPanGestureRecognizer {
+            return true
+        }
+        
+        return false
     }
 }
 


### PR DESCRIPTION
## Summary
- Cancel taps on the RowButton when a scroll action is started to prevent accidental tapping of the RowButton.

## Motivation
- https://jira.corp.stripe.com/browse/MOBILESDK-2947

## Testing
- Manual

## Changelog
N/A
