### PR TITLE
Downloading strings from Lokalise filters out modules missing localization_dir

### DIFF
--- a/ci_scripts/download_localized_strings_from_lokalise.sh
+++ b/ci_scripts/download_localized_strings_from_lokalise.sh
@@ -23,11 +23,12 @@ source ci_scripts/localization_vars.sh
 # This is the custom status ID for our project with which the localizers mark completed translations
 FINAL_STATUS_ID=587
 
-lokalise2 --token $API_TOKEN \
+lokalise2 --token "$API_TOKEN" \
           --project-id $PROJECT_ID \
           file download \
           --format strings \
-          --filter-langs $LANGUAGES \
+          --filter-langs "$LANGUAGES" \
+          --filter-filenames "$LOKALISE_FILENAMES" \
           --custom-translation-status-ids $FINAL_STATUS_ID \
           --export-sort "a_z" \
           --directory-prefix . \

--- a/ci_scripts/l10n/config.rb
+++ b/ci_scripts/l10n/config.rb
@@ -52,3 +52,7 @@ LANGUAGES = %w[
 LOCALIZATION_DIRECTORIES = YAML.load_file('modules.yaml')['modules'].map do |m|
   m['localization_dir']
 end.compact.freeze
+
+LOKALISE_FILENAMES = LOCALIZATION_DIRECTORIES.map do |d|
+  "#{d}/Resources/Localizations/%LANG_ISO%.lproj/Localizable.strings"
+end.compact.freeze

--- a/ci_scripts/localization_vars.sh
+++ b/ci_scripts/localization_vars.sh
@@ -9,3 +9,6 @@ LOCALIZATION_DIRECTORIES=($(ruby -e "\$LOAD_PATH << Dir.pwd;require './ci_script
 
 # Languages that we localize to
 LANGUAGES=($(ruby -I . -e "\$LOAD_PATH << Dir.pwd;require './ci_scripts/l10n/config';puts LANGUAGES.join(',')"))
+
+# File names in lokalise
+LOKALISE_FILENAMES=($(ruby -I . -e "\$LOAD_PATH << Dir.pwd;require './ci_scripts/l10n/config';puts LOKALISE_FILENAMES.join(',')"))


### PR DESCRIPTION
## Summary
Updates `ci_scripts/download_localized_strings_from_lokalise.sh` to filter out strings from modules that don't define a `localization_dir`. This means that current and future projects can define localized messages and open PRs that will initiate translation, but SDK releases won't pick up those strings until the PR adding `localization_dir` is merged.

## Motivation
More ergonomic development of localizing new projects! Allows us to separate translated strings being available and those strings being added to the SDK.

## Testing
Ran the updated script with `StripeFinancialConnections` defining and not defining a `localization_dir` in `modules.yaml`. When the script ran without the `localization_dir` it didn't add the localized string files for `StripeFinancialConnections`, but when ran with the `localization_dir` it did!