### PR TITLE
Fixes issue when saving usbankaccount as default

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController.swift
@@ -60,7 +60,7 @@ final class UpdatePaymentMethodViewController: UIViewController {
     weak var delegate: UpdatePaymentMethodViewControllerDelegate?
 
     var updateParams: UpdatePaymentMethodOptions? {
-        let confirmParams = IntentConfirmParams(type: PaymentSheet.PaymentMethodType.stripe(.card))
+        let confirmParams = IntentConfirmParams(type: PaymentSheet.PaymentMethodType.stripe(configuration.paymentMethod.type))
 
         if let params = paymentMethodForm.updateParams(params: confirmParams),
            params.paymentMethodParams.type == .card,


### PR DESCRIPTION
## Summary
Fixes assertion failure when attempting to set usbank account as default payment method, introduced by:
https://github.com/stripe/stripe-ios/commit/a87ba8217a1681b824d173ac13dd9bdd56ef1aa4

## Motivation
stpAssertionFailure is issued

## Testing
manual

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
