### PR TITLE
Set blik timeout to 60 seconds

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
@@ -728,7 +728,7 @@ class PaymentSheetStandardLPMUIThreeTests: PaymentSheetStandardLPMUICase {
 
         // Pay
         XCTAssertTrue(app.buttons["Pay PLN 50.99"].waitForExistenceAndTap(timeout: 5.0))
-        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 20.0))
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 60.0))
     }
 
     func testBacsDebit() {


### PR DESCRIPTION
## Summary
Blik has a timeout of 60 seconds, but our tests only waits for 20.  We're probably better off waiting for the entire timeout.

## Motivation
Flakey test

## Testing
manually
