### PR TITLE
Temporarily disable `testAsyncPresentCompletion`

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
@@ -67,7 +67,8 @@ class FinancialConnectionsSheetTests: XCTestCase {
         wait(for: [expectation], timeout: 5.0)
     }
 
-    func testAsyncPresentCompletion() async {
+    // TODO(mats): Investigate deadlock caused by this test.
+    func disabled_testAsyncPresentCompletion() async {
         let sheet = FinancialConnectionsSheet(
             financialConnectionsSessionClientSecret: mockClientSecret,
             returnURL: nil,


### PR DESCRIPTION
## Summary

Temporarily disables `testAsyncPresentCompletion` while we investigate deadlocks it caused on CI.

## Motivation

Green master

## Testing

N/a

## Changelog

N/a