### PR TITLE
End editing when updating a card

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController.swift
@@ -230,7 +230,7 @@ final class UpdatePaymentMethodViewController: UIViewController {
         guard let delegate else {
             return
         }
-        // Ensure endEditing is called prior to isUserInteractionEnabled
+        // Ensure endEditing(true) is called prior to setting isUserInteractionEnabled
         view.endEditing(true)
         view.isUserInteractionEnabled = false
         updateButton.update(state: .spinnerWithInteractionDisabled)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController.swift
@@ -230,6 +230,8 @@ final class UpdatePaymentMethodViewController: UIViewController {
         guard let delegate else {
             return
         }
+        // Ensure endEditing is called prior to isUserInteractionEnabled
+        view.endEditing(true)
         view.isUserInteractionEnabled = false
         updateButton.update(state: .spinnerWithInteractionDisabled)
 


### PR DESCRIPTION
## Summary
Calls end editing before attempting update a card.

## Motivation
Errors were sometimes not being displayed because the field was still editing. 

## Testing
Manual testing

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
