### PR TITLE
Fix remove last payment method w/ CustomerSessions for vertical and Embedded

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -502,6 +502,39 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Cash App Pay"].waitForExistence(timeout: 10))
     }
 
+    func testPaymentMethodRemoveLast() {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.mode = .paymentWithSetup
+        settings.uiStyle = .embedded
+        settings.customerMode = .new
+        settings.customerKeyType = .customerSession
+        settings.paymentMethodRemoveLast = .disabled
+        settings.applePayEnabled = .on
+        settings.integrationType = .deferred_csc
+
+        loadPlayground(app, settings)
+        app.buttons["Present embedded payment element"].waitForExistenceAndTap()
+
+        app.buttons["Card"].waitForExistenceAndTap(timeout: 10)
+        XCTAssertTrue(app.staticTexts["Add card"].waitForExistence(timeout: 10))
+        try! fillCardData(app, postalEnabled: true, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
+
+        // Checkout
+        XCTAssertTrue(app.buttons["Continue"].isEnabled)
+        app.buttons["Continue"].waitForExistenceAndTap()
+        XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
+        XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
+        XCTAssertTrue(app.buttons["Checkout"].waitForExistenceAndTap(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
+
+        // Reload after confirmation and re-present and ensure 'edit' does not exist
+        XCTAssertTrue(app.buttons["Reload"].waitForExistenceAndTap(timeout: 10))
+        XCTAssertTrue(app.buttons["Present embedded payment element"].waitForExistenceAndTap(timeout: 10))
+        XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
+        XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
+        XCTAssertFalse(app.buttons["Edit"].waitForExistence(timeout: 3))
+    }
+
     func testConfirmationWithUserButton_savedPaymentMethod() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.uiStyle = .embedded

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITest.swift
@@ -295,6 +295,43 @@ class PaymentSheetVerticalUITests: PaymentSheetUITestCase {
         }
     }
 
+    func testPaymentMethodRemoveLast_verticalMode() {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.layout = .vertical
+        settings.uiStyle = .paymentSheet
+        settings.customerMode = .new
+        settings.integrationType = .deferred_csc
+        settings.customerMode = .new
+        settings.customerKeyType = .customerSession
+        settings.paymentMethodRemoveLast = .disabled
+        settings.applePayEnabled = .off
+        settings.apmsEnabled = .off
+        settings.linkPassthroughMode = .passthrough
+        settings.requireCVCRecollection = .on
+        loadPlayground(app, settings)
+
+        app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
+        app.buttons["Card"].waitForExistenceAndTap()
+        try! fillCardData(app)
+        app.switches["Save payment details to Example, Inc. for future purchases"].waitForExistenceAndTap()
+        app.buttons["Pay $50.99"].waitForExistenceAndTap()
+
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+
+        // Reload w/ same customer
+        reload(app, settings: settings)
+
+        XCTAssertFalse(successText.exists)
+
+        // Present and ensure sheet is present
+        app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
+        XCTAssertTrue(app.buttons["Pay $50.99"].waitForExistence(timeout: 10))
+
+        // Verify that edit control does not render
+        XCTAssertFalse(app.buttons["Edit"].waitForExistenceAndTap())
+    }
+
     func testCVCRecollection_verticalMode() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.layout = .vertical

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -207,8 +207,15 @@ extension STPElementsSession {
         }
         return allowsRemovalOfPaymentMethods
     }
-    var paymentMethodRemoveLastForPaymentSheet: Bool {
-        return customer?.customerSession.mobilePaymentElementComponent.features?.paymentMethodRemoveLast ?? true
+
+    func paymentMethodRemoveLast(configuration: PaymentElementConfiguration) -> Bool{
+        if !configuration.allowsRemovalOfLastSavedPaymentMethod {
+            // Merchant has set local configuration to false, so honor it.
+            return false
+        } else {
+            // Merchant is using client side default, so defer to CustomerSession's value
+            return customer?.customerSession.mobilePaymentElementComponent.features?.paymentMethodRemoveLast ?? true
+        }
     }
 
     var paymentMethodSetAsDefaultForPaymentSheet: Bool {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -31,7 +31,7 @@ extension EmbeddedPaymentElement {
             savedPaymentMethodsCount: loadResult.savedPaymentMethods.count,
             isFirstCardCoBranded: loadResult.savedPaymentMethods.first?.isCoBrandedCard ?? false,
             isCBCEligible: loadResult.elementsSession.isCardBrandChoiceEligible,
-            allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod,
+            allowsRemovalOfLastSavedPaymentMethod: loadResult.elementsSession.paymentMethodRemoveLast(configuration: configuration),
             allowsPaymentMethodRemoval: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
             isFlatCheckmarkStyle: configuration.appearance.embeddedPaymentElement.row.style == .flatWithCheckmark
         )
@@ -167,7 +167,7 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
                                                                                appearance: configuration.appearance,
                                                                                hostedSurface: .paymentSheet,
                                                                                cardBrandFilter: configuration.cardBrandFilter,
-                                                                               canRemove: configuration.allowsRemovalOfLastSavedPaymentMethod && elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
+                                                                               canRemove: elementsSession.paymentMethodRemoveLast(configuration: configuration) && elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                                                                                isCBCEligible: paymentMethod.isCoBrandedCard && elementsSession.isCardBrandChoiceEligible,
                                                                                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
                                                                                isDefault: paymentMethod == elementsSession.customer?.getDefaultPaymentMethod())
@@ -237,7 +237,7 @@ extension EmbeddedPaymentElement: UpdatePaymentMethodViewControllerDelegate {
             savedPaymentMethodsCount: savedPaymentMethods.count,
             isFirstCardCoBranded: savedPaymentMethods.first?.isCoBrandedCard ?? false,
             isCBCEligible: elementsSession.isCardBrandChoiceEligible,
-            allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod,
+            allowsRemovalOfLastSavedPaymentMethod: elementsSession.paymentMethodRemoveLast(configuration: configuration),
             allowsPaymentMethodRemoval: elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
             isFlatCheckmarkStyle: configuration.appearance.embeddedPaymentElement.row.style == .flatWithCheckmark
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -35,6 +35,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
     private let configuration: PaymentElementConfiguration
     private let elementsSession: STPElementsSession
     private let paymentMethodRemove: Bool
+    private let paymentMethodRemoveLast: Bool
     private let paymentMethodSetAsDefault: Bool
     private let isCBCEligible: Bool
     private let analyticsHelper: PaymentSheetAnalyticsHelper
@@ -84,7 +85,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
 
     var canRemovePaymentMethods: Bool {
         // Can remove a payment method if we have more than one payment method or if we have one payment method and `allowsRemovalOfLastSavedPaymentMethod` is true AND paymentMethodRemove is true
-        return (paymentMethodRows.count > 1 ? true : configuration.allowsRemovalOfLastSavedPaymentMethod) && paymentMethodRemove
+        return (paymentMethodRows.count > 1 ? true : paymentMethodRemoveLast) && paymentMethodRemove
     }
 
     var canEditPaymentMethods: Bool {
@@ -171,6 +172,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         self.configuration = configuration
         self.elementsSession = elementsSession
         self.paymentMethodRemove = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
+        self.paymentMethodRemoveLast = elementsSession.paymentMethodRemoveLast(configuration: configuration)
         self.paymentMethodSetAsDefault = elementsSession.paymentMethodSetAsDefaultForPaymentSheet
         self.isCBCEligible = elementsSession.isCardBrandChoiceEligible
         self.analyticsHelper = analyticsHelper

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -205,7 +205,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
                 merchantDisplayName: configuration.merchantDisplayName,
                 isCVCRecollectionEnabled: false,
                 isTestMode: configuration.apiClient.isTestmode,
-                allowsRemovalOfLastSavedPaymentMethod: PaymentSheetViewController.allowsRemovalOfLastPaymentMethod(elementsSession: elementsSession, configuration: configuration),
+                allowsRemovalOfLastSavedPaymentMethod: elementsSession.paymentMethodRemoveLast(configuration: configuration),
                 allowsRemovalOfPaymentMethods: elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                 allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet
             ),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -377,7 +377,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
             savedPaymentMethodsCount: savedPaymentMethods.count,
             isFirstCardCoBranded: savedPaymentMethods.first?.isCoBrandedCard ?? false,
             isCBCEligible: loadResult.elementsSession.isCardBrandChoiceEligible,
-            allowsRemovalOfLastSavedPaymentMethod: configuration.allowsRemovalOfLastSavedPaymentMethod,
+            allowsRemovalOfLastSavedPaymentMethod: loadResult.elementsSession.paymentMethodRemoveLast(configuration: configuration),
             allowsPaymentMethodRemoval: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
         )
         return VerticalPaymentMethodListViewController(
@@ -608,7 +608,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                                                                                appearance: configuration.appearance,
                                                                                hostedSurface: .paymentSheet,
                                                                                cardBrandFilter: configuration.cardBrandFilter,
-                                                                               canRemove: configuration.allowsRemovalOfLastSavedPaymentMethod && elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
+                                                                               canRemove: elementsSession.paymentMethodRemoveLast(configuration: configuration) && elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                                                                                isCBCEligible: paymentMethod.isCoBrandedCard && elementsSession.isCardBrandChoiceEligible,
                                                                                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
                                                                                isDefault: paymentMethod == elementsSession.customer?.getDefaultPaymentMethod())

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -173,7 +173,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                 merchantDisplayName: configuration.merchantDisplayName,
                 isCVCRecollectionEnabled: isCVCRecollectionEnabled,
                 isTestMode: configuration.apiClient.isTestmode,
-                allowsRemovalOfLastSavedPaymentMethod: PaymentSheetViewController.allowsRemovalOfLastPaymentMethod(elementsSession: elementsSession, configuration: configuration),
+                allowsRemovalOfLastSavedPaymentMethod: elementsSession.paymentMethodRemoveLast(configuration: configuration),
                 allowsRemovalOfPaymentMethods: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                 allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet
             ),
@@ -487,18 +487,6 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                     }
                 }
             }
