### PR TITLE
Allow retries on paymentsheet backend

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+PaymentSheetTestUtilities.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+PaymentSheetTestUtilities.swift
@@ -6,36 +6,32 @@
 import XCTest
 
 extension XCTestCase {
-    func reload(_ app: XCUIApplication, settings: PaymentSheetTestPlaygroundSettings) {
-        app.buttons["Reload"].waitForExistenceAndTap(timeout: 10)
-        waitForReload(app, settings: settings)
+    func reload(_ app: XCUIApplication, settings: PaymentSheetTestPlaygroundSettings, retry: Int = 0, maxRetries: Int = 3) {
+        app.buttons["Reload"].waitForExistenceAndTap(timeout: 5)
+        waitForReload(app, settings: settings, retry: retry, maxRetries: maxRetries)
     }
 
-    func waitForReload(_ app: XCUIApplication, settings: PaymentSheetTestPlaygroundSettings) {
+    func waitForReload(_ app: XCUIApplication, settings: PaymentSheetTestPlaygroundSettings, retry: Int = 0, maxRetries: Int = 3) {
+        let timeout: TimeInterval = 5
+
+        var successfullyLoaded = false
         switch settings.uiStyle {
         case .paymentSheet:
-            let presentButton = app.buttons["Present PaymentSheet"]
-            expectation(
-                for: NSPredicate(format: "enabled == true"),
-                evaluatedWith: presentButton,
-                handler: nil
-            )
+            successfullyLoaded = app.buttons["Present PaymentSheet"].waitForExistence(timeout: timeout)
         case .flowController:
-            let confirm = app.buttons["Confirm"]
-            expectation(
-                for: NSPredicate(format: "enabled == true"),
-                evaluatedWith: confirm,
-                handler: nil
-            )
+            successfullyLoaded = app.buttons["Confirm"].waitForExistence(timeout: timeout)
         case .embedded:
-            let confirm = app.buttons["Present embedded payment element"]
-            expectation(
-                for: NSPredicate(format: "enabled == true"),
-                evaluatedWith: confirm,
-                handler: nil
-            )
+            successfullyLoaded = app.buttons["Present embedded payment element"].waitForExistence(timeout: timeout)
         }
-        waitForExpectations(timeout: 10, handler: nil)
+
+        if !successfullyLoaded {
+            if retry < maxRetries {
+                // Hit the reload button and try again
+                reload(app, settings: settings, retry: retry + 1, maxRetries: maxRetries)
+            } else {
+                XCTFail("Failed to load payment sheet after \(maxRetries) retries")
+            }
+        }
     }
     func loadPlayground(_ app: XCUIApplication, _ settings: PaymentSheetTestPlaygroundSettings) {
         if #available(iOS 15.0, *) {


### PR DESCRIPTION
## Summary
I believe our backend is sometimes failing to load payment sheet. Lets try and reload up to 3 times, and wait 5 seconds each time.

## Motivation
Attempting to make UI tests in CI more stable.

## Testing
Manually, and relying on CI.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
