### PR TITLE
Present from the main window VC if no VC is set in SwiftUI

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
@@ -126,6 +126,11 @@ import Combine
             return .failed(error: ViewModelError.notLoaded)
         }
 
+        // Hack: If Embedded has not been presented yet, we may not have a VC. If that's the case, populate it with the default VC for the window.
+        if embeddedPaymentElement.presentingViewController == nil {
+            embeddedPaymentElement.presentingViewController = UIWindow.visibleViewController
+        }
+        
         let result = await embeddedPaymentElement.confirm()
         return result
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
@@ -5,9 +5,9 @@
 //  Created by Nick Porter on 1/29/25.
 //
 
-import SwiftUI
 import Combine
 @_spi(STP) import StripeCore
+import SwiftUI
 
 /// A view model that manages an `EmbeddedPaymentElement`.
 @MainActor
@@ -41,7 +41,7 @@ import Combine
     // MARK: - Internal properties
 
     private(set) var embeddedPaymentElement: EmbeddedPaymentElement?
-    
+
     @Published var height: CGFloat = 0.0
 
     // MARK: - Private properties
@@ -109,7 +109,7 @@ import Combine
                 return .failed(error: ViewModelError.notLoaded)
             }
         }
-        
+
         // Check if update was called before load, if so throw an error
         guard let embeddedPaymentElement else {
             return .failed(error: ViewModelError.notLoaded)
@@ -130,7 +130,7 @@ import Combine
         if embeddedPaymentElement.presentingViewController == nil {
             embeddedPaymentElement.presentingViewController = UIWindow.visibleViewController
         }
-        
+
         let result = await embeddedPaymentElement.confirm()
         return result
     }
@@ -145,7 +145,7 @@ import Combine
         embeddedPaymentElement?.testHeightChange()
     }
 #endif
-    
+
     private func calculateAndPublishHeight(embeddedPaymentElement: EmbeddedPaymentElement) {
         let newHeight = embeddedPaymentElement.view.systemLayoutSizeFitting(CGSize(width: embeddedPaymentElement.view.bounds.width, height: UIView.layoutFittingCompressedSize.height)).height
 


### PR DESCRIPTION
## Summary
In our Embedded + SwiftUI bindings, it's possible that the `presentingViewController` has not yet been set when calling `confirm`. For example, a user may have loaded embedded, displayed details using the `currentPaymentOption`, but did not render Embedded before the user clicked "confirm".

In this case, we should set the `presentingViewController` on confirm, as that's what we would do anyway once Embedded was shown. (We'll only do this in SwiftUI for now, as that's the only situation where we manage the `presentingViewController` for the user.

## Motivation
Fixing an assertion failure when paying without presenting the Embedded VC

## Testing
Existing tests, tested in sample app

## Changelog
Minor fix, embedded not yet released