### PR TITLE
Remove clientside dev flag for payment method update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x yyyy-yy-yy
+### PaymentSheet
+* [Added] Ability to update saved cards when using CustomerSessions (private preview)
+
 ## 24.11.1 2025-04-14
 ### PaymentSheet
 * [Added] Added support for PayNow and PromptPay to Embedded Payment Element (private preview).

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSessionPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSessionPlaygroundView.swift
@@ -54,7 +54,6 @@ struct CustomerSessionPlaygroundView: View {
                     }
                     SettingPickerView(setting: $viewModel.paymentMethodRemove)
                     SettingPickerView(setting: $viewModel.paymentMethodRemoveLast)
-                    SettingPickerView(setting: $viewModel.paymentMethodUpdate)
                     SettingPickerView(setting: paymentMethodRedisplayBinding)
                     if viewModel.paymentMethodRedisplay == .enabled {
                         SettingPickerView(setting: $viewModel.paymentMethodAllowRedisplayFilters)

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetCustomerSessionPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetCustomerSessionPlaygroundView.swift
@@ -24,7 +24,6 @@ struct CustomerSheetCustomerSessionPlaygroundView: View {
                 VStack {
                     SettingPickerView(setting: $viewModel.paymentMethodRemove)
                     SettingPickerView(setting: $viewModel.paymentMethodRemoveLast)
-                    SettingPickerView(setting: $viewModel.paymentMethodUpdate)
                     SettingPickerView(setting: $viewModel.paymentMethodAllowRedisplayFilters)
                     SettingPickerView(setting: $viewModel.paymentMethodSyncDefault)
                 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -4,7 +4,7 @@
 //
 
 import Combine
-@_spi(STP) @_spi(CustomerSessionBetaAccess) @_spi(UpdatePaymentMethodBeta) import StripePaymentSheet
+@_spi(STP) @_spi(CustomerSessionBetaAccess) import StripePaymentSheet
 import SwiftUI
 
 class CustomerSheetTestPlaygroundController: ObservableObject {
@@ -141,7 +141,7 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
         case .allowVisa:
             configuration.cardBrandAcceptance = .allowed(brands: [.visa])
         }
-        configuration.updatePaymentMethodEnabled = settings.paymentMethodUpdate == .enabled
+
         return configuration
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -116,12 +116,6 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
         case enabled
         case disabled
     }
-    enum PaymentMethodUpdate: String, PickerEnum {
-        static let enumName: String = "PaymentMethodUpdate"
-
-        case enabled
-        case disabled
-    }
     enum PaymentMethodAllowRedisplayFilters: String, PickerEnum {
         static var enumName: String { "PaymentMethodRedisplayFilters" }
 
@@ -180,7 +174,6 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     var allowsRemovalOfLastSavedPaymentMethod: AllowsRemovalOfLastSavedPaymentMethod
     var paymentMethodRemove: PaymentMethodRemove
     var paymentMethodRemoveLast: PaymentMethodRemoveLast
-    var paymentMethodUpdate: PaymentMethodUpdate
     var paymentMethodAllowRedisplayFilters: PaymentMethodAllowRedisplayFilters
     var paymentMethodSyncDefault: PaymentMethodSyncDefault
     var cardBrandAcceptance: CardBrandAcceptance
@@ -204,7 +197,6 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
                                                    allowsRemovalOfLastSavedPaymentMethod: .on,
                                                    paymentMethodRemove: .enabled,
                                                    paymentMethodRemoveLast: .enabled,
-                                                   paymentMethodUpdate: .disabled,
                                                    paymentMethodAllowRedisplayFilters: .always,
                                                    paymentMethodSyncDefault: .disabled,
                                                    cardBrandAcceptance: .all)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -306,12 +306,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case enabled
         case disabled
     }
-    enum PaymentMethodUpdate: String, PickerEnum {
-        static var enumName: String { "PaymentMethodUpdate" }
-
-        case enabled
-        case disabled
-    }
     enum PaymentMethodRemoveLast: String, PickerEnum {
         static var enumName: String { "PaymentMethodRemoveLast" }
 
@@ -608,7 +602,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var allowRedisplayOverride: AllowRedisplayOverride
     var paymentMethodRemove: PaymentMethodRemove
     var paymentMethodRemoveLast: PaymentMethodRemoveLast
-    var paymentMethodUpdate: PaymentMethodUpdate
     var paymentMethodRedisplay: PaymentMethodRedisplay
     var paymentMethodAllowRedisplayFilters: PaymentMethodAllowRedisplayFilters
     var paymentMethodSetAsDefault: PaymentMethodSetAsDefault
@@ -662,7 +655,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             allowRedisplayOverride: .notSet,
             paymentMethodRemove: .enabled,
             paymentMethodRemoveLast: .enabled,
-            paymentMethodUpdate: .disabled,
             paymentMethodRedisplay: .enabled,
             paymentMethodAllowRedisplayFilters: .always,
             paymentMethodSetAsDefault: .disabled,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -14,7 +14,7 @@ import Contacts
 import PassKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
-@_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(PaymentSheetSkipConfirmation) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(EmbeddedPaymentElementPrivateBeta) @_spi(UpdatePaymentMethodBeta) @_spi(CustomPaymentMethodsBeta) import StripePaymentSheet
+@_spi(CustomerSessionBetaAccess) @_spi(STP) @_spi(PaymentSheetSkipConfirmation) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(EmbeddedPaymentElementPrivateBeta) @_spi(CustomPaymentMethodsBeta) import StripePaymentSheet
 import SwiftUI
 import UIKit
 
@@ -194,8 +194,6 @@ class PlaygroundController: ObservableObject {
             configuration.cardBrandAcceptance = .allowed(brands: [.visa])
         }
 
-        configuration.updatePaymentMethodEnabled = settings.paymentMethodUpdate == .enabled
-
         switch settings.style {
         case .automatic:
             configuration.style = .automatic
@@ -293,8 +291,6 @@ class PlaygroundController: ObservableObject {
         case .allowVisa:
             configuration.cardBrandAcceptance = .allowed(brands: [.visa])
         }
-
-        configuration.updatePaymentMethodEnabled = settings.paymentMethodUpdate == .enabled
 
         return configuration
     }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -607,8 +607,15 @@ class CustomerSheetUITest: XCTestCase {
         app.buttons["Save"].tap()
         XCTAssertTrue(app.buttons["Confirm"].waitForExistence(timeout: timeout))
 
-        // Shouldn't be able to edit only one saved PM when allowsRemovalOfLastSavedPaymentMethod = .off
-        XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1))
+        // Go to the edit screen
+        XCTAssertTrue(app.buttons["Edit"].waitForExistenceAndTap())
+        XCTAssertTrue(app.staticTexts["Done"].waitForExistence(timeout: 1)) // Sanity check "Done" button is there
+        XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: timeout))
+
+        // Shouldn't be able to remove non-CBC eligible card when allowsRemovalOfLastSavedPaymentMethod = .off
+        XCTAssertFalse(app.buttons["Remove"].waitForExistence(timeout: 1))
+        XCTAssertTrue(app.buttons["Back"].waitForExistenceAndTap(timeout: timeout))
+        XCTAssertTrue(app.buttons["Done"].waitForExistenceAndTap(timeout: timeout))
 
         // Add another PM
         app.buttons["+ Add"].waitForExistenceAndTap()
