### PR TITLE
Updated deferred validator for PMO SFU

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
@@ -127,6 +127,13 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
                                                                         intentConfiguration: intentConfig,
                                                                         paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
+        // pi sepa_debit got filtered out, but sepa_debit pmo sfu set on the IntentConfiguration
+        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"], "us_bank_account": ["setup_future_usage": "off_session"]]))
+        intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.USBankAccount: .offSession, .card: .offSession, .SEPADebit: .offSession])), confirmHandler: confirmHandler)
+        XCTAssertNoThrow(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
+                                                                        intentConfiguration: intentConfig,
+                                                                        paymentMethod: STPPaymentMethod._testCard(),
+                                                                        isFlowController: false))
     }
 
     func testPaymentIntentNotFlowControllerManualConfirmationMethod() throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
@@ -89,16 +89,9 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
                                                                         intentConfiguration: intentConfig,
                                                                         paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
-        // payment intent pmo nil and intent config pmo non-nil
-        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD")
-        intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.USBankAccount: .offSession, .card: .offSession])), confirmHandler: confirmHandler)
-        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
-                                                                        intentConfiguration: intentConfig,
-                                                                        paymentMethod: STPPaymentMethod._testCard(),
-                                                                        isFlowController: false))
         // intent config pmo nil but intent pmo is non-nil
-        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD")
-        intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.card: .none])), confirmHandler: confirmHandler)
+        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"]]))
+        intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD"), confirmHandler: confirmHandler)
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
                                                                         paymentMethod: STPPaymentMethod._testCard(),


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Relaxing the deferred validation for PMO SFU— some values get filtered out on the intent if they're not available (e.g. sepa_debit with usd and US merchant), but they may be set on the configuration. Now, instead of checking that the intent and the configuration contain the same keys for PMO SFU, we only check that PMO SFU matches for values present on the intent.
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Bug bash
https://docs.google.com/document/d/1H7dceJHfxLCQ8YlNS1gu8ceO-qh2gavmuDVGfnw3oqE/edit?tab=t.0
## Testing
<!-- How was the code tested? Be as specific as possible. -->
Unit test, tried the scenario again (card, US bank, SEPA set to on/off session, deferred, try to pay with anything) without error
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A