### PR TITLE
Send customer ephemeral key to backend

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -28,6 +28,8 @@ extension STPAPIClient {
         }
         if case .customerSession(let clientSecret) = customerAccessProvider {
             parameters["customer_session_client_secret"] = clientSecret
+        } else if case .legacyCustomerEphemeralKey(let ephemeralKey) = customerAccessProvider {
+            parameters["legacy_customer_ephemeral_key"] = ephemeralKey
         }
         if let clientDefaultPaymentMethod {
             parameters["client_default_payment_method"] = clientDefaultPaymentMethod

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -133,4 +133,28 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         XCTAssertNil(parameters["customer_session_client_secret"])
         XCTAssertNil(parameters["client_default_payment_method"])
     }
+
+    func testElementsSessionParameters_sendsLegacyCustomerEphemeralKey() throws {
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(
+            mode: .paymentIntentClientSecret("pi_123_secret_456"),
+            epmConfiguration: nil,
+            cpmConfiguration: nil,
+            clientDefaultPaymentMethod: nil,
+            customerAccessProvider: .legacyCustomerEphemeralKey("ek_123")
+        )
+        XCTAssertEqual(parameters["legacy_customer_ephemeral_key"] as? String, "ek_123")
+        XCTAssertNil(parameters["customer_session_client_secret"])
+    }
+
+    func testElementsSessionParameters_sendsNoLegacyCustomerEphemeralKey() throws {
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(
+            mode: .paymentIntentClientSecret("pi_123_secret_456"),
+            epmConfiguration: nil,
+            cpmConfiguration: nil,
+            clientDefaultPaymentMethod: nil,
+            customerAccessProvider: nil
+        )
+        XCTAssertNil(parameters["legacy_customer_ephemeral_key"])
+        XCTAssertNil(parameters["customer_session_client_secret"])
+    }
 }

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadDoesNotFilterSavedApplePayCardsWhenDisabled/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadDoesNotFilterSavedApplePayCardsWhenDisabled/0000_post_create_ephemeral_key.tail
@@ -15,4 +15,4 @@ Content-Length: 149
 x-content-type-options: nosniff
 x-frame-options: SAMEORIGIN
 
