### PR TITLE
Add verified test merchant to FC Example app

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -182,6 +182,7 @@ final class PlaygroundConfiguration {
         enum CustomId: String {
             case `default` = "default"
             case networking = "networking"
+            case verified = "verified"
             case connect = "connect"
             case customKeys = "custom_keys"
             case partnerD = "partner_d"
@@ -200,6 +201,11 @@ final class PlaygroundConfiguration {
         Merchant(
             customId: .networking,
             displayName: "Networking",
+            isTestModeSupported: true
+        ),
+        Merchant(
+            customId: .verified,
+            displayName: "Verified",
             isTestModeSupported: true
         ),
         Merchant(


### PR DESCRIPTION
## Summary

Adds a verified test merchant to the FC Example app. The credentials have already been added to our Glitch server.

## Motivation

For testing verified endpoints.

## Testing

Manually tested the account works as expected: 

<img width=40% alt="image" src="https://github.com/user-attachments/assets/20312226-b218-44de-9423-5ab457ba6a63" />

## Changelog

N/a
