### PR TITLE
[Connect] Fix bug where delegate callbacks would not fire on dismiss.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## x.x.x x-x-x
+## 24.9.0 2025-03-24
+### Connect (Private Preview)
+* [Fixed] Fixed an issue where Account Onboarding exit events were not being properly emitted.
+
 ### PaymentSheet
 * [Fixed] Embedded Payment Element (private beta) possibly showing empty forms after calling `update()`.
 

--- a/Example/StripeConnectExample/StripeConnect Example.xcodeproj/project.pbxproj
+++ b/Example/StripeConnectExample/StripeConnect Example.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		41810D712C89F4CD00F10EB7 /* AppearanceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41810D702C89F4CD00F10EB7 /* AppearanceSettings.swift */; };
 		41810D762C8A005D00F10EB7 /* AppearanceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41810D752C8A005D00F10EB7 /* AppearanceInfo.swift */; };
 		41810D782C8A006F00F10EB7 /* AppSettings+AppearanceInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41810D772C8A006F00F10EB7 /* AppSettings+AppearanceInfo.swift */; };
+		41B2856F2D8CC5C500B6B34D /* ToastManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B2856E2D8CC5C300B6B34D /* ToastManager.swift */; };
 		41E126E32D80B97000623208 /* XCUIApplication+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E126E22D80B96900623208 /* XCUIApplication+Extension.swift */; };
 		41E126E52D80BD7100623208 /* StripeConnectExampleAppKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E126E42D80BD6D00623208 /* StripeConnectExampleAppKeys.swift */; };
 		41E126E62D80BEF700623208 /* StripeConnectExampleAppKeys.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E126E42D80BD6D00623208 /* StripeConnectExampleAppKeys.swift */; };
@@ -105,6 +106,7 @@
 		41810D702C89F4CD00F10EB7 /* AppearanceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettings.swift; sourceTree = "<group>"; };
 		41810D752C8A005D00F10EB7 /* AppearanceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceInfo.swift; sourceTree = "<group>"; };
 		41810D772C8A006F00F10EB7 /* AppSettings+AppearanceInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppSettings+AppearanceInfo.swift"; sourceTree = "<group>"; };
+		41B2856E2D8CC5C300B6B34D /* ToastManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastManager.swift; sourceTree = "<group>"; };
 		41E126E22D80B96900623208 /* XCUIApplication+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+Extension.swift"; sourceTree = "<group>"; };
 		41E126E42D80BD6D00623208 /* StripeConnectExampleAppKeys.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeConnectExampleAppKeys.swift; sourceTree = "<group>"; };
 		41E9A1BC2C7CC85100EDE131 /* SwiftUIContainerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIContainerViewController.swift; sourceTree = "<group>"; };
@@ -300,6 +302,7 @@
 		41E9A1BB2C7CC83500EDE131 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
+				41B2856E2D8CC5C300B6B34D /* ToastManager.swift */,
 				41E9A1BC2C7CC85100EDE131 /* SwiftUIContainerViewController.swift */,
 				41E9A1BE2C7CD3C700EDE131 /* UIViewController+NavigationEmbed.swift */,
 				4161C2862C9DD035005BD67C /* URL+Valid.swift */,
@@ -442,6 +445,7 @@
 				41810D762C8A005D00F10EB7 /* AppearanceInfo.swift in Sources */,
 				41810D712C89F4CD00F10EB7 /* AppearanceSettings.swift in Sources */,
 				41E9A1BF2C7CD3C700EDE131 /* UIViewController+NavigationEmbed.swift in Sources */,
