### PR TITLE
Fixed text overlap on Card Scan Screen.

### DIFF
--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/SimpleScanViewController.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/SimpleScanViewController.swift
@@ -314,6 +314,7 @@ class SimpleScanViewController: ScanBaseViewController {
             .foregroundColor: UIColor.white
         ]
         privacyLinkText.accessibilityIdentifier = "Privacy Link Text"
+        privacyLinkText.clipsToBounds = true
     }
 
     func setupDebugViewUi() {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Set clipsToBounds to true on the privacy link text on SimpleScanViewController.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
I am facing the same issue described in the issue #3303 
When camera permission is denied, the privacy text is not hidden, and the permission button overlaps the privacy text.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
N/A

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
[Fixed] Issue that overlaps the camera permission denied text on the Card Scan Screen.
