### PR TITLE
Fix appearance issues when configuration is not automatic

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
@@ -197,13 +197,20 @@ private extension UIColor {
                 return light
             }
 
-            switch $0.userInterfaceStyle {
-            case .light, .unspecified:
+            switch PresentationManager.shared.configuration.style {
+            case .alwaysLight:
                 return light
-            case .dark:
+            case .alwaysDark:
                 return dark
-            @unknown default:
-                return light
+            case .automatic:
+                switch $0.userInterfaceStyle {
+                case .light, .unspecified:
+                    return light
+                case .dark:
+                    return dark
+                @unknown default:
+                    return light
+                }
             }
         })
     }


### PR DESCRIPTION
## Summary

This fixes some appearance issues that were happening when:

- Device is set to light mode (or dark mode)
- Financial Connections is configured to display in always dark mode (or in always light mode, respectively)

This bug was happening because not all subviews were inheriting the `userInterfaceStyle` override applied to the view controllers.

## Motivation

🌚 💅 

## Testing

One example of this issue was happening with the `OneTimeCodeTextField` view. Here, the device is set to light mode, and the configuration is set to `.alwaysDark`.

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 - 2025-02-11 at 15 59 24](https://github.com/user-attachments/assets/82dca0cd-230a-43d5-94d4-130b09fd2791) | ![Simulator Screenshot - iPhone 16 - 2025-02-13 at 12 21 30](https://github.com/user-attachments/assets/05402d62-5401-47ce-a0d3-48a827186746) | 

## Changelog

N/a
