### PR TITLE
Launch web flow when attestation errors are received

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -61,6 +61,7 @@
 		492039952CA4972B00CE2072 /* FinancialConnectionsWebFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492039942CA4972B00CE2072 /* FinancialConnectionsWebFlowTests.swift */; };
 		492651662C24C9E7001DDBCA /* TestModeAutofillBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492651652C24C9E7001DDBCA /* TestModeAutofillBannerView.swift */; };
 		492651682C25C0C2001DDBCA /* info@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 492651672C25C0C2001DDBCA /* info@3x.png */; };
+		49424EB02D48050A0088F3D9 /* WebPrefillDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49424EAF2D48050A0088F3D9 /* WebPrefillDetails.swift */; };
 		494D62072C45B9B700106519 /* link_logo@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 494D62062C45B9B700106519 /* link_logo@3x.png */; };
 		495539EE2C484DC200543D18 /* FinancialConnectionsTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */; };
 		496A6AE72C29E0BB00D34F8E /* testmode@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 496A6AE62C29E0BB00D34F8E /* testmode@3x.png */; };
@@ -327,6 +328,7 @@
 		492039942CA4972B00CE2072 /* FinancialConnectionsWebFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsWebFlowTests.swift; sourceTree = "<group>"; };
 		492651652C24C9E7001DDBCA /* TestModeAutofillBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModeAutofillBannerView.swift; sourceTree = "<group>"; };
 		492651672C25C0C2001DDBCA /* info@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "info@3x.png"; sourceTree = "<group>"; };
+		49424EAF2D48050A0088F3D9 /* WebPrefillDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebPrefillDetails.swift; sourceTree = "<group>"; };
 		494D62062C45B9B700106519 /* link_logo@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "link_logo@3x.png"; sourceTree = "<group>"; };
 		495539ED2C484DC200543D18 /* FinancialConnectionsTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsTheme.swift; sourceTree = "<group>"; };
 		496A6AE62C29E0BB00D34F8E /* testmode@3x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "testmode@3x.png"; sourceTree = "<group>"; };
@@ -1041,6 +1043,7 @@
 				6A3739152C4060BD00D1F765 /* AutoResizableUIView.swift */,
 				6A6F989B2C4F1BF00035C03D /* CreatePaneParameters.swift */,
 				49F047522C63B430006BAD3E /* StripeSchemeAddress.swift */,
+				49424EAF2D48050A0088F3D9 /* WebPrefillDetails.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -1392,6 +1395,7 @@
 				707C265C4179A8FEC98913FE /* ConsentBodyView.swift in Sources */,
 				49F1B83E2D2EC82300136303 /* FinancialConnectionsAsyncAPIClient+Legacy.swift in Sources */,
 				465AE8A58AD2183E1E2042FE /* ConsentDataSource.swift in Sources */,
