### PR TITLE
Add PaymentDetails ID to incentives call

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -1155,7 +1155,8 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
 
     func updateAvailableIncentives(
         consumerSessionClientSecret: String,
-        sessionID: String
+        sessionID: String,
+        paymentDetailsID: String
     ) -> Future<AvailableIncentives> {
         let parameters: [String: Any] = [
             "request_surface": requestSurface,
@@ -1163,6 +1164,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
                 "consumer_session_client_secret": consumerSessionClientSecret
             ],
             "session_id": sessionID,
+            "payment_details_id": paymentDetailsID,
         ]
 
         return post(


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request adds the `payment_details_id` to the call to `incentives/update_available`.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[Web pull request](https://git.corp.stripe.com/stripe-internal/pay-server/pull/968445)

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
