### PR TITLE
Allow commits for release due to false positive on PII

### DIFF
--- a/ci_scripts/push_spm_mirror.rb
+++ b/ci_scripts/push_spm_mirror.rb
@@ -50,7 +50,7 @@ Dir.mktmpdir do |tmp_dir|
 
   Dir.chdir(tmp_dir + '/stripe-ios-spm') do
     run_command('git add .')
-    run_command("git commit -m \"Stripe SDK #{@version} GIT_VALID_PII_OVERRIDE\"")
+    run_command("git commit -m \"Stripe SDK #{@version}\" --no-verify")
     run_command("git tag #{@version}")
     run_command('git push origin --tags')
   end

--- a/ci_scripts/push_spm_mirror.rb
+++ b/ci_scripts/push_spm_mirror.rb
@@ -50,7 +50,7 @@ Dir.mktmpdir do |tmp_dir|
 
   Dir.chdir(tmp_dir + '/stripe-ios-spm') do
     run_command('git add .')
-    run_command("git commit -m \"Stripe SDK #{@version}\"")
+    run_command("git commit -m \"Stripe SDK #{@version} GIT_VALID_PII_OVERRIDE\"")
     run_command("git tag #{@version}")
     run_command('git push origin --tags')
   end


### PR DESCRIPTION
## Summary
Updates the release script to add `GIT_VALID_PII_OVERRIDE` to the message.  Unable to figure out how to use `--no-verify` on push, as the script breaks on commit.

## Motivation
Friction during releasing

## Testing
Manually tested during last release

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
