### PR TITLE
[Async Migration] Consent pane

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -188,6 +188,16 @@ final class FinancialConnectionsAsyncAPIClient {
 }
 
 protocol FinancialConnectionsAsyncAPI {
+    var isLinkWithStripe: Bool { get set }
+    var consumerPublishableKey: String? { get set }
+    var consumerSession: ConsumerSessionData? { get set }
+
+    func completeAssertion(
+        possibleError: Error?,
+        api: FinancialConnectionsAPIClientLogger.API,
+        pane: FinancialConnectionsSessionManifest.NextPane
+    ) -> Error?
+
     func synchronize(
         clientSecret: String,
         returnURL: String?,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -89,6 +89,7 @@ class HostController {
     // MARK: - Properties
 
     private let apiClient: any FinancialConnectionsAPI
+    private let asyncApiClient: any FinancialConnectionsAsyncAPI
     private let clientSecret: String
     private let returnURL: String?
     private let configuration: FinancialConnectionsSheet.Configuration
@@ -117,6 +118,7 @@ class HostController {
 
     init(
         apiClient: any FinancialConnectionsAPI,
+        asyncApiClient: any FinancialConnectionsAsyncAPI,
         analyticsClientV1: STPAnalyticsClientProtocol,
         clientSecret: String,
         returnURL: String?,
@@ -126,6 +128,7 @@ class HostController {
         stripeAccount: String?
     ) {
         self.apiClient = apiClient
+        self.asyncApiClient = asyncApiClient
         self.analyticsClientV1 = analyticsClientV1
         self.clientSecret = clientSecret
         self.returnURL = returnURL
@@ -243,6 +246,7 @@ private extension HostController {
             consentPaneModel: synchronizePayload.text?.consentPane,
             accountPickerPane: synchronizePayload.text?.accountPickerPane,
             apiClient: apiClient,
+            asyncApiClient: asyncApiClient,
             clientSecret: clientSecret,
             analyticsClient: analyticsClient,
             elementsSessionContext: elementsSessionContext

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -298,14 +298,16 @@ final public class FinancialConnectionsSheet {
             }
         }
 
+        let asyncApiClient = FinancialConnectionsAsyncAPIClient(apiClient: apiClient)
         let financialConnectionsApiClient: any FinancialConnectionsAPI
         if ExperimentStore.shared.useAsyncAPIClient {
-            financialConnectionsApiClient = FinancialConnectionsAsyncAPIClient(apiClient: apiClient)
+            financialConnectionsApiClient = asyncApiClient
         } else {
             financialConnectionsApiClient = FinancialConnectionsAPIClient(apiClient: apiClient)
         }
         hostController = HostController(
             apiClient: financialConnectionsApiClient,
+            asyncApiClient: asyncApiClient,
             analyticsClientV1: analyticsClient,
             clientSecret: financialConnectionsSessionClientSecret,
             returnURL: returnURL,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1492,7 +1492,7 @@ private func CreatePaneViewController(
                 manifest: dataManager.manifest,
                 consent: consentPaneModel,
                 merchantLogo: dataManager.merchantLogo,
-                apiClient: dataManager.apiClient,
+                apiClient: dataManager.asyncApiClient,
                 clientSecret: dataManager.clientSecret,
                 analyticsClient: dataManager.analyticsClient,
                 elementsSessionContext: dataManager.elementsSessionContext

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -17,6 +17,7 @@ protocol NativeFlowDataManager: AnyObject {
     var consentPaneModel: FinancialConnectionsConsent? { get }
     var accountPickerPane: FinancialConnectionsAccountPickerPane? { get }
     var apiClient: any FinancialConnectionsAPI { get }
+    var asyncApiClient: any FinancialConnectionsAsyncAPI { get }
     var clientSecret: String { get }
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var elementsSessionContext: ElementsSessionContext? { get }
@@ -85,6 +86,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     var idConsentContent: FinancialConnectionsIDConsentContent?
     let accountPickerPane: FinancialConnectionsAccountPickerPane?
     var apiClient: any FinancialConnectionsAPI
+    var asyncApiClient: any FinancialConnectionsAsyncAPI
     let clientSecret: String
     let analyticsClient: FinancialConnectionsAnalyticsClient
     let elementsSessionContext: ElementsSessionContext?
@@ -106,12 +108,14 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     var consumerSession: ConsumerSessionData? {
         didSet {
             apiClient.consumerSession = consumerSession
+            asyncApiClient.consumerSession = consumerSession
         }
     }
 
     var consumerPublishableKey: String? {
         didSet {
             apiClient.consumerPublishableKey = consumerPublishableKey
+            asyncApiClient.consumerPublishableKey = consumerPublishableKey
         }
     }
 
@@ -123,6 +127,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         consentPaneModel: FinancialConnectionsConsent?,
         accountPickerPane: FinancialConnectionsAccountPickerPane?,
         apiClient: any FinancialConnectionsAPI,
+        asyncApiClient: any FinancialConnectionsAsyncAPI,
         clientSecret: String,
         analyticsClient: FinancialConnectionsAnalyticsClient,
         elementsSessionContext: ElementsSessionContext?
@@ -134,6 +139,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         self.consentPaneModel = consentPaneModel
         self.accountPickerPane = accountPickerPane
         self.apiClient = apiClient
+        self.asyncApiClient = asyncApiClient
         self.clientSecret = clientSecret
         self.analyticsClient = analyticsClient
         self.elementsSessionContext = elementsSessionContext
@@ -175,7 +181,9 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
     }
 
     private func didUpdateManifest() {
-        apiClient.isLinkWithStripe = manifest.isLinkWithStripe == true
+        let isLinkWithStripe = manifest.isLinkWithStripe == true
+        apiClient.isLinkWithStripe = isLinkWithStripe
+        asyncApiClient.isLinkWithStripe = isLinkWithStripe
         analyticsClient.setAdditionalParameters(fromManifest: manifest)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
@@ -23,6 +23,9 @@ class FinancialConnectionsSheetTests: XCTestCase {
     private let mockApiClient = FinancialConnectionsAPIClient(
         apiClient: APIStubbedTestCase.stubbedAPIClient()
     )
+    private let mockAsyncApiClient = FinancialConnectionsAsyncAPIClient(
+        apiClient: APIStubbedTestCase.stubbedAPIClient()
+    )
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -49,6 +52,7 @@ class FinancialConnectionsSheetTests: XCTestCase {
         // Mock that financialConnections is completed
         let host = HostController(
             apiClient: mockApiClient,
+            asyncApiClient: mockAsyncApiClient,
             analyticsClientV1: mockAnalyticsClient,
             clientSecret: "test",
             returnURL: nil,
@@ -81,6 +85,7 @@ class FinancialConnectionsSheetTests: XCTestCase {
         // Mock that financialConnections is completed
         let host = HostController(
             apiClient: mockApiClient,
+            asyncApiClient: mockAsyncApiClient,
             analyticsClientV1: mockAnalyticsClient,
             clientSecret: "test",
             returnURL: nil,
@@ -129,6 +134,7 @@ class FinancialConnectionsSheetTests: XCTestCase {
         // Mock that financialConnections is completed
         let host = HostController(
             apiClient: mockApiClient,
+            asyncApiClient: mockAsyncApiClient,
             analyticsClientV1: mockAnalyticsClient,
             clientSecret: "test",
             returnURL: nil,


### PR DESCRIPTION
> [!NOTE]  
>Part 1 of many in the migration to the Swift Concurrency based API client.

## Summary

Migrates the Consent view controller and data source to the `FinancialConnectionsAsyncAPI`. There should be no functional changes.

## Motivation

Async everywhere

## Testing
Manually tested. For context, we've been using the async API client default in the Financial Connections Example app for many weeks now.

https://github.com/user-attachments/assets/f926df96-f529-42b5-bd61-bf41c2861c33

## Changelog

N/a - this change is fully behind the scenes.