### PR TITLE
Fix `target_version_is_newer` CI script

### DIFF
--- a/ci_scripts/validate_version_number.rb
+++ b/ci_scripts/validate_version_number.rb
@@ -17,8 +17,8 @@ def validate_version_number_format(version_number)
 end
 
 def target_version_is_newer(target_version, current_version)
-  target_major, target_minor, target_patch = target_version.split('.')
-  current_major, current_minor, current_patch = current_version.split('.')
+  target_major, target_minor, target_patch = target_version.split('.').map(&:to_i)
+  current_major, current_minor, current_patch = current_version.split('.').map(&:to_i)
 
   if target_major < current_major
     false
@@ -39,13 +39,13 @@ def get_current_version()
 end
 
 def validate_target_version_is_newer(target_version)
-    current_version = get_current_version()
-    if !target_version_is_newer(target_version, current_version)
-        raise "Expected target version #{target_version} to be newer than #{current_version}."
-    end
+  current_version = get_current_version()
+  if !target_version_is_newer(target_version, current_version)
+    raise "Expected target version #{target_version} to be newer than #{current_version}."
+  end
 end
 
 def validate_version_number()
-    validate_version_number_format(@version)
-    validate_target_version_is_newer(@version)
+  validate_version_number_format(@version)
+  validate_target_version_is_newer(@version)
 end


### PR DESCRIPTION
## Summary

Fixes a bug in our CI script `target_version_is_newer` that was flagging `24.10.0` as not newer than `24.9.0`. This was due to Ruby's String comparison, that performs lexicographical (dictionary) comparison, not numerical comparison.

## Motivation

Fixes our CI script

## Testing

On `master`:

<img width="1277" alt="Screenshot 2025-03-31 at 4 07 57 PM" src="https://github.com/user-attachments/assets/18bde8bc-c9d4-4713-8773-ccbace22e734" />

On this branch:

<img width="296" alt="Screenshot 2025-03-31 at 4 11 22 PM" src="https://github.com/user-attachments/assets/34c88e43-b9ac-4fa0-9db0-7eb1cd0556b7" />

## Changelog

N/a
