### PR TITLE
Force apms disabled and card pm for CBC tests

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
@@ -883,6 +883,8 @@ class PaymentSheetStandardLPMUICBCTests: PaymentSheetStandardLPMUICase {
         settings.merchantCountryCode = .FR
         settings.currency = .eur
         settings.preferredNetworksEnabled = .off
+        settings.apmsEnabled = .off
+        settings.supportedPaymentMethods = "card"
         loadPlayground(app, settings)
 
         _testCardBrandChoice(settings: settings)
@@ -897,6 +899,8 @@ class PaymentSheetStandardLPMUICBCTests: PaymentSheetStandardLPMUICase {
         settings.merchantCountryCode = .FR
         settings.currency = .eur
         settings.preferredNetworksEnabled = .off
+        settings.apmsEnabled = .off
+        settings.supportedPaymentMethods = "card"
         loadPlayground(app, settings)
 
         _testCardBrandChoice(isSetup: true, settings: settings)
@@ -911,6 +915,8 @@ class PaymentSheetStandardLPMUICBCTests: PaymentSheetStandardLPMUICase {
         settings.currency = .eur
         settings.preferredNetworksEnabled = .off
         settings.integrationType = .deferred_csc
+        settings.apmsEnabled = .off
+        settings.supportedPaymentMethods = "card"
         loadPlayground(app, settings)
 
         _testCardBrandChoice(settings: settings)
@@ -924,6 +930,9 @@ class PaymentSheetStandardLPMUICBCTests: PaymentSheetStandardLPMUICase {
         settings.merchantCountryCode = .FR
         settings.currency = .eur
         settings.preferredNetworksEnabled = .on
+        settings.apmsEnabled = .off
+        settings.supportedPaymentMethods = "card"
+
         loadPlayground(app, settings)
 
         app.buttons["Present PaymentSheet"].tap()
@@ -979,6 +988,8 @@ class PaymentSheetStandardLPMUICBCTests: PaymentSheetStandardLPMUICase {
         settings.customerMode = .new
         settings.merchantCountryCode = .FR
         settings.currency = .eur
+        settings.apmsEnabled = .off
+        settings.supportedPaymentMethods = "card"
         loadPlayground(app, settings)
 
         app.buttons["Present PaymentSheet"].waitForExistenceAndTap(timeout: 5)
@@ -1078,6 +1089,8 @@ class PaymentSheetStandardLPMUICBCTests: PaymentSheetStandardLPMUICase {
         settings.currency = .eur
         settings.customerMode = .returning
         settings.layout = .horizontal
+        settings.apmsEnabled = .off
+        settings.supportedPaymentMethods = "card"
 
         loadPlayground(app, settings)
 


### PR DESCRIPTION
## Summary
Disable apms and set 'card' as the only pm for these tests

## Motivation
Occasionally seeing these tests flake as card is not being selected as the first PM.

## Testing
Locally on my laptop

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
