### PR TITLE
Fix bug after updating selected CBC card

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -181,6 +181,7 @@
 		61C87E1E2CB81FAD001B7DA9 /* CardBrandFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61C87E1C2CB81F9B001B7DA9 /* CardBrandFilterTests.swift */; };
 		61CB0BD02BED985100E24A4C /* VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CBE6672BED97EE005F7FEB /* VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift */; };
 		61CBE6662BED9749005F7FEB /* VerticalSavedPaymentMethodsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CBE6652BED9749005F7FEB /* VerticalSavedPaymentMethodsViewController.swift */; };
+		61CCFE6B2D5AB7EB00DA8892 /* SavedPaymentMethodRowButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61CCFE6A2D5AB7EB00DA8892 /* SavedPaymentMethodRowButtonTests.swift */; };
 		61D842892CADE4B9009D2D51 /* PaymentElementConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D842882CADE4B9009D2D51 /* PaymentElementConfiguration.swift */; };
 		61D842912CB06047009D2D51 /* FormMandateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D842902CB06047009D2D51 /* FormMandateProviderTests.swift */; };
 		61D8688E2C06553E001FAD84 /* RightAccessoryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D8688D2C06553E001FAD84 /* RightAccessoryButton.swift */; };
@@ -612,6 +613,7 @@
 		61C87E1C2CB81F9B001B7DA9 /* CardBrandFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardBrandFilterTests.swift; sourceTree = "<group>"; };
 		61CBE6652BED9749005F7FEB /* VerticalSavedPaymentMethodsViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalSavedPaymentMethodsViewController.swift; sourceTree = "<group>"; };
 		61CBE6672BED97EE005F7FEB /* VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
+		61CCFE6A2D5AB7EB00DA8892 /* SavedPaymentMethodRowButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPaymentMethodRowButtonTests.swift; sourceTree = "<group>"; };
 		61D842882CADE4B9009D2D51 /* PaymentElementConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentElementConfiguration.swift; sourceTree = "<group>"; };
 		61D842902CB06047009D2D51 /* FormMandateProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormMandateProviderTests.swift; sourceTree = "<group>"; };
 		61D8688D2C06553E001FAD84 /* RightAccessoryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightAccessoryButton.swift; sourceTree = "<group>"; };
@@ -1676,6 +1678,7 @@
 				31699A822BE183D40048677F /* DownloadManagerTest.swift */,
 				73FB30705EC36BD0868904A2 /* Elements+TestHelpers.swift */,
 				B6CACC9F2CBD9A3300682ECE /* EmbeddedPaymentElementTest.swift */,
+				61CCFE6A2D5AB7EB00DA8892 /* SavedPaymentMethodRowButtonTests.swift */,
 				6123E94E2D4A86BA0088FBE8 /* EmbeddedPaymentElementViewModelTests.swift */,
 				B63DC6792CC06AC80011C27E /* EmbeddedPaymentElementSnapshotTests.swift */,
 				61FB6BCC2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift */,
@@ -2067,6 +2070,7 @@
 				B64FEF122C0FAC1E00F7CA26 /* PaymentSheetVerticalViewControllerTest.swift in Sources */,
 				4A1A0A542B824C830A200BE0 /* StubbedBackend.swift in Sources */,
 				6151DDC02B14FDCF00ED4F7E /* UpdatePaymentMethodViewControllerSnapshotTests.swift in Sources */,
