### PR TITLE
Increase area of back button tap targeting

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
@@ -28,6 +28,7 @@ class SheetNavigationBar: UIView {
         stack.alignment = .center
         return stack
     }()
+    // Used for allowing larger tap area to the left of closeButtonLeft
     fileprivate lazy var dummyView: UIView = {
         let dummyView = UIView(frame: .zero)
         return dummyView

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
@@ -22,9 +22,15 @@ class SheetNavigationBar: UIView {
     static let height: CGFloat = 48
     weak var delegate: SheetNavigationBarDelegate?
     fileprivate lazy var leftItemsStackView: UIStackView = {
-        let stack = UIStackView(arrangedSubviews: [closeButtonLeft, backButton, testModeView])
+        let stack = UIStackView(arrangedSubviews: [dummyView, closeButtonLeft, backButton, testModeView])
         stack.spacing = PaymentSheetUI.defaultPadding
+        stack.setCustomSpacing(PaymentSheetUI.navBarPadding, after: dummyView)
+        stack.alignment = .center
         return stack
+    }()
+    fileprivate lazy var dummyView: UIView = {
+        let dummyView = UIView(frame: .zero)
+        return dummyView
     }()
     fileprivate lazy var closeButtonLeft: UIButton = {
         let button = SheetNavigationButton(type: .custom)
@@ -88,11 +94,11 @@ class SheetNavigationBar: UIView {
         }
 
         NSLayoutConstraint.activate([
-            leftItemsStackView.leadingAnchor.constraint(
-                equalTo: leadingAnchor, constant: PaymentSheetUI.navBarPadding),
+            leftItemsStackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 0),
             leftItemsStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
             leftItemsStackView.trailingAnchor.constraint(lessThanOrEqualTo: closeButtonRight.leadingAnchor),
             leftItemsStackView.trailingAnchor.constraint(lessThanOrEqualTo: additionalButton.leadingAnchor),
+            leftItemsStackView.heightAnchor.constraint(equalTo: heightAnchor),
 
             additionalButton.trailingAnchor.constraint(
                 equalTo: trailingAnchor, constant: -PaymentSheetUI.navBarPadding),


### PR DESCRIPTION
## Summary
Increases the tappable area of the back button

## Motivation
back button is too hard to tap!

## Testing
Manual testing and relying on all the snapshot tests in `PaymentSheetVerticalViewControllerSnapshotTest`

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
