### PR TITLE
Fix keeping row selection across updates even when form is invalid

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -50,6 +50,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Reload"].waitForExistence(timeout: 10))
         // ...should cause Card to no longer be the selected payment method.
         XCTAssertFalse(app.staticTexts["Payment method"].exists)
+        XCTAssertFalse(app.buttons["Card"].isSelected)
 
         // ....Tapping card should show the card form with details preserved
         app.buttons["Card"].waitForExistenceAndTap()
@@ -65,6 +66,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         // ...card entered for setup should be preserved after update
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
+        XCTAssertTrue(app.buttons["Card"].isSelected)
 
         // ...selecting Alipay w/ deferred PaymentIntent...
         app.buttons["Alipay"].waitForExistenceAndTap()
@@ -82,6 +84,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Reload"].waitForExistence(timeout: 10))
         // ...should cause Alipay to no longer be the selected payment method, since it is not valid for setup.
         XCTAssertFalse(app.staticTexts["Payment method"].exists)
+        XCTAssertFalse(app.buttons["Alipay"].exists)
 
         // ...go back into deferred PaymentIntent mode
         app.buttons.matching(identifier: "Payment").element(boundBy: 1).waitForExistenceAndTap()
@@ -96,6 +99,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Reload"].waitForExistence(timeout: 10))
         // ...should cause Cash App Pay to be the selected payment method, since it is valid for setup.
         XCTAssertEqual(app.staticTexts["Payment method"].label, "Cash App Pay")
+        XCTAssertTrue(app.buttons["Cash App Pay"].isSelected)
 
         // ...go back into deferred PaymentIntent mode
         app.buttons.matching(identifier: "Payment").element(boundBy: 1).waitForExistenceAndTap()
@@ -115,9 +119,11 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Reload"].waitForExistence(timeout: 10))
         // ...should cause Klarna to no longer be the selected payment method.
         XCTAssertFalse(app.staticTexts["Payment method"].exists)
+        XCTAssertFalse(app.buttons["Klarna"].isSelected)
         // ...selecting Klarna should present a Klarna form with the previously entered email
         app.buttons["Klarna"].waitForExistenceAndTap()
         app.buttons["Continue"].waitForExistenceAndTap()
+        XCTAssertTrue(app.buttons["Klarna"].isSelected)
 
         let klarnaAnalytics = analyticsLog.compactMap({ $0[string: "event"] })
         XCTAssertEqual(
@@ -131,6 +137,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Reload"].waitForExistence(timeout: 10))
         // ... Klarna should still be selected
         XCTAssertEqual(app.staticTexts["Payment method"].label, "Klarna")
+        XCTAssertTrue(app.buttons["Klarna"].isSelected)
 
         // Confirm the Klarna payment
         XCTAssertTrue(app.buttons["Checkout"].waitForExistence(timeout: 10))


### PR DESCRIPTION
## Summary 
Tried to make the `update` implementation clearer and more foolproof while fixing a bug I introduced in https://github.com/stripe/stripe-ios/pull/4529 where the embedded view was persisting the row selection even when the form was invalid.

## Testing
Added checks to ensure the bug can't happen again

## Changelog
n/a