### PR TITLE
Fix Link selection issue in FlowController

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -354,6 +354,43 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         )
     }
 
+    func testPaymentSheetFlowControllerLinkWalletSelection() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.uiStyle = .flowController
+        settings.layout = .horizontal
+        settings.applePayEnabled = .off
+        settings.apmsEnabled = .off
+        settings.supportedPaymentMethods = "link,card"
+        loadPlayground(app, settings)
+
+        let paymentMethodButton = app.buttons["Payment method"]
+        paymentMethodButton.waitForExistenceAndTap(timeout: 10)
+
+        // Fill out card form first
+        try! fillCardData(app)
+        app.buttons["Continue"].tap()
+        sleep(2)
+        XCTAssertEqual(paymentMethodButton.label, "•••• 4242, card, 12345, US")
+
+        // Now select Link
+        paymentMethodButton.tap()
+        app.buttons["Pay with Link"].waitForExistenceAndTap()
+        sleep(2)
+        XCTAssertEqual(paymentMethodButton.label, "Link, link")
+
+        // Open and close PaymentSheet without making changes
+        paymentMethodButton.tap()
+        app.tapCoordinate(at: CGPoint(x: 100, y: 100))
+        sleep(2)
+        XCTAssertEqual(paymentMethodButton.label, "Link, link")
+
+        // Open again and choose to continue with card
+        paymentMethodButton.tap()
+        app.buttons["Continue"].tap()
+        sleep(2)
+        XCTAssertEqual(paymentMethodButton.label, "•••• 4242, card, 12345, US")
+    }
+
     func testPaymentSheetSwiftUI() throws {
         app.launch()
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -27,13 +27,13 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
     var selectedPaymentOption: PaymentOption? {
         switch mode {
         case .addingNew:
-            if let paymentOption = addPaymentMethodViewController.paymentOption {
+            if isHackyLinkButtonSelected {
+                return .link(option: .wallet)
+            } else if let paymentOption = addPaymentMethodViewController.paymentOption {
                 return paymentOption
             } else if let paymentOption = savedPaymentOptionsViewController.selectedPaymentOption {
                 // If no valid payment option from adding, fallback on any saved payment method
                 return paymentOption
-            } else if isHackyLinkButtonSelected {
-                return .link(option: .wallet)
             } else if isApplePayEnabled {
                 return .applePay
             }
@@ -432,6 +432,9 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
 
     @objc
     private func didTapContinueButton() {
+        // The user is continuing with an LPM, so we un-select Link
+        isHackyLinkButtonSelected = false
+
         if let selectedPaymentOption {
             analyticsHelper.logConfirmButtonTapped(paymentOption: selectedPaymentOption)
         } else {
@@ -450,8 +453,6 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
     }
 
     func didDismiss(didCancel: Bool) {
-        // When we close the window, unset the hacky Link button. This will reset the PaymentOption to nil, if needed.
-        isHackyLinkButtonSelected = false
         // If the customer was adding a new payment method and it's incomplete/invalid, return to the saved PM screen
         flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: didCancel)
         if savedPaymentOptionsViewController.isRemovingPaymentMethods {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue in FlowController where selecting Link after having previously selected an LPM wouldn't result in the payment method being changed.

**Before**: Tapping `Pay with Link` after having filled out the card form doesn't do anything. It also discards the selection if no new selection is made.

https://github.com/user-attachments/assets/c5fff708-25e3-49f5-8ceb-9b3f383c39f5

**After**: Tapping `Pay with Link` after having filled out the card form changes the payment method to `Link`. It also correctly preserves the selection if no new selection is made.

https://github.com/user-attachments/assets/8e800e89-682d-433e-bbad-35ddcc18de0b

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
