### PR TITLE
Fix embedded bug where update didnt set form VC delegate and clean up…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
@@ -155,8 +155,6 @@ class EmbeddedFormViewController: UIViewController {
 
     weak var delegate: EmbeddedFormViewControllerDelegate?
 
-    // MARK: - Initializers
-
     init(configuration: EmbeddedPaymentElement.Configuration,
          intent: Intent,
          elementsSession: STPElementsSession,
@@ -164,7 +162,9 @@ class EmbeddedFormViewController: UIViewController {
          paymentMethodType: PaymentSheet.PaymentMethodType,
          previousPaymentOption: PaymentOption? = nil,
          analyticsHelper: PaymentSheetAnalyticsHelper,
-         formCache: PaymentMethodFormCache = .init()) {
+         formCache: PaymentMethodFormCache = .init(),
+         delegate: EmbeddedFormViewControllerDelegate
+    ) {
         self.intent = intent
         self.elementsSession = elementsSession
         self.shouldUseNewCardNewCardHeader = shouldUseNewCardNewCardHeader
@@ -173,6 +173,7 @@ class EmbeddedFormViewController: UIViewController {
         self.analyticsHelper = analyticsHelper
         self.paymentMethodType = paymentMethodType
         self.formCache = formCache
+        self.delegate = delegate
 
         super.init(nibName: nil, bundle: nil)
 
@@ -250,7 +251,12 @@ class EmbeddedFormViewController: UIViewController {
     }
 
     private func didCancel() {
-        delegate?.embeddedFormViewControllerDidCancel(self)
+        if let delegate {
+            delegate.embeddedFormViewControllerDidCancel(self)
+        } else {
+            stpAssertionFailure()
+            dismiss(animated: true)
+        }
     }
 
     required init?(coder: NSCoder) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -103,7 +103,10 @@ extension EmbeddedPaymentElement {
     }
 
     // Helper method to create Form VC for a payment method row, if applicable.
-    func makeFormViewControllerIfNecessary(selection: EmbeddedPaymentMethodsView.Selection?) -> EmbeddedFormViewController? {
+    func makeFormViewControllerIfNecessary(
+        selection: EmbeddedPaymentMethodsView.Selection?,
+        previousPaymentOption: PaymentOption?
+    ) -> EmbeddedFormViewController? {
         guard case let .new(paymentMethodType) = selection else {
             return nil
         }
@@ -114,7 +117,7 @@ extension EmbeddedPaymentElement {
             elementsSession: elementsSession,
             shouldUseNewCardNewCardHeader: savedPaymentMethods.first?.type == .card,
             paymentMethodType: paymentMethodType,
-            previousPaymentOption: self.selectedFormViewController?.previousPaymentOption,
+            previousPaymentOption:previousPaymentOption,
             analyticsHelper: analyticsHelper,
             formCache: formCache,
             delegate: self
@@ -136,7 +139,10 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
     func embeddedPaymentMethodsViewDidUpdateSelection() {
         // 1. Update the currently selection's form VC to match the selection.
         // Note `paymentOption` derives from this property
-        self.selectedFormViewController = makeFormViewControllerIfNecessary(selection: embeddedPaymentMethodsView.selection)
+        self.selectedFormViewController = makeFormViewControllerIfNecessary(
+            selection: embeddedPaymentMethodsView.selection,
+            previousPaymentOption:  selectedFormViewController?.previousPaymentOption
+        )
 
         // 2. Inform the delegate of the updated payment option
         informDelegateIfPaymentOptionUpdated()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -116,9 +116,9 @@ extension EmbeddedPaymentElement {
             paymentMethodType: paymentMethodType,
             previousPaymentOption: self.selectedFormViewController?.previousPaymentOption,
             analyticsHelper: analyticsHelper,
-            formCache: formCache
+            formCache: formCache,
+            delegate: self
         )
-        formViewController.delegate = self
         guard formViewController.collectsUserInput else {
             return nil
         }
@@ -151,6 +151,7 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         delegate?.embeddedPaymentElementWillPresent(embeddedPaymentElement: self)
         let bottomSheet = bottomSheetController(with: selectedFormViewController)
         stpAssert(presentingViewController != nil, "Presenting view controller not found, set EmbeddedPaymentElement.presentingViewController.")
+        stpAssert(selectedFormViewController.delegate != nil)
         presentingViewController?.presentAsBottomSheet(bottomSheet, appearance: configuration.appearance)
 
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -139,7 +139,6 @@ public final class EmbeddedPaymentElement {
 
             // 2. At this point, we're still the latest update and update is successful - update self properties and inform our delegate.
             let previousPaymentOption = self._paymentOption
-            let previousDisplayData = self.paymentOption
             self.loadResult = loadResult
             self.savedPaymentMethods = loadResult.savedPaymentMethods
             self.formCache = .init() // Clear the cache because the form may have changed e.g. different mandate or different fields.
@@ -150,11 +149,12 @@ public final class EmbeddedPaymentElement {
                 previousPaymentOption: previousPaymentOption,
                 delegate: self
             )
-            self.selectedFormViewController = makeFormViewControllerIfNecessary(selection: self.embeddedPaymentMethodsView.selection)
+            self.selectedFormViewController = makeFormViewControllerIfNecessary(
+                selection: self.embeddedPaymentMethodsView.selection,
+                previousPaymentOption: previousPaymentOption
+            )
             self.containerView.updateEmbeddedPaymentMethodsView(embeddedPaymentMethodsView)
-            if previousDisplayData != self.paymentOption {
-                self.delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: self)
-            }
+            informDelegateIfPaymentOptionUpdated()
             return .succeeded
         }
         self.latestUpdateTask = currentUpdateTask
@@ -204,7 +204,7 @@ public final class EmbeddedPaymentElement {
 #endif
 
         // Notify the delegate that the payment option has changed
-        delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: self)
+        informDelegateIfPaymentOptionUpdated()
     }
 
     #if DEBUG

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedFormViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedFormViewControllerSnapshotTests.swift
@@ -40,7 +40,8 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
             shouldUseNewCardNewCardHeader: loadResult.savedPaymentMethods.first?.type == .card,
             paymentMethodType: .stripe(paymentMethodType),
             previousPaymentOption: previousPaymentOption,
-            analyticsHelper: ._testValue()
+            analyticsHelper: ._testValue(),
+            delegate: self
         )
     }
 
@@ -176,4 +177,18 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
         verify(sut)
     }
 
+}
+
+extension EmbeddedFormViewControllerSnapshotTests: EmbeddedFormViewControllerDelegate {
+    func embeddedFormViewControllerShouldConfirm(_ embeddedFormViewController: StripePaymentSheet.EmbeddedFormViewController, with paymentOption: StripePaymentSheet.PaymentOption, completion: @escaping (StripePaymentSheet.PaymentSheetResult, StripeCore.STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void) {
+    }
+    
+    func embeddedFormViewControllerDidCompleteConfirmation(_ embeddedFormViewController: StripePaymentSheet.EmbeddedFormViewController, result: StripePaymentSheet.PaymentSheetResult) {
+    }
+    
+    func embeddedFormViewControllerDidCancel(_ embeddedFormViewController: StripePaymentSheet.EmbeddedFormViewController) {
+    }
+    
+    func embeddedFormViewControllerDidContinue(_ embeddedFormViewController: StripePaymentSheet.EmbeddedFormViewController) {
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedFormViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedFormViewControllerSnapshotTests.swift
@@ -9,6 +9,7 @@
 @_spi(STP) import StripePayments
 @_spi(STP)  @_spi(EmbeddedPaymentElementPrivateBeta) @testable import StripePaymentSheet
 @_spi(STP) import StripeUICore
+@_spi(STP) import StripeCore
 import XCTest
 
 final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
@@ -180,7 +181,7 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
 }
 
 extension EmbeddedFormViewControllerSnapshotTests: EmbeddedFormViewControllerDelegate {
-    func embeddedFormViewControllerShouldConfirm(_ embeddedFormViewController: StripePaymentSheet.EmbeddedFormViewController, with paymentOption: StripePaymentSheet.PaymentOption, completion: @escaping (StripePaymentSheet.PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void) {
+    func embeddedFormViewControllerShouldConfirm(_ embeddedFormViewController: StripePaymentSheet.EmbeddedFormViewController, with paymentOption: StripePaymentSheet.PaymentOption, completion: @escaping (StripePaymentSheet.PaymentSheetResult, StripeCore.STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void) {
     }
     
     func embeddedFormViewControllerDidCompleteConfirmation(_ embeddedFormViewController: StripePaymentSheet.EmbeddedFormViewController, result: StripePaymentSheet.PaymentSheetResult) {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedFormViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedFormViewControllerSnapshotTests.swift
@@ -84,7 +84,7 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
     }
 
     func testDisplayCard_continueFormSheetAction() {
-        var configuration = EmbeddedPaymentElement.Configuration()
+        let configuration = EmbeddedPaymentElement.Configuration()
         let sut = makeEmbeddedFormViewController(
             configuration: configuration,
             paymentMethodType: .card
@@ -180,7 +180,7 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
 }
 
 extension EmbeddedFormViewControllerSnapshotTests: EmbeddedFormViewControllerDelegate {
-    func embeddedFormViewControllerShouldConfirm(_ embeddedFormViewController: StripePaymentSheet.EmbeddedFormViewController, with paymentOption: StripePaymentSheet.PaymentOption, completion: @escaping (StripePaymentSheet.PaymentSheetResult, StripeCore.STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void) {
+    func embeddedFormViewControllerShouldConfirm(_ embeddedFormViewController: StripePaymentSheet.EmbeddedFormViewController, with paymentOption: StripePaymentSheet.PaymentOption, completion: @escaping (StripePaymentSheet.PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void) {
     }
     
     func embeddedFormViewControllerDidCompleteConfirmation(_ embeddedFormViewController: StripePaymentSheet.EmbeddedFormViewController, result: StripePaymentSheet.PaymentSheetResult) {


### PR DESCRIPTION
… implementation

## Summary
<!-- Simple summary of what was changed. -->

## Motivation
If you fill out a form (eg card), then update, then tap back into the form, the sheet is stuck open and can't be dismissed. 

## Testing
Manual tests. Added checks/asserts so that tests will fail if this regresses.

## Changelog
Not user facing, bug didn't get released.