### PR TITLE
Update `icon.background` for dark mode

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
@@ -61,7 +61,7 @@ extension FinancialConnectionsAppearance.Colors {
         textFieldFocused: .brand600,
         logo: .dynamic(light: .brand600, dark: .neutral0),
         iconTint: .brand500,
-        iconBackground: .brand25,
+        iconBackground: .dynamic(light: .brand25, dark: .brand25Dark),
         spinner: .brand500,
         border: .brand600
     )
@@ -73,7 +73,7 @@ extension FinancialConnectionsAppearance.Colors {
         textFieldFocused: .linkGreen200,
         logo: .dynamic(light: .linkGreen900, dark: .neutral0),
         iconTint: .linkGreen500,
-        iconBackground: .linkGreen50,
+        iconBackground: .dynamic(light: .linkGreen50, dark: .linkGreen50Dark),
         spinner: .linkGreen200,
         border: .linkGreen200
     )
@@ -157,6 +157,10 @@ private extension UIColor {
         return UIColor(red: 247 / 255.0, green: 245 / 255.0, blue: 253 / 255.0, alpha: 1)  // #f7f5fd
     }
 
+    static var brand25Dark: UIColor {
+        return UIColor(red: 26 / 255.0, green: 27 / 255.0, blue: 46 / 255.0, alpha: 1)  // #1A1B2E
+    }
+
     static var brand500: UIColor {
         return UIColor(red: 103 / 255.0, green: 93 / 255.0, blue: 255 / 255.0, alpha: 1)  // #675dff
     }
@@ -168,6 +172,10 @@ private extension UIColor {
     // MARK: Link
     static var linkGreen50: UIColor {
         return UIColor(red: 230 / 255.0, green: 255 / 255.0, blue: 237 / 255.0, alpha: 1)  // #e6ffed
+    }
+
+    static var linkGreen50Dark: UIColor {
+        return UIColor(red: 22 / 255.0, green: 33 / 255.0, blue: 31 / 255.0, alpha: 1)  // #16211f
     }
 
     static var linkGreen200: UIColor {


### PR DESCRIPTION
## Summary

Updates the icon background color used in dark mode. The previous light appearance color seemed out of place in a dark appearance.

## Motivation

💅 

## Testing

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 - 2025-02-03 at 10 41 08](https://github.com/user-attachments/assets/c0c7c97e-fb7b-41c5-b6a2-dff11a403ea3) | ![Simulator Screenshot - iPhone 16 - 2025-02-03 at 15 11 40](https://github.com/user-attachments/assets/21562d4e-d5c3-4e47-a23e-a67ff14cc7de) | 
| ![Simulator Screenshot - iPhone 16 - 2025-02-03 at 10 43 34](https://github.com/user-attachments/assets/798d5a81-c28e-4c5d-8fb3-2dd60b903778) | ![Simulator Screenshot - iPhone 16 - 2025-02-03 at 13 00 23](https://github.com/user-attachments/assets/59c3852d-6145-47aa-86e3-8701eeb1e0ac) | 

## Changelog

N/a