### PR TITLE
[Connect] Add fetch app info event.

### DIFF
--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -71,6 +71,8 @@
 		4186664A2C66AC66003DB62E /* OnSetterFunctionCalledMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 418666492C66AC66003DB62E /* OnSetterFunctionCalledMessageHandler.swift */; };
 		4186664C2C66AC8C003DB62E /* OnLoaderStartMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4186664B2C66AC8C003DB62E /* OnLoaderStartMessageHandler.swift */; };
 		4186664E2C66ACB3003DB62E /* OnLoadErrorMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4186664D2C66ACB3003DB62E /* OnLoadErrorMessageHandler.swift */; };
+		4199F94F2DA85E1F00D06805 /* FetchAppInfoMessageHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4199F94E2DA85E1800D06805 /* FetchAppInfoMessageHandler.swift */; };
+		4199F9512DA85FB300D06805 /* FetchAppInfoMessageHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4199F9502DA85FAB00D06805 /* FetchAppInfoMessageHandlerTests.swift */; };
 		41A2A5642C5ABD6C0077FC74 /* StripeConnectTests.xctestplan in Resources */ = {isa = PBXBuildFile; fileRef = 41A2A5632C5ABD6C0077FC74 /* StripeConnectTests.xctestplan */; };
 		41A2A5682C5AC5120077FC74 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 41A2A5672C5AC5120077FC74 /* StripeCore.framework */; };
 		41B28EEF2D91E60900B6B34D /* ConnectActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41B28EEE2D91E60000B6B34D /* ConnectActivityIndicator.swift */; };
@@ -275,6 +277,8 @@
 		418666492C66AC66003DB62E /* OnSetterFunctionCalledMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnSetterFunctionCalledMessageHandler.swift; sourceTree = "<group>"; };
 		4186664B2C66AC8C003DB62E /* OnLoaderStartMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnLoaderStartMessageHandler.swift; sourceTree = "<group>"; };
 		4186664D2C66ACB3003DB62E /* OnLoadErrorMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnLoadErrorMessageHandler.swift; sourceTree = "<group>"; };
+		4199F94E2DA85E1800D06805 /* FetchAppInfoMessageHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAppInfoMessageHandler.swift; sourceTree = "<group>"; };
+		4199F9502DA85FAB00D06805 /* FetchAppInfoMessageHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchAppInfoMessageHandlerTests.swift; sourceTree = "<group>"; };
 		41A2A5632C5ABD6C0077FC74 /* StripeConnectTests.xctestplan */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = StripeConnectTests.xctestplan; sourceTree = "<group>"; };
 		41A2A5672C5AC5120077FC74 /* StripeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		41B28EEE2D91E60000B6B34D /* ConnectActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectActivityIndicator.swift; sourceTree = "<group>"; };
@@ -439,6 +443,7 @@
 				413987B82C63F34B001D375E /* DebugMessageHandler.swift */,
 				413987B92C63F34B001D375E /* FetchClientSecretMessageHandler.swift */,
 				413987DC2C640A29001D375E /* FetchInitParamsMessageHandler.swift */,
+				4199F94E2DA85E1800D06805 /* FetchAppInfoMessageHandler.swift */,
 				E6165CBE2CA7BF2200B76DA5 /* FetchInitComponentPropsMessageHandler.swift */,
 				4186664B2C66AC8C003DB62E /* OnLoaderStartMessageHandler.swift */,
 				4186664D2C66ACB3003DB62E /* OnLoadErrorMessageHandler.swift */,
@@ -605,6 +610,7 @@
 				4161C2692C9CD0B1005BD67C /* Onboarding */,
 				41814EEA2C6BCAB30014EB5E /* DebugMessageHandlerTests.swift */,
 				41814EEC2C6BED8C0014EB5E /* FetchClientSecretMessageHandlerTests.swift */,
+				4199F9502DA85FAB00D06805 /* FetchAppInfoMessageHandlerTests.swift */,
 				41814EEE2C6BEF2C0014EB5E /* FetchInitParamsMessageHandlerTests.swift */,
 				E6165CC02CA7D09900B76DA5 /* FetchInitComponentPropsMessageHandlerTests.swift */,
 				41814EF22C6BFA4B0014EB5E /* OnLoaderStartMessageHandlerTests.swift */,
