### PR TITLE
Revert "Fix compilation on xcode163 (#4790)"

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/UIViewController+KeyboardAvoiding.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/UIViewController+KeyboardAvoiding.swift
@@ -132,7 +132,7 @@ class STPKeyboardDetectingViewController: UIViewController {
 
             var contentInsets = scrollView.contentInset
             var scrollIndicatorInsets: UIEdgeInsets = .zero
-            #if !targetEnvironment(macCatalyst)
+            #if !TARGET_OS_MACCATALYST
             scrollIndicatorInsets = scrollView.verticalScrollIndicatorInsets
             #else
             scrollIndicatorInsets = scrollView.scrollIndicatorInsets


### PR DESCRIPTION
This reverts commit 00597abd23d37b4d554119c9eb8d72236c6cd191.

## Summary
Seems to break our macOS builds in xcode cloud

## Motivation
Reverting change

## Testing
None

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
