### PR TITLE
[FCLite] Make FC Lite available in MPE

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -288,9 +288,12 @@ final class PlaygroundViewModel: ObservableObject {
     }
 
     func didSelectShow() {
+        let useFCLite = playgroundConfiguration.sdkType == .fcLite
+        FinancialConnectionsSDKAvailability.shouldPreferFCLite = useFCLite
+
         switch playgroundConfiguration.integrationType {
         case .standalone:
-            if playgroundConfiguration.sdkType == .fcLite {
+            if useFCLite {
                 setupFcLite()
             } else {
                 setupStandalone()

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -289,6 +289,7 @@ final class PlaygroundViewModel: ObservableObject {
 
     func didSelectShow() {
         let useFCLite = playgroundConfiguration.sdkType == .fcLite
+        FinancialConnectionsSDKAvailability.fcLiteFeatureEnabled = useFCLite
         FinancialConnectionsSDKAvailability.shouldPreferFCLite = useFCLite
 
         switch playgroundConfiguration.integrationType {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -56,6 +56,7 @@ struct PaymentSheetTestPlayground: View {
         SettingView(setting: $playgroundController.settings.autoreload)
         SettingView(setting: $playgroundController.settings.shakeAmbiguousViews)
         SettingView(setting: $playgroundController.settings.instantDebitsIncentives)
+        SettingView(setting: $playgroundController.settings.fcLiteEnabled)
     }
 
     var body: some View {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -348,6 +348,12 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case on
         case off
     }
+    enum FCLiteEnabled: String, PickerEnum {
+        static var enumName: String { "FCLite enabled" }
+
+        case on
+        case off
+    }
     enum ExternalPaymentMethods: String, PickerEnum {
         static let enumName: String = "External PMs"
         // Based on https://git.corp.stripe.com/stripe-internal/stripe-js-v3/blob/55d7fd10/src/externalPaymentMethods/constants.ts#L13
@@ -523,6 +529,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var autoreload: Autoreload
     var shakeAmbiguousViews: ShakeAmbiguousViews
     var instantDebitsIncentives: InstantDebitsIncentives
+    var fcLiteEnabled: FCLiteEnabled
     var externalPaymentMethods: ExternalPaymentMethods
     var customPaymentMethods: CustomPaymentMethods
     var preferredNetworksEnabled: PreferredNetworksEnabled
@@ -575,6 +582,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             autoreload: .on,
             shakeAmbiguousViews: .off,
             instantDebitsIncentives: .off,
+            fcLiteEnabled: .off,
             externalPaymentMethods: .off,
             customPaymentMethods: .off,
             preferredNetworksEnabled: .off,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -491,6 +491,10 @@ class PlaygroundController: ObservableObject {
             // Hack to enable incentives in Instant Debits
             let enableInstantDebitsIncentives = newValue.instantDebitsIncentives == .on
             UserDefaults.standard.set(enableInstantDebitsIncentives, forKey: "FINANCIAL_CONNECTIONS_INSTANT_DEBITS_INCENTIVES")
+
+            let enableFcLite = newValue.fcLiteEnabled == .on
+            FinancialConnectionsSDKAvailability.fcLiteFeatureEnabled = enableFcLite
+            FinancialConnectionsSDKAvailability.shouldPreferFCLite = enableFcLite
         }.store(in: &subscribers)
 
         // Listen for analytics

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -897,7 +897,7 @@ extension PlaygroundController {
             else {
                 if let data = data,
                    (response as? HTTPURLResponse)?.statusCode == 400 {
-                    let errorMessage = String(data: data, encoding: .utf8)!
+                    let errorMessage = String(decoding: data, as: UTF8.self)
                     // read the error message
                     intentCreationCallback(.failure(ConfirmHandlerError.confirmError(errorMessage)))
                 } else {

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		47B19F96CCEA290541E3B988 /* CardSectionElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D03000A6807B09BFD8E6CB1 /* CardSectionElement.swift */; };
 		48DA2EFE0944E737B0F197B0 /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = B2AFFAD776D5F21DF837F1BD /* OHHTTPStubs */; };
 		49803444CD948F1ED28FF021 /* PaymentSheetFormFactory+FormSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7A1EFF100C589FDFF4D516 /* PaymentSheetFormFactory+FormSpec.swift */; };
+		498BF1722D92FF6A006E866B /* FCLiteImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498BF1712D92FF6A006E866B /* FCLiteImplementation.swift */; };
 		49909A162D8AF9760031EC33 /* FinancialConnectionsLite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49909A152D8AF9760031EC33 /* FinancialConnectionsLite.swift */; };
 		49909A1C2D8AFA600031EC33 /* FCLiteApiClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49909A1B2D8AFA600031EC33 /* FCLiteApiClient.swift */; };
 		49909A1E2D8AFAB70031EC33 /* FCLiteManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49909A1D2D8AFAB70031EC33 /* FCLiteManifest.swift */; };
@@ -580,6 +581,7 @@
 		45B6DC9BD9183495E5649369 /* LinkAccountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkAccountService.swift; sourceTree = "<group>"; };
 		47C5DB8C01BA7137369C8B4D /* TextFieldElement+Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextFieldElement+Card.swift"; sourceTree = "<group>"; };
 		492B254E43F3BB9F9CEAEA06 /* PaymentSheetLoaderStubbedTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetLoaderStubbedTest.swift; sourceTree = "<group>"; };
+		498BF1712D92FF6A006E866B /* FCLiteImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteImplementation.swift; sourceTree = "<group>"; };
 		49909A152D8AF9760031EC33 /* FinancialConnectionsLite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsLite.swift; sourceTree = "<group>"; };
 		49909A1B2D8AFA600031EC33 /* FCLiteApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteApiClient.swift; sourceTree = "<group>"; };
 		49909A1D2D8AFAB70031EC33 /* FCLiteManifest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteManifest.swift; sourceTree = "<group>"; };
@@ -1142,6 +1144,7 @@
 				49909A182D8AF9B50031EC33 /* Controllers */,
 				49909A172D8AF9AE0031EC33 /* API Client */,
 				49909A152D8AF9760031EC33 /* FinancialConnectionsLite.swift */,
+				498BF1712D92FF6A006E866B /* FCLiteImplementation.swift */,
 			);
 			path = "FC Lite";
 			sourceTree = "<group>";
@@ -2245,6 +2248,7 @@
 				F3A34AD1CC2CBB899738C9D7 /* LinkInlineSignupElement.swift in Sources */,
 				56BB7C81AB3A24D3AD88A904 /* LinkInlineSignupView-CheckboxElement.swift in Sources */,
 				7479F814D1BC58A6B19F054C /* LinkInlineSignupView.swift in Sources */,
+				498BF1722D92FF6A006E866B /* FCLiteImplementation.swift in Sources */,
 				3147CEC02CC080570067B5E4 /* LinkInMemoryCookieStore.swift in Sources */,
 				3147CEC12CC080570067B5E4 /* LinkCookieStore.swift in Sources */,
 				3147CEC22CC080570067B5E4 /* LinkSecureCookieStore.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -136,6 +136,7 @@
 		47AD56A9889DF5EFBBA9CEFB /* PollingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ADE49E72DD5EDA448D12D88 /* PollingViewTests.swift */; };
 		47B19F96CCEA290541E3B988 /* CardSectionElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D03000A6807B09BFD8E6CB1 /* CardSectionElement.swift */; };
 		48DA2EFE0944E737B0F197B0 /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = B2AFFAD776D5F21DF837F1BD /* OHHTTPStubs */; };
