### PR TITLE
Fix logic for when editing is available for update

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -95,11 +95,11 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
             return false
         case 1:
             // If there's exactly one PM, customer can only edit if configuration allows removal or if that single PM is editable
-            return (configuration.paymentMethodRemove && configuration.allowsRemovalOfLastSavedPaymentMethod) || viewModels.contains(where: {
+            return (configuration.paymentMethodRemove && configuration.allowsRemovalOfLastSavedPaymentMethod) || configuration.paymentMethodUpdate || configuration.paymentMethodSyncDefault || viewModels.contains(where: {
                 $0.isCoBrandedCard && cbcEligible
             })
         default:
-            return configuration.paymentMethodRemove || viewModels.contains(where: {
+            return configuration.paymentMethodRemove || configuration.paymentMethodUpdate || configuration.paymentMethodSyncDefault || viewModels.contains(where: {
                 $0.isCoBrandedCard && cbcEligible
             })
         }
@@ -396,7 +396,8 @@ extension CustomerSavedPaymentMethodsCollectionViewController: UICollectionViewD
 
         cell.setViewModel(viewModel.toSavedPaymentOptionsViewControllerSelection(),
                           cbcEligible: cbcEligible,
-                          allowsPaymentMethodRemoval: configuration.paymentMethodRemove)
+                          allowsPaymentMethodRemoval: configuration.paymentMethodRemove,
+                          allowsPaymentMethodUpdate: configuration.paymentMethodUpdate)
         cell.delegate = self
         cell.isRemovingPaymentMethods = self.collectionView.isRemovingPaymentMethods
         cell.appearance = appearance

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -95,11 +95,11 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
             return false
         case 1:
             // If there's exactly one PM, customer can only edit if configuration allows removal or if that single PM is editable
-            return (configuration.paymentMethodRemove && configuration.allowsRemovalOfLastSavedPaymentMethod) || configuration.paymentMethodUpdate || configuration.paymentMethodSyncDefault || viewModels.contains(where: {
+            return (configuration.paymentMethodRemove && configuration.allowsRemovalOfLastSavedPaymentMethod) || configuration.paymentMethodUpdate || viewModels.contains(where: {
                 $0.isCoBrandedCard && cbcEligible
             })
         default:
-            return configuration.paymentMethodRemove || configuration.paymentMethodUpdate || configuration.paymentMethodSyncDefault || viewModels.contains(where: {
+            return configuration.paymentMethodRemove || configuration.paymentMethodUpdate || viewModels.contains(where: {
                 $0.isCoBrandedCard && cbcEligible
             })
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -33,6 +33,7 @@ extension EmbeddedPaymentElement {
             isCBCEligible: loadResult.elementsSession.isCardBrandChoiceEligible,
             allowsRemovalOfLastSavedPaymentMethod: loadResult.elementsSession.paymentMethodRemoveLast(configuration: configuration),
             allowsPaymentMethodRemoval: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
+            allowsPaymentMethodUpdate: loadResult.elementsSession.paymentMethodUpdateForPaymentSheet(configuration),
             isFlatCheckmarkStyle: configuration.appearance.embeddedPaymentElement.row.style == .flatWithCheckmark
         )
         let initialSelection: RowButtonType? = {
@@ -310,6 +311,7 @@ extension EmbeddedPaymentElement: UpdatePaymentMethodViewControllerDelegate {
             isCBCEligible: elementsSession.isCardBrandChoiceEligible,
             allowsRemovalOfLastSavedPaymentMethod: elementsSession.paymentMethodRemoveLast(configuration: configuration),
             allowsPaymentMethodRemoval: elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
+            allowsPaymentMethodUpdate: elementsSession.paymentMethodUpdateForPaymentSheet(configuration),
             isFlatCheckmarkStyle: configuration.appearance.embeddedPaymentElement.row.style == .flatWithCheckmark
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -142,6 +142,7 @@ extension SavedPaymentMethodCollectionView {
 
         var cbcEligible: Bool = false
         var allowsPaymentMethodRemoval: Bool = true
+        var allowsPaymentMethodUpdate: Bool = false
         var allowsSetAsDefaultPM: Bool = false
         var needsVerticalPaddingForBadge: Bool = false
         var showDefaultPMBadge: Bool = false
@@ -152,7 +153,7 @@ extension SavedPaymentMethodCollectionView {
             guard PaymentSheet.supportedSavedPaymentMethods.contains(where: { viewModel?.savedPaymentMethod?.type == $0 }) else {
                 fatalError("Payment method does not match supported saved payment methods.")
             }
-            return allowsSetAsDefaultPM || allowsPaymentMethodRemoval || (viewModel?.savedPaymentMethod?.isCoBrandedCard ?? false && cbcEligible)
+            return allowsSetAsDefaultPM || allowsPaymentMethodRemoval || allowsPaymentMethodUpdate || (viewModel?.savedPaymentMethod?.isCoBrandedCard ?? false && cbcEligible)
         }
 
         // MARK: - UICollectionViewCell
@@ -261,13 +262,14 @@ extension SavedPaymentMethodCollectionView {
         }()
 
         // MARK: - Internal Methods
-        func setViewModel(_ viewModel: SavedPaymentOptionsViewController.Selection, cbcEligible: Bool, allowsPaymentMethodRemoval: Bool, allowsSetAsDefaultPM: Bool = false, needsVerticalPaddingForBadge: Bool = false, showDefaultPMBadge: Bool = false) {
+        func setViewModel(_ viewModel: SavedPaymentOptionsViewController.Selection, cbcEligible: Bool, allowsPaymentMethodRemoval: Bool, allowsPaymentMethodUpdate: Bool, allowsSetAsDefaultPM: Bool = false, needsVerticalPaddingForBadge: Bool = false, showDefaultPMBadge: Bool = false) {
             paymentMethodLogo.isHidden = false
             plus.isHidden = true
             shadowRoundedRectangle.isHidden = false
             self.viewModel = viewModel
             self.cbcEligible = cbcEligible
             self.allowsPaymentMethodRemoval = allowsPaymentMethodRemoval
+            self.allowsPaymentMethodUpdate = allowsPaymentMethodUpdate
             self.allowsSetAsDefaultPM = allowsSetAsDefaultPM
             self.needsVerticalPaddingForBadge = needsVerticalPaddingForBadge
             self.showDefaultPMBadge = showDefaultPMBadge

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -107,6 +107,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         let allowsRemovalOfLastSavedPaymentMethod: Bool
         let allowsRemovalOfPaymentMethods: Bool
         let allowsSetAsDefaultPM: Bool
+        let allowsUpdatePaymentMethod: Bool
     }
 
     // MARK: - Internal Properties
@@ -118,11 +119,11 @@ class SavedPaymentOptionsViewController: UIViewController {
             return false
         case 1:
             // If there's exactly one PM, customer can only edit if configuration allows removal or allows setting as default or if that single PM allows for the card brand choice or other card details to be updated.
-            return (configuration.allowsRemovalOfPaymentMethods && configuration.allowsRemovalOfLastSavedPaymentMethod) || configuration.allowsSetAsDefaultPM || viewModels.contains(where: {
+            return (configuration.allowsRemovalOfPaymentMethods && configuration.allowsRemovalOfLastSavedPaymentMethod) || configuration.allowsSetAsDefaultPM || configuration.allowsUpdatePaymentMethod || viewModels.contains(where: {
                 $0.isCoBrandedCard && cbcEligible
             })
         default:
-            return configuration.allowsRemovalOfPaymentMethods || configuration.allowsSetAsDefaultPM || viewModels.contains(where: {
+            return configuration.allowsRemovalOfPaymentMethods || configuration.allowsUpdatePaymentMethod || configuration.allowsSetAsDefaultPM || viewModels.contains(where: {
                 $0.isCoBrandedCard && cbcEligible
             })
         }
@@ -527,7 +528,7 @@ extension SavedPaymentOptionsViewController: UICollectionViewDataSource, UIColle
             stpAssertionFailure()
             return UICollectionViewCell()
         }
-        cell.setViewModel(viewModel, cbcEligible: cbcEligible, allowsPaymentMethodRemoval: self.configuration.allowsRemovalOfPaymentMethods, allowsSetAsDefaultPM: configuration.allowsSetAsDefaultPM, needsVerticalPaddingForBadge: hasDefault, showDefaultPMBadge: isDefaultPaymentMethod(savedPaymentMethodId: viewModel.savedPaymentMethod?.stripeId))
+        cell.setViewModel(viewModel, cbcEligible: cbcEligible, allowsPaymentMethodRemoval: self.configuration.allowsRemovalOfPaymentMethods, allowsPaymentMethodUpdate: self.configuration.allowsUpdatePaymentMethod, allowsSetAsDefaultPM: configuration.allowsSetAsDefaultPM, needsVerticalPaddingForBadge: hasDefault, showDefaultPMBadge: isDefaultPaymentMethod(savedPaymentMethodId: viewModel.savedPaymentMethod?.stripeId))
         cell.delegate = self
         cell.isRemovingPaymentMethods = self.collectionView.isRemovingPaymentMethods
         cell.appearance = appearance

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -39,6 +39,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
     private let paymentMethodRemove: Bool
     private let paymentMethodRemoveLast: Bool
     private let paymentMethodSetAsDefault: Bool
+    private let paymentMethodUpdate: Bool
     private let isCBCEligible: Bool
     private let analyticsHelper: PaymentSheetAnalyticsHelper
 
@@ -92,7 +93,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
     }
 
     var canEditPaymentMethods: Bool {
-        return hasCoBrandedCards && isCBCEligible
+        return (hasCoBrandedCards && isCBCEligible) || paymentMethodUpdate
     }
 
     /// Indicates whether the chevron should be shown
@@ -182,6 +183,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         self.defaultPaymentMethod = defaultPaymentMethod
         self.paymentMethodRemove = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
         self.paymentMethodRemoveLast = elementsSession.paymentMethodRemoveLast(configuration: configuration)
+        self.paymentMethodUpdate = elementsSession.paymentMethodUpdateForPaymentSheet(configuration)
         self.paymentMethodSetAsDefault = elementsSession.paymentMethodSetAsDefaultForPaymentSheet
         self.isCBCEligible = elementsSession.isCardBrandChoiceEligible
         self.analyticsHelper = analyticsHelper
@@ -350,7 +352,7 @@ extension VerticalSavedPaymentMethodsViewController: SavedPaymentMethodRowButton
                                                                            hostedSurface: .paymentSheet,
                                                                            cardBrandFilter: configuration.cardBrandFilter,
                                                                            canRemove: canRemovePaymentMethods,
-                                                                           canUpdate: elementsSession.paymentMethodUpdateForPaymentSheet(configuration),
+                                                                           canUpdate: paymentMethodUpdate,
                                                                            isCBCEligible: paymentMethod.isCoBrandedCard && isCBCEligible,
                                                                            allowsSetAsDefaultPM: paymentMethodSetAsDefault,
                                                                            isDefault: isDefaultPaymentMethod(paymentMethodId: paymentMethod.stripeId))

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RightAccessoryButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RightAccessoryButton.swift
@@ -173,6 +173,7 @@ extension RowButton.RightAccessoryButton {
                                        isCBCEligible: Bool,
                                        allowsRemovalOfLastSavedPaymentMethod: Bool,
                                        allowsPaymentMethodRemoval: Bool,
+                                       allowsPaymentMethodUpdate: Bool,
                                        isFlatCheckmarkStyle: Bool = false) -> AccessoryType? {
         guard savedPaymentMethodsCount > 0 else { return nil }
 
@@ -182,6 +183,6 @@ extension RowButton.RightAccessoryButton {
         }
 
         // We only have 1 payment method... show the edit icon if the card brand can be updated or if it can be removed
-        return (isFirstCardCoBranded && isCBCEligible) || (allowsRemovalOfLastSavedPaymentMethod && allowsPaymentMethodRemoval) ? .edit : nil
+        return (isFirstCardCoBranded && isCBCEligible) || (allowsRemovalOfLastSavedPaymentMethod && allowsPaymentMethodRemoval) || allowsPaymentMethodUpdate ? .edit : nil
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -208,7 +208,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
                 allowsRemovalOfLastSavedPaymentMethod: elementsSession.paymentMethodRemoveLast(configuration: configuration),
                 allowsRemovalOfPaymentMethods: elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                 allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
-                allowsUpdatePaymentMethod: configuration.updatePaymentMethodEnabled
+                allowsUpdatePaymentMethod: elementsSession.paymentMethodUpdateForPaymentSheet(configuration)
             ),
             paymentSheetConfiguration: configuration,
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -207,7 +207,8 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
                 isTestMode: configuration.apiClient.isTestmode,
                 allowsRemovalOfLastSavedPaymentMethod: elementsSession.paymentMethodRemoveLast(configuration: configuration),
                 allowsRemovalOfPaymentMethods: elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
-                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet
+                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
+                allowsUpdatePaymentMethod: configuration.updatePaymentMethodEnabled
             ),
             paymentSheetConfiguration: configuration,
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -381,7 +381,8 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
             isFirstCardCoBranded: savedPaymentMethods.first?.isCoBrandedCard ?? false,
             isCBCEligible: loadResult.elementsSession.isCardBrandChoiceEligible,
             allowsRemovalOfLastSavedPaymentMethod: loadResult.elementsSession.paymentMethodRemoveLast(configuration: configuration),
-            allowsPaymentMethodRemoval: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
+            allowsPaymentMethodRemoval: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
+            allowsPaymentMethodUpdate: loadResult.elementsSession.paymentMethodUpdateForPaymentSheet(configuration)
         )
         return VerticalPaymentMethodListViewController(
             initialSelection: initialSelection,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -176,7 +176,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                 allowsRemovalOfLastSavedPaymentMethod: elementsSession.paymentMethodRemoveLast(configuration: configuration),
                 allowsRemovalOfPaymentMethods: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                 allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
-                allowsUpdatePaymentMethod: configuration.updatePaymentMethodEnabled
+                allowsUpdatePaymentMethod: elementsSession.paymentMethodUpdateForPaymentSheet(configuration)
             ),
             paymentSheetConfiguration: configuration,
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -175,7 +175,8 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                 isTestMode: configuration.apiClient.isTestmode,
                 allowsRemovalOfLastSavedPaymentMethod: elementsSession.paymentMethodRemoveLast(configuration: configuration),
                 allowsRemovalOfPaymentMethods: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
-                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet
+                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
+                allowsUpdatePaymentMethod: configuration.updatePaymentMethodEnabled
             ),
             paymentSheetConfiguration: configuration,
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewControllerTests.swift
@@ -10,290 +10,169 @@ class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
     var customerSheetConfiguration: CustomerSheet.Configuration = {
         return CustomerSheet.Configuration()
     }()
+    func testNoPM() {
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
 
-    func testCanEditPaymentMethods_noPMs() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [],
-                                                     cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
 
-    // MARK: - Single Card, cbcEligible
-    func testCanEditPaymentMethods_singlePM_removeLast0_remove0() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                     cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singlePM_removeLast0_remove1() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                     cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singlePM_removeLast1_remove0() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                     cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singlePM_removeLast1_remove1() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                     cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
+        // Skip where removePM == false && removeLastPM == true
 
-    // MARK: - Single Card, !cbcEligible
-    func testCanEditPaymentMethods_singlePM_removeLast0_remove0_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                     cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
+
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
     }
-    func testCanEditPaymentMethods_singlePM_removeLast0_remove1_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                     cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singlePM_removeLast1_remove0_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                     cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singlePM_removeLast1_remove1_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                     cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
+    func testSinglePM_nonCoBranded() {
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+
+        // Skip where removePM = false && removeLastPM = true
+
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
     }
 
-    // MARK: - Single Card, w/ Co-branded, cbcEligible
-    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove0() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove1() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove0() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove1() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    // MARK: - Single Card, w/ Co-branded, !cbcEligible
-    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove0_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove1_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove0_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove1_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
+    func testSinglePM_coBranded() {
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+
+        // Skip where removePM = false && removeLastPM = true
+
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
     }
 
-    // MARK: - Two Cards, cbcEligible
-    func testCanEditPaymentMethods_TwoPM_removeLast0_remove0() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                     cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast0_remove1() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                     cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast1_remove0() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                     cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast1_remove1() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                     cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
+    func testTwoPMs_nonCoBranded() {
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+
+        // Skip where removePM = false && removeLastPM = true
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
     }
 
-    // MARK: - Two Cards, cbcEligible, !cbcEligible
-    func testCanEditPaymentMethods_TwoPM_removeLast0_remove0_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                     cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast0_remove1_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                     cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast1_remove0_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                     cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast1_remove1_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                     cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
+    func testTwoPMs_coBranded() {
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
 
-    // MARK: - Two Cards, w/ Co-branded, cbcEligible
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove0() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove1() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove0() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove1() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
 
-    // MARK: - Two Cards, w/ Co-branded, !cbcEligible
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove0_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove1_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: false,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove0_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: false)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove1_notCBCEligible() {
-        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
-                                          paymentMethodRemove: true)
-        let controller = customerSavedPaymentMethods(configuration,
-                                                     savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                     cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
+        // Skip where removePM = false && removeLastPM = true
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
     }
 
     func testHideNonCardUSBank_SetAsDefault() {
         let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: true,
                                           paymentMethodRemove: true,
+                                          paymentMethodUpdate: false,
                                           paymentMethodSyncDefault: true)
         let controller = customerSavedPaymentMethods(configuration,
                                                      savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testUSBankAccount(), STPPaymentMethod._testSEPA()],
@@ -301,11 +180,24 @@ class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
         XCTAssertFalse(controller.savedPaymentMethods.contains(where: { $0.type == .SEPADebit }))
     }
 
+    func _testCanEditPaymentMethods(removePM: Bool,
+                                    removeLastPM: Bool,
+                                    defaultPM: Bool,
+                                    updatePM: Bool,
+                                    cbcEligible: Bool,
+                                    savedPaymentMethods: [STPPaymentMethod]) -> Bool {
+        let configuration = configuration(allowsRemovalOfLastSavedPaymentMethod: removeLastPM,
+                                          paymentMethodRemove: removePM,
+                                          paymentMethodUpdate: updatePM,
+                                          paymentMethodSyncDefault: defaultPM)
+        let controller = customerSavedPaymentMethods(configuration, savedPaymentMethods: savedPaymentMethods, cbcEligible: cbcEligible)
+        return controller.canEditPaymentMethods
+    }
+
     func configuration(allowsRemovalOfLastSavedPaymentMethod: Bool,
                        paymentMethodRemove: Bool,
-                       paymentMethodUpdate: Bool = false,
-                       paymentMethodSyncDefault: Bool = false,
-                       showApplePay: Bool = false
+                       paymentMethodUpdate: Bool,
+                       paymentMethodSyncDefault: Bool
     ) -> CustomerSavedPaymentMethodsCollectionViewController.Configuration {
 
         let billingDetailsCollectionConfiguration = PaymentSheet.BillingDetailsCollectionConfiguration(name: .never,
@@ -313,7 +205,7 @@ class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
                                                                                                        email: .never,
                                                                                                        address: .never)
         return CustomerSavedPaymentMethodsCollectionViewController.Configuration(billingDetailsCollectionConfiguration: billingDetailsCollectionConfiguration,
-                                                                                 showApplePay: showApplePay,
+                                                                                 showApplePay: false,
                                                                                  allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
                                                                                  paymentMethodRemove: paymentMethodRemove,
                                                                                  paymentMethodUpdate: paymentMethodUpdate,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewControllerTests.swift
@@ -47,8 +47,8 @@ class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
 
-        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
-        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
 
@@ -58,8 +58,8 @@ class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
         XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
-        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
-        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
 
@@ -79,7 +79,7 @@ class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
 
-        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
@@ -90,7 +90,7 @@ class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
-        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
@@ -111,8 +111,8 @@ class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
 
-        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
-        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
 
@@ -143,7 +143,7 @@ class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
 
-        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
         XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/RightAccessoryButtonTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/RightAccessoryButtonTest.swift
@@ -21,12 +21,15 @@ final class RightAccessoryButtonTest: XCTestCase {
             for isCBCEligible in booleans {
                 for allowsRemovalOfLastSavedPaymentMethod in booleans {
                     for allowsPaymentMethodRemoval in booleans {
-                        let result = RowButton.RightAccessoryButton.getAccessoryButtonType(savedPaymentMethodsCount: 0,
-                                                                                           isFirstCardCoBranded: isFirstCardCoBranded,
-                                                                                           isCBCEligible: isCBCEligible,
-                                                                                           allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
-                                                                                           allowsPaymentMethodRemoval: allowsPaymentMethodRemoval)
-                        XCTAssertNil(result)
+                        for allowsPaymentMethodUpdate in booleans {
+                            let result = RowButton.RightAccessoryButton.getAccessoryButtonType(savedPaymentMethodsCount: 0,
+                                                                                               isFirstCardCoBranded: isFirstCardCoBranded,
+                                                                                               isCBCEligible: isCBCEligible,
+                                                                                               allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
+                                                                                               allowsPaymentMethodRemoval: allowsPaymentMethodRemoval,
+                                                                                               allowsPaymentMethodUpdate: allowsPaymentMethodUpdate)
+                            XCTAssertNil(result)
+                        }
                     }
                 }
             }
@@ -42,16 +45,20 @@ final class RightAccessoryButtonTest: XCTestCase {
             for isCBCEligible in booleans {
                 for allowsRemovalOfLastSavedPaymentMethod in booleans {
                     for allowsPaymentMethodRemoval in booleans {
+                        for allowsPaymentMethodUpdate in booleans {
 
-                        // We should only show the edit button if it is update-able or removable
-                        let canEdit = (isFirstCardCoBranded && isCBCEligible) || (allowsRemovalOfLastSavedPaymentMethod && allowsPaymentMethodRemoval)
-                        let expected: RowButton.RightAccessoryButton.AccessoryType? = canEdit ? .edit : nil
-                        let result = RowButton.RightAccessoryButton.getAccessoryButtonType(savedPaymentMethodsCount: 1,
-                                                                                           isFirstCardCoBranded: isFirstCardCoBranded,
-                                                                                           isCBCEligible: isCBCEligible,
-                                                                                           allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
-                                                                                           allowsPaymentMethodRemoval: allowsPaymentMethodRemoval)
-                        XCTAssertEqual(result, expected)
+                            // We should only show the edit button if it is update-able or removable
+                            let canEdit = (isFirstCardCoBranded && isCBCEligible) || (allowsRemovalOfLastSavedPaymentMethod && allowsPaymentMethodRemoval) || allowsPaymentMethodUpdate
+                            let expected: RowButton.RightAccessoryButton.AccessoryType? = canEdit ? .edit : nil
+                            let result = RowButton.RightAccessoryButton.getAccessoryButtonType(savedPaymentMethodsCount: 1,
+                                                                                               isFirstCardCoBranded: isFirstCardCoBranded,
+                                                                                               isCBCEligible: isCBCEligible,
+                                                                                               allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
+                                                                                               allowsPaymentMethodRemoval: allowsPaymentMethodRemoval,
+                                                                                               allowsPaymentMethodUpdate: allowsPaymentMethodUpdate)
+
+                            XCTAssertEqual(result, expected)
+                        }
                     }
                 }
             }
@@ -69,24 +76,28 @@ final class RightAccessoryButtonTest: XCTestCase {
             for isCBCEligible in booleans {
                 for allowsRemovalOfLastSavedPaymentMethod in booleans {
                     for allowsPaymentMethodRemoval in booleans {
-                        let result = RowButton.RightAccessoryButton.getAccessoryButtonType(savedPaymentMethodsCount: 2,
-                                                                                           isFirstCardCoBranded: isFirstCardCoBranded,
-                                                                                           isCBCEligible: isCBCEligible,
-                                                                                           allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
-                                                                                           allowsPaymentMethodRemoval: allowsPaymentMethodRemoval)
-                        XCTAssertEqual(result, .viewMoreChevron)
+                        for allowsPaymentMethodUpdate in booleans {
+                            let result = RowButton.RightAccessoryButton.getAccessoryButtonType(savedPaymentMethodsCount: 2,
+                                                                                               isFirstCardCoBranded: isFirstCardCoBranded,
+                                                                                               isCBCEligible: isCBCEligible,
+                                                                                               allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
+                                                                                               allowsPaymentMethodRemoval: allowsPaymentMethodRemoval,
+                                                                                               allowsPaymentMethodUpdate: allowsPaymentMethodUpdate)
+                            XCTAssertEqual(result, .viewMoreChevron)
+                        }
                     }
                 }
             }
         }
     }
-    
+
     func testViewMore_Returned_When_SavedPaymentsGreaterThanOne_FlatCheckmarkStyle() {
         let result = RowButton.RightAccessoryButton.getAccessoryButtonType(savedPaymentMethodsCount: 2,
                                                                            isFirstCardCoBranded: true,
                                                                            isCBCEligible: true,
                                                                            allowsRemovalOfLastSavedPaymentMethod: true,
                                                                            allowsPaymentMethodRemoval: true,
+                                                                           allowsPaymentMethodUpdate: true,
                                                                            isFlatCheckmarkStyle: true)
         XCTAssertEqual(result, .viewMore)
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerSnapshotTests.swift
@@ -36,7 +36,7 @@ final class SavedPaymentOptionsViewControllerSnapshotTests: STPSnapshotTestCase 
             STPPaymentMethod._testUSBankAccount(),
             STPPaymentMethod._testSEPA(),
         ]
-        let config = SavedPaymentOptionsViewController.Configuration(customerID: "cus_123", showApplePay: true, showLink: true, removeSavedPaymentMethodMessage: nil, merchantDisplayName: "Test Merchant", isCVCRecollectionEnabled: false, isTestMode: false, allowsRemovalOfLastSavedPaymentMethod: false, allowsRemovalOfPaymentMethods: true, allowsSetAsDefaultPM: showDefaultPMBadge)
+        let config = SavedPaymentOptionsViewController.Configuration(customerID: "cus_123", showApplePay: true, showLink: true, removeSavedPaymentMethodMessage: nil, merchantDisplayName: "Test Merchant", isCVCRecollectionEnabled: false, isTestMode: false, allowsRemovalOfLastSavedPaymentMethod: false, allowsRemovalOfPaymentMethods: true, allowsSetAsDefaultPM: showDefaultPMBadge, allowsUpdatePaymentMethod: false)
         let intent = Intent.deferredIntent(intentConfig: .init(mode: .payment(amount: 0, currency: "USD", setupFutureUsage: nil, captureMethod: .automatic), confirmHandler: { _, _, _ in }))
         let sut = SavedPaymentOptionsViewController(savedPaymentMethods: paymentMethods,
                                                     configuration: config,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
@@ -12,323 +12,163 @@ class SavedPaymentOptionsViewControllerTests: XCTestCase {
         return PaymentSheet.Configuration._testValue_MostPermissive()
     }()
 
-    func testCanEditPaymentMethods_noPMs() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [],
-                                                       cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
+    func testNoPM() {
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
+
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
+
+        // Skip where removePM == false && removeLastPM == true
+
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
+
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: []))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: []))
+    }
+    func testSinglePM_nonCoBranded() {
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+
+        // Skip where removePM = false && removeLastPM = true
+
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard()]))
     }
 
-    // MARK: - Single Card, cbcEligible
-    func testCanEditPaymentMethods_singlePM_removeLast0_remove0() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                       cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
+    func testSinglePM_coBranded() {
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+
+        // Skip where removePM = false && removeLastPM = true
+
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()]))
     }
-    func testCanEditPaymentMethods_singlePM_removeLast0_remove1() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                       cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singlePM_removeLast1_remove0() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                       cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singlePM_removeLast1_remove1() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                       cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
+    func testTwoPMs_nonCoBranded() {
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+
+        // Skip where removePM = false && removeLastPM = true
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()]))
+
     }
 