@@ -629,8 +636,7 @@ class CustomerSheetUITest: XCTestCase {
         sleep(1)
 
         // Should be kicked out of edit mode now that we have one saved PM
-        XCTAssertFalse(app.staticTexts["Done"].waitForExistence(timeout: 1)) // "Done" button is gone - we are not in edit mode
-        XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1)) // "Edit" button is gone - we can't edit
+        XCTAssertTrue(app.buttons["Done"].waitForExistenceAndTap(timeout: timeout))
 
         // Add a CBC enabled PM
         app.buttons["+ Add"].waitForExistenceAndTap()
@@ -681,8 +687,15 @@ class CustomerSheetUITest: XCTestCase {
         app.buttons["Save"].tap()
         XCTAssertTrue(app.buttons["Confirm"].waitForExistence(timeout: timeout))
 
-        // Shouldn't be able to edit non-CBC eligible card when paymentMethodRemove = .disabled
-        XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1))
+        // Go to the edit screen
+        XCTAssertTrue(app.buttons["Edit"].waitForExistenceAndTap())
+        XCTAssertTrue(app.staticTexts["Done"].waitForExistence(timeout: 1)) // Sanity check "Done" button is there
+        XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: timeout))
+
+        // Shouldn't be able to remove non-CBC eligible card when paymentMethodRemove = .disabled
+        XCTAssertFalse(app.buttons["Remove"].waitForExistence(timeout: 1))
+        XCTAssertTrue(app.buttons["Back"].waitForExistenceAndTap(timeout: timeout))
+        XCTAssertTrue(app.buttons["Done"].waitForExistenceAndTap(timeout: timeout))
 
         // Add a CBC enabled PM
         app.buttons["+ Add"].waitForExistenceAndTap()
