### PR TITLE
Deflake testPreservesFormDetails

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -545,7 +545,7 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
             app.typeText("4")
             // ...and tapping to a different form and back...
             XCTAssertTrue(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Cash App Pay")?.waitForExistenceAndTap() ?? false)
-            XCTAssertTrue(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Card")?.waitForExistenceAndTap() ?? false)
+            XCTAssertTrue(scroll(collectionView: app.collectionViews.firstMatch, toFindCellWithId: "Card", direction: .left)?.waitForExistenceAndTap() ?? false)
             // ...should preserve the card form
             XCTAssertEqual(numberField.value as? String, "4, Your card number is incomplete.")
             // ...tapping to the saved PM screen and back should do the same


### PR DESCRIPTION
## Summary
Sometimes cashapp appears as the last payment method, but our testing logic doesn't know how to scroll to the left, so i've updated the testing utilities to scroll left.

## Motivation
Test is flakey

## Testing
Manually forced the payment methods  in `PaymentSheetLoader.swift` to be:
```
+                    paymentMethodTypes: [.stripe(.card), .stripe(.amazonPay), .stripe(.USBankAccount), .stripe(.cashApp)]
```
Then ran this specific test to ensure we can scroll left and right

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