-    // MARK: - Single Card, !cbcEligible
-    func testCanEditPaymentMethods_singlePM_removeLast0_remove0_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                       cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singlePM_removeLast0_remove1_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                       cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singlePM_removeLast1_remove0_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                       cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singlePM_removeLast1_remove1_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                       cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
+    func testTwoPMs_coBranded() {
+        XCTAssertFalse(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
 
-    // MARK: - Single Card, w/ Co-branded, cbcEligible
-    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove0() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove1() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove0() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove1() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: false, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
 
-    // MARK: - Single Card, w/ Co-branded, !cbcEligible
-    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove0_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast0_remove1_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove0_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_singleCBCPM_removeLast1_remove1_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
+        // Skip where removePM = false && removeLastPM = true
 
-    // MARK: - Two Cards, cbcEligible
-    func testCanEditPaymentMethods_TwoPM_removeLast0_remove0() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                       cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast0_remove1() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                       cbcEligible: true)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast1_remove0() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                       cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast1_remove1() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                       cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: false, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
 
-    // MARK: - Two Cards, !cbcEligible
-    func testCanEditPaymentMethods_TwoPM_removeLast0_remove0_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                       cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast0_remove1_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                       cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast1_remove0_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                       cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPM_removeLast1_remove1_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardAmex()],
-                                                       cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-
-    // MARK: - Two Cards, w/ Co-branded, cbcEligible
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove0() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove1() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove0() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove1() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: true)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-
-    // MARK: - Two Cards, w/ Co-branded, !cbcEligible
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove0_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast0_remove1_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: false)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: false)
-        XCTAssertFalse(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove0_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-    func testCanEditPaymentMethods_TwoPMCBC_removeLast1_remove1_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: true,
-                                                      allowsRemovalOfPaymentMethods: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()],
-                                                       cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-
-    func testCanEditPaymentMethods_OnePM_remove0_default1_notCBCEligible() {
-        let configuration = savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: false,
-                                                      allowsRemovalOfPaymentMethods: false,
-                                                      allowsSetAsDefaultPaymentMethod: true)
-        let controller = savedPaymentOptionsController(configuration,
-                                                       savedPaymentMethods: [STPPaymentMethod._testCard()],
-                                                       cbcEligible: false)
-        XCTAssertTrue(controller.canEditPaymentMethods)
-    }
-
-    // MARK: Helpers
-    func savedPaymentOptionsConfig(allowsRemovalOfLastSavedPaymentMethod: Bool, allowsRemovalOfPaymentMethods: Bool, allowsSetAsDefaultPaymentMethod: Bool = false) -> SavedPaymentOptionsViewController.Configuration {
-        return SavedPaymentOptionsViewController.Configuration(customerID: "cus_123",
-                                                               showApplePay: true,
-                                                               showLink: true,
-                                                               removeSavedPaymentMethodMessage: nil,
-                                                               merchantDisplayName: "abc",
-                                                               isCVCRecollectionEnabled: true,
-                                                               isTestMode: true,
-                                                               allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
-                                                               allowsRemovalOfPaymentMethods: allowsRemovalOfPaymentMethods,
-                                                               allowsSetAsDefaultPM: allowsSetAsDefaultPaymentMethod)
-    }
-
-    func savedPaymentOptionsController(_ configuration: SavedPaymentOptionsViewController.Configuration,
-                                       savedPaymentMethods: [STPPaymentMethod],
-                                       cbcEligible: Bool) -> SavedPaymentOptionsViewController {
-        return SavedPaymentOptionsViewController(savedPaymentMethods: savedPaymentMethods,
-                                                 configuration: configuration,
-                                                 paymentSheetConfiguration: paymentSheetConfiguration,
-                                                 intent: Intent._testValue(),
-                                                 appearance: .default,
-                                                 elementsSession: .emptyElementsSession,
-                                                 cbcEligible: cbcEligible,
-                                                 analyticsHelper: ._testValue(),
-                                                 delegate: nil)
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: false, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: false, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: false, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
+        XCTAssertTrue(_testCanEditPaymentMethods(removePM: true, removeLastPM: true, defaultPM: true, updatePM: true, cbcEligible: true, savedPaymentMethods: [STPPaymentMethod._testCard(), STPPaymentMethod._testCardCoBranded()]))
     }
 
     // Test case for when the preferred brand of a card is nil that we look at the display brand
