### PR TITLE
Default to CustomerSession for CustomerSheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		65D034E37B345C1B64785451 /* StripeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1FD1F5193E4A361EA9E8FED3 /* StripeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		6A5CCDA42C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A5CCDA32C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift */; };
 		6B03B12F2CDA890700F95A9D /* XCUITest+PaymentSheetTestUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B03B12E2CDA88F900F95A9D /* XCUITest+PaymentSheetTestUtilities.swift */; };
+		6BCB57EA2D81FB15000C4117 /* CustomerSheetCustomerSessionPlaygroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BCB57E92D81FB13000C4117 /* CustomerSheetCustomerSessionPlaygroundView.swift */; };
 		6BFE613D2D407C420094DFE2 /* CustomerSessionPlaygroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BFE613C2D407C3B0094DFE2 /* CustomerSessionPlaygroundView.swift */; };
 		75D1997DA514F6DB82FF1CFC /* StripePaymentSheet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 240DDF52B887E788853A838B /* StripePaymentSheet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		79E8C77C99A25E38F96747F1 /* PaymentSheetTestPlaygroundSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1261A6BDCDB7E81D08F137F0 /* PaymentSheetTestPlaygroundSettings.swift */; };
@@ -203,6 +204,7 @@
 		6891CC1208EA3F4DE934760E /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		6A5CCDA32C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPaymentControllerUITest.swift; sourceTree = "<group>"; };
 		6B03B12E2CDA88F900F95A9D /* XCUITest+PaymentSheetTestUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUITest+PaymentSheetTestUtilities.swift"; sourceTree = "<group>"; };
+		6BCB57E92D81FB13000C4117 /* CustomerSheetCustomerSessionPlaygroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSheetCustomerSessionPlaygroundView.swift; sourceTree = "<group>"; };
 		6BFE613C2D407C3B0094DFE2 /* CustomerSessionPlaygroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSessionPlaygroundView.swift; sourceTree = "<group>"; };
 		6CD01636EA3B4C6F84E9CC86 /* PaymentSheetUITest-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "PaymentSheetUITest-Release.xcconfig"; sourceTree = "<group>"; };
 		6E4F3FA49534E745C5EDC1C0 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
@@ -444,6 +446,7 @@
 				05E317C6C8459B147C041D93 /* AppDelegate.swift */,
 				5D025413F3246E241A1DFE5C /* AppearancePlaygroundView.swift */,
 				6BFE613C2D407C3B0094DFE2 /* CustomerSessionPlaygroundView.swift */,
+				6BCB57E92D81FB13000C4117 /* CustomerSheetCustomerSessionPlaygroundView.swift */,
 				DEC6711266D93A72ED4938F8 /* CustomerSheetTestPlayground.swift */,
 				B54E58F2CA450CF49ECD5637 /* CustomerSheetTestPlaygroundController.swift */,
 				F2F10B63B9ECBC62AFCF8B32 /* CustomerSheetTestPlaygroundSettings.swift */,
@@ -710,6 +713,7 @@
 				31AB49B72C9E72DB007E74E7 /* UIView+PaymentSheetDebugging.swift in Sources */,
 				973DA944730BD761CE479F8E /* QRView.swift in Sources */,
 				E3D7A04974C35D2D8D31CDCD /* SceneDelegate.swift in Sources */,
