### PR TITLE
(Actually) Enable Async API client by default in FC Example app

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -636,7 +636,7 @@ final class PlaygroundConfiguration {
         if let useAsyncAPIClient = dictionary[Self.useAsyncAPIClientKey] as? Bool {
             self.useAsyncAPIClient = useAsyncAPIClient
         } else {
-            self.useAsyncAPIClient = false
+            self.useAsyncAPIClient = true
         }
 
         if let styleString = dictionary[Self.styleKey] as? String,


### PR DESCRIPTION
## Summary

I thought I had done this a few weeks ago (in https://github.com/stripe/stripe-ios/pull/4505), but I also need to update this property. 

## Motivation

Dogfood async API client

## Testing

Manual testing done

## Changelog

N/a