### PR TITLE
Remove activity spinner fade out animation when a spacing unit is set

### DIFF
--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
@@ -317,12 +317,18 @@ private extension ConnectComponentWebViewController {
         addMessageHandler(setterMessageHandler)
         addMessageHandler(OnLoaderStartMessageHandler { [analyticsClient, activityIndicator] _ in
             analyticsClient.logComponentLoaded(loadEnd: .now)
-            UIView.animate(withDuration: 1.0, animations: {
-                activityIndicator.alpha = 0.0
-            }, completion: { _ in
-                activityIndicator.stopAnimating()
-                activityIndicator.alpha = 1.0
-            })
+            if self.componentManager.appearance.spacingUnit != nil {
+                    // When spacingUnit is set, immediately hide without animation as the spinners will not be aligned
+                    activityIndicator.stopAnimating()
+                } else {
+                    // When using default spacing, use the nice fade out animation
+                    UIView.animate(withDuration: 1.0, animations: {
+                        activityIndicator.alpha = 0.0
+                    }, completion: { _ in
+                        activityIndicator.stopAnimating()
+                        activityIndicator.alpha = 1.0
+                    })
+                }
 
         })
         addMessageHandler(FetchInitParamsMessageHandler.init(didReceiveMessage: {[weak self] _ in


### PR DESCRIPTION
## Summary

When a spacing unit is set, the placement of the spinner will change as it grows with that unit. It's okay if we have two different spinners, but it's not okay to have two on the screen at the same time! CAX will take on a project to emit a new event so we don't need to lean on this trick in the future. 

Before: 


https://github.com/user-attachments/assets/898a70bd-9f27-438b-a21a-a909c6c1c90b



After:


https://github.com/user-attachments/assets/4bce2a1f-0bec-40ee-a590-ee7acdc1b4b9



## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
