### PR TITLE
Disable `IntegrationTesterUICardTests.testHSBCHTMLIssue()`

### DIFF
--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
@@ -84,7 +84,8 @@ class IntegrationTesterUICardTests: IntegrationTesterUITests {
     }
 
     let hsbcCard = "4000582600000292"
-    func testHSBCHTMLIssue() throws {
+    // TODO(RUN_MOBILESDK-4224): Investigate flakyness
+    func disabled_testHSBCHTMLIssue() throws {
         testHSBCWebViewLinksTrigger(cardNumber: hsbcCard)
     }
 


### PR DESCRIPTION
## Summary

This test has a >50% failure rate on CI. Disabling it until it can be investigated.

## Motivation

Reduce CI flakyness.

## Testing

N/a

## Changelog

N/a
