### PR TITLE
Release FC Lite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## x.x.x yyyy-yy-yy
 ### PaymentSheet
+* [Added] Bank payments are now available in the PaymentSheet without requiring a dependency on `StripeFinancialConnections`.
 * [Added] Ability to update saved cards when using CustomerSessions (private preview)
 
 ## 24.11.1 2025-04-14

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -278,7 +278,6 @@ final class PlaygroundViewModel: ObservableObject {
 
     func didSelectShow() {
         let useFCLite = playgroundConfiguration.sdkType == .fcLite
-        FinancialConnectionsSDKAvailability.fcLiteFeatureEnabled = useFCLite
         FinancialConnectionsSDKAvailability.shouldPreferFCLite = useFCLite
 
         switch playgroundConfiguration.integrationType {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -496,7 +496,6 @@ class PlaygroundController: ObservableObject {
             UserDefaults.standard.set(enableInstantDebitsIncentives, forKey: "FINANCIAL_CONNECTIONS_INSTANT_DEBITS_INCENTIVES")
 
             let enableFcLite = newValue.fcLiteEnabled == .on
-            FinancialConnectionsSDKAvailability.fcLiteFeatureEnabled = enableFcLite
             FinancialConnectionsSDKAvailability.shouldPreferFCLite = enableFcLite
         }.store(in: &subscribers)
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsHelperTest.swift
@@ -204,7 +204,7 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
             XCTAssertEqual(loadSucceededPayload["integration_shape"] as? String, shapeString)
             XCTAssertEqual(loadSucceededPayload["set_as_default_enabled"] as? Bool, true)
             XCTAssertEqual(loadSucceededPayload["has_default_payment_method"] as? Bool, true)
-            XCTAssertEqual(loadSucceededPayload["fc_sdk_availability"] as? String, "NONE")
+            XCTAssertEqual(loadSucceededPayload["fc_sdk_availability"] as? String, "LITE")
         }
     }
 
@@ -407,7 +407,7 @@ final class PaymentSheetAnalyticsHelperTest: XCTestCase {
         XCTAssertLessThan(analyticsClient._testLogHistory.last!["duration"] as! Double, 1.0)
         XCTAssertEqual(analyticsClient._testLogHistory.last!["selected_lpm"] as? String, "link")
         XCTAssertEqual(analyticsClient._testLogHistory.last!["link_context"] as? String, "wallet")
-        XCTAssertEqual(analyticsClient._testLogHistory.last!["fc_sdk_availability"] as? String, "NONE")
+        XCTAssertEqual(analyticsClient._testLogHistory.last!["fc_sdk_availability"] as? String, "LITE")
     }
 
     func testLogPaymentLinkContextWithLinkedBank() {

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -21,11 +21,9 @@ import UIKit
 
     @_spi(STP) public static var fcLiteKillswitchEnabled: Bool = false
     @_spi(STP) public static var shouldPreferFCLite: Bool = false
-    // Remove this when ready to release FC Lite:
-    @_spi(STP) public static var fcLiteFeatureEnabled: Bool = false
 
     private static var FCLiteClassIfEnabled: FinancialConnectionsSDKInterface.Type? {
-        guard fcLiteFeatureEnabled, !fcLiteKillswitchEnabled else {
+        guard !fcLiteKillswitchEnabled else {
             return nil
         }
         return Self.FinancialConnectionsLiteImplementation


### PR DESCRIPTION
## Summary

Removes the client side guardrails to release FC Lite. This flow will be used when the `StripeFinancialConnections` SDK is not available.

> [!NOTE]  
> FC Lite access can be controlled remotely via `elements_disable_fc_lite`.

## Motivation

Bank payments 📈 

## Testing

Manual testing, bug bashes, unit tests, and E2E tests.

## Changelog

```
[Added] Bank payments are now available in the PaymentSheet without requiring a dependency on `StripeFinancialConnections`.
```