### PR TITLE
Fix Mac Catalyst build error in StripeFinancialConnections

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/UIViewController+KeyboardAvoiding.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/UIViewController+KeyboardAvoiding.swift
@@ -131,12 +131,7 @@ class STPKeyboardDetectingViewController: UIViewController {
             let scrollViewSuperView = managedScrollView.superview
 
             var contentInsets = scrollView.contentInset
-            var scrollIndicatorInsets: UIEdgeInsets = .zero
-            #if !targetEnvironment(macCatalyst)
-            scrollIndicatorInsets = scrollView.verticalScrollIndicatorInsets
-            #else
-            scrollIndicatorInsets = scrollView.scrollIndicatorInsets
-            #endif
+            var scrollIndicatorInsets = scrollView.verticalScrollIndicatorInsets
 
             let windowFrame = scrollViewSuperView?.convert(
                 scrollViewSuperView?.frame ?? CGRect.zero,


### PR DESCRIPTION
## Summary

Fixes a build error when compiling for Mac Catalyst. The error was: 

```
UIViewController+KeyboardAvoiding.swift:138
Getter for 'scrollIndicatorInsets' was deprecated in Mac Catalyst 13.1: The scrollIndicatorInsets getter is deprecated, use the verticalScrollIndicatorInsets and horizontalScrollIndicatorInsets getters instead.
```

## Motivation

Fix MacOS builds

## Testing

Manually tested

## Changelog

N/a