### PR TITLE
Fix PaymentDetails CVC checks

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
@@ -165,7 +165,7 @@ extension ConsumerPaymentDetails.Details.Card {
 
     var shouldRecollectCardCVC: Bool {
         switch checks?.cvcCheck {
-        case .fail, .unavailable, .unchecked:
+        case .fail, .unavailable, .unchecked, .stateInvalid:
             return true
         default:
             return false

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
@@ -167,7 +167,7 @@ extension ConsumerPaymentDetails.Details.Card {
         switch checks?.cvcCheck {
         case .fail, .unavailable, .unchecked, .stateInvalid:
             return true
-        default:
+        case .pass, .unparsable, nil:
             return false
         }
     }


### PR DESCRIPTION
## Summary
`stateInvalid` is another state in which we should perform CVC recollection.

## Testing
These states are tested `test_shouldRecollectCardCVC` test in `PayWithLinkViewController_WalletViewModelTests`. Not sure if it's useful to test all cases of this specific function, I've removed `.default` so that the compiler will force us to reason about each case in the future.