### PR TITLE
Clear payment option for immediateAction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### PaymentSheet
+* [Added] Added `rowSelectionBehavior` API to Embedded Payment Element (private preview).
+
 ## 24.10.0 2025-03-31
 ### PaymentSheet
 * [Added] Added `LinkConfiguration` to allow control over Link in PaymentSheet.

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -222,6 +222,9 @@ class PlaygroundController: ObservableObject {
 
         var configuration = EmbeddedPaymentElement.Configuration()
         configuration.formSheetAction = formSheetAction
+        configuration.rowSelectionBehavior = .immediateAction(didSelectPaymentOption: {
+            // no-op
+        })
         configuration.embeddedViewDisplaysMandateText = settings.embeddedViewDisplaysMandateText == .on
         configuration.externalPaymentMethodConfiguration = externalPaymentMethodConfiguration
         configuration.customPaymentMethodConfiguration = customPaymentMethodConfiguration

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -222,9 +222,6 @@ class PlaygroundController: ObservableObject {
 
         var configuration = EmbeddedPaymentElement.Configuration()
         configuration.formSheetAction = formSheetAction
-        configuration.rowSelectionBehavior = .immediateAction(didSelectPaymentOption: {
-            // no-op
-        })
         configuration.embeddedViewDisplaysMandateText = settings.embeddedViewDisplaysMandateText == .on
         configuration.externalPaymentMethodConfiguration = externalPaymentMethodConfiguration
         configuration.customPaymentMethodConfiguration = customPaymentMethodConfiguration

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -550,6 +550,15 @@ extension EmbeddedPaymentElement {
         })
     }
 
+    func clearPaymentOptionIfNeeded() {
+        guard case .immediateAction = configuration.rowSelectionBehavior,
+           case .confirm = configuration.formSheetAction else {
+            return
+        }
+
+        clearPaymentOption()
+    }
+
     static func validateRowSelectionConfiguration(configuration: Configuration) throws {
         if case .immediateAction = configuration.rowSelectionBehavior,
            case .confirm = configuration.formSheetAction {
@@ -596,6 +605,17 @@ extension EmbeddedPaymentElement.Configuration.RowSelectionBehavior: Equatable {
         case (.immediateAction, .immediateAction):
             return true
         default:
+            return false
+        }
+    }
+}
+
+extension PaymentSheetResult {
+    var isCanceledOrFailed: Bool {
+        switch self {
+        case .canceled, .failed:
+            return true
+        case .completed:
             return false
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -52,6 +52,11 @@ class EmbeddedPaymentElementTest: XCTestCase {
     var delegateDidUpdateHeightCalled = false
     var delegateWillPresentCalled = false
 
+    func tearDown() {
+        super.tearDown()
+        STPAnalyticsClient.sharedClient._testLogHistory = []
+    }
+    
     // MARK: - `update` tests
 
     func testUpdate() async throws {
@@ -274,8 +279,6 @@ class EmbeddedPaymentElementTest: XCTestCase {
     }
 
     func testConfirmCard() async throws {
-        STPAnalyticsClient.sharedClient._testLogHistory = []
-        
         // Given an EmbeddedPaymentElement instance...
         let sut = try await EmbeddedPaymentElement.create(intentConfiguration: paymentIntentConfigWithConfirmHandler, configuration: configuration)
         sut.delegate = self

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -56,7 +56,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
         super.tearDown()
         STPAnalyticsClient.sharedClient._testLogHistory = []
     }
-    
+
     // MARK: - `update` tests
 
     func testUpdate() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -743,6 +743,28 @@ class EmbeddedPaymentElementTest: XCTestCase {
         }
     }
 
+    func testCancelingFormResetsPaymentOption() async throws {
+        // Create our EmbeddedPaymentElement
+        let sut = try await EmbeddedPaymentElement.create(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+        sut.delegate = self
+        sut.presentingViewController = UIViewController()
+
+        // Fill out a card
+        sut.embeddedPaymentMethodsView.didTap(
+            rowButton: sut.embeddedPaymentMethodsView.getRowButton(accessibilityIdentifier: "Card")
+        )
+        let cardForm = sut.formCache[.stripe(.card)]!
+        cardForm.getTextFieldElement("Card number").setText("4242424242424242")
+        cardForm.getTextFieldElement("MM / YY").setText("1240")
+        cardForm.getTextFieldElement("CVC").setText("123")
+        cardForm.getTextFieldElement("ZIP").setText("12345")
+        sut.selectedFormViewController?.didTapOrSwipeToDismiss() // Tap cancel to close
+        XCTAssertNil(sut.paymentOption, "Payment option should be nil after filling out the card form, but hitting cancel.")
+    }
+
     // MARK: Immediate action tests
 
     func testCreateFails_whenImmediateActionWithConfirmAndCustomer() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -52,7 +52,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
     var delegateDidUpdateHeightCalled = false
     var delegateWillPresentCalled = false
 
-    func tearDown() {
+    override func tearDown() {
         super.tearDown()
         STPAnalyticsClient.sharedClient._testLogHistory = []
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -274,6 +274,8 @@ class EmbeddedPaymentElementTest: XCTestCase {
     }
 
     func testConfirmCard() async throws {
+        STPAnalyticsClient.sharedClient._testLogHistory = []
+        
         // Given an EmbeddedPaymentElement instance...
         let sut = try await EmbeddedPaymentElement.create(intentConfiguration: paymentIntentConfigWithConfirmHandler, configuration: configuration)
         sut.delegate = self


### PR DESCRIPTION
## Summary
- When rowSelectionBehavior = immediateAction and action = confirm, we also:
   - Call clearPaymentOption after successful loads/updates, and after confirmation cancels or fails.

## Motivation
- https://docs.google.com/document/d/1_LyLbnJV0KnHPp739xXUYAFr9bdjRvxp-Mh20Y2ZmWM/edit?tab=t.0#heading=h.o12ytfel7pea

## Testing
- Manual
- Unit tests

## Changelog
See diff