### PR TITLE
Replace `las_client_secret` in logs with `las_id`

### DIFF
--- a/StripeCore/StripeCore/Source/Connections Bindings/InstantDebitsLinkedBank.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/InstantDebitsLinkedBank.swift
@@ -13,18 +13,21 @@ import Foundation
     public let last4: String?
     public let linkMode: LinkMode?
     public let incentiveEligible: Bool
-    
+    public let linkAccountSessionId: String?
+
     public init(
         paymentMethod: LinkBankPaymentMethod,
         bankName: String?,
         last4: String?,
         linkMode: LinkMode?,
-        incentiveEligible: Bool
+        incentiveEligible: Bool,
+        linkAccountSessionId: String?
     ) {
         self.paymentMethod = paymentMethod
         self.bankName = bankName
         self.last4 = last4
         self.linkMode = linkMode
         self.incentiveEligible = incentiveEligible
+        self.linkAccountSessionId = linkAccountSessionId
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -158,16 +158,15 @@ extension FinancialConnectionsAnalyticsClient {
     }
 
     func setAdditionalParameters(
-        linkAccountSessionClientSecret: String,
         publishableKey: String?,
         stripeAccount: String?
     ) {
-        additionalParameters["las_client_secret"] = linkAccountSessionClientSecret
         additionalParameters["key"] = publishableKey
         additionalParameters["stripe_account"] = stripeAccount
     }
 
     func setAdditionalParameters(fromManifest manifest: FinancialConnectionsSessionManifest) {
+        additionalParameters["las_id"] = manifest.id
         additionalParameters["livemode"] = manifest.livemode
         additionalParameters["product"] = manifest.product
         additionalParameters["is_stripe_direct"] = manifest.isStripeDirect

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
@@ -8,16 +8,17 @@
 import Foundation
 @_spi(STP) import StripeCore
 
-/// Analytic that contains a `financial connections session clientSecret` payload param
+/// Analytic that contains a `financial connections session id` payload param.
+/// **Note:** Avoid logging the client secret.
 protocol FinancialConnectionsSheetAnalytic: Analytic {
-    var clientSecret: String { get }
+    var linkAccountSessionId: String? { get }
     var additionalParams: [String: Any] { get }
 }
 
 extension FinancialConnectionsSheetAnalytic {
     var params: [String: Any] {
         var params = additionalParams
-        params["las_client_secret"] = clientSecret
+        params["las_id"] = linkAccountSessionId
         return params
     }
 }
@@ -25,14 +26,14 @@ extension FinancialConnectionsSheetAnalytic {
 /// Logged when the sheet is presented
 struct FinancialConnectionsSheetPresentedAnalytic: FinancialConnectionsSheetAnalytic {
     let event = STPAnalyticEvent.financialConnectionsSheetPresented
-    let clientSecret: String
+    let linkAccountSessionId: String?
     let additionalParams: [String: Any] = [:]
 }
 
 /// Logged when the sheet is closed by the end-user
 struct FinancialConnectionsSheetClosedAnalytic: FinancialConnectionsSheetAnalytic {
     let event = STPAnalyticEvent.financialConnectionsSheetClosed
-    let clientSecret: String
+    let linkAccountSessionId: String?
     let result: String
 
     var additionalParams: [String: Any] {
@@ -45,7 +46,7 @@ struct FinancialConnectionsSheetClosedAnalytic: FinancialConnectionsSheetAnalyti
 /// Logged when the financial connections sheet flow is determined
 struct FinancialConnectionsSheetFlowDetermined: FinancialConnectionsSheetAnalytic {
     let event = STPAnalyticEvent.financialConnectionsSheetFlowDetermined
-    let clientSecret: String
+    let linkAccountSessionId: String?
     let flow: FlowRouter.Flow
     let killswitchActive: Bool
 
@@ -60,7 +61,7 @@ struct FinancialConnectionsSheetFlowDetermined: FinancialConnectionsSheetAnalyti
 /// Logged if there's an error presenting the sheet
 struct FinancialConnectionsSheetFailedAnalytic: FinancialConnectionsSheetAnalytic {
     let event = STPAnalyticEvent.financialConnectionsSheetFailed
-    let clientSecret: String
+    let linkAccountSessionId: String?
     let additionalParams: [String: Any] = [:]
     let error: Error
 }
@@ -68,14 +69,14 @@ struct FinancialConnectionsSheetFailedAnalytic: FinancialConnectionsSheetAnalyti
 /// Logged at the begining of the initial `synchronize` API call.
 struct FinancialConnectionsSheetInitialSynchronizeStarted: FinancialConnectionsSheetAnalytic {
     let event = STPAnalyticEvent.financialConnectionsSheetInitialSynchronizeStarted
-    let clientSecret: String
-    let additionalParams: [String: Any] = [:]
+    let linkAccountSessionId: String?
+    var additionalParams: [String: Any] = [:]
 }
 
 /// Logged when the initial `synchronize` API call completes. Includes whether or not the call was a success, and the error otherwise.
 struct FinancialConnectionsSheetInitialSynchronizeCompleted: FinancialConnectionsSheetAnalytic {
     let event = STPAnalyticEvent.financialConnectionsSheetInitialSynchronizeCompleted
-    let clientSecret: String
+    let linkAccountSessionId: String?
     let success: Bool
     let possibleError: Error?
 
@@ -92,23 +93,23 @@ struct FinancialConnectionsSheetInitialSynchronizeCompleted: FinancialConnection
 struct FinancialConnectionsSheetCompletionAnalytic {
     /// Returns either a `FinancialConnectionsSheetClosedAnalytic` or `FinancialConnectionsSheetFailedAnalytic` depending on the result
     static func make(
-        clientSecret: String,
+        linkAccountSessionId: String?,
         result: HostControllerResult
     ) -> FinancialConnectionsSheetAnalytic {
         switch result {
         case .completed:
             return FinancialConnectionsSheetClosedAnalytic(
-                clientSecret: clientSecret,
+                linkAccountSessionId: linkAccountSessionId,
                 result: "completed"
             )
         case .canceled:
             return FinancialConnectionsSheetClosedAnalytic(
-                clientSecret: clientSecret,
+                linkAccountSessionId: linkAccountSessionId,
                 result: "cancelled"
             )
         case .failed(let error):
             return FinancialConnectionsSheetFailedAnalytic(
-                clientSecret: clientSecret,
+                linkAccountSessionId: linkAccountSessionId,
                 error: error
             )
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsSheetAnalytics.swift
@@ -70,7 +70,7 @@ struct FinancialConnectionsSheetFailedAnalytic: FinancialConnectionsSheetAnalyti
 struct FinancialConnectionsSheetInitialSynchronizeStarted: FinancialConnectionsSheetAnalytic {
     let event = STPAnalyticEvent.financialConnectionsSheetInitialSynchronizeStarted
     let linkAccountSessionId: String?
-    var additionalParams: [String: Any] = [:]
+    let additionalParams: [String: Any] = [:]
 }
 
 /// Logged when the initial `synchronize` API call completes. Includes whether or not the call was a success, and the error otherwise.

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -121,7 +121,6 @@ class HostController {
         self.elementsSessionContext = elementsSessionContext
         self.analyticsClient = FinancialConnectionsAnalyticsClient()
         analyticsClient.setAdditionalParameters(
-            linkAccountSessionClientSecret: clientSecret,
             publishableKey: publishableKey,
             stripeAccount: stripeAccount
         )
@@ -156,7 +155,7 @@ extension HostController: HostViewControllerDelegate {
         let flow = flowRouter.flow
         analyticsClientV1.log(
             analytic: FinancialConnectionsSheetFlowDetermined(
-                clientSecret: clientSecret,
+                linkAccountSessionId: synchronizePayload.manifest.id,
                 flow: flow,
                 killswitchActive: flowRouter.killswitchActive
             ),

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
@@ -105,7 +105,9 @@ extension HostViewController {
         loadingView.showLoading(true)
 
         analyticsClientV1.log(
-            analytic: FinancialConnectionsSheetInitialSynchronizeStarted(clientSecret: clientSecret),
+            analytic: FinancialConnectionsSheetInitialSynchronizeStarted(
+                linkAccountSessionId: nil // We don't have the session ID yet.
+            ),
             apiClient: apiClient.backingAPIClient
         )
 
@@ -118,9 +120,15 @@ extension HostViewController {
             .observe { [weak self] result in
                 guard let self = self else { return }
 
+                let linkAccountSessionId: String? = {
+                    guard case .success(let synchronizePayload) = result else {
+                        return nil
+                    }
+                    return synchronizePayload.manifest.id
+                }()
                 analyticsClientV1.log(
                     analytic: FinancialConnectionsSheetInitialSynchronizeCompleted(
-                        clientSecret: clientSecret,
+                        linkAccountSessionId: linkAccountSessionId,
                         success: result.success,
                         possibleError: result.error
                     ),

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -230,9 +230,22 @@ final public class FinancialConnectionsSheet {
     ) {
         // Overwrite completion closure to retain self until called
         let completion: (HostControllerResult) -> Void = { result in
+            let linkAccountSessionId: String? = {
+                guard case .completed(let completedResult) = result else {
+                    return nil
+                }
+
+                switch completedResult {
+                case .financialConnections(let session):
+                    return session.id
+                case .instantDebits(let linkedBank):
+                    return linkedBank.linkAccountSessionId
+                }
+            }()
+
             self.analyticsClient.log(
                 analytic: FinancialConnectionsSheetCompletionAnalytic.make(
-                    clientSecret: self.financialConnectionsSessionClientSecret,
+                    linkAccountSessionId: linkAccountSessionId,
                     result: result
                 ),
                 apiClient: self.apiClient
@@ -286,7 +299,8 @@ final public class FinancialConnectionsSheet {
 
         analyticsClient.log(
             analytic: FinancialConnectionsSheetPresentedAnalytic(
-                clientSecret: self.financialConnectionsSessionClientSecret
+                // We don't have the session ID yet.
+                linkAccountSessionId: nil
             ),
             apiClient: apiClient
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -110,8 +110,10 @@ final public class FinancialConnectionsSheet {
     /// Contains all configurable properties of Financial Connections.
     public let configuration: FinancialConnectionsSheet.Configuration
 
+    /// An internal result type that holds a `HostControllerResult` and an optional Link Account Session ID for logging.
+    private typealias HostControllerOutcome = (result: HostControllerResult, sessionId: String?)
     /// Completion block called when the sheet is closed or fails to open
-    private var completion: ((HostControllerResult, String?) -> Void)?
+    private var completion: ((HostControllerOutcome) -> Void)?
 
     private var hostController: HostController?
 
@@ -229,15 +231,15 @@ final public class FinancialConnectionsSheet {
         completion: @escaping (HostControllerResult) -> Void
     ) {
         // Overwrite completion closure to retain self until called
-        let completion: (HostControllerResult, String?) -> Void = { result, linkAccountSessionId in
+        let completion: (HostControllerOutcome) -> Void = { outcome in
             self.analyticsClient.log(
                 analytic: FinancialConnectionsSheetCompletionAnalytic.make(
-                    linkAccountSessionId: linkAccountSessionId,
-                    result: result
+                    linkAccountSessionId: outcome.sessionId,
+                    result: outcome.result
                 ),
                 apiClient: self.apiClient
             )
-            completion(result)
+            completion(outcome.result)
             self.completion = nil
         }
         self.completion = completion
@@ -248,7 +250,8 @@ final public class FinancialConnectionsSheet {
             let error = FinancialConnectionsSheetError.unknown(
                 debugDescription: "presentingViewController is already presenting a view controller"
             )
-            completion(.failed(error: error), nil)
+            let flowResult = HostControllerOutcome(result: .failed(error: error), sessionId: nil)
+            completion(flowResult)
             return
         }
 
@@ -261,7 +264,8 @@ final public class FinancialConnectionsSheet {
                     debugDescription:
                         "invalid returnURL: \(urlString) parameter passed in when creating FinancialConnectionsSheet"
                 )
-                completion(.failed(error: error), nil)
+                let flowResult = HostControllerOutcome(result: .failed(error: error), sessionId: nil)
+                completion(flowResult)
                 return
             }
         }
@@ -327,16 +331,17 @@ extension FinancialConnectionsSheet: HostControllerDelegate {
         viewController.dismiss(
             animated: true,
             completion: {
+                let flowResult = HostControllerOutcome(result: result, sessionId: linkAccountSessionId)
                 if let wrapperViewController = self.wrapperViewController {
                     wrapperViewController.dismiss(
                         animated: false,
                         completion: {
-                            self.completion?(result, linkAccountSessionId)
+                            self.completion?(flowResult)
                         }
                     )
                     self.wrapperViewController = nil
                 } else {
-                    self.completion?(result, linkAccountSessionId)
+                    self.completion?(flowResult)
                 }
             }
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -579,7 +579,7 @@ extension NativeFlowController {
                 paymentMethod: paymentMethod
             )
         }
-        .observe { result in
+        .observe { [weak self] result in
             switch result {
             case .success(let paymentMethodWithIncentiveEligibility):
                 let linkedBank = InstantDebitsLinkedBank(
@@ -587,7 +587,8 @@ extension NativeFlowController {
                     bankName: bankAccountDetails?.bankName,
                     last4: bankAccountDetails?.last4,
                     linkMode: linkMode,
-                    incentiveEligible: paymentMethodWithIncentiveEligibility.incentiveEligible
+                    incentiveEligible: paymentMethodWithIncentiveEligibility.incentiveEligible,
+                    linkAccountSessionId: self?.dataManager.manifest.id
                 )
                 completion(.success(linkedBank))
             case .failure(let error):

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -176,7 +176,8 @@ extension FinancialConnectionsWebFlowViewController {
                         if let paymentMethod = returnUrl.extractLinkBankPaymentMethod() {
                             let instantDebitsLinkedBank = createInstantDebitsLinkedBank(
                                 from: returnUrl,
-                                with: paymentMethod
+                                with: paymentMethod,
+                                linkAccountSessionId: manifest.id
                             )
                             self.notifyDelegateOfSuccess(result: .instantDebits(instantDebitsLinkedBank))
                         } else {
@@ -212,7 +213,8 @@ extension FinancialConnectionsWebFlowViewController {
 
     private func createInstantDebitsLinkedBank(
         from url: URL,
-        with paymentMethod: LinkBankPaymentMethod
+        with paymentMethod: LinkBankPaymentMethod,
+        linkAccountSessionId: String
     ) -> InstantDebitsLinkedBank {
         return InstantDebitsLinkedBank(
             paymentMethod: paymentMethod,
@@ -221,7 +223,8 @@ extension FinancialConnectionsWebFlowViewController {
                 .replacingOccurrences(of: "+", with: " "),
             last4: url.extractValue(forKey: "last4"),
             linkMode: elementsSessionContext?.linkMode,
-            incentiveEligible: url.extractValue(forKey: "incentive_eligible").flatMap { Bool($0) } ?? false
+            incentiveEligible: url.extractValue(forKey: "incentive_eligible").flatMap { Bool($0) } ?? false,
+            linkAccountSessionId: linkAccountSessionId
         )
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAnalyticsTest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAnalyticsTest.swift
@@ -14,7 +14,7 @@ final class FinancialConnectionsSheetAnalyticsTest: XCTestCase {
 
     func testFinancialConnectionsSheetFailedAnalyticEncoding() {
         let analytic = FinancialConnectionsSheetFailedAnalytic(
-            clientSecret: "test",
+            linkAccountSessionId: "linkAccountSessionId",
             error: FinancialConnectionsSheetError.unknown(debugDescription: "some description")
         )
         XCTAssertNotNil(analytic.error)
@@ -38,37 +38,37 @@ final class FinancialConnectionsSheetAnalyticsTest: XCTestCase {
             statusDetails: nil
         )
         let analytic = FinancialConnectionsSheetCompletionAnalytic.make(
-            clientSecret: "secret",
+            linkAccountSessionId: "linkAccountSessionId",
             result: .completed(.financialConnections(session))
         )
         guard let closedAnalytic = analytic as? FinancialConnectionsSheetClosedAnalytic else {
             return XCTFail("Expected `FinancialConnectionsSheetClosedAnalytic`")
         }
 
-        XCTAssertEqual(closedAnalytic.clientSecret, "secret")
+        XCTAssertEqual(closedAnalytic.linkAccountSessionId, "linkAccountSessionId")
         XCTAssertEqual(closedAnalytic.result, "completed")
     }
 
     func testFinancialConnectionsSheetCompletionAnalyticCanceled() {
-        let analytic = FinancialConnectionsSheetCompletionAnalytic.make(clientSecret: "secret", result: .canceled)
+        let analytic = FinancialConnectionsSheetCompletionAnalytic.make(linkAccountSessionId: "linkAccountSessionId", result: .canceled)
         guard let closedAnalytic = analytic as? FinancialConnectionsSheetClosedAnalytic else {
             return XCTFail("Expected `FinancialConnectionsSheetClosedAnalytic`")
         }
 
-        XCTAssertEqual(closedAnalytic.clientSecret, "secret")
+        XCTAssertEqual(closedAnalytic.linkAccountSessionId, "linkAccountSessionId")
         XCTAssertEqual(closedAnalytic.result, "cancelled")
     }
 
     func testFinancialConnectionsSheetCompletionAnalyticFailed() {
         let analytic = FinancialConnectionsSheetCompletionAnalytic.make(
-            clientSecret: "secret",
+            linkAccountSessionId: "linkAccountSessionId",
             result: .failed(error: FinancialConnectionsSheetError.unknown(debugDescription: "some description"))
         )
         guard let failedAnalytic = analytic as? FinancialConnectionsSheetFailedAnalytic else {
             return XCTFail("Expected `FinancialConnectionsSheetFailedAnalytic`")
         }
 
-        XCTAssertEqual(failedAnalytic.clientSecret, "secret")
+        XCTAssertEqual(failedAnalytic.linkAccountSessionId, "linkAccountSessionId")
         XCTAssert(failedAnalytic.error is FinancialConnectionsSheetError)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
@@ -46,7 +46,8 @@ class FinancialConnectionsSheetTests: XCTestCase {
         else {
             return XCTFail("Expected `FinancialConnectionsSheetPresentedAnalytic`")
         }
-        XCTAssertEqual(presentedAnalytic.clientSecret, mockClientSecret)
+        // We don't have a `linkAccountSessionId` at this point.
+        XCTAssertNil(presentedAnalytic.linkAccountSessionId)
 
         // Mock that financialConnections is completed
         let host = HostController(
@@ -67,7 +68,8 @@ class FinancialConnectionsSheetTests: XCTestCase {
         else {
             return XCTFail("Expected `FinancialConnectionsSheetClosedAnalytic`")
         }
-        XCTAssertEqual(closedAnalytic.clientSecret, mockClientSecret)
+        // Canceled results do not provide a `linkAccountSessionId`.
+        XCTAssertNil(closedAnalytic.linkAccountSessionId)
         XCTAssertEqual(closedAnalytic.result, "cancelled")
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
@@ -60,7 +60,12 @@ class FinancialConnectionsSheetTests: XCTestCase {
             publishableKey: "test",
             stripeAccount: nil
         )
-        sheet.hostController(host, viewController: UIViewController(), didFinish: .canceled)
+        sheet.hostController(
+            host,
+            viewController: UIViewController(),
+            didFinish: .canceled,
+            linkAccountSessionId: "fcsess_123"
+        )
 
         // Verify closed analytic is logged
         XCTAssertEqual(mockAnalyticsClient.loggedAnalytics.count, 2)
@@ -68,8 +73,8 @@ class FinancialConnectionsSheetTests: XCTestCase {
         else {
             return XCTFail("Expected `FinancialConnectionsSheetClosedAnalytic`")
         }
-        // Canceled results do not provide a `linkAccountSessionId`.
-        XCTAssertNil(closedAnalytic.linkAccountSessionId)
+
+        XCTAssertEqual(closedAnalytic.linkAccountSessionId, "fcsess_123")
         XCTAssertEqual(closedAnalytic.result, "cancelled")
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -511,7 +511,8 @@ class EmbeddedPaymentElementTest: XCTestCase {
             bankName: "Stripe Bank",
             last4: "6789",
             linkMode: nil,
-            incentiveEligible: false
+            incentiveEligible: false,
+            linkAccountSessionId: "fcsess_"
         )
 
         // Inject the test payment option and assert the label

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
@@ -115,19 +115,19 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
         let integrationShapes: [(PaymentSheetAnalyticsHelper.IntegrationShape, String)] = [
             (.complete, "paymentsheet"),
             (.embedded, "embedded"),
-            (.flowController, "flowcontroller")
+            (.flowController, "flowcontroller"),
         ]
-        
+
         for (shape, shapeString) in integrationShapes {
             let sut = PaymentSheetAnalyticsHelper(integrationShape: shape, configuration: PaymentSheet.Configuration(), analyticsClient: analyticsClient)
-            
+
             // Reset the analytics client for each iteration
             analyticsClient._testLogHistory.removeAll()
-            
+
             // Load started -> failed
             sut.logLoadStarted()
             sut.logLoadFailed(error: NSError(domain: "domain", code: 1))
-            
+
             XCTAssertEqual(analyticsClient._testLogHistory[0]["event"] as? String, "mc_load_started")
             XCTAssertEqual(analyticsClient._testLogHistory[0]["integration_shape"] as? String, shapeString)
             XCTAssertEqual(analyticsClient._testLogHistory[1]["event"] as? String, "mc_load_failed")
@@ -140,15 +140,15 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
         let integrationShapes: [(PaymentSheetAnalyticsHelper.IntegrationShape, String)] = [
             (.complete, "paymentsheet"),
             (.embedded, "embedded"),
-            (.flowController, "flowcontroller")
+            (.flowController, "flowcontroller"),
         ]
-        
+
         for (shape, shapeString) in integrationShapes {
             let sut = PaymentSheetAnalyticsHelper(integrationShape: shape, configuration: PaymentSheet.Configuration(), analyticsClient: analyticsClient)
-            
+
             // Reset the analytics client for each iteration
             analyticsClient._testLogHistory.removeAll()
-            
+
             // Load started -> succeeded
             sut.logLoadStarted()
             sut.logLoadSucceeded(
@@ -157,10 +157,10 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
                 defaultPaymentMethod: .applePay,
                 orderedPaymentMethodTypes: [.stripe(.card), .external(._testPayPalValue())]
             )
-            
+
             XCTAssertEqual(analyticsClient._testLogHistory[0]["event"] as? String, "mc_load_started")
             XCTAssertEqual(analyticsClient._testLogHistory[0]["integration_shape"] as? String, shapeString)
-            
+
             let loadSucceededPayload = analyticsClient._testLogHistory[1]
             XCTAssertEqual(loadSucceededPayload["event"] as? String, "mc_load_succeeded")
             XCTAssertLessThan(loadSucceededPayload["duration"] as! Double, 1.0)
@@ -359,14 +359,16 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
             bankName: nil,
             last4: nil,
             linkMode: .linkPaymentMethod,
-            incentiveEligible: false
+            incentiveEligible: false,
+            linkAccountSessionId: "fcsess_"
         )
         let linkCardBrandLinkedBank = InstantDebitsLinkedBank(
             paymentMethod: LinkBankPaymentMethod(id: "paymentMethodId"),
             bankName: nil,
             last4: nil,
             linkMode: .linkCardBrand,
-            incentiveEligible: false
+            incentiveEligible: false,
+            linkAccountSessionId: "fcsess_"
         )
 
         let instantDebitConfirmParams = IntentConfirmParams(type: .instantDebits)
@@ -399,15 +401,15 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
         )
         XCTAssertEqual(analyticsClient._testLogHistory.last!["link_context"] as? String, "link_card_brand")
     }
-    
+
     func testLogEmbeddedUpdate() {
         let sut = PaymentSheetAnalyticsHelper(integrationShape: .embedded, configuration: PaymentSheet.Configuration(), analyticsClient: analyticsClient)
         let testDuration: TimeInterval = 10.5
-        
+
         // Test update started
         sut.logEmbeddedUpdateStarted()
         XCTAssertEqual(analyticsClient._testLogHistory.last!["event"] as? String, "mc_embedded_update_started")
-        
+
         // Test successful update
         sut.logEmbeddedUpdateFinished(result: .succeeded, duration: testDuration)
         XCTAssertEqual(analyticsClient._testLogHistory.last!["event"] as? String, "mc_embedded_update_finished")
@@ -415,7 +417,7 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
         XCTAssertEqual(analyticsClient._testLogHistory.last!["duration"] as? TimeInterval, testDuration)
         XCTAssertNil(analyticsClient._testLogHistory.last!["error_type"])
         XCTAssertNil(analyticsClient._testLogHistory.last!["error_code"])
-        
+
         // Test failed update
         sut.logEmbeddedUpdateStarted()
         let error = NSError(domain: "test", code: 123)
@@ -425,7 +427,7 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
         XCTAssertEqual(analyticsClient._testLogHistory.last!["duration"] as? TimeInterval, testDuration)
         XCTAssertEqual(analyticsClient._testLogHistory.last!["error_type"] as? String, "test")
         XCTAssertEqual(analyticsClient._testLogHistory.last!["error_code"] as? String, "123")
-        
+
         // Test canceled update
         sut.logEmbeddedUpdateStarted()
         sut.logEmbeddedUpdateFinished(result: .canceled, duration: testDuration)


### PR DESCRIPTION
## Summary

Instead of logging the client secret, we should now log the link account session client secret. This replaces those parameters, passes along the link account session ID when it is available (i.e. after we have received the manifest).

## Motivation

This is in the spirit of least-privilege.

## Testing

N/a

## Changelog

N/a