### PR TITLE
Minor tweaks to dark mode colors

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
@@ -22,9 +22,9 @@ struct FinancialConnectionsAppearance: Equatable {
         static let icon: UIColor = .dynamic(light: .neutral700, dark: .neutral25)
         static let borderNeutral: UIColor = .dynamic(light: .neutral100, dark: .neutral100Dark)
         static let spinnerNeutral: UIColor = .neutral200
-        static let warningLight: UIColor = .dynamic(light: .attention50, dark: .attention50Dark)
+        static let warningLight: UIColor = .dynamic(light: .attention50, dark: .attention100Dark)
         static let warning: UIColor = .attention300
-        static let shadow: UIColor = .dynamic(light: .black, dark: .neutral0)
+        static let shadow: UIColor = .black
 
         // These colors change based on the manifest's theme.
         let primary: UIColor
@@ -139,8 +139,8 @@ private extension UIColor {
         return UIColor(red: 254 / 255.0, green: 249 / 255.0, blue: 218 / 255.0, alpha: 1)  // #fef9da
     }
 
-    static var attention50Dark: UIColor {
-        return UIColor(red: 64 / 255.0, green: 10 / 255.0, blue: 0 / 255.0, alpha: 1)  // #400a00
+    static var attention100Dark: UIColor {
+        return UIColor(red: 48 / 255.0, green: 37 / 255.0, blue: 20 / 255.0, alpha: 1)  // #302514
     }
 
     static var attention300: UIColor {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/InstitutionIconView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/InstitutionIconView.swift
@@ -30,7 +30,7 @@ final class InstitutionIconView: UIView {
         institutionImageView.layer.cornerRadius = cornerRadius
         institutionImageView.clipsToBounds = true
 
-        layer.shadowColor = FinancialConnectionsAppearance.Colors.textDefault.cgColor
+        layer.shadowColor = FinancialConnectionsAppearance.Colors.shadow.cgColor
         layer.shadowOpacity = 0.3
         layer.shadowRadius = 1
         layer.shadowOffset = CGSize(


### PR DESCRIPTION
## Summary

This makes a few minor tweaks for the colors used in dark mode. These changes are a result of the UX review + bug bash.

- Shadows are always black (no longer switch to white in dark mode).

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 - 2025-02-03 at 10 44 08](https://github.com/user-attachments/assets/0e075944-2c57-4fe3-a960-552de684aede)  | ![Simulator Screenshot - iPhone 16 - 2025-02-13 at 13 59 54](https://github.com/user-attachments/assets/0d6c5d9c-4a94-4eeb-8fb5-253829972c16) |
| ![Simulator Screenshot - iPhone 16 - 2025-02-06 at 11 02 55](https://github.com/user-attachments/assets/4452a533-d87c-4d04-98b4-b36a810a1a0c) | ![Simulator Screenshot - iPhone 16 - 2025-02-13 at 14 07 18](https://github.com/user-attachments/assets/0fd53b5a-6c18-4b61-a1a4-aa7d8d2e840a) |

- Test mode banner uses a lighter color, and the action text uses a darker brand color

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 - 2025-02-03 at 10 43 41](https://github.com/user-attachments/assets/3612b284-d76e-4bf2-bd19-c1f41b1f3231) | ![Simulator Screenshot - iPhone 16 - 2025-02-13 at 14 06 19](https://github.com/user-attachments/assets/a9b96b09-b874-4f57-a2f7-25c6ede93720) |

## Motivation

🌚 💅 

## Testing

Manual testing (see screenshots above)

## Changelog

N/a