@@ -696,7 +709,8 @@ class CustomerSheetUITest: XCTestCase {
 
         // Assert there are no remove buttons on each tile and the update screen
         XCTAssertNil(scroll(collectionView: app.collectionViews.firstMatch, toFindButtonWithId: "CircularButton.Remove"))
-        XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: timeout))
+        XCTAssertTrue(app.buttons["CircularButton.Edit"].firstMatch.waitForExistenceAndTap(timeout: timeout))
+        XCTAssertFalse(app.buttons["Remove"].waitForExistence(timeout: 1))
 
         // Dismiss Sheet
         app.buttons["Back"].waitForExistenceAndTap(timeout: timeout)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -768,7 +768,6 @@ class CustomerSheetUITest: XCTestCase {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .returning
         settings.customerKeyType = .customerSession
-        settings.paymentMethodUpdate = .enabled
         settings.merchantCountryCode = .FR
         loadPlayground(
             app,
@@ -838,7 +837,6 @@ class CustomerSheetUITest: XCTestCase {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .returning
         settings.customerKeyType = .customerSession
-        settings.paymentMethodUpdate = .enabled
         settings.merchantCountryCode = .FR
         settings.collectAddress = .full
         loadPlayground(

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -537,7 +537,8 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Present embedded payment element"].waitForExistenceAndTap(timeout: 10))
         XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 10))
         XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4242")
-        XCTAssertFalse(app.buttons["Edit"].waitForExistence(timeout: 3))
+        XCTAssertTrue(app.buttons["Edit"].waitForExistenceAndTap(timeout: 3))
+        XCTAssertFalse(app.buttons["Remove"].waitForExistence(timeout: 3))
     }
 
     func testConfirmationWithUserButton_savedPaymentMethod() {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1460,11 +1460,11 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.applePayEnabled = .on
         settings.apmsEnabled = .off
-        settings.linkPassthroughMode = .pm
+        settings.linkDisplay = .never
         settings.allowsRemovalOfLastSavedPaymentMethod = .off
         settings.customerKeyType = .legacy
 
-        try _testRemoveLastSavedPaymentMethodPaymentSheet(settings: settings)
+        try _testRemoveLastSavedPaymentMethodPaymentSheet(settings: settings, hasEditPMFunction: false)
     }
     func testRemoveLastSavedPaymentMethodPaymentSheet() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
@@ -1475,7 +1475,7 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.applePayEnabled = .on
         settings.apmsEnabled = .off
-        settings.linkPassthroughMode = .pm
+        settings.linkDisplay = .never
 
         settings.allowsRemovalOfLastSavedPaymentMethod = .on
         settings.customerKeyType = .customerSession
@@ -1483,9 +1483,9 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.paymentMethodSave = .enabled
         settings.allowsRemovalOfLastSavedPaymentMethod = .on
 
-        try _testRemoveLastSavedPaymentMethodPaymentSheet(settings: settings, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
+        try _testRemoveLastSavedPaymentMethodPaymentSheet(settings: settings, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases", hasEditPMFunction: true)
     }
-    func _testRemoveLastSavedPaymentMethodPaymentSheet(settings: PaymentSheetTestPlaygroundSettings, tapCheckboxWithText: String? = nil) throws {
+    func _testRemoveLastSavedPaymentMethodPaymentSheet(settings: PaymentSheetTestPlaygroundSettings, tapCheckboxWithText: String? = nil, hasEditPMFunction: Bool) throws {
         loadPlayground(app, settings)
 
         app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
@@ -1501,8 +1501,21 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
         XCTAssertTrue(app.buttons["Pay $50.99"].waitForExistence(timeout: 10))
         XCTAssertTrue(app.buttons["Pay $50.99"].isEnabled)
-        // Shouldn't be able to edit only one saved PM when allowsRemovalOfLastSavedPaymentMethod = .off
-        XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1))
+
+        if hasEditPMFunction {
+            // Go to the edit screen
+            XCTAssertTrue(app.buttons["Edit"].waitForExistenceAndTap())
+            XCTAssertTrue(app.staticTexts["Done"].waitForExistence(timeout: 1)) // Sanity check "Done" button is there
+            XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: 3))
+
+            // Shouldn't be able to remove non-CBC eligible card when removeLast is disabled
+            XCTAssertFalse(app.buttons["Remove"].waitForExistence(timeout: 1))
+            XCTAssertTrue(app.buttons["Back"].waitForExistenceAndTap(timeout: 3))
+            XCTAssertTrue(app.buttons["Done"].waitForExistenceAndTap(timeout: 3))
+        } else {
+            // Shouldn't be able to edit only one saved PM when allowsRemovalOfLastSavedPaymentMethod = .off
+            XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1))
+        }
 
         // Add another PM
         app.buttons["+ Add"].waitForExistenceAndTap()
