### PR TITLE
Fix testmode autofill banner in darkmode

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/TestModeAutofillBannerView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/TestModeAutofillBannerView.swift
@@ -63,9 +63,7 @@ class TestModeAutofillBannerView: UIView {
         let label = UILabel()
         label.attributedText = attributedString
         label.font = FinancialConnectionsFont.body(.small).uiFont
-        // Staticly use the light-mode font color here to contrast with yellow background.
-        let lightTrait = UITraitCollection(userInterfaceStyle: .light)
-        label.textColor = FinancialConnectionsAppearance.Colors.textDefault.resolvedColor(with: lightTrait)
+        label.textColor = FinancialConnectionsAppearance.Colors.textDefault
         label.numberOfLines = 0
         label.lineBreakMode = .byWordWrapping
         return label

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
@@ -22,7 +22,7 @@ struct FinancialConnectionsAppearance: Equatable {
         static let icon: UIColor = .dynamic(light: .neutral700, dark: .neutral25)
         static let borderNeutral: UIColor = .dynamic(light: .neutral100, dark: .neutral100Dark)
         static let spinnerNeutral: UIColor = .neutral200
-        static let warningLight: UIColor = .attention50
+        static let warningLight: UIColor = .dynamic(light: .attention50, dark: .attention50Dark)
         static let warning: UIColor = .attention300
 
         // These colors change based on the manifest's theme.
@@ -136,6 +136,10 @@ private extension UIColor {
     // MARK: Attention
     static var attention50: UIColor {
         return UIColor(red: 254 / 255.0, green: 249 / 255.0, blue: 218 / 255.0, alpha: 1)  // #fef9da
+    }
+
+    static var attention50Dark: UIColor {
+        return UIColor(red: 64 / 255.0, green: 10 / 255.0, blue: 0 / 255.0, alpha: 1)  // #400a00
     }
 
     static var attention300: UIColor {


### PR DESCRIPTION
## Summary

Adjust the colors used on the testmode autofill banner to be dark-mode friendly.

## Motivation

✨ 

## Testing

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 - 2025-02-03 at 09 42 49](https://github.com/user-attachments/assets/7d675544-5c0d-4f16-837d-a10da42672a3) | ![Simulator Screenshot - iPhone 16 - 2025-02-03 at 09 41 12](https://github.com/user-attachments/assets/ee5c8acd-ae70-4b76-a4e6-4a8eee2f2894) | 

## Changelog

N/a