### PR TITLE
Present Link as a modal

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -81,6 +81,7 @@ extension PaymentSheet {
         if UIDevice.current.userInterfaceIdiom == .pad {
             payWithLinkVC.modalPresentationStyle = .formSheet
         }
+        payWithLinkVC.isModalInPresentation = true
 
         presentingController.present(payWithLinkVC, animated: true, completion: completion)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -80,8 +80,6 @@ extension PaymentSheet {
 
         if UIDevice.current.userInterfaceIdiom == .pad {
             payWithLinkVC.modalPresentationStyle = .formSheet
-        } else {
-            payWithLinkVC.modalPresentationStyle = .overFullScreen
         }
 
         presentingController.present(payWithLinkVC, animated: true, completion: completion)


### PR DESCRIPTION
## Summary

This switches the Link controller from being full screen, to being presented modally. It also disables swipe-to-dismiss. 

## Motivation

One step closer to making the modal dynamically adjust its height based on its content.

## Testing

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 - 2025-04-30 at 09 39 16](https://github.com/user-attachments/assets/d956ea64-7108-4c04-8243-0ac286607d82) | ![Simulator Screenshot - iPhone 16 - 2025-04-30 at 09 40 36](https://github.com/user-attachments/assets/99efd731-d7ec-4d68-8a4a-6d5ed707ac0d) |

Swipe to dismiss

https://github.com/user-attachments/assets/ef64f1d8-0cd3-4efb-9a5b-ac12bf5764c3

## Changelog

N/a