### PR TITLE
Minor Link Global Holdback tweaks

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkGlobalHoldback.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkGlobalHoldback.swift
@@ -13,7 +13,7 @@ struct LinkGlobalHoldback: LoggableExperiment {
     let arbId: String
     let group: ExperimentGroup
 
-    private let defaultValuesProvided: [String]
+    private let defaultValuesProvided: String
     private let hasSPMs: Bool
     private let integrationShape: String
     private let isReturningLinkUser: Bool
@@ -59,7 +59,7 @@ struct LinkGlobalHoldback: LoggableExperiment {
         // A non-nil consumer session represents an existing Link user.
         self.isReturningLinkUser = linkAccount?.currentSession != nil
         self.linkNative = linkAccount?.useMobileEndpoints == true
-        self.linkDefaultOptIn = elementsSession.linkSettings?.linkDefaultOptIn?.rawValue ?? "NONE"
+        self.linkDefaultOptIn = (elementsSession.linkSettings?.linkDefaultOptIn ?? .none).rawValue
         self.integrationShape = integrationShape.analyticsValue
         self.linkDisplayed = isLinkEnabled
 
@@ -73,7 +73,7 @@ struct LinkGlobalHoldback: LoggableExperiment {
         if configuration.defaultBillingDetails.phone != nil {
             defaultValuesProvided.append("phone")
         }
-        self.defaultValuesProvided = defaultValuesProvided
+        self.defaultValuesProvided = defaultValuesProvided.joined(separator: " ")
 
         // SPM is enabled when:
         // 1. Session has a valid customer
@@ -81,7 +81,7 @@ struct LinkGlobalHoldback: LoggableExperiment {
         // 3. Link is not enabled (unless an additional beta flag is enabled)
         let hasCustomer = elementsSession.customer != nil
         let paymentMethodSaveEnabled = elementsSession.customerSessionMobilePaymentElementFeatures?.paymentMethodSave == true
-        let linkEnabledOrEnableLinkSPMFlagEnabled = !isLinkEnabled || elementsSession.flags["elements_enable_link_spm"] == true
-        self.hasSPMs = hasCustomer && paymentMethodSaveEnabled && linkEnabledOrEnableLinkSPMFlagEnabled
+        let linkNotEnabledOrEnableLinkSPMFlag = !isLinkEnabled || elementsSession.flags["elements_enable_link_spm"] == true
+        self.hasSPMs = hasCustomer && paymentMethodSaveEnabled && linkNotEnabledOrEnableLinkSPMFlag
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
@@ -99,6 +99,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
         )
         var configuration = PaymentSheet.Configuration()
         configuration.defaultBillingDetails.name = "Test Name"
+        configuration.defaultBillingDetails.email = "email"
         let linkAccount = PaymentSheetLinkAccount(
             email: "email",
             session: nil,
@@ -127,7 +128,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
         XCTAssertEqual(payload["dimension-link_native"] as? Bool, true)
         XCTAssertEqual(payload["dimension-link_default_opt_in"] as? String, "FULL")
         XCTAssertEqual(payload["dimension-integration_type"] as? String, "mpe_ios")
-        XCTAssertEqual(payload["dimension-dvs_provided"] as? [String], ["name"])
+        XCTAssertEqual(payload["dimension-dvs_provided"] as? String, "email name")
         XCTAssertEqual(payload["dimension-is_returning_link_user"] as? Bool, false)
         XCTAssertEqual(payload["dimension-link_displayed"] as? Bool, PaymentSheet.isLinkEnabled(elementsSession: session, configuration: configuration))
         XCTAssertEqual(payload["dimension-integration_shape"] as? String, "paymentsheet")


### PR DESCRIPTION
## Summary

Main change here is changing the `dvs_provided` dimension from an array to a space-joined string to match web. Also includes a few non-functional tweaks.

## Motivation

Alignment with web

## Testing

Example event:

<img width="852" alt="image" src="https://github.com/user-attachments/assets/52671652-6755-42ba-bf9e-f11900023da8" />

## Changelog

N/a
