### PR TITLE
Reduce flakes w/ FC based UI tests

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -817,7 +817,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         fullNameField.forceTapElement()
         fullNameField.typeText("Jane Doe")
 
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
 
         // Ensure Cash App Pay is selected and start checking out
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
@@ -825,7 +825,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.swipeUp() // scroll to see the checkout button
         XCTAssertTrue(app.buttons["Checkout"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Checkout"].isEnabled)
-        app.buttons["Checkout"].tap()
+        app.buttons["Checkout"].waitForExistenceAndTap()
 
         webviewAuthorizePaymentButton.waitForExistenceAndTap(timeout: 10)
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
@@ -564,7 +564,7 @@ class PaymentSheetStandardLPMUITwoTests: PaymentSheetStandardLPMUICase {
         app.buttons["+ Add"].waitForExistenceAndTap()
         tapPaymentMethod("SEPA Debit")
         try! fillSepaData(app, iban: "AT611904300234573201", tapCheckboxWithText: "Save this account for future Example, Inc. payments")
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
         app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
@@ -580,8 +580,8 @@ class PaymentSheetStandardLPMUITwoTests: PaymentSheetStandardLPMUICase {
         app.tap()
         XCTAssertTrue(app.staticTexts["Payment canceled."].waitForExistence(timeout: 10.0))
         // Tapping confirm again and hitting continue should confirm the payment
-        app.buttons["Confirm"].tap()
-        app.buttons["Continue"].tap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
+        app.buttons["Continue"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
         // Reload w/ same customer
@@ -592,8 +592,8 @@ class PaymentSheetStandardLPMUITwoTests: PaymentSheetStandardLPMUICase {
 
         XCTAssertTrue(app.otherElements.matching(identifier: "mandatetextview").element.exists)
         // ...you shouldn't see the mandate again when you confirm
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -160,7 +160,7 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         let addCardButton = app.buttons["Card"].waitForExistenceAndTap()
 
         try! fillCardData(app)
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
 
         let buyButton = app.staticTexts["Buy"]
         XCTAssertTrue(buyButton.waitForExistence(timeout: 4.0))
@@ -204,7 +204,7 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
 
         try! fillCardData(app)
 
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
 
         // Update quantity of an item to force an update
         let saladStepper = app.steppers["salad_stepper"]
@@ -265,7 +265,7 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         XCTAssertFalse(saveThisCardToggle.isSelected)
 
         // Complete payment
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
 
         // Check analytics
         XCTAssertEqual(
@@ -309,8 +309,8 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         XCTAssertTrue(saveThisCardToggle.isSelected)
 
         // Complete payment
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
         successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
 
@@ -381,7 +381,7 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
 
         app.buttons["Card"].waitForExistenceAndTap()
         try! fillCardData(app)
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
 
         // XCTest is too eager to tap the buy button: Wait until the sheet dismisses first.
         waitToDisappear(app.textFields["Card number"])
@@ -654,8 +654,8 @@ class PaymentSheetDeferredUITests: PaymentSheetUITestCase {
 
         try? fillCardData(app, container: nil)
 
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
 
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
@@ -681,8 +681,8 @@ class PaymentSheetDeferredUITests: PaymentSheetUITestCase {
 
         try? fillCardData(app, container: nil)
 
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
 
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
@@ -967,8 +967,8 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
 
         try? fillCardData(app, container: nil)
 
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
 
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
@@ -994,7 +994,7 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
 
         try? fillCardData(app, container: nil)
 
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
         app.buttons["Confirm"].waitForExistenceAndTap()
 
         let successText = app.staticTexts["Success!"]
@@ -1021,8 +1021,8 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
 
         try? fillCardData(app, container: nil)
 
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
 
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
@@ -1159,8 +1159,8 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         XCTAssertFalse(saveThisCardToggle.isSelected)
 
         // Complete payment
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
         var successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
 
@@ -1176,8 +1176,8 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         XCTAssertTrue(saveThisCardToggle.isSelected)
 
         // Complete payment
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
         successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
 
@@ -1251,7 +1251,7 @@ class PaymentSheetExternalPMUITests: PaymentSheetUITestCase {
 
         scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "PayPal")?.waitForExistenceAndTap()
 
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
 
         // Verify EPMs vend the correct PaymentOptionDisplayData
         XCTAssertTrue(app.staticTexts["PayPal"].waitForExistence(timeout: 5.0))
@@ -1360,8 +1360,8 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         try! fillCardData(app)
 
         // Complete payment
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
         // Reload w/ same customer
@@ -1372,8 +1372,8 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         // Add another PM
         app.buttons["+ Add"].waitForExistenceAndTap()
         try! fillCardData(app)
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
         // Should be able to edit two saved PMs
@@ -1545,8 +1545,8 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         try! fillCardData(app, tapCheckboxWithText: tapCheckboxWithText)
 
         // Complete payment
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
         // Reload w/ same customer
@@ -1566,8 +1566,8 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         app.buttons["+ Add"].waitForExistenceAndTap()
         try! fillCardData(app, cardNumber: "5555555555554444", tapCheckboxWithText: tapCheckboxWithText)
 
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
         // Should be able to edit two saved PMs
@@ -1719,8 +1719,8 @@ class PaymentSheetCustomerSessionCBCUITests: PaymentSheetUITestCase {
         app.buttons["+ Add"].waitForExistenceAndTap()
         try fillCardData(app, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
 
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 5.0))
         reload(app, settings: settings)
 
@@ -1762,8 +1762,8 @@ class PaymentSheetCVCRecollectionUITests: PaymentSheetUITestCase {
         saveThisCardToggle.tap()
         XCTAssertTrue(saveThisCardToggle.isSelected)
 
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
 
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
@@ -1849,8 +1849,8 @@ class PaymentSheetCVCRecollectionUITests: PaymentSheetUITestCase {
         saveThisCardToggle.tap()
         XCTAssertTrue(saveThisCardToggle.isSelected)
 
-        app.buttons["Continue"].tap()
-        app.buttons["Confirm"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
 
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
@@ -2341,7 +2341,7 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
 
         // Disable postal code input, it is pre-filled by `defaultBillingAddress`
         try! fillCardData(app, postalEnabled: false)
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
         app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
@@ -2381,7 +2381,7 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
 
         // Disable postal code input, it is pre-filled by `defaultBillingAddress`
         try! fillCardData(app, postalEnabled: false)
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
         app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
@@ -2406,7 +2406,7 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         saveThisCardToggle.tap()
         XCTAssertTrue(saveThisCardToggle.isSelected)
 
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
         app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
@@ -2441,7 +2441,7 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         // Begin by saving a card for this new user who is not signed up for Link
         XCTAssertTrue(app.buttons["Continue"].waitForExistence(timeout: 5))
         try! fillCardData(app)
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
         app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
@@ -2478,7 +2478,7 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         saveThisCardToggle.tap()
         XCTAssertTrue(saveThisCardToggle.isSelected)
 
-        app.buttons["Continue"].tap()
+        app.buttons["Continue"].waitForExistenceAndTap()
         app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
@@ -2657,7 +2657,7 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
         case .paymentSheet:
             app.buttons["Pay $50.99"].tap()
         case .flowController:
-            app.buttons["Continue"].tap()
+            app.buttons["Continue"].waitForExistenceAndTap()
             app.buttons["Confirm"].waitForExistenceAndTap()
         case .embedded:
             // TODO(porter) Fill in embedded UI test steps

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITest.swift
@@ -114,7 +114,7 @@ class PaymentSheetVerticalUITests: PaymentSheetUITestCase {
         // Switch to the saved card...
         app.buttons["View more"].waitForExistenceAndTap()
         app.buttons["•••• 4242"].waitForExistenceAndTap()
-        app.buttons["Continue"].tap() // For some reason, waitForExistenceAndTap() does not tap this!
+        app.buttons["Continue"].waitForExistenceAndTap() // For some reason, waitForExistenceAndTap() does not tap this!
         XCTAssertEqual(
             analyticsLog.map({ $0[string: "event"] }),
             ["mc_load_started", "link.account_lookup.complete", "mc_load_succeeded", "mc_custom_init_customer_applepay", "mc_custom_sheet_newpm_show", "mc_custom_paymentoption_savedpm_select", "mc_confirm_button_tapped"]


### PR DESCRIPTION
## Summary
Noticed that there is some delay for the confirm button to appear after hitting continue which causes some flakiness in our ui tests.

## Motivation
Reduce flakeyness in our UI tests

## Testing
None, relying on CI.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
