### PR TITLE
Remove reset() from PaymentSheet

### DIFF
--- a/CHANGELOG_v25_draft.md
+++ b/CHANGELOG_v25_draft.md
@@ -1,2 +1,5 @@
+### PaymentSheet
+* [Removed] Removed `PaymentSheet.reset()` in favor of `PaymentSheet.resetCustomer()`.
+
 ### Financial Connections
 * [Added] Added an async versions of `present(from:)` and `presentForToken(from:)`.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -209,18 +209,6 @@ public class PaymentSheet {
     /// You must call this method when the user logs out from your app.
     /// This will ensure that any persisted authentication state in PaymentSheet,
     /// such as authentication cookies, is also cleared during logout.
-    ///
-    /// - Warning: Deprecated. Use `PaymentSheet.resetCustomer()` instead.
-    @available(*, deprecated, renamed: "resetCustomer()")
-    public static func reset() {
-        resetCustomer()
-    }
-
-    /// Deletes all persisted authentication state associated with a customer.
-    ///
-    /// You must call this method when the user logs out from your app.
-    /// This will ensure that any persisted authentication state in PaymentSheet,
-    /// such as authentication cookies, is also cleared during logout.
     public static func resetCustomer() {
         UserDefaults.standard.clearLinkDefaults()
     }


### PR DESCRIPTION
## Summary
- Removed `reset` in favor of `resetCustomer`

## Motivation
https://docs.google.com/document/d/1DVnqjz5gLAP_JbjxZJ0Ptdv72hO0jTfreYx6_CdcGn0/edit?tab=t.0

## Testing
- Compiler

## Changelog
See diff
