### PR TITLE
Add attestation event logging to FC API clients

### DIFF
--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -113,25 +113,25 @@ import UIKit
         }
     }
 
-    @_spi(STP) public enum AttestationError: Error {
+    @_spi(STP) public enum AttestationError: String, Error {
         /// Attestation is not supported on this device.
-        case attestationNotSupported
+        case attestationNotSupported = "attestation_not_supported"
         /// Device ID is unavailable.
-        case noDeviceID
+        case noDeviceID = "no_device_id"
         /// App ID is unavailable.
-        case noAppID
+        case noAppID = "no_app_id"
         /// Retried assertion, but it failed.
-        case secondAssertionFailureAfterRetryingAttestation
+        case secondAssertionFailureAfterRetryingAttestation = "second_assertion_failure_after_retrying_attestation"
         /// Can't attest any more keys today.
-        case attestationRateLimitExceeded
+        case attestationRateLimitExceeded = "attestation_rate_limit_exceeded"
         /// The challenge couldn't be converted to UTF-8 data.
-        case invalidChallengeData
+        case invalidChallengeData = "invalid_challenge_data"
         /// The backend asked us not to attest
-        case shouldNotAttest
+        case shouldNotAttest = "should_not_attest"
         /// The backend asked us to attest, but the key is already attested
-        case shouldAttestButKeyIsAlreadyAttested
+        case shouldAttestButKeyIsAlreadyAttested = "should_attest_but_key_is_already_attested"
         /// A publishable key was not set
-        case noPublishableKey
+        case noPublishableKey = "no_publishable_key"
     }
 
     // MARK: - Internal

--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		495539EE2C484DC200543D18 /* FinancialConnectionsTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */; };
 		496A6AE72C29E0BB00D34F8E /* testmode@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 496A6AE62C29E0BB00D34F8E /* testmode@3x.png */; };
 		497142BC2C514B08000DFA64 /* FlowRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497142BB2C514B08000DFA64 /* FlowRouterTests.swift */; };
+		499EEAFD2D3E948B00E1BE85 /* FinancialConnectionsAPIClientLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499EEAFC2D3E948B00E1BE85 /* FinancialConnectionsAPIClientLogger.swift */; };
 		49A0B5862C5D2F3C00D697D9 /* FinancialConnectionsAPIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A0B5852C5D2F3C00D697D9 /* FinancialConnectionsAPIClientTests.swift */; };
 		49AC518C2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49AC518B2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift */; };
 		49C911372C597EAF00589E0D /* LinkLoginDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C911332C597EAF00589E0D /* LinkLoginDataSource.swift */; };
@@ -330,6 +331,7 @@
 		495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsTheme.swift; sourceTree = "<group>"; };
 		496A6AE62C29E0BB00D34F8E /* testmode@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testmode@3x.png"; sourceTree = "<group>"; };
 		497142BB2C514B08000DFA64 /* FlowRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowRouterTests.swift; sourceTree = "<group>"; };
+		499EEAFC2D3E948B00E1BE85 /* FinancialConnectionsAPIClientLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsAPIClientLogger.swift; sourceTree = "<group>"; };
 		49A0B5852C5D2F3C00D697D9 /* FinancialConnectionsAPIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsAPIClientTests.swift; sourceTree = "<group>"; };
 		49AC518B2C52DE2C00B712CC /* FinancialConnectionsLinkLoginPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsLinkLoginPane.swift; sourceTree = "<group>"; };
 		49C911332C597EAF00589E0D /* LinkLoginDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinkLoginDataSource.swift; sourceTree = "<group>"; };
@@ -657,6 +659,7 @@
 				4E2EAD7059FF8358E674774A /* FinancialConnectionsAPIClient.swift */,
 				49F1B8392D2DAE7100136303 /* FinancialConnectionsAsyncAPIClient.swift */,
 				49F1B83D2D2EC82300136303 /* FinancialConnectionsAsyncAPIClient+Legacy.swift */,
+				499EEAFC2D3E948B00E1BE85 /* FinancialConnectionsAPIClientLogger.swift */,
 			);
 			path = "API Bindings";
 			sourceTree = "<group>";
@@ -1319,6 +1322,7 @@
 				CBF7BE2271D309F2B1E794CC /* FinancialConnectionsDataAccessNotice.swift in Sources */,
 				F67624595BD2CD7B6793BFDA /* FinancialConnectionsImage.swift in Sources */,
 				07712610C7D2F484AAB96982 /* FinancialConnectionsInstitution.swift in Sources */,
