### PR TITLE
Log FC SDK availability for some MPE events

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -418,6 +418,10 @@ final class PaymentSheetAnalyticsHelper {
         additionalParams["link_context"] = linkContext
         additionalParams["link_ui"] = linkUI
 
+        if event.shouldLogFcSdkAvailability {
+            additionalParams["fc_sdk_availability"] = FinancialConnectionsSDKAvailability.analyticsValue
+        }
+
         if let error {
             additionalParams.mergeAssertingOnOverwrites(error.serializeForV1Analytics())
         }
@@ -512,5 +516,18 @@ extension EmbeddedPaymentElement.UpdateResult {
         case .failed:
             return "failed"
         }
+    }
+}
+
+extension STPAnalyticEvent {
+    var shouldLogFcSdkAvailability: Bool {
+        let allowlist: Set<STPAnalyticEvent> = [
+            .paymentSheetLoadSucceeded,
+            .paymentSheetCarouselPaymentMethodTapped,
+            .bankAccountCollectorStarted,
+            .bankAccountCollectorFinished,
+            .paymentSheetConfirmButtonTapped,
+        ]
+        return allowlist.contains(self)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
@@ -14,6 +14,11 @@ import XCTest
 
 final class PaymentSheetAnalyticsHelperTest: XCTestCase {
     let analyticsClient = STPTestingAnalyticsClient()
+    
+    override func tearDown() {
+        super.tearDown()
+        FinancialConnectionsSDKAvailability.fcLiteFeatureEnabled = false
+    }
 
     @MainActor
     func testPaymentSheetAddsUsage() {
@@ -143,6 +148,8 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
             (.flowController, "flowcontroller"),
         ]
 
+        FinancialConnectionsSDKAvailability.fcLiteFeatureEnabled = true
+
         for (shape, shapeString) in integrationShapes {
             let sut = PaymentSheetAnalyticsHelper(integrationShape: shape, configuration: PaymentSheet.Configuration(), analyticsClient: analyticsClient)
 
@@ -204,6 +211,7 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
             XCTAssertEqual(loadSucceededPayload["integration_shape"] as? String, shapeString)
             XCTAssertEqual(loadSucceededPayload["set_as_default_enabled"] as? Bool, true)
             XCTAssertEqual(loadSucceededPayload["has_default_payment_method"] as? Bool, true)
+            XCTAssertEqual(loadSucceededPayload["fc_sdk_availability"] as? String, "LITE")
         }
     }
 
@@ -406,6 +414,7 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
         XCTAssertLessThan(analyticsClient._testLogHistory.last!["duration"] as! Double, 1.0)
         XCTAssertEqual(analyticsClient._testLogHistory.last!["selected_lpm"] as? String, "link")
         XCTAssertEqual(analyticsClient._testLogHistory.last!["link_context"] as? String, "wallet")
+        XCTAssertEqual(analyticsClient._testLogHistory.last!["fc_sdk_availability"] as? String, "NONE")
     }
 
     func testLogPaymentLinkContextWithLinkedBank() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
@@ -14,11 +14,6 @@ import XCTest
 
 final class PaymentSheetAnalyticsHelperTest: XCTestCase {
     let analyticsClient = STPTestingAnalyticsClient()
-    
-    override func tearDown() {
-        super.tearDown()
-        FinancialConnectionsSDKAvailability.fcLiteFeatureEnabled = false
-    }
 
     @MainActor
     func testPaymentSheetAddsUsage() {
@@ -148,8 +143,6 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
             (.flowController, "flowcontroller"),
         ]
 
-        FinancialConnectionsSDKAvailability.fcLiteFeatureEnabled = true
-
         for (shape, shapeString) in integrationShapes {
             let sut = PaymentSheetAnalyticsHelper(integrationShape: shape, configuration: PaymentSheet.Configuration(), analyticsClient: analyticsClient)
 
@@ -211,7 +204,7 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
             XCTAssertEqual(loadSucceededPayload["integration_shape"] as? String, shapeString)
             XCTAssertEqual(loadSucceededPayload["set_as_default_enabled"] as? Bool, true)
             XCTAssertEqual(loadSucceededPayload["has_default_payment_method"] as? Bool, true)
-            XCTAssertEqual(loadSucceededPayload["fc_sdk_availability"] as? String, "LITE")
+            XCTAssertEqual(loadSucceededPayload["fc_sdk_availability"] as? String, "NONE")
         }
     }
 

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -31,6 +31,16 @@ import UIKit
         return Self.FinancialConnectionsLiteImplementation
     }
 
+    @_spi(STP) public static let analyticsValue: String = {
+        if FinancialConnectionsSDKClass != nil {
+            return "FULL"
+        } else if FCLiteClassIfEnabled != nil {
+            return "LITE"
+        } else {
+            return "NONE"
+        }
+    }()
+
     static let isUnitTest: Bool = {
         #if targetEnvironment(simulator)
         return NSClassFromString("XCTest") != nil


### PR DESCRIPTION
## Summary

Adds a new parameter `fc_sdk_availability` to the following events: 

- `mc_load_succeeded`
- `mc_carousel_payment_method_tapped`
- `stripeios.bankaccountcollector.started`
- `stripeios.bankaccountcollector.finished`
- `mc_confirm_button_tapped`

## Motivation

More details: https://docs.google.com/document/d/18CRScF4Rv5UD9wdQwFXDXHoObb05s0L9va1xV0Lwlpo/edit?tab=t.0#bookmark=id.2a28d4kfuy5l

## Testing

N/a

## Changelog

N/a
