### PR TITLE
[FCLite] Add UI test

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard1.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard1.xctestplan
@@ -33,6 +33,8 @@
       "skippedTests" : [
         "EmbeddedUITests",
         "EmbeddedUITests\/testUpdate()",
+        "FCLiteUITests",
+        "FCLiteUITests\/testFCLiteInitialPaneAndDismiss()",
         "PaymentSheetBillingCollectionLPMUITests",
         "PaymentSheetBillingCollectionUICardTests",
         "PaymentSheetBillingCollectionUITestCase",

--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard3.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard3.xctestplan
@@ -35,6 +35,8 @@
         "CustomerSheetUITest",
         "EmbeddedUITests",
         "EmbeddedUITests\/testUpdate()",
+        "FCLiteUITests",
+        "FCLiteUITests\/testFCLiteInitialPaneAndDismiss()",
         "LinkPaymentControllerUITest",
         "PaymentSheetBillingCollectionBankTests",
         "PaymentSheetCVCRecollectionUITests",

--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard4.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard4.xctestplan
@@ -33,6 +33,8 @@
       "skippedTests" : [
         "CustomerSheetSnapshotTests",
         "CustomerSheetUITest",
+        "FCLiteUITests",
+        "FCLiteUITests\/testFCLiteInitialPaneAndDismiss()",
         "LinkPaymentControllerUITest",
         "PaymentSheetBillingCollectionBankTests",
         "PaymentSheetBillingCollectionLPMUITests",

--- a/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		424BBBEBF25E5F020FF40F36 /* Stripe3DS2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C2655A8B1DF0649CD996E045 /* Stripe3DS2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		432E82C3F5EC56E89D257563 /* ExampleSwiftUIPaymentSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7AFD32B5EAD3BEEEC3D4260 /* ExampleSwiftUIPaymentSheet.swift */; };
 		4694B03B08B7DA9706A2ED9D /* AppearancePlaygroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D025413F3246E241A1DFE5C /* AppearancePlaygroundView.swift */; };
+		4954E96F2D960E340061585F /* FCLiteUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4954E96E2D960E340061585F /* FCLiteUITests.swift */; };
 		4E3F7EFF78BC4F14D18024E7 /* PaymentSheetLocalizationScreenshotGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA08203146CADE9649CF0EAD /* PaymentSheetLocalizationScreenshotGenerator.swift */; };
 		540F279CE5B41C122AD1DEF6 /* PaymentSheetUITest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA299EAF5914484195167EB /* PaymentSheetUITest.swift */; };
 		5441EB34BBE32DD98B7A6883 /* CustomerSheetTestPlaygroundSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2806FC6A4514AA88A26B32CD /* CustomerSheetTestPlaygroundSettings.swift */; };
@@ -186,6 +187,7 @@
 		4546705B6D6BCA883F5532B8 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		4609AB90957A6F72852677BF /* PaymentSheet-Example-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "PaymentSheet-Example-Release.xcconfig"; sourceTree = "<group>"; };
 		47F5ABF3CE2F657E0085EBB2 /* mt */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = mt; path = mt.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
+		4954E96E2D960E340061585F /* FCLiteUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteUITests.swift; sourceTree = "<group>"; };
 		4A52C114362A90EF8A5BBA1A /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		4AD9595F2BD9D48997A44309 /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		4E74185DD2F7DC4BBDC4774A /* ExampleCheckoutDeferredViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleCheckoutDeferredViewController.swift; sourceTree = "<group>"; };
@@ -434,6 +436,7 @@
 				36BB679CF53EEF943F0BAAC9 /* XCUITest+Utilities.swift */,
 				6B03B12E2CDA88F900F95A9D /* XCUITest+PaymentSheetTestUtilities.swift */,
 				6A5CCDA32C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift */,
+				4954E96E2D960E340061585F /* FCLiteUITests.swift */,
 			);
 			path = PaymentSheetUITest;
 			sourceTree = "<group>";
@@ -680,6 +683,7 @@
 				540F279CE5B41C122AD1DEF6 /* PaymentSheetUITest.swift in Sources */,
 				6A5CCDA42C0E6F5D003306A4 /* LinkPaymentControllerUITest.swift in Sources */,
 				6B03B12F2CDA890700F95A9D /* XCUITest+PaymentSheetTestUtilities.swift in Sources */,