@@ -1525,12 +1538,18 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Remove"].waitForExistenceAndTap())
         XCTAssertTrue(app.alerts.buttons["Remove"].waitForExistenceAndTap())
 
-        // Should be kicked out of edit mode now that we have one saved PM
-        XCTAssertFalse(app.staticTexts["Done"].waitForExistence(timeout: 1)) // "Done" button is gone - we are not in edit mode
-        XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1)) // "Edit" button is gone - we can't edit
-        XCTAssertTrue(app.buttons["Close"].waitForExistence(timeout: 1))
-        app.buttons["Close"].waitForExistenceAndTap()
-
+        if hasEditPMFunction {
+            XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: 3))
+            XCTAssertFalse(app.buttons["Remove"].waitForExistence(timeout: 1))
+            XCTAssertTrue(app.buttons["Back"].waitForExistenceAndTap(timeout: 3))
+            XCTAssertTrue(app.buttons["Close"].waitForExistenceAndTap(timeout: 3))
+        } else {
+            // Should be kicked out of edit mode now that we have one saved PM
+            XCTAssertFalse(app.staticTexts["Done"].waitForExistence(timeout: 1)) // "Done" button is gone - we are not in edit mode
+            XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1)) // "Edit" button is gone - we can't edit
+            XCTAssertTrue(app.buttons["Close"].waitForExistence(timeout: 1))
+            app.buttons["Close"].waitForExistenceAndTap()
+        }
         // Reload w/ same customer & ensure 5555 card was detached
         reload(app, settings: settings)
         app.buttons["Present PaymentSheet"].waitForExistenceAndTap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1640,7 +1640,6 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.linkDisplay = .never
 
         settings.customerKeyType = .customerSession
