### PR TITLE
Complete cancelled FCLite sessions

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/API Client/FCLiteApiClient.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/API Client/FCLiteApiClient.swift
@@ -12,11 +12,13 @@ struct FCLiteAPIClient {
     private enum Endpoint {
         case synchronize
         case sessionReceipt
+        case complete
 
         var path: String {
             switch self {
             case .synchronize: "financial_connections/sessions/synchronize"
             case .sessionReceipt: "link_account_sessions/session_receipt"
+            case .complete: "link_account_sessions/complete"
             }
         }
     }
@@ -93,5 +95,14 @@ extension FCLiteAPIClient {
             "client_secret": clientSecret,
         ]
         return try await get(endpoint: .sessionReceipt, parameters: parameters)
+    }
+    
+    func complete(
+        clientSecret: String
+    ) async throws -> FinancialConnectionsSession {
+        let parameters: [String: Any] = [
+            "client_secret": clientSecret,
+        ]
+        return try await post(endpoint: .complete, parameters: parameters)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/API Client/FCLiteApiClient.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/API Client/FCLiteApiClient.swift
@@ -96,7 +96,7 @@ extension FCLiteAPIClient {
         ]
         return try await get(endpoint: .sessionReceipt, parameters: parameters)
     }
-    
+
     func complete(
         clientSecret: String
     ) async throws -> FinancialConnectionsSession {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/Controllers/FCLiteAuthFlowViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/Controllers/FCLiteAuthFlowViewController.swift
@@ -13,8 +13,14 @@ import UIKit
 
 class FCLiteAuthFlowViewController: UIViewController {
     enum WebFlowResult {
+        enum CancellationType {
+            case none
+            case cancelledWithinWebview
+            case cancelledOutsideWebView
+        }
+        
         case success(returnUrl: URL)
-        case cancelled
+        case cancelled(CancellationType)
         case failure(Error)
     }
 
@@ -143,7 +149,7 @@ extension FCLiteAuthFlowViewController: WKNavigationDelegate {
             completion(.success(returnUrl: url))
         } else if url.matchesSchemeHostAndPath(of: manifest.cancelURL) {
             decisionHandler(.cancel)
-            completion(.cancelled)
+            completion(.cancelled(.cancelledWithinWebview))
         } else {
             decisionHandler(.allow)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/Controllers/FCLiteAuthFlowViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/Controllers/FCLiteAuthFlowViewController.swift
@@ -14,11 +14,10 @@ import UIKit
 class FCLiteAuthFlowViewController: UIViewController {
     enum WebFlowResult {
         enum CancellationType {
-            case none
             case cancelledWithinWebview
             case cancelledOutsideWebView
         }
-        
+
         case success(returnUrl: URL)
         case cancelled(CancellationType)
         case failure(Error)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/Controllers/FCLiteContainerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/Controllers/FCLiteContainerViewController.swift
@@ -106,7 +106,7 @@ class FCLiteContainerViewController: UIViewController {
     }
 
     private func fetchSessionAndComplete(
-        cancellationType: FCLiteAuthFlowViewController.WebFlowResult.CancellationType = .none
+        cancellationType: FCLiteAuthFlowViewController.WebFlowResult.CancellationType? = nil
     ) async {
         DispatchQueue.main.async {
             // Pop back to root to show a loading spinner.
@@ -125,7 +125,7 @@ class FCLiteContainerViewController: UIViewController {
                 session = try await apiClient.sessionReceipt(clientSecret: clientSecret)
             }
 
-            if session.paymentAccount == nil, cancellationType != .none {
+            if session.paymentAccount == nil, cancellationType != nil {
                 completion(.cancelled)
                 return
             }


### PR DESCRIPTION
## Summary

When the FC Lite flow is dismissed by the user, we still attempt to get a session object. In this scenario, we should call the `complete` endpoint ourselves instead of the `session_receipt` endpoint. When the flow is cancelled from within the webview (i.e. tapping the `X`), the web flow calls the `complete` endpoint, so we just get the session receipt.

## Motivation

Fixes bugs when swiping to dismiss.

## Testing

Before: 

https://github.com/user-attachments/assets/8e2500f6-2ebd-489b-9676-8f2d8cf3dc23

After:

https://github.com/user-attachments/assets/e1da957c-3a77-4be3-9e55-f23a6cb544da

Dismissing the flow during various points in the flow:

https://github.com/user-attachments/assets/42c4597a-f6e4-4ff5-8454-809079dd177e

## Changelog

N/a
