### PR TITLE
Add Fruit Store to Payment Sheet Example app

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
@@ -51,6 +51,15 @@
 		973DA944730BD761CE479F8E /* QRView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575345B1A7F6EBD12A1A5F9C /* QRView.swift */; };
 		9F126696AD86BF2E861B5CC5 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16547B41C80B97FC2EFD0798 /* StripeFinancialConnections.framework */; };
 		A0037CC8E331CFF5CEE2D580 /* ExampleSwiftUICustomPaymentFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447A394B34A55D5B1CD5C0C1 /* ExampleSwiftUICustomPaymentFlow.swift */; };
+		A0317DE12DC97162003EF979 /* Buttons.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0317DDA2DC97162003EF979 /* Buttons.swift */; };
+		A0317DE22DC97162003EF979 /* StoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0317DDE2DC97162003EF979 /* StoreView.swift */; };
+		A0317DE32DC97162003EF979 /* SigninView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0317DDB2DC97162003EF979 /* SigninView.swift */; };
+		A0317DE42DC97162003EF979 /* RefillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0317DDF2DC97162003EF979 /* RefillView.swift */; };
+		A0317DE52DC97162003EF979 /* FruitModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0317DD82DC97162003EF979 /* FruitModel.swift */; };
+		A0317DE62DC97162003EF979 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0317DDC2DC97162003EF979 /* ContentView.swift */; };
+		A0317DE72DC97162003EF979 /* FruitServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0317DD52DC97162003EF979 /* FruitServer.swift */; };
+		A0317DE82DC97162003EF979 /* CustomerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0317DDD2DC97162003EF979 /* CustomerView.swift */; };
+		A0317DE92DC97162003EF979 /* MockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0317DD62DC97162003EF979 /* MockServer.swift */; };
 		A071C07B6FFACC5DEFC6AA01 /* ExampleSwiftUIViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20765908089ACB79B556592 /* ExampleSwiftUIViews.swift */; };
 		A262D76C3319002A2F6EE395 /* CustomerSheetTestPlaygroundSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2A8BAE3842A0E892D06BB9 /* CustomerSheetTestPlaygroundSettings.swift */; };
 		A3884C372DA701A700CAE78E /* PaymentMethodOptionsSetupFutureUsagePlaygroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3884C362DA701A700CAE78E /* PaymentMethodOptionsSetupFutureUsagePlaygroundView.swift */; };
@@ -243,6 +252,15 @@
 		9D55109311453F8D8F44A144 /* pl-PL */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pl-PL"; path = "pl-PL.lproj/Main.strings"; sourceTree = "<group>"; };
 		9D6F8659F31E23DF549E5057 /* el-GR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "el-GR"; path = "el-GR.lproj/Main.strings"; sourceTree = "<group>"; };
 		9F9C96D25ED549D6255FC274 /* StripeUICore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeUICore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A0317DD52DC97162003EF979 /* FruitServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitServer.swift; sourceTree = "<group>"; };
+		A0317DD62DC97162003EF979 /* MockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockServer.swift; sourceTree = "<group>"; };
+		A0317DD82DC97162003EF979 /* FruitModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FruitModel.swift; sourceTree = "<group>"; };
+		A0317DDA2DC97162003EF979 /* Buttons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Buttons.swift; sourceTree = "<group>"; };
+		A0317DDB2DC97162003EF979 /* SigninView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigninView.swift; sourceTree = "<group>"; };
+		A0317DDC2DC97162003EF979 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		A0317DDD2DC97162003EF979 /* CustomerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerView.swift; sourceTree = "<group>"; };
+		A0317DDE2DC97162003EF979 /* StoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreView.swift; sourceTree = "<group>"; };
+		A0317DDF2DC97162003EF979 /* RefillView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefillView.swift; sourceTree = "<group>"; };
 		A10301FB96F08B8ADF93B2DB /* lv-LV */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "lv-LV"; path = "lv-LV.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		A10F554509B65711F00BE91C /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		A1D77C5D868315EAB494325C /* lv-LV */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "lv-LV"; path = "lv-LV.lproj/Main.strings"; sourceTree = "<group>"; };
@@ -408,6 +426,46 @@
 			path = PaymentSheetLocalizationScreenshotGenerator;
 			sourceTree = "<group>";
 		};