-        settings.paymentMethodUpdate = .enabled
         loadPlayground(app, settings)
         app.buttons["Apple Pay, apple_pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
         XCTAssertTrue(app.staticTexts["Edit"].waitForExistenceAndTap(timeout: 15))
@@ -1709,7 +1708,6 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.collectAddress = .full
 
         settings.customerKeyType = .customerSession
-        settings.paymentMethodUpdate = .enabled
         loadPlayground(app, settings)
         app.buttons["Apple Pay, apple_pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
         XCTAssertTrue(app.staticTexts["Edit"].waitForExistenceAndTap(timeout: 15))

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1549,13 +1549,13 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.applePayEnabled = .on
         settings.apmsEnabled = .off
-        settings.linkPassthroughMode = .pm
+        settings.linkDisplay = .never
 
         settings.customerKeyType = .legacy
         settings.allowsRemovalOfLastSavedPaymentMethod = .off
         loadPlayground(app, settings)
 
-        try _testRemoveLastSavedPaymentMethodFlowController(settings: settings)
+        try _testRemoveLastSavedPaymentMethodFlowController(settings: settings, hasEditPMFunction: false)
     }
     func test_RemoveLastSavedPaymentMethodFlowController_customerSession() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
@@ -1566,7 +1566,7 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.customerMode = .new
         settings.applePayEnabled = .on
         settings.apmsEnabled = .off
-        settings.linkPassthroughMode = .pm
+        settings.linkDisplay = .never
 
         settings.customerKeyType = .customerSession
         settings.paymentMethodRemoveLast = .disabled
@@ -1574,10 +1574,12 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         settings.allowsRemovalOfLastSavedPaymentMethod = .on
         loadPlayground(app, settings)
 
-        try _testRemoveLastSavedPaymentMethodFlowController(settings: settings, tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
+        try _testRemoveLastSavedPaymentMethodFlowController(settings: settings,
+                                                            tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases",
+                                                            hasEditPMFunction: true)
     }
 
-    func _testRemoveLastSavedPaymentMethodFlowController(settings: PaymentSheetTestPlaygroundSettings, tapCheckboxWithText: String? = nil) throws {
+    func _testRemoveLastSavedPaymentMethodFlowController(settings: PaymentSheetTestPlaygroundSettings, tapCheckboxWithText: String? = nil, hasEditPMFunction: Bool) throws {
         app.buttons["Apple Pay, apple_pay"].waitForExistenceAndTap(timeout: 30) // Should default to Apple Pay
         app.buttons["+ Add"].waitForExistenceAndTap()
 
@@ -1592,9 +1594,20 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         reload(app, settings: settings)
         app.staticTexts["•••• 4242"].waitForExistenceAndTap()  // The card should be saved now and selected as default instead of Apple Pay
 
-        // Shouldn't be able to edit only one saved PM when allowsRemovalOfLastSavedPaymentMethod = .off
-        XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1))
+        if hasEditPMFunction {
+            // Go to the edit screen
+            XCTAssertTrue(app.buttons["Edit"].waitForExistenceAndTap())
+            XCTAssertTrue(app.staticTexts["Done"].waitForExistence(timeout: 1)) // Sanity check "Done" button is there
+            XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: 3))
 
+            // Shouldn't be able to remove non-CBC eligible card when removeLast is disabled
+            XCTAssertFalse(app.buttons["Remove"].waitForExistence(timeout: 1))
+            XCTAssertTrue(app.buttons["Back"].waitForExistenceAndTap(timeout: 3))
+            XCTAssertTrue(app.buttons["Done"].waitForExistenceAndTap(timeout: 3))
+        } else {
+            // Shouldn't be able to edit only one saved PM when allowsRemovalOfLastSavedPaymentMethod = .off
+            XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1))
+        }
         // Ensure we can tap another payment method, which will dismiss Flow Controller
         app.buttons["Apple Pay"].waitForExistenceAndTap()
 
@@ -1620,11 +1633,17 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Remove"].waitForExistenceAndTap())
         XCTAssertTrue(app.alerts.buttons["Remove"].waitForExistenceAndTap())
 
