### PR TITLE
Remove E2E tests references to step up

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -13,8 +13,6 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
     func testNativeNetworkingTestMode() throws {
         let emailAddresss = "\(UUID().uuidString)@UITestForIOS.com"
         executeNativeNetworkingTestModeSignUpFlowTest(emailAddress: emailAddresss)
-        // TODO(mats): Reenable once step up verification issues are resolved (BANKCON-14617).
-        // executeNativeNetworkingTestModeSignInFlowTest(emailAddress: emailAddresss)
         executeNativeNetworkingTestModeAutofillSignInFlowTest(emailAddress: emailAddresss)
         let bankAccountName = "Insufficient Funds"
         executeNativeNetworkingTestModeAddBankAccount(
@@ -84,57 +82,6 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         )
     }
 
-    private func executeNativeNetworkingTestModeSignInFlowTest(emailAddress: String) {
-        let app = XCUIApplication.fc_launch(
-            playgroundConfigurationString:
-"""
-{"use_case":"payment_intent","experience":"financial_connections","sdk_type":"native","test_mode":true,"merchant":"networking","payment_method_permission":true,"transactions_permission":true,"email":"\(emailAddress)"}
-"""
-        )
-
-        app.fc_playgroundCell.tap()
-        app.fc_playgroundShowAuthFlowButton.tap()
-
-        app.fc_nativeConsentAgreeButton.tap()
-
-        let linkContinueButton = app.buttons["link_continue_button"]
-        XCTAssertTrue(linkContinueButton.waitForExistence(timeout: 60.0))
-        linkContinueButton.tap()
-
-        let verificationOTPTextView = app.scrollViews.otherElements.textViews["Code field"]
-        XCTAssertTrue(verificationOTPTextView.waitForExistence(timeout: 60.0))
-        verificationOTPTextView.tap()
-        verificationOTPTextView.typeText("111111")
-
-        let successInstitution = app.scrollViews.staticTexts["Success"]
-        XCTAssertTrue(successInstitution.waitForExistence(timeout: 120.0)) // need to wait for various API calls to appear
-        successInstitution.tap()
-
-        let connectAccountButton = app.buttons["Connect account"]
-        XCTAssertTrue(connectAccountButton.waitForExistence(timeout: 60.0))
-        connectAccountButton.tap()
-
-        let stepUpVerificationOTPTextView = app.scrollViews.otherElements.textViews["Code field"]
-        XCTAssertTrue(stepUpVerificationOTPTextView.waitForExistence(timeout: 60.0))
-        stepUpVerificationOTPTextView.tap()
-        stepUpVerificationOTPTextView.typeText("111111")
-
-        let successPaneDoneButton = app.fc_nativeSuccessDoneButton
-
-        // ensure that there wasn't a Link failure
-        //
-        // unexpected text: "Your account was connected, but couldn't be saved to Link"
-        XCTAssert(!app.textViews.containing(NSPredicate(format: "label CONTAINS 'but'")).firstMatch.exists)
-
-        successPaneDoneButton.tap()
-
-        // ensure alert body contains "Stripe Bank" (AKA one bank is linked)
-        XCTAssert(
-            app.fc_playgroundSuccessAlertView.staticTexts.containing(NSPredicate(format: "label CONTAINS 'StripeBank'")).firstMatch
-                .exists
-        )
-    }
-
     private func executeNativeNetworkingTestModeAutofillSignInFlowTest(emailAddress: String) {
         let app = XCUIApplication.fc_launch(
             playgroundConfigurationString:
@@ -163,9 +110,6 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         let connectAccountButton = app.buttons["Connect account"]
         XCTAssertTrue(connectAccountButton.waitForExistence(timeout: 60.0))
         connectAccountButton.tap()
-
-        XCTAssertTrue(testModeAutofillButton.waitForExistence(timeout: 10.0))
-        testModeAutofillButton.tap()
 
         let successPaneDoneButton = app.fc_nativeSuccessDoneButton
 


### PR DESCRIPTION
## Summary

Step up was disabled, but some of our E2E still expected it. 

Example build failure: https://app.bitrise.io/build/c39998d6-cc77-4742-ac40-da7c1b1ffa49

Context on step up removal: https://docs.google.com/document/d/1QU5mmcmF59n6OIWer5DVnUDrKOiCLLUFfyoRtklGInc/edit?tab=t.0#heading=h.gv9ejmdl8ma7

## Motivation

Fix master

## Testing

N/a

## Changelog

N/a