+				41B2856F2D8CC5C500B6B34D /* ToastManager.swift in Sources */,
 				416E9EE02C78C10800A0B917 /* MainViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/StripeConnectExample/StripeConnectExample/Helpers/ToastManager.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Helpers/ToastManager.swift
@@ -1,0 +1,97 @@
+//
+//  ToastManager.swift
+//  StripeConnect Example
+//
+//  Created by Chris Mays on 3/20/25.
+//
+
+import SwiftUI
+import UIKit
+
+struct ToastMessage: Identifiable, Equatable {
+    let id = UUID()
+    let message: String
+    let createdAt = Date()
+}
+
+class ToastManager: ObservableObject {
+    static let shared = ToastManager()
+    @Published var toasts: [ToastMessage] = []
+    private let displayDuration: TimeInterval = 20.0
+    private var toastWindow: UIWindow?
+
+    private func setupWindowIfNeeded() {
+        guard toastWindow == nil else { return }
+
+        let window = UIWindow()
+        window.backgroundColor = .clear
+        window.windowLevel = .alert + 1
+        window.isUserInteractionEnabled = false
+        window.accessibilityIdentifier = "ToastWindow"
+        if let windowScene = UIApplication.shared.connectedScenes
+            .filter({ $0.activationState == .foregroundActive })
+            .first as? UIWindowScene {
+            window.windowScene = windowScene
+        }
+
+        let rootVC = UIHostingController(
+            rootView: ToastContainerView().environmentObject(self)
+        )
+        rootVC.view.backgroundColor = .clear
+        window.rootViewController = rootVC
+        rootVC.view.isAccessibilityElement = true
+        window.isHidden = false
+        toastWindow = window
+    }
+
+    func show(_ message: String) {
+        setupWindowIfNeeded()
+        let toast = ToastMessage(message: message)
+
+        DispatchQueue.main.async {
+            self.toasts.append(toast)
+            DispatchQueue.main.asyncAfter(deadline: .now() + self.displayDuration) {
+                self.removeToast(toast)
+            }
+        }
+    }
+
+    private func removeToast(_ toast: ToastMessage) {
+        DispatchQueue.main.async {
+            withAnimation {
+                if let index = self.toasts.firstIndex(of: toast) {
+                    self.toasts.remove(at: index)
+                }
+            }
+        }
+    }
+}
+
+struct ToastContainerView: View {
+    @EnvironmentObject var toastManager: ToastManager
+
+    var body: some View {
+        VStack {
+            Spacer()
+
+            ForEach(toastManager.toasts) { toast in
+                Text(toast.message)
+                    .padding(.horizontal, 16)
+                    .padding(.vertical, 10)
+                    .background(
+                        Capsule()
+                            .fill(Color.black.opacity(0.7))
+                    )
+                    .accessibilityIdentifier(toast.message)
+                    .foregroundColor(.white)
+                    .font(.system(size: 14))
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+            .padding(.bottom, 16)
+        }
+        .animation(.easeInOut, value: toastManager.toasts)
+    }
+}

--- a/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
@@ -202,9 +202,10 @@ class MainViewController: UITableViewController {
 extension MainViewController: AccountOnboardingControllerDelegate {
     func accountOnboardingDidExit(_ accountOnboarding: AccountOnboardingController) {
         //  Retrieve account details to check the status of details_submitted, charges_enabled, payouts_enabled, and other capabilities
+        ToastManager.shared.show("Did exit called")
     }
 
     func accountOnboarding(_ accountOnboarding: AccountOnboardingController, didFailLoadWithError error: any Error) {
-        presentAlert(title: "Error loading account onboarding", message: (error as NSError).debugDescription)
+        ToastManager.shared.show("Error loading account onboarding")
     }
 }

--- a/Example/StripeConnectExample/StripeConnectExampleUITests/StripeConnectOnboardingTests.swift
+++ b/Example/StripeConnectExample/StripeConnectExampleUITests/StripeConnectOnboardingTests.swift
@@ -12,9 +12,26 @@ final class StripeConnectOnboardingTests: XCTestCase {
         let app = XCUIApplication.sc_launch()
         app.sc_onboarding_cell.tap()
         app.verify_onboarding_loaded()
-        app.verify_close_component()
-
-        // Verify we land back on main page
+        app.tap_close_component()
         _ = app.sc_onboarding_cell
+        app.verifyToast(message: "Did exit called")
+    }
+
+    func testOpenAndSubmit() throws {
+        let app = XCUIApplication.sc_launch()
+        app.sc_onboarding_cell.tap()
+        app.verify_onboarding_loaded()
+        app.tap_submit_button()
+        _ = app.sc_onboarding_cell
+        app.verifyToast(message: "Did exit called")
+    }
+
+    func testFailedLaunch() throws {
+        let app = XCUIApplication.sc_launch(account: "bad_account")
+        app.sc_onboarding_cell.tap()
+        app.verify_onboarding_failed()
+        app.tap_close_component()
+        _ = app.sc_onboarding_cell
+        app.verifyToast(message: "Did exit called")
     }
 }

--- a/Example/StripeConnectExample/StripeConnectExampleUITests/XCUIApplication+Extension.swift
+++ b/Example/StripeConnectExample/StripeConnectExampleUITests/XCUIApplication+Extension.swift
@@ -19,10 +19,27 @@ extension XCUIApplication {
         return app
     }
 
-    func verify_close_component() {
-        let confirmText = buttons["closeButton"]
+    func tap_close_component() {
+        let closeButton = buttons["closeButton"]
+        XCTAssertTrue(closeButton.waitForExistence(timeout: 10.0), "\(#function) waiting failed")
+        closeButton.tap()
+    }
+
+    func tap_submit_button() {
+        let webview = webViews.firstMatch
+        XCTAssertTrue(webview.waitForExistence(timeout: 20))
+        webview.swipeUp(velocity: .fast)
+        webview.swipeUp(velocity: .fast)
+        let confirmButton = buttons["​ Confirm"]
+        XCTAssertTrue(confirmButton.waitForExistence(timeout: 20))
+        confirmButton.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5)).tap()
+    }
+
+    func verifyToast(message: String) {
+        let window = windows["ToastWindow"]
+        XCTAssertTrue(window.waitForExistence(timeout: 10.0), "\(#function) waiting failed")
+        let confirmText = window.staticTexts[message]
         XCTAssertTrue(confirmText.waitForExistence(timeout: 10.0), "\(#function) waiting failed")
-        confirmText.tap()
     }
 }
 
@@ -36,6 +53,11 @@ extension XCUIApplication {
 
     func verify_onboarding_loaded() {
         let confirmText = staticTexts["Review and confirm"]
+        XCTAssertTrue(confirmText.waitForExistence(timeout: 20.0), "\(#function) waiting failed")
+    }
+
+    func verify_onboarding_failed() {
+        let confirmText = staticTexts["Something went wrong."]
         XCTAssertTrue(confirmText.waitForExistence(timeout: 20.0), "\(#function) waiting failed")
     }
 }

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
@@ -295,7 +295,8 @@ extension ConnectComponentWebViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        if isBeingDismissed {
+        let dismissedVC = self.navigationController ?? self
+        if dismissedVC.isBeingDismissed {
             onDismiss?()
         }
     }


### PR DESCRIPTION
## Summary
This fixes an issue where the accountOnboardingDidExit callback would not fire on dismiss. I have also added UI Tests to cover both the accountOnboardingDidExit and didFailLoadWithError to ensure no further regressions.

## Demo UI Tests


https://github.com/user-attachments/assets/3cfeb01c-0441-42e7-bea7-2513139783e7

