### PR TITLE
Add StripePaymentSheet dependency to FC Example app

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
+++ b/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		24E793526FA832586DB7FC96 /* BannerHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8601634DE1E43030B0D469 /* BannerHelper.swift */; };
 		2FFB7D24916B79615F334BD4 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 936C5935D51A54BE9F183ECA /* Main.storyboard */; };
 		307E63F1F0E10D8B419C3DAB /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = FF678252EB811ACE4D0EC296 /* LaunchScreen.storyboard */; };
+		496BCB452D32D1A300BFC3EE /* StripePaymentSheet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496BCB442D32D1A300BFC3EE /* StripePaymentSheet.framework */; };
 		49B5463A2C6E54DB008DC127 /* InstantDebitsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B546392C6E54DB008DC127 /* InstantDebitsUITests.swift */; };
 		597C7552115D87218591934C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07DA32DE3842C0AD47047104 /* AppDelegate.swift */; };
 		59C21AF5DEA23997E909ACA4 /* StripeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 03E7365D673694C8D7EDFB20 /* StripeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -96,6 +97,7 @@
 		363C5AD7E84C53FF964C6A0D /* PlaygroundViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaygroundViewModel.swift; sourceTree = "<group>"; };
 		3E18F0765C9C715F64080DD3 /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
 		3E1E39731621D996DDD83DAC /* StripeCoreTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCoreTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		496BCB442D32D1A300BFC3EE /* StripePaymentSheet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripePaymentSheet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		49B546392C6E54DB008DC127 /* InstantDebitsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InstantDebitsUITests.swift; sourceTree = "<group>"; };
 		4F33EDB6E5F9D5101B65E0E1 /* FinancialConnectionsNetworkingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsNetworkingUITests.swift; sourceTree = "<group>"; };
 		5785AD2F7A6D71D9470B0DB6 /* StripeFinancialConnections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -132,6 +134,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				496BCB452D32D1A300BFC3EE /* StripePaymentSheet.framework in Frameworks */,
 				6AF9C66D47F81DD9B103FB64 /* StripeCore.framework in Frameworks */,
 				DA6FA2C369E10A2B4663B434 /* StripeFinancialConnections.framework in Frameworks */,
 				5B38135D1C37FC1812F4203A /* StripeUICore.framework in Frameworks */,
@@ -172,6 +175,7 @@
 		35967318CD64200FCEDF41E7 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				496BCB442D32D1A300BFC3EE /* StripePaymentSheet.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";


### PR DESCRIPTION
## Summary

Fixes https://app.bitrise.io/build/ee8ed1a5-ff37-418f-89f2-5fffdff57874?tab=log

`StripePaymentSheet` was being imported but not linked to the `FinancialConnections Example` app.

## Motivation

Fixes CI

## Testing

Trust CI

## Changelog

N/a