### PR TITLE
Added timeout to failing test

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -471,6 +471,7 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
                 ) { result, _ in
                     switch result {
                     case .completed:
+                        self.waitForDefaultPaymentMethodToBePersisted()
                         // 3. Fetch the SI
                         self.apiClient.retrieveSetupIntent(withClientSecret: clientSecret)
                         { setupIntent, _ in


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Added a timeout after confirming and before retrieving a SetupIntent to check default payment method
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
testPaymentSheetLoadAndConfirmWithSetupIntentSetAsDefault failed on CI
## Testing
<!-- How was the code tested? Be as specific as possible. -->
Ran the test 100 times without failure
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A