### PR TITLE
Add BDCC flag for CPMs in playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -527,8 +527,9 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     }
 
     enum CustomPaymentMethods: String, PickerEnum {
-        static let enumName: String = "Custom Payment Methods"
+        static let enumName: String = "CPMs"
         case on
+        case onWithBDCC = "on w/ BDCC"
         case off
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -432,7 +432,7 @@ class PlaygroundController: ObservableObject {
                 fatalError()
             }
         } else if self.settings.uiStyle == .paymentSheet {
-            self.rootViewController.presentedViewController?.presentedViewController?.present(alert, animated: true)
+            self.rootViewController.presentedViewController?.present(alert, animated: true)
         } else {
             self.rootViewController.present(alert, animated: true)
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -422,20 +422,12 @@ class PlaygroundController: ObservableObject {
             completion(.failed(error: exampleError))
         })
 
-        if self.settings.uiStyle == .embedded {
-            switch embeddedConfiguration.formSheetAction {
-            case .confirm:
-                self.rootViewController.presentedViewController?.presentedViewController?.present(alert, animated: true)
-            case .continue:
-                self.rootViewController.presentedViewController?.present(alert, animated: true)
-            @unknown default:
-                fatalError()
-            }
-        } else if self.settings.uiStyle == .paymentSheet {
-            self.rootViewController.presentedViewController?.present(alert, animated: true)
-        } else {
-            self.rootViewController.present(alert, animated: true)
+        guard let topMostVC = UIViewController.topMostViewController() else {
+            print("Unable to find top most view controller")
+            return
         }
+
+        topMostVC.present(alert, animated: true)
     }
 
     var clientSecret: String?

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -421,7 +421,7 @@ class PlaygroundController: ObservableObject {
             let exampleError = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Something went wrong!"])
             completion(.failed(error: exampleError))
         })
-        
+
         if self.settings.uiStyle == .embedded {
             switch embeddedConfiguration.formSheetAction {
             case .confirm:

--- a/Example/PaymentSheet Example/PaymentSheet Example/ViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ViewController.swift
@@ -40,12 +40,26 @@ class ViewController: UIViewController {
     @IBSegueAction func showSwiftUICusotmerSheetSwiftUI(_ coder: NSCoder) -> UIViewController? {
         return UIHostingController(coder: coder, rootView: ExampleSwiftUICustomerSheet())
     }
-    
+
     @IBSegueAction func showSwiftUIEmbedded(_ coder: NSCoder) -> UIViewController? {
         if #available(iOS 15.0, *) {
             return UIHostingController(coder: coder, rootView: MyEmbeddedCheckoutView())
         } else {
             fatalError(">= iOS 15.0 required")
         }
+    }
+}
+
+extension UIViewController {
+
+    static func topMostViewController() -> UIViewController? {
+        guard let window = UIApplication.shared.keyWindow else {
+            return nil
+        }
+        var topMostViewController = window.rootViewController
+        while let presentedViewController = topMostViewController?.presentedViewController {
+            topMostViewController = presentedViewController
+        }
+        return topMostViewController
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ExternalPaymentOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ExternalPaymentOption.swift
@@ -107,7 +107,7 @@ class ExternalPaymentOption {
                 var message = customPaymentMethod.error
                 // mode_mismatch from the server isn't helpful, let's try to be better.
                 if message == "mode_mismatch" {
-                    message = "mode_mismatch. Ensure this customer payment method was created for either test or live mode depending on your current environment."
+                    message = "mode_mismatch. Ensure this custom payment method was created for either test or live mode depending on your current environment."
                 }
                 
                 return message ?? "unknown"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ExternalPaymentOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ExternalPaymentOption.swift
@@ -109,7 +109,7 @@ class ExternalPaymentOption {
                 if message == "mode_mismatch" {
                     message = "mode_mismatch. Ensure this custom payment method was created for either test or live mode depending on your current environment."
                 }
-                
+
                 return message ?? "unknown"
             }()
             assertionFailure("Failed to render payment method type: \(customPaymentMethod.type) with error \(errorMessage)")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ExternalPaymentOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ExternalPaymentOption.swift
@@ -103,7 +103,16 @@ class ExternalPaymentOption {
               let label = customPaymentMethod.displayName,
               let logoUrl = customPaymentMethod.logoUrl else {
             STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetInvalidCPM)
-            assertionFailure("Failed to render payment method type: \(customPaymentMethod.type) with error \(customPaymentMethod.error ?? "unknown")")
+            let errorMessage: String = {
+                var message = customPaymentMethod.error
+                // mode_mismatch from the server isn't helpful, let's try to be better.
+                if message == "mode_mismatch" {
+                    message = "mode_mismatch. Ensure this customer payment method was created for either test or live mode depending on your current environment."
+                }
+                
+                return message ?? "unknown"
+            }()
+            assertionFailure("Failed to render payment method type: \(customPaymentMethod.type) with error \(errorMessage)")
             return nil
         }
 


### PR DESCRIPTION
## Summary
- Adds a flag to enable BDCC for CPMs in the playground
- Tries in a best effort manner to improve the mode_mismatch error message. It's not helpful.

## Motivation
- https://docs.google.com/document/d/1UNuVxLk2zJBbx6AEqWQ8IPuysv3agmXRgtxefc6Mbnk/edit?tab=t.0

## Testing
- Manual

## Changelog
N/A
