### PR TITLE
Apple Pay Later availability checks card PMO SFU

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -184,7 +184,7 @@ extension STPApplePayContext {
             }
         }
 
-        if intent.isSettingUp {
+        if configuration.shouldReadPaymentMethodOptionsSetupFutureUsage ? intent.isSetupFutureUsageSet(for: .card) : intent.isSettingUp {
             // Disable Apple Pay Later if the merchant is setting up the payment method for future usage
 #if compiler(>=5.9)
             if #available(macOS 14.0, iOS 17.0, *) {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -57,10 +57,13 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
     }
 
     func testCreatePaymentRequest_PaymentIntentWithPMOSetupFutureUsage() {
+        var config = PaymentSheet.Configuration._testValue_MostPermissive()
+        config.applePay = applePayConfiguration
+        config.shouldReadPaymentMethodOptionsSetupFutureUsage = true
         let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card], paymentMethodOptionsSetupFutureUsage: [.card: "off_session"])
         let deferredIntent = Intent.deferredIntent(intentConfig: .init(mode: .payment(amount: 2345, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.card: .offSession])), confirmHandler: dummyDeferredConfirmHandler))
         for intent in [intent, deferredIntent] {
-            let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
+            let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: config, applePay: applePayConfiguration)
             XCTAssertEqual(sut.paymentSummaryItems[0].amount, 23.45)
             XCTAssertEqual(sut.paymentSummaryItems[0].type, .final)
             XCTAssertEqual(sut.currencyCode, "USD")
@@ -75,10 +78,13 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
     }
 
     func testCreatePaymentRequest_PaymentIntentWithTopLevelSetupFutureUsagePMOSetupFutureUsageNone() {
+        var config = PaymentSheet.Configuration._testValue_MostPermissive()
+        config.applePay = applePayConfiguration
+        config.shouldReadPaymentMethodOptionsSetupFutureUsage = true
         let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card], setupFutureUsage: .offSession, paymentMethodOptionsSetupFutureUsage: [.card: "none"])
         let deferredIntent = Intent.deferredIntent(intentConfig: .init(mode: .payment(amount: 2345, currency: "USD", setupFutureUsage: .offSession, paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.card: .none])), confirmHandler: dummyDeferredConfirmHandler))
         for intent in [intent, deferredIntent] {
-            let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
+            let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: config, applePay: applePayConfiguration)
             XCTAssertEqual(sut.paymentSummaryItems[0].amount, 23.45)
             XCTAssertEqual(sut.paymentSummaryItems[0].type, .final)
             XCTAssertEqual(sut.currencyCode, "USD")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -7,7 +7,7 @@
 
 @testable import StripeApplePay
 @_spi(STP) import StripeCore
-@testable import StripePaymentSheet
+@testable @_spi(PaymentMethodOptionsSetupFutureUsagePreview) import StripePaymentSheet
 @testable import StripePaymentsTestUtils
 import XCTest
 
@@ -51,6 +51,42 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
 #if compiler(>=5.9)
             if #available(macOS 14.0, iOS 17.0, *) {
                 XCTAssertEqual(sut.applePayLaterAvailability, .unavailable(.recurringTransaction))
+            }
+#endif
+        }
+    }
+
+    func testCreatePaymentRequest_PaymentIntentWithPMOSetupFutureUsage() {
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card], paymentMethodOptionsSetupFutureUsage: [.card: "off_session"])
+        let deferredIntent = Intent.deferredIntent(intentConfig: .init(mode: .payment(amount: 2345, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.card: .offSession])), confirmHandler: dummyDeferredConfirmHandler))
+        for intent in [intent, deferredIntent] {
+            let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
+            XCTAssertEqual(sut.paymentSummaryItems[0].amount, 23.45)
+            XCTAssertEqual(sut.paymentSummaryItems[0].type, .final)
+            XCTAssertEqual(sut.currencyCode, "USD")
+            XCTAssertEqual(sut.merchantIdentifier, "merchant_id")
+            XCTAssertEqual(sut.countryCode, "GB")
+#if compiler(>=5.9)
+            if #available(macOS 14.0, iOS 17.0, *) {
+                XCTAssertEqual(sut.applePayLaterAvailability, .unavailable(.recurringTransaction))
+            }
+#endif
+        }
+    }
+
+    func testCreatePaymentRequest_PaymentIntentWithTopLevelSetupFutureUsagePMOSetupFutureUsageNone() {
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card], setupFutureUsage: .offSession, paymentMethodOptionsSetupFutureUsage: [.card: "none"])
+        let deferredIntent = Intent.deferredIntent(intentConfig: .init(mode: .payment(amount: 2345, currency: "USD", setupFutureUsage: .offSession, paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.card: .none])), confirmHandler: dummyDeferredConfirmHandler))
+        for intent in [intent, deferredIntent] {
+            let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
+            XCTAssertEqual(sut.paymentSummaryItems[0].amount, 23.45)
+            XCTAssertEqual(sut.paymentSummaryItems[0].type, .final)
+            XCTAssertEqual(sut.currencyCode, "USD")
+            XCTAssertEqual(sut.merchantIdentifier, "merchant_id")
+            XCTAssertEqual(sut.countryCode, "GB")
+#if compiler(>=5.9)
+            if #available(macOS 14.0, iOS 17.0, *) {
+                XCTAssertEqual(sut.applePayLaterAvailability, .available)
             }
 #endif
         }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Check card SFU to determine whether or not to allow Apple Pay Later.
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
PMO SFU project
## Testing
<!-- How was the code tested? Be as specific as possible. -->
Unit test for applePayLaterAvailability
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A