### PR TITLE
Disable Link for merchants using CBF

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		61D842892CADE4B9009D2D51 /* PaymentElementConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D842882CADE4B9009D2D51 /* PaymentElementConfiguration.swift */; };
 		61D842912CB06047009D2D51 /* FormMandateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D842902CB06047009D2D51 /* FormMandateProviderTests.swift */; };
 		61D8688E2C06553E001FAD84 /* RightAccessoryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D8688D2C06553E001FAD84 /* RightAccessoryButton.swift */; };
+		61ED657C2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ED657B2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift */; };
 		61FB6BCD2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB6BCC2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift */; };
 		623C2D9F87929D6DA9C09E23 /* STPCameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39B31D0B890A4F8E4819B15 /* STPCameraView.swift */; };
 		630A3B22BC5C176928538511 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B7188D37BDE69B56D8223046 /* Main.storyboard */; };
@@ -607,6 +608,7 @@
 		61D842882CADE4B9009D2D51 /* PaymentElementConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentElementConfiguration.swift; sourceTree = "<group>"; };
 		61D842902CB06047009D2D51 /* FormMandateProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormMandateProviderTests.swift; sourceTree = "<group>"; };
 		61D8688D2C06553E001FAD84 /* RightAccessoryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightAccessoryButton.swift; sourceTree = "<group>"; };
+		61ED657B2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentSheet+PaymentMethodAvailabilityTest.swift"; sourceTree = "<group>"; };
 		61FB6BCC2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedPaymentMethodsViewSnapshotTests.swift; sourceTree = "<group>"; };
 		62CE362B80042827F47ABC3F /* AffirmCopyLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AffirmCopyLabel.swift; sourceTree = "<group>"; };
 		64C8F350CDB5A29F62E86592 /* FlowControllerStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowControllerStateTests.swift; sourceTree = "<group>"; };
@@ -1694,6 +1696,7 @@
 				0901281208BEB220D0B491A8 /* PaymentSheetLinkAccountTests.swift */,
 				492B254E43F3BB9F9CEAEA06 /* PaymentSheetLoaderStubbedTest.swift */,
 				C90A2636C2A577AF36FB793B /* PaymentSheetLoaderTest.swift */,
+				61ED657B2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift */,
 				61C87E1C2CB81F9B001B7DA9 /* CardBrandFilterTests.swift */,
 				C47D00B9DE812D0801B4E33F /* PaymentSheetLPMConfirmFlowTests.swift */,
 				D926018024823367971A8907 /* PaymentSheetPaymentMethodTypeTest.swift */,
@@ -2033,6 +2036,7 @@
 				615AADB12CB97A9400D0AED9 /* STPCardValidator+BrandFilteringTest.swift in Sources */,
 				619AF08A2BF56FC000D1C981 /* VerticalSavedPaymentMethodsViewControllerTests.swift in Sources */,
 				47AD56A9889DF5EFBBA9CEFB /* PollingViewTests.swift in Sources */,
