### PR TITLE
Dismiss keyboard when removing payment method

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController.swift
@@ -218,6 +218,12 @@ final class UpdatePaymentMethodViewController: UIViewController {
     }
 
     @objc private func removePaymentMethod() {
+        for element in self.paymentMethodForm.getAllUnwrappedSubElements() {
+            if let textElement = element as? TextFieldElement {
+                textElement.endEditing(true, continueToNextField: false)
+            }
+        }
+
         let alertController = UIAlertController.makeRemoveAlertController(paymentMethod: configuration.paymentMethod,
                                                                           removeSavedPaymentMethodMessage: removeSavedPaymentMethodMessage) { [weak self] in
             guard let self = self else { return }


### PR DESCRIPTION
## Summary
Dismisses keyboard when a user hits the remove button to avoid animation jank

## Motivation
Has animation jank if keyboard is up.

## Testing
Manual

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
