### PR TITLE
Create common type for EPMs and CPMs

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -191,6 +191,8 @@
 		61D946062D7901B400BFCD0C /* CustomPaymentMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61D946052D7901B400BFCD0C /* CustomPaymentMethod.swift */; };
 		61ED657C2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61ED657B2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift */; };
 		61FB6BCD2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FB6BCC2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift */; };
+		61FDF8EC2D81E12C004B3B0D /* ExternalPaymentOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FDF8EB2D81E12C004B3B0D /* ExternalPaymentOption.swift */; };
+		61FDF8EE2D81FA7F004B3B0D /* ExternalPaymentOptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61FDF8ED2D81FA7F004B3B0D /* ExternalPaymentOptionTests.swift */; };
 		623C2D9F87929D6DA9C09E23 /* STPCameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39B31D0B890A4F8E4819B15 /* STPCameraView.swift */; };
 		630A3B22BC5C176928538511 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B7188D37BDE69B56D8223046 /* Main.storyboard */; };
 		648FDD85FD6ECDA1BBC71D45 /* CustomerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83FA9C54257694EC0F205A5C /* CustomerSheet.swift */; };
@@ -628,6 +630,8 @@
 		61D946052D7901B400BFCD0C /* CustomPaymentMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPaymentMethod.swift; sourceTree = "<group>"; };
 		61ED657B2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentSheet+PaymentMethodAvailabilityTest.swift"; sourceTree = "<group>"; };
 		61FB6BCC2C8901B200F8E074 /* EmbeddedPaymentMethodsViewSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedPaymentMethodsViewSnapshotTests.swift; sourceTree = "<group>"; };
+		61FDF8EB2D81E12C004B3B0D /* ExternalPaymentOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalPaymentOption.swift; sourceTree = "<group>"; };
+		61FDF8ED2D81FA7F004B3B0D /* ExternalPaymentOptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalPaymentOptionTests.swift; sourceTree = "<group>"; };
 		62CE362B80042827F47ABC3F /* AffirmCopyLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AffirmCopyLabel.swift; sourceTree = "<group>"; };
 		64C8F350CDB5A29F62E86592 /* FlowControllerStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlowControllerStateTests.swift; sourceTree = "<group>"; };
 		64D658AC15478BF1E0A76B9D /* TestModeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestModeView.swift; sourceTree = "<group>"; };
@@ -1090,6 +1094,7 @@
 				2C59FD8C17CA1D740BCAFA4D /* STPPaymentIntentShippingDetailsParams+PaymentSheet.swift */,
 				61D842882CADE4B9009D2D51 /* PaymentElementConfiguration.swift */,
 				61C87E1A2CB818ED001B7DA9 /* CardBrandFilter.swift */,
+				61FDF8EB2D81E12C004B3B0D /* ExternalPaymentOption.swift */,
 			);
 			path = PaymentSheet;
 			sourceTree = "<group>";
@@ -1728,6 +1733,7 @@
 				C90A2636C2A577AF36FB793B /* PaymentSheetLoaderTest.swift */,
 				61ED657B2D41AE1A00DD5E92 /* PaymentSheet+PaymentMethodAvailabilityTest.swift */,
 				61C87E1C2CB81F9B001B7DA9 /* CardBrandFilterTests.swift */,
+				61FDF8ED2D81FA7F004B3B0D /* ExternalPaymentOptionTests.swift */,
 				C47D00B9DE812D0801B4E33F /* PaymentSheetLPMConfirmFlowTests.swift */,
 				D926018024823367971A8907 /* PaymentSheetPaymentMethodTypeTest.swift */,
 				7E2803AA0D975AF78D787757 /* PaymentSheetSnapshotTests.swift */,
@@ -2043,6 +2049,7 @@
 				3D3607748436E625FF6CF921 /* PaymentSheet+APITest.swift in Sources */,
 				68F13446778AF2CAA631ACDE /* PaymentSheet+DeferredAPITest.swift in Sources */,
 				830DB7F3A2D341445BDB600F /* PaymentSheetAddressTests.swift in Sources */,
+				61FDF8EE2D81FA7F004B3B0D /* ExternalPaymentOptionTests.swift in Sources */,
 				731DA57DAF9979D11AA5A0F6 /* PaymentSheetDeferredValidatorTests.swift in Sources */,
 				96575C19CD0FE05ADA0B0094 /* PaymentSheetErrorTest.swift in Sources */,
 				6BC1594C2C4EDA4E00BDDF4B /* CustomerSheet_ConfirmFlowTests.swift in Sources */,
@@ -2168,6 +2175,7 @@
 				A3B2F2B62CF1149200C0E88C /* SavedPaymentMethodFormFactory+Card.swift in Sources */,
 				61CBE6662BED9749005F7FEB /* VerticalSavedPaymentMethodsViewController.swift in Sources */,
 				29C91CE046099B86D8DCF310 /* STPAnalyticsClient+Link.swift in Sources */,
