### PR TITLE
Refactor Account Picker text strings for better localization

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
@@ -30,19 +30,6 @@ final class AccountPickerNoAccountEligibleErrorView: UIView {
 
         // Financial Connections support credit cards, but not in all flows
         // (ex. ACH only supports checking/savings).
-        let supportedAccountTypes: String = {
-            if paymentMethodType == .link {
-                return STPLocalizedString(
-                    "US checking",
-                    "A type of payment account. We will insert this string into other messages to explain users what payment accounts are eligible for payments. For example, we may display a message that says 'The accounts you selected aren't US checking accounts.'"
-                )
-            } else {
-                return STPLocalizedString(
-                    "checking or savings",
-                    "A type of payment account. We will insert this string into other messages to explain users what payment accounts are eligible for payments. For example, we may display a message that says 'The accounts you selected aren't checking or savings accounts.'"
-                )
-            }
-        }()
         let subtitleFirstSentence: String = {
             if let bussinessName = bussinessName {
                 if numberOfIneligibleAccounts == 1 {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
@@ -46,41 +46,75 @@ final class AccountPickerNoAccountEligibleErrorView: UIView {
         let subtitleFirstSentence: String = {
             if let bussinessName = bussinessName {
                 if numberOfIneligibleAccounts == 1 {
-                    let localizedString = STPLocalizedString(
-                        "We found 1 %@ account but you can only link %@ accounts to %@.",
-                        "A description/subtitle that instructs the user that the bank account they selected is not eligible. For example, maybe the user selected a credit card, but we only accept debit cards. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). The third '%@' is replaced by the business name (Ex. Coca-Cola Inc). For example, it may read 'We found 1 Chase account but you can only link checking or savings to Coca-Cola Inc.'"
-                    )
-                    return String(format: localizedString, institution.name, supportedAccountTypes, bussinessName)
+                    let localizedString: String = {
+                        if paymentMethodType == .link {
+                            return STPLocalizedString(
+                                "We found 1 %@ account but you can only link US checking accounts to %@.",
+                                "A description/subtitle that instructs the user that the bank account they selected is not eligible. For example, maybe the user selected a credit card, but we only accept debit cards. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). The third '%@' is replaced by the business name (Ex. Coca-Cola Inc). For example, it may read 'We found 1 Chase account but you can only link checking or savings to Coca-Cola Inc.'"
+                            )
+                        } else {
+                            return STPLocalizedString(
+                                "We found 1 %@ account but you can only link checking or savings accounts to %@.",
+                                "A description/subtitle that instructs the user that the bank account they selected is not eligible. For example, maybe the user selected a credit card, but we only accept debit cards. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). The third '%@' is replaced by the business name (Ex. Coca-Cola Inc). For example, it may read 'We found 1 Chase account but you can only link checking or savings to Coca-Cola Inc.'"
+                            )
+                        }
+                    }()
+                    return String(format: localizedString, institution.name, bussinessName)
                 } else {
-                    let localizedString = STPLocalizedString(
-                        "We found %d %@ accounts but you can only link %@ accounts to %@.",
-                        "A description/subtitle that instructs the user that the bank accounts they selected are not eligible. For example, maybe the user selected credit cards, but we only accept debit cards. The '%d' is replaced by the number of ineligible accounts. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). The third '%@' is replaced by the business name (Ex. Coca-Cola Inc). For example, it may read 'We found 2 Chase accounts but you can only link checking or savings to Coca-Cola Inc.'"
-                    )
+                    let localizedString: String = {
+                        if paymentMethodType == .link {
+                            return STPLocalizedString(
+                                "We found %d %@ accounts but you can only link US checking accounts to %@.",
+                                "A description/subtitle that instructs the user that the bank accounts they selected are not eligible. For example, maybe the user selected credit cards, but we only accept debit cards. The '%d' is replaced by the number of ineligible accounts. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). The third '%@' is replaced by the business name (Ex. Coca-Cola Inc). For example, it may read 'We found 2 Chase accounts but you can only link checking or savings to Coca-Cola Inc.'"
+                            )
+                        } else {
+                            return STPLocalizedString(
+                                "We found %d %@ accounts but you can only link checking or savings accounts to %@.",
+                                "A description/subtitle that instructs the user that the bank accounts they selected are not eligible. For example, maybe the user selected credit cards, but we only accept debit cards. The '%d' is replaced by the number of ineligible accounts. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). The third '%@' is replaced by the business name (Ex. Coca-Cola Inc). For example, it may read 'We found 2 Chase accounts but you can only link checking or savings to Coca-Cola Inc.'"
+                            )
+                        }
+                    }()
                     return String(
                         format: localizedString,
                         numberOfIneligibleAccounts,
                         institution.name,
-                        supportedAccountTypes,
                         bussinessName
                     )
                 }
             } else {
                 if numberOfIneligibleAccounts == 1 {
-                    let localizedString = STPLocalizedString(
-                        "We found 1 %@ account but you can only link %@ accounts.",
-                        "A description/subtitle that instructs the user that the bank account they selected is not eligible. For example, maybe the user selected a credit card, but we only accept debit cards. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). For example, it may read 'We found 1 Chase account but you can only link checking or savings.'"
-                    )
-                    return String(format: localizedString, institution.name, supportedAccountTypes)
+                    let localizedString: String = {
+                        if paymentMethodType == .link {
+                            return STPLocalizedString(
+                                "We found 1 %@ account but you can only link US checking accounts.",
+                                "A description/subtitle that instructs the user that the bank account they selected is not eligible. For example, maybe the user selected a credit card, but we only accept debit cards. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). For example, it may read 'We found 1 Chase account but you can only link checking or savings.'"
+                            )
+                        } else {
+                            return STPLocalizedString(
+                                "We found 1 %@ account but you can only link checking or savings accounts.",
+                                "A description/subtitle that instructs the user that the bank account they selected is not eligible. For example, maybe the user selected a credit card, but we only accept debit cards. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). For example, it may read 'We found 1 Chase account but you can only link checking or savings.'"
+                            )
+                        }
+                    }()
+                    return String(format: localizedString, institution.name)
                 } else {
-                    let localizedString = STPLocalizedString(
-                        "We found %d %@ accounts but you can only link %@ accounts.",
-                        "A description/subtitle that instructs the user that the bank accounts they selected are not eligible. For example, maybe the user selected credit cards, but we only accept debit cards. The '%d' is replaced by the number of ineligible accounts. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). For example, it may read 'We found 2 Chase accounts but you can only link checking or savings.'"
-                    )
+                    let localizedString: String = {
+                        if paymentMethodType == .link {
+                            STPLocalizedString(
+                                "We found %d %@ accounts but you can only link US checking accounts.",
+                                "A description/subtitle that instructs the user that the bank accounts they selected are not eligible. For example, maybe the user selected credit cards, but we only accept debit cards. The '%d' is replaced by the number of ineligible accounts. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). For example, it may read 'We found 2 Chase accounts but you can only link checking or savings.'"
+                            )
+                        } else {
+                            STPLocalizedString(
+                                "We found %d %@ accounts but you can only link checking or savings accounts.",
+                                "A description/subtitle that instructs the user that the bank accounts they selected are not eligible. For example, maybe the user selected credit cards, but we only accept debit cards. The '%d' is replaced by the number of ineligible accounts. The first '%@' is replaced by the name of the bank. The second '%@' is replaced by the supported payment accounts (ex. US checking). For example, it may read 'We found 2 Chase accounts but you can only link checking or savings.'"
+                            )
+                        }
+                    }()
                     return String(
                         format: localizedString,
                         numberOfIneligibleAccounts,
-                        institution.name,
-                        supportedAccountTypes
+                        institution.name
                     )
                 }
             }
@@ -110,14 +144,14 @@ final class AccountPickerNoAccountEligibleErrorView: UIView {
                     if institutionSkipAccountSelection {
                         if numberOfIneligibleAccounts == 1 {
                             return STPLocalizedString(
-                                    "The account you selected isn't available for payments",
-                                    "The title of a screen that shows an error. The error appears after we failed to load users bank accounts. Here we describe to the user that the account they selected isn't eligible."
-                                )
+                                "The account you selected isn't available for payments",
+                                "The title of a screen that shows an error. The error appears after we failed to load users bank accounts. Here we describe to the user that the account they selected isn't eligible."
+                            )
                         } else {
                             return STPLocalizedString(
-                                    "The accounts you selected aren't available for payments",
-                                    "The title of a screen that shows an error. The error appears after we failed to load users bank accounts. Here we describe to the user that the accounts they selected aren't eligible. '%@' gets replaced by the eligible type of bank accounts, i.e. checking or savings. For example, maybe user selected a credit card, but we only support debit cards."
-                                )
+                                "The accounts you selected aren't available for payments",
+                                "The title of a screen that shows an error. The error appears after we failed to load users bank accounts. Here we describe to the user that the accounts they selected aren't eligible. '%@' gets replaced by the eligible type of bank accounts, i.e. checking or savings. For example, maybe user selected a credit card, but we only support debit cards."
+                            )
                         }
                     } else {
                         return STPLocalizedString(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
@@ -31,7 +31,7 @@ final class AccountPickerNoAccountEligibleErrorView: UIView {
         // Financial Connections support credit cards, but not in all flows
         // (ex. ACH only supports checking/savings).
         let subtitleFirstSentence: String = {
-            if let bussinessName = bussinessName {
+            if let businessName {
                 if numberOfIneligibleAccounts == 1 {
                     let localizedString: String = {
                         if paymentMethodType == .link {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerNoAccountEligibleErrorView.swift
@@ -15,7 +15,7 @@ final class AccountPickerNoAccountEligibleErrorView: UIView {
 
     init(
         institution: FinancialConnectionsInstitution,
-        bussinessName: String?,
+        businessName: String?,
         institutionSkipAccountSelection: Bool,
         numberOfIneligibleAccounts: Int,
         paymentMethodType: FinancialConnectionsPaymentMethodType,
@@ -46,7 +46,7 @@ final class AccountPickerNoAccountEligibleErrorView: UIView {
                             )
                         }
                     }()
-                    return String(format: localizedString, institution.name, bussinessName)
+                    return String(format: localizedString, institution.name, businessName)
                 } else {
                     let localizedString: String = {
                         if paymentMethodType == .link {
@@ -65,7 +65,7 @@ final class AccountPickerNoAccountEligibleErrorView: UIView {
                         format: localizedString,
                         numberOfIneligibleAccounts,
                         institution.name,
-                        bussinessName
+                        businessName
                     )
                 }
             } else {
@@ -196,7 +196,7 @@ private struct AccountPickerNoAccountEligibleErrorViewUIViewRepresentable: UIVie
                 icon: nil,
                 logo: nil
             ),
-            bussinessName: businessName,
+            businessName: businessName,
             institutionSkipAccountSelection: institutionSkipAccountSelection,
             numberOfIneligibleAccounts: numberOfIneligibleAccounts,
             paymentMethodType: paymentMethodType,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -259,7 +259,7 @@ final class AccountPickerViewController: UIViewController {
     private func showNoEligibleAccountsErrorView(numberOfIneligibleAccounts: Int, error: Error) {
         let errorView = AccountPickerNoAccountEligibleErrorView(
             institution: self.dataSource.institution,
-            bussinessName: self.businessName,
+            businessName: self.businessName,
             institutionSkipAccountSelection: self.dataSource.authSession.institutionSkipAccountSelection
                 ?? false,
             numberOfIneligibleAccounts: numberOfIneligibleAccounts,


### PR DESCRIPTION
## Summary
Updates some text on the native account picker so that they're more likely to be localized correctly.

## Motivation
We've received feedback that the templating of some of the strings on the page may result in incorrect localization in certain  languages due to compounded nouns and adjective declension.

## Testing
No functional changes and visually inspected with previews.