### PR TITLE
Fix CardScan animation

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
@@ -461,7 +461,7 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
         if let startTime = startTime {
             duration = Date().timeIntervalSince(startTime)
         }
-        
+
         DispatchQueue.main.async(execute: {
             if params == nil {
                 STPAnalyticsClient.sharedClient.logCardScanCancelled(withDuration: duration ?? 0.0)
@@ -474,7 +474,7 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
                 self.cameraView?.captureSession = nil
             }
         })
-        
+
         isScanning = false
         captureDevice?.unlockForConfiguration()
         captureSession?.stopRunning()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
@@ -461,21 +461,23 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
         if let startTime = startTime {
             duration = Date().timeIntervalSince(startTime)
         }
-        isScanning = false
-        captureDevice?.unlockForConfiguration()
-        captureSession?.stopRunning()
-
+        
         DispatchQueue.main.async(execute: {
             if params == nil {
                 STPAnalyticsClient.sharedClient.logCardScanCancelled(withDuration: duration ?? 0.0)
             } else {
                 STPAnalyticsClient.sharedClient.logCardScanSucceeded(withDuration: duration ?? 0.0)
             }
-            self.feedbackGenerator = nil
-
-            self.cameraView?.captureSession = nil
             self.delegate?.cardScanner(self, didFinishWith: params, error: error)
+            self.feedbackGenerator = nil
+            DispatchQueue.main.async {
+                self.cameraView?.captureSession = nil
+            }
         })
+        
+        isScanning = false
+        captureDevice?.unlockForConfiguration()
+        captureSession?.stopRunning()
     }
 
     // MARK: Orientation

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
@@ -461,6 +461,9 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
         if let startTime = startTime {
             duration = Date().timeIntervalSince(startTime)
         }
+        isScanning = false
+        captureDevice?.unlockForConfiguration()
+        captureSession?.stopRunning()
 
         DispatchQueue.main.async(execute: {
             if params == nil {
@@ -474,10 +477,6 @@ class STPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
                 self.cameraView?.captureSession = nil
             }
         })