+				6BCB57EA2D81FB15000C4117 /* CustomerSheetCustomerSessionPlaygroundView.swift in Sources */,
 				8F5C48FC825539B96F592315 /* ViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetCustomerSessionPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetCustomerSessionPlaygroundView.swift
@@ -1,0 +1,35 @@
+//
+//  CustomerSheetCustomerSessionPlaygroundView.swift
+//  PaymentSheet Example
+
+import StripePaymentSheet
+import SwiftUI
+
+struct CustomerSheetCustomerSessionPlaygroundView: View {
+    @State var viewModel: CustomerSheetTestPlaygroundSettings
+    var doneAction: ((CustomerSheetTestPlaygroundSettings) -> Void) = { _ in }
+
+    var body: some View {
+        VStack {
+            HStack {
+                Text("Customer Session")
+                    .font(.title)
+                    .bold()
+                Spacer()
+                Button("Done") {
+                    doneAction(viewModel)
+                }
+            }.padding()
+            Group {
+                VStack {
+                    SettingPickerView(setting: $viewModel.paymentMethodRemove)
+                    SettingPickerView(setting: $viewModel.paymentMethodRemoveLast)
+                    SettingPickerView(setting: $viewModel.paymentMethodUpdate)
+                    SettingPickerView(setting: $viewModel.paymentMethodAllowRedisplayFilters)
+                    SettingPickerView(setting: $viewModel.paymentMethodSyncDefault)
+                }
+            }.padding()
+
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -39,22 +39,16 @@ struct CustomerSheetTestPlayground: View {
                         }
                         SettingView(setting: $playgroundController.settings.customerMode)
                         SettingView(setting: customerKeyTypeBinding)
-                        TextField("CustomerId", text: customerIdBinding)
-                    }
-                    Group {
-                        if playgroundController.settings.customerKeyType == .customerSession {
-                            VStack {
-                                HStack {
-                                    Text("Customer Session Settings")
-                                        .font(.subheadline)
-                                        .bold()
-                                    Spacer()
-                                }
-                                SettingPickerView(setting: $playgroundController.settings.paymentMethodRemove)
-                                SettingPickerView(setting: $playgroundController.settings.paymentMethodRemoveLast)
-                                SettingPickerView(setting: $playgroundController.settings.paymentMethodUpdate)
-                                SettingPickerView(setting: $playgroundController.settings.paymentMethodAllowRedisplayFilters)
-                                SettingPickerView(setting: $playgroundController.settings.paymentMethodSyncDefault)
+                        HStack {
+                            TextField("CustomerId", text: customerIdBinding)
+                            if playgroundController.settings.customerKeyType == .customerSession {
+                                Spacer()
+                                Button {
+                                    playgroundController.customerSessionSettingsTapped()
+                                } label: {
+                                    Text("CSSettings")
+                                        .font(.callout.smallCaps())
+                                }.buttonStyle(.bordered)
                             }
                         }
                     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -61,14 +61,8 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
         load()
     }
     func didTapSetToUnsupported() {
-        Task {
-            do {
-                try await _customerAdapter?.setSelectedPaymentOption(paymentOption: .link)
-                self.load()
-            } catch {
-                // no-op
-            }
-        }
+        CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: settings.customerId)
+        self.load()
     }
 
     func appearanceButtonTapped() {
@@ -288,6 +282,13 @@ extension CustomerSheetTestPlaygroundController {
                 self.isLoading = false
             }
         }
+    }
+    func customerSessionSettingsTapped() {
+        let vc = UIHostingController(rootView: CustomerSheetCustomerSessionPlaygroundView(viewModel: settings, doneAction: { updatedSettings in
+            self.settings = updatedSettings
+            self.rootViewController.dismiss(animated: true, completion: nil)
+        }))
+        rootViewController.present(vc, animated: true, completion: nil)
     }
 }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -188,7 +188,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     static func defaultValues() -> CustomerSheetTestPlaygroundSettings {
         return CustomerSheetTestPlaygroundSettings(customerMode: .new,
                                                    customerId: nil,
-                                                   customerKeyType: .legacy,
+                                                   customerKeyType: .customerSession,
                                                    paymentMethodMode: .setupIntent,
                                                    applePay: .on,
                                                    headerTextForSelectionScreen: nil,

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -556,7 +556,7 @@ class CustomerSheetUITest: XCTestCase {
         // circularEditButton shows up in the view hierarchy, but it's not actually on the screen or tappable so we scroll a little
         let startCoordinate = app.collectionViews.firstMatch.coordinate(withNormalizedOffset: CGVector(dx: 0.9, dy: 0.99))
         startCoordinate.press(forDuration: 0.1, thenDragTo: app.collectionViews.firstMatch.coordinate(withNormalizedOffset: CGVector(dx: 0.1, dy: 0.99)))
-        XCTAssertTrue(app.buttons.matching(identifier: "CircularButton.Edit").element(boundBy: 1).waitForExistenceAndTap())
+        XCTAssertTrue(app.buttons.matching(identifier: "CircularButton.Edit").firstMatch.waitForExistenceAndTap())
         XCTAssertTrue(app.otherElements.matching(identifier: "Card Brand Dropdown").firstMatch.waitForExistenceAndTap())
         app.pickerWheels.firstMatch.selectNextOption()
         app.toolbars.buttons["Done"].tap()
@@ -565,7 +565,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 3))
         XCTAssertEqual(app.images.matching(identifier: "carousel_card_visa").count, 2)
 
-        app.buttons.matching(identifier: "CircularButton.Edit").element(boundBy: 2).waitForExistenceAndTap()
+        app.buttons.matching(identifier: "CircularButton.Edit").firstMatch.waitForExistenceAndTap()
         app.buttons["Remove"].waitForExistenceAndTap()
         app.alerts.buttons["Remove"].waitForExistenceAndTap()
         XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 3))


### PR DESCRIPTION
## Summary
In preparation of dogfooding, I feel it would make things easier if we default to CustomerSessions.

## Motivation
Preping for dogfooding update payment method.

## Testing
Relying on existing tests and updated some tests.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
