### PR TITLE
[Async Migration] Host Controller

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -188,6 +188,8 @@ final class FinancialConnectionsAsyncAPIClient {
 }
 
 protocol FinancialConnectionsAsyncAPI {
+    var backingAPIClient: STPAPIClient { get }
+
     var isLinkWithStripe: Bool { get set }
     var consumerPublishableKey: String? { get set }
     var consumerSession: ConsumerSessionData? { get set }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostController.swift
@@ -103,7 +103,7 @@ class HostController {
         analyticsClientV1: analyticsClientV1,
         clientSecret: clientSecret,
         returnURL: returnURL,
-        apiClient: apiClient,
+        apiClient: asyncApiClient,
         delegate: self
     )
     lazy var navigationController: FinancialConnectionsNavigationController = {


### PR DESCRIPTION
> [!NOTE]  
>Part 2 of many in the migration to the Swift Concurrency based API client.

## Summary

Migrates the host controller to the `FinancialConnectionsAsyncAPI`. There should be no functional changes.

## Motivation

Async everywhere

## Testing

Manually tested. For context, we've been using the async API client default in the Financial Connections Example app for many weeks now.

## Changelog

N/a