+		A0317DD22DC97158003EF979 /* Fruit Store */ = {
+			isa = PBXGroup;
+			children = (
+				A0317DD72DC97162003EF979 /* Server */,
+				A0317DD92DC97162003EF979 /* Models */,
+				A0317DE02DC97162003EF979 /* Views */,
+			);
+			path = "Fruit Store";
+			sourceTree = "<group>";
+		};
+		A0317DD72DC97162003EF979 /* Server */ = {
+			isa = PBXGroup;
+			children = (
+				A0317DD52DC97162003EF979 /* FruitServer.swift */,
+				A0317DD62DC97162003EF979 /* MockServer.swift */,
+			);
+			path = Server;
+			sourceTree = "<group>";
+		};
+		A0317DD92DC97162003EF979 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				A0317DD82DC97162003EF979 /* FruitModel.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		A0317DE02DC97162003EF979 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				A0317DDA2DC97162003EF979 /* Buttons.swift */,
+				A0317DDB2DC97162003EF979 /* SigninView.swift */,
+				A0317DDC2DC97162003EF979 /* ContentView.swift */,
+				A0317DDD2DC97162003EF979 /* CustomerView.swift */,
+				A0317DDE2DC97162003EF979 /* StoreView.swift */,
+				A0317DDF2DC97162003EF979 /* RefillView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		ACF2A07E6D470CDF889DE14C /* Project */ = {
 			isa = PBXGroup;
 			children = (
@@ -451,6 +509,7 @@
 		C4BE75A2EECEF0AC9EC24CD8 /* PaymentSheet Example */ = {
 			isa = PBXGroup;
 			children = (
+				A0317DD22DC97158003EF979 /* Fruit Store */,
 				31CDFC2B2BA36F5B00B3DD91 /* PrivacyInfo.xcprivacy */,
 				132709C10C0114D239ED3FE9 /* Resources */,
 				05E317C6C8459B147C041D93 /* AppDelegate.swift */,
@@ -716,6 +775,15 @@
 				EB3C76C2A5704F94F0414BEF /* ExampleCheckoutViewController.swift in Sources */,
 				D235E82A7173E8051BC5A261 /* ExampleCustomCheckoutViewController.swift in Sources */,
 				3266C6EB6B045F613228C895 /* ExampleCustomDeferredCheckoutViewController.swift in Sources */,
+				A0317DE12DC97162003EF979 /* Buttons.swift in Sources */,
+				A0317DE22DC97162003EF979 /* StoreView.swift in Sources */,
+				A0317DE32DC97162003EF979 /* SigninView.swift in Sources */,
+				A0317DE42DC97162003EF979 /* RefillView.swift in Sources */,
+				A0317DE52DC97162003EF979 /* FruitModel.swift in Sources */,
+				A0317DE62DC97162003EF979 /* ContentView.swift in Sources */,
+				A0317DE72DC97162003EF979 /* FruitServer.swift in Sources */,
+				A0317DE82DC97162003EF979 /* CustomerView.swift in Sources */,
+				A0317DE92DC97162003EF979 /* MockServer.swift in Sources */,
 				61FB6BC72C88C8BF00F8E074 /* EmbeddedPlaygroundViewController.swift in Sources */,
 				56EF0879D7EAC041B147680C /* ExampleLinkPaymentCheckoutViewController.swift in Sources */,
 				A0037CC8E331CFF5CEE2D580 /* ExampleSwiftUICustomPaymentFlow.swift in Sources */,

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Models/FruitModel.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Models/FruitModel.swift
@@ -22,6 +22,10 @@ class FruitModel: ObservableObject {
     /// The FruitStore server
     let server: Server = MockServer()
 
+    init() {
+        NotificationCenter.default.addObserver(self, selector: #selector(didCompleteRefill), name: Notification.Name("returnFromCheckout"), object: nil)
+    }
+
     // MARK: Authentication
 
     /// Login using credentials from a Sign in with Apple button.
@@ -129,20 +133,8 @@ class FruitModel: ObservableObject {
 
     /// Called by the URL handler when we receive a deep link from Checkout
     /// back to our app.
-    func didCompleteRefill(url: URL) {
-        // After the customer pays, Checkout will send a `checkout.session.completed` to
-        // your server's webhook. Checkout will wait up to 10 seconds for your backend to
-        // acknowledge the event before redirecting the user to your `success_url`, which
-        // should be a Universal Link to your app.
-        //
-        // In scenarios where your endpoint is down or the event isn’t acknowledged properly,
-        // the customer could be redirected to the `success_url` before you have updated
-        // your customer object with the new purchase. In this situation, you may want to
-        // retry this update call until the customer object is up to date.
-        //
-        // See https://stripe.com/docs/payments/checkout/fulfill-orders#handle-the-event
-        // for more details.
-
+    @objc
+    func didCompleteRefill() {
         updateFromServer(force: true)
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Models/FruitModel.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Models/FruitModel.swift
@@ -1,0 +1,242 @@
+//
+//  FruitModel.swift
+//  FruitStore
+//
+
+import Foundation
+import UIKit
+import AuthenticationServices
+
+class FruitModel: ObservableObject {
+    /// The current customer's details
+    @Published var customer: Customer? = .fetchFromUserDefaults()
+    /// Whether a request is in progress
+    @Published var loading = false
+    
+    /// The last time the cached Customer was updated.
+    var lastUpdated: Date = .distantPast
+    
+    /// The last error communicating with the server, if any.
+    @Published var lastError: ServerError?
+    
+    /// The FruitStore server
+    let server: Server = MockServer()
+    
+    // MARK: Authentication
+    
+    /// Login using credentials from a Sign in with Apple button.
+    func login(_ authorization: ASAuthorization) {
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            server.fetchSessionToken(with: appleIDCredential) { result in
+                switch result {
+                case .success(_): break
+                case .failure(let error):
+                    self.lastError = error
+                }
+                self.updateFromServer(force: true)
+            }
+        } else {
+            // Error
+        }
+    }
+    
+    /// Login with a temporary account.
+    /// In a real app, you should not allow the user to make purchases unless you
+    /// have some way of identifying the user after the app has been deleted. Otherwise,
+    /// a user may not be able to restore their purchased content after deleting your app.
+    func loginGuest() {
+        server.fetchGuestSessionToken { result in
+            switch result {
+            case .success(_): break
+            case .failure(let error):
+                self.lastError = error
+            }
+            self.updateFromServer(force: true)
+        }
+    }
+    
+    /// Delete the user's stored cache and credentials.
+    func logout() {
+        customer?.clearUserDefaults()
+        customer = nil
+        server.logout()
+    }
+    
+    // MARK: User inventory management
+    
+    /// Update the customer model from the server. This will only update
+    /// a maximum of once every 60 seconds unless `force` is true.
+    func updateFromServer(force: Bool) {
+        if force ||
+            (!loading && lastUpdated.addingTimeInterval(60) < Date()) {
+            loading = true
+            // Fetch latest customer info from server
+            server.fetchCustomer { result in
+                switch result {
+                case .success(let customer):
+                    self.customer = customer
+                    customer.writeToUserDefaults()
+                    self.lastUpdated = Date()
+                    self.lastError = nil
+                case .failure(let error):
+                    // If we have a cached Customer, we can use those details until our next sync.
+                    // This is convenient for productivity software or offline games, but it introduces
+                    // a potential vulnerability: A user could modify their NSUserDefaults and block
+                    // your server to unlock content.
+                    // For certain types of content, you may want to always check the server before
+                    // granting the user access.
+                    self.lastError = error
+                }
+                self.loading = false
+            }
+        }
+    }
+    
+    /// Attempt to buy a fruit.
+    func buy(_ fruit: Fruit) {
+        self.loading = true
+        server.buy(fruit: fruit) { result in
+            switch result {
+            case .success(let customer):
+                self.customer = customer
+                customer.writeToUserDefaults()
+                self.lastUpdated = Date()
+                self.lastError = nil
+            case .failure(let error):
+                self.lastError = error
+            }
+            self.loading = false
+        }
+    }
+    
+    /// Open a Checkout page to refill the user's coin balance.
+    func openRefillPage() {
+        server.getRefillURL { result in
+            switch result {
+            case .success(let url):
+                UIApplication.shared.open(url, options: [:], completionHandler: nil)
+            case .failure(let error):
+                self.lastError = error
+            }
+        }
+        
+        /// TODO: Remove me!
+        /// If we're using the MockServer, we'll want to simulate a coin refill immediately.
+        if let server = self.server as? MockServer {
+            server.refillCoins()
+        }
+    }
+    
+    /// Called by the URL handler when we receive a deep link from Checkout
+    /// back to our app.
+    func didCompleteRefill(url: URL) {
+        // After the customer pays, Checkout will send a `checkout.session.completed` to
+        // your server's webhook. Checkout will wait up to 10 seconds for your backend to
+        // acknowledge the event before redirecting the user to your `success_url`, which
+        // should be a Universal Link to your app.
+        //
+        // In scenarios where your endpoint is down or the event isn’t acknowledged properly,
+        // the customer could be redirected to the `success_url` before you have updated
+        // your customer object with the new purchase. In this situation, you may want to
+        // retry this update call until the customer object is up to date.
+        //
+        // See https://stripe.com/docs/payments/checkout/fulfill-orders#handle-the-event
+        // for more details.
+        
+        updateFromServer(force: true)
+    }
+    
+}
+
+/// A purchasable fruit.
+struct Fruit: Codable {
+    var emoji: String
+    
+    var name: String {
+        // TODO: Don't hardcode these.
+        switch emoji {
+        case "🍒":
+            return "Cherries"
+        case "🍊":
+            return "Orange"
+        case "🍉":
+            return "Watermelon"
+        default:
+            return "Emoji"
+        }
+    }
+}
+
+/// Details about the customer's list of purchases.
+struct Customer {
+    /// The customer's name.
+    var name: String
+    /// The current balance in the customer's coin wallet.
+    var wallet: Int
+    /// The list of fruits owned by the customer.
+    var purchased: [Fruit]
+    /// Whether the customer has an active Pro subscription.
+    var hasProSubscription: Bool
+    
+    init(name: String,
+         wallet: Int,
+         purchased: [Fruit],
+         hasProSubscription: Bool) {
+        self.name = name
+        self.wallet = wallet
+        self.purchased = purchased
+        self.hasProSubscription = hasProSubscription
+    }
+    
+    init?(_ params: [String: Any]) {
+        guard let balance = params["balance"] as? Int,
+        let fruit = params["fruits"] as? [String] else {
+            return nil
+        }
+        self.name = params["name"] as? String ?? "Katie Bell"
+        self.wallet = balance
+        self.purchased = fruit.map({Fruit(emoji: $0)})
+        // Always true until we add subscription support to the demo
+        self.hasProSubscription = true
+    }
+    
+    static let NameKey = "name"
+    static let WalletKey = "wallet"
+    static let PurchasedKey = "purchased"
+    static let HasProSubscriptionKey = "hasProSubscription"
+}
+
+/// Customer cache
+extension Customer {
+    /// Saves a Customer in the UserDefaults cache.
+    func writeToUserDefaults() {
+        let defaults = UserDefaults.standard
+        defaults.set(name, forKey: Self.NameKey)
+        defaults.set(wallet, forKey: Self.WalletKey)
+        defaults.set(try? PropertyListEncoder().encode(purchased), forKey: Self.PurchasedKey)
+        defaults.set(hasProSubscription, forKey: Self.HasProSubscriptionKey)
+    }
+    
+    /// Clears the Customer from the UserDefaults cache.
+    func clearUserDefaults() {
+        let defaults = UserDefaults.standard
+        defaults.set(nil, forKey: Self.NameKey)
+        defaults.set(nil, forKey: Self.WalletKey)
+        defaults.set(nil, forKey: Self.PurchasedKey)
+        defaults.set(nil, forKey: Self.HasProSubscriptionKey)
+    }
+    
+    /// Initializes a Customer from the UserDefaults cache if available.
+    static func fetchFromUserDefaults() -> Customer? {
+        let defaults = UserDefaults.standard
+        if let data = defaults.object(forKey: PurchasedKey) as? Data,
+           let name = defaults.string(forKey: NameKey) {
+            let wallet = defaults.integer(forKey: WalletKey)
+            let hasProSubscription = defaults.bool(forKey: HasProSubscriptionKey)
+            let purchased = (try? PropertyListDecoder().decode([Fruit].self, from: data)) ?? []
+            return Customer(name: name, wallet: wallet, purchased: purchased, hasProSubscription: hasProSubscription)
+        }
+        return nil
+    }
+    
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Server/FruitServer.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Server/FruitServer.swift
@@ -1,0 +1,177 @@
+//
+//  FruitServer.swift
+//  FruitStore
+
+import Foundation
+import AuthenticationServices
+
+fileprivate let BackendAPIURL = URL(string: "https://fruitstore-backend.herokuapp.com")!
+
+class FruitServer: Server {
+    // The cached session token
+    var sessionToken: String? {
+        get {
+            return UserDefaults.standard.string(forKey: SessionTokenKey)
+        }
+        set {
+            return UserDefaults.standard.setValue(newValue, forKey: SessionTokenKey)
+        }
+    }
+    let SessionTokenKey = "sessionToken"
+
+    func fetchSessionToken(with appleIDCredential: ASAuthorizationAppleIDCredential, completion: @escaping (Result<String, ServerError>) -> Void) {
+        guard let identityToken = appleIDCredential.identityToken,
+              let identityTokenString = String(data: identityToken, encoding: .utf8) else {
+            completion(.failure(.other))
+            return
+        }
+        
+        let params = ["user_id": appleIDCredential.user, "token": identityTokenString]
+        callServer(endpoint: "apple_login", method: "POST", params: params) { result in
+            guard let sessionToken = result["session_token"] as? String else {
+                completion(.failure(.other))
+                return
+            }
+            self.sessionToken = sessionToken
+            completion(.success(sessionToken))
+        }
+    }
+
+    func fetchGuestSessionToken(completion: @escaping (Result<String, ServerError>) -> Void) {
+        callServer(endpoint: "guest_login", method: "POST") { result in
+            guard let sessionToken = result["session_token"] as? String else {
+                completion(.failure(.other))
+                return
+            }
+            self.sessionToken = sessionToken
+            completion(.success(sessionToken))
+        }
+    }
+
+    func fetchCustomer(completion: @escaping (Result<Customer, ServerError>) -> Void) {
+        guard let sessionToken = sessionToken else {
+            completion(.failure(.tokenMissing))
+            return
+        }
+        
+        let params = ["session_token": sessionToken]
+        callServer(endpoint: "customer", method: "GET", params: params) { result in
+            guard let customer = Customer(result) else {
+                completion(.failure(.serverError(error: result.description)))
+                return
+            }
+            completion(.success(customer))
+        }
+    }
+
+    func buy(fruit: Fruit, completion: @escaping (Result<Customer, ServerError>) -> Void) {
+        guard let sessionToken = sessionToken else {
+            completion(.failure(.tokenMissing))
+            return
+        }
+        
+        let params = ["session_token": sessionToken, "fruit": fruit.emoji]
+        callServer(endpoint: "buy", method: "POST", params: params) { result in
+            if let error = result["error"] as? String {
+                // TODO: Replace this with an actual error code
+                if error.contains("balance") {
+                    completion(.failure(.insufficientFunds(coinsNeeded: 10)))
+                    return
+                }
+            }
+            guard let customer = Customer(result) else {
+                completion(.failure(.serverError(error: result.description)))
+                return
+            }
+            completion(.success(customer))
+        }
+    }
+
+    func getRefillURL(completion: @escaping (Result<URL, ServerError>) -> Void) {
+        guard let sessionToken = sessionToken else {
+            completion(.failure(.tokenMissing))
+            return
+        }
+        
+        let params = ["session_token": sessionToken]
+        callServer(endpoint: "refill_url", method: "GET", params: params) { result in
+            guard let urlString = result["url"] as? String,
+                  let url = URL(string: urlString) else {
+                completion(.failure(.serverError(error: result.description)))
+                return
+            }
+            completion(.success(url))
+        }
+    }
+
+    func logout() {
+        sessionToken = nil
+    }
+
+    private func callServer(endpoint: String, method: String, params: [String : Any] = [:], completion: @escaping ([String : Any]) -> Void) {
+        var request = URLRequest(url: BackendAPIURL.appendingPathComponent(endpoint))
+        request.httpMethod = method
+        
+//        if request.httpMethod == "POST" {
+//            request.httpBody = try! JSONSerialization.data(withJSONObject: params, options: .prettyPrinted)
+//            request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+//            request.addValue("application/json", forHTTPHeaderField: "Accept")
+//        } else {
+            var urlComponents = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)!
+            urlComponents.queryItems = params.map({ URLQueryItem(name: $0, value: $1 as? String)})
+            request.url = urlComponents.url
+//        }
+        
+        let task = URLSession.shared.dataTask(with: request, completionHandler: { (data, response, error) in
+          guard let unwrappedData = data,
+                let json = try? JSONSerialization.jsonObject(with: unwrappedData, options: []) as? [String : Any] else {
+            if let data = data {
+                print("\(String(decoding: data, as: UTF8.self))")
+            } else {
+                print("\(error ?? NSError())")
+            }
+            return
+          }
+          
+          DispatchQueue.main.async {
+              if let error = json["error"] as? String {
+                  if error == "Session is invalid." {
+                      self.logout()
+                  }
+              }
+            completion(json)
+          }
+        })
+        task.resume()
+    }
+    
+}
+
+protocol Server {
+    func fetchSessionToken(with appleIDCredential: ASAuthorizationAppleIDCredential, completion: @escaping (Result<String, ServerError>) -> Void)
+    func fetchGuestSessionToken(completion: @escaping (Result<String, ServerError>) -> Void)
+    func fetchCustomer(completion: @escaping (Result<Customer, ServerError>) -> Void)
+    func buy(fruit: Fruit, completion: @escaping (Result<Customer, ServerError>) -> Void)
+    func getRefillURL(completion: @escaping (Result<URL, ServerError>) -> Void)
+    func logout()
+}
+
+enum ServerError: Error {
+    case insufficientFunds(coinsNeeded: Int)
+    case tokenMissing
+    case serverError(error: String)
+    case other
+    
+    var localizedDescription: String {
+        switch self {
+        case .insufficientFunds(let amount):
+            return "You need \(amount) coins to buy this fruit."
+        case .tokenMissing:
+            return "This action requires authentication."
+        case .serverError(let error):
+            return "An error occurred when communicating with the server: \(error)"
+        case .other:
+            return "An error occurred."
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Server/MockServer.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Server/MockServer.swift
@@ -1,0 +1,93 @@
+//
+//  MockServer.swift
+//  FruitStore
+
+import Foundation
+import AuthenticationServices
+
+class MockServer: Server {
+    var customer: Customer = Customer(name: "David", wallet: 100, purchased: [], hasProSubscription: true)
+    let fakeServerDelay = 0.1
+    
+    // The cached session token
+    var sessionToken: String? {
+        get {
+            return UserDefaults.standard.string(forKey: SessionTokenKey)
+        }
+        set {
+            return UserDefaults.standard.setValue(newValue, forKey: SessionTokenKey)
+        }
+    }
+    let SessionTokenKey = "sessionToken"
+    
+    func fetchSessionToken(with appleIDCredential: ASAuthorizationAppleIDCredential, completion: @escaping (Result<String, ServerError>) -> Void) {
+        guard let identityToken = appleIDCredential.identityToken,
+              let identityTokenString = String(data: identityToken, encoding: .utf8) else {
+            completion(.failure(.other))
+            return
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + fakeServerDelay) {
+            let sessionToken = "ABC123"
+            self.sessionToken = sessionToken
+            completion(.success(sessionToken))
+        }
+    }
+
+    func fetchGuestSessionToken(completion: @escaping (Result<String, ServerError>) -> Void) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + fakeServerDelay) {
+            let sessionToken = "ABC123"
+            self.sessionToken = sessionToken
+            completion(.success(sessionToken))
+        }
+    }
+
+    func fetchCustomer(completion: @escaping (Result<Customer, ServerError>) -> Void) {
+        guard let sessionToken = sessionToken else {
+            completion(.failure(.tokenMissing))
+            return
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + fakeServerDelay) {
+            completion(.success(self.customer))
+        }
+    }
+    
+    func buy(fruit: Fruit, completion: @escaping (Result<Customer, ServerError>) -> Void) {
+        guard let sessionToken = sessionToken else {
+            completion(.failure(.tokenMissing))
+            return
+        }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + fakeServerDelay) {
+            let price = 10
+            if self.customer.wallet - price < 0 {
+                completion(.failure(.insufficientFunds(coinsNeeded: price)))
+            } else {
+                self.customer.wallet = self.customer.wallet - 10
+                self.customer.purchased.append(fruit)
+                completion(.success(self.customer))
+            }
+        }
+    }
+    
+    func getRefillURL(completion: @escaping (Result<URL, ServerError>) -> Void) {
+        guard let sessionToken = sessionToken else {
+            completion(.failure(.tokenMissing))
+            return
+        }
+        
+        DispatchQueue.main.asyncAfter(deadline: .now() + fakeServerDelay) {
+            completion(.success(URL(string: "https://buy.stripe.com/test_cN2g236nNebEaWc8wx")!))
+        }
+    }
+    
+    func logout() {
+        sessionToken = nil
+    }
+    
+    // For testing only
+    func refillCoins() {
+        customer.wallet = customer.wallet + 100
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Server/MockServer.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Server/MockServer.swift
@@ -2,13 +2,13 @@
 //  MockServer.swift
 //  FruitStore
 
-import Foundation
 import AuthenticationServices
+import Foundation
 
 class MockServer: Server {
     var customer: Customer = Customer(name: "David", wallet: 100, purchased: [], hasProSubscription: true)
     let fakeServerDelay = 0.1
-    
+
     // The cached session token
     var sessionToken: String? {
         get {
@@ -19,14 +19,14 @@ class MockServer: Server {
         }
     }
     let SessionTokenKey = "sessionToken"
-    
+
     func fetchSessionToken(with appleIDCredential: ASAuthorizationAppleIDCredential, completion: @escaping (Result<String, ServerError>) -> Void) {
         guard let identityToken = appleIDCredential.identityToken,
               let identityTokenString = String(data: identityToken, encoding: .utf8) else {
             completion(.failure(.other))
             return
         }
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + fakeServerDelay) {
             let sessionToken = "ABC123"
             self.sessionToken = sessionToken
@@ -47,12 +47,12 @@ class MockServer: Server {
             completion(.failure(.tokenMissing))
             return
         }
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + fakeServerDelay) {
             completion(.success(self.customer))
         }
     }
-    
+
     func buy(fruit: Fruit, completion: @escaping (Result<Customer, ServerError>) -> Void) {
         guard let sessionToken = sessionToken else {
             completion(.failure(.tokenMissing))
@@ -70,22 +70,22 @@ class MockServer: Server {
             }
         }
     }
-    
+
     func getRefillURL(completion: @escaping (Result<URL, ServerError>) -> Void) {
         guard let sessionToken = sessionToken else {
             completion(.failure(.tokenMissing))
             return
         }
-        
+
         DispatchQueue.main.asyncAfter(deadline: .now() + fakeServerDelay) {
             completion(.success(URL(string: "https://buy.stripe.com/test_cN2g236nNebEaWc8wx")!))
         }
     }
-    
+
     func logout() {
         sessionToken = nil
     }
-    
+
     // For testing only
     func refillCoins() {
         customer.wallet = customer.wallet + 100

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/Buttons.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/Buttons.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 struct FruitStorePaymentButtonView: View {
     var text: String
-    
+
     var body: some View {
         HStack {
             Text(text).fontWeight(.bold)
@@ -24,7 +24,7 @@ struct FruitStorePaymentButtonView: View {
 
 struct FruitBuyButtonView: View {
     var fruit: Fruit
-    
+
     var body: some View {
         HStack {
             Text("\(fruit.emoji)")
@@ -39,7 +39,6 @@ struct FruitBuyButtonView: View {
         .accessibility(identifier: "Buy \(fruit.emoji)")
     }
 }
-
 
 struct BuyFruitButtonView: View {
     var body: some View {
@@ -56,7 +55,7 @@ struct BuyFruitButtonView: View {
 
 struct ProButtonView: View {
     let enabled: Bool
-    
+
     var body: some View {
         if enabled {
             Text("PRO")
@@ -77,7 +76,6 @@ struct ProButtonView: View {
         }
     }
 }
-
 
 struct BuyCoinsButtonView: View {
     var body: some View {
@@ -103,8 +101,6 @@ struct LogoutButtonView: View {
             .cornerRadius(3.0)
     }
 }
-
-
 
 struct Button_Previews: PreviewProvider {
     static var previews: some View {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/Buttons.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/Buttons.swift
@@ -1,0 +1,116 @@
+//
+//  Buttons.swift
+//  FruitStore
+//
+
+import Foundation
+import SwiftUI
+
+struct ExamplePaymentButtonView: View {
+    var text: String
+    
+    var body: some View {
+        HStack {
+            Text(text).fontWeight(.bold)
+        }
+        .frame(minWidth: 200)
+        .padding()
+        .foregroundColor(.white)
+        .background(Color.blue)
+        .cornerRadius(6)
+        .accessibility(identifier: "Buy button")
+    }
+}
+
+struct FruitBuyButtonView: View {
+    var fruit: Fruit
+    
+    var body: some View {
+        HStack {
+            Text("\(fruit.emoji)")
+        }
+        .padding()
+        .background(Color(.white))
+        .cornerRadius(6)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color.blue, lineWidth: 2)
+        )
+        .accessibility(identifier: "Buy \(fruit.emoji)")
+    }
+}
+
+
+struct BuyFruitButtonView: View {
+    var body: some View {
+        Text("Buy")
+            .bold()
+            .font(.system(size: 16, weight: .regular, design: .rounded))
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+            .foregroundColor(.white)
+            .background(ForegroundColor)
+            .cornerRadius(30.0)
+    }
+}
+
+struct ProButtonView: View {
+    let enabled: Bool
+    
+    var body: some View {
+        if enabled {
+            Text("PRO")
+                .bold()
+                .font(.footnote)
+                .padding(2)
+                .foregroundColor(.white)
+                .background(Color(.black))
+                .cornerRadius(3.0)
+        } else {
+            Text("PRO")
+                .bold()
+                .font(.footnote)
+                .padding(2)
+                .foregroundColor(.white)
+                .background(Color(.systemGray2))
+                .cornerRadius(3.0)
+        }
+    }
+}
+
+
+struct BuyCoinsButtonView: View {
+    var body: some View {
+        Text("Buy coins")
+            .bold()
+            .font(.system(size: 16, weight: .regular, design: .rounded))
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+            .foregroundColor(.white)
+            .background(ForegroundColor)
+            .cornerRadius(30.0)
+    }
+}
+
+struct LogoutButtonView: View {
+    var body: some View {
+        Text("LOG OUT")
+            .bold()
+            .font(.footnote)
+            .padding(2)
+            .foregroundColor(.white)
+            .background(Color(.black))
+            .cornerRadius(3.0)
+    }
+}
+
+
+
+struct Button_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            BuyFruitButtonView()
+            BuyCoinsButtonView()
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/Buttons.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/Buttons.swift
@@ -6,7 +6,7 @@
 import Foundation
 import SwiftUI
 
-struct ExamplePaymentButtonView: View {
+struct FruitStorePaymentButtonView: View {
     var text: String
     
     var body: some View {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/ContentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/ContentView.swift
@@ -10,6 +10,7 @@ let ForegroundColor = Color(.sRGB, red: 231/255, green: 91/255, blue: 47/255, op
 let TextColor = Color(.sRGB, red: 60/255, green: 66/255, blue: 87/255, opacity: 1.0)
 let SecondaryButtonColor = Color(.sRGB, red: 199/255, green: 69/255, blue: 28/255, opacity: 1.0)
 
+@available(iOS 14.0, *)
 struct AppView: View {
     @StateObject var model = FruitModel()
     @Environment(\.scenePhase) var scenePhase
@@ -59,7 +60,7 @@ struct ErrorView: View {
     }
 }
 
-
+@available(iOS 14.0, *)
 struct AppView_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/ContentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/ContentView.swift
@@ -14,7 +14,7 @@ let SecondaryButtonColor = Color(.sRGB, red: 199/255, green: 69/255, blue: 28/25
 struct AppView: View {
     @StateObject var model = FruitModel()
     @Environment(\.scenePhase) var scenePhase
-    
+
     var body: some View {
         ZStack {
             BackgroundColor
@@ -50,7 +50,7 @@ struct AppView: View {
 
 struct ErrorView: View {
     let error: ServerError
-    
+
     var body: some View {
         Text("⚠️ \(error.localizedDescription)")
             .bold()

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/ContentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/ContentView.swift
@@ -1,0 +1,81 @@
+//
+//  ContentView.swift
+//  FruitStore
+//
+
+import SwiftUI
+
+let BackgroundColor = Color(.sRGB, red: 253/255, green: 232/255, blue: 225/255, opacity: 1.0)
+let ForegroundColor = Color(.sRGB, red: 231/255, green: 91/255, blue: 47/255, opacity: 1.0)
+let TextColor = Color(.sRGB, red: 60/255, green: 66/255, blue: 87/255, opacity: 1.0)
+let SecondaryButtonColor = Color(.sRGB, red: 199/255, green: 69/255, blue: 28/255, opacity: 1.0)
+
+struct AppView: View {
+    @StateObject var model = FruitModel()
+    @Environment(\.scenePhase) var scenePhase
+    
+    var body: some View {
+        ZStack {
+            BackgroundColor
+                .ignoresSafeArea()
+            VStack {
+                if let customer = model.customer {
+                    CustomerView(customer: customer)
+                        .padding(.horizontal, 20)
+                        .padding(.top, 12)
+                    StoreView()
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 12)
+                    Spacer()
+                    if let error = model.lastError {
+                        ErrorView(error: error)
+                            .padding()
+                    }
+                } else {
+                    SigninView()
+                }
+            }
+        }
+        .onAppear { model.updateFromServer(force: false) }
+        .onChange(of: scenePhase) { newScenePhase in
+            if newScenePhase == .active {
+                // Refresh the Customer if needed when the app is foregrounded.
+                model.updateFromServer(force: false)
+            }
+          }
+        .environmentObject(model)
+    }
+}
+
+struct ErrorView: View {
+    let error: ServerError
+    
+    var body: some View {
+        Text("⚠️ \(error.localizedDescription)")
+            .bold()
+            .font(.system(.subheadline, design: .rounded))
+            .foregroundColor(TextColor)
+            .multilineTextAlignment(.center)
+    }
+}
+
+
+struct AppView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ZStack {
+                BackgroundColor.ignoresSafeArea()
+                VStack {
+                    CustomerView(customer: Customer(name: "Katie Bell", wallet: 85, purchased: [Fruit(emoji: "🍒"), Fruit(emoji: "🍊")], hasProSubscription: false))
+                        .padding(.horizontal, 10)
+                        .environmentObject(FruitModel())
+                    Spacer()
+                    StoreView()
+                        .padding(.horizontal, 10)
+                        .environmentObject(FruitModel())
+                }
+            }
+
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/CustomerView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/CustomerView.swift
@@ -4,8 +4,8 @@
 //
 
 import Foundation
-import SwiftUI
 import StoreKit
+import SwiftUI
 
 @available(iOS 14.0, *)
 struct CustomerView: View {
@@ -13,7 +13,7 @@ struct CustomerView: View {
     @EnvironmentObject var model: FruitModel
     @State private var animationState = false
     @State private var proEnabled = false
-    
+
     var body: some View {
         VStack {
             HStack(alignment: .top) {
@@ -58,7 +58,7 @@ struct FruitBowlView: View {
     @EnvironmentObject var model: FruitModel
     @State private var animationState = false
     @State private var proEnabled = false
-    
+
     var body: some View {
         VStack(alignment: .leading) {
             Text("Your fruit bowl")
@@ -112,7 +112,7 @@ struct FruitBowlView: View {
 
 fileprivate extension Customer {
     var purchasedString: String? {
-        let emojiString = purchased.map({$0.emoji}).joined()
+        let emojiString = purchased.map({ $0.emoji }).joined()
         return emojiString.isEmpty ? nil : emojiString
     }
 }
@@ -124,7 +124,7 @@ struct CustomerView_Previews: PreviewProvider {
             ZStack {
             BackgroundColor
                 .ignoresSafeArea()
-            CustomerView(customer: Customer(name: "Katie Bell", wallet: 85, purchased: [Fruit(emoji: "🍒"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"), Fruit(emoji: "🍒"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"), Fruit(emoji: "🍒"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊")], hasProSubscription: false))
+            CustomerView(customer: Customer(name: "Katie Bell", wallet: 85, purchased: [Fruit(emoji: "🍒"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍒"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍒"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊")], hasProSubscription: false))
                 .environmentObject(FruitModel())
             }
             ZStack {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/CustomerView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/CustomerView.swift
@@ -1,0 +1,142 @@
+//
+//  CustomerView.swift
+//  FruitStore
+//
+
+import Foundation
+import SwiftUI
+import StoreKit
+
+struct CustomerView: View {
+    let customer: Customer
+    @EnvironmentObject var model: FruitModel
+    @State private var animationState = false
+    @State private var proEnabled = false
+    
+    var body: some View {
+        VStack {
+            HStack(alignment: .top) {
+                VStack(alignment: .leading) {
+                    Text(customer.name)
+                        .font(.system(size: 24, weight: .bold, design: .rounded))
+                        .foregroundColor(TextColor)
+                        .onTapGesture {
+                            model.logout()
+                        }
+                    Text("\(customer.wallet) coins")
+                        .font(.system(size: 16, weight: .regular, design: .rounded))
+                        .foregroundColor(TextColor)
+//                    Button("Log out") {
+//                        model.logout()
+//                    }
+                }
+                Spacer()
+                if model.loading {
+                    ProgressView()
+                        .padding(.trailing, 6)
+                        .padding(.top, 12)
+                }
+                if SKPaymentQueue.canMakePayments() {
+                    Button {
+                        model.openRefillPage()
+                    } label: {
+                        BuyCoinsButtonView()
+                    }.onOpenURL { url in
+                        model.didCompleteRefill(url: url)
+                    }
+                }
+            }
+            .padding(.bottom, 12)
+            FruitBowlView(customer: customer)
+        }
+    }
+}
+
+struct FruitBowlView: View {
+    let customer: Customer
+    @EnvironmentObject var model: FruitModel
+    @State private var animationState = false
+    @State private var proEnabled = false
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("Your fruit bowl")
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .foregroundColor(TextColor)
+                .padding(.top, 24)
+                .padding(.horizontal, 24)
+            if proEnabled && customer.hasProSubscription {
+//                LinearGradient(gradient: Gradient(colors: [.purple, .blue, .red, .orange]),
+//                               startPoint: animationState ? .topLeading : .bottomLeading,
+//                               endPoint: animationState ? .bottomTrailing : .topTrailing)
+//                    .hueRotation(.degrees(animationState ? 90 : 0))
+//                    .onAppear(perform: {
+//                        withAnimation(.easeInOut(duration: 3.0).repeatForever(autoreverses: true)) {
+//                            animationState.toggle()
+//                        }
+//                    })
+//                    .mask(Text(customer.purchasedString)
+//                            .font(.system(size: 32))
+//                    )
+            } else {
+                if let purchasedString = customer.purchasedString {
+                    Text(purchasedString)
+                        .multilineTextAlignment(.center)
+                        .frame(maxWidth: .infinity, maxHeight: 240)
+//                        .padding(.top, 60)
+//                        .padding(.bottom, 100)
+                        .padding(.horizontal, 12)
+                        .font(.system(size: 48))
+                        .minimumScaleFactor(0.01)
+                } else {
+                    VStack {
+                        Text("No fruit")
+                            .font(.system(size: 24, weight: .medium, design: .rounded))
+                            .foregroundColor(Color(.systemGray))
+                            .multilineTextAlignment(.center)
+                        Text("Buy some at the fruit stand")
+                            .font(.system(size: 16, weight: .medium, design: .rounded))
+                            .foregroundColor(Color(.systemGray))
+                            .multilineTextAlignment(.center)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: 240)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color.white)
+        .cornerRadius(24.0)
+    }
+}
+
+fileprivate extension Customer {
+    var purchasedString: String? {
+        let emojiString = purchased.map({$0.emoji}).joined()
+        return emojiString.isEmpty ? nil : emojiString
+    }
+}
+
+struct CustomerView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ZStack {
+            BackgroundColor
+                .ignoresSafeArea()
+            CustomerView(customer: Customer(name: "Katie Bell", wallet: 85, purchased: [Fruit(emoji: "🍒"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"), Fruit(emoji: "🍒"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"), Fruit(emoji: "🍒"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"), Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊"),  Fruit(emoji: "🍊")], hasProSubscription: false))
+                .environmentObject(FruitModel())
+            }
+            ZStack {
+            BackgroundColor
+                .ignoresSafeArea()
+            CustomerView(customer: Customer(name: "Katie Bell", wallet: 85, purchased: [], hasProSubscription: false))
+                .environmentObject(FruitModel())
+            }
+            ZStack {
+            BackgroundColor
+                .ignoresSafeArea()
+            CustomerView(customer: Customer(name: "Katie Bell", wallet: 85, purchased: [Fruit(emoji: "🍒"), Fruit(emoji: "🍊")], hasProSubscription: false))
+                .environmentObject(FruitModel())
+            }
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/CustomerView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/CustomerView.swift
@@ -7,6 +7,7 @@ import Foundation
 import SwiftUI
 import StoreKit
 
+@available(iOS 14.0, *)
 struct CustomerView: View {
     let customer: Customer
     @EnvironmentObject var model: FruitModel
@@ -116,6 +117,7 @@ fileprivate extension Customer {
     }
 }
 
+@available(iOS 14.0, *)
 struct CustomerView_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/CustomerView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/CustomerView.swift
@@ -42,8 +42,6 @@ struct CustomerView: View {
                         model.openRefillPage()
                     } label: {
                         BuyCoinsButtonView()
-                    }.onOpenURL { url in
-                        model.didCompleteRefill(url: url)
                     }
                 }
             }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/RefillView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/RefillView.swift
@@ -7,6 +7,7 @@ import Foundation
 import SwiftUI
 import StoreKit
 
+@available(iOS 14.0, *)
 struct RefillView: View {
     @EnvironmentObject var model: FruitModel
 
@@ -16,7 +17,7 @@ struct RefillView: View {
             Button {
                 model.openRefillPage()
             } label: {
-                ExamplePaymentButtonView(text: "Buy 100 coins 💰")
+                FruitStorePaymentButtonView(text: "Buy 100 coins 💰")
                     .padding()
             }.onOpenURL { url in
                 model.didCompleteRefill(url: url)

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/RefillView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/RefillView.swift
@@ -1,0 +1,28 @@
+//
+//  RefillView.swift
+//  FruitStore
+//
+
+import Foundation
+import SwiftUI
+import StoreKit
+
+struct RefillView: View {
+    @EnvironmentObject var model: FruitModel
+
+    var body: some View {
+        // Check if payments are blocked by Parental Controls on this device.
+        if SKPaymentQueue.canMakePayments() {
+            Button {
+                model.openRefillPage()
+            } label: {
+                ExamplePaymentButtonView(text: "Buy 100 coins 💰")
+                    .padding()
+            }.onOpenURL { url in
+                model.didCompleteRefill(url: url)
+            }
+        } else {
+            Text("Payments are disabled on this device.")
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/RefillView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/RefillView.swift
@@ -19,8 +19,6 @@ struct RefillView: View {
             } label: {
                 FruitStorePaymentButtonView(text: "Buy 100 coins 💰")
                     .padding()
-            }.onOpenURL { url in
-                model.didCompleteRefill(url: url)
             }
         } else {
             Text("Payments are disabled on this device.")

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/RefillView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/RefillView.swift
@@ -4,8 +4,8 @@
 //
 
 import Foundation
-import SwiftUI
 import StoreKit
+import SwiftUI
 
 @available(iOS 14.0, *)
 struct RefillView: View {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/SigninView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/SigninView.swift
@@ -7,6 +7,7 @@ import Foundation
 import SwiftUI
 import AuthenticationServices
 
+@available(iOS 14.0, *)
 struct SigninView: View {
     @EnvironmentObject var model: FruitModel
     @State var errorAlertPresented = false
@@ -51,6 +52,7 @@ struct SigninView: View {
     }
 }
 
+@available(iOS 14.0, *)
 struct SignInView_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/SigninView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/SigninView.swift
@@ -1,0 +1,66 @@
+//
+//  SigninView.swift
+//  FruitStore
+// 
+
+import Foundation
+import SwiftUI
+import AuthenticationServices
+
+struct SigninView: View {
+    @EnvironmentObject var model: FruitModel
+    @State var errorAlertPresented = false
+    @State var loginError: String?
+    
+    var body: some View {
+        VStack {
+            VStack {
+                Spacer()
+                Image("large_icon")
+                    .resizable()
+                    .frame(maxWidth: 176, maxHeight: 176)
+                Spacer()
+            }
+            Spacer()
+            SignInWithAppleButton { request in
+                request.requestedScopes = [.email, .fullName]
+            } onCompletion: { result in
+                switch result {
+                case .success(let authResults):
+                    model.login(authResults)
+                case .failure(let error):
+                    loginError = error.localizedDescription
+                    errorAlertPresented = true
+                }
+            }.alert(isPresented: $errorAlertPresented, content: {
+                Alert(title: Text("Authorization failed: \(loginError ?? "Unknown Error")"))
+            })
+            .frame(maxHeight: 54)
+            .cornerRadius(60)
+            .padding(.horizontal, 46)
+            .padding(.vertical, 12)
+            Button(action: {
+                model.loginGuest()
+            }, label: {
+                Text("or sign in as guest")
+                    .font(.system(size: 20, weight: .medium, design: .rounded))
+                .foregroundColor(SecondaryButtonColor)
+            })
+            .padding(.bottom, 20)
+        }
+    }
+}
+
+struct SignInView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ZStack {
+                BackgroundColor.ignoresSafeArea()
+                VStack {
+                    SigninView()
+                }
+            }
+
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/SigninView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/SigninView.swift
@@ -3,16 +3,16 @@
 //  FruitStore
 // 
 
+import AuthenticationServices
 import Foundation
 import SwiftUI
-import AuthenticationServices
 
 @available(iOS 14.0, *)
 struct SigninView: View {
     @EnvironmentObject var model: FruitModel
     @State var errorAlertPresented = false
     @State var loginError: String?
-    
+
     var body: some View {
         VStack {
             VStack {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/StoreView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/StoreView.swift
@@ -11,8 +11,8 @@ struct StoreView: View {
 
     let forSale = [Fruit(emoji: "🍊"),
                    Fruit(emoji: "🍒"),
-                   Fruit(emoji: "🍉")]
-    
+                   Fruit(emoji: "🍉"), ]
+
     var body: some View {
         VStack(alignment: .leading) {
             Text("The fruit stand")
@@ -69,7 +69,6 @@ struct StoreView_Previews: PreviewProvider {
                 }
             }
 
-            
             ZStack {
                 BackgroundColor.ignoresSafeArea()
                 VStack {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/StoreView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/StoreView.swift
@@ -1,0 +1,90 @@
+//
+//  StoreView.swift
+//  FruitStore
+//
+
+import Foundation
+import SwiftUI
+
+struct StoreView: View {
+    @EnvironmentObject var model: FruitModel
+
+    let forSale = [Fruit(emoji: "🍊"),
+                   Fruit(emoji: "🍒"),
+                   Fruit(emoji: "🍉")]
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text("The fruit stand")
+                .foregroundColor(TextColor)
+                .font(.system(size: 20, weight: .bold, design: .rounded))
+                .padding(.top, 24)
+                .padding(.horizontal, 24)
+            HStack {
+                ForEach(forSale, id: \.self.emoji) { fruit in
+                    VStack {
+                        Text(fruit.emoji)
+                            .font(.system(size: 48))
+                        Text(fruit.name)
+                            .font(.system(size: 16, weight: .medium, design: .rounded))
+                            .foregroundColor(TextColor)
+                        Text("10 coins")
+                            .font(.system(size: 12, weight: .medium, design: .rounded))
+                            .foregroundColor(TextColor)
+                        Button {
+                            model.buy(fruit)
+                        } label: {
+                            BuyFruitButtonView()
+                                .padding()
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                }
+            }
+
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 28)
+        }
+        .frame(idealWidth: .infinity, maxWidth: .infinity)
+        .background(Color.white)
+        .cornerRadius(24.0)
+    }
+}
+
+
+
+struct StoreView_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            ZStack {
+                BackgroundColor.ignoresSafeArea()
+                VStack {
+                    CustomerView(customer: Customer(name: "Katie Bell", wallet: 85, purchased: [], hasProSubscription: false))
+                        .padding(.horizontal, 20)
+                        .environmentObject(FruitModel())
+                    StoreView()
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 12)
+                        .environmentObject(FruitModel())
+                    Spacer()
+                }
+            }
+
+            
+            ZStack {
+                BackgroundColor.ignoresSafeArea()
+                VStack {
+                    CustomerView(customer: Customer(name: "Katie Bell", wallet: 85, purchased: [Fruit(emoji: "🍒"), Fruit(emoji: "🍊")], hasProSubscription: false))
+                        .padding(.horizontal, 20)
+                        .environmentObject(FruitModel())
+                    StoreView()
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 12)
+                        .environmentObject(FruitModel())
+                    Spacer()
+                }
+            }
+
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/StoreView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Fruit Store/Views/StoreView.swift
@@ -51,8 +51,7 @@ struct StoreView: View {
     }
 }
 
-
-
+@available(iOS 15.0, *)
 struct StoreView_Previews: PreviewProvider {
     static var previews: some View {
         Group {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example.entitlements
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheet Example.entitlements
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<string>applinks:vaulted-well-elderberry.glitch.me?mode=developer</string>
+	</array>
 	<key>com.apple.developer.devicecheck.appattest-environment</key>
 	<string>development</string>
 	<key>com.apple.developer.in-app-payments</key>

--- a/Example/PaymentSheet Example/PaymentSheet Example/Resources/Base.lproj/Main.storyboard
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Resources/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="R4a-Xk-VIc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23727" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="R4a-Xk-VIc">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23721"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -18,7 +18,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="kSk-Ih-EmG">
-                                <rect key="frame" x="8" y="394" width="398" height="166.5"/>
+                                <rect key="frame" x="8" y="400" width="398" height="168"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Examples" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="b2f-ni-mEr" userLabel="Examples">
                                         <rect key="frame" x="162.5" y="0.0" width="73.5" height="0.0"/>
@@ -106,14 +106,22 @@
                                             <segue destination="AjW-Xm-4P3" kind="show" destinationCreationSelector="showSwiftUIEmbedded:" id="FpB-aG-WQh"/>
                                         </connections>
                                     </button>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="tGL-aJ-ETM" userLabel="Fruit Store (Web checkout)">
+                                        <rect key="frame" x="106.5" y="132" width="185" height="0.0"/>
+                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <state key="normal" title="Fruit Store (Web checkout)"/>
+                                        <connections>
+                                            <segue destination="AjW-Xm-4P3" kind="show" destinationCreationSelector="showFruitStore:" id="kyB-Y7-GCE"/>
+                                        </connections>
+                                    </button>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Test Playgrounds" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5HP-ay-2IP" userLabel="Test playgrounds">
-                                        <rect key="frame" x="133.5" y="132" width="131" height="0.0"/>
+                                        <rect key="frame" x="133.5" y="144" width="131" height="0.0"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="or6-aq-0to">
-                                        <rect key="frame" x="84.5" y="144" width="229" height="0.0"/>
+                                        <rect key="frame" x="84.5" y="156" width="229" height="0.0"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="CustomerSheet (test playground)"/>
                                         <connections>
@@ -121,7 +129,7 @@
                                         </connections>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="ynH-6g-uwR">
-                                        <rect key="frame" x="88" y="156" width="222" height="10.5"/>
+                                        <rect key="frame" x="88" y="168" width="222" height="0.0"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <state key="normal" title="PaymentSheet (test playground)"/>
                                         <connections>
@@ -152,7 +160,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="R4a-Xk-VIc" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="J5c-Jd-I6G">
-                        <rect key="frame" x="0.0" y="48" width="414" height="44"/>
+                        <rect key="frame" x="0.0" y="96" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -173,7 +181,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="uGe-f3-L0f">
-                                <rect key="frame" x="20" y="112" width="374" height="545.5"/>
+                                <rect key="frame" x="20" y="160" width="374" height="545.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your cart" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DgE-aS-jOe">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="26.5"/>
@@ -466,7 +474,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="Cwu-4O-ebm">
-                                <rect key="frame" x="20" y="112" width="374" height="615.5"/>
+                                <rect key="frame" x="20" y="160" width="374" height="615.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your cart" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7AO-8y-orQ">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="26.5"/>
@@ -823,7 +831,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="mr3-z9-EDE">
-                                <rect key="frame" x="20" y="112" width="374" height="638.5"/>
+                                <rect key="frame" x="20" y="160" width="374" height="638.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="32D-09-UHJ">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="26.5"/>
@@ -1207,7 +1215,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="lj2-Un-smr">
-                                <rect key="frame" x="20" y="112" width="374" height="568.5"/>
+                                <rect key="frame" x="20" y="160" width="374" height="568.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Your cart" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fbM-40-zo9">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="26.5"/>
@@ -1549,7 +1557,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="oL1-pO-vWD">
-                                <rect key="frame" x="20" y="112" width="374" height="620"/>
+                                <rect key="frame" x="20" y="160" width="374" height="620"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="0wk-wc-Q0C">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="31"/>
@@ -1923,7 +1931,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="LKX-dc-2Dj">
-                                <rect key="frame" x="20" y="112" width="374" height="673.5"/>
+                                <rect key="frame" x="20" y="160" width="374" height="673.5"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" translatesAutoresizingMaskIntoConstraints="NO" id="tav-0l-Zgd">
                                         <rect key="frame" x="0.0" y="0.0" width="374" height="26.5"/>
@@ -2302,7 +2310,7 @@
         </scene>
     </scenes>
     <inferredMetricsTieBreakers>
-        <segue reference="FpB-aG-WQh"/>
+        <segue reference="kyB-Y7-GCE"/>
     </inferredMetricsTieBreakers>
     <resources>
         <systemColor name="labelColor">

--- a/Example/PaymentSheet Example/PaymentSheet Example/SceneDelegate.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/SceneDelegate.swift
@@ -89,6 +89,16 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         guard (scene as? UIWindowScene) != nil else { return }
     }
 
+    func scene(_ scene: UIScene, continue userActivity: NSUserActivity) {
+        guard let url = userActivity.webpageURL else {
+            return
+        }
+
+        if url.lastPathComponent.contains("cool_test_page_bought_coins") {
+            NotificationCenter.default.post(name: Notification.Name("returnFromCheckout"), object: nil)
+        }
+    }
+
     func sceneDidDisconnect(_ scene: UIScene) {
         // Called as the scene is being released by the system.
         // This occurs shortly after the scene enters the background, or when its session is discarded.

--- a/Example/PaymentSheet Example/PaymentSheet Example/ViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ViewController.swift
@@ -11,6 +11,14 @@ import SwiftUI
 import UIKit
 
 class ViewController: UIViewController {
+    @IBSegueAction func showFruitStore(_ coder: NSCoder) -> UIViewController? {
+        if #available(iOS 15.0, *) {
+            return UIHostingController(coder: coder, rootView: AppView())
+        } else {
+            fatalError(">= iOS 15.0 required")
+        }
+    }
+
     @IBAction func myUnwindAction(unwindSegue: UIStoryboardSegue) {
 
     }


### PR DESCRIPTION
## Summary
Add the Fruit Store example mini-app to the Payment Sheet Example app. This is a temporary change while a better long term demo solution is made.

## Motivation
This example will be used to showcase the experience of linking out to the Stripe web checkout flow on mobile.

## Testing
https://github.com/user-attachments/assets/5407b17b-7a96-4484-8203-621319d49c55
