### PR TITLE
Update DebugView.swift to not say testmode

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/DebugView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/DebugView.swift
@@ -309,9 +309,9 @@ extension DebugView: CompleteOptionViewDelegate {
 
 extension DebugView {
     // Debug strings, not translatable.
-    static let testModeTitle: String = "You're currently in testmode"
+    static let testModeTitle: String = "You're currently testing"
 
-    static let testModeContent: String = "This page is only shown in testmode."
+    static let testModeContent: String = "This page is only shown for test accounts."
 
     static let finishMobileFlow: String = "Terminate mobile SDK flow"
 


### PR DESCRIPTION
## Summary

Remove uses of testmode from the SDK

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

This helps get us ready for the sandboxes GA

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
