### PR TITLE
Allowing JP and CN characters in name field

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
@@ -193,7 +193,14 @@ class TextFieldView: UIView {
         // the same relative position in case attributedText adds more characters
         let cursorOffsetFromEnd = textField.selectedTextRange.map { textField.offset(from: textField.endOfDocument, to: $0.end) }
 
-        textField.attributedText = viewModel.attributedText
+        // Don't mess with attributed text if the IME is currently in progress (Japanese/Chinese/Hindi characters)
+        // Note: Setting textField.attributedText cancels the IME
+        if textField.markedTextRange != nil {
+            textField.text = viewModel.attributedText.string
+        } else {
+            textField.attributedText = viewModel.attributedText
+        }
+
         if let cursorOffsetFromEnd = cursorOffsetFromEnd,
            let cursor = textField.position(from: textField.endOfDocument, offset: cursorOffsetFromEnd) {
             // Re-set the cursor back to where it was


### PR DESCRIPTION
## Summary
Setting a UITextField's attributedText field apparently cancels the ability to type most hiragana and katakana characters.  For example, it's impossible to any hiragana represented as two(or more) roman characters: "ko"(こ) , "ni"　（に）, "chi"　（ち）, "wa"　（わ） but possible to input single roman characters that represent "a" (あ）, "i'（い）, "e"　（え）,  "u"（う）"o"（お).

Note that this is also possible with Hiragana keyboard (Shaped like a T9).  Attempt to type "ta" (た)  and then you'll realize you're unable to access the modifiers which make it:  "da" (だ).

## Motivation
Unable to input characters.

## Testing
Manually. The testing story here isn't great.  Unit tests don't easy/useful... I can try to write some ui tests (but would require setting the emulator's keyboard to JP), which i'm not quite sure how to do right now.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
