### PR TITLE
Try to de-flake vertical testDarkMode test

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewControllerSnapshotTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewControllerSnapshotTest.swift
@@ -47,7 +47,7 @@ final class VerticalPaymentMethodListViewControllerSnapshotTest: STPSnapshotTest
         .swish,
         .UPI,
     ]
-    
+
     override func setUp() {
         super.setUp()
         DownloadManager.sharedManager.resetCache()
@@ -72,8 +72,9 @@ final class VerticalPaymentMethodListViewControllerSnapshotTest: STPSnapshotTest
         let sut = VerticalPaymentMethodListViewController(initialSelection: .saved(paymentMethod: ._testCard()), savedPaymentMethod: ._testCard(), paymentMethodTypes: paymentMethods.map { .stripe($0) }, shouldShowApplePay: true, shouldShowLink: true, savedPaymentMethodAccessoryType: .edit, overrideHeaderView: nil, appearance: .default, currency: "USD", amount: 1099, incentive: nil, delegate: self)
         let window = UIWindow()
         window.isHidden = false
-        window.addAndPinSubview(sut.view, insets: .zero)
         window.overrideUserInterfaceStyle = .dark
+        window.rootViewController = sut
+        window.addAndPinSubview(sut.view, insets: .zero)
         STPSnapshotVerifyView(window, autoSizingHeightForWidth: 375)
     }
 


### PR DESCRIPTION
## Summary
Copy what other, non-flakey dark mode snapshot tests do.

## Motivation
This test flakes ~40% of the time :O

## Testing
No testing, I can't get this test to flake locally :( IDK if this fixes the issue, but now the code matches other non-flakey darkmode snapshot tests.

## Changelog
Not user facing