+		4954E9712D96FA0C0061585F /* FCLiteImplementationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4954E9702D96FA0C0061585F /* FCLiteImplementationTests.swift */; };
 		49803444CD948F1ED28FF021 /* PaymentSheetFormFactory+FormSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7A1EFF100C589FDFF4D516 /* PaymentSheetFormFactory+FormSpec.swift */; };
 		498BF1722D92FF6A006E866B /* FCLiteImplementation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498BF1712D92FF6A006E866B /* FCLiteImplementation.swift */; };
 		49909A162D8AF9760031EC33 /* FinancialConnectionsLite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49909A152D8AF9760031EC33 /* FinancialConnectionsLite.swift */; };
@@ -581,6 +582,7 @@
 		45B6DC9BD9183495E5649369 /* LinkAccountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkAccountService.swift; sourceTree = "<group>"; };
 		47C5DB8C01BA7137369C8B4D /* TextFieldElement+Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextFieldElement+Card.swift"; sourceTree = "<group>"; };
 		492B254E43F3BB9F9CEAEA06 /* PaymentSheetLoaderStubbedTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetLoaderStubbedTest.swift; sourceTree = "<group>"; };
+		4954E9702D96FA0C0061585F /* FCLiteImplementationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteImplementationTests.swift; sourceTree = "<group>"; };
 		498BF1712D92FF6A006E866B /* FCLiteImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteImplementation.swift; sourceTree = "<group>"; };
 		49909A152D8AF9760031EC33 /* FinancialConnectionsLite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsLite.swift; sourceTree = "<group>"; };
 		49909A1B2D8AFA600031EC33 /* FCLiteApiClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteApiClient.swift; sourceTree = "<group>"; };
@@ -1841,6 +1843,7 @@
 				61CBE6672BED97EE005F7FEB /* VerticalSavedPaymentMethodsViewControllerSnapshotTests.swift */,
 				619AF0882BF56F9100D1C981 /* VerticalSavedPaymentMethodsViewControllerTests.swift */,
 				49909A2D2D8B19800031EC33 /* FCLiteAuthFlowViewControllerTests.swift */,
