### PR TITLE
Fix Invalid UITypeHTML Parameter Validation

### DIFF
--- a/Stripe3DS2/Stripe3DS2/STDSChallengeResponseObject.m
+++ b/Stripe3DS2/Stripe3DS2/STDSChallengeResponseObject.m
@@ -249,8 +249,11 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *challengeInfoHeader = [json _stds_stringForKey:@"challengeInfoHeader" required: (oobContinueLabel != nil) || headerRequired error:&error]; // TC_SDK_10292_001
     NSString *challengeInfoText =  [json _stds_stringForKey:@"challengeInfoText" required:(oobContinueLabel != nil) || infoTextRequired error:&error]; // TC_SDK_10292_001
     NSString *challengeAdditionalInfoText =  [json _stds_stringForKey:@"challengeAddInfo" required:NO error:&error];
-    if (!error && submitAuthenticationLabel && (!challengeInfoLabel && !challengeInfoHeader && !challengeInfoText)) {
-        error = [NSError _stds_missingJSONFieldError:@"challengeInfoLabel or challengeInfoText"];
+    
+    if (acsUIType != STDSACSUITypeHTML) {
+        if (!error && submitAuthenticationLabel && (!challengeInfoLabel && !challengeInfoHeader && !challengeInfoText)) {
+            error = [NSError _stds_missingJSONFieldError:@"challengeInfoLabel or challengeInfoText"];
+        }
     }
     
     NSString *showChallengeInfoTextIndicatorRawString;

--- a/Stripe3DS2/Stripe3DS2/STDSChallengeResponseObject.m
+++ b/Stripe3DS2/Stripe3DS2/STDSChallengeResponseObject.m
@@ -249,7 +249,7 @@ NS_ASSUME_NONNULL_BEGIN
     NSString *challengeInfoHeader = [json _stds_stringForKey:@"challengeInfoHeader" required: (oobContinueLabel != nil) || headerRequired error:&error]; // TC_SDK_10292_001
     NSString *challengeInfoText =  [json _stds_stringForKey:@"challengeInfoText" required:(oobContinueLabel != nil) || infoTextRequired error:&error]; // TC_SDK_10292_001
     NSString *challengeAdditionalInfoText =  [json _stds_stringForKey:@"challengeAddInfo" required:NO error:&error];
-    if (!error && submitAuthenticationLabel && (!challengeInfoLabel || !challengeInfoHeader || !challengeInfoText)) {
+    if (!error && submitAuthenticationLabel && (!challengeInfoLabel && !challengeInfoHeader && !challengeInfoText)) {
         error = [NSError _stds_missingJSONFieldError:@"challengeInfoLabel or challengeInfoText"];
     }
     


### PR DESCRIPTION
## Summary
Changed the logic to check for *any* of the additional labels *are* there, per the spec, rather than invalidating if any of them *are not* there.

Add a check to make sure we're not displaying the HTML UI type when checking if any of these labels exist.

## Motivation
To match the requirements of the spec, and to provide additional guarding against ACS servers sending data they shouldn't for different UI types.

## Testing
Used the payment sheet tester to see if the specific ACS server that is causing an issue, still causes an issue.