### PR TITLE
Only support Link cards in SPM

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/PaymentMethodWithLinkDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/PaymentMethodWithLinkDetails.swift
@@ -29,9 +29,16 @@ class PaymentMethodWithLinkDetails: NSObject, STPAPIResponseDecodable {
             return nil
         }
 
+        let linkDetailsJson = response["link_payment_details"] as? [AnyHashable: Any]
+
+        if isUnsupportedLinkPaymentDetailsType(linkDetailsJson) {
+            // This is a Link payment method, but we don't support the type yet. We can't render them, so hide them.
+            return nil
+        }
+
         var linkDetails: ConsumerPaymentDetails?
 
-        if let linkDetailsJson = response["link_payment_details"] as? [AnyHashable: Any] {
+        if let linkDetailsJson {
             let decoder = JSONDecoder()
             decoder.keyDecodingStrategy = .convertFromSnakeCase
 
@@ -45,5 +52,14 @@ class PaymentMethodWithLinkDetails: NSObject, STPAPIResponseDecodable {
             linkDetails: linkDetails,
             allResponseFields: response
         )
+    }
+
+    private static func isUnsupportedLinkPaymentDetailsType(_ json: [AnyHashable: Any]?) -> Bool {
+        guard let json else {
+            // Not a Link payment method, so we're fine
+            return false
+        }
+
+        return json["type"] as? String != "CARD"
     }
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request updates `PaymentMethodWithLinkDetails.decodedObject()` to ignore Link payment methods that aren't cards, as we don't support those yet.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