@@ -338,5 +178,35 @@ class SavedPaymentOptionsViewControllerTests: XCTestCase {
         let removalMessage = coBrandedCard.removalMessage
 
         XCTAssertEqual(removalMessage.message, "Cartes Bancaires •••• 4242")
+    }
+
+    // MARK: Helpers
+    func _testCanEditPaymentMethods(removePM: Bool,
+                                    removeLastPM: Bool,
+                                    defaultPM: Bool,
+                                    updatePM: Bool,
+                                    cbcEligible: Bool,
+                                    savedPaymentMethods: [STPPaymentMethod]) -> Bool {
+        let configuration = SavedPaymentOptionsViewController.Configuration(customerID: "cus_123",
+                                                                            showApplePay: true,
+                                                                            showLink: true,
+                                                                            removeSavedPaymentMethodMessage: nil,
+                                                                            merchantDisplayName: "abc",
+                                                                            isCVCRecollectionEnabled: true,
+                                                                            isTestMode: true,
+                                                                            allowsRemovalOfLastSavedPaymentMethod: removeLastPM,
+                                                                            allowsRemovalOfPaymentMethods: removePM,
+                                                                            allowsSetAsDefaultPM: defaultPM,
+                                                                            allowsUpdatePaymentMethod: updatePM)
+        let controller = SavedPaymentOptionsViewController(savedPaymentMethods: savedPaymentMethods,
+                                                           configuration: configuration,
+                                                           paymentSheetConfiguration: paymentSheetConfiguration,
+                                                           intent: Intent._testValue(),
+                                                           appearance: .default,
+                                                           elementsSession: .emptyElementsSession,
+                                                           cbcEligible: cbcEligible,
+                                                           analyticsHelper: ._testValue(),
+                                                           delegate: nil)
+        return controller.canEditPaymentMethods
     }
 }


### PR DESCRIPTION
## Summary
Allows users who have integrated with CustomerSessions to update cards if they have paymentmethodRemove || paymentmethodDefault set to disabled.

## Motivation
Currently updating cards is only available if you enable paymentMethodDefault or paymentmethodRemove.

## Testing
updated existing tests and manually tested

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
