### PR TITLE
Add draft CPM API

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -446,6 +446,7 @@ extension EmbeddedPaymentElement {
     public typealias Address = PaymentSheet.Address
     public typealias BillingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration
     public typealias ExternalPaymentMethodConfiguration = PaymentSheet.ExternalPaymentMethodConfiguration
+    public typealias CustomPaymentMethodConfiguration = PaymentSheet.CustomPaymentMethodConfiguration
 }
 
 // MARK: - EmbeddedPaymentElement.PaymentOptionDisplayData

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
@@ -112,6 +112,9 @@ extension EmbeddedPaymentElement {
         /// Configuration for external payment methods.
         public var externalPaymentMethodConfiguration: ExternalPaymentMethodConfiguration?
 
+        /// Configuration for custom payment methods.
+        @_spi(CustomPaymentMethodsBeta) public var customPaymentMethodConfiguration: CustomPaymentMethodConfiguration?
+
         /// By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the customer.
         /// You can override the default order in which payment methods are displayed in PaymentSheet with a list of payment method types.
         /// See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid types.  You may also pass external payment methods.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -183,6 +183,9 @@ extension PaymentSheet {
         /// Configuration for external payment methods.
         public var externalPaymentMethodConfiguration: ExternalPaymentMethodConfiguration?
 
+        /// Configuration for custom payment methods.
+        @_spi(CustomPaymentMethodsBeta) public var customPaymentMethodConfiguration: CustomPaymentMethodConfiguration?
+
         /// By default, PaymentSheet will use a dynamic ordering that optimizes payment method display for the customer.
         /// You can override the default order in which payment methods are displayed in PaymentSheet with a list of payment method types.
         /// See https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for the list of valid types.  You may also pass external payment methods.
@@ -507,6 +510,59 @@ extension PaymentSheet {
         /// Your implementation should complete the payment and call the `completion` parameter with the result.
         /// - Note: This is always called on the main thread.
         public var externalPaymentMethodConfirmHandler: ExternalPaymentMethodConfirmHandler
+    }
+
+    /// Configuration for custom payment methods
+    @_spi(CustomPaymentMethodsBeta) public struct CustomPaymentMethodConfiguration {
+
+        /// Defines a custom payment method type that can be displayed in PaymentSheet
+        public struct CustomPaymentMethod {
+
+            /// The unique identifier for this custom payment method type in the format of "cmpt_..."
+            /// Obtained from the Stripe Dashboard at https://dashboard.stripe.com/settings/custom_payment_methods
+            let id: String
+
+            /// Optional subcopy text to be displayed below the custom payment method's display name.
+            let subcopy: String?
+
+            /// When true, PaymentSheet will collect billing details for this custom payment method type
+            /// in accordance with the `billingDetailsCollectionConfiguration` settings.
+            /// This has no effect if `billingDetailsCollectionConfiguration` is not configured.
+            var shouldCollectBillingDetails = false
+
+            /// Initializes an `CustomPaymentMethod`
+            /// - Parameters:
+            ///   - id: The unique identifier for this custom payment method type in the format of "cmpt_..."
+            ///   - subcopy: Optional subcopy text to be displayed below the custom payment method's display name.
+            public init(id: String, subcopy: String? = nil) {
+                self.id = id
+                self.subcopy = subcopy
+            }
+        }
+
+        /// Initializes an `CustomPaymentMethodConfiguration`
+        /// - Parameter customPaymentMethods: A list of custom payment methods to display in PaymentSheet.
+        /// - Parameter customPaymentMethodConfirmHandler: A handler called when the customer confirms the payment using a custom payment method.
+        public init(customPaymentMethods: [CustomPaymentMethod], customPaymentMethodConfirmHandler: @escaping PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodConfirmHandler) {
+            self.customPaymentMethods = customPaymentMethods
+            self.customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler
+        }
+
+        /// A list of custom payment methods to display in PaymentSheet.
+        public var customPaymentMethods: [CustomPaymentMethod] = []
+
+        /// - Parameter customPaymentMethodType: The custom payment method to confirm payment with e.g., "cmpt_xxx"
+        /// - Parameter billingDetails: An object containing any billing details you've configured PaymentSheet to collect.
+        /// - Returns: The result of the attempt to confirm payment using the given custom payment method.
+        public typealias CustomPaymentMethodConfirmHandler = (
+            _ customPaymentMethodType: String,
+            _ billingDetails: STPPaymentMethodBillingDetails
+        ) async -> PaymentSheetResult
+
+        /// This handler is called when the customer confirms the payment using an custom payment method.
+        /// Your implementation should complete the payment and return the result.
+        /// - Note: This is always called on the main thread.
+        public var customPaymentMethodConfirmHandler: CustomPaymentMethodConfirmHandler
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -516,7 +516,7 @@ extension PaymentSheet {
     @_spi(CustomPaymentMethodsBeta) public struct CustomPaymentMethodConfiguration {
 
         /// Defines a custom payment method type that can be displayed in PaymentSheet
-        public struct CustomPaymentMethod {
+        public struct CustomPaymentMethodType {
 
             /// The unique identifier for this custom payment method type in the format of "cmpt_..."
             /// Obtained from the Stripe Dashboard at https://dashboard.stripe.com/settings/custom_payment_methods
@@ -530,7 +530,7 @@ extension PaymentSheet {
             /// This has no effect if `billingDetailsCollectionConfiguration` is not configured.
             var shouldCollectBillingDetails = false
 
-            /// Initializes an `CustomPaymentMethod`
+            /// Initializes an `CustomPaymentMethodType`
             /// - Parameters:
             ///   - id: The unique identifier for this custom payment method type in the format of "cmpt_..."
             ///   - subcopy: Optional subcopy text to be displayed below the custom payment method's display name.
@@ -541,21 +541,21 @@ extension PaymentSheet {
         }
 
         /// Initializes an `CustomPaymentMethodConfiguration`
-        /// - Parameter customPaymentMethods: A list of custom payment methods to display in PaymentSheet.
+        /// - Parameter customPaymentMethodTypes: A list of custom payment methods to display in PaymentSheet.
         /// - Parameter customPaymentMethodConfirmHandler: A handler called when the customer confirms the payment using a custom payment method.
-        public init(customPaymentMethods: [CustomPaymentMethod], customPaymentMethodConfirmHandler: @escaping PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodConfirmHandler) {
-            self.customPaymentMethods = customPaymentMethods
+        public init(customPaymentMethodTypes: [CustomPaymentMethodType], customPaymentMethodConfirmHandler: @escaping PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodConfirmHandler) {
+            self.customPaymentMethodTypes = customPaymentMethodTypes
             self.customPaymentMethodConfirmHandler = customPaymentMethodConfirmHandler
         }
 
-        /// A list of custom payment methods to display in PaymentSheet.
-        public var customPaymentMethods: [CustomPaymentMethod] = []
+        /// A list of custom payment methods types to display in PaymentSheet.
+        public var customPaymentMethodTypes: [CustomPaymentMethodType] = []
 
-        /// - Parameter customPaymentMethodType: The custom payment method to confirm payment with e.g., "cmpt_xxx"
+        /// - Parameter customPaymentMethodType: The custom payment method to confirm payment with
         /// - Parameter billingDetails: An object containing any billing details you've configured PaymentSheet to collect.
         /// - Returns: The result of the attempt to confirm payment using the given custom payment method.
         public typealias CustomPaymentMethodConfirmHandler = (
-            _ customPaymentMethodType: String,
+            _ customPaymentMethodType: CustomPaymentMethodType,
             _ billingDetails: STPPaymentMethodBillingDetails
         ) async -> PaymentSheetResult
 


### PR DESCRIPTION
## Summary
- Adds a first draft of the CPM public API
- This API is not final and still needs API review, but adding this so we can easily test and make progress on the internal implementation of CPMs while in API review.

## Motivation
- Start on CPMs

## Testing
N/A

## Changelog
N/A
