### PR TITLE
Updates tap targeting for viewMore

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFlatWithCheckmark.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFlatWithCheckmark.swift
@@ -36,6 +36,12 @@ final class RowButtonFlatWithCheckmark: RowButton {
         stackView.alignment = .leading
         stackView.setCustomSpacing(8, after: labelsStackView)
 
+        // Accessory view is too small to tap, so extend the tap targeting to include the entire stack view
+        if let accessoryView,
+           accessoryView.responds(to: #selector(handleTap)) {
+            stackView.addGestureRecognizer(UITapGestureRecognizer(target: accessoryView, action: #selector(handleTap)))
+        }
+
         let horizontalStackView = UIStackView(arrangedSubviews: [stackView,
                                                                  defaultBadgeLabel,
                                                                  UIView.makeSpacerView(),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFlatWithRadioView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFlatWithRadioView.swift
@@ -34,11 +34,10 @@ final class RowButtonFlatWithRadioView: RowButton {
         let horizontalStackView = UIStackView(arrangedSubviews: [labelsStackView,
                                                                  defaultBadgeLabel,
                                                                  UIView.makeSpacerView(),
-                                                                 promoBadge,
-                                                                 accessoryView, ].compactMap { $0 })
+                                                                 promoBadge, ].compactMap { $0 })
         horizontalStackView.spacing = 8
 
-        [radioButton, imageView, horizontalStackView].compactMap { $0 }
+        [radioButton, imageView, horizontalStackView, accessoryView].compactMap { $0 }
             .forEach { view in
                 view.translatesAutoresizingMaskIntoConstraints = false
                 view.isAccessibilityElement = false
@@ -73,10 +72,25 @@ final class RowButtonFlatWithRadioView: RowButton {
 
             // Label constraints
             horizontalStackView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 12),
-            horizontalStackView.trailingAnchor.constraint(equalTo: trailingAnchor),
             horizontalStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
             horizontalStackView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: insets),
             horizontalStackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -insets),
         ])
+        if let accessoryView, !accessoryView.isHidden {
+            // Optional accessoryView
+            NSLayoutConstraint.activate([
+                accessoryView.leadingAnchor.constraint(equalTo: horizontalStackView.trailingAnchor, constant: 8),
+                accessoryView.trailingAnchor.constraint(equalTo: trailingAnchor),
+                accessoryView.centerYAnchor.constraint(equalTo: centerYAnchor),
+                // Extend to the top and bottom edges to increase tap targeting
+                accessoryView.topAnchor.constraint(equalTo: topAnchor, constant: 0),
+                accessoryView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0),
+            ])
+        } else {
+            // If no accessoryView, then constrain the stackView's trailing anchor
+            NSLayoutConstraint.activate([
+                horizontalStackView.trailingAnchor.constraint(equalTo: trailingAnchor)
+            ])
+        }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFloating.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFloating.swift
@@ -43,10 +43,9 @@ final class RowButtonFloating: RowButton {
                                                                  defaultBadgeLabel,
                                                                  UIView.makeSpacerView(),
                                                                  promoBadge,
-                                                                 accessoryView, ].compactMap { $0 })
+                                                                ].compactMap { $0 })
         horizontalStackView.spacing = 8
-
-        [imageView, horizontalStackView].compactMap { $0 }
+        [imageView, horizontalStackView, accessoryView].compactMap { $0 }
             .forEach { view in
                 view.translatesAutoresizingMaskIntoConstraints = false
                 view.isAccessibilityElement = false
@@ -74,11 +73,26 @@ final class RowButtonFloating: RowButton {
 
             // Label constraints
             horizontalStackView.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 12),
-            horizontalStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
             horizontalStackView.centerYAnchor.constraint(equalTo: centerYAnchor),
             horizontalStackView.topAnchor.constraint(greaterThanOrEqualTo: topAnchor, constant: insets),
             horizontalStackView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -insets),
         ])
+        if let accessoryView, !accessoryView.isHidden {
+            // Optional accessoryView
+            NSLayoutConstraint.activate([
+                accessoryView.leadingAnchor.constraint(equalTo: horizontalStackView.trailingAnchor, constant: 8),
+                accessoryView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+                accessoryView.centerYAnchor.constraint(equalTo: centerYAnchor),
+                // Extend to the top and bottom edges to increase tap targeting
+                accessoryView.topAnchor.constraint(equalTo: topAnchor, constant: 0),
+                accessoryView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: 0),
+            ])
+        } else {
+            // If no accessoryView, then constrain the stackView's trailing anchor
+            NSLayoutConstraint.activate([
+                horizontalStackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12)
+            ])
+        }
     }
 
     override func handleEvent(_ event: STPEvent) {


### PR DESCRIPTION
## Summary
Increases the tappable area for viewing more saved payment methods for all three types of rows -- floating button, checkmark, and radio

For floating button and radio, i've extended the view to the edges.
For checkmark, I've made the label of the digits above "view more" to be tappable.

## Motivation
Tap targeting is too small.


## Testing
Manual testing, and relying on existing screenshot tests to ensure I have not broken any layout issues.


|    | before | After |
| -------- | ------- | ------- |
| floating  | <img width="410" alt="before_floating" src="https://github.com/user-attachments/assets/94ec5bba-686d-41c8-ad1e-69028669a462" /> |   <img width="400" alt="fb_after" src="https://github.com/user-attachments/assets/54572e62-8f1a-40bf-836e-992c5b32efbf" /> |
| radio | <img width="418" alt="before_embed_radio" src="https://github.com/user-attachments/assets/9e969aae-0f91-4d2e-a6e4-edb09692078d" />  | <img width="406" alt="after_embed_radio" src="https://github.com/user-attachments/assets/9909cd38-0aee-4816-b644-568749005a05" /> | 
| check    | <img width="406" alt="before_embed_check" src="https://github.com/user-attachments/assets/d400bc56-c89e-472b-928b-19f8cce192ab" />   | <img width="405" alt="after_embed_check" src="https://github.com/user-attachments/assets/01716d8e-a08e-437e-abc8-0e9156cc5854" /> (note, the blue portion in this image is tappable!) |






