### PR TITLE
Fix `testAsyncPresentCompletion()` using `@MainActor`

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
@@ -67,6 +67,7 @@ class FinancialConnectionsSheetTests: XCTestCase {
         wait(for: [expectation], timeout: 5.0)
     }
 
+    @MainActor
     func testAsyncPresentCompletion() async {
         let expectation = XCTestExpectation(description: "Sheet completion")
 


### PR DESCRIPTION
## Summary

Fixes `testAsyncPresentCompletion()` using `@MainActor`. It was flaking on CI: https://app.bitrise.io/build/6a63d614-a3cb-4c85-9f27-10bb0f12fc71

## Motivation

De-flake a flaky test

## Testing

Trust CI!

## Changelog

N/a