### PR TITLE
Always pass attestation parameters to `/synchronize`

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -364,12 +364,10 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         mobileParameters["app_return_url"] = returnURL
 
         let attest = backingAPIClient.stripeAttest
-        if attest.isSupported {
-            mobileParameters["supports_app_verification"] = true
-            mobileParameters["verified_app_id"] = Bundle.main.bundleIdentifier
-        }
-        parameters["mobile"] = mobileParameters
+        mobileParameters["supports_app_verification"] = attest.isSupported
+        mobileParameters["verified_app_id"] = Bundle.main.bundleIdentifier
 
+        parameters["mobile"] = mobileParameters
         return self.post(
             resource: "financial_connections/sessions/synchronize",
             parameters: parameters,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -367,10 +367,9 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
         mobileParameters["app_return_url"] = returnURL
 
         let attest = backingAPIClient.stripeAttest
-        if attest.isSupported {
-            mobileParameters["supports_app_verification"] = true
-            mobileParameters["verified_app_id"] = Bundle.main.bundleIdentifier
-        }
+        mobileParameters["supports_app_verification"] = attest.isSupported
+        mobileParameters["verified_app_id"] = Bundle.main.bundleIdentifier
+
         parameters["mobile"] = mobileParameters
         return try await post(endpoint: .synchronize, parameters: parameters)
     }


### PR DESCRIPTION
## Summary

Per https://github.com/stripe/stripe-android/pull/9966 we should always include these parameters in the `/synchronize` call. 

Explanation:
>The application id is used backend side to check if the current merchant is trusted ([see code](https://git.corp.stripe.com/stripe-internal/pay-server/blob/master/lib/bank_connections/auth_session/command/set_or_update_link_account_session_mobile_app_verification_enabled.rb#L122-L123)).
Currently, if the client does not support verified apps, we're not sending the app id. That incorrectly catalogs the current session as merchant_not_trusted, where in reality the reason to disable app verification is client_attestation_unsupported.

## Motivation

https://github.com/stripe/stripe-android/pull/9966

## Testing

Trust E2E tests

## Changelog

N/a
