### PR TITLE
Update mandate before notifying delegate

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -56,6 +56,7 @@ class EmbeddedPaymentMethodsView: UIView {
         didSet {
             previousSelectedRowButton = oldValue
             let selectedRowButtonTypeDidChange = oldValue?.type != selectedRowButton?.type
+            updateMandate()
             if selectedRowButtonTypeDidChange {
                 selectedRowChangeButtonState = nil
                 delegate?.embeddedPaymentMethodsViewDidUpdateSelection()
@@ -63,7 +64,6 @@ class EmbeddedPaymentMethodsView: UIView {
             if let selectedRowButton {
                 selectedRowButton.isSelected = true
             }
-            updateMandate()
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -363,7 +363,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
 
         // Select the "Card" payment method
         sut.embeddedPaymentMethodsView.didTap(rowButton: sut.embeddedPaymentMethodsView.getRowButton(accessibilityIdentifier: "Cash App Pay"))
-        // The delegate should have been notified with proper data
+        // The delegate should have been notified
         XCTAssertTrue(delegateDidUpdatePaymentOptionCalled)
         XCTAssertEqual(sut.paymentOption?.label, "Cash App Pay")
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -16,6 +16,8 @@ import XCTest
 @MainActor
 // https://jira.corp.stripe.com/browse/MOBILESDK-2607 Make these STPNetworkStubbingTestCase; blocked on getting them to record image requests
 class EmbeddedPaymentElementTest: XCTestCase {
+    var delegatePaymentOption: EmbeddedPaymentElement.PaymentOptionDisplayData?
+
     lazy var configuration: EmbeddedPaymentElement.Configuration = {
         var config = EmbeddedPaymentElement.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
         config.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
@@ -40,7 +42,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
     let paymentIntentConfig2 = EmbeddedPaymentElement.IntentConfiguration(mode: .payment(amount: 999, currency: "USD"), paymentMethodTypes: ["card", "cashapp"]) { _, _, _ in
         // These tests don't confirm, so this is unused
     }
-    let setupIntentConfig = EmbeddedPaymentElement.IntentConfiguration(mode: .setup(setupFutureUsage: .offSession), paymentMethodTypes: ["card", "cashapp"]) { _, _, _ in
+    let setupIntentConfig = EmbeddedPaymentElement.IntentConfiguration(mode: .setup(setupFutureUsage: .offSession), paymentMethodTypes: ["card", "cashapp", "amazon_pay"]) { _, _, _ in
         // These tests don't confirm, so this is unused
     }
     var delegateDidUpdatePaymentOptionCalled = false
@@ -324,6 +326,31 @@ class EmbeddedPaymentElementTest: XCTestCase {
         }
     }
 
+    func testPaymentOptionDisplayData() async throws {
+        // Given a EmbeddedPaymentElement instance...
+        let sut = try await EmbeddedPaymentElement.create(intentConfiguration: setupIntentConfig, configuration: configuration)
+        sut.delegate = self
+        sut.presentingViewController = UIViewController()
+        sut.view.autosizeHeight(width: 320)
+
+        // Initially, no paymentOption should be selected
+        XCTAssertNil(sut.paymentOption)
+
+        // Select the "Cash App Pay" payment method
+        sut.embeddedPaymentMethodsView.didTap(rowButton: sut.embeddedPaymentMethodsView.getRowButton(accessibilityIdentifier: "Cash App Pay"))
+        // The delegate should have been notified with proper data
+        XCTAssertEqual(delegatePaymentOption?.label, "Cash App Pay")
+        XCTAssertEqual(delegatePaymentOption?.paymentMethodType, "cashapp")
+        XCTAssertTrue(delegatePaymentOption?.mandateText?.string.contains("Cash App") ?? false)
+
+        // Tap another row, payment option data should be updated
+        sut.embeddedPaymentMethodsView.didTap(rowButton: sut.embeddedPaymentMethodsView.getRowButton(accessibilityIdentifier: "Amazon Pay"))
+        // The delegate should have been notified with proper data
+        XCTAssertEqual(delegatePaymentOption?.label, "Amazon Pay")
+        XCTAssertEqual(delegatePaymentOption?.paymentMethodType, "amazon_pay")
+        XCTAssertTrue(delegatePaymentOption?.mandateText?.string.contains("Amazon Pay") ?? false)
+    }
+
     func testClearPaymentOptionAfterSelection() async throws {
         // Given a EmbeddedPaymentElement instance...
         let sut = try await EmbeddedPaymentElement.create(intentConfiguration: paymentIntentConfig, configuration: configuration)
@@ -336,7 +363,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
 
         // Select the "Card" payment method
         sut.embeddedPaymentMethodsView.didTap(rowButton: sut.embeddedPaymentMethodsView.getRowButton(accessibilityIdentifier: "Cash App Pay"))
-        // The delegate should have been notified
+        // The delegate should have been notified with proper data
         XCTAssertTrue(delegateDidUpdatePaymentOptionCalled)
         XCTAssertEqual(sut.paymentOption?.label, "Cash App Pay")
 
@@ -539,6 +566,7 @@ extension EmbeddedPaymentElementTest: EmbeddedPaymentElementDelegate {
     }
 
     func embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: StripePaymentSheet.EmbeddedPaymentElement) {
+        delegatePaymentOption = embeddedPaymentElement.paymentOption
         delegateDidUpdatePaymentOptionCalled = true
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
@@ -50,13 +50,13 @@ final class EmbeddedPaymentMethodsViewTests: XCTestCase {
 
         // Simulate tapping Cash App and verify delegate is called
         embeddedView.didTap(rowButton: embeddedView.getRowButton(accessibilityIdentifier: "Cash App Pay"))
-        XCTAssertEqual(mockDelegate.calls, [.didUpdateSelection, .didUpdateHeight, .didTapPaymentMethodRow])
+        XCTAssertEqual(mockDelegate.calls, [.didUpdateHeight, .didUpdateSelection, .didTapPaymentMethodRow])
         XCTAssertEqual(embeddedView.selectedRowButton?.type, .new(paymentMethodType: .stripe(.cashApp)), "Cash App Pay should be the current selection")
         mockDelegate.calls = []
 
         // Simulate tapping Klarna and verify delegate is called
         embeddedView.didTap(rowButton: embeddedView.getRowButton(accessibilityIdentifier: "Klarna"))
-        XCTAssertEqual(mockDelegate.calls, [.didUpdateSelection, .didUpdateHeight, .didTapPaymentMethodRow])
+        XCTAssertEqual(mockDelegate.calls, [.didUpdateHeight, .didUpdateSelection, .didTapPaymentMethodRow])
         XCTAssertEqual(embeddedView.selectedRowButton?.type, .new(paymentMethodType: .stripe(.klarna)), "Klarna should be the current selection")
         mockDelegate.calls = []
 
@@ -65,7 +65,7 @@ final class EmbeddedPaymentMethodsViewTests: XCTestCase {
         // ...should go back to Cash App
         XCTAssertEqual(embeddedView.selectedRowButton?.type, .new(paymentMethodType: .stripe(.cashApp)))
         // ...and call/not call the various delegate methods
-        XCTAssertEqual(mockDelegate.calls, [.didUpdateSelection, .didUpdateHeight])
+        XCTAssertEqual(mockDelegate.calls, [.didUpdateHeight, .didUpdateSelection])
         mockDelegate.calls = []
 
         // Resetting...
@@ -73,12 +73,12 @@ final class EmbeddedPaymentMethodsViewTests: XCTestCase {
         // ...should go to nil
         XCTAssertNil(embeddedView.selectedRowButton)
         // ...and call/not call the various delegate methods
-        XCTAssertEqual(mockDelegate.calls, [.didUpdateSelection, .didUpdateHeight])
+        XCTAssertEqual(mockDelegate.calls, [.didUpdateHeight, .didUpdateSelection, ])
         mockDelegate.calls = []
 
         // Simulate tapping PayPal and verify delegate is called
         embeddedView.didTap(rowButton: embeddedView.getRowButton(accessibilityIdentifier: "PayPal"))
-        XCTAssertEqual(mockDelegate.calls, [.didUpdateSelection, .didUpdateHeight, .didTapPaymentMethodRow])
+        XCTAssertEqual(mockDelegate.calls, [.didUpdateHeight, .didUpdateSelection, .didTapPaymentMethodRow])
         XCTAssertEqual(embeddedView.selectedRowButton?.type, .new(paymentMethodType: .stripe(.payPal)), "PayPal should be the current selection")
         mockDelegate.calls = []
 


### PR DESCRIPTION
## Summary
- Fixes a bug introduced in https://github.com/stripe/stripe-ios/pull/4538 where we update the mandate after notifying the delegate the payment option has changed
- This bug was only evident in our playground example app when you would have the merchant display the mandate not us
- This resulted in a nil mandateText being provided on our payment option to merchants

## Motivation
- 🐛 

## Testing
- Manual
- New test

## Changelog
N/A
