### PR TITLE
Use mobile signup endpoint for verified FC flows

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
+++ b/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		363C5AD7E84C53FF964C6A0D /* PlaygroundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundViewModel.swift; sourceTree = "<group>"; };
 		3E18F0765C9C715F64080DD3 /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
 		3E1E39731621D996DDD83DAC /* StripeCoreTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCoreTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		496515B42D356DFF007B94BB /* FinancialConnections Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = "FinancialConnections Example.entitlements"; path = "FinancialConnections Example/FinancialConnections Example.entitlements"; sourceTree = "<group>"; };
 		496BCB442D32D1A300BFC3EE /* StripePaymentSheet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripePaymentSheet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		49B546392C6E54DB008DC127 /* InstantDebitsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantDebitsUITests.swift; sourceTree = "<group>"; };
 		4F33EDB6E5F9D5101B65E0E1 /* FinancialConnectionsNetworkingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsNetworkingUITests.swift; sourceTree = "<group>"; };
@@ -166,6 +167,7 @@
 		16B505A9E0578F89DFF3F7BC = {
 			isa = PBXGroup;
 			children = (
+				496515B42D356DFF007B94BB /* FinancialConnections Example.entitlements */,
 				50C2BF2068C431D89BFF6E11 /* Project */,
 				35967318CD64200FCEDF41E7 /* Frameworks */,
 				EDE09A27F1A22ECA0F4D45B4 /* Products */,
@@ -445,6 +447,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 701003016E153D5DF2B00442 /* FinancialConnections-Example-Debug.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "FinancialConnections Example/FinancialConnections Example.entitlements";
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				INFOPLIST_FILE = "FinancialConnections Example/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.example.Connections-Example";
@@ -477,6 +480,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5B50C88219DC0F3F0BFC5CE4 /* FinancialConnections-Example-Release.xcconfig */;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = "FinancialConnections Example/FinancialConnections Example.entitlements";
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				INFOPLIST_FILE = "FinancialConnections Example/Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.example.Connections-Example";

--- a/Example/FinancialConnections Example/FinancialConnections Example/FinancialConnections Example.entitlements
+++ b/Example/FinancialConnections Example/FinancialConnections Example/FinancialConnections Example.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.devicecheck.appattest-environment</key>
+	<string>development</string>
+</dict>
+</plist>

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -82,6 +82,15 @@ import UIKit
         return appAttestService.isSupported
     }
 
+    @_spi(STP) public static func isLinkAssertionError(error: Error) -> Bool {
+        if let error = error as? StripeCore.StripeError,
+           case let .apiError(apiError) = error,
+           apiError.code == "link_failed_to_attest_request" {
+            return true
+        }
+        return false
+    }
+
     // MARK: Public structs
 
     /// Contains the signed data and various information used to sign the request.

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -403,7 +403,7 @@ import UIKit
     // MARK: Assertion concurrency
 
     // Called when an assertion handle is completed or times out
-    private func assertionCompleted() {
+    @_spi(STP) public func assertionCompleted() {
         assertionInProgress = false
 
         // Resume the next waiter if there is one

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -23,7 +23,7 @@ protocol LinkLoginDataSource: AnyObject {
     func attachToAccountAndSynchronize(
         with linkSignUpResponse: LinkSignUpResponse
     ) -> Future<FinancialConnectionsSynchronize>
-    func reportAttestationErrorIfNeeded(error: Error)
+    func completeAssertion(possibleError: Error?)
 }
 
 final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
@@ -117,7 +117,7 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
         )
     }
 