-
-        isScanning = false
-        captureDevice?.unlockForConfiguration()
-        captureSession?.stopRunning()
     }
 
     // MARK: Orientation

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
@@ -30,7 +30,6 @@ final class CardSectionWithScannerView: UIView {
     }()
     lazy var cardScanningView: CardScanningView = {
         let scanningView = CardScanningView()
-        scanningView.alpha = 0
         scanningView.isHidden = true
         scanningView.delegate = self
         return scanningView
@@ -69,11 +68,17 @@ final class CardSectionWithScannerView: UIView {
     }
 
     private func setCardScanVisible(_ isCardScanVisible: Bool) {
+        if !isCardScanVisible {
+            self.cardScanningView.prepDismissAnimation()
+        }
         UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1.0, initialSpringVelocity: 0.3, options: [.curveEaseInOut]) {
             self.cardScanButton.alpha = isCardScanVisible ? 0 : 1
-            self.cardScanningView.alpha = isCardScanVisible ? 1 : 0
             self.cardScanningView.setHiddenIfNecessary(!isCardScanVisible)
             self.layoutIfNeeded()
+        } completion: { _ in
+            if !isCardScanVisible {
+                self.cardScanningView.completeDismissAnimation()
+            }
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
@@ -73,7 +73,6 @@ final class CardSectionWithScannerView: UIView {
         }
         UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1.0, initialSpringVelocity: 0.3, options: [.curveEaseInOut]) {
             self.cardScanButton.alpha = isCardScanVisible ? 0 : 1
-            self.cardScanningView.alpha = isCardScanVisible ? 1 : 0
             self.cardScanningView.setHiddenIfNecessary(!isCardScanVisible)
             self.layoutIfNeeded()
         } completion: { _ in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
@@ -73,6 +73,7 @@ final class CardSectionWithScannerView: UIView {
         }
         UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1.0, initialSpringVelocity: 0.3, options: [.curveEaseInOut]) {
             self.cardScanButton.alpha = isCardScanVisible ? 0 : 1
+            self.cardScanningView.alpha = isCardScanVisible ? 1 : 0
             self.cardScanningView.setHiddenIfNecessary(!isCardScanVisible)
             self.layoutIfNeeded()
         } completion: { _ in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
@@ -69,10 +69,11 @@ final class CardSectionWithScannerView: UIView {
     }
 
     private func setCardScanVisible(_ isCardScanVisible: Bool) {
-        UIView.animate(withDuration: PaymentSheetUI.defaultAnimationDuration) {
+        UIView.animate(withDuration: 0.3, delay: 0, usingSpringWithDamping: 1.0, initialSpringVelocity: 0.3, options: [.curveEaseInOut]) {
             self.cardScanButton.alpha = isCardScanVisible ? 0 : 1
-            self.cardScanningView.setHiddenIfNecessary(!isCardScanVisible)
             self.cardScanningView.alpha = isCardScanVisible ? 1 : 0
+            self.cardScanningView.setHiddenIfNecessary(!isCardScanVisible)
+            self.layoutIfNeeded()
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
@@ -120,7 +120,7 @@ class CardScanningView: UIView, STPCardScannerDelegate {
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
-    
+
     private lazy var containerView: UIView = {
         let containerView = UIView()
         containerView.translatesAutoresizingMaskIntoConstraints = false
@@ -203,14 +203,14 @@ class CardScanningView: UIView, STPCardScannerDelegate {
         let bottomConstraint = containerView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
         bottomConstraint.priority = .defaultHigh
         self.clipsToBounds = true
-        
+
         self.addConstraints(
             [
                 containerView.topAnchor.constraint(equalTo: self.topAnchor),
                 containerView.leftAnchor.constraint(equalTo: self.leftAnchor),
                 containerView.rightAnchor.constraint(equalTo: self.rightAnchor),
                 bottomConstraint,
-                
+
                 cameraView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 0),
                 cameraView.leftAnchor.constraint(equalTo: containerView.leftAnchor, constant: 0),
                 cameraView.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: 0),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
@@ -120,6 +120,12 @@ class CardScanningView: UIView, STPCardScannerDelegate {
         button.translatesAutoresizingMaskIntoConstraints = false
         return button
     }()
+    
+    private lazy var containerView: UIView = {
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        return containerView
+    }()
 
     private func setupBlurView() {
         let vibrancyEffect = UIVibrancyEffect(blurEffect: blurEffect)
@@ -177,50 +183,63 @@ class CardScanningView: UIView, STPCardScannerDelegate {
 
         closeButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
 
-        self.addSubview(cameraView)
-        self.addSubview(cardOutlineView)
-        self.addSubview(cardOuterBlurView)
-        self.addSubview(errorLabel)
-        self.addSubview(closeButton)
+        self.addSubview(containerView)
+        containerView.addSubview(cameraView)
+        containerView.addSubview(cardOutlineView)
+        containerView.addSubview(cardOuterBlurView)
+        containerView.addSubview(errorLabel)
+        containerView.addSubview(closeButton)
 
-        self.layer.cornerRadius = CardScanningView.cornerRadius
+        containerView.layer.cornerRadius = CardScanningView.cornerRadius
         self.cameraView = cameraView
         cameraView.layer.cornerRadius = CardScanningView.cornerRadius
         self.cameraView?.translatesAutoresizingMaskIntoConstraints = false
         // The first few frames of the camera view will be black, so our background should be black too.
         self.cameraView?.backgroundColor = UIColor.black
+
+        // To get the right animation, we'll add a breakable bottom constraint
+        // and enable clipsToBounds. Then, when hidden, the view will shrink while
+        // the contents remain pinned to the top.
+        let bottomConstraint = containerView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        bottomConstraint.priority = .defaultHigh
+        self.clipsToBounds = true
+        
         self.addConstraints(
             [
-                cameraView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0),
-                cameraView.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 0),
-                cameraView.rightAnchor.constraint(equalTo: self.rightAnchor, constant: 0),
-                cameraView.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
+                containerView.topAnchor.constraint(equalTo: self.topAnchor),
+                containerView.leftAnchor.constraint(equalTo: self.leftAnchor),
+                containerView.rightAnchor.constraint(equalTo: self.rightAnchor),
+                bottomConstraint,
+                
+                cameraView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 0),
+                cameraView.leftAnchor.constraint(equalTo: containerView.leftAnchor, constant: 0),
+                cameraView.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: 0),
+                cameraView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 0),
 
-                cardOuterBlurView.topAnchor.constraint(equalTo: self.topAnchor, constant: 0),
-                cardOuterBlurView.leftAnchor.constraint(equalTo: self.leftAnchor, constant: 0),
-                cardOuterBlurView.rightAnchor.constraint(equalTo: self.rightAnchor, constant: 0),
-                cardOuterBlurView.bottomAnchor.constraint(equalTo: self.bottomAnchor, constant: 0),
+                cardOuterBlurView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 0),
+                cardOuterBlurView.leftAnchor.constraint(equalTo: containerView.leftAnchor, constant: 0),
+                cardOuterBlurView.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: 0),
+                cardOuterBlurView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 0),
 
-                errorLabel.centerYAnchor.constraint(equalTo: self.centerYAnchor, constant: 0),
+                errorLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor, constant: 0),
                 errorLabel.leftAnchor.constraint(equalTo: cardOutlineView.leftAnchor, constant: 8),
                 errorLabel.rightAnchor.constraint(
                     equalTo: cardOutlineView.rightAnchor, constant: -8),
 
-                closeButton.topAnchor.constraint(equalTo: self.topAnchor, constant: 8),
-                closeButton.rightAnchor.constraint(equalTo: self.rightAnchor, constant: -8),
+                closeButton.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 8),
+                closeButton.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: -8),
 
                 cardOutlineView.heightAnchor.constraint(
-                    equalTo: cardOutlineView.widthAnchor, multiplier: CardScanningView.cardSizeRatio
-                ),
+                    equalTo: cardOutlineView.widthAnchor, multiplier: CardScanningView.cardSizeRatio),
 
                 cardOutlineView.topAnchor.constraint(
-                    equalTo: self.topAnchor, constant: CardScanningView.cardInset),
+                    equalTo: containerView.topAnchor, constant: CardScanningView.cardInset),
                 cardOutlineView.leftAnchor.constraint(
-                    equalTo: self.leftAnchor, constant: CardScanningView.cardInset),
+                    equalTo: containerView.leftAnchor, constant: CardScanningView.cardInset),
                 cardOutlineView.rightAnchor.constraint(
-                    equalTo: self.rightAnchor, constant: -CardScanningView.cardInset),
+                    equalTo: containerView.rightAnchor, constant: -CardScanningView.cardInset),
                 cardOutlineView.bottomAnchor.constraint(
-                    equalTo: self.bottomAnchor, constant: -CardScanningView.cardInset),
+                    equalTo: containerView.bottomAnchor, constant: -CardScanningView.cardInset),
             ])
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
@@ -169,6 +169,22 @@ class CardScanningView: UIView, STPCardScannerDelegate {
         self.stop()
     }
 
