### PR TITLE
Add EmbeddedPaymentElementViewModel

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -159,6 +159,8 @@
 		6103F2BC2BE45990002D67F8 /* SavedPaymentMethodManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6103F2BB2BE45990002D67F8 /* SavedPaymentMethodManager.swift */; };
 		610EAAF02C0F5D9400124AB2 /* FormHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610EAAEF2C0F5D9400124AB2 /* FormHeaderView.swift */; };
 		6117D7122CB065E7005C4EC1 /* MandateTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6117D7112CB065E7005C4EC1 /* MandateTextProvider.swift */; };
+		6123E94D2D4A84800088FBE8 /* EmbeddedPaymentElement+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6123E94C2D4A84800088FBE8 /* EmbeddedPaymentElement+SwiftUI.swift */; };
+		6123E94F2D4A86BA0088FBE8 /* EmbeddedPaymentElementViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6123E94E2D4A86BA0088FBE8 /* EmbeddedPaymentElementViewModelTests.swift */; };
 		614068E22CB0BF10003D2F12 /* EmbeddedPaymentMethodsViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 614068E12CB0BF10003D2F12 /* EmbeddedPaymentMethodsViewTests.swift */; };
 		6141C5072C0A47A700E81735 /* RightAccessoryButtonTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6141C5062C0A47A700E81735 /* RightAccessoryButtonTest.swift */; };
 		614A8AE72BE53C6900E8688B /* SavedPaymentMethodManagerTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6103F2BD2BE53737002D67F8 /* SavedPaymentMethodManagerTest.swift */; };
@@ -586,6 +588,8 @@
 		6103F2BD2BE53737002D67F8 /* SavedPaymentMethodManagerTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPaymentMethodManagerTest.swift; sourceTree = "<group>"; };
 		610EAAEF2C0F5D9400124AB2 /* FormHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormHeaderView.swift; sourceTree = "<group>"; };
 		6117D7112CB065E7005C4EC1 /* MandateTextProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MandateTextProvider.swift; sourceTree = "<group>"; };
+		6123E94C2D4A84800088FBE8 /* EmbeddedPaymentElement+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EmbeddedPaymentElement+SwiftUI.swift"; sourceTree = "<group>"; };
+		6123E94E2D4A86BA0088FBE8 /* EmbeddedPaymentElementViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedPaymentElementViewModelTests.swift; sourceTree = "<group>"; };
 		6139AA50F07A1E2AC7E9827F /* AUBECSMandate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AUBECSMandate.swift; sourceTree = "<group>"; };
 		614068E12CB0BF10003D2F12 /* EmbeddedPaymentMethodsViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedPaymentMethodsViewTests.swift; sourceTree = "<group>"; };
 		6141C5062C0A47A700E81735 /* RightAccessoryButtonTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightAccessoryButtonTest.swift; sourceTree = "<group>"; };
@@ -1137,6 +1141,7 @@
 			isa = PBXGroup;
 			children = (
 				B615E8702CA4CBEE007D684C /* EmbeddedPaymentElement.swift */,
+				6123E94C2D4A84800088FBE8 /* EmbeddedPaymentElement+SwiftUI.swift */,
 				615C2C4F2CBDBA61003F0173 /* EmbeddedFormViewController.swift */,
 				B6CACC9D2CB8B8E800682ECE /* EmbeddedPaymentElement+Internal.swift */,
 				B615E8722CA4CC04007D684C /* EmbeddedPaymentElementConfiguration.swift */,
@@ -1668,6 +1673,7 @@
 				31699A822BE183D40048677F /* DownloadManagerTest.swift */,
 				73FB30705EC36BD0868904A2 /* Elements+TestHelpers.swift */,
 				B6CACC9F2CBD9A3300682ECE /* EmbeddedPaymentElementTest.swift */,
+				6123E94E2D4A86BA0088FBE8 /* EmbeddedPaymentElementViewModelTests.swift */,
 				B63DC6792CC06AC80011C27E /* EmbeddedPaymentElementSnapshotTests.swift */,
 				61FB6BCC2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift */,
 				61A799512CC2053500D7DFFA /* EmbeddedFormViewControllerSnapshotTests.swift */,