+				4954E9702D96FA0C0061585F /* FCLiteImplementationTests.swift */,
 			);
 			path = PaymentSheet;
 			sourceTree = "<group>";
@@ -2118,6 +2121,7 @@
 				619AF0852BF56C5E00D1C981 /* PaymentMethodRowButtonSnapshotTests.swift in Sources */,
 				B6CACCA02CBD9A3300682ECE /* EmbeddedPaymentElementTest.swift in Sources */,
 				2EC9C94DD8D62E4F4EFC8AB8 /* IntentStatusPollerTest.swift in Sources */,
+				4954E9712D96FA0C0061585F /* FCLiteImplementationTests.swift in Sources */,
 				ABC3A7CF6D5B21D0C9684A09 /* LinkPopupURLParserTests.swift in Sources */,
 				F94F6A157CEB937896B682D4 /* LinkURLGeneratorTests.swift in Sources */,
 				10A336F0F2331F22F1A0AC1B /* LinkStubs.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/FCLiteImplementation.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/FCLiteImplementation.swift
@@ -8,7 +8,7 @@
 @_spi(STP) import StripeCore
 import UIKit
 
-/// NOTE: If you change the name of this class, make sure to also change it `FinancialConnectionsSDKAvailability` file.
+/// NOTE: If you change the name of this class, make sure to also change it in the `FinancialConnectionsSDKAvailability` file.
 @_spi(STP) public class FCLiteImplementation: FinancialConnectionsSDKInterface {
     required public init() {}
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/FCLiteImplementation.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/FCLiteImplementation.swift
@@ -1,0 +1,33 @@
+//
+//  FCLiteImplementation.swift
+//  StripePaymentSheet
+//
+//  Created by Mat Schmid on 2025-03-25.
+//
+
+@_spi(STP) import StripeCore
+import UIKit
+
+/// NOTE: If you change the name of this class, make sure to also change it `FinancialConnectionsSDKAvailability` file.
+@_spi(STP) public class FCLiteImplementation: FinancialConnectionsSDKInterface {
+    required public init() {}
+
+    public func presentFinancialConnectionsSheet(
+        apiClient: STPAPIClient,
+        clientSecret: String,
+        returnURL: String?,
+        style: FinancialConnectionsStyle,
+        elementsSessionContext: ElementsSessionContext?,
+        onEvent: ((FinancialConnectionsEvent) -> Void)?,
+        from presentingViewController: UIViewController,
+        completion: @escaping (FinancialConnectionsSDKResult) -> Void
+    ) {
+        let returnUrl = returnURL.flatMap(URL.init(string:))
+
+        let fcLite = FinancialConnectionsLite(
+            clientSecret: clientSecret,
+            returnUrl: returnUrl
+        )
+        fcLite.present(from: presentingViewController, completion: completion)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -110,6 +110,10 @@ final class PaymentSheetLoader {
                 let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
                 let isApplePayEnabled = PaymentSheet.isApplePayEnabled(elementsSession: elementsSession, configuration: configuration)
 
+                // Disable FC Lite if killswitch is enabled
+                let isFcLiteKillswitchEnabled = elementsSession.flags["elements_disable_fc_lite"] == true
+                FinancialConnectionsSDKAvailability.fcLiteKillswitchEnabled = isFcLiteKillswitchEnabled
+
                 // Send load finished analytic
                 // This is hacky; the logic to determine the default selected payment method belongs to the SavedPaymentOptionsViewController. We invoke it here just to report it to analytics before that VC loads.
                 let (defaultSelectedIndex, paymentOptionsViewModels) = SavedPaymentOptionsViewController.makeViewModels(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FCLiteImplementationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FCLiteImplementationTests.swift
@@ -1,0 +1,18 @@
+//
+//  FCLiteImplementationTests.swift
+//  StripePaymentSheetTests
+//
+//  Created by Mat Schmid on 2025-03-28.
+//
+
+@_spi(STP) import StripeCore
+import XCTest
+
+class FCLiteImplementationTests: XCTestCase {
+    func testFCLiteImplementationAvailable() {
+        let FinancialConnectionsLiteImplementation: FinancialConnectionsSDKInterface.Type? =
+            NSClassFromString("StripePaymentSheet.FCLiteImplementation")
+            as? FinancialConnectionsSDKInterface.Type
+        XCTAssertNotNil(FinancialConnectionsLiteImplementation)
+    }
+}

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -8,12 +8,15 @@
 
 import Foundation
 @_spi(STP) import StripeCore
-import SwiftUI
 import UIKit
 
 @_spi(STP) public struct FinancialConnectionsSDKAvailability {
     static let FinancialConnectionsSDKClass: FinancialConnectionsSDKInterface.Type? =
         NSClassFromString("StripeFinancialConnections.FinancialConnectionsSDKImplementation")
+        as? FinancialConnectionsSDKInterface.Type
+
+    static let FinancialConnectionsLiteClass: FinancialConnectionsSDKInterface.Type? =
+        NSClassFromString("StripePaymentSheet.FCLiteImplementation")
         as? FinancialConnectionsSDKInterface.Type
 
     static let isUnitTest: Bool = {
@@ -41,7 +44,7 @@ import UIKit
             let financialConnectionsSDKAvailable = ProcessInfo.processInfo.environment["FinancialConnectionsSDKAvailable"] == "true"
             return financialConnectionsSDKAvailable
         } else {
-            return FinancialConnectionsSDKClass != nil
+            return (FinancialConnectionsSDKClass != nil || FinancialConnectionsLiteClass != nil)
         }
     }
 
@@ -51,7 +54,7 @@ import UIKit
             return StubbedConnectionsSDKInterface()
         }
 
-        guard let klass = FinancialConnectionsSDKClass else {
+        guard let klass = /*FinancialConnectionsSDKClass ??*/ FinancialConnectionsLiteClass else {
             return nil
         }
 

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -21,9 +21,11 @@ import UIKit
 
     @_spi(STP) public static var fcLiteKillswitchEnabled: Bool = false
     @_spi(STP) public static var shouldPreferFCLite: Bool = false
+    // Remove this when ready to release FC Lite:
+    @_spi(STP) public static var fcLiteFeatureEnabled: Bool = false
 
     private static var FCLiteClassIfEnabled: FinancialConnectionsSDKInterface.Type? {
-        guard !Self.fcLiteKillswitchEnabled else {
+        guard fcLiteFeatureEnabled, !fcLiteKillswitchEnabled else {
             return nil
         }
         return Self.FinancialConnectionsLiteImplementation


### PR DESCRIPTION
## Summary

This integrates FC Lite into MPE. The main idea here is we first check if the full SDK is available, use that if so, and otherwise fallback on FC Lite.

> [!IMPORTANT]  
>This PR does not release FC Lite. There is a guardrail in place (`fcLiteFeatureEnabled`) that prevents it from being accessed, and this is only currently enabled by our example apps.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing

Manual testing done! Here's the Payment Sheet example app: 

https://github.com/user-attachments/assets/d9c7f0ef-fcff-48ea-b5fd-ed89b64f36fb

And the Financial Connections example app:

https://github.com/user-attachments/assets/e47df2f8-362e-49d0-a7db-0b5f401d8c8b

## Changelog

N/a
