### PR TITLE
Animation jank when removing the last payment method in vertical

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -377,11 +377,10 @@ extension VerticalSavedPaymentMethodsViewController: UpdatePaymentMethodViewCont
         }
         // if it's the last saved pm, there's some animation jank from trying to quickly dismiss the update pm screen and the manage screen, so we wait until the update pm screen is dismissed, animate the payment method fading, and return to the main screen
         if paymentMethodRows.count == 1 {
-            _ = viewController.bottomSheetController?.popContentViewController() {
+            _ = viewController.bottomSheetController?.popContentViewController {
                 self.remove(paymentMethod: paymentMethod)
             }
-        }
-        else {
+        } else {
             remove(paymentMethod: paymentMethod)
             _ = viewController.bottomSheetController?.popContentViewController()
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -50,7 +50,10 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         didSet {
             let additionalButtonTitle = isEditingPaymentMethods ? UIButton.doneButtonTitle : UIButton.editButtonTitle
             navigationBar.additionalButton.setTitle(additionalButtonTitle, for: .normal)
-            headerLabel.text = headerText
+            // Update header text unless we removed the last pm and we're getting kicked out to the main screen
+            if !paymentMethodRows.isEmpty {
+                headerLabel.text = headerText
+            }
 
             // If we are entering edit mode, put all buttons in an edit state, otherwise put back in their previous state
             if isEditingPaymentMethods {
@@ -263,7 +266,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
 
         // If we deleted the last payment method kick back out to the main screen
         if paymentMethodRows.isEmpty {
-            complete()
+            complete(afterDelay: 0.3)
         }
     }
 
@@ -372,8 +375,16 @@ extension VerticalSavedPaymentMethodsViewController: UpdatePaymentMethodViewCont
         if isDefaultPaymentMethod(paymentMethodId: paymentMethod.stripeId) {
             defaultPaymentMethod = nil
         }
-        remove(paymentMethod: paymentMethod)
-       _ = viewController.bottomSheetController?.popContentViewController()
+        // if it's the last saved pm, there's some animation jank from trying to quickly dismiss the update pm screen and the manage screen, so we wait until the update pm screen is dismissed, animate the payment method fading, and return to the main screen
+        if paymentMethodRows.count == 1 {
+            _ = viewController.bottomSheetController?.popContentViewController() {
+                self.remove(paymentMethod: paymentMethod)
+            }
+        }
+        else {
+            remove(paymentMethod: paymentMethod)
+            _ = viewController.bottomSheetController?.popContentViewController()
+        }
     }
 
     func didUpdate(viewController: UpdatePaymentMethodViewController,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
When removing the last payment method, show the payment method fading out before returning to the main screen instead of popping the update screen and manage screen in quick succession.
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
[MOBILESDK-2839](https://jira.corp.stripe.com/browse/MOBILESDK-2839)

## Testing
<!-- How was the code tested? Be as specific as possible. -->

- Manually

Before:

https://github.com/user-attachments/assets/079fe4b1-a1b0-4d25-a015-d3b7963b3d92




After:

https://github.com/user-attachments/assets/acae03de-f3d5-4031-98aa-3d2247c6c680


## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A