### PR TITLE
Handle QR code + web view LPMs for embedded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### PaymentSheet
+* [Added] Added support for PayNow and PromptPay to Embedded Payment Element (private preview).
+
 ## 24.11.0 2025-04-07
 ### PaymentSheet
 * [Added] Added `rowSelectionBehavior` API to Embedded Payment Element (private preview).

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -1045,6 +1045,25 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         alert.buttons[buttonToTap].tap()
     }
 
+    func testPayNow() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.customerMode = .new
+        settings.mode = .payment
+        settings.integrationType = .deferred_csc
+        settings.uiStyle = .embedded
+        settings.formSheetAction = .continue
+        settings.currency = .sgd
+        settings.merchantCountryCode = .SG
+        loadPlayground(app, settings)
+        app.buttons["Present embedded payment element"].waitForExistenceAndTap()
+
+        XCTAssertTrue(app.buttons["PayNow"].waitForExistenceAndTap())
+        XCTAssertTrue(app.buttons["Checkout"].waitForExistenceAndTap())
+
+        app.webViews.webViews.webViews.buttons["Simulate scan"].waitForExistenceAndTap(timeout: 15)
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 25.0))
+    }
+
     // Returning customers have two payment methods in a non-deterministic order.
     // Ensure state of payment method of label1 is selected prior to starting tests.
     func ensureSPMSelection(_ label1: String, insteadOf label2: String) {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -1061,6 +1061,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Checkout"].waitForExistenceAndTap())
 
         app.webViews.webViews.webViews.buttons["Simulate scan"].waitForExistenceAndTap(timeout: 15)
+        webviewAuthorizePaymentButton.waitForExistenceAndTap(timeout: 10)
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 25.0))
     }
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
@@ -184,7 +184,7 @@ class PaymentSheetBillingCollectionLPMUITests: PaymentSheetBillingCollectionUITe
         settings.applePayEnabled = .off
         settings.shippingInfo = .onWithDefaults
         settings.apmsEnabled = .off
-        settings.linkEnabledMode = .off
+        settings.linkEnabledMode = .native
         settings.linkPassthroughMode = .passthrough
         settings.defaultBillingAddress =  .on
         settings.attachDefaults =  .on
@@ -207,6 +207,8 @@ class PaymentSheetBillingCollectionLPMUITests: PaymentSheetBillingCollectionUITe
         saveAddressButton.tap()
 
         checkoutButton.tap()
