### PR TITLE
Fix a bug on setting presentingViewController in SwiftUI

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -1014,7 +1014,15 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         let continueButton = app.buttons["Continue"]
         XCTAssertTrue(continueButton.isEnabled)
         continueButton.tap()
-
+        
+        // Ensure we can present the card form via the "Change" button
+        let changeButton = app.buttons["Change"].firstMatch
+        let allButtons = app.buttons.allElementsBoundByIndex
+        
+        XCTAssertTrue(changeButton.waitForExistenceAndTap())
+        XCTAssertTrue(app.staticTexts["Add card"].waitForExistence(timeout: 10))
+        continueButton.tap()
+        
         let confirmButton = app.buttons["Confirm Payment"]
         XCTAssertTrue(confirmButton.waitForExistenceAndTap())
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -1004,7 +1004,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertFalse(paymentMethodLabel.exists)
         XCTAssertFalse(cashAppPayButton.isSelected)
     }
-    
+
     func testSwiftUI() throws {
         app.launch()
         XCTAssertTrue(app.buttons["EmbeddedPaymentElement (SwiftUI)"].waitForExistenceAndTap())
@@ -1014,15 +1014,15 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         let continueButton = app.buttons["Continue"]
         XCTAssertTrue(continueButton.isEnabled)
         continueButton.tap()
-        
+
         // Ensure we can present the card form via the "Change" button
         let changeButton = app.buttons["Change"].firstMatch
         let allButtons = app.buttons.allElementsBoundByIndex
-        
+
         XCTAssertTrue(changeButton.waitForExistenceAndTap())
         XCTAssertTrue(app.staticTexts["Add card"].waitForExistence(timeout: 10))
         continueButton.tap()
-        
+
         let confirmButton = app.buttons["Confirm Payment"]
         XCTAssertTrue(confirmButton.waitForExistenceAndTap())
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedViewRepresentable.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedViewRepresentable.swift
@@ -37,8 +37,21 @@ struct EmbeddedViewRepresentable: UIViewRepresentable {
     }
 
     public func updateUIView(_ uiView: UIView, context: Context) {
-        // Update the presenting view controller in case it has changed
-        viewModel.embeddedPaymentElement?.presentingViewController = UIWindow.visibleViewController
+        guard let visibleVC = UIWindow.visibleViewController else { return }
+        
+        // If visibleVC in the process of dismissing, skip for now and retry shortly.
+        // updateUIView can be trigged by a view controller (such as a form) being dismissed
+        guard !visibleVC.isBeingDismissed else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                // Re-trigger SwiftUI’s update cycle
+                viewModel.objectWillChange.send()
+            }
+            return
+        }
+
+        if !(visibleVC is StripePaymentSheet.BottomSheetViewController) {
+            viewModel.embeddedPaymentElement?.presentingViewController = visibleVC
+        }
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedViewRepresentable.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedViewRepresentable.swift
@@ -5,9 +5,9 @@
 //  Created by Nick Porter on 1/30/25.
 //
 
-import SwiftUI
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
+import SwiftUI
 
 struct EmbeddedViewRepresentable: UIViewRepresentable {
     @ObservedObject var viewModel: EmbeddedPaymentElementViewModel
@@ -30,7 +30,7 @@ struct EmbeddedViewRepresentable: UIViewRepresentable {
         NSLayoutConstraint.activate([
             paymentElementView.topAnchor.constraint(equalTo: containerView.topAnchor),
             paymentElementView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
-            paymentElementView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
+            paymentElementView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
         ])
 
         return containerView
@@ -38,7 +38,7 @@ struct EmbeddedViewRepresentable: UIViewRepresentable {
 
     public func updateUIView(_ uiView: UIView, context: Context) {
         guard let visibleVC = UIWindow.visibleViewController else { return }
-        
+
         // If visibleVC in the process of dismissing, skip for now and retry shortly.
         // updateUIView can be trigged by a view controller (such as a form) being dismissed
         guard !visibleVC.isBeingDismissed else {


### PR DESCRIPTION
## Summary
- There was a bug where we would set the presentingViewController to one of our own VCs which is incorrect and would cause the "Change" button to no-op.
- The bug was caused in the following scenario: User fills out card, hits continue, then hits change. When tapping change no form would be presented, it would no-op.
- This was caused by `updateUIView` on our UIViewRepresentable being called while our form VC is being dismissed. So when we compute the top most VC, we get back our bottom sheet VC even though it's in the process of dismissing.
- The fix is two fold: 1. Make sure we never set presenting VC to one of our own. 2. If the top most VC is in the process of dismissing when `updateUIView` is called, wait 0.1 seconds and try again.

## Motivation
- Embedded SwiftUI bug fix

## Testing
- Manual
- Updated UI test

## Changelog
N/A