-    func reportAttestationErrorIfNeeded(error: Error) {
-        apiClient.reportAttestationErrorIfNeeded(error: error)
+    func completeAssertion(possibleError: Error?) {
+        apiClient.completeAssertion(possibleError: possibleError)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -23,6 +23,7 @@ protocol LinkLoginDataSource: AnyObject {
     func attachToAccountAndSynchronize(
         with linkSignUpResponse: LinkSignUpResponse
     ) -> Future<FinancialConnectionsSynchronize>
+    func reportAttestationErrorIfNeeded(error: Error)
 }
 
 final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
@@ -75,13 +76,15 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
         phoneNumber: String,
         country: String
     ) -> Future<LinkSignUpResponse> {
-        apiClient.linkAccountSignUp(
+        let verified = manifest.appVerificationEnabled ?? false
+        return apiClient.linkAccountSignUp(
             emailAddress: emailAddress,
             phoneNumber: phoneNumber,
             country: country,
             amount: elementsSessionContext?.amount,
             currency: elementsSessionContext?.currency,
-            incentiveEligibilitySession: elementsSessionContext?.incentiveEligibilitySession
+            incentiveEligibilitySession: elementsSessionContext?.incentiveEligibilitySession,
+            useMobileEndpoints: verified
         )
     }
 
@@ -112,5 +115,9 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
             linkAccountSession: linkAccountSession,
             consumerSessionClientSecret: consumerSessionClientSecret
         )
+    }
+
+    func reportAttestationErrorIfNeeded(error: Error) {
+        apiClient.reportAttestationErrorIfNeeded(error: error)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -36,6 +36,10 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
     private let clientSecret: String
     private let returnURL: String?
     private let apiClient: FinancialConnectionsAPIClient
+    
+    private var verified: Bool {
+        manifest.appVerificationEnabled ?? false
+    }
 
     init(
         manifest: FinancialConnectionsSessionManifest,
@@ -76,7 +80,6 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
         phoneNumber: String,
         country: String
     ) -> Future<LinkSignUpResponse> {
-        let verified = manifest.appVerificationEnabled ?? false
         return apiClient.linkAccountSignUp(
             emailAddress: emailAddress,
             phoneNumber: phoneNumber,
@@ -118,6 +121,7 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
     }
 
     func completeAssertion(possibleError: Error?) {
+        guard verified else { return }
         apiClient.completeAssertion(possibleError: possibleError)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -210,6 +210,7 @@ final class LinkLoginViewController: UIViewController {
             case .success(let response):
                 self.delegate?.linkLoginViewController(self, signedUpAttachedAndSynchronized: response)
             case .failure(let error):
+                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 self.delegate?.linkLoginViewController(self, didReceiveTerminalError: error)
             }
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -206,11 +206,13 @@ final class LinkLoginViewController: UIViewController {
             guard let self else { return }
             self.footerButton?.isLoading = false
 
+            // Mark the assertion as completed and log possible errors.
+            self.dataSource.completeAssertion(possibleError: result.error)
+
             switch result {
             case .success(let response):
                 self.delegate?.linkLoginViewController(self, signedUpAttachedAndSynchronized: response)
             case .failure(let error):
-                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 self.delegate?.linkLoginViewController(self, didReceiveTerminalError: error)
             }
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -33,6 +33,10 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
 
+    private var verified: Bool {
+        manifest.appVerificationEnabled ?? false
+    }
+
     init(
         manifest: FinancialConnectionsSessionManifest,
         selectedAccounts: [FinancialConnectionsPartnerAccount]?,
@@ -74,7 +78,6 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
         phoneNumber: String,
         countryCode: String
     ) -> Future<String?> {
-        let verified = manifest.appVerificationEnabled ?? false
         if verified {
             // In the verified scenario, first call the `/mobile/sign_up` endpoint with attestation parameters,
             // then call `/save_accounts_to_link` and omit the email and phone parameters.
@@ -122,6 +125,7 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
     }
 
     func completeAssertion(possibleError: Error?) {
+        guard verified else { return }
         apiClient.completeAssertion(possibleError: possibleError)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -20,7 +20,7 @@ protocol NetworkingLinkSignupDataSource: AnyObject {
         phoneNumber: String,
         countryCode: String
     ) -> Future<String?>
-    func reportAttestationErrorIfNeeded(error: Error)
+    func completeAssertion(possibleError: Error?)
 }
 
 final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDataSource {
@@ -121,7 +121,7 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
         }
     }
 
-    func reportAttestationErrorIfNeeded(error: Error) {
-        apiClient.reportAttestationErrorIfNeeded(error: error)
+    func completeAssertion(possibleError: Error?) {
+        apiClient.completeAssertion(possibleError: possibleError)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -20,6 +20,7 @@ protocol NetworkingLinkSignupDataSource: AnyObject {
         phoneNumber: String,
         countryCode: String
     ) -> Future<String?>
+    func reportAttestationErrorIfNeeded(error: Error)
 }
 
 final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDataSource {
@@ -73,16 +74,54 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
         phoneNumber: String,
         countryCode: String
     ) -> Future<String?> {
-        return apiClient.saveAccountsToNetworkAndLink(
-            shouldPollAccounts: !manifest.shouldAttachLinkedPaymentMethod,
-            selectedAccounts: selectedAccounts,
-            emailAddress: emailAddress,
-            phoneNumber: phoneNumber,
-            country: countryCode, // ex. "US"
-            consumerSessionClientSecret: nil,
-            clientSecret: clientSecret
-        ).chained { (_, customSuccessPaneMessage) in
-            return Promise(value: customSuccessPaneMessage)
+        let verified = manifest.appVerificationEnabled ?? false
+        if verified {
+            // In the verified scenario, first call the `/mobile/sign_up` endpoint with attestation parameters,
+            // then call `/save_accounts_to_link` and omit the email and phone parameters.
+            return apiClient.linkAccountSignUp(
+                emailAddress: emailAddress,
+                phoneNumber: phoneNumber,
+                country: countryCode,
+                amount: nil,
+                currency: nil,
+                incentiveEligibilitySession: nil,
+                useMobileEndpoints: verified
+            ).chained { [weak self] _ -> Future<FinancialConnectionsAPI.SaveAccountsToNetworkAndLinkResponse> in
+                guard let self else {
+                    return Promise(error: FinancialConnectionsSheetError.unknown(
+                        debugDescription: "Networking Link Signup data source deallocated.")
+                    )
+                }
+                // Intentionally omit email and phone in this subsequent call
+                return apiClient.saveAccountsToNetworkAndLink(
+                    shouldPollAccounts: !manifest.shouldAttachLinkedPaymentMethod,
+                    selectedAccounts: selectedAccounts,
+                    emailAddress: nil,
+                    phoneNumber: nil,
+                    country: countryCode,
+                    consumerSessionClientSecret: nil,
+                    clientSecret: clientSecret
+                )
+            }
+            .chained { (_, customSuccessPaneMessage) in
+                return Promise(value: customSuccessPaneMessage)
+            }
+        } else {
+            return apiClient.saveAccountsToNetworkAndLink(
+                shouldPollAccounts: !manifest.shouldAttachLinkedPaymentMethod,
+                selectedAccounts: selectedAccounts,
+                emailAddress: emailAddress,
+                phoneNumber: phoneNumber,
+                country: countryCode, // ex. "US"
+                consumerSessionClientSecret: nil,
+                clientSecret: clientSecret
+            ).chained { (_, customSuccessPaneMessage) in
+                return Promise(value: customSuccessPaneMessage)
+            }
         }
+    }
+
+    func reportAttestationErrorIfNeeded(error: Error) {
+        apiClient.reportAttestationErrorIfNeeded(error: error)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -219,6 +219,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
                     withError: nil
                 )
             case .failure(let error):
+                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 // on error, we still go to success pane, but show a small error
                 // notice above the done button of the success pane
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -210,6 +210,10 @@ final class NetworkingLinkSignupViewController: UIViewController {
         )
         .observe { [weak self] result in
             guard let self = self else { return }
+
+            // Mark the assertion as completed and log possible errors.
+            self.dataSource.completeAssertion(possibleError: result.error)
+
             switch result {
             case .success(let customSuccessPaneMessage):
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(
@@ -219,7 +223,6 @@ final class NetworkingLinkSignupViewController: UIViewController {
                     withError: nil
                 )
             case .failure(let error):
-                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 // on error, we still go to success pane, but show a small error
                 // notice above the done button of the success pane
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -203,7 +203,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
         country: String,
         amount: Int?,
         currency: String?,
-        incentiveEligibilitySession: ElementsSessionContext.IntentID?
+        incentiveEligibilitySession: ElementsSessionContext.IntentID?,
+        useMobileEndpoints: Bool
     ) -> Future<LinkSignUpResponse> {
         return Promise<StripeFinancialConnections.LinkSignUpResponse>()
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -64,7 +64,7 @@ extension STPAPIClient {
                     // If there's an assertion error, send it to StripeAttest
                     if useMobileEndpoints,
                        case .failure(let error) = result,
-                       Self.isLinkAssertionError(error: error) {
+                       StripeAttest.isLinkAssertionError(error: error) {
                         await self.stripeAttest.receivedAssertionError(error)
                     }
                     // Mark the assertion handle as completed
@@ -130,7 +130,7 @@ extension STPAPIClient {
                     // If there's an assertion error, send it to StripeAttest
                     if useMobileEndpoints,
                        case .failure(let error) = result,
-                       Self.isLinkAssertionError(error: error) {
+                       StripeAttest.isLinkAssertionError(error: error) {
                         await self.stripeAttest.receivedAssertionError(error)
                     }
                     // Mark the assertion handle as completed
@@ -139,15 +139,6 @@ extension STPAPIClient {
                 }
             }
         }
-    }
-
-    @_spi(STP) public static func isLinkAssertionError(error: Error) -> Bool {
-        if let error = error as? StripeCore.StripeError,
-           case let .apiError(apiError) = error,
-           apiError.code == "link_failed_to_attest_request" {
-            return true
-        }
-        return false
     }
 
     private func makePaymentDetailsRequest(

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewModel.swift
@@ -218,7 +218,7 @@ private extension PayWithLinkViewController.SignUpViewModel {
                 case .failure(let error):
                     self.linkAccount = nil
                     self.errorMessage = error.nonGenericDescription
-                    if STPAPIClient.isLinkAssertionError(error: error) {
+                    if StripeAttest.isLinkAssertionError(error: error) {
                         self.delegate?.viewModelDidEncounterAttestationError(self)
                     }
                 }


### PR DESCRIPTION
## Summary

This updates our Link account sign up API to call the new `/consumers/mobile/sign_up` endpoint during verified flows. In these verified flows, we also attach attestation parameters to the API request. Here are the changes made to the consumers of this API:

- `LinkLogin` (Instant Debits): Call the new mobile sign up endpoint (`/consumers/mobile/sign_up`) during verified flows, and continue to call the non-mobile sign up endpoint (`/consumers/accounts/sign_up`) for non-verified flows.
- `NetworkingLinkSignup` (Networking): Call the new mobile sign up endpoint (`/consumers/mobile/sign_up`) during verified flows, passing the app attestation token, then call the `save_accounts_to_link` API (with no email / phone number). Continue to just call `save_accounts_to_link` in non-verified flows.

## Motivation

https://docs.google.com/document/d/1joKz5UZHLVazmecfMHbq6gB6n4wj5u8To6AtqYgq_tc/edit?usp=sharing

## Testing

Hard to test the _success_ case (AFAIK, only real devices can use App Attest), but tested that, when hardcoding a `verified = true` state, the app attestation parameters are being based to the signup endpoint:

<img width="1090" alt="Screenshot 2025-01-13 at 10 46 55 AM" src="https://github.com/user-attachments/assets/42a0cbb2-a2cd-4004-83ec-55bd70819611" />

And the request fails with the expected error: 

<img width="1083" alt="Screenshot 2025-01-13 at 10 47 40 AM" src="https://github.com/user-attachments/assets/67a320df-9bf8-4d80-a10f-e414c16f71ef" />

## Changelog

N/a