### PR TITLE
Add style picker in MPE Playground app

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -24,6 +24,7 @@ struct PaymentSheetTestPlayground: View {
         if playgroundController.settings.uiStyle != .embedded {
             SettingView(setting: $playgroundController.settings.layout)
         }
+        SettingView(setting: $playgroundController.settings.style)
         SettingView(setting: $playgroundController.settings.shippingInfo)
         SettingView(setting: $playgroundController.settings.applePayEnabled)
         SettingView(setting: $playgroundController.settings.applePayButtonType)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -452,9 +452,17 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
+    enum ConfigurationStyle: String, PickerEnum {
+        static let enumName: String = "Style"
+        case automatic
+        case alwaysLight
+        case alwaysDark
+    }
+
     var uiStyle: UIStyle
     var layout: Layout
     var mode: Mode
+    var style: ConfigurationStyle
     var customerKeyType: CustomerKeyType
     var integrationType: IntegrationType
     var customerMode: CustomerMode
@@ -505,6 +513,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             uiStyle: .paymentSheet,
             layout: .automatic,
             mode: .payment,
+            style: .automatic,
             customerKeyType: .customerSession,
             integrationType: .normal,
             customerMode: .guest,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -184,6 +184,15 @@ class PlaygroundController: ObservableObject {
             configuration.cardBrandAcceptance = .allowed(brands: [.visa])
         }
         configuration.allowsSetAsDefaultPM = settings.allowsSetAsDefaultPM == .on
+
+        switch settings.style {
+        case .automatic:
+            configuration.style = .automatic
+        case .alwaysLight:
+            configuration.style = .alwaysLight
+        case .alwaysDark:
+            configuration.style = .alwaysDark
+        }
         return configuration
     }
 


### PR DESCRIPTION
## Summary

Allows configuring the specified `PaymentSheet.Configuration.UserInterfaceStyle` passed to the payment sheet in the playground app. Default picker value is `automatic`, which is the default configuration value, so this shouldn't introduce any new behavior.

## Motivation

For testing different appearance configurations

## Testing

https://github.com/user-attachments/assets/3380711c-6dec-46a0-adf4-e42fd4abc5db

## Changelog

N/a
