### PR TITLE
Adds app verification fields in FC manifest and synchronize call

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -80,6 +80,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
     let activeAuthSession: FinancialConnectionsAuthSession?
     let activeInstitution: FinancialConnectionsInstitution?
     let allowManualEntry: Bool
+    let appVerificationEnabled: Bool?
     let assignmentEventId: String?
     let businessName: String?
     let cancelUrl: String?
@@ -135,6 +136,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
         activeAuthSession: FinancialConnectionsAuthSession? = nil,
         activeInstitution: FinancialConnectionsInstitution? = nil,
         allowManualEntry: Bool,
+        appVerificationEnabled: Bool? = nil,
         assignmentEventId: String? = nil,
         businessName: String? = nil,
         cancelUrl: String? = nil,
@@ -173,6 +175,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
         self.activeAuthSession = activeAuthSession
         self.activeInstitution = activeInstitution
         self.allowManualEntry = allowManualEntry
+        self.appVerificationEnabled = appVerificationEnabled
         self.assignmentEventId = assignmentEventId
         self.businessName = businessName
         self.cancelUrl = cancelUrl
@@ -215,6 +218,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
         case activeAuthSession
         case activeInstitution
         case allowManualEntry
+        case appVerificationEnabled
         case assignmentEventId
         case businessName
         case cancelUrl


### PR DESCRIPTION
## Summary

- Adds the `appVerificationEnabled` field to the Financial Connections manifest model.
    - This will tell us whether or not we should use the verified endpoints. That work will come next
- Passes the `mobile[supports_app_verification]` and `mobile[verified_app_id]` parameters to the `/synchronize` endpoint if app attestation is supported.

## Motivation

https://docs.google.com/document/d/1joKz5UZHLVazmecfMHbq6gB6n4wj5u8To6AtqYgq_tc/edit?usp=sharing

## Testing

Manual testing

## Changelog

N/a