### PR TITLE
Use mobile lookup endpoint for verified FC flows

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Info.plist
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Info.plist
@@ -60,5 +60,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Allow the app to scan cards.</string>
 </dict>
 </plist>

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -45,7 +45,7 @@ final class FinancialConnectionsAPIClient {
 
     /// Applies attestation-related parameters to the given base parameters
     /// In case of an assertion error, returns the unmodified base parameters
-    func applyAttestationParameters(
+    func assertAndApplyAttestationParameters(
         to baseParameters: [String: Any]
     ) -> Future<[String: Any]> {
         let promise = Promise<[String: Any]>()
@@ -930,7 +930,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
             parameters["request_surface"] = requestSurface
             parameters["session_id"] = sessionId
             parameters["email_source"] = emailSource.rawValue
-            return applyAttestationParameters(to: parameters)
+            return assertAndApplyAttestationParameters(to: parameters)
                 .chained { [weak self] updatedParameters in
                     guard let self else {
                         return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "FinancialConnectionsAPIClient was deallocated."))
@@ -1040,7 +1040,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         }
 
         if useMobileEndpoints {
-            return applyAttestationParameters(to: parameters)
+            return assertAndApplyAttestationParameters(to: parameters)
                 .chained { [weak self] updatedParameters in
                     guard let self else {
                         return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "FinancialConnectionsAPIClient was deallocated."))

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -12,7 +12,7 @@ final class FinancialConnectionsAPIClient {
     private enum EncodingError: Error {
         case cannotCastToDictionary
     }
-    
+
     enum EmailSource: String {
         case userAction = "user_action"
         case customerObject = "customer_object"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
@@ -308,12 +308,18 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
 
     func consumerSessionLookup(
         emailAddress: String,
-        clientSecret: String
+        clientSecret: String,
+        sessionId: String,
+        emailSource: FinancialConnectionsAPIClient.EmailSource,
+        useMobileEndpoints: Bool
     ) -> Future<LookupConsumerSessionResponse> {
         wrapAsyncToFuture {
             try await self.consumerSessionLookup(
                 emailAddress: emailAddress,
-                clientSecret: clientSecret
+                clientSecret: clientSecret,
+                sessionId: sessionId,
+                emailSource: emailSource,
+                useMobileEndpoints: useMobileEndpoints
             )
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -55,7 +55,7 @@ final class FinancialConnectionsAsyncAPIClient {
 
     /// Applies attestation-related parameters to the given base parameters
     /// In case of an assertion error, returns the unmodified base parameters
-    func applyAttestationParameters(to baseParameters: [String: Any]) async -> [String: Any] {
+    func assertAndApplyAttestationParameters(to baseParameters: [String: Any]) async -> [String: Any] {
         do {
             let attest = backingAPIClient.stripeAttest
             let handle = try await attest.assert()
@@ -829,7 +829,7 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
             parameters["request_surface"] = requestSurface
             parameters["session_id"] = sessionId
             parameters["email_source"] = emailSource.rawValue
-            let updatedParameters = await applyAttestationParameters(to: parameters)
+            let updatedParameters = await assertAndApplyAttestationParameters(to: parameters)
             return try await post(endpoint: .mobileConsumerSessionLookup, parameters: updatedParameters)
         } else {
             parameters["client_secret"] = clientSecret
@@ -927,7 +927,7 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
             }
         }
         if useMobileEndpoints {
-            let updatedParameters = await applyAttestationParameters(to: parameters)
+            let updatedParameters = await assertAndApplyAttestationParameters(to: parameters)
             return try await post(endpoint: .mobileLinkAccountSignup, parameters: updatedParameters)
         } else {
             return try await post(endpoint: .linkAccountsSignUp, parameters: parameters)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -280,7 +280,10 @@ protocol FinancialConnectionsAsyncAPI {
 
     func consumerSessionLookup(
         emailAddress: String,
-        clientSecret: String
+        clientSecret: String,
+        sessionId: String,
+        emailSource: FinancialConnectionsAPIClient.EmailSource,
+        useMobileEndpoints: Bool
     ) async throws -> LookupConsumerSessionResponse
 
     // MARK: - Link API's
@@ -811,16 +814,27 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
 
     func consumerSessionLookup(
         emailAddress: String,
-        clientSecret: String
+        clientSecret: String,
+        sessionId: String,
+        emailSource: FinancialConnectionsAPIClient.EmailSource,
+        useMobileEndpoints: Bool
     ) async throws -> LookupConsumerSessionResponse {
-        let parameters: [String: Any] = [
+        var parameters: [String: Any] = [
             "email_address":
                 emailAddress
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .lowercased(),
-            "client_secret": clientSecret,
         ]
-        return try await post(endpoint: .consumerSessions, parameters: parameters)
+        if useMobileEndpoints {
+            parameters["request_surface"] = requestSurface
+            parameters["session_id"] = sessionId
+            parameters["email_source"] = emailSource.rawValue
+            let updatedParameters = await applyAttestationParameters(to: parameters)
+            return try await post(endpoint: .mobileConsumerSessionLookup, parameters: updatedParameters)
+        } else {
+            parameters["client_secret"] = clientSecret
+            return try await post(endpoint: .consumerSessions, parameters: parameters)
+        }
     }
 
     // MARK: - Link API's
@@ -1076,6 +1090,7 @@ enum APIEndpoint: String {
     case availableIncentives = "consumers/incentives/update_available"
 
     // Verified
+    case mobileConsumerSessionLookup = "consumers/mobile/sessions/lookup"
     case mobileLinkAccountSignup = "consumers/mobile/sign_up"
 
     /// As a rule of thumb, `shouldUseConsumerPublishableKey` should be `true` for requests that happen after the user is verified.
@@ -1093,7 +1108,7 @@ enum APIEndpoint: String {
              .linkStepUpAuthenticationVerified, .linkVerified, .saveAccountsToLink,
              .consumerSessions, .pollAccountNumbers, .startVerification, .confirmVerification,
              .linkAccountsSignUp, .attachLinkConsumerToLinkAccountSession,
-             .sharePaymentDetails, .paymentMethods, .mobileLinkAccountSignup:
+             .sharePaymentDetails, .paymentMethods, .mobileLinkAccountSignup, .mobileConsumerSessionLookup:
             return false
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -91,6 +91,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
     let experimentAssignments: [String: String]?
     let features: [String: Bool]?
     let hostedAuthUrl: String?
+    let id: String
     let initialInstitution: FinancialConnectionsInstitution?
     let instantVerificationDisabled: Bool
     let institutionSearchDisabled: Bool
@@ -151,6 +152,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
         experimentAssignments: [String: String]? = nil,
         features: [String: Bool]? = nil,
         hostedAuthUrl: String? = nil,
+        id: String,
         initialInstitution: FinancialConnectionsInstitution? = nil,
         instantVerificationDisabled: Bool,
         institutionSearchDisabled: Bool,
@@ -190,6 +192,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
         self.experimentAssignments = experimentAssignments
         self.features = features
         self.hostedAuthUrl = hostedAuthUrl
+        self.id = id
         self.initialInstitution = initialInstitution
         self.instantVerificationDisabled = instantVerificationDisabled
         self.institutionSearchDisabled = institutionSearchDisabled
@@ -233,6 +236,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
         case experimentAssignments
         case features
         case hostedAuthUrl
+        case id
         case initialInstitution
         case instantVerificationDisabled
         case institutionSearchDisabled

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -127,6 +127,10 @@ struct FinancialConnectionsSessionManifest: Decodable {
         !livemode
     }
 
+    var verified: Bool {
+        appVerificationEnabled ?? false
+    }
+
     init(
         accountholderCustomerEmailAddress: String? = nil,
         accountholderIsLinkConsumer: Bool? = nil,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -14,7 +14,7 @@ protocol LinkLoginDataSource: AnyObject {
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
 
     func synchronize() -> Future<FinancialConnectionsLinkLoginPane>
-    func lookup(emailAddress: String) -> Future<LookupConsumerSessionResponse>
+    func lookup(emailAddress: String, manuallyEntered: Bool) -> Future<LookupConsumerSessionResponse>
     func signUp(
         emailAddress: String,
         phoneNumber: String,
@@ -67,10 +67,12 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
         }
     }
 
-    func lookup(emailAddress: String) -> Future<LookupConsumerSessionResponse> {
+    func lookup(emailAddress: String, manuallyEntered: Bool) -> Future<LookupConsumerSessionResponse> {
         return apiClient.consumerSessionLookup(
             emailAddress: emailAddress,
             clientSecret: clientSecret,
+            sessionId: manifest.id,
+            emailSource: manuallyEntered ? .userAction : .customerObject,
             useMobileEndpoints: manifest.verified
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -82,7 +82,6 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
         phoneNumber: String,
         country: String
     ) -> Future<LinkSignUpResponse> {
-        let verified = manifest.appVerificationEnabled ?? false
         return apiClient.linkAccountSignUp(
             emailAddress: emailAddress,
             phoneNumber: phoneNumber,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -213,7 +213,6 @@ final class LinkLoginViewController: UIViewController {
             case .success(let response):
                 self.delegate?.linkLoginViewController(self, signedUpAttachedAndSynchronized: response)
             case .failure(let error):
-                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 self.delegate?.linkLoginViewController(self, didReceiveTerminalError: error)
             }
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -51,6 +51,10 @@ final class LinkLoginViewController: UIViewController {
 
     private var paneLayoutView: PaneLayoutView?
     private var footerButton: StripeUICore.Button?
+    private var prefillEmailAddress: String? {
+        let email = dataSource.manifest.accountholderCustomerEmailAddress ?? dataSource.elementsSessionContext?.prefillDetails?.email
+        return email?.isEmpty == false ? email : nil
+    }
 
     init(dataSource: LinkLoginDataSource) {
         self.dataSource = dataSource
@@ -118,11 +122,10 @@ final class LinkLoginViewController: UIViewController {
         paneLayoutView?.scrollView.keyboardDismissMode = .onDrag
         #endif
 
-        let emailAddress = dataSource.manifest.accountholderCustomerEmailAddress ?? dataSource.elementsSessionContext?.prefillDetails?.email
-        if let emailAddress, !emailAddress.isEmpty {
+        if let prefillEmailAddress {
             // Immediately set the button state to loading here to bypass the debouncing by the textfield.
             footerButton?.isLoading = true
-            formView.prefillEmailAddress(emailAddress)
+            formView.prefillEmailAddress(prefillEmailAddress)
 
             let phoneNumber = dataSource.manifest.accountholderPhoneNumber ?? dataSource.elementsSessionContext?.prefillDetails?.formattedPhoneNumber
             formView.prefillPhoneNumber(phoneNumber)
@@ -157,8 +160,12 @@ final class LinkLoginViewController: UIViewController {
         formView.emailTextField.showLoadingView(true)
         footerButton?.isLoading = true
 
+        let manuallyEnteredEmail = emailAddress != prefillEmailAddress
         dataSource
-            .lookup(emailAddress: emailAddress)
+            .lookup(
+                emailAddress: emailAddress,
+                manuallyEntered: manuallyEnteredEmail
+            )
             .observe { [weak self, weak formView, weak footerButton] result in
                 formView?.emailTextField.showLoadingView(false)
                 footerButton?.isLoading = false

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -213,6 +213,7 @@ final class LinkLoginViewController: UIViewController {
             case .success(let response):
                 self.delegate?.linkLoginViewController(self, signedUpAttachedAndSynchronized: response)
             case .failure(let error):
+                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 self.delegate?.linkLoginViewController(self, didReceiveTerminalError: error)
             }
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -164,6 +164,8 @@ final class LinkLoginViewController: UIViewController {
                 footerButton?.isLoading = false
 
                 guard let self else { return }
+                self.dataSource.completeAssertionIfNeeded(possibleError: result.error)
+
                 switch result {
                 case .success(let response):
                     if response.exists {
@@ -205,9 +207,7 @@ final class LinkLoginViewController: UIViewController {
         .observe { [weak self] result in
             guard let self else { return }
             self.footerButton?.isLoading = false
-
-            // Mark the assertion as completed and log possible errors.
-            self.dataSource.completeAssertion(possibleError: result.error)
+            self.dataSource.completeAssertionIfNeeded(possibleError: result.error)
 
             switch result {
             case .success(let response):

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -14,7 +14,7 @@ protocol NetworkingLinkSignupDataSource: AnyObject {
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
 
     func synchronize() -> Future<FinancialConnectionsNetworkingLinkSignup>
-    func lookup(emailAddress: String) -> Future<LookupConsumerSessionResponse>
+    func lookup(emailAddress: String, manuallyEntered: Bool) -> Future<LookupConsumerSessionResponse>
     func saveToLink(
         emailAddress: String,
         phoneNumber: String,
@@ -65,10 +65,12 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
         }
     }
 
-    func lookup(emailAddress: String) -> Future<LookupConsumerSessionResponse> {
+    func lookup(emailAddress: String, manuallyEntered: Bool) -> Future<LookupConsumerSessionResponse> {
         return apiClient.consumerSessionLookup(
             emailAddress: emailAddress,
             clientSecret: clientSecret,
+            sessionId: manifest.id,
+            emailSource: manuallyEntered ? .userAction : .customerObject,
             useMobileEndpoints: manifest.verified
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -91,7 +91,7 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
                 currency: nil,
                 incentiveEligibilitySession: nil,
                 useMobileEndpoints: manifest.verified
-            ).chained { [weak self] _ -> Future<FinancialConnectionsAPI.SaveAccountsToNetworkAndLinkResponse> in
+            ).chained { [weak self] response -> Future<FinancialConnectionsAPI.SaveAccountsToNetworkAndLinkResponse> in
                 guard let self else {
                     return Promise(error: FinancialConnectionsSheetError.unknown(
                         debugDescription: "Networking Link Signup data source deallocated.")
@@ -103,8 +103,8 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
                     selectedAccounts: selectedAccounts,
                     emailAddress: nil,
                     phoneNumber: nil,
-                    country: countryCode,
-                    consumerSessionClientSecret: nil,
+                    country: nil,
+                    consumerSessionClientSecret: response.consumerSession.clientSecret,
                     clientSecret: clientSecret
                 )
             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -223,6 +223,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
                     withError: nil
                 )
             case .failure(let error):
+                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 // on error, we still go to success pane, but show a small error
                 // notice above the done button of the success pane
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -210,9 +210,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
         )
         .observe { [weak self] result in
             guard let self = self else { return }
-
-            // Mark the assertion as completed and log possible errors.
-            self.dataSource.completeAssertion(possibleError: result.error)
+            self.dataSource.completeAssertionIfNeeded(possibleError: result.error)
 
             switch result {
             case .success(let customSuccessPaneMessage):
@@ -293,6 +291,8 @@ extension NetworkingLinkSignupViewController: LinkSignupFormViewDelegate {
             .lookup(emailAddress: emailAddress)
             .observe { [weak self, weak bodyFormView] result in
                 guard let self = self else { return }
+                self.dataSource.completeAssertionIfNeeded(possibleError: result.error)
+
                 switch result {
                 case .success(let response):
                     if response.exists {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -223,7 +223,6 @@ final class NetworkingLinkSignupViewController: UIViewController {
                     withError: nil
                 )
             case .failure(let error):
-                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 // on error, we still go to success pane, but show a small error
                 // notice above the done button of the success pane
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -44,6 +44,7 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
         self.analyticsClient = analyticsClient
         let networkingOTPDataSource = NetworkingOTPDataSourceImplementation(
             otpType: "EMAIL",
+            manifest: manifest,
             emailAddress: consumerSession.emailAddress,
             customEmailType: "NETWORKED_CONNECTIONS_OTP_EMAIL",
             connectionsMerchantName: manifest.businessName,
@@ -51,9 +52,7 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
             consumerSession: consumerSession,
             apiClient: apiClient,
             clientSecret: clientSecret,
-            analyticsClient: analyticsClient,
-            isTestMode: manifest.isTestMode,
-            theme: manifest.theme
+            analyticsClient: analyticsClient
         )
         self.networkingOTPDataSource = networkingOTPDataSource
         networkingOTPDataSource.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -52,6 +52,7 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
         self.analyticsClient = analyticsClient
         let networkingOTPDataSource = NetworkingOTPDataSourceImplementation(
             otpType: "SMS",
+            manifest: manifest,
             emailAddress: accountholderCustomerEmailAddress,
             customEmailType: nil,
             connectionsMerchantName: nil,
@@ -59,9 +60,7 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
             consumerSession: nil,
             apiClient: apiClient,
             clientSecret: clientSecret,
-            analyticsClient: analyticsClient,
-            isTestMode: manifest.isTestMode,
-            theme: manifest.theme
+            analyticsClient: analyticsClient
         )
         self.networkingOTPDataSource = networkingOTPDataSource
         networkingOTPDataSource.delegate = self

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -28,9 +28,16 @@ protocol NetworkingOTPDataSource: AnyObject {
 final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
 
     let otpType: String
+    let pane: FinancialConnectionsSessionManifest.NextPane
+    let analyticsClient: FinancialConnectionsAnalyticsClient
     private let emailAddress: String
     private let customEmailType: String?
     private let connectionsMerchantName: String?
+    private let apiClient: any FinancialConnectionsAPI
+    private let manifest: FinancialConnectionsSessionManifest
+    private let clientSecret: String
+    weak var delegate: NetworkingOTPDataSourceDelegate?
+
     private var consumerSession: ConsumerSessionData? {
         didSet {
             if let consumerSession = consumerSession {
@@ -38,14 +45,14 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
             }
         }
     }
-    let pane: FinancialConnectionsSessionManifest.NextPane
-    private let apiClient: any FinancialConnectionsAPI
-    private let manifest: FinancialConnectionsSessionManifest
-    private let clientSecret: String
-    let analyticsClient: FinancialConnectionsAnalyticsClient
-    let isTestMode: Bool
-    let theme: FinancialConnectionsTheme
-    weak var delegate: NetworkingOTPDataSourceDelegate?
+
+    var isTestMode: Bool {
+        manifest.isTestMode
+    }
+
+    var theme: FinancialConnectionsTheme {
+        manifest.theme
+    }
 
     init(
         otpType: String,
@@ -69,8 +76,6 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
-        self.isTestMode = manifest.isTestMode
-        self.theme = manifest.theme
     }
 
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse> {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -78,6 +78,8 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
             .consumerSessionLookup(
                 emailAddress: emailAddress,
                 clientSecret: clientSecret,
+                sessionId: manifest.id,
+                emailSource: .customerObject,
                 useMobileEndpoints: manifest.verified
             )
             .chained { [weak self] lookupConsumerSessionResponse in

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -263,6 +263,7 @@ private struct NetowrkingOTPViewRepresentable: UIViewRepresentable {
                 consentRequired: false,
                 customManualEntryHandling: false,
                 disableLinkMoreAccounts: false,
+                id: "id",
                 instantVerificationDisabled: false,
                 institutionSearchDisabled: false,
                 livemode: true,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -160,6 +160,8 @@ final class NetworkingOTPView: UIView {
         dataSource.lookupConsumerSession()
             .observe { [weak self] result in
                 guard let self = self else { return }
+                self.dataSource.completeAssertionIfNeeded(possibleError: result.error)
+
                 switch result {
                 case .success(let lookupConsumerSessionResponse):
                     if lookupConsumerSessionResponse.exists {
@@ -251,11 +253,27 @@ final class NetworkingOTPView: UIView {
 import SwiftUI
 
 private struct NetowrkingOTPViewRepresentable: UIViewRepresentable {
-    let theme: FinancialConnectionsTheme
+    let theme: FinancialConnectionsSessionManifest.Theme
 
     func makeUIView(context: Context) -> NetworkingOTPView {
         NetworkingOTPView(dataSource: NetworkingOTPDataSourceImplementation(
             otpType: "",
+            manifest: FinancialConnectionsSessionManifest(
+                allowManualEntry: false,
+                consentRequired: false,
+                customManualEntryHandling: false,
+                disableLinkMoreAccounts: false,
+                instantVerificationDisabled: false,
+                institutionSearchDisabled: false,
+                livemode: true,
+                manualEntryMode: .automatic,
+                manualEntryUsesMicrodeposits: false,
+                nextPane: .success,
+                permissions: [],
+                product: "product",
+                singleAccount: true,
+                _theme: theme
+            ),
             emailAddress: "",
             customEmailType: nil,
             connectionsMerchantName: nil,
@@ -263,9 +281,7 @@ private struct NetowrkingOTPViewRepresentable: UIViewRepresentable {
             consumerSession: nil,
             apiClient: FinancialConnectionsAPIClient(apiClient: .shared),
             clientSecret: "",
-            analyticsClient: FinancialConnectionsAnalyticsClient(),
-            isTestMode: false,
-            theme: theme
+            analyticsClient: FinancialConnectionsAnalyticsClient()
         ))
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -176,6 +176,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
     func consumerSessionLookup(
         emailAddress: String,
         clientSecret: String,
+        sessionId: String,
+        emailSource: FinancialConnectionsAPIClient.EmailSource,
         useMobileEndpoints: Bool
     ) -> Future<StripeFinancialConnections.LookupConsumerSessionResponse> {
         return Promise<StripeFinancialConnections.LookupConsumerSessionResponse>()

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -175,7 +175,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
 
     func consumerSessionLookup(
         emailAddress: String,
-        clientSecret: String
+        clientSecret: String,
+        useMobileEndpoints: Bool
     ) -> Future<StripeFinancialConnections.LookupConsumerSessionResponse> {
         return Promise<StripeFinancialConnections.LookupConsumerSessionResponse>()
     }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
@@ -110,7 +110,7 @@ class FinancialConnectionsAPIClientTests: XCTestCase {
         ]
         let apiClient = FinancialConnectionsAPIClient(apiClient: mockApiClient)
         apiClient
-            .applyAttestationParameters(to: baseParameters)
+            .assertAndApplyAttestationParameters(to: baseParameters)
             .observe { result in
                 switch result {
                 case .success(let updatedParameters):

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
@@ -99,4 +99,31 @@ class FinancialConnectionsAPIClientTests: XCTestCase {
         XCTAssertEqual(encodedBillingAddress?["postal_code"] as? String, "90210")
         XCTAssertEqual(encodedBillingAddress?["country_code"] as? String, "US")
     }
+
+    func testApplyAttestationParameters() {
+        // Mark API client as testmode to use a mock assertion
+        mockApiClient.publishableKey = "pk_test"
+
+        let expectation = expectation(description: "applyAttestationParameters completed")
+        let baseParameters: [String: Any] = [
+            "base_parameter": true,
+        ]
+        let apiClient = FinancialConnectionsAPIClient(apiClient: mockApiClient)
+        apiClient
+            .applyAttestationParameters(to: baseParameters)
+            .observe { result in
+                switch result {
+                case .success(let updatedParameters):
+                    XCTAssertNotNil(updatedParameters["base_parameter"])
+                    XCTAssertNotNil(updatedParameters["app_id"])
+                    XCTAssertNotNil(updatedParameters["key_id"])
+                    XCTAssertNotNil(updatedParameters["device_id"])
+                    XCTAssertNotNil(updatedParameters["ios_assertion_object"])
+                case .failure(let error):
+                    XCTFail("Unexpected error when applying attestation parameters: \(error)")
+                }
+                expectation.fulfill()
+            }
+        wait(for: [expectation], timeout: 2.0)
+    }
 }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FlowRouterTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FlowRouterTests.swift
@@ -166,6 +166,7 @@ class FlowRouterTests: XCTestCase {
                 disableLinkMoreAccounts: false,
                 experimentAssignments: ["connections_mobile_native": nativeExperimentEnabled ? "treatment" : ""],
                 features: ["bank_connections_mobile_native_version_killswitch": killswitchActive],
+                id: "id",
                 instantVerificationDisabled: false,
                 institutionSearchDisabled: false,
                 livemode: false,


### PR DESCRIPTION
## Summary

This updates out Link account / consumer session lookup API to call the new `/consumers/mobile/sessions/lookup` endpoint during verified flows. In these verified flows, we also attach attestation parameters to the API request. The data sources that are affected are;

- `LinkLoginDataSource`
- `NetworkingLinkSignupDataSource`
- `NetworkingOTPDataSource`

## Motivation

https://docs.google.com/document/d/1joKz5UZHLVazmecfMHbq6gB6n4wj5u8To6AtqYgq_tc/edit?usp=sharing

## Testing

Unit test added to ensure attestation parameters are correctly applied. Working on manually testing the verified APIs work as expected - TestFlight build has been pushed.

## Changelog

N/a