### PR TITLE
Send and decode CPMs from elements/sessions

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -374,7 +374,7 @@ class PlaygroundController: ObservableObject {
         switch settings.customPaymentMethods {
         case .on:
             // Obtained from https://dashboard.stripe.com/settings/custom_payment_methods
-            let customPaymentMethodType = PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodType(id: "cpmt_1QpId5Lu5o3P18ZpLwSqMXws",
+            let customPaymentMethodType = PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodType(id: "cpmt_1QpIMNLu5o3P18Zpwln1Sm6I",
                                                                                                                 subcopy: "Pay with BufoPay")
             return .init(customPaymentMethodTypes: [customPaymentMethodType], customPaymentMethodConfirmHandler: handleCustomPaymentMethod(_:_:))
         case .off:

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -226,6 +226,7 @@ import Foundation
     case paymentSheetElementsSessionLoadFailed = "mc_elements_session_load_failed"
     case paymentSheetElementsSessionCustomerDeserializeFailed = "mc_elements_session_customer_deserialize_failed"
     case paymentSheetElementsSessionEPMLoadFailed = "mc_elements_session_epms_load_failed"
+    case paymentSheetElementsSessionCPMLoadFailed = "mc_elements_session_cpms_load_failed"
 
     // MARK: - PaymentSheet card brand choice
     case paymentSheetDisplayCardBrandDropdownIndicator = "mc_display_cbc_dropdown"

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -188,6 +188,7 @@
 		61D842892CADE4B9009D2D51 /* PaymentElementConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D842882CADE4B9009D2D51 /* PaymentElementConfiguration.swift */; };
 		61D842912CB06047009D2D51 /* FormMandateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D842902CB06047009D2D51 /* FormMandateProviderTests.swift */; };
 		61D8688E2C06553E001FAD84 /* RightAccessoryButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D8688D2C06553E001FAD84 /* RightAccessoryButton.swift */; };
+		61D946062D7901B400BFCD0C /* CustomPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D946052D7901B400BFCD0C /* CustomPaymentMethod.swift */; };
 		61ED657C2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ED657B2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift */; };
 		61FB6BCD2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB6BCC2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift */; };
 		623C2D9F87929D6DA9C09E23 /* STPCameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39B31D0B890A4F8E4819B15 /* STPCameraView.swift */; };
@@ -623,6 +624,7 @@
 		61D842882CADE4B9009D2D51 /* PaymentElementConfiguration.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PaymentElementConfiguration.swift; sourceTree = "<group>"; };
 		61D842902CB06047009D2D51 /* FormMandateProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormMandateProviderTests.swift; sourceTree = "<group>"; };
 		61D8688D2C06553E001FAD84 /* RightAccessoryButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightAccessoryButton.swift; sourceTree = "<group>"; };
+		61D946052D7901B400BFCD0C /* CustomPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPaymentMethod.swift; sourceTree = "<group>"; };
 		61ED657B2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentSheet+PaymentMethodAvailabilityTest.swift"; sourceTree = "<group>"; };
 		61FB6BCC2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedPaymentMethodsViewSnapshotTests.swift; sourceTree = "<group>"; };
 		62CE362B80042827F47ABC3F /* AffirmCopyLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AffirmCopyLabel.swift; sourceTree = "<group>"; };
@@ -925,6 +927,7 @@
 			isa = PBXGroup;
 			children = (
 				2BFA5FA03C7093654EC6926F /* ExternalPaymentMethod.swift */,
+				61D946052D7901B400BFCD0C /* CustomPaymentMethod.swift */,
 				CC3498CF4AEAA8F169616CDF /* STPCardBrandChoice.swift */,
 				5CA2D5E6CAA2990D88F64A4D /* STPElementsSession.swift */,
 				6B31B9B72B9019730064E210 /* ElementsCustomer.swift */,
@@ -2144,6 +2147,7 @@
 				AA3A96D74B1659CB5725E95F /* CardExpiryDate.swift in Sources */,
 				64DE5688E4FBE92E1F49810C /* ExternalPaymentMethod.swift in Sources */,
 				229A4A578609A3711F02682E /* STPCardBrandChoice.swift in Sources */,