+    var snapshotView: UIView?
+
+    // The shape layers don't animate cleanly during setHidden,
+    // so let's use a snapshot view instead.
+    func prepDismissAnimation() {
+        if let snapshot = self.containerView.snapshotView(afterScreenUpdates: true) {
+            self.addSubview(snapshot)
+            self.snapshotView = snapshot
+        }
+    }
+
+    func completeDismissAnimation() {
+        snapshotView?.removeFromSuperview()
+        snapshotView = nil
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         self.setupBlurView()


### PR DESCRIPTION
## Summary
This "Scan Card" animation has been bugging me: It overlaps the other fields as it animates out.

* To fix this, I pinned it to the top of a container view, unpinned the bottom, and enabled clipsToBounds. It'll now stay stuck to the top of the container while the container's size animates down to 0.
* I also moved the disabling of the captureSession to *after* the animation kicks off to make closing the view a little more responsive, as disconnecting the camera input blocks the main thread for a bit.
* Also switched the animation to use a basic spring.

| Before | After |
| ------ | ----- |
| ![CleanShot 2025-03-25 at 14 41 10](https://github.com/user-attachments/assets/f1d58a56-378a-4ef3-b59e-8c9b07273d8d) | ![CleanShot 2025-03-25 at 14 39 29](https://github.com/user-attachments/assets/1724d3b7-f13f-41fe-92b4-18100a8e836a) |

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1302

## Testing
Tested in simulator and on an iPhone 16 Pro

## Changelog
Not significant enough