### PR TITLE
Fix embedded deferred intent confirmation type

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -389,7 +389,7 @@ extension STPAnalyticsClient {
     enum DeferredIntentConfirmationType: String {
         case server = "server"
         case client = "client"
-        /// The merchant backend used the special string instead of a intent client secret, so we completed the payment without confirming an intent.
+        /// The merchant backend used `COMPLETE_WITHOUT_CONFIRMING_INTENT` instead of a intent client secret, so we completed the payment without confirming an intent.
         case completeWithoutConfirmingIntent = "none"
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -389,7 +389,8 @@ extension STPAnalyticsClient {
     enum DeferredIntentConfirmationType: String {
         case server = "server"
         case client = "client"
-        case none = "none"
+        /// The merchant backend used the special string instead of a intent client secret, so we completed the payment without confirming an intent.
+        case completeWithoutConfirmingIntent = "none"
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -341,11 +341,14 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
 
 extension EmbeddedPaymentElement {
 
-    func _confirm() async -> (result: PaymentSheetResult, deferredIntentConfirmationType: STPAnalyticsClient.DeferredIntentConfirmationType?) {
+    func _confirm() async -> (
+        result: PaymentSheetResult,
+        deferredIntentConfirmationType: STPAnalyticsClient.DeferredIntentConfirmationType?
+    ) {
         verifyIntegration()
 
         guard !hasConfirmedIntent else {
-            return (.failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent), STPAnalyticsClient.DeferredIntentConfirmationType.none)
+            return (.failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent), nil)
         }
         // Wait for the last update to finish and fail if didn't succeed. A failure means the view is out of sync with the intent and could e.g. not be showing a required mandate.
         if let latestUpdateTask {
@@ -354,14 +357,14 @@ extension EmbeddedPaymentElement {
                 // The view is in sync with the intent. Continue on with confirm!
                 break
             case .failed(error: let error):
-                return (.failed(error: error), STPAnalyticsClient.DeferredIntentConfirmationType.none)
+                return (.failed(error: error), nil)
             case .canceled:
                 let errorMessage = "confirm was called when the current update task is canceled. This shouldn't be possible; the current update task should only cancel if another task began."
                 stpAssertionFailure(errorMessage)
                 let error = PaymentSheetError.flowControllerConfirmFailed(message: errorMessage)
                 let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetError, error: error)
                 STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
-                return (.failed(error: error), STPAnalyticsClient.DeferredIntentConfirmationType.none)
+                return (.failed(error: error), nil)
             }
         }
 
@@ -385,12 +388,12 @@ extension EmbeddedPaymentElement {
         }()
 
         guard let authContext else {
-            return (.failed(error: PaymentSheetError.unknown(debugDescription: "Unexpectedly found nil authContext.")), STPAnalyticsClient.DeferredIntentConfirmationType.none)
+            return (.failed(error: PaymentSheetError.unknown(debugDescription: "Unexpectedly found nil authContext.")), nil)
         }
 
         guard let paymentOption = _paymentOption else {
             return (.failed(error: PaymentSheetError.unknown(debugDescription: "Unexpectedly found nil payment option.")),
-                    STPAnalyticsClient.DeferredIntentConfirmationType.none)
+                    nil)
         }
 
         let (result, deferredIntentConfirmationType) = await PaymentSheet.confirm(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -177,7 +177,7 @@ public final class EmbeddedPaymentElement {
             self.intent = loadResult.intent
             self.embeddedPaymentMethodsView = embeddedPaymentMethodsView
             self.containerView.updateEmbeddedPaymentMethodsView(embeddedPaymentMethodsView)
-            self.formCache = .init()
+            self.formCache = .init() // Clear the cache because the form may have changed e.g. different mandate or different fields.
             if oldPaymentOption != self.paymentOption {
                 self.delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: self)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -46,7 +46,7 @@ extension PaymentSheet {
                                                                                  shouldSavePaymentMethod: confirmType.shouldSave)
                 guard clientSecret != IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT else {
                     // Force close PaymentSheet and early exit
-                    completion(.completed, STPAnalyticsClient.DeferredIntentConfirmationType.none)
+                    completion(.completed, STPAnalyticsClient.DeferredIntentConfirmationType.completeWithoutConfirmingIntent)
                     return
                 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -88,7 +88,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
             case .client:
                 return .client
             case .none:
-                return STPAnalyticsClient.DeferredIntentConfirmationType.none
+                return .completeWithoutConfirmingIntent
             }
         }()
         switch status {


### PR DESCRIPTION
## Summary
`STPAnalyticsClient.DeferredIntentConfirmationType.none` should only be sent when we complete confirmation using `COMPLETE_WITHOUT_CONFIRMING_INTENT`. 

It's understandably confusing so I also renamed `none` to `completeWithoutConfirmingIntent`.