@@ -1024,6 +1030,7 @@
 				E6660CFD2CC2F9A7002A7631 /* FinancialConnectionsPresenter.swift in Sources */,
 				416E9E842C76AE0A00A0B917 /* ComponentType.swift in Sources */,
 				410D0FCE2C6D000B009B0E26 /* OpenAuthenticatedWebViewMessageHandler.swift in Sources */,
+				4199F94F2DA85E1F00D06805 /* FetchAppInfoMessageHandler.swift in Sources */,
 				E6165CBF2CA7BF2200B76DA5 /* FetchInitComponentPropsMessageHandler.swift in Sources */,
 				413D18482C7FBAA70051AA42 /* CSSHelpers.swift in Sources */,
 				413987CD2C63F34B001D375E /* MessageSender.swift in Sources */,
@@ -1109,6 +1116,7 @@
 				41814EEF2C6BEF2C0014EB5E /* FetchInitParamsMessageHandlerTests.swift in Sources */,
 				41810D692C88C4B100F10EB7 /* AppearanceTests.swift in Sources */,
 				410D0FD22C6D047A009B0E26 /* AccountSessionClaimedMessageHandlerTests.swift in Sources */,
+				4199F9512DA85FB300D06805 /* FetchAppInfoMessageHandlerTests.swift in Sources */,
 				41814EF12C6BF94B0014EB5E /* OnExitMessageHandlerTests.swift in Sources */,
 				4161C2732C9D0A8A005BD67C /* AccountOnboardingControllerTests.swift in Sources */,
 				E6F485FE2C9E36B2000D914F /* PaymentDetailsViewControllerTests.swift in Sources */,

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
@@ -50,6 +50,8 @@ class ConnectComponentWebViewController: ConnectWebViewController {
 
     let componentType: ComponentType
 
+    let bundleIdProvider: () -> String?
+
     init<InitProps: Encodable>(
         componentManager: EmbeddedComponentManager,
         componentType: ComponentType,
@@ -61,7 +63,8 @@ class ConnectComponentWebViewController: ConnectWebViewController {
         notificationCenter: NotificationCenter = NotificationCenter.default,
         webLocale: Locale = Locale.autoupdatingCurrent,
         authenticatedWebViewManager: AuthenticatedWebViewManager = .init(),
-        financialConnectionsPresenter: FinancialConnectionsPresenter = .init()
+        financialConnectionsPresenter: FinancialConnectionsPresenter = .init(),
+        bundleIdProvider: @escaping () -> String? = Bundle.stp_applicationBundleId
     ) {
         self.componentManager = componentManager
         self.notificationCenter = notificationCenter
@@ -70,6 +73,7 @@ class ConnectComponentWebViewController: ConnectWebViewController {
         self.didFailLoadWithError = didFailLoadWithError
         self.financialConnectionsPresenter = financialConnectionsPresenter
         self.componentType = componentType
+        self.bundleIdProvider = bundleIdProvider
 
         let config = WKWebViewConfiguration()
 
@@ -130,7 +134,9 @@ class ConnectComponentWebViewController: ConnectWebViewController {
                      notificationCenter: NotificationCenter = NotificationCenter.default,
                      webLocale: Locale = Locale.autoupdatingCurrent,
                      authenticatedWebViewManager: AuthenticatedWebViewManager = .init(),
-                     financialConnectionsPresenter: FinancialConnectionsPresenter = .init()) {
+                     financialConnectionsPresenter: FinancialConnectionsPresenter = .init(),
+                     bundleIdProvider: @escaping () -> String? = Bundle.stp_applicationBundleId
+    ) {
         self.init(componentManager: componentManager,
                   componentType: componentType,
                   loadContent: loadContent,
@@ -140,7 +146,8 @@ class ConnectComponentWebViewController: ConnectWebViewController {
                   notificationCenter: notificationCenter,
                   webLocale: webLocale,
                   authenticatedWebViewManager: authenticatedWebViewManager,
-                  financialConnectionsPresenter: financialConnectionsPresenter)
+                  financialConnectionsPresenter: financialConnectionsPresenter,
+                  bundleIdProvider: bundleIdProvider)
     }
 
     required init?(coder: NSCoder) {
@@ -334,6 +341,9 @@ private extension ConnectComponentWebViewController {
             return .init(locale: webLocale.toLanguageTag(),
                          appearance: .init(appearance: componentManager.appearance, traitCollection: self.traitCollection),
                          fonts: componentManager.fonts.map({ .init(customFontSource: $0) }))
+        }))
+        addMessageHandler(FetchAppInfoMessageHandler.init(didReceiveMessage: { [weak self] _ in
+            return .init(applicationId: self?.bundleIdProvider() ?? "")
         }))
         addMessageHandler(FetchInitComponentPropsMessageHandler(fetchInitProps))
         addMessageHandler(OnLoadErrorMessageHandler { [weak self, analyticsClient] value in

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/FetchAppInfoMessageHandler.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/MessageHandlers/FetchAppInfoMessageHandler.swift
@@ -1,0 +1,19 @@
+//
+//  FetchAppInfoMessageHandler.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 4/10/25.
+//
+
+import Foundation
+
+// This message is emitted when connect embed requests info about the app.
+@available(iOS 15, *)
+class FetchAppInfoMessageHandler: ScriptMessageHandlerWithReply<VoidPayload, FetchAppInfoMessageHandler.Reply> {
+    struct Reply: Encodable {
+        let applicationId: String
+    }
+    init(didReceiveMessage: @escaping (VoidPayload) async throws -> Reply) {
+        super.init(name: "fetchAppInfo", didReceiveMessage: didReceiveMessage)
+    }
+}

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
@@ -50,6 +50,40 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
     }
 
     @MainActor
+    func testFetchAppInfo() async throws {
+        let message = FetchAppInfoMessageHandler.Reply(applicationId: "com.test.app")
+        let componentManager = componentManagerAssertingOnFetch()
+        let webVC = ConnectComponentWebViewController(componentManager: componentManager,
+                                                      componentType: .payouts,
+                                                      loadContent: false,
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
+                                                      didFailLoadWithError: { _ in },
+                                                      webLocale: Locale(identifier: "fr_FR"),
+                                                      bundleIdProvider: { "com.test.app" })
+
+        try await webVC.webView.evaluateMessageWithReply(name: "fetchAppInfo",
+                                                         json: "{}",
+                                                         expectedResponse: message)
+    }
+
+    @MainActor
+    func testFetchAppInfoWithNilAppId() async throws {
+        let message = FetchAppInfoMessageHandler.Reply(applicationId: "")
+        let componentManager = componentManagerAssertingOnFetch()
+        let webVC = ConnectComponentWebViewController(componentManager: componentManager,
+                                                      componentType: .payouts,
+                                                      loadContent: false,
+                                                      analyticsClientFactory: MockComponentAnalyticsClient.init,
+                                                      didFailLoadWithError: { _ in },
+                                                      webLocale: Locale(identifier: "fr_FR"),
+                                                      bundleIdProvider: { nil })
+
+        try await webVC.webView.evaluateMessageWithReply(name: "fetchAppInfo",
+                                                         json: "{}",
+                                                         expectedResponse: message)
+    }
+
+    @MainActor
     func testUpdateAppearance() async throws {
         let componentManager = componentManagerAssertingOnFetch()
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchAppInfoMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchAppInfoMessageHandlerTests.swift
@@ -1,0 +1,24 @@
+//
+//  FetchAppInfoMessageHandlerTests.swift
+//  StripeConnect
+//
+//  Created by Chris Mays on 4/10/25.
+//
+
+@testable import StripeConnect
+import XCTest
+
+class FetchAppInfoMessageHandlerTests: ScriptWebTestBase {
+
+    @MainActor
+    func testMessageSend() async throws {
+        let message = FetchAppInfoMessageHandler.Reply(applicationId: "com.stripe.example")
+        webView.addMessageReplyHandler(messageHandler: FetchAppInfoMessageHandler(didReceiveMessage: { _ in
+            return message
+        }))
+
+        try await webView.evaluateMessageWithReply(name: "fetchAppInfo",
+                                                   json: "{}",
+                                                   expectedResponse: message)
+    }
+}


### PR DESCRIPTION
## Summary
Adds the fetchAppInfo event to stripe connect.

## Demo
Validated connect embed was calling the message handler and added tests:
<img width="805" alt="Screenshot 2025-04-10 at 4 34 40 PM" src="https://github.com/user-attachments/assets/63d6f90d-469c-443c-aef5-d22ce29017dc" />