-{"ephemeral_key_secret":"ek_test_YWNjdF8xTnBJWVJJcTJMbXB5SUNvLE9sQk90aUVOdGlnaTdqSDcyRG0yU3JnSEwyRFJhSlA_00z0KwXKgx","customer":"cus_OtOGvD0ZVacBoj"}
+{"ephemeral_key_secret":"ek_test_YWNjdF8xTnBJWVJJcTJMbXB5SUNvLG1PbVR0MzhDR0JqbGpmbnd1Rm5BdHNUMUMzeHFKd3M_00hvSa08Mb","customer":"cus_OtOGvD0ZVacBoj"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadDoesNotFilterSavedApplePayCardsWhenDisabled/0002_get_v1_elements_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadDoesNotFilterSavedApplePayCardsWhenDisabled/0002_get_v1_elements_sessions.tail
@@ -1,5 +1,5 @@
 GET
-https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?deferred_intent%5Bamount%5D=1000&deferred_intent%5Bcapture_method%5D=automatic&deferred_intent%5Bcurrency%5D=JPY&deferred_intent%5Bmode%5D=payment&key=pk_test_51NpIYRIq2LmpyICoBLPaTxfWFW4I34pnWuBjKXf8CgOlVih7Ni6oDfPRHGTzBEnpsrHiPvqP2UyydilqY66BWp8N00mQCJ1PU5&locale=en-US&mobile_app_id=com\.stripe\.StripeiOSTestHostApp&type=deferred_intent$
+https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?deferred_intent%5Bamount%5D=1000&deferred_intent%5Bcapture_method%5D=automatic&deferred_intent%5Bcurrency%5D=JPY&deferred_intent%5Bmode%5D=payment&key=pk_test_51NpIYRIq2LmpyICoBLPaTxfWFW4I34pnWuBjKXf8CgOlVih7Ni6oDfPRHGTzBEnpsrHiPvqP2UyydilqY66BWp8N00mQCJ1PU5&legacy_customer_ephemeral_key=ek_test_YWNjdF8xTnBJWVJJcTJMbXB5SUNvLG1PbVR0MzhDR0JqbGpmbnd1Rm5BdHNUMUMzeHFKd3M_00hvSa08Mb&locale=en-US&mobile_app_id=com\.stripe\.StripeiOSTestHostApp&type=deferred_intent$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0000_post_create_ephemeral_key.tail
@@ -15,4 +15,4 @@ Content-Length: 149
 x-content-type-options: nosniff
 x-frame-options: SAMEORIGIN
 
-{"ephemeral_key_secret":"ek_test_YWNjdF8xTnBJWVJJcTJMbXB5SUNvLGI2aEZvRGJVSFlxMjd5dU1wRWRMcU5aZWF0OTlVWmM_00gwPGjdtK","customer":"cus_OtOGvD0ZVacBoj"}
+{"ephemeral_key_secret":"ek_test_YWNjdF8xTnBJWVJJcTJMbXB5SUNvLGRrMHlBaHFwVnQxb1RYd25NRGVkaVA1UFZ3ZkNiMmE_00pr0e14TP","customer":"cus_OtOGvD0ZVacBoj"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0002_get_v1_elements_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersCardBrandAcceptance/0002_get_v1_elements_sessions.tail
@@ -1,5 +1,5 @@
 GET
-https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?deferred_intent%5Bamount%5D=1000&deferred_intent%5Bcapture_method%5D=automatic&deferred_intent%5Bcurrency%5D=JPY&deferred_intent%5Bmode%5D=payment&key=pk_test_51NpIYRIq2LmpyICoBLPaTxfWFW4I34pnWuBjKXf8CgOlVih7Ni6oDfPRHGTzBEnpsrHiPvqP2UyydilqY66BWp8N00mQCJ1PU5&locale=en-US&mobile_app_id=com\.stripe\.StripeiOSTestHostApp&type=deferred_intent$
+https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?deferred_intent%5Bamount%5D=1000&deferred_intent%5Bcapture_method%5D=automatic&deferred_intent%5Bcurrency%5D=JPY&deferred_intent%5Bmode%5D=payment&key=pk_test_51NpIYRIq2LmpyICoBLPaTxfWFW4I34pnWuBjKXf8CgOlVih7Ni6oDfPRHGTzBEnpsrHiPvqP2UyydilqY66BWp8N00mQCJ1PU5&legacy_customer_ephemeral_key=ek_test_YWNjdF8xTnBJWVJJcTJMbXB5SUNvLGRrMHlBaHFwVnQxb1RYd25NRGVkaVA1UFZ3ZkNiMmE_00pr0e14TP&locale=en-US&mobile_app_id=com\.stripe\.StripeiOSTestHostApp&type=deferred_intent$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersSavedApplePayCards/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersSavedApplePayCards/0000_post_create_ephemeral_key.tail
@@ -15,4 +15,4 @@ Content-Length: 149
 x-content-type-options: nosniff
 x-frame-options: SAMEORIGIN
 
-{"ephemeral_key_secret":"ek_test_YWNjdF8xTnBJWVJJcTJMbXB5SUNvLEpRVlVUbWd6NFZOT285WTRlN2ZLenI5QjBrMjA0NUo_00X1AtSyUz","customer":"cus_OtOGvD0ZVacBoj"}
+{"ephemeral_key_secret":"ek_test_YWNjdF8xTnBJWVJJcTJMbXB5SUNvLENDd01ob3hZNzB1TUM0amk4bm8ybkYyMVA5d2RmVzQ_006dvDUixy","customer":"cus_OtOGvD0ZVacBoj"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersSavedApplePayCards/0002_get_v1_elements_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/PaymentSheetLoaderTest/testPaymentSheetLoadFiltersSavedApplePayCards/0002_get_v1_elements_sessions.tail
@@ -1,5 +1,5 @@
 GET
-https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?deferred_intent%5Bamount%5D=1000&deferred_intent%5Bcapture_method%5D=automatic&deferred_intent%5Bcurrency%5D=JPY&deferred_intent%5Bmode%5D=payment&key=pk_test_51NpIYRIq2LmpyICoBLPaTxfWFW4I34pnWuBjKXf8CgOlVih7Ni6oDfPRHGTzBEnpsrHiPvqP2UyydilqY66BWp8N00mQCJ1PU5&locale=en-US&mobile_app_id=com\.stripe\.StripeiOSTestHostApp&type=deferred_intent$
+https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?deferred_intent%5Bamount%5D=1000&deferred_intent%5Bcapture_method%5D=automatic&deferred_intent%5Bcurrency%5D=JPY&deferred_intent%5Bmode%5D=payment&key=pk_test_51NpIYRIq2LmpyICoBLPaTxfWFW4I34pnWuBjKXf8CgOlVih7Ni6oDfPRHGTzBEnpsrHiPvqP2UyydilqY66BWp8N00mQCJ1PU5&legacy_customer_ephemeral_key=ek_test_YWNjdF8xTnBJWVJJcTJMbXB5SUNvLENDd01ob3hZNzB1TUM0amk4bm8ybkYyMVA5d2RmVzQ_006dvDUixy&locale=en-US&mobile_app_id=com\.stripe\.StripeiOSTestHostApp&type=deferred_intent$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request adds a `legacy_customer_ephemeral_key` parameter to the Elements session request. This parameter helps us determine if inline signup can be enabled. The related backend work can be found [here](https://git.corp.stripe.com/stripe-internal/pay-server/pull/1084214).

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
