### PR TITLE
Support networking relink flows

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		C7D2763ACCE2CC71E788E18F /* FinancialConnectionsLegalDetailsNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07526E95D85120F6492E78AE /* FinancialConnectionsLegalDetailsNotice.swift */; };
 		C906FC4DE38F16032B787607 /* ResetFlowDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1C78684DD0B2D168C86229 /* ResetFlowDataSource.swift */; };
 		CB734C25A19D38A87876FB2B /* FinancialConnectionsAnalyticsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AB8A480620B5C3567F453C /* FinancialConnectionsAnalyticsTest.swift */; };
+		CBB6227D2D4846670003AF44 /* FinancialConnectionsRepairSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB6227C2D4846670003AF44 /* FinancialConnectionsRepairSession.swift */; };
 		CBEAB081DD7353928F485071 /* APIPollingHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710183EE587F6FDA077FC150 /* APIPollingHelperTests.swift */; };
 		CBF7BE2271D309F2B1E794CC /* FinancialConnectionsDataAccessNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32ED8A7E94822F14AD94A698 /* FinancialConnectionsDataAccessNotice.swift */; };
 		CF47070B2A4CA27FEE9AE5FA /* generic_error@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = 6A764CF4DB5B5F6F488132A8 /* generic_error@3x.png */; };
@@ -498,6 +499,7 @@
 		C93F7139E9BFB044902962D0 /* FinancialConnectionsImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsImage.swift; sourceTree = "<group>"; };
 		CA2DA47ECE153F888FA675CE /* StripeiOS Tests-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS Tests-Debug.xcconfig"; sourceTree = "<group>"; };
 		CB3C49A180D1697B03C79A59 /* UIViewController+KeyboardAvoiding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+KeyboardAvoiding.swift"; sourceTree = "<group>"; };
+		CBB6227C2D4846670003AF44 /* FinancialConnectionsRepairSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsRepairSession.swift; sourceTree = "<group>"; };
 		CDD861E4EB8BA294545B7651 /* NetworkingLinkVerificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingLinkVerificationViewController.swift; sourceTree = "<group>"; };
 		CE10909F3FC7D60E13B65226 /* et-EE */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "et-EE"; path = "et-EE.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		CEC1BC95816DAD5AE9680662 /* FinancialConnectionsAccountFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsAccountFetcher.swift; sourceTree = "<group>"; };
@@ -765,6 +767,7 @@
 				D890BD770F4E33D23ABA37EA /* BankAccountToken.swift */,
 				359BF8ACFB35A16EBD96C4F0 /* FinancialConnectionsAccount.swift */,
 				5C837C27C2577391B91FF0E5 /* FinancialConnectionsAuthSession.swift */,
+				CBB6227C2D4846670003AF44 /* FinancialConnectionsRepairSession.swift */,
 				B3FD6A7D1638E42AA00C88C4 /* FinancialConnectionsBulletPoint.swift */,
 				3FD9739F1AA7CBA76DD3E1E2 /* FinancialConnectionsConsent.swift */,
 				32ED8A7E94822F14AD94A698 /* FinancialConnectionsDataAccessNotice.swift */,
@@ -1376,6 +1379,7 @@
 				76FB143918C5463B587091BB /* STPLocalizedString.swift in Sources */,
 				6A1D43052B17AD76005A1EB0 /* InstitutionTableFooterView.swift in Sources */,
 				ABB28C3F6604C2BA2FCA079D /* String+Extensions.swift in Sources */,
