### PR TITLE
Don't assert presentingViewController/delegate are non-nil in Embeddd…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -189,18 +189,6 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         let bottomSheetVC = bottomSheetController(with: verticalSavedPaymentMethodsViewController)
         presentingViewController?.presentAsBottomSheet(bottomSheetVC, appearance: configuration.appearance)
     }
-
-    func verifyIntegration() {
-        guard delegate != nil else {
-            stpAssertionFailure("Delegate not set. Please set EmbeddedPaymentElement.delegate.")
-            return
-        }
-
-        guard presentingViewController != nil else {
-            stpAssertionFailure("Presenting view controller not found. Please set EmbeddedPaymentElement.presentingViewController.")
-            return
-        }
-    }
 }
 
 // MARK: UpdatePaymentMethodViewControllerDelegate
@@ -342,8 +330,6 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
 extension EmbeddedPaymentElement {
 
     func _confirm() async -> (result: PaymentSheetResult, deferredIntentConfirmationType: STPAnalyticsClient.DeferredIntentConfirmationType?) {
-        verifyIntegration()
-
         guard !hasConfirmedIntent else {
             return (.failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent), STPAnalyticsClient.DeferredIntentConfirmationType.none)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -104,8 +104,6 @@ public final class EmbeddedPaymentElement {
     public func update(
         intentConfiguration: IntentConfiguration
     ) async -> UpdateResult {
-        verifyIntegration()
-
         // Do not process any update calls if we have already successfully confirmed an intent
         guard !hasConfirmedIntent else {
             return .failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent)
@@ -199,8 +197,6 @@ public final class EmbeddedPaymentElement {
 
     /// Sets the currently selected payment option to `nil`.
     public func clearPaymentOption() {
-        verifyIntegration()
-
         // If a payment has been successfully completed, we don't allow clearing the payment option.
         guard !hasConfirmedIntent else { return }
 
@@ -224,7 +220,6 @@ public final class EmbeddedPaymentElement {
 
     #if DEBUG
     public func testHeightChange() {
-        verifyIntegration()
         stpAssert(configuration.embeddedViewDisplaysMandateText, "Before using this testing feature, ensure that embeddedViewDisplaysMandateText is set to true")
         self.embeddedPaymentMethodsView.testHeightChange()
     }


### PR DESCRIPTION
…ed APIs that don't require them

## Motivation
It's not invalid to call most of these APIs without a `presentingViewController` or `delegate`. There are cases where you don't need either e.g. you may call `update`/`clearPaymentOption` while EmbeddedPaymentElement is off screen.

## Testing
Existing tests

## Changelog
Not user facing