### PR TITLE
Add metric for a user canceling out of apple pay flow

### DIFF
--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -494,6 +494,8 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
         // Note: This method is called if the user cancels (taps outside the sheet) or Apple Pay times out (empirically 30 seconds)
         switch paymentState {
         case .notStarted:
+            let analytic = Analytic(event: .applePayContextCanceledPayment)
+            self.analyticsClient.log(analytic: analytic, apiClient: self.apiClient)
             controller.dismiss {
                 stpDispatchToMainThreadIfNecessary {
                     self.callDidCompleteDelegate(status: .userCancellation, error: nil)

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -35,6 +35,7 @@ import Foundation
     case _3DS2ChallengeFlowCompleted = "stripeios.3ds2_challenge_flow_completed"
     case _3DS2ChallengeFlowErrored = "stripeios.3ds2_challenge_flow_errored"
     case _3DS2RedirectUserCanceled = "stripeios.3ds2_redirect_canceled"
+    case applePayContextCanceledPayment = "stripeios.applepaycontext.canceled"
     case applePayContextCompletePaymentFinished = "stripeios.applepaycontext.complete_payment.finished"
     case paymentHandlerConfirmStarted = "stripeios.paymenthandler.confirm.started"
     case paymentHandlerConfirmFinished = "stripeios.paymenthandler.confirm.finished"


### PR DESCRIPTION
## Summary
Adds metric for canceling out of apple pay

## Motivation
instrumentation

## Testing
manually tested code is executed

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
