### PR TITLE
Move consumer session creation before verification screens

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1067,7 +1067,7 @@ extension NativeFlowController: NetworkingLinkLoginWarmupViewControllerDelegate 
     ) {
         showTerminalError(error)
     }
-    
+
     func networkingLinkLoginWarmupViewControllerDidFailAttestationVerdict(
         _ viewController: NetworkingLinkLoginWarmupViewController,
         prefillDetails: WebPrefillDetails
@@ -1134,10 +1134,6 @@ extension NativeFlowController: AttachLinkedPaymentAccountViewControllerDelegate
 // MARK: - NetworkingLinkVerificationViewControllerDelegate
 
 extension NativeFlowController: NetworkingLinkVerificationViewControllerDelegate {
-    func networkingLinkVerificationViewController(_ viewController: NetworkingLinkVerificationViewController, didReceiveConsumerPublishableKey consumerPublishableKey: String) {
-        dataManager.consumerPublishableKey = consumerPublishableKey
-    }
-
     func networkingLinkVerificationViewController(
         _ viewController: NetworkingLinkVerificationViewController,
         didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane,
@@ -1153,17 +1149,6 @@ extension NativeFlowController: NetworkingLinkVerificationViewControllerDelegate
         didReceiveTerminalError error: Error
     ) {
         showTerminalError(error)
-    }
-
-    func networkingLinkVerificationViewControllerDidFailAttestationVerdict(
-        _ viewController: NetworkingLinkVerificationViewController,
-        prefillDetails: WebPrefillDetails
-    ) {
-        delegate?.nativeFlowController(
-            self,
-            shouldLaunchWebFlow: dataManager.manifest,
-            prefillDetails: prefillDetails
-        )
     }
 }
 
@@ -1234,10 +1219,6 @@ extension NativeFlowController: LinkAccountPickerViewControllerDelegate {
 
 extension NativeFlowController: NetworkingSaveToLinkVerificationViewControllerDelegate {
 
-    func networkingSaveToLinkVerificationViewController(_ viewController: NetworkingSaveToLinkVerificationViewController, didReceiveConsumerPublishableKey consumerPublishableKey: String) {
-        dataManager.consumerPublishableKey = consumerPublishableKey
-    }
-
     func networkingSaveToLinkVerificationViewControllerDidFinish(
         _ viewController: NetworkingSaveToLinkVerificationViewController,
         saveToLinkWithStripeSucceeded: Bool?,
@@ -1256,26 +1237,11 @@ extension NativeFlowController: NetworkingSaveToLinkVerificationViewControllerDe
     ) {
         showTerminalError(error)
     }
-
-    func networkingSaveToLinkVerificationViewControllerDidFailAttestationVerdict(
-        _ viewController: NetworkingSaveToLinkVerificationViewController,
-        prefillDetails: WebPrefillDetails
-    ) {
-        delegate?.nativeFlowController(
-            self,
-            shouldLaunchWebFlow: dataManager.manifest,
-            prefillDetails: prefillDetails
-        )
-    }
 }
 
 // MARK: - NetworkingLinkStepUpVerificationViewControllerDelegate
 
 extension NativeFlowController: NetworkingLinkStepUpVerificationViewControllerDelegate {
-
-    func networkingLinkStepUpVerificationViewController(_ viewController: NetworkingLinkStepUpVerificationViewController, didReceiveConsumerPublishableKey consumerPublishableKey: String) {
-        dataManager.consumerPublishableKey = consumerPublishableKey
-    }
 
     func networkingLinkStepUpVerificationViewController(
         _ viewController: NetworkingLinkStepUpVerificationViewController,
@@ -1295,23 +1261,6 @@ extension NativeFlowController: NetworkingLinkStepUpVerificationViewControllerDe
         didReceiveTerminalError error: Error
     ) {
         showTerminalError(error)
-    }
-
-    func networkingLinkStepUpVerificationViewControllerEncounteredSoftError(
-        _ viewController: NetworkingLinkStepUpVerificationViewController
-    ) {
-        pushPane(.institutionPicker, animated: true)
-    }
-
-    func networkingLinkStepUpVerificationViewControllerDidFailAttestationVerdict(
-        _ viewController: NetworkingLinkStepUpVerificationViewController,
-        prefillDetails: WebPrefillDetails
-    ) {
-        delegate?.nativeFlowController(
-            self,
-            shouldLaunchWebFlow: dataManager.manifest,
-            prefillDetails: prefillDetails
-        )
     }
 }
 
@@ -1679,8 +1628,7 @@ private func CreatePaneViewController(
             clientSecret: dataManager.clientSecret,
             analyticsClient: dataManager.analyticsClient,
             nextPaneOrDrawerOnSecondaryCta: parameters?.nextPaneOrDrawerOnSecondaryCta,
-            elementsSessionContext: dataManager.elementsSessionContext,
-            consumerSession: dataManager.consumerSession
+            elementsSessionContext: dataManager.elementsSessionContext
         )
         let networkingLinkWarmupViewController = NetworkingLinkLoginWarmupViewController(
             dataSource: networkingLinkWarmupDataSource,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
@@ -11,8 +11,14 @@ import Foundation
 protocol NetworkingLinkLoginWarmupDataSource: AnyObject {
     var manifest: FinancialConnectionsSessionManifest { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
+    var email: String? { get }
 
+    func lookupConsumerSession() -> Future<LookupConsumerSessionResponse>
     func disableNetworking() -> Future<FinancialConnectionsSessionManifest>
+    func completeAssertionIfNeeded(
+        possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API
+    ) -> Error?
 }
 
 final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLoginWarmupDataSource {
@@ -22,19 +28,49 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
     private let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
     private let nextPaneOrDrawerOnSecondaryCta: String?
+    private let elementsSessionContext: ElementsSessionContext?
+    private let consumerSession: ConsumerSessionData?
+
+    var email: String? {
+        manifest.accountholderCustomerEmailAddress ?? elementsSessionContext?.prefillDetails?.email
+    }
 
     init(
         manifest: FinancialConnectionsSessionManifest,
         apiClient: any FinancialConnectionsAPI,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient,
-        nextPaneOrDrawerOnSecondaryCta: String?
+        nextPaneOrDrawerOnSecondaryCta: String?,
+        elementsSessionContext: ElementsSessionContext?,
+        consumerSession: ConsumerSessionData?
     ) {
         self.manifest = manifest
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
         self.nextPaneOrDrawerOnSecondaryCta = nextPaneOrDrawerOnSecondaryCta
+        self.elementsSessionContext = elementsSessionContext
+        self.consumerSession = consumerSession
+    }
+
+    func lookupConsumerSession() -> Future<LookupConsumerSessionResponse> {
+        guard let email else {
+            let error = FinancialConnectionsSheetError.unknown(debugDescription: "Unexpected nil email in warmup data source")
+            analyticsClient.logUnexpectedError(
+                error,
+                errorName: "NoEmailInWarmupPaneError",
+                pane: .networkingLinkLoginWarmup
+            )
+            return Promise(error: error)
+        }
+        return apiClient.consumerSessionLookup(
+            emailAddress: email,
+            clientSecret: clientSecret,
+            sessionId: manifest.id,
+            emailSource: .customerObject,
+            useMobileEndpoints: manifest.verified,
+            pane: .networkingLinkLoginWarmup
+        )
     }
 
     func disableNetworking() -> Future<FinancialConnectionsSessionManifest> {
@@ -42,6 +78,19 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
             disabledReason: "returning_consumer_opt_out",
             clientSuggestedNextPaneOnDisableNetworking: nextPaneOrDrawerOnSecondaryCta,
             clientSecret: clientSecret
+        )
+    }
+    
+    // Marks the assertion as completed and logs possible errors during verified flows.
+    func completeAssertionIfNeeded(
+        possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API
+    ) -> Error? {
+        guard manifest.verified else { return nil }
+        return apiClient.completeAssertion(
+            possibleError: possibleError,
+            api: api,
+            pane: .linkLogin
         )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
@@ -29,7 +29,6 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
     let analyticsClient: FinancialConnectionsAnalyticsClient
     private let nextPaneOrDrawerOnSecondaryCta: String?
     private let elementsSessionContext: ElementsSessionContext?
-    private let consumerSession: ConsumerSessionData?
 
     var email: String? {
         manifest.accountholderCustomerEmailAddress ?? elementsSessionContext?.prefillDetails?.email
@@ -41,8 +40,7 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient,
         nextPaneOrDrawerOnSecondaryCta: String?,
-        elementsSessionContext: ElementsSessionContext?,
-        consumerSession: ConsumerSessionData?
+        elementsSessionContext: ElementsSessionContext?
     ) {
         self.manifest = manifest
         self.apiClient = apiClient
@@ -50,7 +48,6 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
         self.analyticsClient = analyticsClient
         self.nextPaneOrDrawerOnSecondaryCta = nextPaneOrDrawerOnSecondaryCta
         self.elementsSessionContext = elementsSessionContext
-        self.consumerSession = consumerSession
     }
 
     func lookupConsumerSession() -> Future<LookupConsumerSessionResponse> {
@@ -80,7 +77,7 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
             clientSecret: clientSecret
         )
     }
-    
+
     // Marks the assertion as completed and logs possible errors during verified flows.
     func completeAssertionIfNeeded(
         possibleError: Error?,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
@@ -87,7 +87,7 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
         return apiClient.completeAssertion(
             possibleError: possibleError,
             api: api,
-            pane: .linkLogin
+            pane: .networkingLinkLoginWarmup
         )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -7,11 +7,16 @@
 
 import Foundation
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
 import UIKit
+
+typealias NetworkingLinkLoginWarmupFooterView = (footerView: UIView?, primaryButton: StripeUICore.Button?, secondaryButton: StripeUICore.Button?)
 
 protocol NetworkingLinkLoginWarmupViewControllerDelegate: AnyObject {
     func networkingLinkLoginWarmupViewControllerDidSelectContinue(
-        _ viewController: NetworkingLinkLoginWarmupViewController
+        _ viewController: NetworkingLinkLoginWarmupViewController,
+        withSession consumerSession: ConsumerSessionData,
+        consumerPublishableKey: String
     )
     func networkingLinkLoginWarmupViewControllerDidSelectCancel(
         _ viewController: NetworkingLinkLoginWarmupViewController
@@ -20,13 +25,54 @@ protocol NetworkingLinkLoginWarmupViewControllerDelegate: AnyObject {
         _ viewController: NetworkingLinkLoginWarmupViewController,
         didSelectSkipWithManifest manifest: FinancialConnectionsSessionManifest
     )
-    func networkingLinkLoginWarmupViewController(_ viewController: NetworkingLinkLoginWarmupViewController, didReceiveTerminalError error: Error)
+    func networkingLinkLoginWarmupViewController(
+        _ viewController: NetworkingLinkLoginWarmupViewController,
+        didReceiveTerminalError error: Error
+    )
+    func networkingLinkLoginWarmupViewControllerDidFailAttestationVerdict(
+        _ viewController: NetworkingLinkLoginWarmupViewController,
+        prefillDetails: WebPrefillDetails
+    )
 }
 
 final class NetworkingLinkLoginWarmupViewController: SheetViewController {
 
     private let dataSource: NetworkingLinkLoginWarmupDataSource
     weak var delegate: NetworkingLinkLoginWarmupViewControllerDelegate?
+    
+    private lazy var warmupFooterView: NetworkingLinkLoginWarmupFooterView = {
+        let secondaryButtonTitle: String
+        if dataSource.manifest.isProductInstantDebits {
+            secondaryButtonTitle = STPLocalizedString(
+                "Cancel",
+                "A button title. This button, when pressed, will simply dismiss the warmup pane, as it is required to continue with Link in the Instant Debits flow."
+            )
+        } else {
+            secondaryButtonTitle = STPLocalizedString(
+                "Not now",
+                "A button title. This button, when pressed, will skip logging in the user with their e-mail to Link (one-click checkout provider)."
+            )
+        }
+        return PaneLayoutView.createFooterView(
+            primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
+                title: STPLocalizedString(
+                    "Continue with Link",
+                    "A button title. This button, when pressed, will automatically log-in the user with their e-mail to Link (one-click checkout provider)."
+                ),
+                accessibilityIdentifier: "link_continue_button",
+                action: { [weak self] in
+                    self?.didSelectContinue()
+                }
+            ),
+            secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
+                title: secondaryButtonTitle,
+                action: { [weak self] in
+                    self?.didSelectSkip()
+                }
+            ),
+            appearance: dataSource.manifest.appearance
+        )
+    }()
 
     init(
         dataSource: NetworkingLinkLoginWarmupDataSource,
@@ -42,18 +88,7 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let footerSecondaryButtonTitle: String
-        if dataSource.manifest.isProductInstantDebits {
-            footerSecondaryButtonTitle = STPLocalizedString(
-                "Cancel",
-                "A button title. This button, when pressed, will simply dismiss the warmup pane, as it is required to continue with Link in the Instant Debits flow."
-            )
-        } else {
-            footerSecondaryButtonTitle = STPLocalizedString(
-                "Not now",
-                "A button title. This button, when pressed, will skip logging in the user with their e-mail to Link (one-click checkout provider)."
-            )
-        }
+
         setup(
             withContentView: PaneLayoutView.createContentView(
                 iconView: RoundedIconView(
@@ -70,31 +105,11 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
                     "The subtitle/description of a screen where users are informed that they can sign-in-to Link."
                 ),
                 contentView: NetworkingLinkLoginWarmupBodyView(
-                    // `accountholderCustomerEmailAddress` should always be non-null, and
-                    // since the email is only used as a visual, it's not worth to throw an error
-                    // if it is null
-                    email: dataSource.manifest.accountholderCustomerEmailAddress ?? "you"
+                    // `email` should always be non-null, and since the email is only used as a visual, it's not worth to throw an error if it is null
+                    email: dataSource.email ?? "you"
                 )
             ),
-            footerView: PaneLayoutView.createFooterView(
-                primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
-                    title: STPLocalizedString(
-                        "Continue with Link",
-                        "A button title. This button, when pressed, will automatically log-in the user with their e-mail to Link (one-click checkout provider)."
-                    ),
-                    accessibilityIdentifier: "link_continue_button",
-                    action: { [weak self] in
-                        self?.didSelectContinue()
-                    }
-                ),
-                secondaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
-                    title: footerSecondaryButtonTitle,
-                    action: { [weak self] in
-                        self?.didSelectSkip()
-                    }
-                ),
-                appearance: dataSource.manifest.appearance
-            ).footerView
+            footerView: warmupFooterView.footerView
         )
     }
 
@@ -103,7 +118,50 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
             eventName: "click.continue",
             pane: .networkingLinkLoginWarmup
         )
-        delegate?.networkingLinkLoginWarmupViewControllerDidSelectContinue(self)
+        
+        warmupFooterView.primaryButton?.isLoading = true
+
+        dataSource
+            .lookupConsumerSession()
+            .observe { [weak self] result in
+                guard let self else { return }
+                
+                warmupFooterView.primaryButton?.isLoading = false
+
+                let attestationError = self.dataSource.completeAssertionIfNeeded(
+                    possibleError: result.error,
+                    api: .consumerSessionLookup
+                )
+
+                if attestationError != nil {
+                    let prefillDetails = WebPrefillDetails(email: self.dataSource.email)
+                    self.delegate?.networkingLinkLoginWarmupViewControllerDidFailAttestationVerdict(self, prefillDetails: prefillDetails)
+                    return
+                }
+
+                switch result {
+                case .success(let response):
+                    if let consumerSession = response.consumerSession, let publishableKey = response.publishableKey {
+                        self.delegate?.networkingLinkLoginWarmupViewControllerDidSelectContinue(
+                            self,
+                            withSession: consumerSession,
+                            consumerPublishableKey: publishableKey
+                        )
+                    } else {
+                        let error = FinancialConnectionsSheetError.unknown(
+                            debugDescription: "Unexpected consumer lookup response without consumer session or publishable key"
+                        )
+                        dataSource.analyticsClient.logUnexpectedError(
+                            error,
+                            errorName: "UnexpectedLookupResponseError",
+                            pane: .networkingLinkLoginWarmup
+                        )
+                        self.delegate?.networkingLinkLoginWarmupViewController(self, didReceiveTerminalError: error)
+                    }
+                case .failure(let error):
+                    self.delegate?.networkingLinkLoginWarmupViewController(self, didReceiveTerminalError: error)
+                }
+            }
     }
 
     private func didSelectSkip() {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -39,7 +39,7 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
 
     private let dataSource: NetworkingLinkLoginWarmupDataSource
     weak var delegate: NetworkingLinkLoginWarmupViewControllerDelegate?
-    
+
     private lazy var warmupFooterView: NetworkingLinkLoginWarmupFooterView = {
         let secondaryButtonTitle: String
         if dataSource.manifest.isProductInstantDebits {
@@ -88,7 +88,6 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
         setup(
             withContentView: PaneLayoutView.createContentView(
                 iconView: RoundedIconView(
@@ -118,14 +117,14 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
             eventName: "click.continue",
             pane: .networkingLinkLoginWarmup
         )
-        
+
         warmupFooterView.primaryButton?.isLoading = true
 
         dataSource
             .lookupConsumerSession()
             .observe { [weak self] result in
                 guard let self else { return }
-                
+
                 warmupFooterView.primaryButton?.isLoading = false
 
                 let attestationError = self.dataSource.completeAssertionIfNeeded(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -50,7 +50,6 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
             pane: .networkingLinkStepUpVerification,
             consumerSession: consumerSession,
             apiClient: apiClient,
-            clientSecret: clientSecret,
             analyticsClient: analyticsClient
         )
         self.networkingOTPDataSource = networkingOTPDataSource

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationDataSource.swift
@@ -45,7 +45,6 @@ final class NetworkingLinkStepUpVerificationDataSourceImplementation: Networking
         let networkingOTPDataSource = NetworkingOTPDataSourceImplementation(
             otpType: "EMAIL",
             manifest: manifest,
-            emailAddress: consumerSession.emailAddress,
             customEmailType: "NETWORKED_CONNECTIONS_OTP_EMAIL",
             connectionsMerchantName: manifest.businessName,
             pane: .networkingLinkStepUpVerification,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
@@ -143,43 +143,6 @@ final class NetworkingLinkStepUpVerificationViewController: UIViewController {
 
 extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDelegate {
 
-    func networkingOTPView(_ view: NetworkingOTPView, didGetConsumerPublishableKey consumerPublishableKey: String) {
-        delegate?.networkingLinkStepUpVerificationViewController(self, didReceiveConsumerPublishableKey: consumerPublishableKey)
-    }
-
-    func networkingOTPViewWillStartConsumerLookup(_ view: NetworkingOTPView) {
-        if !didShowContent {
-            showFullScreenLoadingView(true)
-        } else {
-            showSmallLoadingView(true)
-        }
-    }
-
-    func networkingOTPViewConsumerNotFound(_ view: NetworkingOTPView) {
-        // side-note: it is redundant to call `showLoadingView` & `showSmallLoadingView` because
-        // usually only one needs to be hidden, but this keeps the code simple
-        showFullScreenLoadingView(false)
-        showSmallLoadingView(false)
-
-        dataSource.analyticsClient.log(
-            eventName: "networking.verification.step_up.error",
-            parameters: [
-                "error": "ConsumerNotFoundError",
-            ],
-            pane: .networkingLinkStepUpVerification
-        )
-        delegate?.networkingLinkStepUpVerificationViewControllerEncounteredSoftError(self)
-    }
-
-    func networkingOTPView(_ view: NetworkingOTPView, didFailConsumerLookup error: Error) {
-        // side-note: it is redundant to call both (`showLoadingView` & `isResendingCode`) because
-        // only one needs to be hidden (depends on the state), but this keeps the code simple
-        showFullScreenLoadingView(false)
-        showSmallLoadingView(false)
-
-        handleFailure(error: error, errorName: "LookupConsumerSessionError")
-    }
-
     func networkingOTPViewWillStartVerification(_ view: NetworkingOTPView) {
         // no-op
     }
@@ -294,15 +257,5 @@ extension NetworkingLinkStepUpVerificationViewController: NetworkingOTPViewDeleg
                 didReceiveTerminalError: error
             )
         }
-    }
-
-    func networkingOTPViewDidFailAttestationVerdict(
-        _ view: NetworkingOTPView,
-        prefillDetails: WebPrefillDetails
-    ) {
-        delegate?.networkingLinkStepUpVerificationViewControllerDidFailAttestationVerdict(
-            self,
-            prefillDetails: prefillDetails
-        )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkStepUpVerification/NetworkingLinkStepUpVerificationViewController.swift
@@ -13,10 +13,6 @@ import UIKit
 protocol NetworkingLinkStepUpVerificationViewControllerDelegate: AnyObject {
     func networkingLinkStepUpVerificationViewController(
         _ viewController: NetworkingLinkStepUpVerificationViewController,
-        didReceiveConsumerPublishableKey consumerPublishableKey: String
-    )
-    func networkingLinkStepUpVerificationViewController(
-        _ viewController: NetworkingLinkStepUpVerificationViewController,
         didCompleteVerificationWithInstitution institution: FinancialConnectionsInstitution?,
         nextPane: FinancialConnectionsSessionManifest.NextPane,
         customSuccessPaneCaption: String?,
@@ -25,13 +21,6 @@ protocol NetworkingLinkStepUpVerificationViewControllerDelegate: AnyObject {
     func networkingLinkStepUpVerificationViewController(
         _ viewController: NetworkingLinkStepUpVerificationViewController,
         didReceiveTerminalError error: Error
-    )
-    func networkingLinkStepUpVerificationViewControllerEncounteredSoftError(
-        _ viewController: NetworkingLinkStepUpVerificationViewController
-    )
-    func networkingLinkStepUpVerificationViewControllerDidFailAttestationVerdict(
-        _ viewController: NetworkingLinkStepUpVerificationViewController,
-        prefillDetails: WebPrefillDetails
     )
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -56,7 +56,6 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
             pane: .networkingLinkVerification,
             consumerSession: consumerSession,
             apiClient: apiClient,
-            clientSecret: clientSecret,
             analyticsClient: analyticsClient
         )
         self.networkingOTPDataSource = networkingOTPDataSource

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationDataSource.swift
@@ -9,10 +9,9 @@ import Foundation
 @_spi(STP) import StripeCore
 
 protocol NetworkingLinkVerificationDataSource: AnyObject {
-    var accountholderCustomerEmailAddress: String { get }
     var manifest: FinancialConnectionsSessionManifest { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
-    var consumerSession: ConsumerSessionData? { get }
+    var consumerSession: ConsumerSessionData { get }
     var networkingOTPDataSource: NetworkingOTPDataSource { get }
 
     func markLinkVerified() -> Future<FinancialConnectionsSessionManifest>
@@ -22,7 +21,6 @@ protocol NetworkingLinkVerificationDataSource: AnyObject {
 
 final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVerificationDataSource {
 
-    let accountholderCustomerEmailAddress: String
     let manifest: FinancialConnectionsSessionManifest
     private var apiClient: any FinancialConnectionsAPI
     private let clientSecret: String
@@ -30,34 +28,33 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
     let analyticsClient: FinancialConnectionsAnalyticsClient
     let networkingOTPDataSource: NetworkingOTPDataSource
 
-    private(set) var consumerSession: ConsumerSessionData? {
+    private(set) var consumerSession: ConsumerSessionData {
         didSet {
             apiClient.consumerSession = consumerSession
         }
     }
 
     init(
-        accountholderCustomerEmailAddress: String,
         manifest: FinancialConnectionsSessionManifest,
         apiClient: any FinancialConnectionsAPI,
         clientSecret: String,
         returnURL: String?,
+        consumerSession: ConsumerSessionData,
         analyticsClient: FinancialConnectionsAnalyticsClient
     ) {
-        self.accountholderCustomerEmailAddress = accountholderCustomerEmailAddress
         self.manifest = manifest
         self.apiClient = apiClient
         self.clientSecret = clientSecret
         self.returnURL = returnURL
         self.analyticsClient = analyticsClient
+        self.consumerSession = consumerSession
         let networkingOTPDataSource = NetworkingOTPDataSourceImplementation(
             otpType: "SMS",
             manifest: manifest,
-            emailAddress: accountholderCustomerEmailAddress,
             customEmailType: nil,
             connectionsMerchantName: nil,
             pane: .networkingLinkVerification,
-            consumerSession: nil,
+            consumerSession: consumerSession,
             apiClient: apiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient
@@ -71,12 +68,9 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
     }
 
     func fetchNetworkedAccounts() -> Future<FinancialConnectionsNetworkedAccountsResponse> {
-        guard let consumerSessionClientSecret = consumerSession?.clientSecret else {
-            return Promise(error: FinancialConnectionsSheetError.unknown(debugDescription: "invalid confirmVerificationSession state: no consumerSessionClientSecret"))
-        }
         return apiClient.fetchNetworkedAccounts(
             clientSecret: clientSecret,
-            consumerSessionClientSecret: consumerSessionClientSecret
+            consumerSessionClientSecret: consumerSession.clientSecret
         )
     }
 
@@ -87,15 +81,9 @@ final class NetworkingLinkVerificationDataSourceImplementation: NetworkingLinkVe
             ))
         }
 
-        guard let consumerSessionClientSecret = consumerSession?.clientSecret else {
-            return Promise(error: FinancialConnectionsSheetError.unknown(
-                debugDescription: "Invalid \(#function) state: no consumerSessionClientSecret"
-            ))
-        }
-
         return apiClient.attachLinkConsumerToLinkAccountSession(
             linkAccountSession: clientSecret,
-            consumerSessionClientSecret: consumerSessionClientSecret
+            consumerSessionClientSecret: consumerSession.clientSecret
         )
         .chained { [weak self] _ in
             guard let self else {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -13,10 +13,6 @@ import UIKit
 protocol NetworkingLinkVerificationViewControllerDelegate: AnyObject {
     func networkingLinkVerificationViewController(
         _ viewController: NetworkingLinkVerificationViewController,
-        didReceiveConsumerPublishableKey consumerPublishableKey: String
-    )
-    func networkingLinkVerificationViewController(
-        _ viewController: NetworkingLinkVerificationViewController,
         didRequestNextPane nextPane: FinancialConnectionsSessionManifest.NextPane,
         consumerSession: ConsumerSessionData?,
         preventBackNavigation: Bool
@@ -24,10 +20,6 @@ protocol NetworkingLinkVerificationViewControllerDelegate: AnyObject {
     func networkingLinkVerificationViewController(
         _ viewController: NetworkingLinkVerificationViewController,
         didReceiveTerminalError error: Error
-    )
-    func networkingLinkVerificationViewControllerDidFailAttestationVerdict(
-        _ viewController: NetworkingLinkVerificationViewController,
-        prefillDetails: WebPrefillDetails
     )
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkVerification/NetworkingLinkVerificationViewController.swift
@@ -57,7 +57,7 @@ final class NetworkingLinkVerificationViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         view.backgroundColor = FinancialConnectionsAppearance.Colors.background
-        otpView.lookupConsumerAndStartVerification()
+        otpView.startVerification()
     }
 
     private func showContent(redactedPhoneNumber: String) {
@@ -90,17 +90,12 @@ final class NetworkingLinkVerificationViewController: UIViewController {
     }
 
     private func requestNextPane(_ pane: FinancialConnectionsSessionManifest.NextPane, preventBackNavigation: Bool) {
-        if let consumerSession = dataSource.consumerSession {
-            delegate?.networkingLinkVerificationViewController(
-                self,
-                didRequestNextPane: pane,
-                consumerSession: consumerSession,
-                preventBackNavigation: preventBackNavigation
-            )
-        } else {
-            assertionFailure("logic error: did not have consumerSession")
-            delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: FinancialConnectionsSheetError.unknown(debugDescription: "logic error: did not have consumerSession"))
-        }
+        delegate?.networkingLinkVerificationViewController(
+            self,
+            didRequestNextPane: pane,
+            consumerSession: dataSource.consumerSession,
+            preventBackNavigation: preventBackNavigation
+        )
     }
 
     private func attachConsumerToLinkAccountAndSynchronize(from view: NetworkingOTPView) {
@@ -133,47 +128,6 @@ final class NetworkingLinkVerificationViewController: UIViewController {
 // MARK: - NetworkingOTPViewDelegate
 
 extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
-    func networkingOTPView(_ view: NetworkingOTPView, didGetConsumerPublishableKey consumerPublishableKey: String) {
-        delegate?.networkingLinkVerificationViewController(self, didReceiveConsumerPublishableKey: consumerPublishableKey)
-    }
-
-    func networkingOTPViewWillStartConsumerLookup(_ view: NetworkingOTPView) {
-        showLoadingView(true)
-    }
-
-    func networkingOTPViewConsumerNotFound(_ view: NetworkingOTPView) {
-        dataSource.analyticsClient.log(
-            eventName: "networking.verification.error",
-            parameters: [
-                "error": "ConsumerNotFoundError"
-            ],
-            pane: .networkingLinkVerification
-        )
-        delegate?.networkingLinkVerificationViewController(
-            self,
-            didRequestNextPane: .institutionPicker,
-            consumerSession: nil,
-            preventBackNavigation: false
-        )
-        showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
-    }
-
-    func networkingOTPView(_ view: NetworkingOTPView, didFailConsumerLookup error: Error) {
-        dataSource.analyticsClient.logUnexpectedError(
-            error,
-            errorName: "LookupConsumerSessionError",
-            pane: .networkingLinkVerification
-        )
-        dataSource.analyticsClient.log(
-            eventName: "networking.verification.error",
-            parameters: [
-                "error": "LookupConsumerSession"
-            ],
-            pane: .networkingLinkVerification
-        )
-        delegate?.networkingLinkVerificationViewController(self, didReceiveTerminalError: error)
-        showLoadingView(false) // started in networkingOTPViewWillStartConsumerLookup
-    }
 
     func networkingOTPViewWillStartVerification(_ view: NetworkingOTPView) {
         // no-op
@@ -269,15 +223,5 @@ extension NetworkingLinkVerificationViewController: NetworkingOTPViewDelegate {
                 didReceiveTerminalError: error
             )
         }
-    }
-
-    func networkingOTPViewDidFailAttestationVerdict(
-        _ view: NetworkingOTPView,
-        prefillDetails: WebPrefillDetails
-    ) {
-        delegate?.networkingLinkVerificationViewControllerDidFailAttestationVerdict(
-            self,
-            prefillDetails: prefillDetails
-        )
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -50,7 +50,6 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
             pane: .networkingSaveToLinkVerification,
             consumerSession: consumerSession,
             apiClient: apiClient,
-            clientSecret: clientSecret,
             analyticsClient: analyticsClient
         )
         self.networkingOTPDataSource = networkingOTPDataSource

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationDataSource.swift
@@ -45,7 +45,6 @@ final class NetworkingSaveToLinkVerificationDataSourceImplementation: Networking
         let networkingOTPDataSource = NetworkingOTPDataSourceImplementation(
             otpType: "SMS",
             manifest: manifest,
-            emailAddress: consumerSession.emailAddress,
             customEmailType: nil,
             connectionsMerchantName: nil,
             pane: .networkingSaveToLinkVerification,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
@@ -11,10 +11,6 @@ import Foundation
 import UIKit
 
 protocol NetworkingSaveToLinkVerificationViewControllerDelegate: AnyObject {
-    func networkingSaveToLinkVerificationViewController(
-        _ viewController: NetworkingSaveToLinkVerificationViewController,
-        didReceiveConsumerPublishableKey consumerPublishableKey: String
-    )
     func networkingSaveToLinkVerificationViewControllerDidFinish(
         _ viewController: NetworkingSaveToLinkVerificationViewController,
         saveToLinkWithStripeSucceeded: Bool?,
@@ -23,11 +19,6 @@ protocol NetworkingSaveToLinkVerificationViewControllerDelegate: AnyObject {
     func networkingSaveToLinkVerificationViewController(
         _ viewController: NetworkingSaveToLinkVerificationViewController,
         didReceiveTerminalError error: Error
-    )
-
-    func networkingSaveToLinkVerificationViewControllerDidFailAttestationVerdict(
-        _ viewController: NetworkingSaveToLinkVerificationViewController,
-        prefillDetails: WebPrefillDetails
     )
 }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingSaveToLinkVerification/NetworkingSaveToLinkVerificationViewController.swift
@@ -155,10 +155,6 @@ extension NetworkingSaveToLinkVerificationViewController: NetworkingOTPViewDeleg
         showContent(redactedPhoneNumber: consumerSession.redactedFormattedPhoneNumber)
     }
 
-    func networkingOTPView(_ view: NetworkingOTPView, didGetConsumerPublishableKey consumerPublishableKey: String) {
-        delegate?.networkingSaveToLinkVerificationViewController(self, didReceiveConsumerPublishableKey: consumerPublishableKey)
-    }
-
     func networkingOTPView(_ view: NetworkingOTPView, didFailToStartVerification error: Error) {
         showLoadingView(false)
         dataSource.analyticsClient.log(
@@ -233,27 +229,5 @@ extension NetworkingSaveToLinkVerificationViewController: NetworkingOTPViewDeleg
                 didReceiveTerminalError: error
             )
         }
-    }
-
-    func networkingOTPViewDidFailAttestationVerdict(
-        _ view: NetworkingOTPView,
-        prefillDetails: WebPrefillDetails
-    ) {
-        delegate?.networkingSaveToLinkVerificationViewControllerDidFailAttestationVerdict(
-            self,
-            prefillDetails: prefillDetails
-        )
-    }
-
-    func networkingOTPViewWillStartConsumerLookup(_ view: NetworkingOTPView) {
-        assertionFailure("we shouldn't call `lookup` for NetworkingSaveToLink")
-    }
-
-    func networkingOTPViewConsumerNotFound(_ view: NetworkingOTPView) {
-        assertionFailure("we shouldn't call `lookup` for NetworkingSaveToLink")
-    }
-
-    func networkingOTPView(_ view: NetworkingOTPView, didFailConsumerLookup error: Error) {
-        assertionFailure("we shouldn't call `lookup` for NetworkingSaveToLink")
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -150,8 +150,6 @@ final class NetworkingOTPView: UIView {
         }
     }
 
-    // TODO: Where should we move the attestation error handling?
-
     func startVerification() {
         delegate?.networkingOTPViewWillStartVerification(self)
         dataSource.startVerificationSession()
@@ -259,7 +257,6 @@ private struct NetowrkingOTPViewRepresentable: UIViewRepresentable {
                 verificationSessions: []
             ),
             apiClient: FinancialConnectionsAPIClient(apiClient: .shared),
-            clientSecret: "",
             analyticsClient: FinancialConnectionsAnalyticsClient()
         ))
     }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request aligns the Financial Connections iOS SDK with Android and Web, where we create a consumer session before we display any verification screens. This removes a decent amount of error handling code (for very unlikely errors) and will make implementing https://github.com/stripe/stripe-ios/pull/4272 correctly easier.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
