### PR TITLE
Refactor error construction logic, prioritize local error messages

### DIFF
--- a/Stripe/StripeiOSTests/StripeErrorTest.swift
+++ b/Stripe/StripeiOSTests/StripeErrorTest.swift
@@ -170,7 +170,7 @@ class StripeErrorTest: XCTestCase {
         // Error type is not `card_error`, so `NSLocalizedDescription` will be a generic error.
         XCTAssertEqual(
             error.userInfo[NSLocalizedDescriptionKey] as! String,
-            NSError.stp_unexpectedErrorMessage()
+            NSError.stp_cardErrorInvalidNumberUserMessage()
         )
         XCTAssertEqual(
             error.userInfo[STPError.cardErrorCodeKey] as! String,

--- a/Stripe/StripeiOSTests/StripeErrorTest.swift
+++ b/Stripe/StripeiOSTests/StripeErrorTest.swift
@@ -167,7 +167,6 @@ class StripeErrorTest: XCTestCase {
         let error = NSError.stp_error(fromStripeResponse: response)!
         XCTAssertEqual(error.domain, STPError.stripeDomain)
         XCTAssertEqual(error.code, STPErrorCode.invalidRequestError.rawValue)
-        // Error type is not `card_error`, so `NSLocalizedDescription` will be a generic error.
         XCTAssertEqual(
             error.userInfo[NSLocalizedDescriptionKey] as! String,
             NSError.stp_cardErrorInvalidNumberUserMessage()

--- a/StripeCore/StripeCore/Source/Helpers/STPError.swift
+++ b/StripeCore/StripeCore/Source/Helpers/STPError.swift
@@ -146,19 +146,23 @@ extension NSError {
         declineCode: Any?,
         httpResponse: HTTPURLResponse?
     ) -> NSError? {
-        var code = 0
+        var userInfo = [AnyHashable: Any]()
 
-        var userInfo: [AnyHashable: Any] = [
-            NSLocalizedDescriptionKey: self.stp_unexpectedErrorMessage(),
-        ]
+        // stripeErrorCodeKey
         userInfo[STPError.stripeErrorCodeKey] = stripeErrorCode ?? ""
+
+        // stripeErrorTypeKey
         userInfo[STPError.stripeErrorTypeKey] = errorType ?? ""
-        if let errorParam = errorParam {
+
+        // errorParameterKey
+        if let errorParam {
             userInfo[STPError.errorParameterKey] = URLEncoder.convertToCamelCase(
                 snakeCase: errorParam
             )
         }
-        if let stripeErrorMessage = stripeErrorMessage {
+
+        // errorMessageKey, hintKey
+        if let stripeErrorMessage {
             userInfo[STPError.errorMessageKey] = stripeErrorMessage
             userInfo[STPError.hintKey] = ServerErrorMapper.mobileErrorMessage(
                 from: stripeErrorMessage,
@@ -168,51 +172,42 @@ extension NSError {
             userInfo[STPError.errorMessageKey] =
                 "Could not interpret the error response that was returned from Stripe."
         }
-        if errorType == "api_error" {
-            code = STPErrorCode.apiError.rawValue
-        } else {
-            if errorType == "invalid_request_error" {
-                switch httpResponse?.statusCode {
-                case 401:
-                    code = STPErrorCode.authenticationError.rawValue
-                default:
-                    code = STPErrorCode.invalidRequestError.rawValue
-                }
-            } else if errorType == "card_error" {
-                code = STPErrorCode.cardError.rawValue
-                // see https://stripe.com/docs/api/errors#errors-message
-                userInfo[NSLocalizedDescriptionKey] = stripeErrorMessage
-            } else {
-                code = STPErrorCode.apiError.rawValue
-            }
 
-            if let stripeErrorCode = stripeErrorCode, !stripeErrorCode.isEmpty {
-                if let cardErrorCode = Utils.cardErrorCode(fromAPIErrorCode: stripeErrorCode) {
-                    if cardErrorCode == STPCardErrorCode.cardDeclined,
-                        let decline_code = declineCode
-                    {
-                        userInfo[STPError.stripeDeclineCodeKey] = decline_code
-                    }
-                    userInfo[STPError.cardErrorCodeKey] = cardErrorCode.rawValue
-                }
-
-                // If the server didn't send an error message, use a local one.
-                if stripeErrorMessage == nil {
-                    let localizedMessage = Utils.localizedMessage(
-                        fromAPIErrorCode: stripeErrorCode,
-                        declineCode: declineCode as? String
-                    )
-
-                    if let localizedMessage = localizedMessage {
-                        userInfo[NSLocalizedDescriptionKey] = localizedMessage
-                    }
-                }
+        // stripeDeclineCodeKey, cardErrorCodeKey
+        if errorType != "api_error", let stripeErrorCode, let cardErrorCode = Utils.cardErrorCode(fromAPIErrorCode: stripeErrorCode) {
+            userInfo[STPError.cardErrorCodeKey] = cardErrorCode.rawValue
+            if cardErrorCode == STPCardErrorCode.cardDeclined, let declineCode {
+                userInfo[STPError.stripeDeclineCodeKey] = declineCode
             }
         }
 
-        // Add the Stripe request id if it exists
+        // localized description
+        userInfo[NSLocalizedDescriptionKey] = if errorType == "card_error" {
+            // see https://stripe.com/docs/api/errors#errors-message
+            stripeErrorMessage
+        } else if let localizedMessage = Utils.localizedMessage(fromAPIErrorCode: stripeErrorCode ?? "", declineCode: declineCode as? String) {
+            localizedMessage
+        } else {
+            stp_unexpectedErrorMessage()
+        }
+
+        // stripeRequestIDKey
         if let requestId = httpResponse?.value(forHTTPHeaderField: "request-id") {
             userInfo[STPError.stripeRequestIDKey] = requestId
+        }
+
+        // code
+        let code = switch errorType {
+        case "invalid_request_error":
+            if case 401 = httpResponse?.statusCode {
+                STPErrorCode.authenticationError.rawValue
+            } else {
+                STPErrorCode.invalidRequestError.rawValue
+            }
+        case "card_error":
+            STPErrorCode.cardError.rawValue
+        default: // including "api_error"
+            STPErrorCode.apiError.rawValue
         }
 
         return NSError(

--- a/StripeCore/StripeCore/Source/Helpers/STPError.swift
+++ b/StripeCore/StripeCore/Source/Helpers/STPError.swift
@@ -182,7 +182,7 @@ extension NSError {
         }
 
         // localized description
-        userInfo[NSLocalizedDescriptionKey] = if errorType == "card_error" {
+        userInfo[NSLocalizedDescriptionKey] = if errorType == "card_error", let stripeErrorMessage {
             // see https://stripe.com/docs/api/errors#errors-message
             stripeErrorMessage
         } else if let localizedMessage = Utils.localizedMessage(fromAPIErrorCode: stripeErrorCode ?? "", declineCode: declineCode as? String) {


### PR DESCRIPTION
## Summary
* refactor logic constructing errors to improve code clarity
* use local error messages as the localized description in more cases than previously

## Motivation
https://github.com/stripe/stripe-ios/issues/3179
https://jira.corp.stripe.com/browse/MOBILESDK-2305

## Testing
StripeErrorTest.testAPIError tests generic error message case
StripeErrorTest.testInvalidRequestErrorIncorrectNumber tests new prioritization of local message
StripeErrorTest.testCardDeclinedError tests missing server message case

## Changelog
- [Changed] Detailed error messages are now also used as the localized error description for API error types other than `card_error`