### PR TITLE
Respect `configuration.style` in native Link UI

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -450,7 +450,11 @@ extension PayWithLinkViewController: PaymentSheetLinkAccountDelegate {
                         completion(.failure(PaymentSheetError.unknown(debugDescription: "No account found")))
                         return
                     }
-                    let verificationController = LinkVerificationController(mode: .modal, linkAccount: account)
+                    let verificationController = LinkVerificationController(
+                        mode: .modal,
+                        linkAccount: account,
+                        configuration: self.context.configuration
+                    )
                     verificationController.present(from: self) { result in
                         switch result {
                         case .completed:

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
@@ -18,9 +18,14 @@ final class LinkVerificationController {
     private var selfRetainer: LinkVerificationController?
     private let verificationViewController: LinkVerificationViewController
 
-    init(mode: LinkVerificationView.Mode = .modal, linkAccount: PaymentSheetLinkAccount) {
+    init(
+        mode: LinkVerificationView.Mode = .modal,
+        linkAccount: PaymentSheetLinkAccount,
+        configuration: PaymentElementConfiguration
+    ) {
         self.verificationViewController = LinkVerificationViewController(mode: mode, linkAccount: linkAccount)
         verificationViewController.delegate = self
+        configuration.style.configure(verificationViewController)
     }
 
     func present(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -102,7 +102,11 @@ extension PaymentSheet {
             return
         }
 
-        let verificationController = LinkVerificationController(mode: .inlineLogin, linkAccount: linkAccount)
+        let verificationController = LinkVerificationController(
+            mode: .inlineLogin,
+            linkAccount: linkAccount,
+            configuration: configuration
+        )
         verificationController.present(from: bottomSheetViewController) { [weak self] result in
             self?.bottomSheetViewController.dismiss(animated: true, completion: nil)
             switch result {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -178,7 +178,11 @@ public class PaymentSheet {
                     self.bottomSheetViewController.setViewControllers([paymentSheetVC])
                 }
                 if let linkAccount = LinkAccountContext.shared.account, loadResult.elementsSession.shouldShowLink2FABeforePaymentSheet(for: linkAccount) {
-                    let verificationController = LinkVerificationController(mode: .inlineLogin, linkAccount: linkAccount)
+                    let verificationController = LinkVerificationController(
+                        mode: .inlineLogin,
+                        linkAccount: linkAccount,
+                        configuration: self.configuration
+                    )
                     verificationController.present(from: self.bottomSheetViewController) { result in
                         switch result {
                         case .completed:

--- a/StripeUICore/StripeUICore/Source/Controls/OneTimeCodeTextField.swift
+++ b/StripeUICore/StripeUICore/Source/Controls/OneTimeCodeTextField.swift
@@ -36,13 +36,17 @@ import UIKit
         /// The height of each digit item.
         let itemHeight: CGFloat
 
+        /// The user interface style of the container.
+        let userInterfaceStyle: UIUserInterfaceStyle
+
         public init(
             numberOfDigits: Int = 6,
             itemSpacing: CGFloat = 6,
             enableDigitGrouping: Bool = true,
             font: UIFont = .systemFont(ofSize: 20),
             itemCornerRadius: CGFloat = 8,
-            itemHeight: CGFloat = 60
+            itemHeight: CGFloat = 60,
+            userInterfaceStyle: UIUserInterfaceStyle = .unspecified
         ) {
             self.numberOfDigits = numberOfDigits
             self.itemSpacing = itemSpacing
@@ -50,6 +54,7 @@ import UIKit
             self.font = font
             self.itemCornerRadius = itemCornerRadius
             self.itemHeight = itemHeight
+            self.userInterfaceStyle = userInterfaceStyle
         }
     }
 
@@ -93,7 +98,8 @@ import UIKit
             configuration: DigitView.Configuration(
                 cornerRadius: configuration.itemCornerRadius,
                 font: configuration.font,
-                itemHeight: configuration.itemHeight
+                itemHeight: configuration.itemHeight,
+                userInterfaceStyle: configuration.userInterfaceStyle
             ),
             theme: theme
         )
@@ -671,15 +677,18 @@ private extension OneTimeCodeTextField {
             let focusRingThickness: CGFloat = 2
             let font: UIFont
             let itemHeight: CGFloat
+            let userInterfaceStyle: UIUserInterfaceStyle
 
             init(
                 cornerRadius: CGFloat,
                 font: UIFont,
-                itemHeight: CGFloat
+                itemHeight: CGFloat,
+                userInterfaceStyle: UIUserInterfaceStyle
             ) {
                 self.cornerRadius = cornerRadius
                 self.font = font
                 self.itemHeight = itemHeight
+                self.userInterfaceStyle = userInterfaceStyle
             }
         }
 
@@ -799,9 +808,12 @@ private extension OneTimeCodeTextField {
         }
 
         private func updateColors() {
-            borderLayer.backgroundColor = isEnabled ? theme.colors.componentBackground.cgColor : theme.colors.disabledBackground.cgColor
-            borderLayer.borderColor = theme.colors.border.cgColor
-            caret.backgroundColor = label.textColor.cgColor
+            let traitCollection = UITraitCollection(userInterfaceStyle: configuration.userInterfaceStyle)
+            let backgroundColor = isEnabled ? theme.colors.componentBackground : theme.colors.disabledBackground
+
+            borderLayer.backgroundColor = backgroundColor.resolvedColor(with: traitCollection).cgColor
+            borderLayer.borderColor = theme.colors.border.resolvedColor(with: traitCollection).cgColor
+            caret.backgroundColor = label.textColor.resolvedColor(with: traitCollection).cgColor
             focusRing.borderColor = tintColor.cgColor
         }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the verification dialog as well as the OTP field in the verification screen didn't response the `userInterfaceStyle` of MPE.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[LINK_MOBILE-117](https://jira.corp.stripe.com/browse/LINK_MOBILE-117)

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
