### PR TITLE
Fix embedded not showing forms after updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### PaymentSheet
+* [Fixed] Embedded Payment Element possibly showing empty forms after calling `update()`.
+
 ## 24.8.0 2025-03-17
 ### PaymentSheet, CustomerSheet
 * [Added] Support for default payment methods in private beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## x.x.x x-x-x
 ### PaymentSheet
-* [Fixed] Embedded Payment Element possibly showing empty forms after calling `update()`.
+* [Fixed] Embedded Payment Element (private beta) possibly showing empty forms after calling `update()`.
 
 ## 24.8.0 2025-03-17
 ### PaymentSheet, CustomerSheet

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -67,12 +67,18 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
         XCTAssertTrue(app.buttons["Card"].isSelected)
+        // ...selecting card should present a form with the fields filled out
+        app.buttons["Card"].waitForExistenceAndTap()
+        // ...sanity check that the form is created
+        XCTAssertTrue(app.staticTexts["Card information"].waitForExistence(timeout: 10))
+        // ...thus the Continue button should be enabled
+        app.buttons["Continue"].waitForExistenceAndTap()
 
         // ...selecting Alipay w/ deferred PaymentIntent...
         app.buttons["Alipay"].waitForExistenceAndTap()
         XCTAssertEqual(app.staticTexts["Payment method"].label, "Alipay")
 
-        let aliPayAnalytics = analyticsLog.compactMap({ $0[string: "event"] })
+        let aliPayAnalytics = analyticsLog.compactMap({ $0[string: "event"] }).prefix(6)
         XCTAssertEqual(
             aliPayAnalytics,
             ["mc_embedded_update_started", "mc_load_started", "link.account_lookup.complete", "mc_load_succeeded", "mc_embedded_update_finished", "mc_carousel_payment_method_tapped"]

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -130,9 +130,12 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
     func embeddedPaymentMethodsViewDidUpdateSelection() {
         // 1. Update the currently selection's form VC to match the selection.
         // Note `paymentOption` derives from this property
+
+        let previousPaymentOption = selectedFormViewController?.previousPaymentOption
+        self.selectedFormViewController = nil
         self.selectedFormViewController = Self.makeFormViewControllerIfNecessary(
             selection: embeddedPaymentMethodsView.selectedRowButton?.type,
-            previousPaymentOption: selectedFormViewController?.previousPaymentOption,
+            previousPaymentOption: previousPaymentOption,
             configuration: configuration,
             intent: intent,
             elementsSession: elementsSession,
@@ -205,7 +208,7 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
             paymentMethodType: paymentMethodType,
             previousPaymentOption: nil,
             analyticsHelper: analyticsHelper,
-            formCache: formCache,
+            formCache: .init(),  // Use a fresh form cache to ensure forms aren't re-added to a different view controller's hierarchy
             delegate: self
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -130,12 +130,9 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
     func embeddedPaymentMethodsViewDidUpdateSelection() {
         // 1. Update the currently selection's form VC to match the selection.
         // Note `paymentOption` derives from this property
-
-        let previousPaymentOption = selectedFormViewController?.previousPaymentOption
-        self.selectedFormViewController = nil
         self.selectedFormViewController = Self.makeFormViewControllerIfNecessary(
             selection: embeddedPaymentMethodsView.selectedRowButton?.type,
-            previousPaymentOption: previousPaymentOption,
+            previousPaymentOption: selectedFormViewController?.previousPaymentOption,
             configuration: configuration,
             intent: intent,
             elementsSession: elementsSession,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -104,6 +104,10 @@ class PaymentMethodFormViewController: UIViewController {
         self.headerView = headerView
         self.formCache = formCache
         if let form = self.formCache[type] {
+            assert(
+                form.view.superview == nil,
+                "The form found in the cache is already part of another view hierarchy. This likely indicates that the formCache is being reused incorrectly."
+            )
             self.form = form
         } else {
             self.form = PaymentSheetFormFactory(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -104,10 +104,6 @@ class PaymentMethodFormViewController: UIViewController {
         self.headerView = headerView
         self.formCache = formCache
         if let form = self.formCache[type] {
-            assert(
-                form.view.superview == nil,
-                "The form found in the cache is already part of another view hierarchy. This likely indicates that the formCache is being reused incorrectly."
-            )
             self.form = form
         } else {
             self.form = PaymentSheetFormFactory(


### PR DESCRIPTION
## Summary
- Fixed a bug where sometimes after updating form would show up as empty.
- This was caused by forms attempting to be added to different/multiple view controller hierarchies, since instances are shared through the cache.

## Motivation
- Bug fix

## Testing
- Updated UI test to catch this

## Changelog
See diff