@@ -2026,6 +2032,7 @@
 				FBAC012322FE99046A484E65 /* PaymentSheetFormFactoryTest.swift in Sources */,
 				B6BF12392C2F2E790033601E /* PaymentSheetImageTests.swift in Sources */,
 				614068E22CB0BF10003D2F12 /* EmbeddedPaymentMethodsViewTests.swift in Sources */,
+				6123E94F2D4A86BA0088FBE8 /* EmbeddedPaymentElementViewModelTests.swift in Sources */,
 				44D0F92C4AA2DF0C9DC4C9B4 /* PaymentSheetLPMConfirmFlowTests.swift in Sources */,
 				ABE13E65678673EC4DE14EF4 /* PaymentSheetLinkAccountTests.swift in Sources */,
 				142C03879DC4CD43BB743022 /* PaymentSheetLoaderStubbedTest.swift in Sources */,
@@ -2185,6 +2192,7 @@
 				46DB5D39B3B76C08AE2C83C8 /* PaymentMethodElement.swift in Sources */,
 				335A19D93A5979557DB4CA4D /* PaymentMethodElementWrapper.swift in Sources */,
 				B615E8732CA4CC04007D684C /* EmbeddedPaymentElementConfiguration.swift in Sources */,
+				6123E94D2D4A84800088FBE8 /* EmbeddedPaymentElement+SwiftUI.swift in Sources */,
 				00A3805F91E6F903FA677393 /* SimpleMandateElement.swift in Sources */,
 				DFA10770E494AFB895BA4EE2 /* TextFieldElement+Card.swift in Sources */,
 				B6B3481CBA798CF22EE8411A /* TextFieldElement+IBAN.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
@@ -42,7 +42,7 @@ import Combine
     /// Creates an empty view model. Call `load` to initialize the `EmbeddedPaymentElementViewModel`
     public init() {}
 
-    /// Asynchronously loads and initializes EmbeddedPaymentElementViewModel. This function should only be called once to initially load the EmbeddedPaymentElementViewModel.
+    /// Asynchronously loads the EmbeddedPaymentElementViewModel. This function should only be called once to initially load the EmbeddedPaymentElementViewModel.
     /// Loads the Customer's payment methods, their default payment method, etc.
     /// - Parameter intentConfiguration: Information about the PaymentIntent or SetupIntent you will create later to complete the confirmation.
     /// - Parameter configuration: Configuration for the PaymentSheet. e.g. your business name, customer details, etc.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
@@ -1,0 +1,142 @@
+//
+//  EmbeddedPaymentElement+SwiftUI.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 1/29/25.
+//
+
+import SwiftUI
+import Combine
+@_spi(STP) import StripeCore
+
+/// A view model that manages an `EmbeddedPaymentElement`.
+@MainActor
+@_spi(EmbeddedPaymentElementPrivateBeta) public final class EmbeddedPaymentElementViewModel: ObservableObject {
+    enum ViewModelError: Error {
+        /// The `EmbeddedPaymentElementViewModel` has not been loaded. Call `load()` before attempting this operation.
+         case notLoaded
+
+        /// `load()` has already been called. `load()` may only be called once.
+         case alreadyLoaded
+     }
+
+    // MARK: - Public properties
+
+    /// Indicates whether the `EmbeddedPaymentElementViewModel` has been successfully loaded.
+    @Published public private(set) var isLoaded: Bool = false
+
+    /// Contains information about the customer's selected payment option.
+    /// Use this to display the payment option in your own UI
+    @Published public private(set) var paymentOption: EmbeddedPaymentElement.PaymentOptionDisplayData?
+
+    // MARK: - Internal properties
+
+    private(set) var embeddedPaymentElement: EmbeddedPaymentElement?
+
+    // MARK: - Private properties
+
+    private var loadTask: Task<Void, Error>?
+
+    // MARK: - Public APIs
+
+    /// Creates an empty view model. Call `load` to initialize the `EmbeddedPaymentElementViewModel`
+    public init() {}
+
+    /// Asynchronously loads and initializes EmbeddedPaymentElementViewModel. This function should only be called once to initially load the EmbeddedPaymentElementViewModel.
+    /// Loads the Customer's payment methods, their default payment method, etc.
+    /// - Parameter intentConfiguration: Information about the PaymentIntent or SetupIntent you will create later to complete the confirmation.
+    /// - Parameter configuration: Configuration for the PaymentSheet. e.g. your business name, customer details, etc.
+    /// - Note: This method may only be called once. Subsequent calls will throw an error.
+    /// - Throws: An error if loading failed.
+    public func load(
+        intentConfiguration: EmbeddedPaymentElement.IntentConfiguration,
+        configuration: EmbeddedPaymentElement.Configuration
+    ) async throws {
+        // If we already have a load task (whether it’s in progress or finished), throw an error
+        guard loadTask == nil else {
+            throw ViewModelError.alreadyLoaded
+        }
+
+        // Store the load task
+        loadTask = Task {
+            let embeddedPaymentElement = try await EmbeddedPaymentElement.create(
+                intentConfiguration: intentConfiguration,
+                configuration: configuration
+            )
+            self.embeddedPaymentElement = embeddedPaymentElement
+            self.embeddedPaymentElement?.delegate = self
+            self.paymentOption = embeddedPaymentElement.paymentOption
+            self.isLoaded = true
+        }
+
+        do {
+            try await loadTask?.value
+        } catch {
+            // Reset loadTask to allow for load retries after errors
+            loadTask = nil
+            throw error
+        }
+    }
+
+    /// Call this method when the IntentConfiguration values you used to initialize `EmbeddedPaymentElementViewModel` (amount, currency, etc.) change.
+    /// This ensures the appropriate payment methods are displayed, collect the right fields, etc.
+    /// - Parameter intentConfiguration: An updated IntentConfiguration.
+    /// - Returns: The result of the update. Any calls made to `update` before this call that are still in progress will return a `.canceled` result.
+    /// - Note: Upon completion, `paymentOption` may become nil if it's no longer available.
+    public func update(
+        intentConfiguration: EmbeddedPaymentElement.IntentConfiguration
+    ) async -> EmbeddedPaymentElement.UpdateResult {
+        // Wait for the load task to complete if it exists
+        if let loadTask = self.loadTask {
+            do {
+                try await loadTask.value
+            } catch {
+                return .failed(error: ViewModelError.notLoaded)
+            }
+        }
+        
+        // Check if update was called before load, if so throw an error
+        guard let embeddedPaymentElement = embeddedPaymentElement else {
+            return .failed(error: ViewModelError.notLoaded)
+        }
+
+        return await embeddedPaymentElement.update(intentConfiguration: intentConfiguration)
+    }
+
+    /// Completes the payment or setup.
+    /// - Returns: The result of the payment after any presented view controllers are dismissed.
+    /// - Note: This method requires that the last call to `update` succeeded. If the last `update` call failed, this call will fail. If this method is called while a call to `update` is in progress, it waits until the `update` call completes.
+    public func confirm() async -> EmbeddedPaymentElementResult {
+        guard let embeddedPaymentElement = embeddedPaymentElement else {
+            return .failed(error: ViewModelError.notLoaded)
+        }
+
+        let result = await embeddedPaymentElement.confirm()
+        return result
+    }
+
+    /// Sets the currently selected payment option to `nil`.
+    public func clearPaymentOption() {
+        embeddedPaymentElement?.clearPaymentOption()
+        self.paymentOption = embeddedPaymentElement?.paymentOption
+    }
+
+#if DEBUG
+    public func testHeightChange() {
+        embeddedPaymentElement?.testHeightChange()
+    }
+#endif
+}
+
+// MARK: EmbeddedPaymentElementDelegate
+
+extension EmbeddedPaymentElementViewModel: EmbeddedPaymentElementDelegate {
+
+    public func embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: EmbeddedPaymentElement) {
+        // TODO(porter) Handle height changes when we add the UIViewRepresentable MOBILESDK-3001
+    }
+
+    public func embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: EmbeddedPaymentElement) {
+        self.paymentOption = embeddedPaymentElement.paymentOption
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
@@ -117,7 +117,6 @@ import Combine
     /// Sets the currently selected payment option to `nil`.
     public func clearPaymentOption() {
         embeddedPaymentElement?.clearPaymentOption()
-        self.paymentOption = embeddedPaymentElement?.paymentOption
     }
 
 #if DEBUG

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
@@ -11,13 +11,22 @@ import Combine
 /// A view model that manages an `EmbeddedPaymentElement`.
 @MainActor
 @_spi(EmbeddedPaymentElementPrivateBeta) public final class EmbeddedPaymentElementViewModel: ObservableObject {
-    enum ViewModelError: Error {
+    enum ViewModelError: Error, CustomDebugStringConvertible {
         /// The `EmbeddedPaymentElementViewModel` has not been loaded. Call `load()` before attempting this operation.
-         case notLoaded
+        case notLoaded
 
         /// `load()` has already been called. `load()` may only be called once.
-         case alreadyLoaded
-     }
+        case alreadyLoaded
+
+        var debugDescription: String {
+            switch self {
+            case .notLoaded:
+                return "EmbeddedPaymentElementViewModel has not been loaded. Call `load()` before attempting this operation."
+            case .alreadyLoaded:
+                return "load() has already been called. `load()` may only be called once."
+            }
+        }
+    }
 
     // MARK: - Public properties
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
@@ -66,7 +66,8 @@ import Combine
         }
 
         // Store the load task
-        loadTask = Task {
+        loadTask = Task { [weak self] in
+            guard let self else { return }
             let embeddedPaymentElement = try await EmbeddedPaymentElement.create(
                 intentConfiguration: intentConfiguration,
                 configuration: configuration

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
@@ -7,7 +7,6 @@
 
 import SwiftUI
 import Combine
-@_spi(STP) import StripeCore
 
 /// A view model that manages an `EmbeddedPaymentElement`.
 @MainActor

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
@@ -67,11 +67,11 @@ import Combine
 
         // Store the load task
         loadTask = Task { [weak self] in
-            guard let self else { return }
             let embeddedPaymentElement = try await EmbeddedPaymentElement.create(
                 intentConfiguration: intentConfiguration,
                 configuration: configuration
             )
+            guard let self else { return }
             self.embeddedPaymentElement = embeddedPaymentElement
             self.embeddedPaymentElement?.delegate = self
             self.paymentOption = embeddedPaymentElement.paymentOption

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementViewModelTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementViewModelTests.swift
@@ -1,0 +1,320 @@
+//
+//  EmbeddedPaymentElementViewModelTests.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 1/29/25.
+//
+
+@testable@_spi(STP) import StripeCore
+import StripeCoreTestUtils
+@testable@_spi(STP) import StripePaymentsTestUtils
+import XCTest
+
+@_spi(EmbeddedPaymentElementPrivateBeta) @_spi(STP) @testable import StripePaymentSheet
+
+@MainActor
+class EmbeddedPaymentElementViewModelTest: XCTestCase {
+    // MARK: - Test Configurations
+
+    lazy var configuration: EmbeddedPaymentElement.Configuration = {
+        var config = EmbeddedPaymentElement.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
+        config.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        return config
+    }()
+
+    let paymentIntentConfig = EmbeddedPaymentElement.IntentConfiguration(
+        mode: .payment(amount: 1000, currency: "USD"),
+        paymentMethodTypes: ["card", "cashapp"]
+    ) { paymentMethod, _, intentCreationCallback in
+        STPTestingAPIClient.shared.fetchPaymentIntent(
+            types: ["card"],
+            currency: "USD",
+            paymentMethodID: paymentMethod.stripeId,
+            confirm: true
+        ) { result in
+            switch result {
+            case .success(let clientSecret):
+                intentCreationCallback(.success(clientSecret))
+            case .failure(let error):
+                intentCreationCallback(.failure(error))
+            }
+        }
+    }
+
+    let paymentIntentConfigUpdated = EmbeddedPaymentElement.IntentConfiguration(
+        mode: .payment(amount: 1001, currency: "USD"),
+        paymentMethodTypes: ["card", "cashapp"]
+    ) { _, _, _ in
+        // no-op
+    }
+
+    let brokenPaymentIntentConfig = EmbeddedPaymentElement.IntentConfiguration(
+        mode: .payment(amount: -1000, currency: "bad currency"),
+        paymentMethodTypes: ["card", "cashapp"]
+    ) { _, _, _ in
+        // // no-op, this should fail due to invalid amounts/currency
+    }
+
+    // MARK: - Tests
+
+    func testLoadSuccess() async throws {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        XCTAssertFalse(viewModel.isLoaded, "viewModel should not be loaded initially.")
+
+        try await viewModel.load(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+        XCTAssertTrue(viewModel.isLoaded, "viewModel should be loaded after calling load().")
+    }
+
+    func testLoadThrowsOnMultipleCalls() async throws {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        try await viewModel.load(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+
+        // Trying to load again should throw
+        await XCTAssertThrowsErrorAsync( try await {
+            try await viewModel.load(
+                intentConfiguration: self.paymentIntentConfig,
+                configuration: self.configuration
+            )
+        }())
+    }
+
+    func testUpdateFailsIfNotLoaded() async {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        // Attempt to update before loading
+        let result = await viewModel.update(intentConfiguration: paymentIntentConfigUpdated)
+        guard case let .failed(error) = result else {
+            return XCTFail("Expected an update to fail if not loaded.")
+        }
+
+        XCTAssertTrue(error is EmbeddedPaymentElementViewModel.ViewModelError)
+        XCTAssertEqual(error as? EmbeddedPaymentElementViewModel.ViewModelError, .notLoaded)
+    }
+
+    func testConfirmFailsIfNotLoaded() async {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        // Attempt to confirm before loading
+        let result = await viewModel.confirm()
+        guard case let .failed(error) = result else {
+            return XCTFail("Expected confirm to fail if not loaded.")
+        }
+
+        XCTAssertTrue(error is EmbeddedPaymentElementViewModel.ViewModelError)
+        XCTAssertEqual(error as? EmbeddedPaymentElementViewModel.ViewModelError, .notLoaded)
+    }
+
+    func testLoadThenUpdate() async throws {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        try await viewModel.load(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+
+        // The update should succeed
+        let result = await viewModel.update(intentConfiguration: paymentIntentConfigUpdated)
+        XCTAssertEqual(result, .succeeded, "Expected .succeeded after updating with a valid config.")
+        XCTAssertTrue(viewModel.isLoaded)
+    }
+
+    func testLoadThenUpdateWithBrokenConfig() async throws {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        try await viewModel.load(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+        XCTAssertTrue(viewModel.isLoaded)
+
+        // The update should fail due to invalid config
+        let result = await viewModel.update(intentConfiguration: brokenPaymentIntentConfig)
+        guard case .failed(_) = result else {
+            return XCTFail("Expected .failed with broken config.")
+        }
+    }
+
+    func testConfirmSucceedsWithValidCard() async throws {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        try await viewModel.load(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+        viewModel.embeddedPaymentElement?.presentingViewController = UIViewController() // typically set by the UIViewRepresentable
+        XCTAssertTrue(viewModel.isLoaded)
+
+        // Provide a valid card
+        let confirmParams = IntentConfirmParams(type: .stripe(.card))
+        confirmParams.paymentMethodParams.card = STPPaymentMethodCardParams()
+        confirmParams.paymentMethodParams.card?.number = "4242424242424242"
+        confirmParams.paymentMethodParams.card?.expMonth = NSNumber(value: 12)
+        confirmParams.paymentMethodParams.card?.expYear = 2040
+        confirmParams.paymentMethodParams.card?.cvc = "123"
+        confirmParams.setDefaultBillingDetailsIfNecessary(for: configuration)
+
+        viewModel.embeddedPaymentElement?._test_paymentOption = .new(confirmParams: confirmParams)
+
+        let result = await viewModel.confirm()
+        switch result {
+        case .completed:
+            // Success
+            break
+        case .failed(let error):
+            XCTFail("Expected confirm to succeed, but failed with error: \(error)")
+        case .canceled:
+            XCTFail("Expected confirm to succeed, but it was canceled")
+        }
+    }
+
+    func testConfirmFailsWithInvalidCard() async throws {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        try await viewModel.load(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+        viewModel.embeddedPaymentElement?.presentingViewController = UIViewController() // typically set by the UIViewRepresentable
+        XCTAssertTrue(viewModel.isLoaded)
+
+        // Provide an invalid card
+        let confirmParams = IntentConfirmParams(type: .stripe(.card))
+        confirmParams.paymentMethodParams.card = STPPaymentMethodCardParams()
+        confirmParams.paymentMethodParams.card?.number = "1234567890123456" // Invalid card number
+        confirmParams.paymentMethodParams.card?.expMonth = NSNumber(value: 12)
+        confirmParams.paymentMethodParams.card?.expYear = 2040
+        confirmParams.paymentMethodParams.card?.cvc = "123"
+        confirmParams.setDefaultBillingDetailsIfNecessary(for: configuration)
+
+        viewModel.embeddedPaymentElement?._test_paymentOption = .new(confirmParams: confirmParams)
+
+        let result = await viewModel.confirm()
+        switch result {
+        case .failed(let error):
+            XCTAssertTrue(error.nonGenericDescription.contains("Your card number is incorrect."),
+                          "Expected card number incorrect error.")
+        default:
+            XCTFail("Expected confirm to fail with invalid card.")
+        }
+    }
+
+    func testClearPaymentOption() async throws {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        try await viewModel.load(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+        XCTAssertTrue(viewModel.isLoaded)
+
+        // Simulate user selecting a payment method
+        viewModel.embeddedPaymentElement?.embeddedPaymentMethodsView.didTap(
+            selection: .new(paymentMethodType: .stripe(.cashApp))
+        )
+        XCTAssertNotNil(viewModel.paymentOption, "Expected a payment option after user selection.")
+
+        // Clear
+        viewModel.clearPaymentOption()
+        XCTAssertNil(viewModel.paymentOption, "Expected payment option to be nil after clear.")
+    }
+
+    func testClearPaymentOptionWhenNoneSelectedDoesNothing() async throws {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        try await viewModel.load(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+        XCTAssertTrue(viewModel.isLoaded)
+        XCTAssertNil(viewModel.paymentOption, "No option should be selected initially.")
+
+        // Clearing when none is selected should be safe/no-op
+        viewModel.clearPaymentOption()
+        XCTAssertNil(viewModel.paymentOption)
+    }
+
+    func testConfirmThenUpdateFails() async throws {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        try await viewModel.load(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+        viewModel.embeddedPaymentElement?.presentingViewController = UIViewController() // typically set by the UIViewRepresentable
+        XCTAssertTrue(viewModel.isLoaded)
+
+        // Confirm a payment
+        let confirmParams = IntentConfirmParams(type: .stripe(.card))
+        confirmParams.paymentMethodParams.card = STPPaymentMethodCardParams()
+        confirmParams.paymentMethodParams.card?.number = "4242424242424242"
+        confirmParams.paymentMethodParams.card?.expMonth = NSNumber(value: 12)
+        confirmParams.paymentMethodParams.card?.expYear = 2040
+        confirmParams.paymentMethodParams.card?.cvc = "123"
+        confirmParams.setDefaultBillingDetailsIfNecessary(for: configuration)
+
+        viewModel.embeddedPaymentElement?._test_paymentOption = .new(confirmParams: confirmParams)
+        let confirmResult = await viewModel.confirm()
+        XCTAssertEqual(confirmResult, .completed)
+
+        // After confirming, an update should fail
+        let updateResult = await viewModel.update(intentConfiguration: paymentIntentConfigUpdated)
+        guard case let .failed(error) = updateResult else {
+            return XCTFail("Expected update to fail after a successful confirmation.")
+        }
+        XCTAssertTrue(error is PaymentSheetError)
+        XCTAssertEqual(
+            (error as! PaymentSheetError).debugDescription,
+            PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent.debugDescription
+        )
+    }
+
+    func testConfirmTwiceFails() async throws {
+        let viewModel = EmbeddedPaymentElementViewModel()
+        try await viewModel.load(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+        viewModel.embeddedPaymentElement?.presentingViewController = UIViewController() // typically set by the UIViewRepresentable
+        XCTAssertTrue(viewModel.isLoaded)
+
+        // Confirm a payment
+        let confirmParams = IntentConfirmParams(type: .stripe(.card))
+        confirmParams.paymentMethodParams.card = STPPaymentMethodCardParams()
+        confirmParams.paymentMethodParams.card?.number = "4242424242424242"
+        confirmParams.paymentMethodParams.card?.expMonth = NSNumber(value: 12)
+        confirmParams.paymentMethodParams.card?.expYear = 2040
+        confirmParams.paymentMethodParams.card?.cvc = "123"
+        confirmParams.setDefaultBillingDetailsIfNecessary(for: configuration)
+
+        viewModel.embeddedPaymentElement?._test_paymentOption = .new(confirmParams: confirmParams)
+        let firstConfirm = await viewModel.confirm()
+        XCTAssertEqual(firstConfirm, .completed)
+
+        // Confirm again should fail
+        let secondConfirm = await viewModel.confirm()
+        guard case let .failed(error) = secondConfirm else {
+            return XCTFail("Expected second confirm to fail after the intent is already confirmed.")
+        }
+        XCTAssertTrue(error is PaymentSheetError)
+        XCTAssertEqual(
+            (error as! PaymentSheetError).debugDescription,
+            PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent.debugDescription
+        )
+    }
+}
+
+// MARK: - Helpers
+
+private extension XCTestCase {
+    /// Helper to await an async throwing call and assert it throws an error.
+    func XCTAssertThrowsErrorAsync(
+        _ expression: @autoclosure @escaping () async throws -> Void,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async {
+        do {
+            try await expression()
+            XCTFail("Expected error to be thrown. " + message(), file: file, line: line)
+        } catch {
+            // Pass
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementViewModelTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementViewModelTests.swift
@@ -92,7 +92,6 @@ class EmbeddedPaymentElementViewModelTest: XCTestCase {
             return XCTFail("Expected an update to fail if not loaded.")
         }
 
-        XCTAssertTrue(error is EmbeddedPaymentElementViewModel.ViewModelError)
         XCTAssertEqual(error as? EmbeddedPaymentElementViewModel.ViewModelError, .notLoaded)
     }
 
@@ -104,7 +103,6 @@ class EmbeddedPaymentElementViewModelTest: XCTestCase {
             return XCTFail("Expected confirm to fail if not loaded.")
         }
 
-        XCTAssertTrue(error is EmbeddedPaymentElementViewModel.ViewModelError)
         XCTAssertEqual(error as? EmbeddedPaymentElementViewModel.ViewModelError, .notLoaded)
     }
 
@@ -258,7 +256,6 @@ class EmbeddedPaymentElementViewModelTest: XCTestCase {
         guard case let .failed(error) = updateResult else {
             return XCTFail("Expected update to fail after a successful confirmation.")
         }
-        XCTAssertTrue(error is PaymentSheetError)
         XCTAssertEqual(
             (error as! PaymentSheetError).debugDescription,
             PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent.debugDescription
@@ -292,7 +289,6 @@ class EmbeddedPaymentElementViewModelTest: XCTestCase {
         guard case let .failed(error) = secondConfirm else {
             return XCTFail("Expected second confirm to fail after the intent is already confirmed.")
         }
-        XCTAssertTrue(error is PaymentSheetError)
         XCTAssertEqual(
             (error as! PaymentSheetError).debugDescription,
             PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent.debugDescription


### PR DESCRIPTION
## Summary
- Adds the view model for the SwiftUI integration of embedded, defines the public interface for SwiftUI.
- View model manages an instance of the embedded payment element under the hood, and exposes SwiftUI specific APIs.
- Adds tests
- Follow up PR will add a UIViewRepresentable to actually display the embedded view using the view model.

## Motivation
https://docs.google.com/document/d/1EM5KA1nCrjSN9XZPZJr_VMppF20XvkOd6cb7rGnxcaw/edit?pli=1&tab=t.0

## Testing
- Unit tests

## Changelog
N/A
