### PR TITLE
Add `dismiss` to ApplePayContext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## X.Y.Z X-Y-Z
+### ApplePay
+* [Added] Added a `dismiss` method to `STPApplePayContext`.
+
+
 ## 24.4.0 2025-01-13
 ### PaymentSheet
 * [Fixed] PaymentSheet using vertical payment method layout now defaults to Apple Pay when the customer doesn't have a default saved payment method.

--- a/Stripe/StripeiOSTests/STPApplePayContextFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPApplePayContextFunctionalTest.swift
@@ -188,6 +188,26 @@ class STPApplePayContextFunctionalTest: STPNetworkStubbingTestCase {
         waitForExpectations(timeout: STPTestingNetworkRequestTimeout, handler: nil)
     }
 
+    func testDismiss() {
+        // Dismissing before presenting...
+        context.dismiss()
+        // ...does nothing
+        XCTAssertNotNil(context.authorizationController)
+
+        // Dismissing after presentation...
+        context.presentApplePay()
+        context.dismiss()
+        // ...cleans up state
+        XCTAssertNil(context.authorizationController)
+        // ...and does not call the didComplete delegate method
+        let didCallCompletion = expectation(description: "applePayContext:didCompleteWithStatus: called")
+        didCallCompletion.isInverted = true
+        delegate?.didCompleteDelegateMethod = { _, _ in
+            didCallCompletion.fulfill()
+        }
+        waitForExpectations(timeout: 1)
+    }
+
     // MARK: - Error tests
 
     func testBadPaymentIntentClientSecretErrors() {

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -149,7 +149,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
     private var presentationWindow: UIWindow?
 
     /// Presents the Apple Pay sheet from the key window, starting the payment process.
-    /// @note This method should only be called once; create a new instance of STPApplePayContext every time you present Apple Pay.
+    /// - Note: This method should only be called once; create a new instance of STPApplePayContext every time you present Apple Pay.
     /// - Parameters:
     ///   - completion:               Called after the Apple Pay sheet is presented
     @available(iOSApplicationExtension, unavailable)
@@ -170,7 +170,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
     }
 
     /// Presents the Apple Pay sheet from the specified window, starting the payment process.
-    /// @note This method should only be called once; create a new instance of STPApplePayContext every time you present Apple Pay.
+    /// - Note: This method should only be called once; create a new instance of STPApplePayContext every time you present Apple Pay.
     /// - Parameters:
     ///   - window:                   The UIWindow to host the Apple Pay sheet
     ///   - completion:               Called after the Apple Pay sheet is presented
@@ -221,6 +221,23 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
     ) {
         let window = viewController.viewIfLoaded?.window
         presentApplePay(from: window, completion: completion)
+    }
+
+    /// Dismisses the Apple Pay sheet.
+    /// - Parameter completion: Called after the Apple Pay sheet is dismissed.
+    /// - Note: Does not call the `applePayContext:didCompleteWithStatus:` delegate method.
+    /// - Note: You must create a new instance of ApplePayContext after using this method.
+    @objc(dismissWithCompletion:)
+    public func dismiss(completion: STPVoidBlock? = nil) {
+        guard didPresentApplePay else {
+            return
+        }
+        authorizationController?.dismiss {
+            stpDispatchToMainThreadIfNecessary {
+                completion?()
+                self._end()
+            }
+        }
     }
 
     /// The API Client to use to make requests.


### PR DESCRIPTION
## Summary
See https://stripe.slack.com/archives/C0353FPANQ0/p1736808910348399 

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2987
https://github.com/stripe/stripe-ios/issues/3558 

## Testing

Added unit test, does not actually test we call `cancel` under the hood though.

Manually tested calling the cancel API after I receive the payment method:

https://github.com/user-attachments/assets/810e8608-771e-4b7e-9b1c-31e4e8f5177b


## Changelog
See CHANGELOG