### PR TITLE
Fix incorrect Panther behavior in Embedded MPE

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -284,8 +284,8 @@ extension EmbeddedPaymentElement.PaymentOptionDisplayData {
             label = String.Localized.apple_pay
             paymentMethodType = "apple_pay"
             billingDetails = nil
-        case .saved(let paymentMethod, _):
-            label = paymentMethod.paymentSheetLabel
+        case .saved(let paymentMethod, let confirmParams):
+            label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams)
             paymentMethodType = paymentMethod.type.identifier
             billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
         case .new(let confirmParams):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -271,7 +271,10 @@ public final class EmbeddedPaymentElement {
             case .external(let type):
                 return .external(paymentMethod: type, billingDetails: params.paymentMethodParams.nonnil_billingDetails)
             case .instantDebits, .linkCardBrand:
-                return .new(confirmParams: params)
+                guard let paymentMethod = params.instantDebitsLinkedBank?.paymentMethod.decode() else {
+                    return nil
+                }
+                return .saved(paymentMethod: paymentMethod, confirmParams: params)
             }
         case .saved(paymentMethod: let paymentMethod):
             return .saved(paymentMethod: paymentMethod, confirmParams: nil)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -526,7 +526,7 @@ extension PaymentMethodFormViewController {
     }
 }
 
-private extension LinkBankPaymentMethod {
+extension LinkBankPaymentMethod {
 
     func decode() -> STPPaymentMethod? {
         return STPPaymentMethod.decodedObject(fromAPIResponse: allResponseFields)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -425,6 +425,27 @@ class EmbeddedPaymentElementTest: XCTestCase {
         XCTAssertEqual((error as! PaymentSheetError).debugDescription, PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent.debugDescription)
     }
 
+    func testCorrectLast4ForInstantBankPaymentsInPassthroughMode() async throws {
+        // Given an EmbeddedPaymentElement that can confirm
+        let sut = try await EmbeddedPaymentElement.create(intentConfiguration: paymentIntentConfigWithConfirmHandler, configuration: configuration)
+        sut.delegate = self
+        sut.presentingViewController = UIViewController()
+        sut.view.autosizeHeight(width: 320)
+
+        // Create test confirmParams with valid Link card brand details
+        let confirmParams = IntentConfirmParams(type: .linkCardBrand)
+        confirmParams.instantDebitsLinkedBank = InstantDebitsLinkedBank(
+            paymentMethod: .init(id: "pm_1234"),
+            bankName: "Stripe Bank",
+            last4: "6789",
+            linkMode: nil,
+            incentiveEligible: false
+        )
+
+        // Inject the test payment option and assert the label
+        sut._test_paymentOption = .saved(paymentMethod: ._testCard(), confirmParams: confirmParams)
+        XCTAssertEqual(sut.paymentOption?.label, "••••6789")
+    }
 }
 
 extension EmbeddedPaymentElementTest: EmbeddedPaymentElementDelegate {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the Embedded MPE would show the incorrect last4 for Instant Bank Payments in passthrough mode.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
