### PR TITLE
[Async Migration] Account Picker

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -1421,7 +1421,7 @@ private func CreatePaneViewController(
     case .accountPicker:
         if let authSession = dataManager.authSession, let institution = dataManager.institution {
             let accountPickerDataSource = AccountPickerDataSourceImplementation(
-                apiClient: dataManager.apiClient,
+                apiClient: dataManager.asyncApiClient,
                 clientSecret: dataManager.clientSecret,
                 accountPickerPane: dataManager.accountPickerPane,
                 authSession: authSession,


### PR DESCRIPTION
> [!NOTE]  
>Part 4 of many in the migration to the Swift Concurrency based API client.

## Summary

Migrates the Account Picker pane and its data source to the `FinancialConnectionsAsyncAPI`. There should be no functional changes.

## Motivation

Async everywhere

## Testing

Manually tested. For context, we've been using the async API client default in the Financial Connections Example app for many weeks now.

https://github.com/user-attachments/assets/cde7482e-6e36-494c-8d61-387c41d3ba3d

## Changelog

N/a
