### PR TITLE
Refactor embedded view selection flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### PaymentSheet
 * [Fixed] Embedded Payment Element (private beta) layout margins default to zero.
-
+* [Fixed] Fixed a bug in Embedded Payment Element (private beta) where it could attempt to present a view controller while already presenting.
 
 ## 24.4.0 2025-01-13
 ### PaymentSheet

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -377,7 +377,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertFalse(app.textViews["By continuing, you agree to authorize payments pursuant to these terms."].waitForExistence(timeout: 3.0))
         let events = analyticsLog.compactMap({ $0[string: "event"] })
             .filter({ !$0.starts(with: "luxe") })
-            .suffix(7)
+            .suffix(5)
 
         XCTAssertEqual(
             events,
@@ -452,36 +452,36 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         payWithApplePay()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
     }
-    
+
     func testSelection_savedPaymentMethod() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.uiStyle = .embedded
         settings.customerMode = .returning
         settings.applePayEnabled = .on
-        
+
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         // Select Cash App Pay
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-        
+
         // Select a saved card
         XCTAssertTrue(app.buttons["View more"].waitForExistenceAndTap())
         XCTAssertTrue(app.staticTexts["Select payment method"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["•••• 4242"].firstMatch.waitForExistenceAndTap())
-        
+
         // Verify we have dismissed the saved payment method view and have the correct card selected
         XCTAssertFalse(app.staticTexts["Select payment method"].waitForExistence(timeout: 2))
         XCTAssertTrue(app.staticTexts["•••• 4242"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-        
+
         // Select Cash App Pay again
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-        
+
         // Delete one payment method so we only have one left, we should not auto select the last remaining saved PM
         XCTAssertTrue(app.buttons["View more"].waitForExistenceAndTap())
         XCTAssertTrue(app.buttons["Edit"].waitForExistenceAndTap())
@@ -489,7 +489,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Remove"].waitForExistenceAndTap())
         dismissAlertView(alertBody: "Visa •••• 4242", alertTitle: "Remove card?", buttonToTap: "Remove")
         XCTAssertTrue(app.buttons["Done"].waitForExistenceAndTap())
-        
+
         // Verify we show the bank account in the saved PM row
         XCTAssertTrue(app.buttons["Edit"].waitForExistence(timeout: 10))
         XCTAssertFalse(app.buttons["••••6789"].isSelected)
@@ -554,13 +554,13 @@ class EmbeddedUITests: PaymentSheetUITestCase {
 
         // Open card and cancel, should reset selection to saved card
         app.buttons["New card"].waitForExistenceAndTap()
-        let _ = app.buttons["Close"].waitForExistence(timeout: 10)
+        _ = app.buttons["Close"].waitForExistence(timeout: 10)
         XCTAssertTrue(app.buttons["New card"].isSelected)
         app.buttons["Close"].tap()
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
         XCTAssertTrue(app.buttons["•••• 4242"].isSelected)
-        
+
         // Open card fill out card, and cancel, should reset selection to saved card
         app.buttons["New card"].waitForExistenceAndTap()
         try! fillCardData(app, cardNumber: "5555555555554444", postalEnabled: true)
@@ -568,7 +568,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
         XCTAssertTrue(app.buttons["•••• 4242"].isSelected)
-        
+
         // Select Cash App Pay
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
@@ -670,7 +670,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Checkout"].waitForExistenceAndTap()
         payWithApplePay()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
-        
+
         // Apple Pay should be selected by default upon reloading with the same customer
         app.buttons["Reload"].tap()
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
@@ -694,7 +694,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         springboard.buttons["Continue"].waitForExistenceAndTap()
         // Stop here; Links's test playground is out of scope
     }
-    
+
     func testCVCRecollection() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .returning
@@ -705,26 +705,26 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.requireCVCRecollection = .on
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         // Select the saved card
         app.buttons["View more"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Select payment method"].waitForExistence(timeout: 10))
         app.buttons["•••• 4242"].firstMatch.waitForExistenceAndTap()
-        
+
         // Ensure the card is selected and start checking out
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
         app.swipeUp() // scroll to see the checkout button
         XCTAssertTrue(app.buttons["Checkout"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         app.buttons["Checkout"].tap()
-        
+
         // CVC field should already be selected
         app.typeText("123")
         app.buttons["Confirm"].waitForExistenceAndTap()
-        
+
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
     }
-    
+
     func testCashAppPay() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .returning
@@ -734,20 +734,20 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.formSheetAction = .continue
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
-        
+
         // Ensure Cash App Pay is selected and start checking out
         XCTAssertEqual(app.staticTexts["Payment method"].label, "Cash App Pay")
         app.swipeUp() // scroll to see the checkout button
         XCTAssertTrue(app.buttons["Checkout"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         app.buttons["Checkout"].tap()
-        
+
         webviewAuthorizePaymentButton.waitForExistenceAndTap(timeout: 10)
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
     }
-    
+
     func testCashAppPayAndSetup() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .returning
@@ -757,20 +757,20 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.formSheetAction = .continue
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
-        
+
         // Ensure Cash App Pay is selected and start checking out
         XCTAssertEqual(app.staticTexts["Payment method"].label, "Cash App Pay")
         app.swipeUp() // scroll to see the checkout button
         XCTAssertTrue(app.buttons["Checkout"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         app.buttons["Checkout"].tap()
-        
+
         webviewAuthorizePaymentButton.waitForExistenceAndTap(timeout: 10)
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
     }
-    
+
     func testCashAppPaySetup() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .returning
@@ -780,20 +780,20 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.formSheetAction = .continue
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
-        
+
         // Ensure Cash App Pay is selected and start checking out
         XCTAssertEqual(app.staticTexts["Payment method"].label, "Cash App Pay")
         app.swipeUp() // scroll to see the checkout button
         XCTAssertTrue(app.buttons["Checkout"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         app.buttons["Checkout"].tap()
-        
+
         webviewAuthorizeSetupButton.waitForExistenceAndTap(timeout: 10)
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
     }
-    
+
     func testCashAppPayBillingAddressCollection() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .returning
@@ -804,16 +804,16 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.collectName = .always
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         app.buttons["Cash App Pay"].waitForExistenceAndTap()
-        
+
         let fullNameField = app.textFields["Full name"]
         XCTAssertTrue(fullNameField.waitForExistence(timeout: 10))
         fullNameField.forceTapElement()
         fullNameField.typeText("Jane Doe")
-        
+
         app.buttons["Continue"].tap()
-        
+
         // Ensure Cash App Pay is selected and start checking out
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "Cash App Pay")
@@ -821,7 +821,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Checkout"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         app.buttons["Checkout"].tap()
-        
+
         webviewAuthorizePaymentButton.waitForExistenceAndTap(timeout: 10)
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
     }
@@ -835,21 +835,21 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.externalPaymentMethods = .paypal
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         app.buttons["PayPal"].waitForExistenceAndTap()
-        
+
         // Ensure PayPal is selected and start checking out
         XCTAssertEqual(app.staticTexts["Payment method"].label, "PayPal")
         app.swipeUp() // scroll to see the checkout button
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
         app.buttons["Checkout"].waitForExistenceAndTap()
-        
+
         XCTAssertNotNil(app.staticTexts["Confirm external_paypal?"])
         app.buttons["Cancel"].waitForExistenceAndTap()
-        
+
         app.buttons["Checkout"].waitForExistenceAndTap()
         app.buttons["Confirm"].waitForExistenceAndTap()
-        
+
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
     }
 
@@ -864,9 +864,9 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.formSheetAction = .confirm
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         app.buttons["SEPA Debit"].waitForExistenceAndTap()
-        
+
         app.textFields["Full name"].waitForExistenceAndTap()
         app.typeText("John Doe" + XCUIKeyboardKey.return.rawValue)
         app.typeText("test@example.com" + XCUIKeyboardKey.return.rawValue)
@@ -878,10 +878,10 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.textFields["ZIP"].tap()
         app.typeText("94102" + XCUIKeyboardKey.return.rawValue)
         app.buttons["Pay €50.99"].tap()
-        
+
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
-    
+
     func testUSBankAccount() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .returning
@@ -891,9 +891,9 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.formSheetAction = .confirm
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         XCTAssertTrue(app.buttons["US bank account"].waitForExistenceAndTap())
-        
+
         // Fill out name and email fields
         let continueButton = app.buttons["Continue"]
         XCTAssertFalse(continueButton.isEnabled)
@@ -908,25 +908,25 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.staticTexts["Test Institution"].forceTapElement()
         // "Success" institution is automatically selected because its the first
         app.buttons["connect_accounts_button"].waitForExistenceAndTap(timeout: 10)
-        
+
         XCUIApplication().toolbars.buttons["Done"].waitForExistenceAndTap()
         app.buttons["Not now"].waitForExistenceAndTap()
-        
+
         XCTAssertTrue(app.staticTexts["Success"].waitForExistence(timeout: 10))
         app.buttons.matching(identifier: "Done").allElementsBoundByIndex.last?.tap()
-        
+
         // Make sure bottom notice mandate is visible
         XCTAssertTrue(app.textViews["By continuing, you agree to authorize payments pursuant to these terms."].waitForExistence(timeout: 5))
-        
+
         let saveThisAccountToggle = app.switches["Save this account for future Example, Inc. payments"]
         XCTAssertFalse(saveThisAccountToggle.isSelected)
         saveThisAccountToggle.tap()
-        
+
         // Confirm
         app.buttons["Pay $50.99"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
-    
+
     func test3DS2CardAlwaysAuthenticate() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
@@ -937,17 +937,17 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         settings.currency = .eur
         loadPlayground(app, settings)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
-        
+
         XCTAssertTrue(app.buttons["Card"].waitForExistenceAndTap())
         XCTAssertTrue(app.staticTexts["Add card"].waitForExistence(timeout: 10))
-        
+
         // Card number from https://docs.stripe.com/testing#regulatory-cards
         try! fillCardData(app, cardNumber: "4000002760003184")
         app.toolbars.buttons["Done"].waitForExistenceAndTap()
         app.buttons["Continue"].waitForExistenceAndTap()
         app.swipeUp() // scroll to see the checkout button
         app.buttons["Checkout"].waitForExistenceAndTap()
-        
+
         // Finish the 3DS2 payment
         let challengeCodeTextField = app.textFields["STDSTextField"]
         XCTAssertTrue(challengeCodeTextField.waitForExistenceAndTap(timeout: 10))
@@ -955,7 +955,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Submit"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
-    
+
     func testClearPaymentOption() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .returning
@@ -991,7 +991,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(paymentMethodLabel.waitForExistence(timeout: 10))
         XCTAssertEqual(paymentMethodLabel.label, "Cash App Pay")
         XCTAssertTrue(cashAppPayButton.isSelected)
-        
+
         // Clear selection again
         clearButton.tap()
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -382,8 +382,8 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertEqual(
             events,
             ["mc_embedded_paymentoption_savedpm_select",
-             "mc_carousel_payment_method_tapped", "mc_open_edit_screen", "mc_embedded_paymentoption_removed",
-             "mc_carousel_payment_method_tapped", "mc_open_edit_screen", "mc_embedded_paymentoption_removed",
+             "mc_open_edit_screen", "mc_embedded_paymentoption_removed",
+             "mc_open_edit_screen", "mc_embedded_paymentoption_removed",
             ]
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
@@ -38,10 +38,10 @@ import UIKit
     /// - Parameter embeddedFormViewController: The view controller that was canceled.
     func embeddedFormViewControllerDidCancel(_ embeddedFormViewController: EmbeddedFormViewController)
 
-    /// Notifies the delegate that the embedded form view controller should close.
+    /// Notifies the delegate that the user completed the form and tapped the primary button..
     /// This method is called when a payment option that can be confirmed later has been provided.
     /// - Parameter embeddedFormViewController: The view controller requesting to close.
-    func embeddedFormViewControllerShouldClose(_ embeddedFormViewController: EmbeddedFormViewController)
+    func embeddedFormViewControllerDidContinue(_ embeddedFormViewController: EmbeddedFormViewController)
 }
 
 class EmbeddedFormViewController: UIViewController {
@@ -68,7 +68,7 @@ class EmbeddedFormViewController: UIViewController {
             navigationBar.isUserInteractionEnabled = isUserInteractionEnabled
         }
     }
-    
+
     var collectsUserInput: Bool {
         return paymentMethodFormViewController.form.collectsUserInput
     }
@@ -79,7 +79,7 @@ class EmbeddedFormViewController: UIViewController {
     var selectedPaymentOption: PaymentSheet.PaymentOption? {
         return paymentMethodFormViewController.paymentOption
     }
-    
+
     private let paymentMethodType: PaymentSheet.PaymentMethodType
     private let configuration: EmbeddedPaymentElement.Configuration
     private let intent: Intent
@@ -363,7 +363,7 @@ class EmbeddedFormViewController: UIViewController {
 
         // If we defer confirmation, simply close the sheet
         if shouldDeferConfirmation {
-            self.delegate?.embeddedFormViewControllerShouldClose(self)
+            self.delegate?.embeddedFormViewControllerDidContinue(self)
             return
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -10,8 +10,6 @@
 @_spi(STP) import StripeUICore
 import UIKit
 
-@_spi(STP) import StripeCore
-
 extension EmbeddedPaymentElement {
     @MainActor
     static func makeView(
@@ -60,8 +58,7 @@ extension EmbeddedPaymentElement {
                 if let defaultPaymentMethod = loadResult.elementsSession.customer?.getDefaultOrFirstPaymentMethod() {
                     customerDefault = CustomerPaymentOption.stripeId(defaultPaymentMethod.stripeId)
                 }
-            }
-            else {
+            } else {
                 customerDefault = CustomerPaymentOption.defaultPaymentMethod(for: configuration.customer?.id)
             }
             switch customerDefault {
@@ -92,38 +89,23 @@ extension EmbeddedPaymentElement {
             savedPaymentMethods: loadResult.savedPaymentMethods,
             customer: configuration.customer,
             incentive: loadResult.elementsSession.incentive,
+            analyticsHelper: analyticsHelper,
             delegate: delegate
         )
     }
-}
 
-// MARK: - EmbeddedPaymentMethodsViewDelegate
-
-extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
-    func heightDidChange() {
-        delegate?.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: self)
+    /// Helper method to inform delegate only if the payment option changed
+    func informDelegateIfPaymentOptionUpdated() {
+        if lastUpdatedPaymentOption != paymentOption {
+            delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: self)
+            lastUpdatedPaymentOption = paymentOption
+        }
     }
 
-    func updateSelectionState(isNewSelection: Bool) {
-        // Deferring notifying delegate until the exit of this function guarantees the new payment option comes from the new instance of `EmbeddedFormViewController`
-        defer {
-            if isNewSelection {
-                delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: self)
-                if let selection = embeddedPaymentMethodsView.selection {
-                    analyticsHelper.logNewPaymentMethodSelected(paymentMethodTypeIdentifier: selection.analyticsIdentifier)
-                }
-            }
-        }
-
-        guard case let .new(paymentMethodType) = embeddedPaymentMethodsView.selection else {
-            // This can occur when selection is being reset to nothing selected or to a saved payment method, so don't assert.
-            self.formViewController = nil
-            return
-        }
-
-        guard let presentingViewController else {
-            stpAssertionFailure("Presenting view controller not found, set EmbeddedPaymentElement.presentingViewController.")
-            return
+    // Helper method to create Form VC for a payment method row, if applicable.
+    func makeFormViewControllerIfNecessary(selection: EmbeddedPaymentMethodsView.Selection?) -> EmbeddedFormViewController? {
+        guard case let .new(paymentMethodType) = selection else {
+            return nil
         }
 
         let formViewController = EmbeddedFormViewController(
@@ -132,25 +114,48 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
             elementsSession: elementsSession,
             shouldUseNewCardNewCardHeader: savedPaymentMethods.first?.type == .card,
             paymentMethodType: paymentMethodType,
-            previousPaymentOption: self.formViewController?.previousPaymentOption,
+            previousPaymentOption: self.selectedFormViewController?.previousPaymentOption,
             analyticsHelper: analyticsHelper,
             formCache: formCache
         )
         formViewController.delegate = self
-
-        // Only show forms that require user input
         guard formViewController.collectsUserInput else {
-            self.formViewController = nil  // Clear out any previous form view controller to update self._paymentOption
-            return
+            return nil
         }
+        return formViewController
+    }
+}
 
-        let bottomSheet = bottomSheetController(with: formViewController)
-        delegate?.embeddedPaymentElementWillPresent(embeddedPaymentElement: self)
-        presentingViewController.presentAsBottomSheet(bottomSheet, appearance: configuration.appearance)
-        self.formViewController = formViewController
+// MARK: - EmbeddedPaymentMethodsViewDelegate
+
+extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
+    func embeddedPaymentMethodsViewDidUpdateHeight() {
+        delegate?.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: self)
     }
 
-    func presentSavedPaymentMethods(selectedSavedPaymentMethod: STPPaymentMethod?) {
+    func embeddedPaymentMethodsViewDidUpdateSelection() {
+        // 1. Update the currently selection's form VC to match the selection.
+        // Note `paymentOption` derives from this property
+        self.selectedFormViewController = makeFormViewControllerIfNecessary(selection: embeddedPaymentMethodsView.selection)
+
+        // 2. Inform the delegate of the updated payment option
+        informDelegateIfPaymentOptionUpdated()
+    }
+
+    func embeddedPaymentMethodsViewDidTapPaymentMethodRow() {
+        guard let selectedFormViewController else {
+            // If the current selection has no form VC, there's nothing to do
+            return
+        }
+        // Present the current selection's form VC
+        delegate?.embeddedPaymentElementWillPresent(embeddedPaymentElement: self)
+        let bottomSheet = bottomSheetController(with: selectedFormViewController)
+        stpAssert(presentingViewController != nil, "Presenting view controller not found, set EmbeddedPaymentElement.presentingViewController.")
+        presentingViewController?.presentAsBottomSheet(bottomSheet, appearance: configuration.appearance)
+
+    }
+
+    func embeddedPaymentMethodsViewDidTapViewMoreSavedPaymentMethods(selectedSavedPaymentMethod: STPPaymentMethod?) {
         // Special case, only 1 card remaining, skip showing the list and show update view controller
         if savedPaymentMethods.count == 1,
            let paymentMethod = savedPaymentMethods.first {
@@ -184,14 +189,14 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         let bottomSheetVC = bottomSheetController(with: verticalSavedPaymentMethodsViewController)
         presentingViewController?.presentAsBottomSheet(bottomSheetVC, appearance: configuration.appearance)
     }
-    
+
     func verifyIntegration() {
-        guard let _ = delegate else {
+        guard delegate != nil else {
             stpAssertionFailure("Delegate not set. Please set EmbeddedPaymentElement.delegate.")
             return
         }
-        
-        guard let _ = presentingViewController else {
+
+        guard presentingViewController != nil else {
             stpAssertionFailure("Presenting view controller not found. Please set EmbeddedPaymentElement.presentingViewController.")
             return
         }
@@ -323,25 +328,22 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
     func embeddedFormViewControllerDidCancel(_ embeddedFormViewController: EmbeddedFormViewController) {
         // If the formViewController was populated with a previous payment option don't reset
         if embeddedFormViewController.previousPaymentOption == nil {
-            self.formViewController = nil
             embeddedPaymentMethodsView.resetSelectionToLastSelection()
         }
         embeddedFormViewController.dismiss(animated: true)
     }
 
-    func embeddedFormViewControllerShouldClose(_ embeddedFormViewController: EmbeddedFormViewController) {
-        embeddedPaymentMethodsView.highlightSelection()
+    func embeddedFormViewControllerDidContinue(_ embeddedFormViewController: EmbeddedFormViewController) {
         embeddedFormViewController.dismiss(animated: true)
-        delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: self)
+        informDelegateIfPaymentOptionUpdated()
     }
-
 }
 
 extension EmbeddedPaymentElement {
 
     func _confirm() async -> (result: PaymentSheetResult, deferredIntentConfirmationType: STPAnalyticsClient.DeferredIntentConfirmationType?) {
         verifyIntegration()
-        
+
         guard !hasConfirmedIntent else {
             return (.failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent), STPAnalyticsClient.DeferredIntentConfirmationType.none)
         }
@@ -366,8 +368,8 @@ extension EmbeddedPaymentElement {
         let authContext: STPAuthenticationContext? = {
             switch configuration.formSheetAction {
             case .confirm:
-                if formViewController?.presentingViewController != nil {
-                    return formViewController
+                if selectedFormViewController?.presentingViewController != nil {
+                    return selectedFormViewController
                 }
                 if let presentingViewController {
                     return STPAuthenticationContextWrapper(presentingViewController: presentingViewController)
@@ -404,13 +406,13 @@ extension EmbeddedPaymentElement {
         analyticsHelper.logPayment(paymentOption: paymentOption,
                                    result: result,
                                    deferredIntentConfirmationType: deferredIntentConfirmationType)
-        
+
         // If the confirmation was successful, disable user interaction
         if case .completed = result {
             hasConfirmedIntent = true
             containerView.isUserInteractionEnabled = false
         }
-        
+
         return (result, deferredIntentConfirmationType)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -6,9 +6,9 @@
 //
 
 @_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripeUICore
-@_spi(STP) import StripePayments
 import UIKit
 
 /// An object that manages a view that displays payment methods and completes a checkout.
@@ -105,12 +105,12 @@ public final class EmbeddedPaymentElement {
         intentConfiguration: IntentConfiguration
     ) async -> UpdateResult {
         verifyIntegration()
-        
+
         // Do not process any update calls if we have already successfully confirmed an intent
         guard !hasConfirmedIntent else {
             return .failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent)
         }
-        
+
         embeddedPaymentMethodsView.isUserInteractionEnabled = false
         // Cancel the old task and let it finish so that merchants receive update results in order
         latestUpdateTask?.cancel()
@@ -137,19 +137,19 @@ public final class EmbeddedPaymentElement {
 
             // Store the old payment option before we update self.formViewController
             let oldPaymentOption = self?.paymentOption
-            
+
             // 2.1. Re-initialize embedded form view controller to update the UI to match the newly loaded data.
-            if let formPaymentMethodType = self?.formViewController?.selectedPaymentOption?.paymentMethodType {
-                self?.formViewController = EmbeddedFormViewController(configuration: configuration,
+            if let formPaymentMethodType = self?.selectedFormViewController?.selectedPaymentOption?.paymentMethodType {
+                self?.selectedFormViewController = EmbeddedFormViewController(configuration: configuration,
                                                                 intent: loadResult.intent,
                                                                 elementsSession: loadResult.elementsSession,
                                                                 shouldUseNewCardNewCardHeader: loadResult.savedPaymentMethods.first?.type == .card,
                                                                 paymentMethodType: formPaymentMethodType,
-                                                                previousPaymentOption: self?.formViewController?.selectedPaymentOption,
+                                                                previousPaymentOption: self?.selectedFormViewController?.selectedPaymentOption,
                                                                 analyticsHelper: analyticsHelper)
-                
+
             }
-            
+
             // 2.4 Re-initialize embedded view to update the UI to match the newly loaded data.
             let embeddedPaymentMethodsView = Self.makeView(
                 configuration: configuration,
@@ -158,7 +158,7 @@ public final class EmbeddedPaymentElement {
                 previousPaymentOption: self?._paymentOption,
                 delegate: self
             )
-            
+
             // 3. Pre-load image into cache
             // Call this on a detached Task b/c this synchronously (!) loads the image from network and we don't want to block the main actor
             let fetchPaymentOption = Task.detached(priority: .userInitiated) {
@@ -193,31 +193,31 @@ public final class EmbeddedPaymentElement {
     /// - Returns: The result of the payment after any presented view controllers are dismissed.
     /// - Note: This method presents authentication screens on the instance's  `presentingViewController` property.
     /// - Note: This method requires that the last call to `update` succeeded. If the last `update` call failed, this call will fail. If this method is called while a call to `update` is in progress, it waits until the `update` call completes.
-    public func confirm() async -> EmbeddedPaymentElementResult {        
+    public func confirm() async -> EmbeddedPaymentElementResult {
         return await _confirm().result
     }
 
     /// Sets the currently selected payment option to `nil`.
     public func clearPaymentOption() {
         verifyIntegration()
-        
+
         // If a payment has been successfully completed, we don't allow clearing the payment option.
         guard !hasConfirmedIntent else { return }
-        
+
         // Early exit for a nil payment option, don't notify delegate since no change in payment option can occur
         guard paymentOption != nil else { return }
-        
+
         // Clear out the form controller to clear any payment option
-        formViewController = nil
-        
+        selectedFormViewController = nil
+
         // Reset the selection on the `embeddedPaymentMethodsView`
         embeddedPaymentMethodsView.resetSelection()
-        
+
 #if DEBUG
         // Clear the testable payment option (only populated during unit testing)
         _test_paymentOption = nil
 #endif
-        
+
         // Notify the delegate that the payment option has changed
         delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: self)
     }
@@ -239,13 +239,16 @@ public final class EmbeddedPaymentElement {
     internal private(set) var analyticsHelper: PaymentSheetAnalyticsHelper
     internal var savedPaymentMethods: [STPPaymentMethod]
     internal private(set) var formCache: PaymentMethodFormCache = .init()
-    internal var formViewController: EmbeddedFormViewController?
+    /// The form view controller for the currently selected payment method.
+    internal var selectedFormViewController: EmbeddedFormViewController?
     /// Indicates if a payment has been successfully completed.
     internal var hasConfirmedIntent = false
 #if DEBUG
     internal var _test_paymentOption: PaymentOption? // for testing only
 #endif
 
+    /// The value of `paymentOption` when we last called `embeddedPaymentElementDidUpdatePaymentOption`
+    internal var lastUpdatedPaymentOption: PaymentOptionDisplayData?
     internal var _paymentOption: PaymentOption? {
     #if DEBUG
         if let testPaymentOption = _test_paymentOption {
@@ -253,10 +256,10 @@ public final class EmbeddedPaymentElement {
         }
     #endif
         // If we have a form use it's payment option
-        if let formViewController {
-            return formViewController.selectedPaymentOption
+        if let selectedFormViewController {
+            return selectedFormViewController.selectedPaymentOption
         }
-        
+
         switch embeddedPaymentMethodsView.selection {
         case .applePay:
             return .applePay
@@ -282,7 +285,7 @@ public final class EmbeddedPaymentElement {
     internal private(set) lazy var savedPaymentMethodManager: SavedPaymentMethodManager = {
         SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession)
     }()
-    
+
     internal private(set) lazy var paymentHandler: STPPaymentHandler = STPPaymentHandler(apiClient: configuration.apiClient)
 
     private init(
@@ -310,6 +313,7 @@ public final class EmbeddedPaymentElement {
             self.delegate?.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: self)
         }
         self.embeddedPaymentMethodsView.delegate = self
+        self.lastUpdatedPaymentOption = paymentOption
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -44,6 +44,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
     }
     var delegateDidUpdatePaymentOptionCalled = false
     var delegateDidUpdateHeightCalled = false
+    var delegateWillPresentCalled = false
 
     // MARK: - `update` tests
 
@@ -298,7 +299,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
         sut.embeddedPaymentMethodsView.didTap(selection: .new(paymentMethodType: .stripe(.cashApp)))
         // The delegate should have been notified
         XCTAssertTrue(delegateDidUpdatePaymentOptionCalled)
-        XCTAssertNotNil(sut.paymentOption)
+        XCTAssertEqual(sut.paymentOption?.label, "CashApp")
 
         // Reset flags
         delegateDidUpdatePaymentOptionCalled = false
@@ -309,6 +310,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
 
         // The paymentOption should now be nil after reset
         XCTAssertNil(sut.paymentOption)
+        XCTAssertNil(sut.selectedFormViewController)
 
         // The delegate should have been notified again after reset
         XCTAssertTrue(delegateDidUpdatePaymentOptionCalled)
@@ -434,6 +436,10 @@ extension EmbeddedPaymentElementTest: EmbeddedPaymentElementDelegate {
 
     func embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: StripePaymentSheet.EmbeddedPaymentElement) {
         delegateDidUpdatePaymentOptionCalled = true
+    }
+
+    func embeddedPaymentElementWillPresent(embeddedPaymentElement: EmbeddedPaymentElement) {
+        delegateWillPresentCalled = true
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -299,7 +299,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
         sut.embeddedPaymentMethodsView.didTap(selection: .new(paymentMethodType: .stripe(.cashApp)))
         // The delegate should have been notified
         XCTAssertTrue(delegateDidUpdatePaymentOptionCalled)
-        XCTAssertEqual(sut.paymentOption?.label, "CashApp")
+        XCTAssertEqual(sut.paymentOption?.label, "Cash App Pay")
 
         // Reset flags
         delegateDidUpdatePaymentOptionCalled = false

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
@@ -279,7 +279,7 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
 
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_bacsDebit_darkBackground() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.colors.componentBackground = .black
@@ -593,7 +593,7 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
         XCTAssertEqual(embeddedView.selection, initialSelection)
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatRadio_promoBadge() {
         let embeddedView = EmbeddedPaymentMethodsView(
             initialSelection: nil,
@@ -606,16 +606,16 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
             mandateProvider: MockMandateProvider(),
             incentive: PaymentMethodIncentive(identifier: "link_instant_debits", displayText: "$5")
         )
-        
+
         verify(embeddedView)
     }
-    
+
     // MARK: Flat with checkmark snapshot tests
 
     func testEmbeddedPaymentMethodsView_flatWithCheckmark() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: nil,
@@ -624,14 +624,14 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: true,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_savedPaymentMethod() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: .saved(paymentMethod: STPPaymentMethod._testCard()),
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: STPPaymentMethod._testCard(),
@@ -641,14 +641,14 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       savedPaymentMethodAccessoryType: .viewMore,
                                                       mandateProvider: MockMandateProvider(),
                                                       savedPaymentMethods: [._testCard()])
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_noApplePay() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: nil,
@@ -657,14 +657,14 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: true,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_noLink() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: nil,
@@ -673,15 +673,15 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: false,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_rowHeight() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
         appearance.embeddedPaymentElement.row.additionalInsets = 20
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp), .stripe(.afterpayClearpay)],
                                                       savedPaymentMethod: nil,
@@ -690,9 +690,9 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: true,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         verify(embeddedView)
-        
+
         // Assert height
         let defaultHeight = RowButton.calculateTallestHeight(appearance: .default, isEmbedded: true)
         let defaultInset = PaymentSheet.Appearance.default.embeddedPaymentElement.row.additionalInsets
@@ -701,12 +701,12 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
             XCTAssertEqual((appearance.embeddedPaymentElement.row.additionalInsets - defaultInset) * 2, newHeight - defaultHeight)
         }
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_rowHeightSingleLine() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
         appearance.embeddedPaymentElement.row.additionalInsets = 20
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: nil,
@@ -715,9 +715,9 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: false,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         verify(embeddedView)
-        
+
         // Assert height
         let defaultHeight = RowButton.calculateTallestHeight(appearance: .default, isEmbedded: true)
         let defaultInset = PaymentSheet.Appearance.default.embeddedPaymentElement.row.additionalInsets
@@ -726,12 +726,12 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
             XCTAssertEqual((appearance.embeddedPaymentElement.row.additionalInsets - defaultInset) * 2, newHeight - defaultHeight)
         }
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_spacing() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
         appearance.embeddedPaymentElement.row.floating.spacing = 30
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: nil,
@@ -740,16 +740,16 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: true,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_selectedBorder() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement .row.style = .flatWithCheckmark
         appearance.selectedBorderWidth = 5.0
         appearance.colors.selectedComponentBorder = .red
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: nil,
@@ -758,19 +758,19 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: true,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         // Simulate tapping the last button (Cash App Pay)
         embeddedView.didTap(selection: .new(paymentMethodType: .stripe(.cashApp)))
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_borderWidth() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement .row.style = .flatWithCheckmark
         appearance.borderWidth = 5.0
         appearance.colors.primary = .red
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: nil,
@@ -779,18 +779,18 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: true,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         // Simulate tapping the last button (Cash App Pay)
         embeddedView.didTap(selection: .new(paymentMethodType: .stripe(.cashApp)))
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_componentBackgroundColor() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
         appearance.colors.componentBackground = .purple
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: nil,
@@ -799,15 +799,15 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: true,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_cornerRadius() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
         appearance.cornerRadius = 15
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: nil,
@@ -816,16 +816,16 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: true,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_smallFont() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
         appearance.font.sizeScaleFactor = 0.5
         appearance.font.base = UIFont(name: "AmericanTypewriter", size: 12)!
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: nil,
@@ -834,16 +834,16 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: true,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_largeFont() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
         appearance.font.sizeScaleFactor = 1.5
         appearance.font.base = UIFont(name: "AmericanTypewriter", size: 12)!
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
                                                       savedPaymentMethod: nil,
@@ -852,14 +852,14 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       shouldShowLink: true,
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider())
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_promoBadge_unselected() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(
             initialSelection: .new(paymentMethodType: .stripe(.card)),
             paymentMethodTypes: [.stripe(.card), .instantDebits, .stripe(.cashApp)],
@@ -871,14 +871,14 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
             mandateProvider: MockMandateProvider(),
             incentive: PaymentMethodIncentive(identifier: "link_instant_debits", displayText: "$5")
         )
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_flatWithCheckmark_promoBadge_selected() {
         var appearance: PaymentSheet.Appearance = .default
         appearance.embeddedPaymentElement.row.style = .flatWithCheckmark
-        
+
         let embeddedView = EmbeddedPaymentMethodsView(
             initialSelection: .new(paymentMethodType: .instantDebits),
             paymentMethodTypes: [.stripe(.card), .instantDebits, .stripe(.cashApp)],
@@ -890,10 +890,9 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
             mandateProvider: MockMandateProvider(),
             incentive: PaymentMethodIncentive(identifier: "link_instant_debits", displayText: "$5")
         )
-        
+
         verify(embeddedView)
     }
-
 
     // MARK: Mandate tests
 
@@ -1067,7 +1066,7 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
 
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_withSavedCard() {
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
@@ -1078,10 +1077,10 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider(),
                                                       savedPaymentMethods: [._testCard()])
-        
+
         verify(embeddedView)
     }
-    
+
     func testEmbeddedPaymentMethodsView_withoutSavedCard() {
         let embeddedView = EmbeddedPaymentMethodsView(initialSelection: nil,
                                                       paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
@@ -1092,10 +1091,9 @@ class EmbeddedPaymentMethodsViewSnapshotTests: STPSnapshotTestCase {
                                                       savedPaymentMethodAccessoryType: .none,
                                                       mandateProvider: MockMandateProvider(),
                                                       savedPaymentMethods: [._testUSBankAccount()])
-        
+
         verify(embeddedView)
     }
-
 
     func verify(
         _ view: UIView,
@@ -1121,5 +1119,40 @@ class MockMandateProvider: MandateTextProvider {
 
     func mandate(for paymentMethodType: PaymentSheet.PaymentMethodType?, savedPaymentMethod: STPPaymentMethod?, bottomNoticeAttributedString: NSAttributedString?) -> NSAttributedString? {
         return mandateResolver(paymentMethodType)
+    }
+}
+
+extension EmbeddedPaymentMethodsView {
+    convenience init(
+        initialSelection: Selection?,
+        paymentMethodTypes: [PaymentSheet.PaymentMethodType],
+        savedPaymentMethod: STPPaymentMethod?,
+        appearance: PaymentSheet.Appearance,
+        shouldShowApplePay: Bool,
+        shouldShowLink: Bool,
+        savedPaymentMethodAccessoryType: RowButton.RightAccessoryButton.AccessoryType?,
+        mandateProvider: MandateTextProvider,
+        shouldShowMandate: Bool = true,
+        savedPaymentMethods: [STPPaymentMethod] = [],
+        customer: PaymentSheet.CustomerConfiguration? = nil,
+        incentive: PaymentMethodIncentive? = nil,
+        delegate: EmbeddedPaymentMethodsViewDelegate? = nil
+    ) {
+        self.init(
+            initialSelection: initialSelection,
+            paymentMethodTypes: paymentMethodTypes,
+            savedPaymentMethod: savedPaymentMethod,
+            appearance: appearance,
+            shouldShowApplePay: shouldShowApplePay,
+            shouldShowLink: shouldShowLink,
+            savedPaymentMethodAccessoryType: savedPaymentMethodAccessoryType,
+            mandateProvider: mandateProvider,
+            shouldShowMandate: shouldShowMandate,
+            savedPaymentMethods: savedPaymentMethods,
+            customer: customer,
+            incentive: incentive,
+            analyticsHelper: ._testValue(),
+            delegate: nil
+        )
     }
 }


### PR DESCRIPTION
## Summary
Refactored the `updateSelectionState` into two separate, smaller methods with single responsibilities: 
- `embeddedPaymentMethodsViewDidUpdateSelection`, called whenever the selection changes
- `embeddedPaymentMethodsViewDidTapPaymentMethodRow`, called whenever a row is tapped

and fixed some bugs from the old implementation.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-2974

The old `updateSelectionState` code had some bugs. It should work like this: 
- If the customer taps the card row, we should present the form, send a "tapped" analytic, etc.
- If we reset the selection back to the card row, we shouldn't do those things.

but instead it:
- Always try to present the form
- Always send a "tapped" analytic if the selection changed

It was also doing too many different things.

## Testing
See expanded view tests.

The old delegate method implementation should probably have been unit tested given its complexity, but IMO they don't need to be now that they're so simple and small.

## Changelog
See changelog