### PR TITLE
Enable async API client by default when using example app

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -456,7 +456,7 @@ final class PlaygroundConfiguration {
             if let useAsyncAPIClient = configurationStore[Self.useAsyncAPIClientKey] as? Bool {
                 return useAsyncAPIClient
             } else {
-                return false
+                return true
             }
         }
         set {


### PR DESCRIPTION
## Summary

Turns on the async API client by default when using the FC Example app. API client used in production is still the "legacy" Futures / Promise based client. This change will have no effect outside of example app usage

## Motivation

This for us to dogfood this client to gain confidence in it

## Testing

N/a

## Changelog

N/a