### PR TITLE
Move view controller helpers to Stripe Core.

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet+SwiftUI.swift
@@ -5,6 +5,7 @@
 //
 
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
 import SwiftUI
 
 extension View {
@@ -73,13 +74,13 @@ extension CustomerSheet {
                     case (false, false):
                         break
                     case (false, true):
-                        guard let viewController = findViewController(for: view) else {
+                        guard let viewController = view.findViewController() else {
                             parent.presented = false
                             return
                         }
                         presentSheet(on: viewController)
                     case (true, false):
-                        guard let viewController = findViewController(for: view) else {
+                        guard let viewController = view.findViewController() else {
                             parent.presented = true
                             return
                         }
@@ -96,7 +97,7 @@ extension CustomerSheet {
             }
 
             func presentSheet(on controller: UIViewController) {
-                let presenter = findViewControllerPresenter(from: controller)
+                let presenter = controller.findViewControllerPresenter()
 
                 parent.customerSheet?.present(from: presenter) { (result: CustomerSheet.CustomerSheetResult) in
                     self.parent.presented = false

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+SwiftUI.swift
@@ -10,6 +10,7 @@
 //
 
 @_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
 import SwiftUI
 
 extension View {
@@ -233,7 +234,7 @@ extension PaymentSheet {
                     case (false, false):
                         break
                     case (false, true):
-                        guard let viewController = findViewController(for: view) else {
+                        guard let viewController = view.findViewController() else {
                             parent.presented = false
                             return
                         }
@@ -256,7 +257,7 @@ extension PaymentSheet {
             }
 
             func presentPaymentSheet(on controller: UIViewController) {
-                let presenter = findViewControllerPresenter(from: controller)
+                let presenter = controller.findViewControllerPresenter()
 
                 parent.paymentSheet?.present(from: presenter) { (result: PaymentSheetResult) in
                     self.parent.presented = false
@@ -296,7 +297,7 @@ extension PaymentSheet {
                     case (false, false):
                         break
                     case (false, true):
-                        guard let viewController = findViewController(for: view) else {
+                        guard let viewController = view.findViewController() else {
                             parent.presented = false
                             return
                         }
@@ -319,7 +320,7 @@ extension PaymentSheet {
             }
 
             func presentPaymentSheet(on controller: UIViewController) {
-                let presenter = findViewControllerPresenter(from: controller)
+                let presenter = controller.findViewControllerPresenter()
 
                 switch parent.action {
                 case .confirm:
@@ -377,49 +378,6 @@ extension PaymentSheet {
             )
         }
     }
-}
-
-// MARK: - Helper functions
-
-func findViewControllerPresenter(from uiViewController: UIViewController) -> UIViewController {
-    // Note: creating a UIViewController inside here results in a nil window
-
-    // This is a bit of a hack: We traverse the view hierarchy looking for the most reasonable VC to present from.
-    // A VC hosted within a SwiftUI cell, for example, doesn't have a parent, so we need to find the UIWindow.
-    var presentingViewController: UIViewController =
-        uiViewController.view.window?.rootViewController ?? uiViewController
-
-    // Find the most-presented UIViewController
-    while let presented = presentingViewController.presentedViewController {
-        presentingViewController = presented
-    }
-
-    return presentingViewController
-}
-
-func findViewController(for uiView: UIView) -> UIViewController? {
-    if let nextResponder = uiView.next as? UIViewController {
-        return nextResponder
-    } else if let nextResponder = uiView.next as? UIView {
-        return findViewController(for: nextResponder)
-    } else {
-        // Can't find a view, attempt to grab the top most view controller
-        return topMostViewController()
-    }
-}
-
-func topMostViewController() -> UIViewController? {
-    guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
-          let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return nil }
-
-    var topController: UIViewController? = window.rootViewController
-
-    // Traverse presented view controllers to find the top most view controller
-    while let presentedViewController = topController?.presentedViewController {
-        topController = presentedViewController
-    }
-
-    return topController
 }
 
 // Helper class to track SwiftUI usage

--- a/StripeUICore/StripeUICore.xcodeproj/project.pbxproj
+++ b/StripeUICore/StripeUICore.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		36376E12AE7ABA21FFC474E6 /* Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4844F0B5436706225DE5A176 /* Events.swift */; };
 		377058C2363FA0348AFBD32E /* AddressSectionElement+DummyAddressLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B66D666BB3EA733B92A60AA /* AddressSectionElement+DummyAddressLine.swift */; };
 		39E61B5E6A88E5AF1922EE62 /* TextFieldFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34178B51599FDCB0D0D7475A /* TextFieldFormatter.swift */; };
+		41B285642D8B637200B6B34D /* UIResponder+Stripe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B285622D8B637200B6B34D /* UIResponder+Stripe.swift */; };
 		4755A24604B396D5A25058CD /* StripeUICore.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8A9F7B4B2E8AA5A7E4FE98 /* StripeUICore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		48D3B7C2983A8A25C6599119 /* OneTimeCodeTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2BFFB32C50AB4EECA90326 /* OneTimeCodeTextField.swift */; };
 		4A5EADAF2F6514299BA4B8D8 /* FormElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1FE2B6BCD6FC77117A2521 /* FormElement.swift */; };
@@ -182,6 +183,7 @@
 		3B8AFA3891DA214D9FBEF650 /* NSAttributedString+StripeUICore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSAttributedString+StripeUICore.swift"; sourceTree = "<group>"; };
 		40DF1A7FC5D84F937042D172 /* StripeCoreTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCoreTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		40E0822DE6CFA0D3CCD5D513 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		41B285622D8B637200B6B34D /* UIResponder+Stripe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIResponder+Stripe.swift"; sourceTree = "<group>"; };
 		43943E8FF7CD279F8D8605D3 /* UIFont+StripeUICore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+StripeUICore.swift"; sourceTree = "<group>"; };
 		4844F0B5436706225DE5A176 /* Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Events.swift; sourceTree = "<group>"; };
 		4893E4B43FEFCE920D432F0C /* ContainerElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerElement.swift; sourceTree = "<group>"; };
@@ -465,6 +467,7 @@
 				51C4AEB27F9734178E20836A /* UIColor+StripeUICore.swift */,
 				43943E8FF7CD279F8D8605D3 /* UIFont+StripeUICore.swift */,
 				4EE651DD3E5873538C7CE743 /* UIKeyboardType+StripeUICore.swift */,
+				41B285622D8B637200B6B34D /* UIResponder+Stripe.swift */,
 				71A81696ECEEF728F25202B6 /* UISpringTimingParameters+StripeUICore.swift */,
 				5855EA2F4F38847E3E47935D /* UIStackView+StripeUICore.swift */,
 				FAA22461E52111D9A4E8B133 /* UITraitCollection+StripeUICore.swift */,
@@ -945,6 +948,7 @@
 				0A3130227F7602524C9824D3 /* TextFieldElement+AddressFactory.swift in Sources */,
 				FC48FCDC5FD43E5E8AFC32D2 /* TextFieldElement+Factory.swift in Sources */,
 				4A5EADAF2F6514299BA4B8D8 /* FormElement.swift in Sources */,
+				41B285642D8B637200B6B34D /* UIResponder+Stripe.swift in Sources */,
 				C1CA6209591EDDBBE019FF22 /* FormView.swift in Sources */,
 				86427678E119E4AD22410E30 /* PhoneNumberElement.swift in Sources */,
 				019C76A03A30A67AE9F1FAEE /* PickerFieldView.swift in Sources */,

--- a/StripeUICore/StripeUICore/Source/Categories/UIResponder+Stripe.swift
+++ b/StripeUICore/StripeUICore/Source/Categories/UIResponder+Stripe.swift
@@ -1,0 +1,22 @@
+//
+//  UIResponder+Stripe.swift
+//  StripeUICore
+//
+//  Created by Chris Mays on 3/19/25.
+//
+
+import UIKit
+
+@_spi(STP) public extension UIResponder {
+    @available(iOSApplicationExtension, unavailable)
+    @objc func findViewController() -> UIViewController? {
+        if let nextResponder = self.next as? UIViewController {
+            return nextResponder
+        } else if let nextResponder = self.next {
+            return nextResponder.findViewController()
+        } else {
+            // Can't find a view, attempt to grab the top most view controller
+            return UIViewController.topMostViewController()
+        }
+    }
+}

--- a/StripeUICore/StripeUICore/Source/Categories/UIViewController+StripeUICore.swift
+++ b/StripeUICore/StripeUICore/Source/Categories/UIViewController+StripeUICore.swift
@@ -53,7 +53,39 @@ import UIKit
             // Recurse for any presented controllers
             return presented.findTopMostPresentedViewController()
         }
-        
+
         return self
+    }
+
+    @available(iOSApplicationExtension, unavailable)
+    func findViewControllerPresenter() -> UIViewController {
+        // Note: creating a UIViewController inside here results in a nil window
+
+        // This is a bit of a hack: We traverse the view hierarchy looking for the most reasonable VC to present from.
+        // A VC hosted within a SwiftUI cell, for example, doesn't have a parent, so we need to find the UIWindow.
+        var presentingViewController: UIViewController =
+        self.view.window?.rootViewController ?? self
+
+        // Find the most-presented UIViewController
+        while let presented = presentingViewController.presentedViewController {
+            presentingViewController = presented
+        }
+
+        return presentingViewController
+    }
+
+    @available(iOSApplicationExtension, unavailable)
+    class func topMostViewController() -> UIViewController? {
+        guard let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+              let window = windowScene.windows.first(where: { $0.isKeyWindow }) else { return nil }
+
+        var topController: UIViewController? = window.rootViewController
+
+        // Traverse presented view controllers to find the top most view controller
+        while let presentedViewController = topController?.presentedViewController {
+            topController = presentedViewController
+        }
+
+        return topController
     }
 }


### PR DESCRIPTION
## Summary
This moves some ViewController helpers used for SwiftUI presentation into StripeCore. I am doing this because we are actively considering using a similar approach to the payment bottom sheet view modifier for the Connect SDK. There is one minor change I made to make findViewController more accurate, called out in a comment.

## Demo


https://github.com/user-attachments/assets/249449e0-cdbf-47b1-8e4f-12017cf83a30

