### PR TITLE
fix Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value Command Injection in RDoc

### DIFF
--- a/ci_scripts/release_common.rb
+++ b/ci_scripts/release_common.rb
@@ -87,7 +87,7 @@ def changelog(version)
 end
 
 def update_placeholder(version, filename)
-  changelog = IO.readlines(filename).map do |line|
+  changelog = File.readlines(filename).map do |line|
     if line.upcase.start_with?('## X')
       "## #{version} #{Time.now.strftime('%Y-%m-%d')}\n"
     elsif line.start_with?('### Migrating from versions < X')


### PR DESCRIPTION
https://github.com/stripe/stripe-ios/blob/8eef9721d69487fc6f23857067bfdaa291994bf1/ci_scripts/release_common.rb#L90-L90

fix the problem should replace the use of `IO.readlines` with `File.readlines`. The `File` class methods do not have the same vulnerability as the `IO` class methods when dealing with non-constant values. This change will ensure that the code is not susceptible to command injection attacks through the `filename` parameter. The specific change needed is in the `update_placeholder` method, where `IO.readlines(filename)` should be replaced with `File.readlines(filename)`.


If `Kernel.open` is given a file name that starts with a `|` character, it will execute the remaining string as a shell command. If a malicious user can control the file name, they can execute arbitrary code. The same vulnerability applies to `IO.read`, `IO.write`, `IO.binread`, `IO.binwrite`, `IO.foreach`, `IO.readlines` and `URI.open`.

## POC
The following shows code that calls `Kernel.open` on a user-supplied file path.
```rb
require "open-uri"

class UsersController < ActionController::Base
  def create
    filename = params[:filename]
    open(filename) # BAD

    web_page = params[:web_page]
    URI.open(web_page) # BAD - calls `Kernel.open` internally
  end
end
```
Instead, `File.open` should be used, as in the following example.
```rb
class UsersController < ActionController::Base
  def create
    filename = params[:filename]
    File.open(filename)

    web_page = params[:web_page]
    Net::HTTP.get(URI.parse(web_page))
  end
end
```
## References
[Command Injection](https://www.owasp.org/index.php/Command_Injection). [Ruby on Rails Cheat Sheet: Command Injection](https://cheatsheetseries.owasp.org/cheatsheets/Ruby_on_Rails_Cheat_Sheet.html#command-injection)
[Command Injection in RDoc](https://www.ruby-lang.org/en/news/2021/05/02/os-command-injection-in-rdoc/)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-88](https://cwe.mitre.org/data/definitions/88.html)
[CWE-73](https://cwe.mitre.org/data/definitions/73.html)