### PR TITLE
Add missing payment sheet telemetry calls

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -149,6 +149,9 @@ final class PaymentSheetLoader {
                     analyticsHelper.startTimeMeasurement(.checkout)
                 }
 
+                // Initialize telemetry. Don't wait for this to finish to call completion.
+                STPTelemetryClient.shared.sendTelemetryData()
+
                 // Call completion
                 let loadResult = LoadResult(
                     intent: intent,

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -921,7 +921,7 @@ extension STPAPIClient {
         )
 
         var params = [
-            "app": String(decoding: appData ?? Data(), as: UTF8.self),
+            "app": String(data: appData ?? Data(), encoding: .utf8) ?? "",
             "source": sourceID,
         ]
         if let returnURLString = returnURLString {

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -537,6 +537,7 @@ extension STPAPIClient {
             params[SourceDataHash] = sourceParamsDict
         }
         if var paymentMethodParamsDict = params[PaymentMethodDataHash] as? [String: Any] {
+            STPTelemetryClient.shared.addTelemetryFields(toParams: &paymentMethodParamsDict)
             paymentMethodParamsDict = Self.paramsAddingPaymentUserAgent(paymentMethodParamsDict)
             params[PaymentMethodDataHash] = paymentMethodParamsDict
         }
@@ -713,8 +714,8 @@ extension STPAPIClient {
 
         let endpoint = setupIntentEndpoint(from: setupIntentParams.clientSecret) + "/confirm"
         var params = STPFormEncoder.dictionary(forObject: setupIntentParams)
+        STPTelemetryClient.shared.addTelemetryFields(toParams: &params)
         if var sourceParamsDict = params[SourceDataHash] as? [String: Any] {
-            STPTelemetryClient.shared.addTelemetryFields(toParams: &sourceParamsDict)
             sourceParamsDict = Self.paramsAddingPaymentUserAgent(sourceParamsDict)
             params[SourceDataHash] = sourceParamsDict
         }
@@ -819,6 +820,7 @@ extension STPAPIClient {
         )
         var parameters = STPFormEncoder.dictionary(forObject: paymentMethodParams)
         parameters = Self.paramsAddingPaymentUserAgent(parameters, additionalValues: additionalPaymentUserAgentValues)
+        STPTelemetryClient.shared.addTelemetryFields(toParams: &parameters)
         APIRequest<STPPaymentMethod>.post(
             with: self,
             endpoint: APIEndpointPaymentMethods,


### PR DESCRIPTION
## Summary
Add telemetry calls for:
- fetching telemetry params after load
- create payment method
- confirm payment intent

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-3163

## Testing
We currently disable telemetry on simulators and do not conduct unit tests on telemetry. I manually verified that telemetry parameters are attached to the create payment method and confirm payment intent API calls.

## Changelog
N/A