+				49424EB02D48050A0088F3D9 /* WebPrefillDetails.swift in Sources */,
 				97C528CE821C6A55D58F68A4 /* ConsentFooterView.swift in Sources */,
 				8927328EE28A0C94B5AB69DB /* ConsentLogoView.swift in Sources */,
 				E9866D5CA186A242BBEA69E1 /* ConsentViewController.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -45,19 +45,27 @@ final class FinancialConnectionsAsyncAPIClient {
     }
 
     /// Marks the assertion as completed and forwards attestation errors to the `StripeAttest` client for logging.
+    /// If any attestation errors are present, return them synchronously while completing the assertion.
     func completeAssertion(
         possibleError: Error?,
         api: FinancialConnectionsAPIClientLogger.API,
         pane: FinancialConnectionsSessionManifest.NextPane
-    ) {
+    ) -> Error? {
         let attest = backingAPIClient.stripeAttest
-        Task {
-            if let error = possibleError, StripeAttest.isLinkAssertionError(error: error) {
+        let attestationError: Error?
+        if let error = possibleError, StripeAttest.isLinkAssertionError(error: error) {
+            attestationError = error
+        } else {
+            attestationError = nil
+        }
+        Task { @Sendable in
+            if let attestationError {
                 logger.log(.attestationVerdictFailed(api), pane: pane)
-                await attest.receivedAssertionError(error)
+                await attest.receivedAssertionError(attestationError)
             }
             await attest.assertionCompleted()
         }
+        return attestationError
     }
 
     /// Applies attestation-related parameters to the given base parameters

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -176,7 +176,7 @@ extension HostController: HostViewControllerDelegate {
 
 private extension HostController {
 
-    func continueWithWebFlow(_ manifest: FinancialConnectionsSessionManifest) {
+    func continueWithWebFlow(_ manifest: FinancialConnectionsSessionManifest, prefillDetails: WebPrefillDetails? = nil) {
         delegate?.hostController(
             self,
             didReceiveEvent: FinancialConnectionsEvent(
@@ -196,7 +196,8 @@ private extension HostController {
             manifest: manifest,
             sessionFetcher: sessionFetcher,
             returnURL: returnURL,
-            elementsSessionContext: elementsSessionContext
+            elementsSessionContext: elementsSessionContext,
+            prefillDetailsOverride: prefillDetails
         )
         webFlowViewController.delegate = self
         navigationController.setViewControllers([webFlowViewController], animated: true)
@@ -263,6 +264,14 @@ extension HostController: NativeFlowControllerDelegate {
         didReceiveEvent event: FinancialConnectionsEvent
     ) {
         delegate?.hostController(self, didReceiveEvent: event)
+    }
+
+    func nativeFlowController(
+        _ nativeFlowController: NativeFlowController,
+        shouldLaunchWebFlow manifest: FinancialConnectionsSessionManifest,
+        prefillDetails: WebPrefillDetails
+    ) {
+        continueWithWebFlow(manifest, prefillDetails: prefillDetails)
     }
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginDataSource.swift
@@ -26,7 +26,7 @@ protocol LinkLoginDataSource: AnyObject {
     func completeAssertionIfNeeded(
         possibleError: Error?,
         api: FinancialConnectionsAPIClientLogger.API
-    )
+    ) -> Error?
 }
 
 final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
@@ -133,9 +133,9 @@ final class LinkLoginDataSourceImplementation: LinkLoginDataSource {
     func completeAssertionIfNeeded(
         possibleError: Error?,
         api: FinancialConnectionsAPIClientLogger.API
-    ) {
-        guard manifest.verified else { return }
-        apiClient.completeAssertion(
+    ) -> Error? {
+        guard manifest.verified else { return nil }
+        return apiClient.completeAssertion(
             possibleError: possibleError,
             api: api,
             pane: .linkLogin

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -30,6 +30,11 @@ protocol LinkLoginViewControllerDelegate: AnyObject {
         _ viewController: LinkLoginViewController,
         didReceiveTerminalError error: Error
     )
+
+    func linkLoginViewControllerDidFailAttestationVerdict(
+        _ viewController: LinkLoginViewController,
+        prefillDetails: WebPrefillDetails
+    )
 }
 
 final class LinkLoginViewController: UIViewController {
@@ -171,10 +176,15 @@ final class LinkLoginViewController: UIViewController {
                 footerButton?.isLoading = false
 
                 guard let self else { return }
-                self.dataSource.completeAssertionIfNeeded(
+                let attestationError = self.dataSource.completeAssertionIfNeeded(
                     possibleError: result.error,
                     api: .consumerSessionLookup
                 )
+                if attestationError != nil {
+                    let prefillDetails = WebPrefillDetails(email: emailAddress)
+                    self.delegate?.linkLoginViewControllerDidFailAttestationVerdict(self, prefillDetails: prefillDetails)
+                    return
+                }
 
                 switch result {
                 case .success(let response):
@@ -217,10 +227,19 @@ final class LinkLoginViewController: UIViewController {
         .observe { [weak self] result in
             guard let self else { return }
             self.footerButton?.isLoading = false
-            self.dataSource.completeAssertionIfNeeded(
+            let attestationError = self.dataSource.completeAssertionIfNeeded(
                 possibleError: result.error,
                 api: .linkSignUp
             )
+            if attestationError != nil {
+                let prefillDetails = WebPrefillDetails(
+                    email: self.formView.email,
+                    phone: self.formView.phoneNumber,
+                    countryCode: self.formView.countryCode
+                )
+                self.delegate?.linkLoginViewControllerDidFailAttestationVerdict(self, prefillDetails: prefillDetails)
+                return
+            }
 
             switch result {
             case .success(let response):

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -23,7 +23,7 @@ protocol NetworkingLinkSignupDataSource: AnyObject {
     func completeAssertionIfNeeded(
         possibleError: Error?,
         api: FinancialConnectionsAPIClientLogger.API
-    )
+    ) -> Error?
 }
 
 final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDataSource {
@@ -136,9 +136,9 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
     func completeAssertionIfNeeded(
         possibleError: Error?,
         api: FinancialConnectionsAPIClientLogger.API
-    ) {
-        guard manifest.verified else { return }
-        apiClient.completeAssertion(
+    ) -> Error? {
+        guard manifest.verified else { return nil }
+        return apiClient.completeAssertion(
             possibleError: possibleError,
             api: api,
             pane: .networkingLinkSignupPane

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
@@ -29,6 +29,10 @@ protocol NetworkingLinkStepUpVerificationViewControllerDelegate: AnyObject {
     func networkingLinkStepUpVerificationViewControllerEncounteredSoftError(
         _ viewController: NetworkingLinkStepUpVerificationViewController
     )
+    func networkingLinkStepUpVerificationViewControllerDidFailAttestationVerdict(
+        _ viewController: NetworkingLinkStepUpVerificationViewController,
+        prefillDetails: WebPrefillDetails
+    )
 }
 
 final class NetworkingLinkStepUpVerificationViewController: UIViewController {
@@ -290,5 +294,15 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
                 didReceiveTerminalError: error
             )
         }
+    }
+
+    func networkingOTPViewDidFailAttestationVerdict(
+        _ view: NetworkingOTPView,
+        prefillDetails: WebPrefillDetails
+    ) {
+        delegate?.networkingLinkStepUpVerificationViewControllerDidFailAttestationVerdict(
+            self,
+            prefillDetails: prefillDetails
+        )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -25,6 +25,10 @@ protocol NetworkingLinkVerificationViewControllerDelegate: AnyObject {
         _ viewController: NetworkingLinkVerificationViewController,
         didReceiveTerminalError error: Error
     )
+    func networkingLinkVerificationViewControllerDidFailAttestationVerdict(
+        _ viewController: NetworkingLinkVerificationViewController,
+        prefillDetails: WebPrefillDetails
+    )
 }
 
 final class NetworkingLinkVerificationViewController: UIViewController {
@@ -265,5 +269,15 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
                 didReceiveTerminalError: error
             )
         }
+    }
+
+    func networkingOTPViewDidFailAttestationVerdict(
+        _ view: NetworkingOTPView,
+        prefillDetails: WebPrefillDetails
+    ) {
+        delegate?.networkingLinkVerificationViewControllerDidFailAttestationVerdict(
+            self,
+            prefillDetails: prefillDetails
+        )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
@@ -24,6 +24,11 @@ protocol NetworkingSaveToLinkVerificationViewControllerDelegate: AnyObject {
         _ viewController: NetworkingSaveToLinkVerificationViewController,
         didReceiveTerminalError error: Error
     )
+
+    func networkingSaveToLinkVerificationViewControllerDidFailAttestationVerdict(
+        _ viewController: NetworkingSaveToLinkVerificationViewController,
+        prefillDetails: WebPrefillDetails
+    )
 }
 
 final class NetworkingSaveToLinkVerificationViewController: UIViewController {
@@ -228,6 +233,16 @@ extension NetworkingSaveToLinkVerificationViewController: NetworkingOTPViewDeleg
                 didReceiveTerminalError: error
             )
         }
+    }
+
+    func networkingOTPViewDidFailAttestationVerdict(
+        _ view: NetworkingOTPView,
+        prefillDetails: WebPrefillDetails
+    ) {
+        delegate?.networkingSaveToLinkVerificationViewControllerDidFailAttestationVerdict(
+            self,
+            prefillDetails: prefillDetails
+        )
     }
 
     func networkingOTPViewWillStartConsumerLookup(_ view: NetworkingOTPView) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -18,6 +18,7 @@ protocol NetworkingOTPDataSource: AnyObject {
     var isTestMode: Bool { get }
     var theme: FinancialConnectionsTheme { get }
     var pane: FinancialConnectionsSessionManifest.NextPane { get }
+    var emailAddress: String { get }
 
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse>
     func startVerificationSession() -> Future<ConsumerSessionResponse>
@@ -25,7 +26,7 @@ protocol NetworkingOTPDataSource: AnyObject {
     func completeAssertionIfNeeded(
         possibleError: Error?,
         api: FinancialConnectionsAPIClientLogger.API
-    )
+    ) -> Error?
 }
 
 final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
@@ -33,7 +34,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
     let otpType: String
     let pane: FinancialConnectionsSessionManifest.NextPane
     let analyticsClient: FinancialConnectionsAnalyticsClient
-    private let emailAddress: String
+    let emailAddress: String
     private let customEmailType: String?
     private let connectionsMerchantName: String?
     private let apiClient: any FinancialConnectionsAPI
@@ -130,9 +131,9 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
     func completeAssertionIfNeeded(
         possibleError: Error?,
         api: FinancialConnectionsAPIClientLogger.API
-    ) {
-        guard manifest.verified else { return }
-        apiClient.completeAssertion(
+    ) -> Error? {
+        guard manifest.verified else { return nil }
+        return apiClient.completeAssertion(
             possibleError: possibleError,
             api: api,
             pane: pane

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -27,6 +27,8 @@ protocol NetworkingOTPViewDelegate: AnyObject {
         didFailToConfirmVerification error: Error,
         isTerminal: Bool
     )
+
+    func networkingOTPViewDidFailAttestationVerdict(_ view: NetworkingOTPView, prefillDetails: WebPrefillDetails)
 }
 
 final class NetworkingOTPView: UIView {
@@ -160,10 +162,15 @@ final class NetworkingOTPView: UIView {
         dataSource.lookupConsumerSession()
             .observe { [weak self] result in
                 guard let self = self else { return }
-                self.dataSource.completeAssertionIfNeeded(
+                let attestationError = self.dataSource.completeAssertionIfNeeded(
                     possibleError: result.error,
                     api: .consumerSessionLookup
                 )
+                if attestationError != nil {
+                    let prefillDetails = WebPrefillDetails(email: self.dataSource.emailAddress)
+                    self.delegate?.networkingOTPViewDidFailAttestationVerdict(self, prefillDetails: prefillDetails)
+                    return
+                }
 
                 switch result {
                 case .success(let lookupConsumerSessionResponse):

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/WebPrefillDetails.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/WebPrefillDetails.swift
@@ -1,0 +1,34 @@
+//
+//  WebPrefillDetails.swift
+//  StripeFinancialConnections
+//
+//  Created by Mat Schmid on 2025-01-27.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+/// The fields used to prefill the Link Login pane.
+protocol PrefillData {
+    var email: String? { get }
+    var phone: String? { get }
+    var countryCode: String? { get }
+}
+
+/// An email and an unformatted phone number + country code will be passed to the web flow.
+struct WebPrefillDetails {
+    let email: String?
+    let phone: String?
+    let countryCode: String?
+
+    init(email: String?, phone: String? = nil, countryCode: String? = nil) {
+        self.email = email
+        self.phone = phone
+        self.countryCode = countryCode
+    }
+}
+
+extension WebPrefillDetails: PrefillData {}
+extension ElementsSessionContext.PrefillDetails: PrefillData {
+    var phone: String? { unformattedPhoneNumber }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -70,6 +70,7 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
     private let manifest: FinancialConnectionsSessionManifest
     private let returnURL: String?
     private let elementsSessionContext: ElementsSessionContext?
+    private let prefillDetailsOverride: WebPrefillDetails?
 
     // MARK: - UI
 
@@ -96,7 +97,8 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
         manifest: FinancialConnectionsSessionManifest,
         sessionFetcher: FinancialConnectionsSessionFetcher,
         returnURL: String?,
-        elementsSessionContext: ElementsSessionContext?
+        elementsSessionContext: ElementsSessionContext?,
+        prefillDetailsOverride: WebPrefillDetails?
     ) {
         self.clientSecret = clientSecret
         self.apiClient = apiClient
@@ -104,6 +106,7 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
         self.sessionFetcher = sessionFetcher
         self.returnURL = returnURL
         self.elementsSessionContext = elementsSessionContext
+        self.prefillDetailsOverride = prefillDetailsOverride
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -158,7 +161,7 @@ extension FinancialConnectionsWebFlowViewController {
             startingAdditionalParameters: additionalQueryParameters,
             isInstantDebits: manifest.isProductInstantDebits,
             linkMode: elementsSessionContext?.linkMode,
-            prefillDetails: elementsSessionContext?.prefillDetails,
+            prefillDetails: prefillDetailsOverride ?? elementsSessionContext?.prefillDetails,
             billingDetails: elementsSessionContext?.billingDetails,
             incentiveEligibilitySession: elementsSessionContext?.incentiveEligibilitySession
         )
@@ -206,7 +209,7 @@ extension FinancialConnectionsWebFlowViewController {
                 self.authSessionManager = nil
             })
     }
-    
+
     private func createInstantDebitsLinkedBank(
         from url: URL,
         with paymentMethod: LinkBankPaymentMethod
@@ -461,7 +464,7 @@ extension FinancialConnectionsWebFlowViewController {
         startingAdditionalParameters: String?,
         isInstantDebits: Bool,
         linkMode: LinkMode?,
-        prefillDetails: ElementsSessionContext.PrefillDetails?,
+        prefillDetails: PrefillData?,
         billingDetails: ElementsSessionContext.BillingDetails?,
         incentiveEligibilitySession: ElementsSessionContext.IntentID?
     ) -> String? {
@@ -521,7 +524,7 @@ extension FinancialConnectionsWebFlowViewController {
             if let email = prefillDetails.email, !email.isEmpty {
                 parameters.append("email=\(email)")
             }
-            if let phoneNumber = prefillDetails.unformattedPhoneNumber, !phoneNumber.isEmpty {
+            if let phoneNumber = prefillDetails.phone, !phoneNumber.isEmpty {
                 parameters.append("linkMobilePhone=\(phoneNumber)")
             }
             if let countryCode = prefillDetails.countryCode, !countryCode.isEmpty {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -470,7 +470,7 @@ extension FinancialConnectionsWebFlowViewController {
     ) -> String? {
         var parameters: [String] = []
 
-        if let startingAdditionalParameters {
+        if let startingAdditionalParameters, startingAdditionalParameters.isEmpty == false {
             parameters.append(startingAdditionalParameters)
         }
 
@@ -531,6 +531,8 @@ extension FinancialConnectionsWebFlowViewController {
                 parameters.append("linkMobilePhoneCountry=\(countryCode)")
             }
         }
+
+        parameters.append("launched_by=ios_sdk")
 
         // Join all values with an &, and URL encode.
         // We encode these parameters since they will be appended to the auth flow URL.

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -20,7 +20,9 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
         possibleError: Error?,
         api: FinancialConnectionsAPIClientLogger.API,
         pane: FinancialConnectionsSessionManifest.NextPane
-    ) {}
+    ) -> Error? {
+        return nil
+    }
 
     func fetchFinancialConnectionsAccounts(clientSecret: String, startingAfterAccountId: String?) -> Promise<
         StripeAPI.FinancialConnectionsSession.AccountList

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsWebFlowTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsWebFlowTests.swift
@@ -10,6 +10,8 @@
 import XCTest
 
 final class FinancialConnectionsWebFlowTests: XCTestCase {
+    static let iosSdkParameter = "&launched_by=ios_sdk"
+
     func test_noAdditionalParameters_empty() {
         let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: nil,
@@ -19,7 +21,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: nil,
             incentiveEligibilitySession: nil
         )
-        XCTAssertNil(additionalParameters)
+        XCTAssertEqual(additionalParameters, "&launched_by=ios_sdk")
     }
 
     func test_someAdditionalParameters_notInstantDebits_noLinkMode() {
@@ -31,7 +33,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: nil,
             incentiveEligibilitySession: nil
         )
-        XCTAssertNil(additionalParameters)
+        XCTAssertEqual(additionalParameters, "&launched_by=ios_sdk")
     }
 
     func test_someAdditionalParameters_instantDebits_noLinkMode() {
@@ -43,7 +45,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: nil,
             incentiveEligibilitySession: nil
         )
-        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true")
+        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true&launched_by=ios_sdk")
     }
 
     func test_additionalParameters_instantDebits_noLinkMode() {
@@ -55,7 +57,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: nil,
             incentiveEligibilitySession: nil
         )
-        XCTAssertEqual(additionalParameters, "&return_payment_method=true&expand_payment_method=true")
+        XCTAssertEqual(additionalParameters, "&return_payment_method=true&expand_payment_method=true&launched_by=ios_sdk")
     }
 
     func test_additionalParameters_notInstantDebits_someLinkMode() {
@@ -67,7 +69,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: nil,
             incentiveEligibilitySession: nil
         )
-        XCTAssertNil(additionalParameters)
+        XCTAssertEqual(additionalParameters, Self.iosSdkParameter)
     }
 
     func test_someAdditionalParameters_instantDebits_passthroughLinkMode() {
@@ -79,7 +81,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: nil,
             incentiveEligibilitySession: nil
         )
-        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true&link_mode=PASSTHROUGH")
+        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true&link_mode=PASSTHROUGH&launched_by=ios_sdk")
     }
 
     func test_additionalParameters_instantDebits_linkCardBrandLinkMode() {
@@ -91,7 +93,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: nil,
             incentiveEligibilitySession: nil
         )
-        XCTAssertEqual(additionalParameters, "&return_payment_method=true&expand_payment_method=true&link_mode=LINK_CARD_BRAND")
+        XCTAssertEqual(additionalParameters, "&return_payment_method=true&expand_payment_method=true&link_mode=LINK_CARD_BRAND&launched_by=ios_sdk")
     }
 
     func test_additionalParameters_emptyPrefillDetails() {
@@ -109,7 +111,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: nil,
             incentiveEligibilitySession: nil
         )
-        XCTAssertNil(additionalParameters)
+        XCTAssertEqual(additionalParameters, "&launched_by=ios_sdk")
     }
 
     func test_additionalParameters_prefilledEmail() {
@@ -127,7 +129,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: nil,
             incentiveEligibilitySession: nil
         )
-        XCTAssertEqual(additionalParameters, "&email=test%40example.com")
+        XCTAssertEqual(additionalParameters, "&email=test%40example.com&launched_by=ios_sdk")
     }
 
     func test_additionalParameters_fullPrefillDetails() {
@@ -145,7 +147,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: nil,
             incentiveEligibilitySession: nil
         )
-        XCTAssertEqual(additionalParameters, "&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
+        XCTAssertEqual(additionalParameters, "&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US&launched_by=ios_sdk")
     }
 
     func test_additionalParameters_fullPrefillDetails_instantDebits_passthroughLinkMode() {
@@ -163,7 +165,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: nil,
             incentiveEligibilitySession: nil
         )
-        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true&link_mode=PASSTHROUGH&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
+        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true&link_mode=PASSTHROUGH&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US&launched_by=ios_sdk")
     }
 
     func test_additionalParameters_emptyBillingDetails() {
@@ -181,7 +183,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: billingDetails,
             incentiveEligibilitySession: nil
         )
-        XCTAssertNil(additionalParameters)
+        XCTAssertEqual(additionalParameters, "&launched_by=ios_sdk")
     }
 
     func test_additionalParameters_billingDetails() {
@@ -206,9 +208,9 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: billingDetails,
             incentiveEligibilitySession: nil
         )
-        XCTAssertEqual(additionalParameters, "&return_payment_method=true&expand_payment_method=true&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON")
+        XCTAssertEqual(additionalParameters, "&return_payment_method=true&expand_payment_method=true&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON&launched_by=ios_sdk")
     }
-    
+
     func test_additionalParameters_incentiveEligible() {
         let additionalParameters = FinancialConnectionsWebFlowViewController.buildEncodedUrlParameters(
             startingAdditionalParameters: nil,
@@ -220,7 +222,7 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
         )
         XCTAssertEqual(
             additionalParameters,
-            "&return_payment_method=true&expand_payment_method=true&instantDebitsIncentive=true&incentiveEligibilitySession=pi_123"
+            "&return_payment_method=true&expand_payment_method=true&instantDebitsIncentive=true&incentiveEligibilitySession=pi_123&launched_by=ios_sdk"
         )
     }
 
@@ -252,6 +254,6 @@ final class FinancialConnectionsWebFlowTests: XCTestCase {
             billingDetails: billingDetails,
             incentiveEligibilitySession: nil
         )
-        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true&link_mode=PASSTHROUGH&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US")
+        XCTAssertEqual(additionalParameters, "&testmode=true&return_payment_method=true&expand_payment_method=true&link_mode=PASSTHROUGH&billingDetails%5Bname%5D=Foo%20Bar&billingDetails%5Bemail%5D=foo%40bar.com&billingDetails%5Bphone%5D=+1%20(123)%20456-7890&billingDetails%5Baddress%5D%5Bcity%5D=Toronto&billingDetails%5Baddress%5D%5Bcountry%5D=CA&billingDetails%5Baddress%5D%5Bline1%5D=123%20Main%20St&billingDetails%5Baddress%5D%5Bpostal_code%5D=A0B%201C2&billingDetails%5Baddress%5D%5Bstate%5D=ON&email=test%40example.com&linkMobilePhone=1234567890&linkMobilePhoneCountry=US&launched_by=ios_sdk")
     }
 }


### PR DESCRIPTION
## Summary

This updates the behavior when attestation-related errors are received in response to the consumer session lookup and Link signup API calls. Instead of showing a terminal error screen, we instead abort the native flow launch the web flow.

## Motivation

Alignment with behavior on Android, and the behavior in the native Link flow when attestation errors are received.

## Testing

Testing failing consumer session lookup request:

https://github.com/user-attachments/assets/c2d8013f-22b3-4a70-a91a-16b365399614

Testing failing sign up request:

https://github.com/user-attachments/assets/4f22238c-264e-4296-8d4a-057f9e55ae43

Testing the RUX flow:

https://github.com/user-attachments/assets/f4771855-e1a3-41b1-ba70-c9e43b86bfe8

## Changelog

N/a