+				499EEAFD2D3E948B00E1BE85 /* FinancialConnectionsAPIClientLogger.swift in Sources */,
 				7386E1F9256B23CE29BF996D /* FinancialConnectionsInstitutionSearchResultResource.swift in Sources */,
 				C7D2763ACCE2CC71E788E18F /* FinancialConnectionsLegalDetailsNotice.swift in Sources */,
 				B271AAF41C9FE6AE392B88D3 /* FinancialConnectionsMixedOAuthParams.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -12,7 +12,7 @@ final class FinancialConnectionsAPIClient {
     private enum EncodingError: Error {
         case cannotCastToDictionary
     }
-
+    
     enum EmailSource: String {
         case userAction = "user_action"
         case customerObject = "customer_object"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -12,7 +12,7 @@ final class FinancialConnectionsAPIClient {
     private enum EncodingError: Error {
         case cannotCastToDictionary
     }
-    
+
     enum EmailSource: String {
         case userAction = "user_action"
         case customerObject = "customer_object"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -386,9 +386,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
             let attestationIsSupported = backingAPIClient.stripeAttest.isSupported
             mobileParameters["supports_app_verification"] = attestationIsSupported
             mobileParameters["verified_app_id"] = Bundle.main.bundleIdentifier
-            if attestationIsSupported {
-                logger.log(.attestationInitSucceeded, pane: .consent)
-            } else {
+            if !attestationIsSupported {
                 logger.log(.attestationInitFailed, pane: .consent)
             }
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -24,6 +24,8 @@ final class FinancialConnectionsAPIClient {
     var consumerPublishableKey: String?
     var consumerSession: ConsumerSessionData?
 
+    private lazy var logger = FinancialConnectionsAPIClientLogger()
+
     var requestSurface: String {
         isLinkWithStripe ? "ios_instant_debits" : "ios_connections"
     }
@@ -46,17 +48,20 @@ final class FinancialConnectionsAPIClient {
     /// Applies attestation-related parameters to the given base parameters
     /// In case of an assertion error, returns the unmodified base parameters
     func assertAndApplyAttestationParameters(
-        to baseParameters: [String: Any]
+        to baseParameters: [String: Any],
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) -> Future<[String: Any]> {
         let promise = Promise<[String: Any]>()
         Task {
             do {
                 let attest = backingAPIClient.stripeAttest
                 let handle = try await attest.assert()
+                logger.log(.attestationRequestTokenSucceeded, pane: pane)
                 let newParameters = baseParameters.merging(handle.assertion.requestFields) { (_, new) in new }
                 promise.resolve(with: newParameters)
             } catch {
                 // Fail silently if we can't get an assertion, we'll try the request anyway. It may fail.
+                logger.log(.attestationRequestTokenFailed, pane: pane)
                 promise.resolve(with: baseParameters)
             }
         }
@@ -64,10 +69,11 @@ final class FinancialConnectionsAPIClient {
     }
 
     /// Marks the assertion as completed and forwards attestation errors to the `StripeAttest` client for logging.
-    func completeAssertion(possibleError: Error?) {
+    func completeAssertion(possibleError: Error?, pane: FinancialConnectionsSessionManifest.NextPane) {
         let attest = backingAPIClient.stripeAttest
         Task {
             if let error = possibleError, StripeAttest.isLinkAssertionError(error: error) {
+                logger.log(.attestationVerdictFailed, pane: pane)
                 await attest.receivedAssertionError(error)
             }
             await attest.assertionCompleted()
@@ -139,11 +145,15 @@ protocol FinancialConnectionsAPI {
     var consumerPublishableKey: String? { get set }
     var consumerSession: ConsumerSessionData? { get set }
 
-    func completeAssertion(possibleError: Error?)
+    func completeAssertion(
+        possibleError: Error?,
+        pane: FinancialConnectionsSessionManifest.NextPane
+    )
 
     func synchronize(
         clientSecret: String,
-        returnURL: String?
+        returnURL: String?,
+        initialSynchronize: Bool
     ) -> Future<FinancialConnectionsSynchronize>
 
     func fetchFinancialConnectionsAccounts(
@@ -256,7 +266,8 @@ protocol FinancialConnectionsAPI {
         clientSecret: String,
         sessionId: String,
         emailSource: FinancialConnectionsAPIClient.EmailSource,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) -> Future<LookupConsumerSessionResponse>
 
     // MARK: - Link API's
@@ -285,7 +296,8 @@ protocol FinancialConnectionsAPI {
         amount: Int?,
         currency: String?,
         incentiveEligibilitySession: ElementsSessionContext.IntentID?,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) -> Future<LinkSignUpResponse>
 
     func attachLinkConsumerToLinkAccountSession(
@@ -348,7 +360,8 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
 
     func synchronize(
         clientSecret: String,
-        returnURL: String?
+        returnURL: String?,
+        initialSynchronize: Bool = false
     ) -> Future<FinancialConnectionsSynchronize> {
         var parameters: [String: Any] = [
             "expand": ["manifest.active_auth_session"],
@@ -363,9 +376,17 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         ]
         mobileParameters["app_return_url"] = returnURL
 
-        let attest = backingAPIClient.stripeAttest
-        mobileParameters["supports_app_verification"] = attest.isSupported
-        mobileParameters["verified_app_id"] = Bundle.main.bundleIdentifier
+        if initialSynchronize {
+            let attestIsSupported = backingAPIClient.stripeAttest.isSupported
+            mobileParameters["supports_app_verification"] = attestIsSupported
+            mobileParameters["verified_app_id"] = Bundle.main.bundleIdentifier
+            if attestIsSupported {
+                logger.log(.attestationInitSucceeded, pane: .consent)
+            } else {
+                logger.log(.attestationInitFailed, pane: .consent)
+            }
+        }
+        parameters["mobile"] = mobileParameters
 
         parameters["mobile"] = mobileParameters
         return self.post(
@@ -915,7 +936,8 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         clientSecret: String,
         sessionId: String,
         emailSource: FinancialConnectionsAPIClient.EmailSource,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) -> Future<LookupConsumerSessionResponse> {
         var parameters: [String: Any] = [
             "email_address":
@@ -928,7 +950,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
             parameters["request_surface"] = requestSurface
             parameters["session_id"] = sessionId
             parameters["email_source"] = emailSource.rawValue
-            return assertAndApplyAttestationParameters(to: parameters)
+            return assertAndApplyAttestationParameters(to: parameters, pane: pane)
                 .chained { [weak self] updatedParameters in
                     guard let self else {
                         return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "FinancialConnectionsAPIClient was deallocated."))
@@ -1001,7 +1023,8 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         amount: Int?,
         currency: String?,
         incentiveEligibilitySession: ElementsSessionContext.IntentID?,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) -> Future<LinkSignUpResponse> {
         var parameters: [String: Any] = [
             "request_surface": requestSurface,
@@ -1038,7 +1061,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         }
 
         if useMobileEndpoints {
-            return assertAndApplyAttestationParameters(to: parameters)
+            return assertAndApplyAttestationParameters(to: parameters, pane: pane)
                 .chained { [weak self] updatedParameters in
                     guard let self else {
                         return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "FinancialConnectionsAPIClient was deallocated."))

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClientLogger.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClientLogger.swift
@@ -1,0 +1,65 @@
+//
+//  FinancialConnectionsAPIClientLogger.swift
+//  StripeFinancialConnections
+//
+//  Created by Mat Schmid on 2025-01-20.
+//
+
+import Foundation
+
+struct FinancialConnectionsAPIClientLogger {
+    private var analyticsClient = FinancialConnectionsAnalyticsClient()
+
+    enum Event {
+        /// When checking if generating attestation is supported succeeds.
+        case attestationInitSucceeded
+        /// When checking if generating attestation is supported does not succeed.
+        case attestationInitFailed
+        /// When an attestation token gets generated successfully.
+        case attestationRequestTokenSucceeded
+        /// When a token generation attempt fails client-side.
+        case attestationRequestTokenFailed
+        /// When an attestation verdict fails backend side and we get an attestation related error.
+        case attestationVerdictFailed
+
+        var name: String {
+            switch self {
+            case .attestationInitSucceeded:
+                return "attestation.init_succeeded"
+            case .attestationInitFailed:
+                return "attestation.init_failed"
+            case .attestationRequestTokenSucceeded:
+                return "attestation.request_token_succeeded"
+            case .attestationRequestTokenFailed:
+                return "attestation.request_token_failed"
+            case .attestationVerdictFailed:
+                return "attestation.verdict_failed"
+            }
+        }
+
+        var parameters: [String: Any] {
+            switch self {
+            case .attestationInitFailed:
+                var reason: String
+                if #available(iOS 14.0, *) {
+                    // If the iOS version is supported, we assume the device is unsupported (i.e. simulator).
+                    reason = "ios_device_unsupported"
+                } else {
+                    // Otherwise, attestation is unavailable due to the OS version being unsupported.
+                    reason = "ios_os_version_unsupported"
+                }
+                return ["reason": reason]
+            default:
+                return [:]
+            }
+        }
+    }
+
+    func log(_ event: Event, pane: FinancialConnectionsSessionManifest.NextPane) {
+        analyticsClient.log(
+            eventName: event.name,
+            parameters: event.parameters,
+            pane: pane
+        )
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
@@ -44,10 +44,15 @@ extension FinancialConnectionsAsyncAPIClient {
 extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
     func synchronize(
         clientSecret: String,
-        returnURL: String?
+        returnURL: String?,
+        initialSynchronize: Bool
     ) -> Future<FinancialConnectionsSynchronize> {
         wrapAsyncToFuture {
-            try await self.synchronize(clientSecret: clientSecret, returnURL: returnURL)
+            try await self.synchronize(
+                clientSecret: clientSecret,
+                returnURL: returnURL,
+                initialSynchronize: initialSynchronize
+            )
         }
     }
 
@@ -311,7 +316,8 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
         clientSecret: String,
         sessionId: String,
         emailSource: FinancialConnectionsAPIClient.EmailSource,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) -> Future<LookupConsumerSessionResponse> {
         wrapAsyncToFuture {
             try await self.consumerSessionLookup(
@@ -319,7 +325,8 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
                 clientSecret: clientSecret,
                 sessionId: sessionId,
                 emailSource: emailSource,
-                useMobileEndpoints: useMobileEndpoints
+                useMobileEndpoints: useMobileEndpoints,
+                pane: pane
             )
         }
     }
@@ -369,7 +376,8 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
         amount: Int?,
         currency: String?,
         incentiveEligibilitySession: ElementsSessionContext.IntentID?,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) -> Future<LinkSignUpResponse> {
         wrapAsyncToFuture {
             try await self.linkAccountSignUp(
@@ -379,7 +387,8 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
                 amount: amount,
                 currency: currency,
                 incentiveEligibilitySession: incentiveEligibilitySession,
-                useMobileEndpoints: useMobileEndpoints
+                useMobileEndpoints: useMobileEndpoints,
+                pane: pane
             )
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -387,9 +387,7 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
             let attestationIsSupported = backingAPIClient.stripeAttest.isSupported
             mobileParameters["supports_app_verification"] = attestationIsSupported
             mobileParameters["verified_app_id"] = Bundle.main.bundleIdentifier
-            if attestationIsSupported {
-                logger.log(.attestationInitSucceeded, pane: .consent)
-            } else {
+            if !attestationIsSupported {
                 logger.log(.attestationInitFailed, pane: .consent)
             }
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -23,6 +23,8 @@ final class FinancialConnectionsAsyncAPIClient {
     var consumerPublishableKey: String?
     var consumerSession: ConsumerSessionData?
 
+    private lazy var logger = FinancialConnectionsAPIClientLogger()
+
     var requestSurface: String {
         isLinkWithStripe ? "ios_instant_debits" : "ios_connections"
     }
@@ -43,10 +45,11 @@ final class FinancialConnectionsAsyncAPIClient {
     }
 
     /// Marks the assertion as completed and forwards attestation errors to the `StripeAttest` client for logging.
-    func completeAssertion(possibleError: Error?) {
+    func completeAssertion(possibleError: Error?, pane: FinancialConnectionsSessionManifest.NextPane) {
         let attest = backingAPIClient.stripeAttest
         Task {
             if let error = possibleError, StripeAttest.isLinkAssertionError(error: error) {
+                logger.log(.attestationVerdictFailed, pane: pane)
                 await attest.receivedAssertionError(error)
             }
             await attest.assertionCompleted()
@@ -55,14 +58,19 @@ final class FinancialConnectionsAsyncAPIClient {
 
     /// Applies attestation-related parameters to the given base parameters
     /// In case of an assertion error, returns the unmodified base parameters
-    func assertAndApplyAttestationParameters(to baseParameters: [String: Any]) async -> [String: Any] {
+    func assertAndApplyAttestationParameters(
+        to baseParameters: [String: Any],
+        pane: FinancialConnectionsSessionManifest.NextPane
+    ) async -> [String: Any] {
         do {
             let attest = backingAPIClient.stripeAttest
             let handle = try await attest.assert()
+            logger.log(.attestationRequestTokenSucceeded, pane: pane)
             let newParameters = baseParameters.merging(handle.assertion.requestFields) { (_, new) in new }
             return newParameters
         } catch {
             // Fail silently if we can't get an assertion, we'll try the request anyway. It may fail.
+            logger.log(.attestationRequestTokenFailed, pane: pane)
             return baseParameters
         }
     }
@@ -169,7 +177,8 @@ final class FinancialConnectionsAsyncAPIClient {
 protocol FinancialConnectionsAsyncAPI {
     func synchronize(
         clientSecret: String,
-        returnURL: String?
+        returnURL: String?,
+        initialSynchronize: Bool
     ) async throws -> FinancialConnectionsSynchronize
 
     func fetchFinancialConnectionsAccounts(
@@ -283,7 +292,8 @@ protocol FinancialConnectionsAsyncAPI {
         clientSecret: String,
         sessionId: String,
         emailSource: FinancialConnectionsAPIClient.EmailSource,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) async throws -> LookupConsumerSessionResponse
 
     // MARK: - Link API's
@@ -312,7 +322,8 @@ protocol FinancialConnectionsAsyncAPI {
         amount: Int?,
         currency: String?,
         incentiveEligibilitySession: ElementsSessionContext.IntentID?,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) async throws -> LinkSignUpResponse
 
     func attachLinkConsumerToLinkAccountSession(
@@ -351,7 +362,8 @@ protocol FinancialConnectionsAsyncAPI {
 extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
     func synchronize(
         clientSecret: String,
-        returnURL: String?
+        returnURL: String?,
+        initialSynchronize: Bool = false
     ) async throws -> FinancialConnectionsSynchronize {
         var parameters: [String: Any] = [
             "expand": ["manifest.active_auth_session"],
@@ -366,10 +378,16 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
         ]
         mobileParameters["app_return_url"] = returnURL
 
-        let attest = backingAPIClient.stripeAttest
-        mobileParameters["supports_app_verification"] = attest.isSupported
-        mobileParameters["verified_app_id"] = Bundle.main.bundleIdentifier
-
+        if initialSynchronize {
+            let attestIsSupported = backingAPIClient.stripeAttest.isSupported
+            mobileParameters["supports_app_verification"] = attestIsSupported
+            mobileParameters["verified_app_id"] = Bundle.main.bundleIdentifier
+            if attestIsSupported {
+                logger.log(.attestationInitSucceeded, pane: .consent)
+            } else {
+                logger.log(.attestationInitFailed, pane: .consent)
+            }
+        }
         parameters["mobile"] = mobileParameters
         return try await post(endpoint: .synchronize, parameters: parameters)
     }
@@ -816,7 +834,8 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
         clientSecret: String,
         sessionId: String,
         emailSource: FinancialConnectionsAPIClient.EmailSource,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) async throws -> LookupConsumerSessionResponse {
         var parameters: [String: Any] = [
             "email_address":
@@ -828,7 +847,7 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
             parameters["request_surface"] = requestSurface
             parameters["session_id"] = sessionId
             parameters["email_source"] = emailSource.rawValue
-            let updatedParameters = await assertAndApplyAttestationParameters(to: parameters)
+            let updatedParameters = await assertAndApplyAttestationParameters(to: parameters, pane: pane)
             return try await post(endpoint: .mobileConsumerSessionLookup, parameters: updatedParameters)
         } else {
             parameters["client_secret"] = clientSecret
@@ -890,7 +909,8 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
         amount: Int?,
         currency: String?,
         incentiveEligibilitySession: ElementsSessionContext.IntentID?,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) async throws -> LinkSignUpResponse {
         var parameters: [String: Any] = [
             "request_surface": requestSurface,
@@ -926,7 +946,7 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
             }
         }
         if useMobileEndpoints {
-            let updatedParameters = await assertAndApplyAttestationParameters(to: parameters)
+            let updatedParameters = await assertAndApplyAttestationParameters(to: parameters, pane: pane)
             return try await post(endpoint: .mobileLinkAccountSignup, parameters: updatedParameters)
         } else {
             return try await post(endpoint: .linkAccountsSignUp, parameters: parameters)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -174,6 +174,7 @@ extension FinancialConnectionsAnalyticsClient {
         additionalParameters["single_account"] = manifest.singleAccount
         additionalParameters["allow_manual_entry"] = manifest.allowManualEntry
         additionalParameters["account_holder_id"] = manifest.accountholderToken
+        additionalParameters["app_verification_enabled"] = manifest.appVerificationEnabled
     }
 
     static func paneFromViewController(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
@@ -112,7 +112,8 @@ extension HostViewController {
         apiClient
             .synchronize(
                 clientSecret: clientSecret,
-                returnURL: returnURL
+                returnURL: returnURL,
+                initialSynchronize: true
             )
             .observe { [weak self] result in
                 guard let self = self else { return }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -56,7 +56,8 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
     func synchronize() -> Future<FinancialConnectionsLinkLoginPane> {
         apiClient.synchronize(
             clientSecret: clientSecret,
-            returnURL: returnURL
+            returnURL: returnURL,
+            initialSynchronize: false
         )
         .chained { synchronize in
             if let linkLoginPane = synchronize.text?.linkLoginPane {
@@ -73,7 +74,8 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
             clientSecret: clientSecret,
             sessionId: manifest.id,
             emailSource: manuallyEntered ? .userAction : .customerObject,
-            useMobileEndpoints: manifest.verified
+            useMobileEndpoints: manifest.verified,
+            pane: .linkLogin
         )
     }
 
@@ -89,7 +91,8 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
             amount: elementsSessionContext?.amount,
             currency: elementsSessionContext?.currency,
             incentiveEligibilitySession: elementsSessionContext?.incentiveEligibilitySession,
-            useMobileEndpoints: manifest.verified
+            useMobileEndpoints: manifest.verified,
+            pane: .linkLogin
         )
     }
 
@@ -107,7 +110,8 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
 
             return apiClient.synchronize(
                 clientSecret: self.clientSecret,
-                returnURL: self.returnURL
+                returnURL: self.returnURL,
+                initialSynchronize: false
             )
         }
     }
@@ -125,6 +129,9 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
     // Marks the assertion as completed and logs possible errors during verified flows.
     func completeAssertionIfNeeded(possibleError: Error?) {
         guard manifest.verified else { return }
-        apiClient.completeAssertion(possibleError: possibleError)
+        apiClient.completeAssertion(
+            possibleError: possibleError,
+            pane: .linkLogin
+        )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -23,7 +23,10 @@ protocol LinkLoginDataSource: AnyObject {
     func attachToAccountAndSynchronize(
         with linkSignUpResponse: LinkSignUpResponse
     ) -> Future<FinancialConnectionsSynchronize>
-    func completeAssertionIfNeeded(possibleError: Error?)
+    func completeAssertionIfNeeded(
+        possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API
+    )
 }
 
 final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
@@ -127,10 +130,14 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
     }
 
     // Marks the assertion as completed and logs possible errors during verified flows.
-    func completeAssertionIfNeeded(possibleError: Error?) {
+    func completeAssertionIfNeeded(
+        possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API
+    ) {
         guard manifest.verified else { return }
         apiClient.completeAssertion(
             possibleError: possibleError,
+            api: api,
             pane: .linkLogin
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -220,6 +220,7 @@ final class LinkLoginViewController: UIViewController {
             case .success(let response):
                 self.delegate?.linkLoginViewController(self, signedUpAttachedAndSynchronized: response)
             case .failure(let error):
+                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 self.delegate?.linkLoginViewController(self, didReceiveTerminalError: error)
             }
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -220,7 +220,6 @@ final class LinkLoginViewController: UIViewController {
             case .success(let response):
                 self.delegate?.linkLoginViewController(self, signedUpAttachedAndSynchronized: response)
             case .failure(let error):
-                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 self.delegate?.linkLoginViewController(self, didReceiveTerminalError: error)
             }
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -171,7 +171,10 @@ final class LinkLoginViewController: UIViewController {
                 footerButton?.isLoading = false
 
                 guard let self else { return }
-                self.dataSource.completeAssertionIfNeeded(possibleError: result.error)
+                self.dataSource.completeAssertionIfNeeded(
+                    possibleError: result.error,
+                    api: .consumerSessionLookup
+                )
 
                 switch result {
                 case .success(let response):
@@ -214,7 +217,10 @@ final class LinkLoginViewController: UIViewController {
         .observe { [weak self] result in
             guard let self else { return }
             self.footerButton?.isLoading = false
-            self.dataSource.completeAssertionIfNeeded(possibleError: result.error)
+            self.dataSource.completeAssertionIfNeeded(
+                possibleError: result.error,
+                api: .linkSignUp
+            )
 
             switch result {
             case .success(let response):

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -20,7 +20,10 @@ protocol NetworkingLinkSignupDataSource: AnyObject {
         phoneNumber: String,
         countryCode: String
     ) -> Future<String?>
-    func completeAssertionIfNeeded(possibleError: Error?)
+    func completeAssertionIfNeeded(
+        possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API
+    )
 }
 
 final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDataSource {
@@ -130,10 +133,14 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
     }
 
     // Marks the assertion as completed and logs possible errors during verified flows.
-    func completeAssertionIfNeeded(possibleError: Error?) {
+    func completeAssertionIfNeeded(
+        possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API
+    ) {
         guard manifest.verified else { return }
         apiClient.completeAssertion(
             possibleError: possibleError,
+            api: api,
             pane: .networkingLinkSignupPane
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -54,7 +54,8 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
     func synchronize() -> Future<FinancialConnectionsNetworkingLinkSignup> {
         return apiClient.synchronize(
             clientSecret: clientSecret,
-            returnURL: returnURL
+            returnURL: returnURL,
+            initialSynchronize: false
         )
         .chained { synchronize in
             if let networkingLinkSignup = synchronize.text?.networkingLinkSignupPane {
@@ -71,7 +72,8 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
             clientSecret: clientSecret,
             sessionId: manifest.id,
             emailSource: manuallyEntered ? .userAction : .customerObject,
-            useMobileEndpoints: manifest.verified
+            useMobileEndpoints: manifest.verified,
+            pane: .networkingLinkSignupPane
         )
     }
 
@@ -90,7 +92,8 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
                 amount: nil,
                 currency: nil,
                 incentiveEligibilitySession: nil,
-                useMobileEndpoints: manifest.verified
+                useMobileEndpoints: manifest.verified,
+                pane: .networkingLinkSignupPane
             ).chained { [weak self] response -> Future<FinancialConnectionsAPI.SaveAccountsToNetworkAndLinkResponse> in
                 guard let self else {
                     return Promise(error: FinancialConnectionsSheetError.unknown(
@@ -129,6 +132,9 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
     // Marks the assertion as completed and logs possible errors during verified flows.
     func completeAssertionIfNeeded(possibleError: Error?) {
         guard manifest.verified else { return }
-        apiClient.completeAssertion(possibleError: possibleError)
+        apiClient.completeAssertion(
+            possibleError: possibleError,
+            pane: .networkingLinkSignupPane
+        )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -224,7 +224,6 @@ final class NetworkingLinkSignupViewController: UIViewController {
                     withError: nil
                 )
             case .failure(let error):
-                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 // on error, we still go to success pane, but show a small error
                 // notice above the done button of the success pane
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -213,7 +213,10 @@ final class NetworkingLinkSignupViewController: UIViewController {
         )
         .observe { [weak self] result in
             guard let self = self else { return }
-            self.dataSource.completeAssertionIfNeeded(possibleError: result.error)
+            self.dataSource.completeAssertionIfNeeded(
+                possibleError: result.error,
+                api: .linkSignUp
+            )
 
             switch result {
             case .success(let customSuccessPaneMessage):
@@ -298,7 +301,10 @@ extension NetworkingLinkSignupViewController: LinkSignupFormViewDelegate {
             )
             .observe { [weak self, weak bodyFormView] result in
                 guard let self = self else { return }
-                self.dataSource.completeAssertionIfNeeded(possibleError: result.error)
+                self.dataSource.completeAssertionIfNeeded(
+                    possibleError: result.error,
+                    api: .consumerSessionLookup
+                )
 
                 switch result {
                 case .success(let response):

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -224,6 +224,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
                     withError: nil
                 )
             case .failure(let error):
+                self.dataSource.reportAttestationErrorIfNeeded(error: error)
                 // on error, we still go to success pane, but show a small error
                 // notice above the done button of the success pane
                 self.delegate?.networkingLinkSignupViewControllerDidFinish(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -106,7 +106,8 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
 
             return self.apiClient.synchronize(
                 clientSecret: self.clientSecret,
-                returnURL: self.returnURL
+                returnURL: self.returnURL,
+                initialSynchronize: false
             )
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
@@ -77,7 +77,8 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
         apiClient
             .synchronize(
                 clientSecret: clientSecret,
-                returnURL: nil
+                returnURL: nil,
+                initialSynchronize: false
             )
             .observe { [weak self] result in
                 guard let self = self else { return }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -22,7 +22,10 @@ protocol NetworkingOTPDataSource: AnyObject {
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse>
     func startVerificationSession() -> Future<ConsumerSessionResponse>
     func confirmVerificationSession(otpCode: String) -> Future<ConsumerSessionResponse>
-    func completeAssertionIfNeeded(possibleError: Error?)
+    func completeAssertionIfNeeded(
+        possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API
+    )
 }
 
 final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
@@ -124,9 +127,16 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
     }
 
     // Marks the assertion as completed and logs possible errors during verified flows.
-    func completeAssertionIfNeeded(possibleError: Error?) {
+    func completeAssertionIfNeeded(
+        possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API
+    ) {
         guard manifest.verified else { return }
-        apiClient.completeAssertion(possibleError: possibleError, pane: pane)
+        apiClient.completeAssertion(
+            possibleError: possibleError,
+            api: api,
+            pane: pane
+        )
     }
 
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -85,7 +85,8 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
                 clientSecret: clientSecret,
                 sessionId: manifest.id,
                 emailSource: .customerObject,
-                useMobileEndpoints: manifest.verified
+                useMobileEndpoints: manifest.verified,
+                pane: pane
             )
             .chained { [weak self] lookupConsumerSessionResponse in
                 self?.consumerSession = lookupConsumerSessionResponse.consumerSession
@@ -125,7 +126,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
     // Marks the assertion as completed and logs possible errors during verified flows.
     func completeAssertionIfNeeded(possibleError: Error?) {
         guard manifest.verified else { return }
-        apiClient.completeAssertion(possibleError: possibleError)
+        apiClient.completeAssertion(possibleError: possibleError, pane: pane)
     }
 
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -160,7 +160,10 @@ final class NetworkingOTPView: UIView {
         dataSource.lookupConsumerSession()
             .observe { [weak self] result in
                 guard let self = self else { return }
-                self.dataSource.completeAssertionIfNeeded(possibleError: result.error)
+                self.dataSource.completeAssertionIfNeeded(
+                    possibleError: result.error,
+                    api: .consumerSessionLookup
+                )
 
                 switch result {
                 case .success(let lookupConsumerSessionResponse):

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -16,7 +16,10 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
     var consumerPublishableKey: String?
     var consumerSession: StripeFinancialConnections.ConsumerSessionData?
 
-    func completeAssertion(possibleError: (any Error)?) {}
+    func completeAssertion(
+        possibleError: Error?,
+        pane: FinancialConnectionsSessionManifest.NextPane
+    ) {}
 
     func fetchFinancialConnectionsAccounts(clientSecret: String, startingAfterAccountId: String?) -> Promise<
         StripeAPI.FinancialConnectionsSession.AccountList
@@ -30,7 +33,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
 
     func synchronize(
         clientSecret: String,
-        returnURL: String?
+        returnURL: String?,
+        initialSynchronize: Bool
     ) -> Future<FinancialConnectionsSynchronize> {
         return Promise<FinancialConnectionsSynchronize>()
     }
@@ -178,7 +182,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
         clientSecret: String,
         sessionId: String,
         emailSource: FinancialConnectionsAPIClient.EmailSource,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) -> Future<StripeFinancialConnections.LookupConsumerSessionResponse> {
         return Promise<StripeFinancialConnections.LookupConsumerSessionResponse>()
     }
@@ -213,7 +218,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
         amount: Int?,
         currency: String?,
         incentiveEligibilitySession: ElementsSessionContext.IntentID?,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        pane: FinancialConnectionsSessionManifest.NextPane
     ) -> Future<LinkSignUpResponse> {
         return Promise<StripeFinancialConnections.LinkSignUpResponse>()
     }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -18,6 +18,7 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
 
     func completeAssertion(
         possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API,
         pane: FinancialConnectionsSessionManifest.NextPane
     ) {}
 

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
@@ -110,7 +110,7 @@ class FinancialConnectionsAPIClientTests: XCTestCase {
         ]
         let apiClient = FinancialConnectionsAPIClient(apiClient: mockApiClient)
         apiClient
-            .assertAndApplyAttestationParameters(to: baseParameters)
+            .assertAndApplyAttestationParameters(to: baseParameters, pane: .consent)
             .observe { result in
                 switch result {
                 case .success(let updatedParameters):

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAPIClientTests.swift
@@ -110,8 +110,11 @@ class FinancialConnectionsAPIClientTests: XCTestCase {
         ]
         let apiClient = FinancialConnectionsAPIClient(apiClient: mockApiClient)
         apiClient
-            .assertAndApplyAttestationParameters(to: baseParameters, pane: .consent)
-            .observe { result in
+            .assertAndApplyAttestationParameters(
+                to: baseParameters,
+                api: .linkSignUp,
+                pane: .consent
+            ).observe { result in
                 switch result {
                 case .success(let updatedParameters):
                     XCTAssertNotNil(updatedParameters["base_parameter"])


### PR DESCRIPTION
## Summary

Adds logging for various attestation-related events in our Financial Connections API clients (both legacy and async clients). Most of the event logging logic has been consolidated in `FinancialConnectionsAPIClientLogger`. As part of this, I also had to make a few secondary changes to the API clients;

1. Only apply attestation-related parameters in the _initial_ `/synchronize` call.
2. Pass the corresponding `pane` and `api` through the consumer session lookup and sign up APIs for logging purposes.

## Motivation

https://docs.google.com/document/d/1joKz5UZHLVazmecfMHbq6gB6n4wj5u8To6AtqYgq_tc/edit?tab=t.0#bookmark=kix.oi6g969wwrz0

## Testing

N/a

## Changelog

N/a