### PR TITLE
Fix deferred intent confirmation in the PaymentSheet Playground + Link

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -826,6 +826,7 @@ extension PlaygroundController {
             "merchant_country_code": settings.merchantCountryCode.rawValue,
             "should_save_payment_method": shouldSavePaymentMethod,
             "mode": intentConfig.mode.requestBody,
+            "link_mode": settings.linkEnabledMode.rawValue,
             "return_url": configuration.returnURL ?? "",
         ] as [String: Any]
 


### PR DESCRIPTION
## Summary
When using an alternate Link enabled mode, send the correct mode to the example backend. If we don't do this, it will use the wrong merchant key to attempt to access the PaymentMethod created by the client, which will fail.

## Testing
In PS Example

## Changelog
None, PS Example