### PR TITLE
Use formatted phone number in Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -65,7 +65,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
     let email: String
 
     var redactedPhoneNumber: String? {
-        return currentSession?.redactedPhoneNumber
+        return currentSession?.redactedFormattedPhoneNumber.replacingOccurrences(of: "*", with: "•")
     }
 
     var isRegistered: Bool {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -15,20 +15,20 @@ import UIKit
 final class ConsumerSession: Decodable {
     let clientSecret: String
     let emailAddress: String
-    let redactedPhoneNumber: String
+    let redactedFormattedPhoneNumber: String
     let verificationSessions: [VerificationSession]
     let supportedPaymentDetailsTypes: Set<ConsumerPaymentDetails.DetailsType>
 
     init(
         clientSecret: String,
         emailAddress: String,
-        redactedPhoneNumber: String,
+        redactedFormattedPhoneNumber: String,
         verificationSessions: [VerificationSession],
         supportedPaymentDetailsTypes: Set<ConsumerPaymentDetails.DetailsType>
     ) {
         self.clientSecret = clientSecret
         self.emailAddress = emailAddress
-        self.redactedPhoneNumber = redactedPhoneNumber
+        self.redactedFormattedPhoneNumber = redactedFormattedPhoneNumber
         self.verificationSessions = verificationSessions
         self.supportedPaymentDetailsTypes = supportedPaymentDetailsTypes
     }
@@ -36,7 +36,7 @@ final class ConsumerSession: Decodable {
     private enum CodingKeys: String, CodingKey {
         case clientSecret
         case emailAddress
-        case redactedPhoneNumber
+        case redactedFormattedPhoneNumber
         case verificationSessions
         case supportedPaymentDetailsTypes = "supportPaymentDetailsTypes"
     }
@@ -45,7 +45,7 @@ final class ConsumerSession: Decodable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.clientSecret = try container.decode(String.self, forKey: .clientSecret)
         self.emailAddress = try container.decode(String.self, forKey: .emailAddress)
-        self.redactedPhoneNumber = try container.decode(String.self, forKey: .redactedPhoneNumber)
+        self.redactedFormattedPhoneNumber = try container.decode(String.self, forKey: .redactedFormattedPhoneNumber)
         self.verificationSessions = try container.decodeIfPresent([ConsumerSession.VerificationSession].self, forKey: .verificationSessions) ?? []
         self.supportedPaymentDetailsTypes = try container.decodeIfPresent(Set<ConsumerPaymentDetails.DetailsType>.self, forKey: .supportedPaymentDetailsTypes) ?? []
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/LinkStubs.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/LinkStubs.swift
@@ -82,7 +82,7 @@ extension LinkStubs {
         return ConsumerSession(
             clientSecret: "client_secret",
             emailAddress: "user@example.com",
-            redactedPhoneNumber: "+1********55",
+            redactedFormattedPhoneNumber: "(***) *** **55",
             verificationSessions: [],
             supportedPaymentDetailsTypes: [.card, .bankAccount]
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
@@ -79,7 +79,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
                     session: .init(
                         clientSecret: "cs_xxx",
                         emailAddress: exampleBillingEmail,
-                        redactedPhoneNumber: "+1-555-xxx-xxxx",
+                        redactedFormattedPhoneNumber: "(***) *** **55",
                         verificationSessions: [.init(type: .sms, state: .verified)],
                         supportedPaymentDetailsTypes: [.card]
                     ),
@@ -173,7 +173,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
                 option: .withPaymentDetails(
                     account: .init(
                         email: "test@example.com",
-                        session: .init(clientSecret: "cs_xxx", emailAddress: "test@example.com", redactedPhoneNumber: "+1-555-xxx-xxxx", verificationSessions: [.init(type: .sms, state: .verified)], supportedPaymentDetailsTypes: [.card]),
+                        session: .init(clientSecret: "cs_xxx", emailAddress: "test@example.com", redactedFormattedPhoneNumber: "(***) *** **55", verificationSessions: [.init(type: .sms, state: .verified)], supportedPaymentDetailsTypes: [.card]),
                         publishableKey: MockParams.publicKey,
                         useMobileEndpoints: false),
                     paymentDetails: .init(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
@@ -105,7 +105,7 @@ class PaymentSheetLinkAccountDelegateStub: PaymentSheetLinkAccountDelegate {
         let stubSession = ConsumerSession(
             clientSecret: "unexpired_key",
             emailAddress: "user@example.com",
-            redactedPhoneNumber: "+1********55",
+            redactedFormattedPhoneNumber: "(***) *** **55",
             verificationSessions: [],
             supportedPaymentDetailsTypes: [.card, .bankAccount]
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/consumers_lookup_200.json
+++ b/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/consumers_lookup_200.json
@@ -5,7 +5,7 @@
   "consumer_session": {
       "client_secret": "pscs_abc123",
       "email_address": "foo@bar.com",
-      "redacted_phone_number": "+1********12",
+      "redacted_formatted_phone_number": "(***) *** **12",
       "verification_sessions": [],
       "support_paymnet_details_types": ["CARD"],
   }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request updates Link to use the formatted phone number, allowing us to show `(•••) ••• ••55` instead of `+1********55`.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
