### PR TITLE
Minor pmo sfu playground refactor

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentMethodOptionsSetupFutureUsagePlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentMethodOptionsSetupFutureUsagePlaygroundView.swift
@@ -46,9 +46,9 @@ struct PaymentMethodOptionsSetupFutureUsagePlaygroundView: View {
 
     var additionalPaymentMethodOptionsSetupFutureUsageBinding: Binding<String> {
         Binding<String> {
-            return viewModel.additionalPaymentMethodOptionsSetupFutureUsage ?? ""
+            return viewModel.paymentMethodOptionsSetupFutureUsage.additionalPaymentMethodOptionsSetupFutureUsage ?? ""
         } set: { newString in
-            viewModel.additionalPaymentMethodOptionsSetupFutureUsage = newString
+            viewModel.paymentMethodOptionsSetupFutureUsage.additionalPaymentMethodOptionsSetupFutureUsage = newString
         }
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -165,6 +165,8 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         // Does not support SFU
         var affirm: SetupFutureUsageNone
 
+        var additionalPaymentMethodOptionsSetupFutureUsage: String?
+
         static func defaultValues() -> PaymentMethodOptionsSetupFutureUsage {
             return PaymentMethodOptionsSetupFutureUsage(
                 card: .unset,
@@ -176,8 +178,26 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             )
         }
 
-        func makeRequestBody(with additionalPaymentMethodOptionsSetupFutureUsage: String?) -> [String: String] {
-            var result: [String: String] = self.toDictionary()
+        func toDictionary() -> [String: String] {
+            var result: [String: String] = [:]
+            if card != .unset {
+                result["card"] = card.rawValue
+            }
+            if usBankAccount != .unset {
+                result["us_bank_account"] = usBankAccount.rawValue
+            }
+            if sepaDebit != .unset {
+                result["sepa_debit"] = sepaDebit.rawValue
+            }
+            if link != .unset {
+                result["link"] = link.rawValue
+            }
+            if klarna != .unset {
+                result["klarna"] = klarna.rawValue
+            }
+            if affirm != .unset {
+                result["affirm"] = affirm.rawValue
+            }
             if let additionalPaymentMethodOptionsSetupFutureUsage {
                 // get the "key:value" strings by splitting on the comma
                 let paymentMethodOptionsSetupFutureUsage = additionalPaymentMethodOptionsSetupFutureUsage
@@ -197,29 +217,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
                         result[paymentMethodType] = setupFutureUsageValue
                     }
                 }
-            }
-            return result
-        }
-
-        private func toDictionary() -> [String: String] {
-            var result: [String: String] = [:]
-            if card != .unset {
-                result["card"] = card.rawValue
-            }
-            if usBankAccount != .unset {
-                result["us_bank_account"] = usBankAccount.rawValue
-            }
-            if sepaDebit != .unset {
-                result["sepa_debit"] = sepaDebit.rawValue
-            }
-            if link != .unset {
-                result["link"] = link.rawValue
-            }
-            if klarna != .unset {
-                result["klarna"] = klarna.rawValue
-            }
-            if affirm != .unset {
-                result["affirm"] = affirm.rawValue
             }
             return result
         }
@@ -598,7 +595,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var apmsEnabled: APMSEnabled
     var supportedPaymentMethods: String?
     var paymentMethodOptionsSetupFutureUsage: PaymentMethodOptionsSetupFutureUsage
-    var additionalPaymentMethodOptionsSetupFutureUsage: String?
 
     var shippingInfo: ShippingInfo
     var applePayEnabled: ApplePayEnabled

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -681,7 +681,7 @@ extension PlaygroundController {
             "merchant_country_code": settings.merchantCountryCode.rawValue,
             "mode": settings.mode.rawValue,
             "automatic_payment_methods": settings.apmsEnabled == .on,
-            "payment_method_options_setup_future_usage": settings.paymentMethodOptionsSetupFutureUsage.makeRequestBody(with: settings.additionalPaymentMethodOptionsSetupFutureUsage),
+            "payment_method_options_setup_future_usage": settings.paymentMethodOptionsSetupFutureUsage.toDictionary(),
             "use_link": settings.linkPassthroughMode == .pm,
             "link_mode": settings.linkEnabledMode.rawValue,
             "use_manual_confirmation": settings.integrationType == .deferred_mc,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Moved additionalPaymentMethodOptionsSetupFutureUsage into the PaymentMethodOptionsSetupFutureUsage struct and updated toDictionary with additionalPaymentMethodOptionsSetupFutureUsage
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
It's annoying passing around additionalPaymentMethodOptionsSetupFutureUsage when additionalPaymentMethodOptionsSetupFutureUsage is always used in conjunction with PaymentMethodOptionsSetupFutureUsage, so this is cleaner
## Testing
<!-- How was the code tested? Be as specific as possible. -->
Manually
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A