### PR TITLE
Allow configuration of the connect-js url

### DIFF
--- a/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Mel Ludowise on 4/30/24.
 //
 
-@_spi(PrivateBetaConnect) import StripeConnect
+@_spi(PrivateBetaConnect) @_spi(DashboardOnly) import StripeConnect
 import SwiftUI
 import UIKit
 
@@ -60,8 +60,10 @@ class MainViewController: UITableViewController {
     }
 
     lazy var embeddedComponentManager: EmbeddedComponentManager = {
+        let webViewURL = AppSettings.shared.webViewURL.flatMap { URL(string: $0) }
         return .init(appearance: AppSettings.shared.appearanceInfo.appearance,
                      fonts: customFonts(),
+                     baseURLOverride: webViewURL,
                      fetchClientSecret: { [weak self, merchant] in
             do {
                 return try await API.accountSession(merchantId: merchant.id).get().clientSecret

--- a/Example/StripeConnectExample/StripeConnectExample/Settings/AppSettingsView.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Settings/AppSettingsView.swift
@@ -17,10 +17,15 @@ struct AppSettingsView: View {
 
     @State var selectedMerchant: MerchantInfo?
     @State var serverURLString: String = AppSettings.shared.selectedServerBaseURL
+    @State var webViewURLString: String = AppSettings.shared.webViewURL ?? ""
     @State var onboardingSettings = AppSettings.shared.onboardingSettings
 
     var isCustomEndpointValid: Bool {
         URL(string: serverURLString)?.isValid == true
+    }
+
+    var isWebViewURLValid: Bool {
+        URL(string: webViewURLString)?.isValid == true
     }
 
     var isUsingCustomMerchant: Bool {
@@ -48,9 +53,11 @@ struct AppSettingsView: View {
 
     var saveEnabled: Bool {
         isCustomEndpointValid &&
+        isWebViewURLValid &&
         isMerchantIdValid &&
         (AppSettings.shared.selectedMerchant(appInfo: appInfo)?.id != selectedMerchant?.id ||
-         AppSettings.shared.selectedServerBaseURL != serverURLString)
+         AppSettings.shared.selectedServerBaseURL != serverURLString ||
+         AppSettings.shared.webViewURL != webViewURLString)
     }
 
     init(appInfo: AppInfo?) {
@@ -118,6 +125,19 @@ struct AppSettingsView: View {
                 } header: {
                     Text("API Server Settings")
                 }
+
+                Section {
+                    TextInput(label: "", placeholder: "https://connect.stripe.com/connect.js", text: $webViewURLString, isValid: isWebViewURLValid)
+                    Button {
+                        webViewURLString = AppSettings.Constants.defaultWebViewURL
+                    } label: {
+                        Text("Reset to default")
+                            .disabled(AppSettings.Constants.defaultWebViewURL == webViewURLString)
+                            .keyboardType(.URL)
+                    }
+                } header: {
+                    Text("Connect.js URL Settings")
+                }
             }
             .listStyle(.insetGrouped)
             .animation(.easeOut(duration: 0.2), value: selectedMerchant)
@@ -137,6 +157,7 @@ struct AppSettingsView: View {
                     Button {
                         AppSettings.shared.setSelectedMerchant(merchant: selectedMerchant)
                         AppSettings.shared.selectedServerBaseURL = serverURLString
+                        AppSettings.shared.webViewURL = webViewURLString.isEmpty ? nil : webViewURLString
                         viewControllerPresenter?.setRootViewController(AppLoadingView().containerViewController)
                     } label: {
                         Text("Save")

--- a/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Storage/AppSettings.swift
@@ -10,8 +10,10 @@ import Foundation
 class AppSettings {
     enum  Constants {
         static let defaultServerBaseURL = "https://stripe-connect-mobile-example-v1.glitch.me/"
+        static let defaultWebViewURL = "https://connect-js.stripe.com/v1.0/ios_webview.html"
         static let serverBaseURLKey = "ServerBaseURL"
         static let appearanceIdKey = "AppearanceId"
+        static let webViewURLKey = "WebViewURL"
 
         static let selectedMerchantKey = "SelectedMerchant"
 
@@ -41,6 +43,16 @@ class AppSettings {
         }
         set {
             defaults.setValue(newValue, forKey: Constants.serverBaseURLKey)
+        }
+    }
+
+    var webViewURL: String? {
+        get {
+            defaults.string(forKey: Constants.webViewURLKey) ?? 
+            Constants.defaultWebViewURL
+        }
+        set {
+            defaults.setValue(newValue, forKey: Constants.webViewURLKey)
         }
     }
 

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
@@ -12,7 +12,7 @@ import UIKit
 /// Manages Connect embedded components
 /// - Important: Include  `@_spi(PrivateBetaConnect)` on import to gain access to this API.
 /// - Note: Connect embedded components are only available in private preview.
-/// - Seealso: [Step by step integration guide](  https://docs.stripe.com/connect/get-started-connect-embedded-components?platform=ios)
+/// - Seealso: [Step by step integration guide](https://docs.stripe.com/connect/get-started-connect-embedded-components?platform=ios)
 @_spi(PrivateBetaConnect)
 @_documentation(visibility: public)
 @available(iOS 15, *)
@@ -54,6 +54,21 @@ public final class EmbeddedComponentManager {
             return nil
         })
         self.publicKeyOverride = publicKeyOverride
+        if let baseURLOverride {
+            baseURL = baseURLOverride
+        }
+    }
+
+    @_spi(DashboardOnly)
+    public convenience init(apiClient: STPAPIClient = STPAPIClient.shared,
+                            appearance: EmbeddedComponentManager.Appearance = .default,
+                            fonts: [EmbeddedComponentManager.CustomFontSource] = [],
+                            baseURLOverride: URL? = nil,
+                            fetchClientSecret: @escaping () async -> String?) {
+        self.init(apiClient: apiClient,
+                 appearance: appearance,
+                 fonts: fonts,
+                 fetchClientSecret: fetchClientSecret)
         if let baseURLOverride {
             baseURL = baseURLOverride
         }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
This allows us to override the Connect-js URL, which is necessary for connecting the example app to a development server.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/CAX-4020

## Testing
<!-- How was the code tested? Be as specific as possible. -->
https://docs.google.com/document/d/1GCKWec-VjQGJjNhgwAal_DYzT2iqROvUcykcGn3-8os/edit?tab=t.0#heading=h.6cf2yj2yal24

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