+				CBB6227D2D4846670003AF44 /* FinancialConnectionsRepairSession.swift in Sources */,
 				3FE4DEFAD6FF77B8D9EE68D3 /* String+Localized.swift in Sources */,
 				3ECA346F75060BD954376EBF /* StripeFinancialConnectionsBundleLocator.swift in Sources */,
 				6ABFE5572B7449390037437C /* ErrorDataSource.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -184,6 +184,8 @@ protocol FinancialConnectionsAPI {
     func fetchInstitutions(clientSecret: String, query: String) -> Future<FinancialConnectionsInstitutionSearchResultResource>
 
     func createAuthSession(clientSecret: String, institutionId: String) -> Promise<FinancialConnectionsAuthSession>
+    
+    func repairAuthSession(clientSecret: String, coreAuthorization: String) -> Promise<FinancialConnectionsRepairSession>
 
     func cancelAuthSession(clientSecret: String, authSessionId: String) -> Promise<FinancialConnectionsAuthSession>
 
@@ -453,6 +455,19 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         ]
         return self.post(
             resource: APIEndpointAuthSessions,
+            parameters: body,
+            useConsumerPublishableKeyIfNeeded: true
+        )
+    }
+    
+    func repairAuthSession(clientSecret: String, coreAuthorization: String) -> Promise<FinancialConnectionsRepairSession> {
+        let body: [String: Any] = [
+            "client_secret": clientSecret,
+            "core_authorization": coreAuthorization,
+            "return_url": "ios",
+        ]
+        return self.post(
+            resource: APIEndpointAuthSessionsRepair,
             parameters: body,
             useConsumerPublishableKeyIfNeeded: true
         )
@@ -1275,6 +1290,7 @@ private let APIEndpointAuthSessionsAuthorized = "connections/auth_sessions/autho
 private let APIEndpointAuthSessionsAccounts = "connections/auth_sessions/accounts"
 private let APIEndpointAuthSessionsSelectedAccounts = "connections/auth_sessions/selected_accounts"
 private let APIEndpointAuthSessionsEvents = "connections/auth_sessions/events"
+private let APIEndpointAuthSessionsRepair = "connections/repair_sessions/generate_url"
 // Networking
 private let APIEndpointDisableNetworking = "link_account_sessions/disable_networking"
 private let APIEndpointLinkStepUpAuthenticationVerified = "link_account_sessions/link_step_up_authentication_verified"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -252,7 +252,8 @@ protocol FinancialConnectionsAPI {
         phoneNumber: String?,
         country: String?,
         consumerSessionClientSecret: String?,
-        clientSecret: String
+        clientSecret: String,
+        isRelink: Bool
     ) -> Future<SaveAccountsToNetworkAndLinkResponse>
 
     func disableNetworking(
@@ -768,7 +769,8 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
         phoneNumber: String?,
         country: String?,
         consumerSessionClientSecret: String?,
-        clientSecret: String
+        clientSecret: String,
+        isRelink: Bool
     ) -> Future<SaveAccountsToNetworkAndLinkResponse> {
         let saveAccountsToLinkHandler: () -> Future<SaveAccountsToNetworkAndLinkResponse> = {
             return self.saveAccountsToLink(
@@ -780,10 +782,11 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
                 clientSecret: clientSecret
             )
             .chained { manifest in
+                let customSuccessPaneMessage = isRelink ? nil : manifest.displayText?.successPane?.subCaption
                 return Promise(
                     value: (
                         manifest: manifest,
-                        customSuccessPaneMessage: manifest.displayText?.successPane?.subCaption
+                        customSuccessPaneMessage: customSuccessPaneMessage
                     )
                 )
             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPIClient.swift
@@ -184,7 +184,7 @@ protocol FinancialConnectionsAPI {
     func fetchInstitutions(clientSecret: String, query: String) -> Future<FinancialConnectionsInstitutionSearchResultResource>
 
     func createAuthSession(clientSecret: String, institutionId: String) -> Promise<FinancialConnectionsAuthSession>
-    
+
     func repairAuthSession(clientSecret: String, coreAuthorization: String) -> Promise<FinancialConnectionsRepairSession>
 
     func cancelAuthSession(clientSecret: String, authSessionId: String) -> Promise<FinancialConnectionsAuthSession>
@@ -193,7 +193,7 @@ protocol FinancialConnectionsAPI {
         clientSecret: String,
         authSessionId: String
     ) -> Future<FinancialConnectionsAuthSession>
-    
+
     func retrieveAuthSessionPolling(
         clientSecret: String,
         authSessionId: String
@@ -465,7 +465,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
             useConsumerPublishableKeyIfNeeded: true
         )
     }
-    
+
     func repairAuthSession(clientSecret: String, coreAuthorization: String) -> Promise<FinancialConnectionsRepairSession> {
         let body: [String: Any] = [
             "client_secret": clientSecret,
@@ -505,7 +505,7 @@ extension FinancialConnectionsAPIClient: FinancialConnectionsAPI {
             useConsumerPublishableKeyIfNeeded: true
         )
     }
-    
+
     func retrieveAuthSessionPolling(
         clientSecret: String,
         authSessionId: String

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
@@ -102,7 +102,7 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
             try await self.createAuthSession(clientSecret: clientSecret, institutionId: institutionId)
         }
     }
-    
+
     func repairAuthSession(clientSecret: String, coreAuthorization: String) -> Promise<FinancialConnectionsRepairSession> {
         wrapAsyncToPromise {
             try await self.repairAuthSession(clientSecret: clientSecret, coreAuthorization: coreAuthorization)
@@ -126,7 +126,7 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
             try await self.retrieveAuthSession(clientSecret: clientSecret, authSessionId: authSessionId)
         }
     }
-    
+
     func retrieveAuthSessionPolling(
         clientSecret: String,
         authSessionId: String

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
@@ -102,6 +102,12 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
             try await self.createAuthSession(clientSecret: clientSecret, institutionId: institutionId)
         }
     }
+    
+    func repairAuthSession(clientSecret: String, coreAuthorization: String) -> Promise<FinancialConnectionsRepairSession> {
+        wrapAsyncToPromise {
+            try await self.repairAuthSession(clientSecret: clientSecret, coreAuthorization: coreAuthorization)
+        }
+    }
 
     func cancelAuthSession(
         clientSecret: String,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
@@ -126,6 +126,15 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
             try await self.retrieveAuthSession(clientSecret: clientSecret, authSessionId: authSessionId)
         }
     }
+    
+    func retrieveAuthSessionPolling(
+        clientSecret: String,
+        authSessionId: String
+    ) -> Future<FinancialConnectionsAuthSession> {
+        wrapAsyncToFuture {
+            try await self.retrieveAuthSessionPolling(clientSecret: clientSecret, authSessionId: authSessionId)
+        }
+    }
 
     func fetchAuthSessionOAuthResults(
         clientSecret: String,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Legacy.swift
@@ -252,7 +252,8 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
         phoneNumber: String?,
         country: String?,
         consumerSessionClientSecret: String?,
-        clientSecret: String
+        clientSecret: String,
+        isRelink: Bool
     ) -> Future<(manifest: FinancialConnectionsSessionManifest, customSuccessPaneMessage: String?)> {
         wrapAsyncToFuture {
             try await self.saveAccountsToNetworkAndLink(
@@ -262,7 +263,8 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
                 phoneNumber: phoneNumber,
                 country: country,
                 consumerSessionClientSecret: consumerSessionClientSecret,
-                clientSecret: clientSecret
+                clientSecret: clientSecret,
+                isRelink: isRelink
             )
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -272,7 +272,8 @@ protocol FinancialConnectionsAsyncAPI {
         phoneNumber: String?,
         country: String?,
         consumerSessionClientSecret: String?,
-        clientSecret: String
+        clientSecret: String,
+        isRelink: Bool
     ) async throws -> (
         manifest: FinancialConnectionsSessionManifest,
         customSuccessPaneMessage: String?
@@ -713,7 +714,8 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
         phoneNumber: String?,
         country: String?,
         consumerSessionClientSecret: String?,
-        clientSecret: String
+        clientSecret: String,
+        isRelink: Bool
     ) async throws -> (
         manifest: FinancialConnectionsSessionManifest,
         customSuccessPaneMessage: String?
@@ -730,10 +732,12 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
                 consumerSessionClientSecret: consumerSessionClientSecret,
                 clientSecret: clientSecret
             )
+            
+            let customSuccessPaneMessage = isRelink ? nil : manifest.displayText?.successPane?.subCaption
 
             return (
                 manifest: manifest,
-                customSuccessPaneMessage: manifest.displayText?.successPane?.subCaption
+                customSuccessPaneMessage: customSuccessPaneMessage
             )
         }
         if

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -501,7 +501,7 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
         ]
         return try await poll(
             initialPollDelay: 0,
-            maxNumberOfRetries: 300, // Stripe.js has 360 retries and 500ms intervals
+            maxNumberOfRetries: 360, // Stripe.js has 360 retries and 500ms intervals
             retryInterval: 0.5
         ) { [weak self] in
             guard let self else {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -215,7 +215,7 @@ protocol FinancialConnectionsAsyncAPI {
         clientSecret: String,
         authSessionId: String
     ) async throws -> FinancialConnectionsAuthSession
-    
+
     func retrieveAuthSessionPolling(
         clientSecret: String,
         authSessionId: String
@@ -462,7 +462,7 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
         ]
         return try await post(endpoint: .authSessions, parameters: parameters)
     }
-    
+
     func repairAuthSession(clientSecret: String, coreAuthorization: String) async throws -> FinancialConnectionsRepairSession {
         let parameters: [String: Any] = [
             "client_secret": clientSecret,
@@ -490,7 +490,7 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
         ]
         return try await post(endpoint: .authSessionsRetrieve, parameters: parameters)
     }
-    
+
     func retrieveAuthSessionPolling(
         clientSecret: String,
         authSessionId: String
@@ -499,7 +499,6 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
             "client_secret": clientSecret,
             "id": authSessionId,
         ]
-        
         return try await poll(
             initialPollDelay: 0,
             maxNumberOfRetries: 300, // Stripe.js has 360 retries and 500ms intervals
@@ -758,7 +757,7 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
                 consumerSessionClientSecret: consumerSessionClientSecret,
                 clientSecret: clientSecret
             )
-            
+
             let customSuccessPaneMessage = isRelink ? nil : manifest.displayText?.successPane?.subCaption
 
             return (

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -456,6 +456,15 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAsyncAPI {
         ]
         return try await post(endpoint: .authSessions, parameters: parameters)
     }
+    
+    func repairAuthSession(clientSecret: String, coreAuthorization: String) async throws -> FinancialConnectionsRepairSession {
+        let parameters: [String: Any] = [
+            "client_secret": clientSecret,
+            "core_authorization": coreAuthorization,
+            "return_url": "ios",
+        ]
+        return try await post(endpoint: .authSessions, parameters: parameters)
+    }
 
     func cancelAuthSession(clientSecret: String, authSessionId: String) async throws -> FinancialConnectionsAuthSession {
         let parameters = [
@@ -1107,6 +1116,7 @@ enum APIEndpoint: String {
     case authSessionsAccounts = "connections/auth_sessions/accounts"
     case authSessionsSelectedAccounts = "connections/auth_sessions/selected_accounts"
     case authSessionsEvents = "connections/auth_sessions/events"
+    case authSessionsRepair = "connections/repair_sessions/generate_url"
 
     // Networking
     case disableNetworking = "link_account_sessions/disable_networking"
@@ -1140,7 +1150,8 @@ enum APIEndpoint: String {
              .featuredInstitutions, .searchInstitutions, .authSessions,
              .authSessionsCancel, .authSessionsRetrieve, .authSessionsOAuthResults,
              .authSessionsAuthorized, .authSessionsAccounts, .authSessionsSelectedAccounts,
-             .authSessionsEvents, .networkedAccounts, .shareNetworkedAccount, .paymentDetails:
+             .authSessionsEvents, .networkedAccounts, .shareNetworkedAccount, .paymentDetails,
+             .authSessionsRepair:
             return true
         case .listAccounts, .sessionReceipt, .consentAcquired, .disableNetworking,
              .linkStepUpAuthenticationVerified, .linkVerified, .saveAccountsToLink,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsNetworkedAccountsResponse.swift
@@ -12,6 +12,7 @@ struct FinancialConnectionsNetworkedAccountsResponse: Decodable {
     let display: Display?
     let nextPaneOnAddAccount: FinancialConnectionsSessionManifest.NextPane?
     let acquireConsentOnPrimaryCtaClick: Bool?
+    let partnerToCoreAuths: [String: String]?
 
     struct Display: Decodable {
         let text: Text?

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsPartnerAccount.swift
@@ -21,6 +21,7 @@ struct FinancialConnectionsPartnerAccount: Decodable {
     let status: String?
     let institution: FinancialConnectionsInstitution?
     let nextPaneOnSelection: FinancialConnectionsSessionManifest.NextPane?
+    let authorization: String?
 
     var allowSelectionNonOptional: Bool {
         return allowSelection ?? true

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsRepairSession.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsRepairSession.swift
@@ -1,0 +1,17 @@
+//
+//  FinancialConnectionsRepairSession.swift
+//  StripeFinancialConnections
+//
+//  Created by Till Hellmund on 1/27/25.
+//
+
+import Foundation
+
+struct FinancialConnectionsRepairSession: Decodable {
+    let id: String
+    let flow: FinancialConnectionsAuthSession.Flow
+    let url: String
+    let isOauth: Bool
+    let display: FinancialConnectionsAuthSession.Display
+    let institution: FinancialConnectionsInstitution
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsRepairSession.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsRepairSession.swift
@@ -9,9 +9,9 @@ import Foundation
 
 struct FinancialConnectionsRepairSession: Decodable {
     let id: String
-    let flow: FinancialConnectionsAuthSession.Flow
-    let url: String
-    let isOauth: Bool
-    let display: FinancialConnectionsAuthSession.Display
-    let institution: FinancialConnectionsInstitution
+    let flow: FinancialConnectionsAuthSession.Flow?
+    let url: String?
+    let isOauth: Bool?
+    let display: FinancialConnectionsAuthSession.Display?
+    let institution: FinancialConnectionsInstitution?
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -185,8 +185,8 @@ extension FinancialConnectionsAnalyticsClient {
             return .consent
         case is InstitutionPickerViewController:
             return .institutionPicker
-        case is PartnerAuthViewController:
-            return .partnerAuth
+        case let partnerAuthViewController as PartnerAuthViewController:
+            return partnerAuthViewController.pane
         case is AccountPickerViewController:
             return .accountPicker
         case is AttachLinkedPaymentAccountViewController:

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerDataSource.swift
@@ -49,6 +49,7 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
     let reduceManualEntryProminenceInErrors: Bool
     let dataAccessNotice: FinancialConnectionsDataAccessNotice?
     let consumerSessionClientSecret: String?
+    private let isRelink: Bool
 
     private(set) var selectedAccounts: [FinancialConnectionsPartnerAccount] = [] {
         didSet {
@@ -67,7 +68,8 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
         analyticsClient: FinancialConnectionsAnalyticsClient,
         reduceManualEntryProminenceInErrors: Bool,
         dataAccessNotice: FinancialConnectionsDataAccessNotice?,
-        consumerSessionClientSecret: String?
+        consumerSessionClientSecret: String?,
+        isRelink: Bool
     ) {
         self.apiClient = apiClient
         self.clientSecret = clientSecret
@@ -79,6 +81,7 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
         self.reduceManualEntryProminenceInErrors = reduceManualEntryProminenceInErrors
         self.dataAccessNotice = dataAccessNotice
         self.consumerSessionClientSecret = consumerSessionClientSecret
+        self.isRelink = isRelink
     }
 
     func pollAuthSessionAccounts() -> Future<FinancialConnectionsAuthSessionAccounts> {
@@ -117,7 +120,8 @@ final class AccountPickerDataSourceImplementation: AccountPickerDataSource {
             phoneNumber: nil,
             country: nil,
             consumerSessionClientSecret: consumerSessionClientSecret,
-            clientSecret: clientSecret
+            clientSecret: clientSecret,
+            isRelink: isRelink
         )
         .chained { (_, customSuccessPaneMessage) in
             return Promise(value: customSuccessPaneMessage)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerBodyView.swift
@@ -142,7 +142,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                             ),
                             logo: nil
                         ),
-                        nextPaneOnSelection: .success
+                        nextPaneOnSelection: .success,
+                        authorization: nil
                     )
                 ),
                 (
@@ -171,7 +172,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         allowSelectionMessage: nil,
                         status: "disabled",
                         institution: nil,
-                        nextPaneOnSelection: .success
+                        nextPaneOnSelection: .success,
+                        authorization: nil
                     )
                 ),
                 (
@@ -198,7 +200,8 @@ private struct LinkAccountPickerBodyViewUIViewRepresentable: UIViewRepresentable
                         allowSelectionMessage: nil,
                         status: "disabled",
                         institution: nil,
-                        nextPaneOnSelection: .success
+                        nextPaneOnSelection: .success,
+                        authorization: nil
                     )
                 ),
             ],

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerDataSource.swift
@@ -21,6 +21,7 @@ protocol LinkAccountPickerDataSource: AnyObject {
     var manifest: FinancialConnectionsSessionManifest { get }
     var selectedAccounts: [FinancialConnectionsAccountTuple] { get }
     var nextPaneOnAddAccount: FinancialConnectionsSessionManifest.NextPane? { get set }
+    var partnerToCoreAuths: [String: String]? { get set }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var dataAccessNotice: FinancialConnectionsDataAccessNotice? { get }
     var acquireConsentOnPrimaryCtaClick: Bool { get }
@@ -37,6 +38,7 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
 
     let manifest: FinancialConnectionsSessionManifest
     var nextPaneOnAddAccount: FinancialConnectionsSessionManifest.NextPane?
+    var partnerToCoreAuths: [String: String]?
     let analyticsClient: FinancialConnectionsAnalyticsClient
     private let apiClient: any FinancialConnectionsAPI
     private let clientSecret: String
@@ -105,6 +107,7 @@ final class LinkAccountPickerDataSourceImplementation: LinkAccountPickerDataSour
         .chained { [weak self] response in
             self?.networkedAccountsResponse = response
             self?.nextPaneOnAddAccount = response.nextPaneOnAddAccount
+            self?.partnerToCoreAuths = response.partnerToCoreAuths
             return Promise(value: response)
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -33,7 +33,7 @@ protocol LinkAccountPickerViewControllerDelegate: AnyObject {
         _ viewController: LinkAccountPickerViewController,
         requestedPartnerAuthWithInstitution institution: FinancialConnectionsInstitution
     )
-    
+
     func linkAccountPickerViewController(
         _ viewController: LinkAccountPickerViewController,
         requestedBankAuthRepairWithInstitution institution: FinancialConnectionsInstitution,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -393,7 +393,9 @@ extension NativeFlowController {
                         )
                         finishAuthSession(.failed(error: FinancialConnectionsCustomManualEntryRequiredError()))
                     } else {
-                        if session.didCompleteSuccessfully || dataManager.pendingRelinkAuthorization != nil {
+                        if !session.accounts.data.isEmpty || session.paymentAccount != nil
+                            || session.bankAccountToken != nil
+                        {
                             if dataManager.manifest.isProductInstantDebits {
                                 // For Instant Debits, create a payment method and complete with it.
                                 createPaymentMethod(for: session) { result in
@@ -1762,12 +1764,5 @@ private func ShouldHideLogoInNavigationBar(
         }
     } else {
         return reducedBranding
-    }
-}
-
-private extension StripeAPI.FinancialConnectionsSession {
-    
-    var didCompleteSuccessfully: Bool {
-        return !accounts.data.isEmpty || paymentAccount != nil || bankAccountToken != nil
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -835,7 +835,7 @@ extension NativeFlowController: PartnerAuthViewControllerDelegate {
 
         showErrorPane(forError: error, referrerPane: .partnerAuth)
     }
-    
+
     func partnerAuthViewController(
         _ viewController: PartnerAuthViewController,
         didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane
@@ -1169,7 +1169,7 @@ extension NativeFlowController: LinkAccountPickerViewControllerDelegate {
         dataManager.institution = institution
         pushPane(.partnerAuth, animated: true)
     }
-    
+
     func linkAccountPickerViewController(
         _ viewController: LinkAccountPickerViewController,
         requestedBankAuthRepairWithInstitution institution: FinancialConnectionsInstitution,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -36,6 +36,7 @@ protocol NativeFlowDataManager: AnyObject {
     var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane? { get set }
     var customSuccessPaneCaption: String? { get set }
     var customSuccessPaneSubCaption: String? { get set }
+    var pendingRepairAuthorization: String? { get set }
 
     func createPaymentDetails(
         consumerSessionClientSecret: String,
@@ -98,6 +99,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane?
     var customSuccessPaneCaption: String?
     var customSuccessPaneSubCaption: String?
+    var pendingRepairAuthorization: String?
 
     var consumerSession: ConsumerSessionData? {
         didSet {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -36,7 +36,7 @@ protocol NativeFlowDataManager: AnyObject {
     var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane? { get set }
     var customSuccessPaneCaption: String? { get set }
     var customSuccessPaneSubCaption: String? { get set }
-    var pendingRepairAuthorization: String? { get set }
+    var pendingRelinkAuthorization: String? { get set }
 
     func createPaymentDetails(
         consumerSessionClientSecret: String,
@@ -99,7 +99,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     var lastPaneLaunched: FinancialConnectionsSessionManifest.NextPane?
     var customSuccessPaneCaption: String?
     var customSuccessPaneSubCaption: String?
-    var pendingRepairAuthorization: String?
+    var pendingRelinkAuthorization: String?
 
     var consumerSession: ConsumerSessionData? {
         didSet {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupDataSource.swift
@@ -111,7 +111,8 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
                     phoneNumber: nil,
                     country: nil,
                     consumerSessionClientSecret: response.consumerSession.clientSecret,
-                    clientSecret: clientSecret
+                    clientSecret: clientSecret,
+                    isRelink: false
                 )
             }
             .chained { (_, customSuccessPaneMessage) in
@@ -125,7 +126,8 @@ final class NetworkingLinkSignupDataSourceImplementation: NetworkingLinkSignupDa
                 phoneNumber: phoneNumber,
                 country: countryCode, // ex. "US"
                 consumerSessionClientSecret: nil,
-                clientSecret: clientSecret
+                clientSecret: clientSecret,
+                isRelink: false
             ).chained { (_, customSuccessPaneMessage) in
                 return Promise(value: customSuccessPaneMessage)
             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -70,7 +70,8 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
             phoneNumber: nil,
             country: nil,
             consumerSessionClientSecret: consumerSession.clientSecret,
-            clientSecret: clientSecret
+            clientSecret: clientSecret,
+            isRelink: false
         )
         .chained { (_, customSuccessPaneMessage) in
             return Promise(value: customSuccessPaneMessage)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
@@ -38,7 +38,7 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
     var disableAuthSessionRetrieval: Bool {
         return manifest.features?["bank_connections_disable_defensive_auth_session_retrieval_on_complete"] == true
     }
-    
+
     var isNetworkingRelinkSession: Bool {
         return relinkAuthorization != nil
     }
@@ -87,7 +87,6 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
                     isOauth: repairSession.isOauth,
                     display: repairSession.display
                 )
-                
                 self?.pendingAuthSession = authSession
                 return Promise(value: authSession)
             }
@@ -184,7 +183,7 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
             }
         )
     }
-    
+
     func pollAuthSession(_ authSession: FinancialConnectionsAuthSession) -> Future<FinancialConnectionsAuthSession> {
         return apiClient.retrieveAuthSessionPolling(
             clientSecret: clientSecret,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
@@ -23,6 +23,7 @@ protocol PartnerAuthDataSource: AnyObject {
     func recordAuthSessionEvent(eventName: String, authSessionId: String)
     func clearReturnURL(authSession: FinancialConnectionsAuthSession, authURL: String) -> Future<FinancialConnectionsAuthSession>
     func retrieveAuthSession(_ authSession: FinancialConnectionsAuthSession) -> Future<FinancialConnectionsAuthSession>
+    func pollAuthSession(_ authSession: FinancialConnectionsAuthSession) -> Future<FinancialConnectionsAuthSession>
 }
 
 final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
@@ -183,12 +184,19 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
             }
         )
     }
+    
+    func pollAuthSession(_ authSession: FinancialConnectionsAuthSession) -> Future<FinancialConnectionsAuthSession> {
+        return apiClient.retrieveAuthSessionPolling(
+            clientSecret: clientSecret,
+            authSessionId: authSession.id
+        )
+    }
 
     func recordAuthSessionEvent(
         eventName: String,
         authSessionId: String
     ) {
-        guard ShouldRecordAuthSessionEvent() else {
+        guard ShouldRecordAuthSessionEvent(), isNetworkingRelinkSession == false else {
             // on Stripe SDK Core analytics client we don't send events
             // for simulator or tests, so don't send these either...
             return

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthDataSource.swift
@@ -195,7 +195,7 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
         eventName: String,
         authSessionId: String
     ) {
-        guard ShouldRecordAuthSessionEvent(), isNetworkingRelinkSession == false else {
+        guard shouldRecordAuthSessionEvent() else {
             // on Stripe SDK Core analytics client we don't send events
             // for simulator or tests, so don't send these either...
             return
@@ -224,12 +224,12 @@ final class PartnerAuthDataSourceImplementation: PartnerAuthDataSource {
             return Promise(value: authSession)
         }
     }
-}
 
-private func ShouldRecordAuthSessionEvent() -> Bool {
-    #if targetEnvironment(simulator)
-    return false
-    #else
-    return NSClassFromString("XCTest") == nil
-    #endif
+    private func shouldRecordAuthSessionEvent() -> Bool {
+        #if targetEnvironment(simulator)
+        return false
+        #else
+        return isNetworkingRelinkSession == false && NSClassFromString("XCTest") == nil
+        #endif
+    }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -54,6 +54,10 @@ final class PartnerAuthViewController: SheetViewController {
     private var loadingView: UIView?
     private var legacyLoadingView: UIView?
     private var showLegacyBrowserOnViewDidAppear = false
+    
+    var pane: FinancialConnectionsSessionManifest.NextPane {
+        return dataSource.isNetworkingRelinkSession ? .bankAuthRepair : .partnerAuth
+    }
 
     init(
         dataSource: PartnerAuthDataSource,
@@ -137,7 +141,7 @@ final class PartnerAuthViewController: SheetViewController {
             prepaneViews = nil // the `deinit` of prepane views will remove views
             let prepaneViews = PrepaneViews(
                 prepaneModel: prepaneModel,
-                isRepairSession: false, // TODO(kgaidis): change this for repair sessions
+                hideSecondaryButton: dataSource.isNetworkingRelinkSession,
                 panePresentationStyle: panePresentationStyle,
                 appearance: dataSource.manifest.appearance,
                 didSelectURL: { [weak self] url in

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -54,7 +54,7 @@ final class PartnerAuthViewController: SheetViewController {
     private var loadingView: UIView?
     private var legacyLoadingView: UIView?
     private var showLegacyBrowserOnViewDidAppear = false
-    
+
     var pane: FinancialConnectionsSessionManifest.NextPane {
         return dataSource.isNetworkingRelinkSession ? .bankAuthRepair : .partnerAuth
     }
@@ -166,14 +166,14 @@ final class PartnerAuthViewController: SheetViewController {
                 didSelectCancel: { [weak self] in
                     guard let self = self else { return }
                     let isModal = panePresentationStyle == .sheet
-                    
+
                     self.dataSource.analyticsClient.log(
                         eventName: isModal ? "click.prepane.cancel" : "click.prepane.choose_another_bank",
                         pane: .partnerAuth
                     )
-                    
+
                     self.dataSource.cancelPendingAuthSessionIfNeeded()
-                    
+
                     if isModal {
                         self.delegate?.partnerAuthViewControllerDidRequestToGoBack(self)
                     } else {
@@ -520,7 +520,7 @@ final class PartnerAuthViewController: SheetViewController {
                 self?.handleAuthSessionRetrieved(result)
             }
     }
-    
+
     private func pollAuthSession(_ authSession: FinancialConnectionsAuthSession) {
         showLoadingView(true)
         dataSource
@@ -529,12 +529,12 @@ final class PartnerAuthViewController: SheetViewController {
                 self?.handleAuthSessionRetrieved(result)
             }
     }
-    
+
     private func handleAuthSessionRetrieved(_ result: Result<FinancialConnectionsAuthSession, any Error>) {
         switch result {
         case .success(let authSession):
             self.didComplete(withAuthSession: authSession)
-            
+
             // hide the loading view after a delay to prevent
             // the screen from flashing _while_ the transition
             // to the next screen takes place

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PrepaneViews.swift
@@ -32,7 +32,7 @@ final class PrepaneViews {
 
     init(
         prepaneModel: FinancialConnectionsOAuthPrepane,
-        isRepairSession: Bool,
+        hideSecondaryButton: Bool,
         panePresentationStyle: PanePresentationStyle,
         appearance: FinancialConnectionsAppearance,
         didSelectURL: @escaping (URL) -> Void,
@@ -71,7 +71,7 @@ final class PrepaneViews {
                 action: didSelectContinue
             ),
             secondaryButtonConfiguration: {
-                if isRepairSession {
+                if hideSecondaryButton {
                     return nil
                 } else {
                     return PaneLayoutView.ButtonConfiguration(
@@ -207,7 +207,7 @@ private class PrepanePreviewView: UIView {
                 cta: "OK"
             )
         ),
-        isRepairSession: false,
+        hideSecondaryButton: false,
         panePresentationStyle: .sheet,
         appearance: .stripe,
         didSelectURL: { _ in },

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -57,7 +57,7 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
     func createAuthSession(clientSecret: String, institutionId: String) -> Promise<FinancialConnectionsAuthSession> {
         return Promise<FinancialConnectionsAuthSession>()
     }
-    
+
     func repairAuthSession(clientSecret: String, coreAuthorization: String) -> Promise<FinancialConnectionsRepairSession> {
         return Promise<FinancialConnectionsRepairSession>()
     }
@@ -72,7 +72,7 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
     ) -> Future<FinancialConnectionsAuthSession> {
         return Promise<FinancialConnectionsAuthSession>()
     }
-    
+
     func retrieveAuthSessionPolling(clientSecret: String, authSessionId: String) -> Future<FinancialConnectionsAuthSession> {
         return Promise<FinancialConnectionsAuthSession>()
     }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -72,6 +72,10 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
     ) -> Future<FinancialConnectionsAuthSession> {
         return Promise<FinancialConnectionsAuthSession>()
     }
+    
+    func retrieveAuthSessionPolling(clientSecret: String, authSessionId: String) -> Future<FinancialConnectionsAuthSession> {
+        return Promise<FinancialConnectionsAuthSession>()
+    }
 
     func fetchAuthSessionOAuthResults(clientSecret: String, authSessionId: String) -> Future<
         FinancialConnectionsMixedOAuthParams
@@ -143,7 +147,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
         phoneNumber: String?,
         country: String?,
         consumerSessionClientSecret: String?,
-        clientSecret: String
+        clientSecret: String,
+        isRelink: Bool
     ) -> Future<(
         manifest: FinancialConnectionsSessionManifest,
         customSuccessPaneMessage: String?

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -57,6 +57,10 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
     func createAuthSession(clientSecret: String, institutionId: String) -> Promise<FinancialConnectionsAuthSession> {
         return Promise<FinancialConnectionsAuthSession>()
     }
+    
+    func repairAuthSession(clientSecret: String, coreAuthorization: String) -> Promise<FinancialConnectionsRepairSession> {
+        return Promise<FinancialConnectionsRepairSession>()
+    }
 
     func cancelAuthSession(clientSecret: String, authSessionId: String) -> Promise<FinancialConnectionsAuthSession> {
         return Promise<FinancialConnectionsAuthSession>()


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request adds support for networking relink flows in Financial Connections and Instant Bank Payments.

We reuse the existing partner auth pane, but add an optional `relinkAuthorization: String?` to `PartnerAuthDataSourceImplementation`. Depending on this payload, we either create an auth session or a repair session; the latter of which we then map to an auth session on the client.

This pull request also includes the minor tweak to hide the secondary button in this flow.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
