### PR TITLE
Dismiss keyboard on scroll in payment sheet and address sheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -343,16 +343,16 @@ extension AddressViewController {
 }
 
 // MARK: - ElementDelegate
-@_spi(STP) extension AddressViewController: ElementDelegate {
-    @_spi(STP) public func didUpdate(element: Element) {
-        guard let addressSection = addressSection else { assertionFailure(); return }
-        self.latestError = nil // clear error on new input
-        let enabled = addressSection.validationState.isValid
-        button.update(state: enabled ? .enabled : .disabled, animated: true)
-        expandAddressSectionIfNeeded()
-    }
+ @_spi(STP) extension AddressViewController: ElementDelegate {
+     @_spi(STP) public func didUpdate(element: Element) {
+         guard let addressSection = addressSection else { assertionFailure(); return }
+         self.latestError = nil // clear error on new input
+         let enabled = addressSection.validationState.isValid
+         button.update(state: enabled ? .enabled : .disabled, animated: true)
+         expandAddressSectionIfNeeded()
+     }
 
-    @_spi(STP) public func continueToNextField(element: Element) {
+     @_spi(STP) public func continueToNextField(element: Element) {
         // no-op
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -84,7 +84,11 @@ public class AddressViewController: UIViewController {
         return header
     }()
     lazy var scrollView: UIScrollView = {
-        return UIScrollView()
+        let scrollView = UIScrollView()
+        #if !os(visionOS)
+        scrollView.keyboardDismissMode = .onDrag
+        #endif
+        return scrollView
     }()
     lazy var errorLabel: UILabel = {
         let label = ElementsUI.makeErrorLabel(theme: configuration.appearance.asElementsTheme)
@@ -183,10 +187,6 @@ public class AddressViewController: UIViewController {
             didLogAddressShow = true
         }
         addressSection?.beginEditing()
-    }
-
-    public override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
     }
 }
 
@@ -343,16 +343,16 @@ extension AddressViewController {
 }
 
 // MARK: - ElementDelegate
- @_spi(STP) extension AddressViewController: ElementDelegate {
-     @_spi(STP) public func didUpdate(element: Element) {
-         guard let addressSection = addressSection else { assertionFailure(); return }
-         self.latestError = nil // clear error on new input
-         let enabled = addressSection.validationState.isValid
-         button.update(state: enabled ? .enabled : .disabled, animated: true)
-         expandAddressSectionIfNeeded()
-     }
+@_spi(STP) extension AddressViewController: ElementDelegate {
+    @_spi(STP) public func didUpdate(element: Element) {
+        guard let addressSection = addressSection else { assertionFailure(); return }
+        self.latestError = nil // clear error on new input
+        let enabled = addressSection.validationState.isValid
+        button.update(state: enabled ? .enabled : .disabled, animated: true)
+        expandAddressSectionIfNeeded()
+    }
 
-     @_spi(STP) public func continueToNextField(element: Element) {
+    @_spi(STP) public func continueToNextField(element: Element) {
         // no-op
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -33,6 +33,9 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
     lazy var scrollView: UIScrollView = {
         let scrollView = UIScrollView()
         scrollView.automaticallyAdjustsScrollIndicatorInsets = false
+        #if !os(visionOS)
+        scrollView.keyboardDismissMode = .onDrag
+        #endif
         scrollView.delegate = self
         return scrollView
     }()


### PR DESCRIPTION
## Summary
Enable the onDrag keyboardDismissalMode for the scroll views in the payment sheet and address view controller.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1746

## Testing
https://github.com/user-attachments/assets/d76fc8d2-f79a-40ac-a7cf-45aab50e5777