-        }
-    }
-}
-// MARK: - Helpers
-extension PaymentSheetViewController {
-    static func allowsRemovalOfLastPaymentMethod(elementsSession: STPElementsSession, configuration: PaymentSheet.Configuration) -> Bool {
-        if !configuration.allowsRemovalOfLastSavedPaymentMethod {
-            // Merchant has set local configuration to false, so honor it.
-            return false
-        } else {
-            // Merchant is using client side default, so defer to CustomerSession's value
-            return elementsSession.paymentMethodRemoveLastForPaymentSheet
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -8,7 +8,7 @@
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripeCoreTestUtils
 @testable@_spi(STP) import StripePayments
-@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP)@_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsTestUtils
 import XCTest
 
@@ -142,7 +142,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
 
         XCTAssertTrue(allowsRemoval)
-        XCTAssertTrue(elementsSession.paymentMethodRemoveLastForPaymentSheet)
+        XCTAssertTrue(elementsSession.customer!.customerSession.mobilePaymentElementComponent.features!.paymentMethodRemoveLast)
         XCTAssertEqual(.paymentSheetWithCustomerSessionPaymentMethodSaveEnabled, savePaymentMethodConsentBehavior)
     }
     func testSPMConsentAndRemoval_pmsD_pmrE() {
@@ -223,7 +223,17 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
 
         XCTAssertTrue(allowsRemoval)
-        XCTAssertTrue(elementsSession.paymentMethodRemoveLastForPaymentSheet)
+        XCTAssertTrue(elementsSession.customer!.customerSession.mobilePaymentElementComponent.features!.paymentMethodRemoveLast)
+
+        // Test that local config can override behavior
+        var configuration1 = PaymentSheet.Configuration()
+        configuration1.allowsRemovalOfLastSavedPaymentMethod = false
+        XCTAssertFalse(elementsSession.paymentMethodRemoveLast(configuration: configuration1))
+
+        // Test that local config works in w/ customerSession
+        var configuration2 = PaymentSheet.Configuration()
+        configuration2.allowsRemovalOfLastSavedPaymentMethod = true
+        XCTAssertTrue(elementsSession.paymentMethodRemoveLast(configuration: configuration2))
     }
     func testPaymentMethodRemoveLast_disabled() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
@@ -243,7 +253,17 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
 
         XCTAssertTrue(allowsRemoval)
-        XCTAssertFalse(elementsSession.paymentMethodRemoveLastForPaymentSheet)
+        XCTAssertFalse(elementsSession.customer!.customerSession.mobilePaymentElementComponent.features!.paymentMethodRemoveLast)
+
+        // Test that local config can override behavior
+        var configuration1 = PaymentSheet.Configuration()
+        configuration1.allowsRemovalOfLastSavedPaymentMethod = false
+        XCTAssertFalse(elementsSession.paymentMethodRemoveLast(configuration: configuration1))
+
+        // Test that local config works in w/ customerSession
+        var configuration2 = PaymentSheet.Configuration()
+        configuration2.allowsRemovalOfLastSavedPaymentMethod = true
+        XCTAssertFalse(elementsSession.paymentMethodRemoveLast(configuration: configuration2))
     }
     func testSPMConsentAndRemoval_invalidComponent() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],


### PR DESCRIPTION
## Summary
Unifies logic of remove last payment method w/ customerSession & local config

## Motivation
vertical & embedded were not respecting the customer session flag

## Testing
Relying on existing test and will add some additional.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
