### PR TITLE
Temporarily disable `testNativeConnectMerchantForTokenCase`

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -585,7 +585,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         XCTAssert(app.fc_playgroundSuccessAlertView.exists)
     }
 
-    func testNativeConnectMerchantForTokenCase() {
+    func disabled_testNativeConnectMerchantForTokenCase() {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
 """


### PR DESCRIPTION
## Summary

[Builds](https://app.bitrise.io/build/d1d14251-1945-4989-a306-fd4aee13d39d?tab=tests) are failing with a weird error. Disabling the test for now to not block `master` as we investigate.

<img width=40% src="https://github.com/user-attachments/assets/648c12c1-0773-4fe5-8980-b07d5d532004">

## Motivation

Keep master green.

## Testing

N/a

## Changelog

N/a