+
+        app.buttons["LinkVerificationCloseButton"].waitForExistenceAndTap()
 
         let cell = try XCTUnwrap(scroll(
             collectionView: app.collectionViews.firstMatch,
@@ -241,7 +243,7 @@ class PaymentSheetBillingCollectionLPMUITests: PaymentSheetBillingCollectionUITe
         settings.applePayEnabled = .off
         settings.shippingInfo = .onWithDefaults
         settings.apmsEnabled = .off
-        settings.linkEnabledMode = .off
+        settings.linkEnabledMode = .native
         settings.linkPassthroughMode = .passthrough
         settings.defaultBillingAddress =  .on
         settings.attachDefaults =  .on

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
@@ -184,7 +184,7 @@ class PaymentSheetBillingCollectionLPMUITests: PaymentSheetBillingCollectionUITe
         settings.applePayEnabled = .off
         settings.shippingInfo = .onWithDefaults
         settings.apmsEnabled = .off
-        settings.linkEnabledMode = .web
+        settings.linkEnabledMode = .native
         settings.linkPassthroughMode = .passthrough
         settings.defaultBillingAddress =  .on
         settings.attachDefaults =  .on
@@ -241,7 +241,7 @@ class PaymentSheetBillingCollectionLPMUITests: PaymentSheetBillingCollectionUITe
         settings.applePayEnabled = .off
         settings.shippingInfo = .onWithDefaults
         settings.apmsEnabled = .off
-        settings.linkEnabledMode = .web
+        settings.linkEnabledMode = .native
         settings.linkPassthroughMode = .passthrough
         settings.defaultBillingAddress =  .on
         settings.attachDefaults =  .on

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUITests.swift
@@ -184,7 +184,7 @@ class PaymentSheetBillingCollectionLPMUITests: PaymentSheetBillingCollectionUITe
         settings.applePayEnabled = .off
         settings.shippingInfo = .onWithDefaults
         settings.apmsEnabled = .off
-        settings.linkEnabledMode = .native
+        settings.linkEnabledMode = .off
         settings.linkPassthroughMode = .passthrough
         settings.defaultBillingAddress =  .on
         settings.attachDefaults =  .on
@@ -241,7 +241,7 @@ class PaymentSheetBillingCollectionLPMUITests: PaymentSheetBillingCollectionUITe
         settings.applePayEnabled = .off
         settings.shippingInfo = .onWithDefaults
         settings.apmsEnabled = .off
-        settings.linkEnabledMode = .native
+        settings.linkEnabledMode = .off
         settings.linkPassthroughMode = .passthrough
         settings.defaultBillingAddress =  .on
         settings.attachDefaults =  .on

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -623,16 +623,13 @@ extension STPAuthenticationContextWrapper: PaymentSheetAuthenticationContext {
         shouldPresentPollingVC = true
     }
 
-    func authenticationContextWillDismiss(_ viewController: UIViewController) {
+    func authenticationContextDidDismiss(_ viewController: UIViewController) {
         // The following code should only be executed if we are dismissing a SFSafariViewController
         guard viewController is SFSafariViewController else { return }
 
         if let pollingViewController = self.pollingVC {
-            // Delay presentation to allow the SFSafariViewController to dismiss completely
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                self._presentingViewController.present(pollingViewController, animated: true)
-                self.shouldPresentPollingVC = false
-            }
+            self._presentingViewController.present(pollingViewController, animated: true)
+            self.shouldPresentPollingVC = false
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -627,7 +627,7 @@ extension STPAuthenticationContextWrapper: PaymentSheetAuthenticationContext {
         // The following code should only be executed if we are dismissing a SFSafariViewController
         guard viewController is SFSafariViewController else { return }
 
-        if let pollingViewController = self.pollingVC {
+        if let pollingViewController = self.pollingVC, shouldPresentPollingVC {
             self._presentingViewController.present(pollingViewController, animated: true)
             self.shouldPresentPollingVC = false
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Yuki Tokuhiro on 10/10/24.
 //
+import SafariServices
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
@@ -581,9 +582,14 @@ extension EmbeddedPaymentElement {
 
 final class STPAuthenticationContextWrapper: UIViewController {
     let _presentingViewController: UIViewController
+    let appearance: PaymentSheet.Appearance
 
-    init(presentingViewController: UIViewController) {
+    private var pollingVC: PollingViewController?
+    private var shouldPresentPollingVC = false
+
+    init(presentingViewController: UIViewController, appearance: PaymentSheet.Appearance) {
         self._presentingViewController = presentingViewController
+        self.appearance = appearance
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -592,7 +598,44 @@ final class STPAuthenticationContextWrapper: UIViewController {
     }
 }
 
-extension STPAuthenticationContextWrapper: STPAuthenticationContext {
+extension STPAuthenticationContextWrapper: PaymentSheetAuthenticationContext {
+
+    func present(_ authenticationViewController: UIViewController, completion: @escaping () -> Void) {
+        DispatchQueue.main.async {
+            self._presentingViewController.present(authenticationViewController, animated: true) {
+                completion()
+            }
+        }
+    }
+
+    func dismiss(_ authenticationViewController: UIViewController, completion: (() -> Void)?) {
+        DispatchQueue.main.async {
+            authenticationViewController.dismiss(animated: true) {
+                completion?()
+            }
+        }
+    }
+
+    func presentPollingVCForAction(action: StripePayments.STPPaymentHandlerPaymentIntentActionParams, type: StripePayments.STPPaymentMethodType, safariViewController: SFSafariViewController?) {
+        // Initialize the polling view controller and flag it for presentation
+        self.pollingVC = PollingViewController(currentAction: action, viewModel: PollingViewModel(paymentMethodType: type),
+                                                      appearance: self.appearance, safariViewController: safariViewController)
+        shouldPresentPollingVC = true
+    }
+
+    func authenticationContextWillDismiss(_ viewController: UIViewController) {
+        // The following code should only be executed if we are dismissing a SFSafariViewController
+        guard viewController is SFSafariViewController else { return }
+
+        if let pollingViewController = self.pollingVC {
+            // Delay presentation to allow the SFSafariViewController to dismiss completely
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                self._presentingViewController.present(pollingViewController, animated: true)
+                self.shouldPresentPollingVC = false
+            }
+        }
+    }
+
     public func authenticationPresentingViewController() -> UIViewController {
         return _presentingViewController
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -624,7 +624,7 @@ extension STPAuthenticationContextWrapper: PaymentSheetAuthenticationContext {
     }
 
     func authenticationContextDidDismiss(_ viewController: UIViewController) {
-        // The following code should only be executed if we are dismissing a SFSafariViewController
+        // The following code should only be executed if we have dismissed a SFSafariViewController
         guard viewController is SFSafariViewController else { return }
 
         if let pollingViewController = self.pollingVC, shouldPresentPollingVC {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -242,7 +242,7 @@ public final class EmbeddedPaymentElement {
             assertionFailure("`confirm` should only be called when `paymentOption` is not nil")
             return .failed(error: PaymentSheetError.confirmingWithInvalidPaymentOption)
         }
-        let authContext = STPAuthenticationContextWrapper(presentingViewController: presentingViewController)
+        let authContext = STPAuthenticationContextWrapper(presentingViewController: presentingViewController, appearance: configuration.appearance)
         let confirmResult = await _confirm(paymentOption: paymentOption, authContext: authContext).result
         if confirmResult.isCanceledOrFailed {
             clearPaymentOptionIfNeeded()

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPAuthenticationContext.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPAuthenticationContext.swift
@@ -33,4 +33,10 @@ import UIKit
     /// it to return the user to your desired view controller.
     @objc(authenticationContextWillDismissViewController:)
     optional func authenticationContextWillDismiss(_ viewController: UIViewController)
+    /// This method is called when an authentication UIViewController has been dismissed.
+    /// Implement this method to have your UI respond to the authentication view controller to being dismissed. For example,
+    /// if you requested authentication while displaying an STPBankSelectionViewController, you may want to hide
+    /// it to return the user to your desired view controller.
+    @objc(authenticationContextDidDismissViewController:)
+    optional func authenticationContextDidDismiss(_ viewController: UIViewController)
 }

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPAuthenticationContext.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPAuthenticationContext.swift
@@ -37,6 +37,7 @@ import UIKit
     /// Implement this method to have your UI respond to the authentication view controller to being dismissed. For example,
     /// if you requested authentication while displaying an STPBankSelectionViewController, you may want to hide
     /// it to return the user to your desired view controller.
+    @_spi(STP)
     @objc(authenticationContextDidDismissViewController:)
     optional func authenticationContextDidDismiss(_ viewController: UIViewController)
 }

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1719,6 +1719,8 @@ public class STPPaymentHandler: NSObject {
                                 // This isn't great, but UIViewController is non-nil in the protocol. Maybe it's better to still call it, even if the VC isn't useful?
                                 context.authenticationContextWillDismiss?(UIViewController())
                             }
+                            // This isn't great, but UIViewController is non-nil in the protocol. Maybe it's better to still call it, even if the VC isn't useful?
+                            self.callContextWillDismissIfNeeded(context, UIViewController())
                             STPURLCallbackHandler.shared().unregisterListener(self)
                             self.analyticsClient.logURLRedirectNextActionCompleted(
                                 with: currentAction.apiClient._stored_configuration,
@@ -2177,6 +2179,17 @@ public class STPPaymentHandler: NSObject {
         }
         return STPPaymentHandlerError(code: errorCode, loggingSafeUserInfo: userInfo) as NSError
     }
+
+    func callContextWillDismissIfNeeded(_ context: (any STPAuthenticationContext)?, _ viewController: UIViewController?) {
+        guard let context, let viewController else { return }
+
+        if context.responds(
+            to: #selector(STPAuthenticationContext.authenticationContextDidDismiss(_:))
+        )
+        {
+            context.authenticationContextDidDismiss?(viewController)
+        }
+    }
 }
 
 /// STPPaymentHandler errors (i.e. errors that are created by the STPPaymentHandler class and have a corresponding STPPaymentHandlerErrorCode) used to be NSErrors.
@@ -2213,6 +2226,9 @@ extension STPPaymentHandler: SFSafariViewControllerDelegate {
         ) ?? false {
             context?.authenticationContextWillDismiss?(controller)
         }
+
+        callContextWillDismissIfNeeded(context, controller)
+
         safariViewController = nil
         STPURLCallbackHandler.shared().unregisterListener(self)
         _retrieveAndCheckIntentForCurrentAction()
@@ -2253,6 +2269,7 @@ extension STPPaymentHandler: SFSafariViewControllerDelegate {
         )
         STPURLCallbackHandler.shared().unregisterListener(self)
         safariViewController?.dismiss(animated: true) {
+            self.callContextWillDismissIfNeeded(context, self.safariViewController)
             self.safariViewController = nil
         }
         _retrieveAndCheckIntentForCurrentAction()

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1720,7 +1720,7 @@ public class STPPaymentHandler: NSObject {
                                 context.authenticationContextWillDismiss?(UIViewController())
                             }
                             // This isn't great, but UIViewController is non-nil in the protocol. Maybe it's better to still call it, even if the VC isn't useful?
-                            self.callContextWillDismissIfNeeded(context, UIViewController())
+                            self.callContextDidDismissIfNeeded(context, UIViewController())
                             STPURLCallbackHandler.shared().unregisterListener(self)
                             self.analyticsClient.logURLRedirectNextActionCompleted(
                                 with: currentAction.apiClient._stored_configuration,
@@ -2180,7 +2180,7 @@ public class STPPaymentHandler: NSObject {
         return STPPaymentHandlerError(code: errorCode, loggingSafeUserInfo: userInfo) as NSError
     }
 
-    func callContextWillDismissIfNeeded(_ context: (any STPAuthenticationContext)?, _ viewController: UIViewController?) {
+    func callContextDidDismissIfNeeded(_ context: (any STPAuthenticationContext)?, _ viewController: UIViewController?) {
         guard let context, let viewController else { return }
 
         if context.responds(
@@ -2227,7 +2227,7 @@ extension STPPaymentHandler: SFSafariViewControllerDelegate {
             context?.authenticationContextWillDismiss?(controller)
         }
 
-        callContextWillDismissIfNeeded(context, controller)
+        callContextDidDismissIfNeeded(context, controller)
 
         safariViewController = nil
         STPURLCallbackHandler.shared().unregisterListener(self)
@@ -2269,7 +2269,7 @@ extension STPPaymentHandler: SFSafariViewControllerDelegate {
         )
         STPURLCallbackHandler.shared().unregisterListener(self)
         safariViewController?.dismiss(animated: true) {
-            self.callContextWillDismissIfNeeded(context, self.safariViewController)
+            self.callContextDidDismissIfNeeded(context, self.safariViewController)
             self.safariViewController = nil
         }
         _retrieveAndCheckIntentForCurrentAction()


### PR DESCRIPTION
## Summary
- Some LPMs like PromptPay/PayNow need to present a PollingViewController after web view has dismissed to check if the payment has been completed. 
- This was an oversight and not implemented on the AuthenticationContext for embedded
- The implementation waits for the SFSafariViewController to dismiss before presenting the polling VC and also keeps a flag in sync for if we need to present the polling VC when it is dismissed to prevent accidental presentations.
- Polling VC is responsible for completing the payment

https://github.com/user-attachments/assets/b9859f74-524c-4282-a852-8a775486939e


## Motivation
- https://stripe.slack.com/archives/C01CY476ESJ/p1744164704749489?thread_ts=1743523239.980129&cid=C01CY476ESJ

## Testing
- Manual
- New UI test

## Changelog
See diff