+				61CCFE6B2D5AB7EB00DA8892 /* SavedPaymentMethodRowButtonTests.swift in Sources */,
 				34CF08CBC636F596B8BA4C12 /* TextFieldElement+CardTest.swift in Sources */,
 				52B734BA0B91706F37025523 /* STPAnalyticsClient+PaymentSheetTests.swift in Sources */,
 				AE8EF3966E7BABDFC3B426ED /* PaymentSheet+DashboardConfirmParamsTest.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/SavedPaymentMethodRowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/SavedPaymentMethodRowButton.swift
@@ -25,11 +25,11 @@ final class SavedPaymentMethodRowButton: UIView {
     }
 
     // MARK: Internal properties
-    
+
     let paymentMethod: STPPaymentMethod
     let showDefaultPMBadge: Bool
     weak var delegate: SavedPaymentMethodRowButtonDelegate?
-    
+
     var state: State = .unselected {
         didSet {
             if oldValue == .selected || oldValue == .unselected {
@@ -49,11 +49,11 @@ final class SavedPaymentMethodRowButton: UIView {
             return false
         }
     }
-    
+
     // MARK: - Private properties
 
     private let appearance: PaymentSheet.Appearance
-    
+
     private var isEditing: Bool {
         switch state {
         case .selected, .unselected:
@@ -62,7 +62,7 @@ final class SavedPaymentMethodRowButton: UIView {
             return true
         }
     }
-    
+
     private(set) var previousSelectedState: State = .unselected
 
     // MARK: Private views
@@ -110,8 +110,7 @@ final class SavedPaymentMethodRowButton: UIView {
     @objc private func handleRowButtonTapped(_: RowButton) {
         if isEditing {
             delegate?.didSelectUpdateButton(self, with: paymentMethod)
-        }
-        else {
+        } else {
             state = .selected
             delegate?.didSelectButton(self, with: paymentMethod)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/SavedPaymentMethodRowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/SavedPaymentMethodRowButton.swift
@@ -25,6 +25,11 @@ final class SavedPaymentMethodRowButton: UIView {
     }
 
     // MARK: Internal properties
+    
+    let paymentMethod: STPPaymentMethod
+    let showDefaultPMBadge: Bool
+    weak var delegate: SavedPaymentMethodRowButtonDelegate?
+    
     var state: State = .unselected {
         didSet {
             if oldValue == .selected || oldValue == .unselected {
@@ -32,11 +37,9 @@ final class SavedPaymentMethodRowButton: UIView {
             }
 
             rowButton.isSelected = isSelected
-            chevronButton.isHidden = !canUpdate && !canRemove
+            chevronButton.isHidden = !isEditing
         }
     }
-
-    var previousSelectedState: State = .unselected
 
     var isSelected: Bool {
         switch state {
@@ -46,9 +49,11 @@ final class SavedPaymentMethodRowButton: UIView {
             return false
         }
     }
+    
+    // MARK: - Private properties
 
-    let showDefaultPMBadge: Bool
-
+    private let appearance: PaymentSheet.Appearance
+    
     private var isEditing: Bool {
         switch state {
         case .selected, .unselected:
@@ -57,41 +62,18 @@ final class SavedPaymentMethodRowButton: UIView {
             return true
         }
     }
-
-    private var canUpdate: Bool {
-        switch state {
-        case .selected, .unselected:
-            return false
-        case .editing(_, let allowsUpdating):
-            return allowsUpdating
-        }
-    }
-
-    private var canRemove: Bool {
-        switch state {
-        case .selected, .unselected:
-            return false
-        case .editing(let allowsRemoval, _):
-            return allowsRemoval
-        }
-    }
-
-    weak var delegate: SavedPaymentMethodRowButtonDelegate?
-
-    // MARK: Internal/private properties
-    let paymentMethod: STPPaymentMethod
-    private let appearance: PaymentSheet.Appearance
+    
+    private(set) var previousSelectedState: State = .unselected
 
     // MARK: Private views
 
-    private lazy var chevronButton: RowButton.RightAccessoryButton = {
+    private(set) lazy var chevronButton: RowButton.RightAccessoryButton = {
         let chevronButton = RowButton.RightAccessoryButton(accessoryType: .update, appearance: appearance, didTap: handleUpdateButtonTapped)
-        chevronButton.isHidden = true
-        chevronButton.isUserInteractionEnabled = isEditing
+        chevronButton.isHidden = !isEditing
         return chevronButton
     }()
 
-    private lazy var rowButton: RowButton = {
+    private(set) lazy var rowButton: RowButton = {
         let button: RowButton = .makeForSavedPaymentMethod(paymentMethod: paymentMethod, appearance: appearance, badgeText: badgeText, rightAccessoryView: chevronButton, didTap: handleRowButtonTapped)
 
         return button
@@ -103,10 +85,14 @@ final class SavedPaymentMethodRowButton: UIView {
 
     init(paymentMethod: STPPaymentMethod,
          appearance: PaymentSheet.Appearance,
-         showDefaultPMBadge: Bool = false) {
+         showDefaultPMBadge: Bool = false,
+         previousSelectedState: State = .unselected,
+         currentState: State = .unselected) {
         self.paymentMethod = paymentMethod
         self.appearance = appearance
         self.showDefaultPMBadge = showDefaultPMBadge
+        self.previousSelectedState = previousSelectedState
+        self.state = currentState
         super.init(frame: .zero)
 
         addAndPinSubview(rowButton)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -375,11 +375,14 @@ extension VerticalSavedPaymentMethodsViewController: UpdatePaymentMethodViewCont
         }
 
         // Create the new button
-        let newButton = SavedPaymentMethodRowButton(paymentMethod: updatedPaymentMethod, appearance: configuration.appearance, showDefaultPMBadge: isDefaultPaymentMethod(paymentMethodId: updatedPaymentMethod.stripeId))
+        let isDefaultPaymentMethod = isDefaultPaymentMethod(paymentMethodId: updatedPaymentMethod.stripeId)
+        let newButton = SavedPaymentMethodRowButton(paymentMethod: updatedPaymentMethod,
+                                                    appearance: configuration.appearance,
+                                                    showDefaultPMBadge: isDefaultPaymentMethod,
+                                                    previousSelectedState: oldButton.previousSelectedState,
+                                                    currentState: oldButton.state)
 
         newButton.delegate = self
-        newButton.previousSelectedState = oldButton.previousSelectedState
-        newButton.state = oldButton.state
 
         // Replace the old button with the new button in the model
         paymentMethodRows[oldButtonModelIndex] = newButton

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
@@ -6,28 +6,28 @@
 //
 
 import Foundation
-import XCTest
 @testable import StripePaymentSheet
+import XCTest
 
 final class SavedPaymentMethodRowButtonTests: XCTestCase {
-    
+
     private let mockPaymentMethod = STPPaymentMethod._testCard()
     private let appearance = PaymentSheet.Appearance()
-    
+
     func testInitializationWithUnselectedState() {
         // Given (default init -> .unselected)
         let sut = SavedPaymentMethodRowButton(
             paymentMethod: mockPaymentMethod,
             appearance: appearance
         )
-        
+
         XCTAssertEqual(sut.state, .unselected)
         XCTAssertFalse(sut.isSelected, "Button should be unselected by default")
         XCTAssertEqual(sut.previousSelectedState, .unselected, "previousSelectedState should be .unselected if not set")
         XCTAssertTrue(sut.chevronButton.isHidden, "Chevron should be hidden in unselected state")
         XCTAssertFalse(sut.rowButton.isSelected, "Row button should not be selected initially")
     }
-    
+
     func testInitializationWithCustomStates() {
         // We provide a previousSelectedState and currentState
         let sut = SavedPaymentMethodRowButton(
@@ -37,40 +37,40 @@ final class SavedPaymentMethodRowButtonTests: XCTestCase {
             previousSelectedState: .selected,
             currentState: .editing(allowsRemoval: true, allowsUpdating: false)
         )
-        
+
         XCTAssertEqual(sut.previousSelectedState, .selected, "previousSelectedState should match the value given at init")
         XCTAssertEqual(sut.state, .editing(allowsRemoval: true, allowsUpdating: false), "currentState should match the value given at init")
         XCTAssertFalse(sut.isSelected, "Button shouldn't be 'selected' when in .editing")
         XCTAssertFalse(sut.chevronButton.isHidden, "Chevron should be visible in editing mode")
     }
-    
+
     func testSetStateEditing() {
         let sut = SavedPaymentMethodRowButton(
             paymentMethod: mockPaymentMethod,
             appearance: appearance
         )
-        
+
         sut.state = .editing(allowsRemoval: true, allowsUpdating: false)
-        
+
         XCTAssertEqual(sut.state, .editing(allowsRemoval: true, allowsUpdating: false))
         XCTAssertFalse(sut.isSelected, "isSelected should be false in editing state")
         XCTAssertFalse(sut.chevronButton.isHidden, "Chevron should be visible in editing mode")
     }
-    
+
     func testStateTransitionUnselectedToSelected() {
         let sut = SavedPaymentMethodRowButton(
             paymentMethod: mockPaymentMethod,
             appearance: appearance,
             currentState: .unselected
         )
-        
+
         sut.state = .selected
-        
+
         XCTAssertTrue(sut.isSelected, "Button should become selected")
         XCTAssertEqual(sut.previousSelectedState, .unselected, "previousSelectedState should track the old value")
         XCTAssertTrue(sut.chevronButton.isHidden, "Chevron is hidden when not editing.")
     }
-    
+
     func testSettingPreviousSelectedStateFromSelectedToEditing() {
         let sut = SavedPaymentMethodRowButton(
             paymentMethod: mockPaymentMethod,
@@ -79,11 +79,67 @@ final class SavedPaymentMethodRowButtonTests: XCTestCase {
         )
 
         sut.state = .editing(allowsRemoval: true, allowsUpdating: true)
-        
+
         XCTAssertEqual(sut.previousSelectedState, .selected, "previousSelectedState should capture the old value of .selected")
         XCTAssertFalse(sut.isSelected, "In editing state, the button is not selected")
         XCTAssertFalse(sut.rowButton.isSelected, "Row button should reflect isSelected == false in .editing")
         XCTAssertFalse(sut.chevronButton.isHidden, "Chevron should be visible in editing mode.")
     }
-    
+
+    func testStateTransitionUnselectedToEditing() {
+        let sut = SavedPaymentMethodRowButton(
+            paymentMethod: mockPaymentMethod,
+            appearance: appearance,
+            currentState: .unselected
+        )
+
+        sut.state = .editing(allowsRemoval: false, allowsUpdating: true)
+
+        XCTAssertFalse(sut.isSelected)
+        XCTAssertEqual(sut.previousSelectedState, .unselected)
+        XCTAssertFalse(sut.chevronButton.isHidden)
+    }
+
+    func testStateTransitionSelectedToUnselected() {
+        let sut = SavedPaymentMethodRowButton(
+            paymentMethod: mockPaymentMethod,
+            appearance: appearance,
+            currentState: .selected
+        )
+
+        sut.state = .unselected
+
+        XCTAssertFalse(sut.isSelected)
+        XCTAssertEqual(sut.previousSelectedState, .selected)
+        XCTAssertTrue(sut.chevronButton.isHidden)
+    }
+
+    func testStateTransitionEditingToUnselected() {
+        let sut = SavedPaymentMethodRowButton(
+            paymentMethod: mockPaymentMethod,
+            appearance: appearance,
+            currentState: .editing(allowsRemoval: true, allowsUpdating: true)
+        )
+
+        sut.state = .unselected
+
+        XCTAssertFalse(sut.isSelected)
+        XCTAssertEqual(sut.previousSelectedState, .unselected)
+        XCTAssertTrue(sut.chevronButton.isHidden)
+    }
+
+    func testStateTransitionEditingToSelected() {
+        let sut = SavedPaymentMethodRowButton(
+            paymentMethod: mockPaymentMethod,
+            appearance: appearance,
+            currentState: .editing(allowsRemoval: false, allowsUpdating: true)
+        )
+
+        sut.state = .selected
+
+        XCTAssertTrue(sut.isSelected)
+        XCTAssertEqual(sut.previousSelectedState, .unselected)
+        XCTAssertTrue(sut.chevronButton.isHidden)
+    }
+
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
@@ -1,0 +1,89 @@
+//
+//  SavedPaymentMethodRowButtonTests.swift
+//  StripePaymentSheetTests
+//
+//  Created by Nick Porter on 2/10/25.
+//
+
+import Foundation
+import XCTest
+@testable import StripePaymentSheet
+
+final class SavedPaymentMethodRowButtonTests: XCTestCase {
+    
+    private let mockPaymentMethod = STPPaymentMethod._testCard()
+    private let appearance = PaymentSheet.Appearance()
+    
+    func testInitializationWithUnselectedState() {
+        // Given (default init -> .unselected)
+        let sut = SavedPaymentMethodRowButton(
+            paymentMethod: mockPaymentMethod,
+            appearance: appearance
+        )
+        
+        XCTAssertEqual(sut.state, .unselected)
+        XCTAssertFalse(sut.isSelected, "Button should be unselected by default")
+        XCTAssertEqual(sut.previousSelectedState, .unselected, "previousSelectedState should be .unselected if not set")
+        XCTAssertTrue(sut.chevronButton.isHidden, "Chevron should be hidden in unselected state")
+        XCTAssertFalse(sut.rowButton.isSelected, "Row button should not be selected initially")
+    }
+    
+    func testInitializationWithCustomStates() {
+        // We provide a previousSelectedState and currentState
+        let sut = SavedPaymentMethodRowButton(
+            paymentMethod: mockPaymentMethod,
+            appearance: appearance,
+            showDefaultPMBadge: false,
+            previousSelectedState: .selected,
+            currentState: .editing(allowsRemoval: true, allowsUpdating: false)
+        )
+        
+        XCTAssertEqual(sut.previousSelectedState, .selected, "previousSelectedState should match the value given at init")
+        XCTAssertEqual(sut.state, .editing(allowsRemoval: true, allowsUpdating: false), "currentState should match the value given at init")
+        XCTAssertFalse(sut.isSelected, "Button shouldn't be 'selected' when in .editing")
+        XCTAssertFalse(sut.chevronButton.isHidden, "Chevron should be visible in editing mode")
+    }
+    
+    func testSetStateEditing() {
+        let sut = SavedPaymentMethodRowButton(
+            paymentMethod: mockPaymentMethod,
+            appearance: appearance
+        )
+        
+        sut.state = .editing(allowsRemoval: true, allowsUpdating: false)
+        
+        XCTAssertEqual(sut.state, .editing(allowsRemoval: true, allowsUpdating: false))
+        XCTAssertFalse(sut.isSelected, "isSelected should be false in editing state")
+        XCTAssertFalse(sut.chevronButton.isHidden, "Chevron should be visible in editing mode")
+    }
+    
+    func testStateTransitionUnselectedToSelected() {
+        let sut = SavedPaymentMethodRowButton(
+            paymentMethod: mockPaymentMethod,
+            appearance: appearance,
+            currentState: .unselected
+        )
+        
+        sut.state = .selected
+        
+        XCTAssertTrue(sut.isSelected, "Button should become selected")
+        XCTAssertEqual(sut.previousSelectedState, .unselected, "previousSelectedState should track the old value")
+        XCTAssertTrue(sut.chevronButton.isHidden, "Chevron is hidden when not editing.")
+    }
+    
+    func testSettingPreviousSelectedStateFromSelectedToEditing() {
+        let sut = SavedPaymentMethodRowButton(
+            paymentMethod: mockPaymentMethod,
+            appearance: appearance,
+            currentState: .selected
+        )
+
+        sut.state = .editing(allowsRemoval: true, allowsUpdating: true)
+        
+        XCTAssertEqual(sut.previousSelectedState, .selected, "previousSelectedState should capture the old value of .selected")
+        XCTAssertFalse(sut.isSelected, "In editing state, the button is not selected")
+        XCTAssertFalse(sut.rowButton.isSelected, "Row button should reflect isSelected == false in .editing")
+        XCTAssertFalse(sut.chevronButton.isHidden, "Chevron should be visible in editing mode.")
+    }
+    
+}


### PR DESCRIPTION
## Summary
- Fixed a bug where when updating a co-branded card, and coming back it was not still selected. See the JIRA ticket for the before.
- Simplified some logic in the SavedPaymentMethodRowButton, and refactored to make it less prone to bugs like this.

After:


https://github.com/user-attachments/assets/736a9951-1524-4357-b609-077aa46fe6fe




## Motivation
- https://jira.corp.stripe.com/browse/MOBILESDK-2725

## Testing
- Manual
- New unit tests

## Changelog
N/A
