### PR TITLE
Disable context menu items in PickerTextField

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerTextField.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerTextField.swift
@@ -31,9 +31,15 @@ class PickerTextField: UITextField {
     }
 
     override func canPerformAction(_ action: Selector, withSender sender: Any?) -> Bool {
-        if action == #selector(UIResponderStandardEditActions.paste(_:)) {
-            return false
+        // Disallow context menu items
+        false
+    }
+
+    override func buildMenu(with builder: any UIMenuBuilder) {
+        // autoFill bypasses the canPerformAction check, so we have to directly remove it from the UIMenuBuilder
+        // enumerating every possible menu to remove them would be too tedious and require too much updating with newer iOS versions, so the others are left to the canPerformAction check
+        if #available(iOS 17.0, *) {
+            builder.remove(menu: .autoFill)
         }
-        return super.canPerformAction(action, withSender: sender)
     }
 }


### PR DESCRIPTION
## Summary
Disable the context menu from appearing in response to double tapping PickerTextFields. This impact items such as the phone number country code and billing address country/state pickers in the payment sheet.

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-1849

## Testing
https://github.com/user-attachments/assets/16caddec-0e01-4d68-9183-c675e5b3d793