+				61D946062D7901B400BFCD0C /* CustomPaymentMethod.swift in Sources */,
 				3EDFACA133567159875143C5 /* STPElementsSession.swift in Sources */,
 				1BFC617EED154D32BFCADAE7 /* SeparatorLabel.swift in Sources */,
 				01D46644D87983FC4387B92C /* InstantDebitsOnlyFinancialConnectionsAuthManager.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -15,11 +15,13 @@ extension STPAPIClient {
 
     func makeElementsSessionsParams(mode: PaymentSheet.InitializationMode,
                                     epmConfiguration: PaymentSheet.ExternalPaymentMethodConfiguration?,
+                                    cpmConfiguration: PaymentSheet.CustomPaymentMethodConfiguration?,
                                     clientDefaultPaymentMethod: String?,
                                     customerAccessProvider: PaymentSheet.CustomerAccessProvider?) -> [String: Any] {
         var parameters: [String: Any] = [
             "locale": Locale.current.toLanguageTag(),
             "external_payment_methods": epmConfiguration?.externalPaymentMethods.compactMap { $0.lowercased() } ?? [],
+            "custom_payment_methods": cpmConfiguration?.customPaymentMethodTypes.compactMap { $0.id } ?? [],
         ]
         if let appId = Bundle.main.bundleIdentifier {
             parameters["mobile_app_id"] = appId
@@ -77,6 +79,7 @@ extension STPAPIClient {
             endpoint: APIEndpointElementsSessions,
             parameters: makeElementsSessionsParams(mode: .paymentIntentClientSecret(paymentIntentClientSecret),
                                                    epmConfiguration: configuration.externalPaymentMethodConfiguration,
+                                                   cpmConfiguration: configuration.customPaymentMethodConfiguration,
                                                    clientDefaultPaymentMethod: clientDefaultPaymentMethod,
                                                    customerAccessProvider: configuration.customer?.customerAccessProvider)
         )
@@ -100,6 +103,7 @@ extension STPAPIClient {
             endpoint: APIEndpointElementsSessions,
             parameters: makeElementsSessionsParams(mode: .setupIntentClientSecret(setupIntentClientSecret),
                                                    epmConfiguration: configuration.externalPaymentMethodConfiguration,
+                                                   cpmConfiguration: configuration.customPaymentMethodConfiguration,
                                                    clientDefaultPaymentMethod: clientDefaultPaymentMethod,
                                                    customerAccessProvider: configuration.customer?.customerAccessProvider)
         )
@@ -120,6 +124,7 @@ extension STPAPIClient {
     ) async throws -> STPElementsSession {
         let parameters = makeElementsSessionsParams(mode: .deferredIntent(intentConfig),
                                                     epmConfiguration: configuration.externalPaymentMethodConfiguration,
+                                                    cpmConfiguration: configuration.customPaymentMethodConfiguration,
                                                     clientDefaultPaymentMethod: clientDefaultPaymentMethod,
                                                     customerAccessProvider: configuration.customer?.customerAccessProvider)
         return try await APIRequest<STPElementsSession>.getWith(

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
@@ -13,15 +13,19 @@ struct CustomPaymentMethod: Decodable {
     /// The type of the external payment method. e.g. `"external_foopay"`
     /// These match the strings specified by the merchant in `ExternalPaymentMethodConfiguration`.
     let displayName: String?
-    /// A localized label for the payment method e.g. "FooPay"
+    
+    /// The type (id) of the external payment method. e.g. `"cpmt_..."`
+    /// These match the ids specified by the merchant in `CustomPaymentMethodConfiguration`.
     let type: String
-
+    
+    /// URL of a 48x pixel tall, variable width PNG representing the payment method.
     let logoUrl: URL?
     
+    /// If there was an error fetching this custom payment method this will be populated with the error
     let error: String?
 
-    /// Helper method to decode the `v1/elements/sessions` response's `external_payment_methods_data` hash.
-    /// - Parameter response: The value of the `external_payment_methods_data` key in the `v1/elements/sessions` response.
+    /// Helper method to decode the `v1/elements/sessions` response's `custom_payment_methods_data` hash.
+    /// - Parameter response: The value of the `custom_payment_methods_data` key in the `v1/elements/sessions` response.
     public static func decoded(fromAPIResponse response: [[AnyHashable: Any]]?) -> [CustomPaymentMethod]? {
         guard let response else {
             return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
@@ -13,7 +13,7 @@ struct CustomPaymentMethod: Decodable {
     /// The display name of this custom payment method as defined in the Stripe dashboard
     let displayName: String?
 
-    /// The type (id) of the external payment method. e.g. `"cpmt_..."`
+    /// The type (id) of the custom payment method. e.g. `"cpmt_..."`
     /// These match the ids specified by the merchant in `CustomPaymentMethodConfiguration`.
     let type: String
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
@@ -20,6 +20,9 @@ struct CustomPaymentMethod: Decodable {
     /// URL of a 48x pixel tall, variable width PNG representing the payment method.
     let logoUrl: URL?
 
+    /// If true, this custom payment method was created using a preset in the Stripe dashboard
+    let isPreset: Bool?
+
     /// If there was an error fetching this custom payment method this will be populated with the error
     let error: String?
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
@@ -1,0 +1,36 @@
+//
+//  CustomPaymentMethod.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 3/5/25.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
+
+struct CustomPaymentMethod: Decodable {
+    /// The type of the external payment method. e.g. `"external_foopay"`
+    /// These match the strings specified by the merchant in `ExternalPaymentMethodConfiguration`.
+    let displayName: String
+    /// A localized label for the payment method e.g. "FooPay"
+    let type: String
+
+    let logoUrl: URL
+
+    /// Helper method to decode the `v1/elements/sessions` response's `external_payment_methods_data` hash.
+    /// - Parameter response: The value of the `external_payment_methods_data` key in the `v1/elements/sessions` response.
+    public static func decoded(fromAPIResponse response: [[AnyHashable: Any]]?) -> [CustomPaymentMethod]? {
+        guard let response else {
+            return nil
+        }
+        do {
+            return try response.map { dict in
+                let data = try JSONSerialization.data(withJSONObject: dict)
+                return try StripeJSONDecoder().decode(CustomPaymentMethod.self, from: data)
+            }
+        } catch {
+            return nil
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
@@ -12,11 +12,13 @@ import Foundation
 struct CustomPaymentMethod: Decodable {
     /// The type of the external payment method. e.g. `"external_foopay"`
     /// These match the strings specified by the merchant in `ExternalPaymentMethodConfiguration`.
-    let displayName: String
+    let displayName: String?
     /// A localized label for the payment method e.g. "FooPay"
     let type: String
 
-    let logoUrl: URL
+    let logoUrl: URL?
+    
+    let error: String?
 
     /// Helper method to decode the `v1/elements/sessions` response's `external_payment_methods_data` hash.
     /// - Parameter response: The value of the `external_payment_methods_data` key in the `v1/elements/sessions` response.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomPaymentMethod.swift
@@ -10,17 +10,16 @@ import Foundation
 @_spi(STP) import StripePayments
 
 struct CustomPaymentMethod: Decodable {
-    /// The type of the external payment method. e.g. `"external_foopay"`
-    /// These match the strings specified by the merchant in `ExternalPaymentMethodConfiguration`.
+    /// The display name of this custom payment method as defined in the Stripe dashboard
     let displayName: String?
-    
+
     /// The type (id) of the external payment method. e.g. `"cpmt_..."`
     /// These match the ids specified by the merchant in `CustomPaymentMethodConfiguration`.
     let type: String
-    
+
     /// URL of a 48x pixel tall, variable width PNG representing the payment method.
     let logoUrl: URL?
-    
+
     /// If there was an error fetching this custom payment method this will be populated with the error
     let error: String?
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -45,7 +45,7 @@ import Foundation
 
     /// An ordered list of external payment methods to display
     let externalPaymentMethods: [ExternalPaymentMethod]
-    
+
     /// An ordered list of custom payment methods to display
     let customPaymentMethods: [CustomPaymentMethod]
 
@@ -174,7 +174,7 @@ extension STPElementsSession: STPAPIResponseDecodable {
             }
             return epms
         }()
-        
+
         let customPaymentMethods: [CustomPaymentMethod] = {
             let customPaymentMethodDataKey = "custom_payment_method_data"
             guard response[customPaymentMethodDataKey] != nil, !(response[customPaymentMethodDataKey] is NSNull) else {
@@ -184,9 +184,9 @@ extension STPElementsSession: STPAPIResponseDecodable {
                 let cpmsJSON = response[customPaymentMethodDataKey] as? [[AnyHashable: Any]],
                 let cpms = CustomPaymentMethod.decoded(fromAPIResponse: cpmsJSON)
             else {
-                // We don't want to fail the entire v1/elements/sessions request if we fail to parse external_payment_methods_data
+                // We don't want to fail the entire v1/elements/sessions request if we fail to parse custom_payment_methods_data
                 // Instead, fall back to an empty array and log an error.
-//                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetElementsSessionEPMLoadFailed)
+                STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetElementsSessionCPMLoadFailed)
                 return []
             }
             return cpms

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentElementConfiguration.swift
@@ -32,6 +32,7 @@ protocol PaymentElementConfiguration: PaymentMethodRequirementProvider {
     var billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration { get set }
     var removeSavedPaymentMethodMessage: String? { get set }
     var externalPaymentMethodConfiguration: PaymentSheet.ExternalPaymentMethodConfiguration? { get set }
+    var customPaymentMethodConfiguration: PaymentSheet.CustomPaymentMethodConfiguration? { get set }
     var paymentMethodOrder: [String]? { get set }
     var allowsRemovalOfLastSavedPaymentMethod: Bool { get set }
     var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance { get set }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -520,7 +520,7 @@ extension PaymentSheet {
         /// Defines a custom payment method type that can be displayed in PaymentSheet
         public struct CustomPaymentMethodType {
 
-            /// The unique identifier for this custom payment method type in the format of "cmpt_..."
+            /// The unique identifier for this custom payment method type in the format of "cpmt_..."
             /// Obtained from the Stripe Dashboard at https://dashboard.stripe.com/settings/custom_payment_methods
             public let id: String
 
@@ -534,7 +534,7 @@ extension PaymentSheet {
 
             /// Initializes an `CustomPaymentMethodType`
             /// - Parameters:
-            ///   - id: The unique identifier for this custom payment method type in the format of "cmpt_..."
+            ///   - id: The unique identifier for this custom payment method type in the format of "cpmt_..."
             ///   - subcopy: Optional subcopy text to be displayed below the custom payment method's display name.
             public init(id: String, subcopy: String? = nil) {
                 self.id = id

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -113,6 +113,77 @@ class STPElementsSessionTest: XCTestCase {
         }))
     }
 
+    func testFailedCPMParsing() {
+        // If STPElementsSession decodes a dict...
+        var elementsSessionJson = STPTestUtils.jsonNamed("ElementsSession")!
+        // ...that contains unparseable custom_payment_method_data
+        elementsSessionJson["custom_payment_method_data"] = [
+            "this dict doesn't match the expected shape": "and will fail to parse",
+        ]
+        let elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
+        // ...it should successfully decode...
+        XCTAssertNotNil(elementsSession)
+        // ...with an empty `customPaymentMethods` property
+        XCTAssertTrue(elementsSession.customPaymentMethods.isEmpty)
+        // ...and send a failure analytic
+        let analyticEvents = STPAnalyticsClient.sharedClient._testLogHistory
+        XCTAssertTrue(analyticEvents.contains(where: { dict in
+            (dict["event"] as? String) == STPAnalyticEvent.paymentSheetElementsSessionCPMLoadFailed.rawValue
+        }))
+    }
+
+    func testSuccessCPMParsing() {
+        // If STPElementsSession decodes a dict...
+        var elementsSessionJson = STPTestUtils.jsonNamed("ElementsSession")!
+
+        let customPaymentMethodsArray: [[String: Any]] = [
+            [
+                "logo_url": "stripe.com",
+                "display_name": "BufoPay (test)",
+                "type": "cpmt_123",
+                "error": NSNull(),
+                "is_preset": false,
+            ],
+            [
+                "logo_url": NSNull(),
+                "display_name": NSNull(),
+                "type": "cpmt_invalid",
+                "error": "not_found",
+                "is_preset": NSNull(),
+            ],
+        ]
+
+        // ...that contains parseable custom_payment_method_data
+        elementsSessionJson["custom_payment_method_data"] = customPaymentMethodsArray
+        let elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
+        // ...it should successfully decode...
+        XCTAssertNotNil(elementsSession)
+        // ...with a populated `customPaymentMethods` property
+        XCTAssertEqual(2, elementsSession.customPaymentMethods.count)
+
+        // ...validate first CPM
+        let firstCPM = elementsSession.customPaymentMethods[0]
+        XCTAssertEqual(firstCPM.displayName, "BufoPay (test)")
+        XCTAssertEqual(firstCPM.type, "cpmt_123")
+        XCTAssertEqual(firstCPM.logoUrl?.absoluteString, "stripe.com")
+        XCTAssertFalse(firstCPM.isPreset ?? true)
+        XCTAssertNil(firstCPM.error)
+
+        // ...validate second CPM (error case)
+        let errorCPM = elementsSession.customPaymentMethods[1]
+        XCTAssertNil(errorCPM.displayName)
+        XCTAssertEqual(errorCPM.type, "cpmt_invalid")
+        XCTAssertNil(errorCPM.logoUrl)
+        XCTAssertEqual(errorCPM.error, "not_found")
+        XCTAssertNil(errorCPM.isPreset)
+
+        // ...and not send a failure analytic
+        let analyticEvents = STPAnalyticsClient.sharedClient._testLogHistory
+        XCTAssertFalse(analyticEvents.contains(where: { dict in
+            (dict["event"] as? String) == STPAnalyticEvent.paymentSheetElementsSessionCPMLoadFailed.rawValue
+        }))
+    }
+
     func testSPMConsentAndRemoval_legacy() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
                                                             customerSessionData: nil)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -52,6 +52,7 @@ extension STPElementsSession {
         cardBrandChoice: STPCardBrandChoice? = nil,
         isApplePayEnabled: Bool = true,
         externalPaymentMethods: [ExternalPaymentMethod] = [],
+        customPaymentMethods: [CustomPaymentMethod] = [],
         customer: ElementsCustomer? = nil,
         isBackupInstance: Bool = false
     ) -> STPElementsSession {
@@ -68,6 +69,7 @@ extension STPElementsSession {
             cardBrandChoice: cardBrandChoice,
             isApplePayEnabled: isApplePayEnabled,
             externalPaymentMethods: externalPaymentMethods,
+            customPaymentMethods: customPaymentMethods,
             customer: customer
         )
     }

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadWithCustomPaymentMethods/0000_post_create_payment_intent.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadWithCustomPaymentMethods/0000_post_create_payment_intent.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_payment_intent$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=7HWFZ9dI20gPrLaKdtfqXE%2FlYDh1PJTItyRy6ZsfjCbsnXPbBb27uwUg6u2ra2y0oLrgYg4jhmXbQIfknNNkqOLdLZZ4LdFEguuCwv%2Bf%2FrMOdrYO95Re8YUjsLbOSkR5Bprs7dub6TVfprDpXR5%2F5PsdhOvhS6fm9TJqwym7n%2BHCjOFMYCL6w6ETj24t0FS371ZGeWdfcBv45j0Zw3Qb%2BqcHPNeq49LWICXJRvpiLTw%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 7833cdb8796815b26ca3b16480aa54f0
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Thu, 06 Mar 2025 18:28:03 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 147
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"intent":"pi_3Qzj9LFY0qyl6XeW0J5r1cii","secret":"pi_3Qzj9LFY0qyl6XeW0J5r1cii_secret_bCJGys1iMhpJsNCNdu91SESZh","status":"requires_payment_method"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadWithCustomPaymentMethods/0001_get_v1_elements_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadWithCustomPaymentMethods/0001_get_v1_elements_sessions.tail
@@ -1,0 +1,632 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?client_secret=pi_3Qzj9LFY0qyl6XeW0J5r1cii_secret_bCJGys1iMhpJsNCNdu91SESZh&custom_payment_methods%5B0%5D=cpmt_1Qzj4rFY0qyl6XeWoHB842bf&expand%5B0%5D=payment_method_preference\.payment_intent\.payment_method&locale=en-US&mobile_app_id=com\.stripe\.StripeiOSTestHostApp&type=payment_intent$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=-EH3xRiFDlaoUnhs9l-tNc7iQdMlKYigLltw5er6jYob-6oYJ7ere4UCLEZPKaxoKYViP_dDsQ_Qqq_f
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: coop="https://q.stripe.com/coop-report"
+x-wc: AB
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+cross-origin-opener-policy-report-only: same-origin; report-to="coop"
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"coop","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/coop-report"}],"include_subdomains":true}
+request-id: req_FnQOYUslmvYRPq
+Content-Length: 22545
+Vary: Origin
+Date: Thu, 06 Mar 2025 18:28:04 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+
+{
+  "payment_method_preference" : {
+    "country_code" : "US",
+    "object" : "payment_method_preference",
+    "payment_intent" : {
+      "payment_method_configuration_details" : null,
+      "canceled_at" : null,
+      "source" : null,
+      "amount" : 5050,
+      "capture_method" : "automatic",
+      "livemode" : false,
+      "shipping" : null,
+      "status" : "requires_payment_method",
+      "object" : "payment_intent",
+      "currency" : "eur",
+      "last_payment_error" : null,
+      "amount_subtotal" : 5050,
+      "automatic_payment_methods" : null,
+      "cancellation_reason" : null,
+      "next_action" : null,
+      "total_details" : {
+        "amount_discount" : 0,
+        "amount_tax" : 0
+      },
+      "payment_method" : null,
+      "client_secret" : "pi_3Qzj9LFY0qyl6XeW0J5r1cii_secret_bCJGys1iMhpJsNCNdu91SESZh",
+      "id" : "pi_3Qzj9LFY0qyl6XeW0J5r1cii",
+      "confirmation_method" : "automatic",
+      "amount_details" : {
+        "tip" : {
+
+        }
+      },
+      "processing" : null,
+      "receipt_email" : null,
+      "payment_method_types" : [
+        "ideal",
+        "card",
+        "bancontact",
+        "sofort"
+      ],
+      "setup_future_usage" : null,
+      "created" : 1741285683,
+      "description" : null
+    },
+    "ordered_payment_method_types" : [
+      "card",
+      "sofort",
+      "bancontact",
+      "ideal"
+    ],
+    "type" : "payment_intent"
+  },
+  "capability_enabled_card_networks" : [
+    "cartes_bancaires",
+    "jcb",
+    "diners",
+    "discover"
+  ],
+  "flags" : {
+    "elements_enable_external_payment_method_check" : false,
+    "elements_enable_external_payment_method_fawry" : false,
+    "elements_enable_remove_last_validation" : false,
+    "elements_disable_custom_klarna_ece_line_item_validation" : false,
+    "financial_connections_enable_deferred_intent_flow" : true,
+    "elements_enable_external_payment_method_kriya" : false,
+    "elements_enable_external_payment_method_grabpay_later" : false,
+    "elements_enable_ephemeral_key_for_confirmation_token_creation" : true,
+    "elements_enable_fraud_signal_data_transfer_to_hcaptcha" : false,
+    "elements_enable_external_payment_method_au_pay" : false,
+    "elements_enable_external_payment_method_bankaxept" : false,
+    "enable_us_bank_account_as_link_funding_source_data_permissions_requested" : false,
+    "ocs_buyer_xp_pmme_new_list_promos_view" : false,
+    "elements_disable_express_checkout_button_amazon_pay" : false,
+    "elements_enable_external_payment_method_dbarai" : false,
+    "elements_enable_external_payment_method_payit" : false,
+    "elements_enable_blik" : true,
+    "elements_disable_link_email_otp" : false,
+    "elements_enable_external_payment_method_gopay" : false,
+    "elements_enable_external_payment_method_vipps" : false,
+    "enable_cashapp_afterpay_logo_checkout" : false,
+    "paypal_express_checkout_recurring_support" : false,
+    "elements_should_hide_us_bank_account_manual_entry_cta" : false,
+    "elements_enable_external_payment_method_eftpos_australia" : false,
+    "paypal_billing_address_support_in_ece" : false,
+    "elements_enable_instant_debits_postal_code_collection" : false,
+    "elements_enable_external_payment_method_scalapay" : false,
+    "elements_enable_external_payment_method_famipay" : false,
+    "elements_enable_external_payment_method_momo" : false,
+    "elements_enable_external_payment_method_online_banking_czech_republic" : false,
+    "elements_enable_external_payment_method_wechat_mobile" : false,
+    "elements_enable_external_payment_method_rabbitline_pay" : false,
+    "elements_enable_external_payment_method_mercado_pago" : false,
+    "elements_enable_south_korea_market_underlying_pms" : false,
+    "elements_disable_payment_element_card_country_zip_validations" : false,
+    "elements_enable_external_payment_method_online_banking_finland" : false,
+    "elements_enable_external_payment_method_planpay" : false,
+    "elements_disable_link_global_holdback_lookup" : false,
+    "enable_apple_pay_crossbrowser_express_checkout_element" : false,
+    "elements_enable_external_payment_method_kbc" : false,
+    "elements_enable_external_payment_method_mondu" : false,
+    "elements_enable_external_payment_method_walley" : false,
+    "elements_enable_external_payment_method_sequra" : false,
+    "elements_enable_external_payment_method_oney" : false,
+    "elements_hide_optional_klarna_fields" : false,
+    "elements_enable_external_payment_method_rakuten_pay" : false,
+    "enable_custom_checkout_currency_selector_element" : false,
+    "elements_klarna_ece_collect_billing_address_and_email" : false,
+    "elements_enable_external_payment_method_tabby" : false,
+    "elements_disable_paypal_express" : false,
+    "elements_enable_external_payment_method_merpay" : false,
+    "elements_enable_external_payment_method_picpay" : false,
+    "elements_enable_external_payment_method_mybank" : false,
+    "elements_enable_write_allow_redisplay" : false,
+    "show_swish_redirect_and_qr_code_auth_flows" : true,
+    "elements_enable_external_payment_method_payconiq" : false,
+    "elements_enable_external_payment_method_postfinance" : false,
+    "elements_hide_card_brand_icons" : false,
+    "elements_enable_external_payment_method_humm" : false,
+    "elements_enable_external_payment_method_tng" : false,
+    "elements_enable_external_payment_method_venmo" : false,
+    "elements_enable_external_payment_method_atone" : false,
+    "elements_enable_external_payment_method_wallets_india" : false,
+    "elements_enable_external_payment_method_netbanking" : false,
+    "elements_enable_19_digit_pans" : false,
+    "elements_enable_external_payment_method_mb_way" : false,
+    "elements_enable_external_payment_method_v_pay" : false,
+    "elements_enable_external_payment_method_truelayer" : false,
+    "payment_element_link_modal_preload_killswitch" : false,
+    "elements_enable_external_payment_method_aplazame" : false,
+    "elements_enable_external_payment_method_aplazo" : false,
+    "elements_enable_external_payment_method_alipay_mobile" : false,
+    "elements_enable_jp_card_installments" : false,
+    "elements_enable_external_payment_method_amazon_pay" : false,
+    "disable_payment_element_if_required_billing_config" : false,
+    "elements_enable_read_allow_redisplay" : false,
+    "elements_enable_external_payment_method_online_banking_thailand" : false,
+    "elements_enable_link_spm" : true,
+    "elements_enable_save_for_future_payments_pre_check" : false,
+    "elements_enable_external_payment_method_azupay" : false,
+    "buyerxp_lpm_holdback_elements_enable_v2_sampling_algorithm" : false,
+    "elements_enable_external_payment_method_paytm" : false,
+    "elements_enable_external_payment_method_titres_restaurant" : false,
+    "elements_enable_external_payment_method_younitedpay" : false,
+    "elements_enable_external_payment_method_line_pay" : false,
+    "elements_enable_external_payment_method_satispay" : false,
+    "cbc_in_link_popup" : true,
+    "elements_disable_payment_element_custom_payment_methods_byof" : false,
+    "elements_enable_external_payment_method_paypay" : false,
+    "elements_enable_passive_captcha" : true,
+    "enable_express_checkout_click_shape_changes" : false,
+    "elements_enable_external_payment_method_paybright" : false,
+    "elements_enable_external_payment_method_online_banking_slovakia" : false,
+    "elements_enable_external_payment_method_pay_easy" : false,
+    "elements_enable_express_checkout_button_demo_pay" : false,
+    "elements_enable_installments_on_deferred_intents" : false,
+    "disable_cbc_in_link_popup" : false,
+    "elements_enable_klarna_express_checkout" : false,
+    "elements_spm_set_as_default" : true,
+    "paypal_express_checkout_recurring_support_elements_for_new_ece_shape" : true,
+    "elements_enable_external_payment_method_samsung_pay" : false,
+    "elements_enable_cb_apple_pay_for_connect_platforms" : true,
+    "elements_stop_move_focus_to_first_errored_field" : true,
+    "elements_enable_external_payment_method_payrexx" : false,
+    "elements_enable_external_payment_method_catch" : false,
+    "elements_enable_external_payment_method_coinbase_pay" : false,
+    "elements_enable_nz_bank_account_spm" : false,
+    "elements_enable_external_payment_method_paypo" : false,
+    "link_enable_card_brand_choice" : true,
+    "elements_enable_external_payment_method_paidy" : false,
+    "elements_enable_external_payment_method_sezzle" : false,
+    "elements_enable_external_payment_method_ebt_snap" : false,
+    "elements_enable_external_payment_method_online_banking_poland" : false,
+    "elements_enable_external_payment_method_trustly" : false,
+    "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+    "elements_enable_external_payment_method_skrill" : false,
+    "link_purchase_protections_rollout" : true,
+    "elements_enable_external_payment_method_divido" : false,
+    "elements_enable_external_payment_method_atome" : false,
+    "show_swish_factoring_notice" : true,
+    "elements_enable_external_payment_method_bpay" : false,
+    "elements_enable_external_payment_method_knet" : false,
+    "elements_enable_external_payment_method_interac" : false,
+    "elements_enable_invalid_country_for_pm_error" : true,
+    "elements_enable_payment_element_custom_payment_methods_byof" : false,
+    "elements_enable_external_payment_method_bizum" : false,
+    "elements_enable_external_payment_method_paydirekt" : false,
+    "elements_enable_external_payment_method_twint" : false,
+    "elements_enable_external_payment_method_gcash" : false,
+    "elements_enable_external_payment_method_swish" : false,
+    "elements_enable_external_payment_method_bluecode" : false,
+    "elements_enable_external_payment_method_pledg" : false,
+    "elements_spm_max_visible_payment_methods" : false,
+    "elements_enable_external_payment_method_paysafecard" : false,
+    "elements_enable_mx_card_installments" : false,
+    "id_bank_transfers_v1_integration" : false,
+    "elements_enable_external_payment_method_iwocapay" : false,
+    "elements_enable_external_payment_method_poli" : false,
+    "elements_spm_messages" : false,
+    "elements_enable_external_payment_method_billie" : false,
+    "elements_enable_br_card_installments" : false,
+    "elements_enable_external_payment_method_dapp" : false,
+    "elements_enable_external_payment_method_payu" : false,
+    "elements_enable_external_payment_method_pix_international" : false,
+    "elements_enable_external_payment_method_laybuy" : false,
+    "elements_enable_external_payment_method_benefit" : false,
+    "elements_enable_external_payment_method_postepay" : false,
+    "legacy_confirmation_tokens" : false,
+    "elements_enable_external_payment_method_fonix" : false,
+    "elements_appearance_payment_accordion_overrides" : false,
+    "elements_enable_external_payment_method_dankort" : false,
+    "elements_enable_external_payment_method_nexi_pay" : false,
+    "ece_apple_pay_payment_request_passthrough" : false,
+    "elements_enable_apple_pay_crossbrowser_express_checkout_element" : false,
+    "elements_enable_external_payment_method_hands_in" : false,
+    "elements_enable_external_payment_method_girocard" : false,
+    "elements_disable_progressive_cursor" : false,
+    "elements_enable_ach_consumer_sign_up_incentive" : true,
+    "elements_enable_external_payment_method_ratepay" : false
+  },
+  "merchant_logo_url" : null,
+  "session_id" : "elements_session_0SCZwF5cNp8",
+  "card_installments_enabled" : false,
+  "account_id" : "acct_1G6m1pFY0qyl6XeW",
+  "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+  "merchant_currency" : "usd",
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : true
+    }
+  },
+  "shipping_address_settings" : {
+    "autocomplete_allowed" : false
+  },
+  "external_payment_method_data" : null,
+  "custom_payment_method_data" : [
+    {
+      "logo_url" : "https:\/\/stripe-camo.global.ssl.fastly.net\/52f68f75426107898f4e414cb43f488c7616e280a358f085ad3cc38a24412415\/68747470733a2f2f66696c65732e7374726970652e636f6d2f66696c65732f4d44423859574e6a64463878527a5a744d58424757544278655777325747565866475a666447567a6446387854334e59626d4577546b3558634452454e465247635752484e57644b61566b3030726f35335471786f",
+      "display_name" : "Test CPM",
+      "type" : "cpmt_1Qzj4rFY0qyl6XeWoHB842bf",
+      "error" : null,
+      "is_preset" : false
+    }
+  ],
+  "meta_pay_signed_container_context" : null,
+  "apple_pay_preference" : "enabled",
+  "lpm_promotions" : null,
+  "merchant_country" : "US",
+  "google_pay_preference" : "enabled",
+  "paypal_express_config" : {
+    "client_id" : null,
+    "paypal_merchant_id" : null
+  },
+  "experiments_data" : {
+    "arb_id" : "030f84f0-d97e-4457-9dc9-afcf3316c97f",
+    "experiment_metadata" : {
+      "seed" : "16ff82d206b6decd96282b7cd400531621a6572956b82fff0f51f77c2dbda6b7",
+      "semi_dominant_payment_methods" : [
+
+      ],
+      "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false
+    },
+    "experiment_assignments" : {
+      "elements_merchant_ui_api_srv" : "control",
+      "ocs_buyer_xp_elements_expanded_tabs_layout" : "control",
+      "link_popup_webview_option_ios" : "control",
+      "apple_pay_crossbrowser_express_checkout" : "control"
+    }
+  },
+  "legacy_customer" : null,
+  "link_settings" : {
+    "link_enable_webauthn_for_link_popup" : false,
+    "link_no_code_default_values_recall" : true,
+    "link_payment_session_context" : null,
+    "link_consumer_incentive" : null,
+    "link_default_opt_in" : "NONE",
+    "link_elements_pageload_sign_up_disabled" : false,
+    "link_crypto_onramp_bank_upsell" : false,
+    "link_funding_sources" : [
+
+    ],
+    "link_disabled_reasons" : {
+      "payment_element_payment_method_mode" : [
+        "link_not_specified_in_payment_method_types"
+      ],
+      "payment_element_passthrough_mode" : [
+        "link_not_enabled_on_payment_config",
+        "not_gated_into_enable_m2_passthrough_mode"
+      ]
+    },
+    "link_supported_payment_methods" : [
+
+    ],
+    "link_elements_is_crypto_onramp" : false,
+    "link_payment_element_disabled_by_targeting" : false,
+    "link_popup_webview_option" : "shared",
+    "link_targeting_results" : {
+      "payment_element_passthrough_mode" : null
+    },
+    "link_disable_email_otp" : false,
+    "link_local_storage_login_enabled" : false,
+    "link_enable_instant_debits_in_testmode" : false,
+    "link_global_holdback_on" : false,
+    "link_session_storage_login_enabled" : false,
+    "link_payment_element_enable_webauthn_login" : false,
+    "link_payment_element_smart_defaults_enabled" : false,
+    "link_mobile_use_attestation_endpoints" : false,
+    "link_authenticated_change_event_enabled" : false,
+    "link_bank_onboarding_enabled" : false,
+    "link_hcaptcha_rqdata" : null,
+    "link_user_session_id_accuracy_test" : false,
+    "link_lookup_hcaptcha_enabled" : false,
+    "link_financial_incentives_experiment_enabled" : false,
+    "link_passthrough_mode_enabled" : false,
+    "link_no_code_default_values_identification" : true,
+    "link_enable_email_otp_for_link_popup" : false,
+    "link_pay_button_element_enabled" : true,
+    "link_crypto_onramp_elements_logout_disabled" : false,
+    "link_mode" : null,
+    "link_no_code_default_values_usage" : true,
+    "link_popup_smart_defaults_enabled" : false,
+    "link_hcaptcha_site_key" : "20000000-ffff-ffff-ffff-000000000002",
+    "link_crypto_onramp_force_cvc_reverification" : false,
+    "link_wanderlust_in_elements_enabled" : false,
+    "link_email_verification_login_enabled" : false,
+    "link_only_for_payment_method_types_enabled" : false,
+    "link_bank_incentives_enabled" : false,
+    "link_new_consumer_incentive_system_enabled" : false,
+    "link_pm_killswitch_on_in_elements" : false
+  },
+  "passive_captcha" : {
+    "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+    "rqdata" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "fields" : [
+        {
+          "type" : "name",
+          "api_path" : {
+            "v1" : "billing_details[name]"
+          }
+        },
+        {
+          "for" : "email",
+          "type" : "placeholder"
+        },
+        {
+          "for" : "phone",
+          "type" : "placeholder"
+        },
+        {
+          "for" : "billing_address",
+          "type" : "placeholder"
+        },
+        {
+          "for" : "sepa_mandate",
+          "type" : "placeholder"
+        }
+      ],
+      "selector_icon" : {
+        "light_theme_png" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-bancontact@3x-5b31be92d86c437286200810aeaa49ce.png",
+        "light_theme_svg" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-bancontact-c6d62da104212dacefee6ea12a070237.svg"
+      },
+      "type" : "bancontact",
+      "next_action_spec" : {
+        "confirm_response_status_specs" : {
+          "requires_action" : {
+            "type" : "redirect_to_url"
+          }
+        },
+        "post_confirm_handling_pi_status_specs" : {
+          "requires_action" : {
+            "type" : "canceled"
+          },
+          "succeeded" : {
+            "type" : "finished"
+          }
+        }
+      }
+    },
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    },
+    {
+      "async" : false,
+      "fields" : [
+        {
+          "type" : "name",
+          "api_path" : {
+            "v1" : "billing_details[name]"
+          }
+        },
+        {
+          "for" : "email",
+          "type" : "placeholder"
+        },
+        {
+          "for" : "phone",
+          "type" : "placeholder"
+        },
+        {
+          "items" : [
+            {
+              "display_text" : "ABN Amro",
+              "api_value" : "abn_amro"
+            },
+            {
+              "display_text" : "ASN Bank",
+              "api_value" : "asn_bank"
+            },
+            {
+              "display_text" : "bunq B.V.",
+              "api_value" : "bunq"
+            },
+            {
+              "display_text" : "ING Bank",
+              "api_value" : "ing"
+            },
+            {
+              "display_text" : "Knab",
+              "api_value" : "knab"
+            },
+            {
+              "display_text" : "N26",
+              "api_value" : "n26"
+            },
+            {
+              "display_text" : "Nationale-Nederlanden",
+              "api_value" : "nn"
+            },
+            {
+              "display_text" : "Rabobank",
+              "api_value" : "rabobank"
+            },
+            {
+              "display_text" : "RegioBank",
+              "api_value" : "regiobank"
+            },
+            {
+              "display_text" : "Revolut",
+              "api_value" : "revolut"
+            },
+            {
+              "display_text" : "SNS Bank",
+              "api_value" : "sns_bank"
+            },
+            {
+              "display_text" : "Triodos Bank",
+              "api_value" : "triodos_bank"
+            },
+            {
+              "display_text" : "Van Lanschot",
+              "api_value" : "van_lanschot"
+            },
+            {
+              "display_text" : "Yoursafe",
+              "api_value" : "yoursafe"
+            }
+          ],
+          "type" : "selector",
+          "translation_id" : "upe.labels.ideal.bank",
+          "api_path" : {
+            "v1" : "ideal[bank]"
+          }
+        },
+        {
+          "for" : "billing_address",
+          "type" : "placeholder"
+        },
+        {
+          "for" : "sepa_mandate",
+          "type" : "placeholder"
+        }
+      ],
+      "selector_icon" : {
+        "light_theme_png" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-ideal@3x-fc5387c2139f55b84777c646208df7ee.png",
+        "light_theme_svg" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-ideal-608d5ba5730f82c25f122960ccaa9836.svg"
+      },
+      "type" : "ideal",
+      "next_action_spec" : {
+        "confirm_response_status_specs" : {
+          "requires_action" : {
+            "type" : "redirect_to_url"
+          }
+        },
+        "post_confirm_handling_pi_status_specs" : {
+          "requires_action" : {
+            "type" : "canceled"
+          },
+          "succeeded" : {
+            "type" : "finished"
+          }
+        }
+      }
+    },
+    {
+      "async" : true,
+      "fields" : [
+        {
+          "for" : "name",
+          "type" : "placeholder"
+        },
+        {
+          "for" : "email",
+          "type" : "placeholder"
+        },
+        {
+          "for" : "phone",
+          "type" : "placeholder"
+        },
+        {
+          "type" : "country",
+          "api_path" : {
+            "v1" : "sofort[country]"
+          },
+          "allowed_country_codes" : [
+            "AT",
+            "BE",
+            "DE",
+            "ES",
+            "NL"
+          ]
+        },
+        {
+          "for" : "billing_address_without_country",
+          "type" : "placeholder"
+        },
+        {
+          "for" : "sepa_mandate",
+          "type" : "placeholder"
+        }
+      ],
+      "selector_icon" : {
+        "dark_theme_png" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-sofort_dark@3x-1b34ec3a7503b3e20be0a069f8046f29.png",
+        "dark_theme_svg" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-sofort_dark-ded76aa1c92357f1b78dab85ed5b6347.svg",
+        "light_theme_png" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-sofort@3x-8842e382bdf77386d547ff0ef56880c1.png",
+        "light_theme_svg" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-sofort-c12d29b37f06a2d05dfb22ea9736104b.svg"
+      },
+      "type" : "sofort",
+      "next_action_spec" : {
+        "confirm_response_status_specs" : {
+          "requires_action" : {
+            "type" : "redirect_to_url"
+          }
+        },
+        "post_confirm_handling_pi_status_specs" : {
+          "requires_action" : {
+            "type" : "canceled"
+          },
+          "succeeded" : {
+            "type" : "finished"
+          },
+          "processing" : {
+            "type" : "finished"
+          }
+        }
+      }
+    }
+  ],
+  "prefill_selectors" : {
+    "default_values" : {
+      "email" : [
+
+      ],
+      "merchant_provides_default_values_on_update" : true
+    }
+  },
+  "unactivated_payment_method_types" : [
+    "sofort",
+    "bancontact",
+    "ideal"
+  ],
+  "unverified_payment_methods_on_domain" : [
+    "apple_pay"
+  ],
+  "order" : null,
+  "link_purchase_protections_data" : {
+    "type" : null,
+    "is_eligible" : false
+  },
+  "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "customer" : null,
+  "klarna_express_config" : {
+    "klarna_mid" : null
+  },
+  "business_name" : "CI Stuff",
+  "ordered_payment_method_types_and_wallets" : [
+    "card",
+    "apple_pay",
+    "google_pay",
+    "sofort",
+    "bancontact",
+    "ideal"
+  ],
+  "customer_error" : null
+}


### PR DESCRIPTION
## Summary
- We send CPM ids from merchants to elements/session then get them back and decode them
- A following PR will render these CPMs in MPE

## Motivation
- CPMs!

## Testing
- Manual
- New unit tests

## Changelog
N/A