+				4954E96F2D960E340061585F /* FCLiteUITests.swift in Sources */,
 				EE0FA73AAB80863583C69D70 /* XCUITest+Utilities.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
@@ -1,0 +1,61 @@
+//
+//  FCLiteUITests.swift
+//  PaymentSheetUITest
+//
+//  Created by Mat Schmid on 2025-03-27.
+//
+
+import XCTest
+
+// FC Lite UI tests should be kept barebones.
+// By nature of this flow being a webview, the content is prone to changes.
+class FCLiteUITests: XCTestCase {
+    var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
+        app = XCUIApplication()
+    }
+
+    func testFCLiteInitialPaneAndDismiss() throws {
+        // Setup playground
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.fcLiteEnabled = .on
+        settings.apmsEnabled = .off
+        settings.supportedPaymentMethods = "card,us_bank_account"
+        settings.layout = .vertical
+
+        loadPlayground(app, settings)
+        app.buttons["Present PaymentSheet"].tap()
+
+        // Launch into FC Lite
+        XCTAssertTrue(app.buttons["US bank account"].waitForExistenceAndTap())
+        let continueButton = app.buttons["Continue"]
+        XCTAssertFalse(continueButton.isEnabled)
+        app.textFields["Full name"].tap()
+        app.typeText("John Doe" + XCUIKeyboardKey.return.rawValue)
+        app.typeText("test-\(UUID().uuidString)@example.com" + XCUIKeyboardKey.return.rawValue)
+        XCTAssertTrue(continueButton.isEnabled)
+        continueButton.tap()
+
+        // Check that we're either on the consent pane or the institution picker pane.
+        // The FC Lite flow should usually open to the consent pane,
+        // but there are niche scenarios where we open to the institution picker pane.
+        let agreeButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Agree'") // Consent pane
+        let institutionButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Institution'") // Institution picker pane
+        let agreeButtonOrInstitutionButtonPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [agreeButtonPredicate, institutionButtonPredicate])
+        let agreeButtonOrInstitutionButton = app.webViews.firstMatch.buttons.containing(agreeButtonOrInstitutionButtonPredicate).firstMatch
+        // Webviews can take a while to load.
+        XCTAssertTrue(agreeButtonOrInstitutionButton.waitForExistence(timeout: 20.0))
+
+        // Dismiss the flow
+        let closeButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Close'")
+        let closeButton = app.webViews.firstMatch.buttons.containing(closeButtonPredicate).firstMatch
+        XCTAssertTrue(closeButton.waitForExistenceAndTap(timeout: 5.0))
+
+        // Ensure the flow is dismissed by checking the continue button.
+        XCTAssertTrue(continueButton.waitForExistence(timeout: 5.0))
+        XCTAssertTrue(continueButton.isHittable)
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
@@ -23,21 +23,16 @@ class FCLiteUITests: XCTestCase {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.fcLiteEnabled = .on
         settings.apmsEnabled = .off
-        settings.supportedPaymentMethods = "card,us_bank_account"
+        settings.supportedPaymentMethods = "us_bank_account"
         settings.layout = .vertical
+        settings.defaultBillingAddress = .randomEmail
 
         loadPlayground(app, settings)
         app.buttons["Present PaymentSheet"].tap()
 
         // Launch into FC Lite
-        XCTAssertTrue(app.buttons["US bank account"].waitForExistenceAndTap())
         let continueButton = app.buttons["Continue"]
-        XCTAssertFalse(continueButton.isEnabled)
-        app.textFields["Full name"].tap()
-        app.typeText("John Doe" + XCUIKeyboardKey.return.rawValue)
-        app.typeText("test-\(UUID().uuidString)@example.com" + XCUIKeyboardKey.return.rawValue)
-        XCTAssertTrue(continueButton.isEnabled)
-        continueButton.tap()
+        XCTAssertTrue(continueButton.waitForExistenceAndTap())
 
         // Check that we're either on the consent pane or the institution picker pane.
         // The FC Lite flow should usually open to the consent pane,
@@ -47,7 +42,7 @@ class FCLiteUITests: XCTestCase {
         let agreeButtonOrInstitutionButtonPredicate = NSCompoundPredicate(orPredicateWithSubpredicates: [agreeButtonPredicate, institutionButtonPredicate])
         let agreeButtonOrInstitutionButton = app.webViews.firstMatch.buttons.containing(agreeButtonOrInstitutionButtonPredicate).firstMatch
         // Webviews can take a while to load.
-        XCTAssertTrue(agreeButtonOrInstitutionButton.waitForExistence(timeout: 20.0))
+        XCTAssertTrue(agreeButtonOrInstitutionButton.waitForExistence(timeout: 30.0))
 
         // Dismiss the flow
         let closeButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Close'")


### PR DESCRIPTION
## Summary

Adds a UI test for the FC Lite flow integration in the PaymentSheet Example app. The test is intentionally kept fairly barebones. By nature of this flow being a webview, the content is prone to changes, and we don't want to introduce flaky tests.

https://github.com/user-attachments/assets/ed83ca0a-8c9c-4e53-9017-6067511a11d1

## Motivation

Ensure the flow opens and closes.

## Testing

✅ 

## Changelog

N/a
