### PR TITLE
Deflake testURLParamsWithCardAndBankFundingSources

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
@@ -137,14 +137,7 @@ class LinkURLGenerator {
 extension Set where Element == LinkSettings.FundingSource {
     func toSortedArray() -> [LinkSettings.FundingSource] {
         return self.sorted { a, b in
-            switch (a, b) {
-            case (.card, .bankAccount):
-                return true
-            case (.bankAccount, .card):
-                return false
-            default:
-                return false
-            }
+            a.rawValue.localizedCaseInsensitiveCompare(b.rawValue) == .orderedAscending
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
@@ -33,7 +33,7 @@ struct LinkURLParams: Encodable {
         var stripePreferredNetworks: [String]
         var supportedCobrandedNetworks: [String: Bool]
     }
-    
+
     var path = "mobile_pay"
     var integrationType = "mobile"
     var paymentObject: PaymentObjectMode
@@ -90,7 +90,7 @@ class LinkURLGenerator {
         let paymentObjectType: LinkURLParams.PaymentObjectMode = elementsSession.linkPassthroughModeEnabled ? .card_payment_method : .link_payment_method
 
         let intentMode: LinkURLParams.IntentMode = intent.isPaymentIntent ? .payment : .setup
-        
+
         let cardBrandChoiceInfo: LinkURLParams.CardBrandChoiceInfo? = {
             guard let cardBrandChoice = elementsSession.cardBrandChoice else { return nil }
             return LinkURLParams.CardBrandChoiceInfo(isMerchantEligibleForCBC: cardBrandChoice.eligible,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
@@ -54,7 +54,7 @@ class LinkURLGeneratorTests: XCTestCase {
         // Create a session ID
         AnalyticsHelper.shared.generateSessionID()
         let sessionID = AnalyticsHelper.shared.sessionID!
-        
+
         let params = try! LinkURLGenerator.linkParams(configuration: config, intent: intent, elementsSession: .emptyElementsSession)
 
         let expectedParams = LinkURLParams(paymentObject: .link_payment_method,
@@ -97,7 +97,8 @@ class LinkURLGeneratorTests: XCTestCase {
                                            paymentInfo: LinkURLParams.PaymentInfo(currency: "EUR", amount: 100),
                                            experiments: [:],
                                            flags: ["cbc_in_link_popup": true,
-                                                   "disable_cbc_in_link_popup": false],
+                                                   "disable_cbc_in_link_popup": false,
+                                                  ],
                                            loggerMetadata: ["mobile_session_id": sessionID],
                                            locale: Locale.init(identifier: "en_US").toLanguageTag(),
                                            intentMode: .payment,
@@ -108,7 +109,7 @@ class LinkURLGeneratorTests: XCTestCase {
 
         XCTAssertEqual(params, expectedParams)
     }
-    
+
     func testURLParamsWithCardFundingSource() {
         var config = PaymentSheet.Configuration()
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "EUR")) { _, _, _ in
@@ -142,7 +143,7 @@ class LinkURLGeneratorTests: XCTestCase {
 
         XCTAssertEqual(params, expectedParams)
     }
-    
+
     func testURLParamsWithCardAndBankFundingSources() {
         var config = PaymentSheet.Configuration()
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "EUR")) { _, _, _ in
@@ -198,31 +199,35 @@ extension STPElementsSession {
                                           "session_id": "123",
                                           "card_brand_choice": ["eligible": true,
                                                                 "preferred_networks": ["cartes_bancaires"],
-                                                                "supported_cobranded_networks": ["cartes_bancaires": true]
+                                                                "supported_cobranded_networks": ["cartes_bancaires": true],
                                                                ],
-                                          "merchant_country" : "FR"
+                                          "merchant_country": "FR",
         ]
         return STPElementsSession.decodedObject(fromAPIResponse: apiResponse)!
     }
-    
+
     static var linkPassthroughElementsSession: STPElementsSession {
         let apiResponse: [String: Any] = ["payment_method_preference": ["ordered_payment_method_types": ["123"],
                                                                         "country_code": "US", ] as [String: Any],
                                           "session_id": "123",
                                           "apple_pay_preference": "enabled",
                                           "link_settings": ["link_funding_sources": ["CARD"],
-                                            "link_passthrough_mode_enabled": true]
+                                                            "link_passthrough_mode_enabled": true,
+                                                           ],
         ]
         return STPElementsSession.decodedObject(fromAPIResponse: apiResponse)!
     }
-    
+
     static var linkPassthroughWithBankElementsSession: STPElementsSession {
         let apiResponse: [String: Any] = ["payment_method_preference": ["ordered_payment_method_types": ["123"],
                                                                         "country_code": "US", ] as [String: Any],
                                           "session_id": "123",
                                           "apple_pay_preference": "enabled",
-                                          "link_settings": ["link_funding_sources": ["BANK_ACCOUNT", "CARD"],
-                                            "link_passthrough_mode_enabled": true]
+                                          "link_settings": ["link_funding_sources": ["BANK_ACCOUNT",
+                                                                                     "CARD",
+                                                                                    ],
+                                                            "link_passthrough_mode_enabled": true,
+                                                           ],
         ]
         return STPElementsSession.decodedObject(fromAPIResponse: apiResponse)!
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
@@ -171,7 +171,7 @@ class LinkURLGeneratorTests: XCTestCase {
                                            intentMode: .payment,
                                            setupFutureUsage: false,
                                            cardBrandChoice: nil,
-                                           linkFundingSources: [.card, .bankAccount]
+                                           linkFundingSources: [.bankAccount, .card]
         )
 
         XCTAssertEqual(params, expectedParams)
@@ -221,7 +221,7 @@ extension STPElementsSession {
                                                                         "country_code": "US", ] as [String: Any],
                                           "session_id": "123",
                                           "apple_pay_preference": "enabled",
-                                          "link_settings": ["link_funding_sources": ["CARD", "BANK_ACCOUNT"],
+                                          "link_settings": ["link_funding_sources": ["BANK_ACCOUNT", "CARD"],
                                             "link_passthrough_mode_enabled": true]
         ]
         return STPElementsSession.decodedObject(fromAPIResponse: apiResponse)!


### PR DESCRIPTION
## Summary
This test has about a 50% chance of failing. To remedy this, I am proposing we continue to deserialize as a Set(), but during encoding, convert to an orderedlist.

## Motivation
Deflaking test

## Testing
Using existing tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
