### PR TITLE
Only set networks if we have fetched card brands

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
@@ -92,7 +92,10 @@ final class CardSectionElement: ContainerElement {
         if cardBrandChoiceEligible {
             cardBrandDropDown = PaymentMethodElementWrapper(DropdownFieldElement.makeCardBrandDropdown(theme: theme)) { field, params in
                 let cardBrand = STPCard.brand(from: field.selectedItem.rawData)
-                cardParams(for: params).networks = STPPaymentMethodCardNetworksParams(preferred: cardBrand != .unknown ? STPCardBrandUtilities.apiValue(from: cardBrand) : nil)
+                // Only set preferred networks for the confirm params if we have more than 1 brand fetched
+                if (cardBrandDropDown?.element.nonPlacerholderItems.count ?? 1) > 1 {
+                    cardParams(for: params).networks = STPPaymentMethodCardNetworksParams(preferred: cardBrand != .unknown ? STPCardBrandUtilities.apiValue(from: cardBrand) : nil)
+                }
                 analyticsHelper?.logCardBrandSelected(hostedSurface: hostedSurface, cardBrand: cardBrand)
                 return params
             }


### PR DESCRIPTION
## Summary
- On our card params we should only set networks if we have more than 1 fetched brand for CBC merchants.
- This ensures we can correctly compute the display brand for merchants who are CBC eligible using the card confirm params

## Motivation
- https://stripe.slack.com/archives/C058XM768SE/p1744809964413229

## Testing
- Manual

## Changelog
N/A