### PR TITLE
Revert gesture recognizer on RowButtonFlatWithCheckmark

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFlatWithCheckmark.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFlatWithCheckmark.swift
@@ -36,12 +36,6 @@ final class RowButtonFlatWithCheckmark: RowButton {
         stackView.alignment = .leading
         stackView.setCustomSpacing(8, after: labelsStackView)
 
-        // Accessory view is too small to tap, so extend the tap targeting to include the entire stack view
-        if let accessoryView,
-           accessoryView.responds(to: #selector(handleTap)) {
-            stackView.addGestureRecognizer(UITapGestureRecognizer(target: accessoryView, action: #selector(handleTap)))
-        }
-
         let horizontalStackView = UIStackView(arrangedSubviews: [stackView,
                                                                  defaultBadgeLabel,
                                                                  UIView.makeSpacerView(),


### PR DESCRIPTION
## Summary
This breaks the ability to tap on label when using RowButtonFlatWithCheckmark

## Motivation
Regression

## Testing
Manual testing

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
