### PR TITLE
Fix embedded nil payment option bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## X.Y.Z 2025-XX-YY
+### PaymentSheet
+* [Fixed] Fixed an issue in Embedded Payment Element (private beta) where the row could be selected even though there's no valid payment option.
+
 ## 24.6.0 2025-02-18
 * [Fixed] The SDK and example apps now compile in Xcode 16.2
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -616,7 +616,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertFalse(app.staticTexts["Payment method"].waitForExistence(timeout: 1))
         XCTAssertFalse(app.buttons["New card"].isSelected)
         XCTAssertFalse(app.buttons["Checkout"].isEnabled)
-        
+
         // Tapping back into card form should preserve previous form details
         app.buttons["New card"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Add new card"].waitForExistence(timeout: 2))

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -533,24 +533,13 @@ class EmbeddedUITests: PaymentSheetUITestCase {
     func testSelection() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.mode = .paymentWithSetup
-        settings.uiStyle = .paymentSheet
-        settings.layout = .horizontal
+        settings.uiStyle = .embedded
         settings.customerKeyType = .legacy
         settings.formSheetAction = .continue
-        settings.customerMode = .new
+        settings.customerMode = .returning
+        settings.allowsDelayedPMs = .off
         loadPlayground(app, settings)
 
-        // Start by saving a new card
-        app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
-        try! fillCardData(app, postalEnabled: true)
-
-        // Complete payment
-        app.buttons["Pay $50.99"].tap()
-        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
-
-        // Switch to embedded mode kicks off a reload
-        app.buttons["embedded"].waitForExistenceAndTap(timeout: 5)
-        app.buttons["Payment"].waitForExistenceAndTap(timeout: 5)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()
 
         // Should auto select a saved payment method
@@ -587,7 +576,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Cash App Pay"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
-        // Try to fill a card
+        // Filling out card should set selection to card
         app.buttons["New card"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Add new card"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["New card"].isSelected) // Should show selected, the form should be filled with a valid card from above
@@ -617,48 +606,21 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["New card"].isSelected)
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
-        // Select a no-form PM such as Cash App Pay
-        app.buttons["Cash App Pay"].waitForExistenceAndTap()
-        XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.buttons["Cash App Pay"].isSelected)
-        XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-
-        // Fill out US Bank Acct.
-        app.buttons["US bank account"].waitForExistenceAndTap()
-        // Fill out name and email fields
-        let continueButton = app.buttons["Continue"]
-        XCTAssertFalse(continueButton.isEnabled)
-        app.textFields["Full name"].tap()
-        app.typeText("John Doe" + XCUIKeyboardKey.return.rawValue)
-        app.typeText("test-\(UUID().uuidString)@example.com" + XCUIKeyboardKey.return.rawValue)
-        XCTAssertTrue(continueButton.isEnabled)
-        continueButton.tap()
-
-        // Go through connections flow
-        app.buttons["Agree and continue"].waitForExistenceAndTap()
-        app.staticTexts["Test Institution"].forceTapElement()
-        // "Success" institution is automatically selected because its the first
-        app.buttons["connect_accounts_button"].waitForExistenceAndTap(timeout: 10)
-
-        skipLinkSignup(app)
-
-        app.buttons["Continue"].waitForExistenceAndTap()
-        XCTAssertTrue(app.staticTexts["Add US bank account"].waitForExistence(timeout: 10))
-        app.buttons["Continue"].waitForExistenceAndTap()
-        XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
-        XCTAssertEqual(app.staticTexts["Payment method"].label, "••••6789")
-        XCTAssertTrue(app.buttons["US bank account"].isSelected)
-        XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-
-        // Confirm with the saved card
-        app.buttons["•••• 4242"].waitForExistenceAndTap()
-        XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
-        XCTAssertTrue(app.buttons["•••• 4242"].isSelected)
-        app.swipeUp() // scroll to see the checkout button
-        XCTAssertTrue(app.buttons["Checkout"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-        app.buttons["Checkout"].tap()
-        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 20))
+        // Making the card form invalid and canceling...
+        app.buttons["New card"].waitForExistenceAndTap()
+        XCTAssertTrue(app.staticTexts["Add new card"].waitForExistence(timeout: 10))
+        cardNumberField.tap()
+        app.typeText(XCUIKeyboardKey.delete.rawValue)
+        app.buttons["Close"].waitForExistenceAndTap()
+        // ...should de-select the row and clear the payment option
+        XCTAssertFalse(app.staticTexts["Payment method"].waitForExistence(timeout: 1))
+        XCTAssertFalse(app.buttons["New card"].isSelected)
+        XCTAssertFalse(app.buttons["Checkout"].isEnabled)
+        
+        // Tapping back into card form should preserve previous form details
+        app.buttons["New card"].waitForExistenceAndTap()
+        XCTAssertTrue(app.staticTexts["Add new card"].waitForExistence(timeout: 2))
+        XCTAssertEqual(cardNumberField.value as? String, "555555555555444, Your card number is incomplete.")
     }
 
     func testApplePay() {

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -283,6 +283,9 @@ e.g, 'Pay faster at Example, Inc. and thousands of businesses.' */
 /* Title for a section listing one or more payment methods. */
 "Payment methods" = "Payment methods";
 
+/* Error message that's displayed when you try to confirm a payment without a valid payment method */
+"Please choose a valid payment method." = "Please choose a valid payment method.";
+
 /* Text on a screen that indicates a payment has failed informing the user we are asking the user to try a different payment method */
 "Please go back and select another payment method" = "Please go back and select another payment method";
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -468,7 +468,7 @@ extension String.Localized {
        )
     }
 
