### PR TITLE
Disregard private relay emails for Link signup

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
@@ -71,6 +71,11 @@ final class LinkAccountService: LinkAccountServiceProtocol {
         doNotLogConsumerFunnelEvent: Bool,
         completion: @escaping (Result<PaymentSheetLinkAccount?, Error>) -> Void
     ) {
+        guard LinkEmailHelper.canLookupEmail(email) else {
+            completion(.success(nil))
+            return
+        }
+
         ConsumerSession.lookupSession(
             for: email,
             emailSource: emailSource,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
@@ -67,8 +67,7 @@ class LinkURLGenerator {
         // Get email from the previously fetched account in the Link button, or the billing details
         var customerEmail = LinkAccountContext.shared.account?.email
 
-        if customerEmail == nil,
-           let defaultBillingEmail = configuration.defaultBillingDetails.email {
+        if customerEmail == nil, let defaultBillingEmail = configuration.defaultBillingDetails.email, LinkEmailHelper.canLookupEmail(defaultBillingEmail) {
             customerEmail = defaultBillingEmail
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
@@ -316,6 +316,17 @@ final class LinkInlineSignupViewModel {
 
 }
 
+enum LinkEmailHelper {
+    static func canLookupEmail(_ email: String?) -> Bool {
+        guard let email else {
+            return false
+        }
+
+        let privateRelayDomains = ["@privaterelay.appleid.com", "@private.relay.apple.com"]
+        return privateRelayDomains.allSatisfy { email.hasSuffix($0) == false }
+    }
+}
+
 private extension LinkInlineSignupViewModel {
 
     func notifyUpdate() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
@@ -305,6 +305,19 @@ class LinkURLGeneratorTests: XCTestCase {
 
         XCTAssertEqual(params, expectedParams)
     }
+
+    func testIgnoresApplePrivateRelayEmails() {
+        var config = PaymentSheet.Configuration()
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "EUR")) { _, _, _ in
+            // Nothing
+        }
+        config.apiClient.publishableKey = "pk_123"
+        config.defaultBillingDetails.email = "ndfbfndpgv@privaterelay.appleid.com"
+        let intent = Intent.deferredIntent(intentConfig: intentConfig)
+
+        let params = try! LinkURLGenerator.linkParams(configuration: config, intent: intent, elementsSession: .linkPassthroughWithBankElementsSession)
+        XCTAssertNil(params.customerInfo.email)
+    }
 }
 
 extension STPElementsSession {


### PR DESCRIPTION
Some merchants allow Sign In with Apple, and then forward the private relay address to us.

GIT_VALID_PII_OVERRIDE

## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
