### PR TITLE
Fix edit button behavior

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -118,11 +118,11 @@ class SavedPaymentOptionsViewController: UIViewController {
             return false
         case 1:
             // If there's exactly one PM, customer can only edit if configuration allows removal or if that single PM allows for the card brand choice to be updated.
-            return (configuration.allowsRemovalOfPaymentMethods && configuration.allowsRemovalOfLastSavedPaymentMethod) || viewModels.contains(where: {
+            return (configuration.allowsRemovalOfPaymentMethods && configuration.allowsRemovalOfLastSavedPaymentMethod) || configuration.allowsSetAsDefaultPM || viewModels.contains(where: {
                 $0.isCoBrandedCard && cbcEligible
             })
         default:
-            return configuration.allowsRemovalOfPaymentMethods || viewModels.contains(where: {
+            return configuration.allowsRemovalOfPaymentMethods || configuration.allowsSetAsDefaultPM || viewModels.contains(where: {
                 $0.isCoBrandedCard && cbcEligible
             })
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -117,7 +117,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         case 0:
             return false
         case 1:
-            // If there's exactly one PM, customer can only edit if configuration allows removal or if that single PM allows for the card brand choice to be updated.
+            // If there's exactly one PM, customer can only edit if configuration allows removal or allows setting as default or if that single PM allows for the card brand choice or other card details to be updated.
             return (configuration.allowsRemovalOfPaymentMethods && configuration.allowsRemovalOfLastSavedPaymentMethod) || configuration.allowsSetAsDefaultPM || viewModels.contains(where: {
                 $0.isCoBrandedCard && cbcEligible
             })

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
@@ -293,8 +293,18 @@ class SavedPaymentOptionsViewControllerTests: XCTestCase {
         XCTAssertTrue(controller.canEditPaymentMethods)
     }
 
+    func testCanEditPaymentMethods_OnePM_remove0_default1_notCBCEligible() {
+        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
+                                                      allowsRemovalOfPaymentMethods: false,
+                                                      allowsSetAsDefaultPaymentMethod: true)
+        let controller = savedPaymentOptionsController(configuration,
+                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
+                                                       cbcEligible: false)
+        XCTAssertTrue(controller.canEditPaymentMethods)
+    }
+
     // MARK: Helpers
-    func savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: Bool, allowsRemovalOfPaymentMethods: Bool) -> SavedPaymentOptionsViewController.Configuration {
+    func savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: Bool, allowsRemovalOfPaymentMethods: Bool, allowsSetAsDefaultPaymentMethod: Bool = false) -> SavedPaymentOptionsViewController.Configuration {
         return SavedPaymentOptionsViewController.Configuration(customerID: "cus_123",
                                                                showApplePay: true,
                                                                showLink: true,
@@ -304,7 +314,7 @@ class SavedPaymentOptionsViewControllerTests: XCTestCase {
                                                                isTestMode: true,
                                                                allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
                                                                allowsRemovalOfPaymentMethods: allowsRemovalOfPaymentMethods,
-                                                               allowsSetAsDefaultPM: false)
+                                                               allowsSetAsDefaultPM: allowsSetAsDefaultPaymentMethod)
     }
 
     func savedPaymentOptionsController(_ configuration: SavedPaymentOptionsViewController.Configuration,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
@@ -330,13 +330,13 @@ class SavedPaymentOptionsViewControllerTests: XCTestCase {
                                                  analyticsHelper: ._testValue(),
                                                  delegate: nil)
     }
-    
+
     // Test case for when the preferred brand of a card is nil that we look at the display brand
     func testRemovalMessagePreferredBrand_nilPreferredBrand() {
         let coBrandedCard = STPPaymentMethod._testCardCoBranded(displayBrand: "cartes_bancaires")
         XCTAssertNil(coBrandedCard.card?.networks?.preferred)
         let removalMessage = coBrandedCard.removalMessage
-        
+
         XCTAssertEqual(removalMessage.message, "Cartes Bancaires •••• 4242")
     }
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Updated the check for whether or not the edit button should be shown to include the default feature check. This oversight was in horizontal mode only
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Bug: disable removing payment methods, enable default
Expected behavior: you can manage the payment methods by setting default
Actual behavior: you cannot edit payment methods
## Testing
<!-- How was the code tested? Be as specific as possible. -->

- Manually
- Test for SavedPaymentOptionsViewController.canEditPaymentMethods value

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A