-    @_spi(STP) public static var set_as_default_payment_method: String {
+    public static var set_as_default_payment_method: String {
         STPLocalizedString(
             "Set as default payment method",
             "Label of a checkbox that when checked makes a payment method as the default one."
@@ -479,6 +479,13 @@ extension String.Localized {
         STPLocalizedString(
             "Change",
             "Label for a button that lets you change the details of a payment method"
+       )
+    }
+
+    static var please_choose_a_valid_payment_method: String {
+        STPLocalizedString(
+            "Please choose a valid payment method.",
+            "Error message that's displayed when you try to confirm a payment without a valid payment method"
        )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -468,7 +468,7 @@ extension String.Localized {
        )
     }
 
-    public static var set_as_default_payment_method: String {
+    static var set_as_default_payment_method: String {
         STPLocalizedString(
             "Set as default payment method",
             "Label of a checkbox that when checked makes a payment method as the default one."

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -325,7 +325,7 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
         // If the formViewController was populated with a previous payment option don't reset
         if embeddedFormViewController.previousPaymentOption == nil {
             let lastSelection = embeddedPaymentMethodsView.previousSelectedRowButton?.type
-            let currentlySelectedType = embeddedPaymentMethodsView.selectedRowButton?.type
+            var currentlySelectedType = embeddedPaymentMethodsView.selectedRowButton?.type
             if let lastSelection, lastSelection != currentlySelectedType {
                 // Go back to the previous selection if there was one
                 embeddedPaymentMethodsView.resetSelectionToLastSelection()
@@ -336,6 +336,9 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
                     embeddedPaymentMethodsView.resetSelection()
                 }
             }
+
+            // The selected row may have been reset, so get it again
+            currentlySelectedType = embeddedPaymentMethodsView.selectedRowButton?.type
 
             // Show change button if the newly selected row needs it
             if let currentlySelectedType {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -153,7 +153,7 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         // Present the current selection's form VC
         delegate?.embeddedPaymentElementWillPresent(embeddedPaymentElement: self)
         let bottomSheet = bottomSheetController(with: selectedFormViewController)
-        stpAssert(presentingViewController != nil, "Presenting view controller not found, set EmbeddedPaymentElement.presentingViewController.")
+        assert(presentingViewController != nil, "Presenting view controller not found, set EmbeddedPaymentElement.presentingViewController.")
         stpAssert(selectedFormViewController.delegate != nil)
         presentingViewController?.presentAsBottomSheet(bottomSheet, appearance: configuration.appearance)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -324,10 +324,22 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
     func embeddedFormViewControllerDidCancel(_ embeddedFormViewController: EmbeddedFormViewController) {
         // If the formViewController was populated with a previous payment option don't reset
         if embeddedFormViewController.previousPaymentOption == nil {
-            embeddedPaymentMethodsView.resetSelectionToLastSelection()
+            let lastSelection = embeddedPaymentMethodsView.previousSelectedRowButton?.type
+            let currentlySelectedType = embeddedPaymentMethodsView.selectedRowButton?.type
+            if let lastSelection, lastSelection != currentlySelectedType {
+                // Go back to the previous selection if there was one
+                embeddedPaymentMethodsView.resetSelectionToLastSelection()
+            } else {
+                // If there wasn't a previous selection, deselect if the selection isn't valid.
+                let isCurrentSelectionValid = embeddedFormViewController.selectedPaymentOption != nil
+                if !isCurrentSelectionValid {
+                    embeddedPaymentMethodsView.resetSelection()
+                }
+            }
+
             // Show change button if the newly selected row needs it
-            if let newSelectedType = embeddedPaymentMethodsView.selectedRowButton?.type {
-                let changeButtonState = getChangeButtonState(for: newSelectedType)
+            if let currentlySelectedType {
+                let changeButtonState = getChangeButtonState(for: currentlySelectedType)
                 if changeButtonState.shouldShowChangeButton {
                     embeddedPaymentMethodsView.selectedRowButton?.addChangeButton(sublabel: changeButtonState.sublabel)
                     embeddedPaymentMethodsView.selectedRowChangeButtonState = (true, changeButtonState.sublabel)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -209,10 +209,11 @@ public final class EmbeddedPaymentElement {
         analyticsHelper.log(event: .mcConfirmEmbedded)
         guard let presentingViewController else {
             let errorMessage = "Presenting view controller is nil. Please set EmbeddedPaymentElement.presentingViewController."
-            stpAssertionFailure(errorMessage)
+            assertionFailure(errorMessage)
             return .failed(error: PaymentSheetError.integrationError(nonPIIDebugDescription: errorMessage))
         }
         guard let paymentOption = _paymentOption else {
+            assertionFailure("`confirm` should only be called when `paymentOption` is not nil")
             return .failed(error: PaymentSheetError.confirmingWithInvalidPaymentOption)
         }
         let authContext = STPAuthenticationContextWrapper(presentingViewController: presentingViewController)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -245,7 +245,7 @@ public final class EmbeddedPaymentElement {
 
     #if DEBUG
     public func testHeightChange() {
-        stpAssert(configuration.embeddedViewDisplaysMandateText, "Before using this testing feature, ensure that embeddedViewDisplaysMandateText is set to true")
+        assert(configuration.embeddedViewDisplaysMandateText, "Before using this testing feature, ensure that embeddedViewDisplaysMandateText is set to true")
         self.embeddedPaymentMethodsView.testHeightChange()
     }
     #endif

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -213,9 +213,7 @@ public final class EmbeddedPaymentElement {
             return .failed(error: PaymentSheetError.integrationError(nonPIIDebugDescription: errorMessage))
         }
         guard let paymentOption = _paymentOption else {
-            let errorMessage = "`confirm` should only be called when `paymentOption` is not nil"
-            stpAssertionFailure(errorMessage)
-            return .failed(error: PaymentSheetError.integrationError(nonPIIDebugDescription: errorMessage))
+            return .failed(error: PaymentSheetError.confirmingWithInvalidPaymentOption)
         }
         let authContext = STPAuthenticationContextWrapper(presentingViewController: presentingViewController)
         return await _confirm(paymentOption: paymentOption, authContext: authContext).result

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -36,7 +36,7 @@ class EmbeddedPaymentMethodsView: UIView {
     private let appearance: PaymentSheet.Appearance
     private let rowButtonAppearance: PaymentSheet.Appearance
     private let customer: PaymentSheet.CustomerConfiguration?
-    var previousSelectedRowButton: RowButton? {
+    private(set) var previousSelectedRowButton: RowButton? {
         didSet {
             guard let previousSelectedRowButton, selectedRowButton?.type != previousSelectedRowButton.type else {
                 return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -36,7 +36,7 @@ class EmbeddedPaymentMethodsView: UIView {
     private let appearance: PaymentSheet.Appearance
     private let rowButtonAppearance: PaymentSheet.Appearance
     private let customer: PaymentSheet.CustomerConfiguration?
-    private var previousSelectedRowButton: RowButton? {
+    var previousSelectedRowButton: RowButton? {
         didSet {
             guard let previousSelectedRowButton, selectedRowButton?.type != previousSelectedRowButton.type else {
                 return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetError.swift
@@ -57,10 +57,16 @@ public enum PaymentSheetError: Error, LocalizedError {
 
     // MARK: - Confirmation errors
     case unexpectedNewPaymentMethod
+    case confirmingWithInvalidPaymentOption
     case embeddedPaymentElementAlreadyConfirmedIntent
 
     public var errorDescription: String? {
-        return NSError.stp_unexpectedErrorMessage()
+        switch self {
+        case .confirmingWithInvalidPaymentOption:
+            return String.Localized.please_choose_a_valid_payment_method
+        default:
+            return NSError.stp_unexpectedErrorMessage()
+        }
     }
 }
 
@@ -132,6 +138,8 @@ extension PaymentSheetError: CustomDebugStringConvertible {
                 return "This instance of EmbeddedPaymentElement has already confirmed an intent successfully. Create a new instance of EmbeddedPaymentElement to confirm a new intent."
             case .integrationError(nonPIIDebugDescription: let nonPIIDebugDescription):
                 return "There's a problem with your integration. \(nonPIIDebugDescription)"
+            case .confirmingWithInvalidPaymentOption:
+                return "`confirm` should only be called when `paymentOption` is not nil"
             }
         }()
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -394,8 +394,7 @@ extension PaymentSheet {
 
             guard let paymentOption = _paymentOption else {
                 assertionFailure("`confirm` should only be called when `paymentOption` is not nil")
-                let error = PaymentSheetError.flowControllerConfirmFailed(message: "confirmPayment was called with a nil paymentOption")
-                completion(.failed(error: error))
+                completion(.failed(error: PaymentSheetError.confirmingWithInvalidPaymentOption))
                 return
             }
 


### PR DESCRIPTION
## Summary
Fixes the following embedded bug:
1. Enter card details, hit continue
2. Go back into card form, make the form invalid, and close the sheet
The problems:
• We don't inform the merchant that the payment option is nil.
• The "card" row button remains selected. It should be cleared out.

Also:
- Adds a localized error string when you attempt confirmation when there's no valid payment option, vend that for FC and Embedded. 
- Fixes incorrect usage of `stpAssertion` ("/// Use this for assertions that **should not trigger in merchant apps**.")

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-3078

## Testing
Added test to UI Test and also removed it redundantly testing US Bank Account (already tested by `testUSBankAccount`) and saved PMs (already tested by `testConfirmationWithUserButton_savedPaymentMethod`)

## Changelog
See changelog