### PR TITLE
Disable embedded UI during confirmation

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -375,7 +375,6 @@ extension EmbeddedPaymentElement {
             deferredIntentConfirmationType: deferredIntentConfirmationType
         )
 
-        // If the confirmation was successful, disable user interaction
         if case .completed = result {
             hasConfirmedIntent = true
         } else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -379,7 +379,6 @@ extension EmbeddedPaymentElement {
         // If the confirmation was successful, disable user interaction
         if case .completed = result {
             hasConfirmedIntent = true
-            embeddedPaymentMethodsView.isUserInteractionEnabled = false
         } else {
             // Re-enable interaction for failed and canceled results
             embeddedPaymentMethodsView.isUserInteractionEnabled = true

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -341,7 +341,6 @@ extension EmbeddedPaymentElement {
             return (.failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent), nil)
         }
         
-        embeddedPaymentMethodsView.isUserInteractionEnabled = false
         // Wait for the last update to finish and fail if didn't succeed. A failure means the view is out of sync with the intent and could e.g. not be showing a required mandate.
         if let latestUpdateTask {
             switch await latestUpdateTask.value {
@@ -359,7 +358,8 @@ extension EmbeddedPaymentElement {
                 return (.failed(error: error), nil)
             }
         }
-
+        
+        embeddedPaymentMethodsView.isUserInteractionEnabled = false
         let (result, deferredIntentConfirmationType) = await PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: authContext,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -340,6 +340,8 @@ extension EmbeddedPaymentElement {
         guard !hasConfirmedIntent else {
             return (.failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent), nil)
         }
+        
+        embeddedPaymentMethodsView.isUserInteractionEnabled = false
         // Wait for the last update to finish and fail if didn't succeed. A failure means the view is out of sync with the intent and could e.g. not be showing a required mandate.
         if let latestUpdateTask {
             switch await latestUpdateTask.value {
@@ -377,7 +379,10 @@ extension EmbeddedPaymentElement {
         // If the confirmation was successful, disable user interaction
         if case .completed = result {
             hasConfirmedIntent = true
-            containerView.isUserInteractionEnabled = false
+            embeddedPaymentMethodsView.isUserInteractionEnabled = false
+        } else {
+            // Re-enable interaction for failed and canceled results
+            embeddedPaymentMethodsView.isUserInteractionEnabled = true
         }
 
         return (result, deferredIntentConfirmationType)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -340,7 +340,6 @@ extension EmbeddedPaymentElement {
         guard !hasConfirmedIntent else {
             return (.failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent), nil)
         }
-        
         // Wait for the last update to finish and fail if didn't succeed. A failure means the view is out of sync with the intent and could e.g. not be showing a required mandate.
         if let latestUpdateTask {
             switch await latestUpdateTask.value {


### PR DESCRIPTION
## Summary
- During confirmation we should disable the user interaction on the embedded view until we have a result
- Re-enable interaction for failed or canceled cases

## Motivation
https://stripe.slack.com/archives/C058XM768SE/p1738259151501839

## Testing
- Manual

## Changelog
N/A (private beta)
