### PR TITLE
Shorten loading spinner overlap to 100ms

### DIFF
--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
@@ -324,7 +324,9 @@ private extension ConnectComponentWebViewController {
         addMessageHandler(setterMessageHandler)
         addMessageHandler(OnLoaderStartMessageHandler { [analyticsClient, activityIndicator] _ in
             analyticsClient.logComponentLoaded(loadEnd: .now)
-            UIView.animate(withDuration: 1.0, animations: {
+            // Keeps the spinner around for 100ms which is just enough on most devices to smooth the transition to the web spinner
+            // Any longer, and the spinner begins to conflict with the embedded loading state
+            UIView.animate(withDuration: 1, animations: {
                 activityIndicator.alpha = 0.0
             }, completion: { _ in
                 activityIndicator.stopAnimating()

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ConnectComponentWebViewController.swift
@@ -326,7 +326,7 @@ private extension ConnectComponentWebViewController {
             analyticsClient.logComponentLoaded(loadEnd: .now)
             // Keeps the spinner around for 100ms which is just enough on most devices to smooth the transition to the web spinner
             // Any longer, and the spinner begins to conflict with the embedded loading state
-            UIView.animate(withDuration: 1, animations: {
+            UIView.animate(withDuration: 0.1, animations: {
                 activityIndicator.alpha = 0.0
             }, completion: { _ in
                 activityIndicator.stopAnimating()


### PR DESCRIPTION
## Summary
After `onLoaderStart` is received, currently, we keep the spinner on for a 1s and decrease its opacity to smooth out the loading transition between the SDK and the webview for account onboarding. 

However, when account onboarding is created with a non-custom account, a different UI loads in without a spinner and this 1s spillover is too long. I didn't want to just delete the fade out entirely because it does look jarring, but reducing this down to 100ms seems to give us a reasonable compromise. 

Before:

https://github.com/user-attachments/assets/52a0efa9-671e-48e5-a8e0-eddf530d6448


After:

https://github.com/user-attachments/assets/396f4c1b-4dae-4405-b91e-85029bb45649


## Motivation
https://jira.corp.stripe.com/browse/CAX-4144

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
