### PR TITLE
Fix linting in CI, lint from the merge base instead of origin/master

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -154,7 +154,7 @@ workflows:
         inputs:
         - content: bundle exec ./ci_scripts/export_builds.rb
         is_always_run: true
-        title: Export builds        
+        title: Export builds
     before_run:
     - prep_all
     after_run:
@@ -493,13 +493,17 @@ workflows:
     - prep_all
     after_run:
     - upload_logs
-    - notify_ci   
+    - notify_ci
     meta:
       bitrise.io:
         stack: osx-xcode-15.0.x
-        machine_type_id: g2.mac.large     
+        machine_type_id: g2.mac.large
   lint-tests:
     steps:
+    - git-clone@8.2:
+        inputs:
+        - merge_pr: "no"
+        - fetch_tags: "yes"
     - script@1:
         inputs:
         - content: ./ci_scripts/lint_modified_files.sh
@@ -520,8 +524,6 @@ workflows:
         inputs:
         - lane: analyze
         title: fastlane analyze
-    before_run:
-    - prep_all
     meta:
       bitrise.io:
         stack: osx-xcode-15.0.x
@@ -547,7 +549,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-15.0.x
-        machine_type_id: g2.mac.large   
+        machine_type_id: g2.mac.large
   pod-lint-tests:
     steps:
     - script@1:
@@ -622,7 +624,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-15.3.x
-        machine_type_id: g2.mac.large        
+        machine_type_id: g2.mac.large
   ui-tests-1:
     steps:
     - script@1:
@@ -650,7 +652,7 @@ workflows:
     - script@1:
         inputs:
         - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
-        title: Warm up emulator (iPhone 12 mini, OS=16.4)    
+        title: Warm up emulator (iPhone 12 mini, OS=16.4)
     - xcode-test@4:
         inputs:
         - destination: $DEFAULT_TEST_DEVICE
@@ -672,7 +674,7 @@ workflows:
     - script@1:
         inputs:
         - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
-        title: Warm up emulator (iPhone 12 mini, OS=16.4)      
+        title: Warm up emulator (iPhone 12 mini, OS=16.4)
     - xcode-test@4:
         inputs:
         - destination: $DEFAULT_TEST_DEVICE
@@ -694,7 +696,7 @@ workflows:
     - script@1:
         inputs:
         - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
-        title: Warm up emulator (iPhone 12 mini, OS=16.4)    
+        title: Warm up emulator (iPhone 12 mini, OS=16.4)
     - xcode-test@4:
         inputs:
         - destination: $DEFAULT_TEST_DEVICE
@@ -716,7 +718,7 @@ workflows:
     - script@1:
         inputs:
         - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
-        title: Warm up emulator (iPhone 12 mini, OS=16.4)    
+        title: Warm up emulator (iPhone 12 mini, OS=16.4)
     - xcode-test@4:
         inputs:
         - destination: $DEFAULT_TEST_DEVICE
@@ -732,7 +734,7 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-15.0.x
-        machine_type_id: g2.mac.large             
+        machine_type_id: g2.mac.large
   upload_logs:
     steps:
     - deploy-to-bitrise-io@2:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -506,6 +506,10 @@ workflows:
         - clone_depth: -1
     - script@1:
         inputs:
+        - content: git fetch origin master
+        title: Fetch origin/master
+    - script@1:
+        inputs:
         - content: ./ci_scripts/lint_modified_files.sh
         title: Run swiftlint
     - script@1:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -503,7 +503,7 @@ workflows:
     - git-clone@8.2:
         inputs:
         - merge_pr: "no"
-        - fetch_tags: "yes"
+        - clone_depth: -1
     - script@1:
         inputs:
         - content: ./ci_scripts/lint_modified_files.sh

--- a/ci_scripts/format_modified_files.sh
+++ b/ci_scripts/format_modified_files.sh
@@ -24,11 +24,11 @@ if ! command -v swiftlint &> /dev/null; then
 fi
 
 IS_HOOK=false
-if [ $(dirname $0) == ".git/hooks" ]; then
+if [ $(dirname "$0") == ".git/hooks" ]; then
   IS_HOOK=true
 fi
 
-START=`date +%s`
+START=$(date +%s)
 
 if [ "$IS_HOOK" = true ]; then
   echo "Formatting before commit (use $(tput setaf 7)git commit --no-verify$(tput sgr0) to skip)."
@@ -41,10 +41,12 @@ if [ "$CURRENT_BRANCH" == "master" ]; then
   echo "Can't format on master branch"
   exit 1
 else
+  # Calculate the merge base between origin/master and HEAD.
+  MERGE_BASE=$(git merge-base origin/master HEAD)
   while IFS= read -r file; do
     export SCRIPT_INPUT_FILE_$count="$file"
     count=$((count + 1))
-  done < <(git diff --diff-filter=AM --name-only origin/master  | grep ".swift$")
+  done < <(git diff --diff-filter=AM --name-only "$MERGE_BASE" | grep ".swift$")
 fi
 
 export SCRIPT_INPUT_FILE_COUNT=$count
@@ -55,7 +57,7 @@ fi
 
 EXIT_CODE=$?
 
-END=`date +%s`
+END=$(date +%s)
 echo ""
 echo "Formatted in $(($END - $START))s."
 if [ "$EXIT_CODE" == '0' ]; then

--- a/ci_scripts/lint_modified_files.sh
+++ b/ci_scripts/lint_modified_files.sh
@@ -19,7 +19,7 @@ if which swiftlint >/dev/null; then
     IS_HOOK=true
   fi
 
-  START=`date +%s`
+  START=$(date +%s)
 
   z40=0000000000000000000000000000000000000000
 
@@ -34,10 +34,12 @@ if which swiftlint >/dev/null; then
     echo "Ignoring lint on master branch"
     exit 0
   else
+    # Compute the merge base between origin/master and HEAD so we only lint changes since we diverged.
+    MERGE_BASE=$(git merge-base origin/master HEAD)
     while IFS= read -r file; do
       export SCRIPT_INPUT_FILE_$count="$file"
       count=$((count + 1))
-    done < <(git diff --diff-filter=AM --name-only origin/master  | grep ".swift$")
+    done < <(git diff --diff-filter=AM --name-only "$MERGE_BASE" | grep ".swift$")
   fi
 
   export SCRIPT_INPUT_FILE_COUNT=$count
@@ -48,7 +50,7 @@ if which swiftlint >/dev/null; then
 
   EXIT_CODE=$?
 
-  END=`date +%s`
+  END=$(date +%s)
   echo ""
   echo "Linted in $(($END - $START))s."
   if [ "$EXIT_CODE" == '0' ]; then


### PR DESCRIPTION
## Summary
* Pull the entire git history so that linting works in CI
* Lint from the merge-base of origin/master, instead of linting against origin/master. This should fix the issue where linting when the current branch isn't up to date with `origin/master` lints a bunch of unrelated files.

## Motivation
Linting wasn't being enforced, and it was also very annoying to run when working on multiple branches at once

## Testing
* CI
* Created some branches locally and checked that:
  * Too many files were being linted before this fix
  * The correct files were being linted after this fix

## Changelog
None