-        // Should be kicked out of edit mode now that we have one saved PM
-        XCTAssertFalse(app.staticTexts["Done"].waitForExistence(timeout: 1)) // "Done" button is gone - we are not in edit mode
-        XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1)) // "Edit" button is gone - we can't edit
-        XCTAssertTrue(app.buttons["Close"].waitForExistence(timeout: 1))
+        if hasEditPMFunction {
+            XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: 3))
+            XCTAssertFalse(app.buttons["Remove"].waitForExistence(timeout: 3))
+        } else {
+            // Should be kicked out of edit mode now that we have one saved PM
+            XCTAssertFalse(app.staticTexts["Done"].waitForExistence(timeout: 1)) // "Done" button is gone - we are not in edit mode
+            XCTAssertFalse(app.staticTexts["Edit"].waitForExistence(timeout: 1)) // "Edit" button is gone - we can't edit
+            XCTAssertTrue(app.buttons["Close"].waitForExistence(timeout: 1))
+        }
     }
+
     func test_updatePaymentMethod() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.layout = .horizontal
@@ -1809,7 +1828,7 @@ class PaymentSheetCustomerSessionCBCUITests: PaymentSheetUITestCase {
 
         // Detect there are no remove buttons on each tile and the update screen
         XCTAssertNil(scroll(collectionView: app.collectionViews.firstMatch, toFindButtonWithId: "CircularButton.Remove")?.tap())
-        XCTAssertTrue(app.buttons["CircularButton.Edit"].waitForExistenceAndTap(timeout: 5))
+        XCTAssertTrue(app.buttons["CircularButton.Edit"].firstMatch.waitForExistenceAndTap(timeout: 5))
         XCTAssertFalse(app.buttons["Remove"].exists)
 
         app.buttons["Back"].waitForExistenceAndTap(timeout: 5)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITest.swift
@@ -329,7 +329,8 @@ class PaymentSheetVerticalUITests: PaymentSheetUITestCase {
         XCTAssertTrue(app.buttons["Pay $50.99"].waitForExistence(timeout: 10))
 
         // Verify that edit control does not render
-        XCTAssertFalse(app.buttons["Edit"].waitForExistenceAndTap())
+        XCTAssertTrue(app.buttons["Edit"].waitForExistenceAndTap())
+        XCTAssertFalse(app.buttons["Remove"].exists)
     }
 
     func testCVCRecollection_verticalMode() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -255,11 +255,11 @@ extension STPElementsSession {
         return customer?.customerSession.mobilePaymentElementComponent.features?.paymentMethodSetAsDefault ?? false
     }
 
-    func paymentMethodUpdateForPaymentSheet(_ configuration: PaymentElementConfiguration) -> Bool {
+    var paymentMethodUpdateForPaymentSheet: Bool {
         return customer?.customerSession.mobilePaymentElementComponent.enabled ?? false
     }
 
-    func paymentMethodUpdateForCustomerSheet(_ configuration: CustomerSheet.Configuration) -> Bool {
+    var paymentMethodUpdateForCustomerSheet: Bool {
         return customer?.customerSession.customerSheetComponent.enabled ?? false
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -256,11 +256,11 @@ extension STPElementsSession {
     }
 
     func paymentMethodUpdateForPaymentSheet(_ configuration: PaymentElementConfiguration) -> Bool {
-        return configuration.updatePaymentMethodEnabled && customer?.customerSession.mobilePaymentElementComponent.enabled ?? false
+        return customer?.customerSession.mobilePaymentElementComponent.enabled ?? false
     }
 
     func paymentMethodUpdateForCustomerSheet(_ configuration: CustomerSheet.Configuration) -> Bool {
-        return configuration.updatePaymentMethodEnabled && customer?.customerSession.customerSheetComponent.enabled ?? false
+        return customer?.customerSession.customerSheetComponent.enabled ?? false
     }
 
     func allowsRemovalOfPaymentMethodsForCustomerSheet() -> Bool {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -81,9 +81,6 @@ extension CustomerSheet {
         /// Note: Card brand filtering is not currently supported by Link.
         public var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = .all
 
-        /// Flag used to stage the development of updating payment method
-        @_spi(UpdatePaymentMethodBeta) public var updatePaymentMethodEnabled: Bool = false
-
         public init () {
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
@@ -213,7 +213,7 @@ extension CustomerSheetDataSource {
         case .customerAdapter:
             return false
         case .customerSession:
-            return elementsSession.paymentMethodUpdateForCustomerSheet(configuration)
+            return elementsSession.paymentMethodUpdateForCustomerSheet
         }
     }
     func paymentMethodSyncDefault(elementsSession: STPElementsSession) -> Bool {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -34,7 +34,7 @@ extension EmbeddedPaymentElement {
             isCBCEligible: loadResult.elementsSession.isCardBrandChoiceEligible,
             allowsRemovalOfLastSavedPaymentMethod: loadResult.elementsSession.paymentMethodRemoveLast(configuration: configuration),
             allowsPaymentMethodRemoval: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
-            allowsPaymentMethodUpdate: loadResult.elementsSession.paymentMethodUpdateForPaymentSheet(configuration),
+            allowsPaymentMethodUpdate: loadResult.elementsSession.paymentMethodUpdateForPaymentSheet,
             isFlatCheckmarkStyle: configuration.appearance.embeddedPaymentElement.row.style == .flatWithCheckmark
         )
         let initialSelection: RowButtonType? = {
@@ -176,7 +176,7 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
                                                                                hostedSurface: .paymentSheet,
                                                                                cardBrandFilter: configuration.cardBrandFilter,
                                                                                canRemove: elementsSession.paymentMethodRemoveLast(configuration: configuration) && elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
-                                                                               canUpdate: elementsSession.paymentMethodUpdateForPaymentSheet(configuration),
+                                                                               canUpdate: elementsSession.paymentMethodUpdateForPaymentSheet,
                                                                                isCBCEligible: paymentMethod.isCoBrandedCard && elementsSession.isCardBrandChoiceEligible,
                                                                                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
                                                                                isDefault: paymentMethod == defaultPaymentMethod)
@@ -317,7 +317,7 @@ extension EmbeddedPaymentElement: UpdatePaymentMethodViewControllerDelegate {
             isCBCEligible: elementsSession.isCardBrandChoiceEligible,
             allowsRemovalOfLastSavedPaymentMethod: elementsSession.paymentMethodRemoveLast(configuration: configuration),
             allowsPaymentMethodRemoval: elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
-            allowsPaymentMethodUpdate: elementsSession.paymentMethodUpdateForPaymentSheet(configuration),
+            allowsPaymentMethodUpdate: elementsSession.paymentMethodUpdateForPaymentSheet,
             isFlatCheckmarkStyle: configuration.appearance.embeddedPaymentElement.row.style == .flatWithCheckmark
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
@@ -137,9 +137,6 @@ extension EmbeddedPaymentElement {
         /// Note: Card brand filtering is not currently supported by Link.
         public var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = .all
 
-        /// Flag used to stage the development of updating payment method
-        @_spi(UpdatePaymentMethodBeta) public var updatePaymentMethodEnabled: Bool = false
-
         /// The view can display payment methods like “Card” that, when tapped, open a form sheet where customers enter their payment method details. The sheet has a button at the bottom. `FormSheetAction` enumerates the actions the button can perform.
         public enum FormSheetAction {
             /// The button says “Pay” or “Setup”. When tapped, we confirm the payment or setup in the form sheet.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentElementConfiguration.swift
@@ -41,7 +41,6 @@ protocol PaymentElementConfiguration: PaymentMethodRequirementProvider {
     var analyticPayload: [String: Any] { get }
     var disableWalletPaymentMethodFiltering: Bool { get set }
     var linkPaymentMethodsOnly: Bool { get set }
-    var updatePaymentMethodEnabled: Bool { get }
     var paymentMethodLayout: PaymentSheet.PaymentMethodLayout { get }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -215,9 +215,6 @@ extension PaymentSheet {
         /// Note: This is only a client-side solution.
         /// Note: Card brand filtering is not currently supported by Link.
         public var cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = .all
-
-        /// Flag used to stage the development of updating payment method
-        @_spi(UpdatePaymentMethodBeta) public var updatePaymentMethodEnabled: Bool = false
     }
 
     /// Defines the layout orientations available for displaying payment methods in PaymentSheet.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -599,7 +599,7 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
                                                                            hostedSurface: .paymentSheet,
                                                                            cardBrandFilter: paymentSheetConfiguration.cardBrandFilter,
                                                                            canRemove: configuration.allowsRemovalOfPaymentMethods && (savedPaymentMethods.count > 1 || configuration.allowsRemovalOfLastSavedPaymentMethod),
-                                                                           canUpdate: elementsSession.paymentMethodUpdateForPaymentSheet(paymentSheetConfiguration),
+                                                                           canUpdate: elementsSession.paymentMethodUpdateForPaymentSheet,
                                                                            isCBCEligible: paymentMethod.isCoBrandedCard && cbcEligible,
                                                                            allowsSetAsDefaultPM: configuration.allowsSetAsDefaultPM,
                                                                            isDefault: isDefaultPaymentMethod(savedPaymentMethodId: paymentMethod.stripeId))

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -183,7 +183,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         self.defaultPaymentMethod = defaultPaymentMethod
         self.paymentMethodRemove = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
         self.paymentMethodRemoveLast = elementsSession.paymentMethodRemoveLast(configuration: configuration)
-        self.paymentMethodUpdate = elementsSession.paymentMethodUpdateForPaymentSheet(configuration)
+        self.paymentMethodUpdate = elementsSession.paymentMethodUpdateForPaymentSheet
         self.paymentMethodSetAsDefault = elementsSession.paymentMethodSetAsDefaultForPaymentSheet
         self.isCBCEligible = elementsSession.isCardBrandChoiceEligible
         self.analyticsHelper = analyticsHelper

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -206,7 +206,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
                 allowsRemovalOfLastSavedPaymentMethod: elementsSession.paymentMethodRemoveLast(configuration: configuration),
                 allowsRemovalOfPaymentMethods: elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                 allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
-                allowsUpdatePaymentMethod: elementsSession.paymentMethodUpdateForPaymentSheet(configuration)
+                allowsUpdatePaymentMethod: elementsSession.paymentMethodUpdateForPaymentSheet
             ),
             paymentSheetConfiguration: configuration,
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -382,7 +382,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
             isCBCEligible: loadResult.elementsSession.isCardBrandChoiceEligible,
             allowsRemovalOfLastSavedPaymentMethod: loadResult.elementsSession.paymentMethodRemoveLast(configuration: configuration),
             allowsPaymentMethodRemoval: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
-            allowsPaymentMethodUpdate: loadResult.elementsSession.paymentMethodUpdateForPaymentSheet(configuration)
+            allowsPaymentMethodUpdate: loadResult.elementsSession.paymentMethodUpdateForPaymentSheet
         )
         return VerticalPaymentMethodListViewController(
             initialSelection: initialSelection,
@@ -628,7 +628,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                                                                                hostedSurface: .paymentSheet,
                                                                                cardBrandFilter: configuration.cardBrandFilter,
                                                                                canRemove: elementsSession.paymentMethodRemoveLast(configuration: configuration) && elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
-                                                                               canUpdate: elementsSession.paymentMethodUpdateForPaymentSheet(configuration),
+                                                                               canUpdate: elementsSession.paymentMethodUpdateForPaymentSheet,
                                                                                isCBCEligible: paymentMethod.isCoBrandedCard && elementsSession.isCardBrandChoiceEligible,
                                                                                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
                                                                                isDefault: paymentMethod == defaultPaymentMethod)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -176,7 +176,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                 allowsRemovalOfLastSavedPaymentMethod: elementsSession.paymentMethodRemoveLast(configuration: configuration),
                 allowsRemovalOfPaymentMethods: loadResult.elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet(),
                 allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
-                allowsUpdatePaymentMethod: elementsSession.paymentMethodUpdateForPaymentSheet(configuration)
+                allowsUpdatePaymentMethod: elementsSession.paymentMethodUpdateForPaymentSheet
             ),
             paymentSheetConfiguration: configuration,
             intent: intent,


### PR DESCRIPTION
## Summary
Removes client side flag for payment method update. This means that any user who opts-into customerSessions will automatically get payment method update.

## Motivation
Decision to remove client side flag

## Testing
Updated existing tests