### PR TITLE
Update US Bank Account payment method parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * [Fixed] Fixed an issue in Embedded Payment Element (private beta) where the row could be selected even though there's no valid payment option.
 * [Added] Support for Crypto in PaymentSheet
 
+### Payments
+* [Fixed] Fixed an issue that caused `STPPaymentMethodUSBankAccount.linkedAccount` to be `nil` for some merchants.
+
 ## 24.6.0 2025-02-18
 * [Fixed] The SDK and example apps now compile in Xcode 16.2
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodUSBankAccount.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodUSBankAccount.swift
@@ -97,7 +97,7 @@ extension STPPaymentMethodUSBankAccount: STPAPIResponseDecodable {
             bankName: bankName,
             fingerprint: fingerprint,
             last4: last4,
-            linkedAccount: response["linked_account"] as? String,
+            linkedAccount: response["financial_connections_account"] as? String,
             networks: networks,
             routingNumber: routingNumber,
             allResponseFields: response


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue in the parsing logic of `STPPaymentMethodUSBankAccount`, which used the `linked_account` key instead of `financial_connections_account`.

We’re changing the key behind the scenes, but keeping the variable name to avoid a breaking change. We’ll rename the field in the next major version bump.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