+				61FDF8EC2D81E12C004B3B0D /* ExternalPaymentOption.swift in Sources */,
 				93FB7933528A45350593D3EC /* UIColor+Link.swift in Sources */,
 				11C23605F97D2DB6F171843E /* LinkUI.swift in Sources */,
 				AB40D7549CDA2E01793CC5D1 /* LinkAccountService.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -366,7 +366,7 @@ extension EmbeddedPaymentElement.PaymentOptionDisplayData {
             paymentMethodType = STPPaymentMethodType.link.identifier
             billingDetails = option.billingDetails?.toPaymentSheetBillingDetails()
         case .external(let paymentMethod, let stpBillingDetails):
-            label = paymentMethod.label
+            label = paymentMethod.displayText
             paymentMethodType = paymentMethod.type
             billingDetails = stpBillingDetails.toPaymentSheetBillingDetails()
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ExternalPaymentOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ExternalPaymentOption.swift
@@ -12,27 +12,26 @@ enum ExternalPaymentOptionConfirmHandler {
     case external(PaymentSheet.ExternalPaymentMethodConfiguration.ExternalPaymentMethodConfirmHandler)
 }
 
-
 /// A type that can represent either a custom or external payment method and handle confirmation
 class ExternalPaymentOption {
     /// A unique identifier for the ExternalPaymentOption, like external_paypal or cpmt_...
     let type: String
-    
+
     /// The display text for this external payment option, typically the name like "PayPal"
     let displayText: String
-    
+
     /// Optional subtext to be shown below the display text
     let displaySubtext: String?
-    
+
     /// URL of a 48x pixel tall, variable width PNG representing the payment method suitable for display against a light background color.
     let lightImageUrl: URL
-    
+
     /// URL of a 48x pixel, variable width tall PNG representing the payment method suitable for display against a dark background color. If `nil`, use `lightImageUrl` instead.
     let darkImageUrl: URL?
-    
+
     /// A function to be called when confirming a ExternalPaymentOption
     private let confirmHandler: ExternalPaymentOptionConfirmHandler
-    
+
     private init(type: String, displayText: String, displaySubtext: String?, lightImageUrl: URL, darkImageUrl: URL?, confirmHandler: ExternalPaymentOptionConfirmHandler) {
         self.type = type
         self.displayText = displayText
@@ -41,7 +40,7 @@ class ExternalPaymentOption {
         self.darkImageUrl = darkImageUrl
         self.confirmHandler = confirmHandler
     }
-    
+
     /// Confirms the payment using this payment option.
     /// - Parameters:
     ///   - billingDetails: The billing details to use for confirmation
@@ -59,7 +58,7 @@ class ExternalPaymentOption {
             }
         }
     }
-    
+
     /// Creates an ExternalPaymentOption from an ExternalPaymentMethod.
     /// - Parameters:
     ///   - externalPaymentMethod: The external payment method to use
@@ -70,7 +69,7 @@ class ExternalPaymentOption {
             assertionFailure("Attempting to create an external payment method, but externalPaymentMethodConfirmHandler isn't set!")
             return nil
         }
-        
+
         return ExternalPaymentOption(
             type: externalPaymentMethod.type,
             displayText: externalPaymentMethod.label,
@@ -80,7 +79,7 @@ class ExternalPaymentOption {
             confirmHandler: .external(confirmHandler)
         )
     }
-    
+
     /// Creates an ExternalPaymentOption from a CustomPaymentMethod.
     /// - Parameters:
     ///   - customPaymentMethod: The custom payment method to use
@@ -91,14 +90,14 @@ class ExternalPaymentOption {
             assertionFailure("Attempting to create an custom payment method, but customPaymentMethodConfirmHandler isn't set!")
             return nil
         }
-        
+
         guard let customPaymentMethodType = configuration?.customPaymentMethodTypes.first(where: { $0.id == customPaymentMethod.type }),
               let label = customPaymentMethod.displayName,
               let logoUrl = customPaymentMethod.logoUrl else {
             assertionFailure("Failed to render payment method type: \(customPaymentMethod.type) with error \(customPaymentMethod.error ?? "unknown")")
             return nil
         }
-        
+
         return ExternalPaymentOption(
             type: customPaymentMethod.type,
             displayText: label,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ExternalPaymentOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ExternalPaymentOption.swift
@@ -1,0 +1,124 @@
+//
+//  ExternalPaymentOption.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 3/12/25.
+//
+
+import Foundation
+
+enum ExternalPaymentOptionConfirmHandler {
+    case custom(PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodType, PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodConfirmHandler)
+    case external(PaymentSheet.ExternalPaymentMethodConfiguration.ExternalPaymentMethodConfirmHandler)
+}
+
+
+/// A type that can represent either a custom or external payment method and handle confirmation
+class ExternalPaymentOption {
+    /// A unique identifier for the ExternalPaymentOption, like external_paypal or cpmt_...
+    let type: String
+    
+    /// The display text for this external payment option, typically the name like "PayPal"
+    let displayText: String
+    
+    /// Optional subtext to be shown below the display text
+    let displaySubtext: String?
+    
+    /// URL of a 48x pixel tall, variable width PNG representing the payment method suitable for display against a light background color.
+    let lightImageUrl: URL
+    
+    /// URL of a 48x pixel, variable width tall PNG representing the payment method suitable for display against a dark background color. If `nil`, use `lightImageUrl` instead.
+    let darkImageUrl: URL?
+    
+    /// A function to be called when confirming a ExternalPaymentOption
+    private let confirmHandler: ExternalPaymentOptionConfirmHandler
+    
+    private init(type: String, displayText: String, displaySubtext: String?, lightImageUrl: URL, darkImageUrl: URL?, confirmHandler: ExternalPaymentOptionConfirmHandler) {
+        self.type = type
+        self.displayText = displayText
+        self.displaySubtext = displaySubtext
+        self.lightImageUrl = lightImageUrl
+        self.darkImageUrl = darkImageUrl
+        self.confirmHandler = confirmHandler
+    }
+    
+    /// Confirms the payment using this payment option.
+    /// - Parameters:
+    ///   - billingDetails: The billing details to use for confirmation
+    ///   - completion: A closure that will be called with the payment result
+    func confirm(billingDetails: STPPaymentMethodBillingDetails, completion: @escaping (PaymentSheetResult) -> Void) {
+        switch confirmHandler {
+        case .custom(let cpm, let confirmHandler):
+            Task {
+                let result = await confirmHandler(cpm, billingDetails)
+                completion(result)
+            }
+        case .external(let confirmHandler):
+            confirmHandler(type, billingDetails) { result in
+                completion(result)
+            }
+        }
+    }
+    
+    /// Creates an ExternalPaymentOption from an ExternalPaymentMethod.
+    /// - Parameters:
+    ///   - externalPaymentMethod: The external payment method to use
+    ///   - configuration: `PaymentSheet.ExternalPaymentMethodConfiguration` containing the confirm handler
+    /// - Returns: A new ExternalPaymentOption instance or nil if creation fails
+    static func from(_ externalPaymentMethod: ExternalPaymentMethod, configuration: PaymentSheet.ExternalPaymentMethodConfiguration?) -> ExternalPaymentOption? {
+        guard let confirmHandler = configuration?.externalPaymentMethodConfirmHandler else {
+            assertionFailure("Attempting to create an external payment method, but externalPaymentMethodConfirmHandler isn't set!")
+            return nil
+        }
+        
+        return ExternalPaymentOption(
+            type: externalPaymentMethod.type,
+            displayText: externalPaymentMethod.label,
+            displaySubtext: nil, // EPMs do not show any subtext
+            lightImageUrl: externalPaymentMethod.lightImageUrl,
+            darkImageUrl: externalPaymentMethod.darkImageUrl,
+            confirmHandler: .external(confirmHandler)
+        )
+    }
+    
+    /// Creates an ExternalPaymentOption from a CustomPaymentMethod.
+    /// - Parameters:
+    ///   - customPaymentMethod: The custom payment method to use
+    ///   - configuration: `PaymentSheet.CustomPaymentMethodConfiguration` containing the confirm handler and type information
+    /// - Returns: A new ExternalPaymentOption instance or nil if creation fails
+    static func from(_ customPaymentMethod: CustomPaymentMethod, configuration: PaymentSheet.CustomPaymentMethodConfiguration?) -> ExternalPaymentOption? {
+        guard let confirmHandler = configuration?.customPaymentMethodConfirmHandler else {
+            assertionFailure("Attempting to create an custom payment method, but customPaymentMethodConfirmHandler isn't set!")
+            return nil
+        }
+        
+        guard let customPaymentMethodType = configuration?.customPaymentMethodTypes.first(where: { $0.id == customPaymentMethod.type }),
+              let label = customPaymentMethod.displayName,
+              let logoUrl = customPaymentMethod.logoUrl else {
+            assertionFailure("Failed to render payment method type: \(customPaymentMethod.type) with error \(customPaymentMethod.error ?? "unknown")")
+            return nil
+        }
+        
+        return ExternalPaymentOption(
+            type: customPaymentMethod.type,
+            displayText: label,
+            displaySubtext: customPaymentMethodType.subcopy,
+            lightImageUrl: logoUrl,
+            darkImageUrl: nil, // CPMs don't have dark mode images
+            confirmHandler: .custom(customPaymentMethodType, confirmHandler)
+        )
+    }
+}
+
+/// Note: ExternalPaymentOption equality is based solely on the type property, as it is a unique identifier.
+extension ExternalPaymentOption: Equatable {
+    static func == (lhs: ExternalPaymentOption, rhs: ExternalPaymentOption) -> Bool {
+        return lhs.type == rhs.type
+    }
+}
+
+extension ExternalPaymentOption: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(type)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -15,7 +15,7 @@ import UIKit
 extension PaymentSheet {
     enum PaymentMethodType: Equatable, Hashable {
         case stripe(STPPaymentMethodType)
-        case external(ExternalPaymentMethod)
+        case external(ExternalPaymentOption)
 
         // Synthetic payment methods. These are payment methods which don't have an `STPPaymentMethodType` defined for the same name.
         // That is, the payment method manifest for a synthetic PMT will show a PMT that doesn't match the form name.
@@ -30,7 +30,7 @@ extension PaymentSheet {
             case .stripe(let paymentMethodType):
                 return paymentMethodType.displayName
             case .external(let externalPaymentMethod):
-                return externalPaymentMethod.label
+                return externalPaymentMethod.displayText
             case .instantDebits, .linkCardBrand:
                 return String.Localized.bank
             }
@@ -179,7 +179,10 @@ extension PaymentSheet {
                 // Stripe PaymentMethod types
                 recommendedStripePaymentMethodTypes.map { PaymentMethodType.stripe($0) }
                 // External Payment Methods
-                + elementsSession.externalPaymentMethods.map { PaymentMethodType.external($0) }
+            + elementsSession.externalPaymentMethods.compactMap {
+                guard let externalPaymentOption = ExternalPaymentOption.from($0, configuration: configuration.externalPaymentMethodConfiguration) else { return nil }
+                return PaymentMethodType.external(externalPaymentOption)
+            }
 
             // We support Instant Bank Payments as a payment method when:
             // - (Primary condition) Link is an available payment method.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -538,15 +538,10 @@ extension PaymentSheet {
                     confirmWithPaymentDetails(linkAccount, paymentDetails, paymentDetails.cvc, shouldSave)
                 }
             }
-        case let .external(paymentMethod, billingDetails):
-            guard let confirmHandler = configuration.externalPaymentMethodConfiguration?.externalPaymentMethodConfirmHandler else {
-                assertionFailure("Attempting to confirm an external payment method, but externalPaymentMethodConfirmhandler isn't set!")
-                completion(.canceled, nil)
-                return
-            }
+        case let .external(externalPaymentOption, billingDetails):
             DispatchQueue.main.async {
                 // Call confirmHandler so that the merchant completes the payment
-                confirmHandler(paymentMethod.type, billingDetails) { result in
+                externalPaymentOption.confirm(billingDetails: billingDetails) { result in
                     // This closure is invoked by the merchant when payment is finished
                     completion(result, nil)
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -23,7 +23,7 @@ extension PaymentSheet {
         case saved(paymentMethod: STPPaymentMethod, confirmParams: IntentConfirmParams?)
         case new(confirmParams: IntentConfirmParams)
         case link(option: LinkConfirmOption)
-        case external(paymentMethod: ExternalPaymentMethod, billingDetails: STPPaymentMethodBillingDetails)
+        case external(paymentMethod: ExternalPaymentOption, billingDetails: STPPaymentMethodBillingDetails)
 
         var paymentMethodTypeAnalyticsValue: String {
             switch self {
@@ -157,7 +157,7 @@ extension PaymentSheet {
                     paymentMethodType = STPPaymentMethodType.link.identifier
                     billingDetails = option.billingDetails?.toPaymentSheetBillingDetails()
                 case .external(let paymentMethod, let stpBillingDetails):
-                    label = paymentMethod.label
+                    label = paymentMethod.displayText
                     paymentMethodType = paymentMethod.type
                     billingDetails = stpBillingDetails.toPaymentSheetBillingDetails()
                 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ExternalPaymentOptionTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ExternalPaymentOptionTests.swift
@@ -1,0 +1,539 @@
+//
+//  ExternalPaymentOptionTests.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 3/12/25.
+//
+
+@_spi(STP) import StripeCore
+@testable @_spi(CustomPaymentMethodsBeta) import StripePaymentSheet
+import XCTest
+
+class ExternalPaymentOptionTests: XCTestCase {
+    
+    // MARK: - Test Data
+    
+    let mockBillingDetails = STPPaymentMethodBillingDetails()
+    let mockLightImageURL = URL(string: "https://example.com/light.png")!
+    let mockDarkImageURL = URL(string: "https://example.com/dark.png")!
+    
+    // Mock External Payment Method
+    func createMockExternalPaymentMethod() -> ExternalPaymentMethod {
+        return ExternalPaymentMethod(
+            type: "external_paypal",
+            label: "PayPal",
+            lightImageUrl: mockLightImageURL,
+            darkImageUrl: mockDarkImageURL
+        )
+    }
+    
+    // Mock Custom Payment Method
+    func createMockCustomPaymentMethod() -> CustomPaymentMethod {
+        return CustomPaymentMethod(
+            displayName: "Apple Pay",
+            type: "cpmt_apple_pay",
+            logoUrl: mockLightImageURL,
+            isPreset: true,
+            error: nil
+        )
+    }
+    
+    // MARK: - Tests for Factory Methods
+    
+    func testFromExternalPaymentMethod_Success() {
+        // Given
+        let mockExternalPaymentMethod = createMockExternalPaymentMethod()
+        let expectation = self.expectation(description: "Confirm handler called")
+        
+        let mockConfiguration = PaymentSheet.ExternalPaymentMethodConfiguration(
+            externalPaymentMethods: ["external_paypal"],
+            externalPaymentMethodConfirmHandler: { type, billingDetails, completion in
+                XCTAssertEqual(type, "external_paypal")
+                XCTAssertEqual(billingDetails, self.mockBillingDetails)
+                completion(.completed)
+                expectation.fulfill()
+            }
+        )
+        
+        // When
+        let paymentOption = ExternalPaymentOption.from(mockExternalPaymentMethod, configuration: mockConfiguration)
+        
+        // Then
+        XCTAssertNotNil(paymentOption)
+        XCTAssertEqual(paymentOption?.type, "external_paypal")
+        XCTAssertEqual(paymentOption?.displayText, "PayPal")
+        XCTAssertNil(paymentOption?.displaySubtext)
+        XCTAssertEqual(paymentOption?.lightImageUrl, mockLightImageURL)
+        XCTAssertEqual(paymentOption?.darkImageUrl, mockDarkImageURL)
+        
+        // Test confirm handler works
+        paymentOption?.confirm(billingDetails: mockBillingDetails) { _ in }
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testFromCustomPaymentMethod_Success() {
+        // Given
+        let mockCustomPaymentMethod = createMockCustomPaymentMethod()
+        let expectation = self.expectation(description: "Custom confirm handler called")
+        
+        let mockCustomType = PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodType(
+            id: "cpmt_apple_pay",
+            subcopy: "Fast and secure checkout"
+        )
+        
+        let mockConfiguration = PaymentSheet.CustomPaymentMethodConfiguration(
+            customPaymentMethodTypes: [mockCustomType],
+            customPaymentMethodConfirmHandler: { cpmType, billingDetails in
+                XCTAssertEqual(cpmType.id, "cpmt_apple_pay")
+                XCTAssertEqual(cpmType.subcopy, "Fast and secure checkout")
+                XCTAssertEqual(billingDetails, self.mockBillingDetails)
+                expectation.fulfill()
+                return .completed
+            }
+        )
+        
+        // When
+        let paymentOption = ExternalPaymentOption.from(mockCustomPaymentMethod, configuration: mockConfiguration)
+        
+        // Then
+        XCTAssertNotNil(paymentOption)
+        XCTAssertEqual(paymentOption?.type, "cpmt_apple_pay")
+        XCTAssertEqual(paymentOption?.displayText, "Apple Pay")
+        XCTAssertEqual(paymentOption?.displaySubtext, "Fast and secure checkout")
+        XCTAssertEqual(paymentOption?.lightImageUrl, mockLightImageURL)
+        XCTAssertNil(paymentOption?.darkImageUrl)
+        
+        // Test confirm handler works
+        paymentOption?.confirm(billingDetails: mockBillingDetails) { _ in }
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    // MARK: - Tests for Confirm Method
+    
+    func testConfirm_CustomPaymentMethod() {
+        // Given
+        let mockCustomPaymentMethod = createMockCustomPaymentMethod()
+        let confirmExpectation = self.expectation(description: "Custom confirm handler called")
+        let completionExpectation = self.expectation(description: "Completion handler called")
+        
+        let mockCustomType = PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodType(
+            id: "cpmt_apple_pay",
+            subcopy: "Fast and secure checkout"
+        )
+        
+        let mockConfiguration = PaymentSheet.CustomPaymentMethodConfiguration(
+            customPaymentMethodTypes: [mockCustomType],
+            customPaymentMethodConfirmHandler: { customType, billingDetails in
+                // Validate the parameters passed to the confirm handler
+                XCTAssertEqual(customType.id, "cpmt_apple_pay")
+                XCTAssertEqual(billingDetails, self.mockBillingDetails)
+                confirmExpectation.fulfill()
+                return .completed
+            }
+        )
+        
+        guard let paymentOption = ExternalPaymentOption.from(mockCustomPaymentMethod, configuration: mockConfiguration) else {
+            XCTFail("Failed to create payment option")
+            return
+        }
+        
+        // When
+        paymentOption.confirm(billingDetails: mockBillingDetails) { result in
+            XCTAssertEqual(result, .completed)
+            completionExpectation.fulfill()
+        }
+        
+        // Then
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testConfirm_ExternalPaymentMethod() {
+        // Given
+        let mockExternalPaymentMethod = createMockExternalPaymentMethod()
+        let confirmExpectation = self.expectation(description: "External confirm handler called")
+        let completionExpectation = self.expectation(description: "Completion handler called")
+        
+        let mockConfiguration = PaymentSheet.ExternalPaymentMethodConfiguration(
+            externalPaymentMethods: ["external_paypal"],
+            externalPaymentMethodConfirmHandler: { type, billingDetails, completion in
+                // Validate the parameters passed to the confirm handler
+                XCTAssertEqual(type, "external_paypal")
+                XCTAssertEqual(billingDetails, self.mockBillingDetails)
+                confirmExpectation.fulfill()
+                completion(.completed)
+            }
+        )
+        
+        guard let paymentOption = ExternalPaymentOption.from(mockExternalPaymentMethod, configuration: mockConfiguration) else {
+            XCTFail("Failed to create payment option")
+            return
+        }
+        
+        // When
+        paymentOption.confirm(billingDetails: mockBillingDetails) { result in
+            XCTAssertEqual(result, .completed)
+            completionExpectation.fulfill()
+        }
+        
+        // Then
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testConfirm_ExternalPaymentMethod_Cancellation() {
+        // Given
+        let mockExternalPaymentMethod = createMockExternalPaymentMethod()
+        let confirmExpectation = self.expectation(description: "External confirm handler called")
+        let completionExpectation = self.expectation(description: "Completion handler called")
+        
+        let mockConfiguration = PaymentSheet.ExternalPaymentMethodConfiguration(
+            externalPaymentMethods: ["external_paypal"],
+            externalPaymentMethodConfirmHandler: { _, _, completion in
+                confirmExpectation.fulfill()
+                completion(.canceled)
+            }
+        )
+        
+        guard let paymentOption = ExternalPaymentOption.from(mockExternalPaymentMethod, configuration: mockConfiguration) else {
+            XCTFail("Failed to create payment option")
+            return
+        }
+        
+        // When
+        paymentOption.confirm(billingDetails: mockBillingDetails) { result in
+            // Verify cancellation is passed through correctly
+            XCTAssertEqual(result, .canceled)
+            completionExpectation.fulfill()
+        }
+        
+        // Then
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    func testConfirm_CustomPaymentMethod_Error() {
+        // Given
+        let mockCustomPaymentMethod = createMockCustomPaymentMethod()
+        let confirmExpectation = self.expectation(description: "Custom confirm handler called")
+        let completionExpectation = self.expectation(description: "Completion handler called")
+        
+        let mockCustomType = PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodType(
+            id: "cpmt_apple_pay",
+            subcopy: "Fast and secure checkout"
+        )
+        
+        let mockConfiguration = PaymentSheet.CustomPaymentMethodConfiguration(
+            customPaymentMethodTypes: [mockCustomType],
+            customPaymentMethodConfirmHandler: { _, _ in
+                confirmExpectation.fulfill()
+                return .failed(error: NSError(domain: "test", code: 123, userInfo: nil))
+            }
+        )
+        
+        guard let paymentOption = ExternalPaymentOption.from(mockCustomPaymentMethod, configuration: mockConfiguration) else {
+            XCTFail("Failed to create payment option")
+            return
+        }
+        
+        // When
+        paymentOption.confirm(billingDetails: mockBillingDetails) { result in
+            if case .failed(let error) = result {
+                XCTAssertEqual((error as NSError).code, 123)
+                XCTAssertEqual((error as NSError).domain, "test")
+            } else {
+                XCTFail("Expected failed result but got \(result)")
+            }
+            completionExpectation.fulfill()
+        }
+        
+        // Then
+        waitForExpectations(timeout: 0.1)
+    }
+    
+    // MARK: - Tests for Equatable and Hashable
+    
+    func testEquatable_SameType_Equal() {
+        // Given
+        let mockConfig = PaymentSheet.ExternalPaymentMethodConfiguration(
+            externalPaymentMethods: ["external_paypal"],
+            externalPaymentMethodConfirmHandler: { _, _, completion in completion(.completed) }
+        )
+        
+        let mockExternalPaymentMethod1 = ExternalPaymentMethod(
+            type: "external_paypal",
+            label: "PayPal",
+            lightImageUrl: URL(string: "https://example.com/light1.png")!,
+            darkImageUrl: URL(string: "https://example.com/dark1.png")!
+        )
+        
+        let mockExternalPaymentMethod2 = ExternalPaymentMethod(
+            type: "external_paypal",
+            label: "PayPal Different Label", // Different label
+            lightImageUrl: URL(string: "https://example.com/light2.png")!, // Different URL
+            darkImageUrl: URL(string: "https://example.com/dark2.png")! // Different URL
+        )
+        
+        // When
+        let option1 = ExternalPaymentOption.from(mockExternalPaymentMethod1, configuration: mockConfig)
+        let option2 = ExternalPaymentOption.from(mockExternalPaymentMethod2, configuration: mockConfig)
+        
+        // Then
+        XCTAssertEqual(option1, option2, "Options with same type should be equal despite different properties")
+    }
+    
+    func testEquatable_DifferentType_NotEqual() {
+        // Given
+        let mockConfig = PaymentSheet.ExternalPaymentMethodConfiguration(
+            externalPaymentMethods: ["external_paypal", "external_klarna"],
+            externalPaymentMethodConfirmHandler: { _, _, completion in completion(.completed) }
+        )
+        
+        let mockExternalPaymentMethod1 = ExternalPaymentMethod(
+            type: "external_paypal",
+            label: "PayPal",
+            lightImageUrl: mockLightImageURL,
+            darkImageUrl: mockDarkImageURL
+        )
+        
+        let mockExternalPaymentMethod2 = ExternalPaymentMethod(
+            type: "external_klarna",
+            label: "Klarna",
+            lightImageUrl: mockLightImageURL,
+            darkImageUrl: mockDarkImageURL
+        )
+        
+        // When
+        let option1 = ExternalPaymentOption.from(mockExternalPaymentMethod1, configuration: mockConfig)
+        let option2 = ExternalPaymentOption.from(mockExternalPaymentMethod2, configuration: mockConfig)
+        
+        // Then
+        XCTAssertNotEqual(option1, option2, "Options with different types should not be equal")
+    }
+    
+    func testHashable_SameTypeHashesToSameValue() {
+        // Given
+        let mockConfig = PaymentSheet.ExternalPaymentMethodConfiguration(
+            externalPaymentMethods: ["external_paypal"],
+            externalPaymentMethodConfirmHandler: { _, _, completion in completion(.completed) }
+        )
+        
+        let mockExternalPaymentMethod1 = ExternalPaymentMethod(
+            type: "external_paypal",
+            label: "PayPal",
+            lightImageUrl: URL(string: "https://example.com/light1.png")!,
+            darkImageUrl: URL(string: "https://example.com/dark1.png")!
+        )
+        
+        let mockExternalPaymentMethod2 = ExternalPaymentMethod(
+            type: "external_paypal",
+            label: "PayPal Different", // Different properties
+            lightImageUrl: URL(string: "https://example.com/light2.png")!,
+            darkImageUrl: nil // Different property
+        )
+        
+        // When
+        let option1 = ExternalPaymentOption.from(mockExternalPaymentMethod1, configuration: mockConfig)!
+        let option2 = ExternalPaymentOption.from(mockExternalPaymentMethod2, configuration: mockConfig)!
+        
+       // Then
+        XCTAssertEqual(
+            option1.hashValue,
+            option2.hashValue,
+            "Options with same type should hash to same value"
+        )
+        
+        // Test in a Set
+        let optionSet = Set(
+            [
+                option1,
+                option2
+            ]
+        )
+        XCTAssertEqual(
+            optionSet.count,
+            1,
+            "Set should only contain one item because options have same hash"
+        )
+        XCTAssertTrue(
+            optionSet.contains(
+                option1
+            ),
+            "Set should contain option1"
+        )
+        XCTAssertTrue(
+            optionSet.contains(
+                option2
+            ),
+            "Set should contain option2 (which is equal to option1)"
+        )
+    }
+    
+    func testHashable_DifferentTypeHashesToDifferentValue() {
+        // Given
+        let mockConfig = PaymentSheet.ExternalPaymentMethodConfiguration(
+            externalPaymentMethods: [
+                "external_paypal",
+                "external_klarna"
+            ],
+            externalPaymentMethodConfirmHandler: {
+                _,
+                _,
+                completion in completion(
+                    .completed
+                )
+            }
+        )
+        
+        let mockExternalPaymentMethod1 = ExternalPaymentMethod(
+            type: "external_paypal",
+            label: "PayPal",
+            lightImageUrl: mockLightImageURL,
+            darkImageUrl: mockDarkImageURL
+        )
+        
+        let mockExternalPaymentMethod2 = ExternalPaymentMethod(
+            type: "external_klarna",
+            label: "Klarna",
+            lightImageUrl: mockLightImageURL,
+            darkImageUrl: mockDarkImageURL
+        )
+        
+        // When
+        let option1 = ExternalPaymentOption.from(
+            mockExternalPaymentMethod1,
+            configuration: mockConfig
+        )!
+        let option2 = ExternalPaymentOption.from(
+            mockExternalPaymentMethod2,
+            configuration: mockConfig
+        )!
+        
+        // Then
+        XCTAssertNotEqual(
+            option1.hashValue,
+            option2.hashValue,
+            "Options with different types should hash to different values"
+        )
+        
+        // Test in a Set
+        let optionSet = Set(
+            [
+                option1,
+                option2
+            ]
+        )
+        XCTAssertEqual(
+            optionSet.count,
+            2,
+            "Set should contain two items because options have different hashes"
+        )
+        XCTAssertTrue(
+            optionSet.contains(
+                option1
+            ),
+            "Set should contain option1"
+        )
+        XCTAssertTrue(
+            optionSet.contains(
+                option2
+            ),
+            "Set should contain option2"
+        )
+    }
+    
+    func testHashable_UsageInDictionary() {
+        // Given
+        let mockConfig = PaymentSheet.ExternalPaymentMethodConfiguration(
+            externalPaymentMethods: [
+                "external_paypal",
+                "external_klarna"
+            ],
+            externalPaymentMethodConfirmHandler: {
+                _,
+                _,
+                completion in completion(
+                    .completed
+                )
+            }
+        )
+        
+        let paypalMethod = ExternalPaymentMethod(
+            type: "external_paypal",
+            label: "PayPal",
+            lightImageUrl: mockLightImageURL,
+            darkImageUrl: mockDarkImageURL
+        )
+        
+        let klarnaMethod = ExternalPaymentMethod(
+            type: "external_klarna",
+            label: "Klarna",
+            lightImageUrl: mockLightImageURL,
+            darkImageUrl: mockDarkImageURL
+        )
+        
+        let paypalOption = ExternalPaymentOption.from(
+            paypalMethod,
+            configuration: mockConfig
+        )!
+        let klarnaOption = ExternalPaymentOption.from(
+            klarnaMethod,
+            configuration: mockConfig
+        )!
+        
+        // Different object but same type as paypalOption
+        let paypalOption2 = ExternalPaymentOption.from(
+            ExternalPaymentMethod(
+                type: "external_paypal",
+                label: "Different Label",
+                lightImageUrl: URL(
+                    string: "https://example.com/different.png"
+                )!,
+                darkImageUrl: nil
+            ),
+            configuration: mockConfig
+        )!
+        
+        // When
+        var paymentOptions: [ExternalPaymentOption: String] = [:]
+        paymentOptions[paypalOption] = "Value for PayPal"
+        paymentOptions[klarnaOption] = "Value for Klarna"
+        
+        // Then
+        XCTAssertEqual(
+            paymentOptions.count,
+            2,
+            "Dictionary should have two entries"
+        )
+        XCTAssertEqual(
+            paymentOptions[paypalOption],
+            "Value for PayPal"
+        )
+        XCTAssertEqual(
+            paymentOptions[klarnaOption],
+            "Value for Klarna"
+        )
+        
+        // When using an equivalent object with same type
+        XCTAssertEqual(
+            paymentOptions[paypalOption2],
+            "Value for PayPal",
+            "Should retrieve the same value using an equivalent object"
+        )
+        
+        // When updating with equivalent object
+        paymentOptions[paypalOption2] = "Updated PayPal Value"
+        XCTAssertEqual(
+            paymentOptions.count,
+            2,
+            "Dictionary should still have two entries"
+        )
+        XCTAssertEqual(
+            paymentOptions[paypalOption],
+            "Updated PayPal Value",
+            "Original key should access updated value"
+        )
+        XCTAssertEqual(
+            paymentOptions[paypalOption2],
+            "Updated PayPal Value",
+            "Equivalent key should access same updated value"
+        )
+   }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ExternalPaymentOptionTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ExternalPaymentOptionTests.swift
@@ -10,13 +10,13 @@
 import XCTest
 
 class ExternalPaymentOptionTests: XCTestCase {
-    
+
     // MARK: - Test Data
-    
+
     let mockBillingDetails = STPPaymentMethodBillingDetails()
     let mockLightImageURL = URL(string: "https://example.com/light.png")!
     let mockDarkImageURL = URL(string: "https://example.com/dark.png")!
-    
+
     // Mock External Payment Method
     func createMockExternalPaymentMethod() -> ExternalPaymentMethod {
         return ExternalPaymentMethod(
@@ -26,25 +26,24 @@ class ExternalPaymentOptionTests: XCTestCase {
             darkImageUrl: mockDarkImageURL
         )
     }
-    
+
     // Mock Custom Payment Method
     func createMockCustomPaymentMethod() -> CustomPaymentMethod {
         return CustomPaymentMethod(
-            displayName: "Apple Pay",
-            type: "cpmt_apple_pay",
+            displayName: "Test CPM",
+            type: "cpmt_1234",
             logoUrl: mockLightImageURL,
             isPreset: true,
             error: nil
         )
     }
-    
-    // MARK: - Tests for Factory Methods
-    
+
+    // MARK: - Tests `from` functions
+
     func testFromExternalPaymentMethod_Success() {
-        // Given
         let mockExternalPaymentMethod = createMockExternalPaymentMethod()
         let expectation = self.expectation(description: "Confirm handler called")
-        
+
         let mockConfiguration = PaymentSheet.ExternalPaymentMethodConfiguration(
             externalPaymentMethods: ["external_paypal"],
             externalPaymentMethodConfirmHandler: { type, billingDetails, completion in
@@ -54,137 +53,123 @@ class ExternalPaymentOptionTests: XCTestCase {
                 expectation.fulfill()
             }
         )
-        
-        // When
+
         let paymentOption = ExternalPaymentOption.from(mockExternalPaymentMethod, configuration: mockConfiguration)
-        
-        // Then
+
         XCTAssertNotNil(paymentOption)
         XCTAssertEqual(paymentOption?.type, "external_paypal")
         XCTAssertEqual(paymentOption?.displayText, "PayPal")
         XCTAssertNil(paymentOption?.displaySubtext)
         XCTAssertEqual(paymentOption?.lightImageUrl, mockLightImageURL)
         XCTAssertEqual(paymentOption?.darkImageUrl, mockDarkImageURL)
-        
+
         // Test confirm handler works
         paymentOption?.confirm(billingDetails: mockBillingDetails) { _ in }
         waitForExpectations(timeout: 0.1)
     }
-    
+
     func testFromCustomPaymentMethod_Success() {
-        // Given
         let mockCustomPaymentMethod = createMockCustomPaymentMethod()
         let expectation = self.expectation(description: "Custom confirm handler called")
-        
+
         let mockCustomType = PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodType(
-            id: "cpmt_apple_pay",
+            id: "cpmt_1234",
             subcopy: "Fast and secure checkout"
         )
-        
+
         let mockConfiguration = PaymentSheet.CustomPaymentMethodConfiguration(
             customPaymentMethodTypes: [mockCustomType],
             customPaymentMethodConfirmHandler: { cpmType, billingDetails in
-                XCTAssertEqual(cpmType.id, "cpmt_apple_pay")
+                XCTAssertEqual(cpmType.id, "cpmt_1234")
                 XCTAssertEqual(cpmType.subcopy, "Fast and secure checkout")
                 XCTAssertEqual(billingDetails, self.mockBillingDetails)
                 expectation.fulfill()
                 return .completed
             }
         )
-        
-        // When
+
         let paymentOption = ExternalPaymentOption.from(mockCustomPaymentMethod, configuration: mockConfiguration)
-        
-        // Then
+
         XCTAssertNotNil(paymentOption)
-        XCTAssertEqual(paymentOption?.type, "cpmt_apple_pay")
-        XCTAssertEqual(paymentOption?.displayText, "Apple Pay")
+        XCTAssertEqual(paymentOption?.type, "cpmt_1234")
+        XCTAssertEqual(paymentOption?.displayText, "Test CPM")
         XCTAssertEqual(paymentOption?.displaySubtext, "Fast and secure checkout")
         XCTAssertEqual(paymentOption?.lightImageUrl, mockLightImageURL)
         XCTAssertNil(paymentOption?.darkImageUrl)
-        
+
         // Test confirm handler works
         paymentOption?.confirm(billingDetails: mockBillingDetails) { _ in }
         waitForExpectations(timeout: 0.1)
     }
-    
+
     // MARK: - Tests for Confirm Method
-    
+
     func testConfirm_CustomPaymentMethod() {
-        // Given
         let mockCustomPaymentMethod = createMockCustomPaymentMethod()
         let confirmExpectation = self.expectation(description: "Custom confirm handler called")
         let completionExpectation = self.expectation(description: "Completion handler called")
-        
+
         let mockCustomType = PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodType(
-            id: "cpmt_apple_pay",
+            id: "cpmt_1234",
             subcopy: "Fast and secure checkout"
         )
-        
+
         let mockConfiguration = PaymentSheet.CustomPaymentMethodConfiguration(
             customPaymentMethodTypes: [mockCustomType],
             customPaymentMethodConfirmHandler: { customType, billingDetails in
-                // Validate the parameters passed to the confirm handler
-                XCTAssertEqual(customType.id, "cpmt_apple_pay")
+                XCTAssertEqual(customType.id, "cpmt_1234")
                 XCTAssertEqual(billingDetails, self.mockBillingDetails)
                 confirmExpectation.fulfill()
                 return .completed
             }
         )
-        
+
         guard let paymentOption = ExternalPaymentOption.from(mockCustomPaymentMethod, configuration: mockConfiguration) else {
-            XCTFail("Failed to create payment option")
+            XCTFail("Failed to create external payment option")
             return
         }
-        
-        // When
+
         paymentOption.confirm(billingDetails: mockBillingDetails) { result in
             XCTAssertEqual(result, .completed)
             completionExpectation.fulfill()
         }
-        
-        // Then
+
         waitForExpectations(timeout: 0.1)
     }
-    
+
     func testConfirm_ExternalPaymentMethod() {
-        // Given
         let mockExternalPaymentMethod = createMockExternalPaymentMethod()
         let confirmExpectation = self.expectation(description: "External confirm handler called")
         let completionExpectation = self.expectation(description: "Completion handler called")
-        
+
         let mockConfiguration = PaymentSheet.ExternalPaymentMethodConfiguration(
             externalPaymentMethods: ["external_paypal"],
             externalPaymentMethodConfirmHandler: { type, billingDetails, completion in
-                // Validate the parameters passed to the confirm handler
                 XCTAssertEqual(type, "external_paypal")
                 XCTAssertEqual(billingDetails, self.mockBillingDetails)
                 confirmExpectation.fulfill()
                 completion(.completed)
             }
         )
-        
+
         guard let paymentOption = ExternalPaymentOption.from(mockExternalPaymentMethod, configuration: mockConfiguration) else {
-            XCTFail("Failed to create payment option")
+            XCTFail("Failed to create external payment option")
             return
         }
-        
-        // When
+
         paymentOption.confirm(billingDetails: mockBillingDetails) { result in
             XCTAssertEqual(result, .completed)
             completionExpectation.fulfill()
         }
-        
-        // Then
+
         waitForExpectations(timeout: 0.1)
     }
-    
+
     func testConfirm_ExternalPaymentMethod_Cancellation() {
-        // Given
         let mockExternalPaymentMethod = createMockExternalPaymentMethod()
         let confirmExpectation = self.expectation(description: "External confirm handler called")
         let completionExpectation = self.expectation(description: "Completion handler called")
-        
+
         let mockConfiguration = PaymentSheet.ExternalPaymentMethodConfiguration(
             externalPaymentMethods: ["external_paypal"],
             externalPaymentMethodConfirmHandler: { _, _, completion in
@@ -192,259 +177,79 @@ class ExternalPaymentOptionTests: XCTestCase {
                 completion(.canceled)
             }
         )
-        
+
         guard let paymentOption = ExternalPaymentOption.from(mockExternalPaymentMethod, configuration: mockConfiguration) else {
-            XCTFail("Failed to create payment option")
+            XCTFail("Failed to create external payment option")
             return
         }
-        
-        // When
+
         paymentOption.confirm(billingDetails: mockBillingDetails) { result in
-            // Verify cancellation is passed through correctly
             XCTAssertEqual(result, .canceled)
             completionExpectation.fulfill()
         }
-        
-        // Then
+
         waitForExpectations(timeout: 0.1)
     }
-    
-    func testConfirm_CustomPaymentMethod_Error() {
-        // Given
-        let mockCustomPaymentMethod = createMockCustomPaymentMethod()
-        let confirmExpectation = self.expectation(description: "Custom confirm handler called")
-        let completionExpectation = self.expectation(description: "Completion handler called")
-        
-        let mockCustomType = PaymentSheet.CustomPaymentMethodConfiguration.CustomPaymentMethodType(
-            id: "cpmt_apple_pay",
-            subcopy: "Fast and secure checkout"
-        )
-        
-        let mockConfiguration = PaymentSheet.CustomPaymentMethodConfiguration(
-            customPaymentMethodTypes: [mockCustomType],
-            customPaymentMethodConfirmHandler: { _, _ in
-                confirmExpectation.fulfill()
-                return .failed(error: NSError(domain: "test", code: 123, userInfo: nil))
-            }
-        )
-        
-        guard let paymentOption = ExternalPaymentOption.from(mockCustomPaymentMethod, configuration: mockConfiguration) else {
-            XCTFail("Failed to create payment option")
-            return
-        }
-        
-        // When
-        paymentOption.confirm(billingDetails: mockBillingDetails) { result in
-            if case .failed(let error) = result {
-                XCTAssertEqual((error as NSError).code, 123)
-                XCTAssertEqual((error as NSError).domain, "test")
-            } else {
-                XCTFail("Expected failed result but got \(result)")
-            }
-            completionExpectation.fulfill()
-        }
-        
-        // Then
-        waitForExpectations(timeout: 0.1)
-    }
-    
+
     // MARK: - Tests for Equatable and Hashable
-    
+
     func testEquatable_SameType_Equal() {
-        // Given
         let mockConfig = PaymentSheet.ExternalPaymentMethodConfiguration(
             externalPaymentMethods: ["external_paypal"],
             externalPaymentMethodConfirmHandler: { _, _, completion in completion(.completed) }
         )
-        
+
         let mockExternalPaymentMethod1 = ExternalPaymentMethod(
             type: "external_paypal",
             label: "PayPal",
             lightImageUrl: URL(string: "https://example.com/light1.png")!,
             darkImageUrl: URL(string: "https://example.com/dark1.png")!
         )
-        
+
         let mockExternalPaymentMethod2 = ExternalPaymentMethod(
             type: "external_paypal",
             label: "PayPal Different Label", // Different label
             lightImageUrl: URL(string: "https://example.com/light2.png")!, // Different URL
             darkImageUrl: URL(string: "https://example.com/dark2.png")! // Different URL
         )
-        
-        // When
+
         let option1 = ExternalPaymentOption.from(mockExternalPaymentMethod1, configuration: mockConfig)
         let option2 = ExternalPaymentOption.from(mockExternalPaymentMethod2, configuration: mockConfig)
-        
-        // Then
+
         XCTAssertEqual(option1, option2, "Options with same type should be equal despite different properties")
     }
-    
+
     func testEquatable_DifferentType_NotEqual() {
-        // Given
         let mockConfig = PaymentSheet.ExternalPaymentMethodConfiguration(
             externalPaymentMethods: ["external_paypal", "external_klarna"],
             externalPaymentMethodConfirmHandler: { _, _, completion in completion(.completed) }
         )
-        
+
         let mockExternalPaymentMethod1 = ExternalPaymentMethod(
             type: "external_paypal",
             label: "PayPal",
             lightImageUrl: mockLightImageURL,
             darkImageUrl: mockDarkImageURL
         )
-        
+
         let mockExternalPaymentMethod2 = ExternalPaymentMethod(
             type: "external_klarna",
             label: "Klarna",
             lightImageUrl: mockLightImageURL,
             darkImageUrl: mockDarkImageURL
         )
-        
-        // When
+
         let option1 = ExternalPaymentOption.from(mockExternalPaymentMethod1, configuration: mockConfig)
         let option2 = ExternalPaymentOption.from(mockExternalPaymentMethod2, configuration: mockConfig)
-        
-        // Then
+
         XCTAssertNotEqual(option1, option2, "Options with different types should not be equal")
     }
-    
-    func testHashable_SameTypeHashesToSameValue() {
-        // Given
-        let mockConfig = PaymentSheet.ExternalPaymentMethodConfiguration(
-            externalPaymentMethods: ["external_paypal"],
-            externalPaymentMethodConfirmHandler: { _, _, completion in completion(.completed) }
-        )
-        
-        let mockExternalPaymentMethod1 = ExternalPaymentMethod(
-            type: "external_paypal",
-            label: "PayPal",
-            lightImageUrl: URL(string: "https://example.com/light1.png")!,
-            darkImageUrl: URL(string: "https://example.com/dark1.png")!
-        )
-        
-        let mockExternalPaymentMethod2 = ExternalPaymentMethod(
-            type: "external_paypal",
-            label: "PayPal Different", // Different properties
-            lightImageUrl: URL(string: "https://example.com/light2.png")!,
-            darkImageUrl: nil // Different property
-        )
-        
-        // When
-        let option1 = ExternalPaymentOption.from(mockExternalPaymentMethod1, configuration: mockConfig)!
-        let option2 = ExternalPaymentOption.from(mockExternalPaymentMethod2, configuration: mockConfig)!
-        
-       // Then
-        XCTAssertEqual(
-            option1.hashValue,
-            option2.hashValue,
-            "Options with same type should hash to same value"
-        )
-        
-        // Test in a Set
-        let optionSet = Set(
-            [
-                option1,
-                option2
-            ]
-        )
-        XCTAssertEqual(
-            optionSet.count,
-            1,
-            "Set should only contain one item because options have same hash"
-        )
-        XCTAssertTrue(
-            optionSet.contains(
-                option1
-            ),
-            "Set should contain option1"
-        )
-        XCTAssertTrue(
-            optionSet.contains(
-                option2
-            ),
-            "Set should contain option2 (which is equal to option1)"
-        )
-    }
-    
-    func testHashable_DifferentTypeHashesToDifferentValue() {
-        // Given
-        let mockConfig = PaymentSheet.ExternalPaymentMethodConfiguration(
-            externalPaymentMethods: [
-                "external_paypal",
-                "external_klarna"
-            ],
-            externalPaymentMethodConfirmHandler: {
-                _,
-                _,
-                completion in completion(
-                    .completed
-                )
-            }
-        )
-        
-        let mockExternalPaymentMethod1 = ExternalPaymentMethod(
-            type: "external_paypal",
-            label: "PayPal",
-            lightImageUrl: mockLightImageURL,
-            darkImageUrl: mockDarkImageURL
-        )
-        
-        let mockExternalPaymentMethod2 = ExternalPaymentMethod(
-            type: "external_klarna",
-            label: "Klarna",
-            lightImageUrl: mockLightImageURL,
-            darkImageUrl: mockDarkImageURL
-        )
-        
-        // When
-        let option1 = ExternalPaymentOption.from(
-            mockExternalPaymentMethod1,
-            configuration: mockConfig
-        )!
-        let option2 = ExternalPaymentOption.from(
-            mockExternalPaymentMethod2,
-            configuration: mockConfig
-        )!
-        
-        // Then
-        XCTAssertNotEqual(
-            option1.hashValue,
-            option2.hashValue,
-            "Options with different types should hash to different values"
-        )
-        
-        // Test in a Set
-        let optionSet = Set(
-            [
-                option1,
-                option2
-            ]
-        )
-        XCTAssertEqual(
-            optionSet.count,
-            2,
-            "Set should contain two items because options have different hashes"
-        )
-        XCTAssertTrue(
-            optionSet.contains(
-                option1
-            ),
-            "Set should contain option1"
-        )
-        XCTAssertTrue(
-            optionSet.contains(
-                option2
-            ),
-            "Set should contain option2"
-        )
-    }
-    
+
     func testHashable_UsageInDictionary() {
-        // Given
         let mockConfig = PaymentSheet.ExternalPaymentMethodConfiguration(
             externalPaymentMethods: [
                 "external_paypal",
-                "external_klarna"
+                "external_klarna",
             ],
             externalPaymentMethodConfirmHandler: {
                 _,
@@ -454,21 +259,21 @@ class ExternalPaymentOptionTests: XCTestCase {
                 )
             }
         )
-        
+
         let paypalMethod = ExternalPaymentMethod(
             type: "external_paypal",
             label: "PayPal",
             lightImageUrl: mockLightImageURL,
             darkImageUrl: mockDarkImageURL
         )
-        
+
         let klarnaMethod = ExternalPaymentMethod(
             type: "external_klarna",
             label: "Klarna",
             lightImageUrl: mockLightImageURL,
             darkImageUrl: mockDarkImageURL
         )
-        
+
         let paypalOption = ExternalPaymentOption.from(
             paypalMethod,
             configuration: mockConfig
@@ -477,7 +282,7 @@ class ExternalPaymentOptionTests: XCTestCase {
             klarnaMethod,
             configuration: mockConfig
         )!
-        
+
         // Different object but same type as paypalOption
         let paypalOption2 = ExternalPaymentOption.from(
             ExternalPaymentMethod(
@@ -490,13 +295,11 @@ class ExternalPaymentOptionTests: XCTestCase {
             ),
             configuration: mockConfig
         )!
-        
-        // When
+
         var paymentOptions: [ExternalPaymentOption: String] = [:]
         paymentOptions[paypalOption] = "Value for PayPal"
         paymentOptions[klarnaOption] = "Value for Klarna"
-        
-        // Then
+
         XCTAssertEqual(
             paymentOptions.count,
             2,
@@ -510,14 +313,14 @@ class ExternalPaymentOptionTests: XCTestCase {
             paymentOptions[klarnaOption],
             "Value for Klarna"
         )
-        
+
         // When using an equivalent object with same type
         XCTAssertEqual(
             paymentOptions[paypalOption2],
             "Value for PayPal",
             "Should retrieve the same value using an equivalent object"
         )
-        
+
         // When updating with equivalent object
         paymentOptions[paypalOption2] = "Updated PayPal Value"
         XCTAssertEqual(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetExternalPaymentMethodTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetExternalPaymentMethodTests.swift
@@ -173,13 +173,17 @@ extension PaymentSheetExternalPaymentMethodTests: STPAuthenticationContext {
     }
 }
 
-extension ExternalPaymentMethod {
-    static func _testPayPalValue() -> ExternalPaymentMethod {
-        return .init(
+extension ExternalPaymentOption {
+    static func _testPayPalValue() -> ExternalPaymentOption {
+        let epm: ExternalPaymentMethod = .init(
             type: "external_paypal",
             label: "PayPal",
             lightImageUrl: URL(string: "https://todo.com")!,
             darkImageUrl: URL(string: "https://todo.com")!
         )
+        let config = PaymentSheet.ExternalPaymentMethodConfiguration(externalPaymentMethods: ["external_paypal"]) { _, _, _ in
+            // no-op
+        }
+        return .from(epm, configuration: config)!
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetExternalPaymentMethodTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetExternalPaymentMethodTests.swift
@@ -44,7 +44,7 @@ final class PaymentSheetExternalPaymentMethodTests: XCTestCase {
             authenticationContext: self,
             intent: intent,
             elementsSession: ._testCardValue(),
-            paymentOption: .external(paymentMethod: ._testPayPalValue(), billingDetails: .init()),
+            paymentOption: .external(paymentMethod: ._testPayPalValue(configuration.externalPaymentMethodConfiguration!), billingDetails: .init()),
             paymentHandler: .shared(),
             analyticsHelper: ._testValue()
         ) { result, analyticsConfirmType in
@@ -97,7 +97,7 @@ final class PaymentSheetExternalPaymentMethodTests: XCTestCase {
         paymentMethodForm.getTextFieldElement("ZIP")?.setText("12345") ?? XCTFail()
 
         // Simulate customer tapping "Buy" - generate params from the form and confirm payment
-        guard let intentConfirmParams = paymentMethodForm.updateParams(params: IntentConfirmParams(type: .external(._testPayPalValue()))) else {
+        guard let intentConfirmParams = paymentMethodForm.updateParams(params: IntentConfirmParams(type: .external(._testPayPalValue(configuration.externalPaymentMethodConfiguration!)))) else {
             XCTFail("Form failed to create params. Validation state: \(paymentMethodForm.validationState)")
             return
         }
@@ -106,7 +106,7 @@ final class PaymentSheetExternalPaymentMethodTests: XCTestCase {
             authenticationContext: self,
             intent: intent,
             elementsSession: ._testCardValue(),
-            paymentOption: .external(paymentMethod: ._testPayPalValue(), billingDetails: intentConfirmParams.paymentMethodParams.nonnil_billingDetails),
+            paymentOption: .external(paymentMethod: ._testPayPalValue(configuration.externalPaymentMethodConfiguration!), billingDetails: intentConfirmParams.paymentMethodParams.nonnil_billingDetails),
             paymentHandler: .shared(),
             analyticsHelper: ._testValue()
         ) { _, _ in }
@@ -130,7 +130,7 @@ final class PaymentSheetExternalPaymentMethodTests: XCTestCase {
                 authenticationContext: self,
                 intent: intent,
                 elementsSession: ._testCardValue(),
-                paymentOption: .external(paymentMethod: ._testPayPalValue(), billingDetails: .init()),
+                paymentOption: .external(paymentMethod: ._testPayPalValue(configuration.externalPaymentMethodConfiguration!), billingDetails: .init()),
                 paymentHandler: .shared(),
                 analyticsHelper: ._testValue()
             ) { result, analyticsConfirmType in
@@ -158,7 +158,7 @@ final class PaymentSheetExternalPaymentMethodTests: XCTestCase {
     }
 
     func makeForm(intent: Intent, configuration: PaymentSheet.Configuration) -> PaymentMethodElement {
-        let formFactory = PaymentSheetFormFactory(intent: intent, elementsSession: ._testCardValue(), configuration: .paymentSheet(configuration), paymentMethod: .external(._testPayPalValue()))
+        let formFactory = PaymentSheetFormFactory(intent: intent, elementsSession: ._testCardValue(), configuration: .paymentSheet(configuration), paymentMethod: .external(._testPayPalValue(configuration.externalPaymentMethodConfiguration!)))
         let paymentMethodForm = formFactory.make()
         let view = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 1000))
         view.addAndPinSubview(paymentMethodForm.view) // This gets rid of distracting autolayout warnings in the logs
@@ -174,16 +174,13 @@ extension PaymentSheetExternalPaymentMethodTests: STPAuthenticationContext {
 }
 
 extension ExternalPaymentOption {
-    static func _testPayPalValue() -> ExternalPaymentOption {
+    static func _testPayPalValue(_ config: PaymentSheet.ExternalPaymentMethodConfiguration) -> ExternalPaymentOption {
         let epm: ExternalPaymentMethod = .init(
             type: "external_paypal",
             label: "PayPal",
             lightImageUrl: URL(string: "https://todo.com")!,
             darkImageUrl: URL(string: "https://todo.com")!
         )
-        let config = PaymentSheet.ExternalPaymentMethodConfiguration(externalPaymentMethods: ["external_paypal"]) { _, _, _ in
-            // no-op
-        }
         return .from(epm, configuration: config)!
     }
 }


### PR DESCRIPTION
## Summary
- Creates ExternalPaymentOption, this is a new class that can handle confirming EPMs and CPMs, so that EPMs/CPMs can share the same code throughout PaymentSheet when it comes to rendering and confirming.
- This is pre-work to make supporting CPMs easier.

## Motivation
- Code reuse for CPMs

## Testing
- Existing tests
- New unit tests

## Changelog
- NA