### PR TITLE
Reset customer ID when changing Link Mode

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example.entitlements
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.developer.devicecheck.appattest-environment</key>
-	<string>development</string>
+	<string>production</string>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
 		<string>merchant.com.stripe.umbrella.test</string>

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example.entitlements
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.developer.devicecheck.appattest-environment</key>
-	<string>production</string>
+	<string>development</string>
 	<key>com.apple.developer.in-app-payments</key>
 	<array>
 		<string>merchant.com.stripe.umbrella.test</string>

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -37,7 +37,7 @@ struct PaymentSheetTestPlayground: View {
         }
         Group {
             if playgroundController.settings.merchantCountryCode == .US {
-                SettingView(setting: $playgroundController.settings.linkEnabledMode)
+                SettingView(setting: linkEnabledModeBinding)
             }
             SettingView(setting: $playgroundController.settings.linkPassthroughMode)
         }
@@ -240,6 +240,18 @@ struct PaymentSheetTestPlayground: View {
                 playgroundController.settings.customerMode = .guest
             }
             playgroundController.settings.merchantCountryCode = newCountry
+        }
+    }
+
+    var linkEnabledModeBinding: Binding<PaymentSheetTestPlaygroundSettings.LinkEnabledMode> {
+        Binding<PaymentSheetTestPlaygroundSettings.LinkEnabledMode> {
+            return playgroundController.settings.linkEnabledMode
+        } set: { newMode in
+            // Reset customer id if Link enabled mode changes, as we change the underlying account ID
+            if playgroundController.settings.linkEnabledMode.rawValue != newMode.rawValue {
+                playgroundController.settings.customerMode = .guest
+            }
+            playgroundController.settings.linkEnabledMode = newMode
         }
     }
 


### PR DESCRIPTION
## Summary
Changing the Link Mode changes the merchant ID, so let's reset the stored customer ID when we change the Link Mode, similar to how we handle changing the merchant country. 

## Motivation
Fixes an issue where setting "returning" mode in the playground then switching the Link mode would cause an error when fetching the customer ID.

## Testing
In PS Example
