### PR TITLE
Remove more deferred intent validation checks

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
@@ -14,17 +14,11 @@ struct PaymentSheetDeferredValidator {
                          intentConfiguration: PaymentSheet.IntentConfiguration,
                          paymentMethod: STPPaymentMethod,
                          isFlowController: Bool) throws {
-        guard case let .payment(_, currency, setupFutureUsage, captureMethod) = intentConfiguration.mode else {
+        guard case let .payment(_, currency, _, _) = intentConfiguration.mode else {
             throw PaymentSheetError.deferredIntentValidationFailed(message: "You returned a PaymentIntent client secret but used a PaymentSheet.IntentConfiguration in setup mode.")
         }
         guard paymentIntent.currency.uppercased() == currency.uppercased() else {
             throw PaymentSheetError.deferredIntentValidationFailed(message: "Your PaymentIntent currency (\(paymentIntent.currency.uppercased())) does not match the PaymentSheet.IntentConfiguration currency (\(currency.uppercased())).")
-        }
-        guard paymentIntent.setupFutureUsage == setupFutureUsage else {
-            throw PaymentSheetError.deferredIntentValidationFailed(message: "Your PaymentIntent setupFutureUsage (\(paymentIntent.setupFutureUsage)) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (\(String(describing: setupFutureUsage))).")
-        }
-        guard paymentIntent.captureMethod == captureMethod else {
-            throw PaymentSheetError.deferredIntentValidationFailed(message: "Your PaymentIntent captureMethod (\(paymentIntent.captureMethod)) does not match the PaymentSheet.IntentConfiguration amount (\(captureMethod)).")
         }
         try validatePaymentMethod(intentPaymentMethod: paymentIntent.paymentMethod, paymentMethod: paymentMethod)
         /*
@@ -39,11 +33,8 @@ struct PaymentSheetDeferredValidator {
     static func validate(setupIntent: STPSetupIntent,
                          intentConfiguration: PaymentSheet.IntentConfiguration,
                          paymentMethod: STPPaymentMethod) throws {
-        guard case let .setup(_, setupFutureUsage) = intentConfiguration.mode else {
+        guard case .setup = intentConfiguration.mode else {
             throw PaymentSheetError.deferredIntentValidationFailed(message: "You returned a SetupIntent client secret but used a PaymentSheet.IntentConfiguration in payment mode.")
-        }
-        guard setupIntent.usage == setupFutureUsage else {
-            throw PaymentSheetError.deferredIntentValidationFailed(message: "Your SetupIntent usage (\(setupIntent.usage)) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (\(String(describing: setupFutureUsage))).")
         }
         try validatePaymentMethod(intentPaymentMethod: setupIntent.paymentMethod, paymentMethod: paymentMethod)
     }


### PR DESCRIPTION
## Summary
Deferred intent validation is too rigid. We don't do anything with capture method or change anything if SFU is off_session vs on_session.

If those things ever becomes important, we can re-add the checks.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-3879

## Testing
Removed relevant tests