+				61ED657C2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift in Sources */,
 				61D842912CB06047009D2D51 /* FormMandateProviderTests.swift in Sources */,
 				61FB6BCD2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift in Sources */,
 				6B76DBD12C530B6C0037CD63 /* PaymentSheetGDPRConfirmFlowTests.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -59,7 +59,9 @@ extension PaymentSheet {
         guard elementsSession.supportsLink else {
             return false
         }
-        return !configuration.requiresBillingDetailCollection()
+        
+        // Disable Link if the merchant is using the billing address collection API or card brand filtering
+        return !configuration.requiresBillingDetailCollection() && configuration.cardBrandAcceptance == .all
     }
 
     /// An unordered list of paymentMethodTypes that can be used with Link in PaymentSheet

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -60,8 +60,17 @@ extension PaymentSheet {
             return false
         }
         
-        // Disable Link if the merchant is using the billing address collection API or card brand filtering
-        return !configuration.requiresBillingDetailCollection() && configuration.cardBrandAcceptance == .all
+        // Disable Link if the merchant is using card brand filtering
+        guard configuration.cardBrandAcceptance == .all else {
+           return false
+        }
+        
+        // Disable Link if the merchant is using billing address collection API
+        guard !configuration.requiresBillingDetailCollection() else {
+          return false
+        }
+        
+        return true
     }
 
     /// An unordered list of paymentMethodTypes that can be used with Link in PaymentSheet

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
@@ -21,7 +21,7 @@ final class PaymentMethodAvailabilityTest: XCTestCase {
         XCTAssertFalse(isLinkEnabled, "Link should be disabled when supportsLink is false and link is not in payment method types")
     }
     
-    func testIsLinkEnabled_supportsLinkFalse_linkPresent() {
+    func testIsLinkEnabled_supportsLinkTrue_linkPresent() {
         let elementsSession = STPElementsSession._testValue(
             paymentMethodTypes: ["card", "link"],
             isLinkPassthroughModeEnabled: false
@@ -29,7 +29,7 @@ final class PaymentMethodAvailabilityTest: XCTestCase {
         let configuration = PaymentSheet.Configuration()
         let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
 
-        XCTAssertFalse(isLinkEnabled, "Link should be disabled when supportsLink is false, even if link is present")
+        XCTAssertTrue(isLinkEnabled, "Link should be enabled when isLinkPassthroughModeEnabled is false, since Link is present in the payment method types")
     }
 
     func testIsLinkEnabled_supportsLinkTrue_linkNotPresent_passthroughEnabled() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
@@ -1,0 +1,94 @@
+//
+//  PaymentSheet+PaymentMethodAvailabilityTest.swift
+//  StripePaymentSheetTests
+//
+//  Created by Nick Porter on 1/22/25.
+//
+
+import XCTest
+@testable @_spi(CardBrandFilteringBeta) import StripePaymentSheet
+
+final class PaymentMethodAvailabilityTest: XCTestCase {
+
+    func testIsLinkEnabled_supportsLinkFalse_linkNotPresent() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card"],
+            isLinkPassthroughModeEnabled: false
+        )
+        let configuration = PaymentSheet.Configuration()
+        let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
+
+        XCTAssertFalse(isLinkEnabled, "Link should be disabled when supportsLink is false and link is not in payment method types")
+    }
+    
+    func testIsLinkEnabled_supportsLinkFalse_linkPresent() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card", "link"],
+            isLinkPassthroughModeEnabled: false
+        )
+        let configuration = PaymentSheet.Configuration()
+        let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
+
+        XCTAssertFalse(isLinkEnabled, "Link should be disabled when supportsLink is false, even if link is present")
+    }
+
+    func testIsLinkEnabled_supportsLinkTrue_linkNotPresent_passthroughEnabled() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card"],
+            isLinkPassthroughModeEnabled: true
+        )
+        let configuration = PaymentSheet.Configuration()
+        let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
+
+        XCTAssertTrue(isLinkEnabled, "Link should be enabled when supportsLink is true because passthrough mode is enabled")
+    }
+
+    func testIsLinkEnabled_requiresBillingDetailCollection() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card", "link"],
+            isLinkPassthroughModeEnabled: true
+
+        )
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .always
+        let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
+
+        XCTAssertFalse(isLinkEnabled, "Link should be disabled when billing details collection is required")
+    }
+
+    func testIsLinkEnabled_cardBrandAcceptanceNotAll() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card", "link"],
+            isLinkPassthroughModeEnabled: true
+
+        )
+        var configuration = PaymentSheet.Configuration()
+        configuration.cardBrandAcceptance = .allowed(brands: [.visa])
+        let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
+        
+        XCTAssertFalse(isLinkEnabled, "Link should be disabled when card brand acceptance is not 'all'")
+    }
+
+    func testIsLinkEnabled_allConditionsMet() {
+        // Given
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card", "link"],
+            isLinkPassthroughModeEnabled: true
+        )
+        let configuration = PaymentSheet.Configuration()
+        let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
+        
+        XCTAssertTrue(isLinkEnabled, "Link should be enabled when all conditions are met")
+    }
+    
+    func testIsLinkEnabled_linkNotExplicitlyAllowedButPassthroughEnabled() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card"],
+            isLinkPassthroughModeEnabled: true
+        )
+        let configuration = PaymentSheet.Configuration()
+        let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
+        
+        XCTAssertTrue(isLinkEnabled, "Link should be enabled when passthrough mode is enabled, even if 'link' is not explicitly in payment method types")
+    }
+}


### PR DESCRIPTION
## Summary
- We will now be disabling Link for merchants who use Card Brand Filtering until the Link popup supports CBF.
- See the ticket for more details

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-3032

## Testing
- Manual
- New unit tests

## Changelog
N/A (private beta for now)