### PR TITLE
Allow redisplay of Link payment methods that originate from inline signup

### DIFF
--- a/Stripe/StripeiOSTests/STPConfirmPaymentMethodOptionsTest.swift
+++ b/Stripe/StripeiOSTests/STPConfirmPaymentMethodOptionsTest.swift
@@ -27,6 +27,7 @@ class STPConfirmPaymentMethodOptionsTest: XCTestCase {
             "weChatPayOptions": "wechat_pay",
             "usBankAccountOptions": "us_bank_account",
             "konbiniOptions": "konbini",
+            "linkOptions": "link",
         ]
 
         XCTAssertEqual(propertyToFieldMap, expected)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -503,7 +503,8 @@ extension PaymentSheetLinkAccount {
     func makePaymentMethodParams(
         from paymentDetails: ConsumerPaymentDetails,
         cvc: String?,
-        billingPhoneNumber: String?
+        billingPhoneNumber: String?,
+        allowRedisplay: STPPaymentMethodAllowRedisplay?
     ) -> STPPaymentMethodParams? {
         guard let currentSession = currentSession else {
             stpAssertionFailure("Cannot make payment method params without an active session.")
@@ -511,6 +512,9 @@ extension PaymentSheetLinkAccount {
         }
 
         let params = STPPaymentMethodParams(type: .link)
+        if let allowRedisplay {
+            params.allowRedisplay = allowRedisplay
+        }
         params.billingDetails = STPPaymentMethodBillingDetails(billingAddress: paymentDetails.billingAddress, email: paymentDetails.billingEmailAddress)
         params.billingDetails?.phone = billingPhoneNumber
         params.link?.paymentDetailsID = paymentDetails.stripeID

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -187,7 +187,13 @@ extension STPConfirmPaymentMethodOptions {
         // Something went wrong if we're trying to save and there's no Customer!
         assert(!(shouldSave && customer == nil))
 
-        guard customer != nil && paymentMethodType == .card || paymentMethodType == .USBankAccount else {
+        var allowedPaymentMethodTypes: [STPPaymentMethodType] = [.card, .USBankAccount]
+
+        if let customer, case .customerSession = customer.customerAccessProvider {
+            allowedPaymentMethodTypes.append(.link)
+        }
+
+        guard customer != nil && allowedPaymentMethodTypes.contains(paymentMethodType) else {
             return
         }
 
@@ -200,6 +206,9 @@ extension STPConfirmPaymentMethodOptions {
             // Note: the SFU value passed in the STPConfirmUSBankAccountOptions init will be overwritten by `additionalAPIParameters`. See https://jira.corp.stripe.com/browse/RUN_MOBILESDK-1737
             usBankAccountOptions = usBankAccountOptions ?? STPConfirmUSBankAccountOptions(setupFutureUsage: .none)
             usBankAccountOptions?.additionalAPIParameters["setup_future_usage"] = sfuValue
+        case .link:
+            linkOptions = linkOptions ?? STPConfirmLinkOptions()
+            linkOptions?.additionalAPIParameters["setup_future_usage"] = sfuValue
         default:
             return
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
@@ -339,6 +339,46 @@ extension STPElementsSession {
                                                             "link_passthrough_mode_enabled": false,
                                                            ],
         ]
+
+        return STPElementsSession.decodedObject(fromAPIResponse: apiResponse)!
+    }
+
+    static var linkElementsSessionWithCustomerSession: STPElementsSession {
+        let apiResponse: [String: Any] = [
+            "payment_method_preference": [
+                "ordered_payment_method_types": ["card", "link"],
+                "country_code": "US",
+            ],
+            "session_id": "123",
+            "apple_pay_preference": "enabled",
+            "link_settings": [
+                "link_funding_sources": ["CARD"],
+                "link_passthrough_mode_enabled": false,
+            ],
+            "customer": [
+                "customer_session": [
+                    "id": "cuss_123",
+                    "customer": "cus_123",
+                    "api_key": "ek_123",
+                    "api_key_expiry": 1716580929,
+                    "livemode": false,
+                    "components": [
+                        "mobile_payment_element": [
+                            "enabled": true,
+                            "features": [
+                              "payment_method_save": "enabled",
+                              "payment_method_remove": "enabled",
+                            ],
+                        ],
+                        "customer_sheet": [
+                          "enabled": false
+                        ],
+                    ],
+                ],
+                "payment_methods": [],
+            ],
+        ]
+
         return STPElementsSession.decodedObject(fromAPIResponse: apiResponse)!
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
@@ -8,7 +8,7 @@ import XCTest
 
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripePayments
-@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) @_spi(CustomerSessionBetaAccess) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsTestUtils
 @testable@_spi(STP) import StripeUICore
 
@@ -219,6 +219,67 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
 
         waitForExpectations(timeout: 10)
     }
+
+    func testLinkInlineSignupInPaymentMethodModePassesCorrectAllowRedisplay() {
+        stubLinkSignup()
+        stubLinkCreatePaymentDetails()
+        stubConfirmPaymentExpecting(isPaymentIntent: true, type: "link", setupFutureUsage: "off_session", allowRedisplay: "always")
+        stubLinkLogout(consumerSessionClientSecret: "pscs_abc123")
+
+        let exp = expectation(description: "confirm completed")
+
+        var configuration = MockParams.configuration(pk: MockParams.publicKey)
+        configuration.customer = .init(id: "cus_123", customerSessionClientSecret: "cuss_123")
+
+        let paymentHandler = STPPaymentHandler(apiClient: configuration.apiClient)
+        let elementsSession = STPElementsSession.linkElementsSessionWithCustomerSession
+
+        var paymentIntentJSON = MockJson.paymentIntent
+        paymentIntentJSON["payment_method_types"] = ["card", "link"]
+
+        let paymentIntent = STPPaymentIntent.decodedObject(fromAPIResponse: paymentIntentJSON)!
+
+        let confirmParams = IntentConfirmParams(type: .stripe(.card))
+        confirmParams.paymentMethodParams.card = STPPaymentMethodCardParams()
+        confirmParams.paymentMethodParams.card?.number = "4242424242424242"
+        confirmParams.paymentMethodParams.card?.expMonth = NSNumber(value: 12)
+        confirmParams.paymentMethodParams.card?.expYear = 2040
+        confirmParams.paymentMethodParams.card?.cvc = "123"
+
+        // User selected to save the payment method
+        confirmParams.saveForFutureUseCheckboxState = .selected
+
+        // We're in payment method mode, so the PaymentOption is Link
+        let paymentOption: PaymentOption = .link(
+            option: .signUp(
+                account: .init(
+                    email: "email@email.com",
+                    session: nil,
+                    publishableKey: "pk_123",
+                    useMobileEndpoints: false
+                ),
+                phoneNumber: PhoneNumber(number: "5555555555", countryCode: "US")!,
+                consentAction: .implied_v0_0,
+                legalName: nil,
+                intentConfirmParams: confirmParams
+            )
+        )
+
+        PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: self,
+            intent: .paymentIntent(paymentIntent),
+            elementsSession: elementsSession,
+            paymentOption: paymentOption,
+            paymentHandler: paymentHandler,
+            analyticsHelper: ._testValue(),
+            completion: { _, _ in
+                exp.fulfill()
+            }
+        )
+
+        waitForExpectations(timeout: 10)
+    }
 }
 
 extension PaymentSheetAPIMockTest: STPAuthenticationContext {
@@ -250,6 +311,35 @@ private extension PaymentSheetAPIMockTest {
 
             // Payment Method Options
             assertParam(params, named: "payment_method_options[card][setup_future_usage]", is: setupFutureUsage, line: line)
+
+            defer { exp.fulfill() }
+            var json = isPaymentIntent ? MockJson.paymentIntent : MockJson.setupIntent
+            json["status"] = "succeeded"
+
+            return HTTPStubsResponse(jsonObject: json, statusCode: 200, headers: nil)
+        }
+    }
+
+    func stubConfirmPaymentExpecting(
+        isPaymentIntent: Bool,
+        type: String,
+        setupFutureUsage: String? = nil,
+        allowRedisplay: String? = nil,
+        line: UInt = #line
+    ) {
+        let exp = expectation(description: "confirm payment requested")
+
+        stub { urlRequest in
+            guard let pathComponents = urlRequest.url?.pathComponents else { return false }
+            return pathComponents.last == "confirm"
+        } response: { [self] request in
+            let params = bodyParams(from: request, line: line)
+
+            assertParam(params, named: "payment_method_data[type]", is: type, line: line)
+            assertParam(params, named: "payment_method_data[allow_redisplay]", is: allowRedisplay, line: line)
+
+            // Payment Method Options
+            assertParam(params, named: "payment_method_options[link][setup_future_usage]", is: setupFutureUsage, line: line)
 
             defer { exp.fulfill() }
             var json = isPaymentIntent ? MockJson.paymentIntent : MockJson.setupIntent
@@ -302,6 +392,119 @@ private extension PaymentSheetAPIMockTest {
             defer { exp.fulfill() }
 
             return HTTPStubsResponse(jsonObject: [], statusCode: 200, headers: nil)
+        }
+    }
+
+    func stubLinkSignup(
+        line: UInt = #line
+    ) {
+        let exp = expectation(description: "Link signup")
+
+        stub { urlRequest in
+            guard let pathComponents = urlRequest.url?.pathComponents else { return false }
+            return pathComponents.last == "sign_up"
+        } response: {_ in
+            defer { exp.fulfill() }
+
+            let responseJSON = """
+              {
+                "publishable_key" : "pk_123",
+                "consumer_session": {
+                  "client_secret": "pscs_abc123",
+                  "email_address": "foo@bar.com",
+                  "redacted_formatted_phone_number": "(***) *** **12",
+                  "verification_sessions": [
+                    {
+                      "state" : "STARTED",
+                      "type" : "SIGNUP"
+                    }
+                  ],
+                  "support_paymnet_details_types": ["CARD"],
+                }
+              }
+            """
+
+            let response = try! JSONSerialization.jsonObject(
+                with: responseJSON.data(using: .utf8)!,
+                options: []
+            ) as! [AnyHashable: Any]
+
+            return HTTPStubsResponse(jsonObject: response, statusCode: 200, headers: nil)
+        }
+    }
+
+    func stubLinkCreatePaymentDetails(
+        line: UInt = #line
+    ) {
+        let exp = expectation(description: "Link signup")
+
+        stub { urlRequest in
+            guard let pathComponents = urlRequest.url?.pathComponents else { return false }
+            return pathComponents.last == "payment_details"
+        } response: { [self] _ in
+            defer { exp.fulfill() }
+
+            let responseJSON = """
+              {
+                "redacted_payment_details" : {
+                  "card_details" : {
+                    "brand_enum" : "visa",
+                    "checks" : {
+                      "address_postal_code_check" : "STATE_INVALID",
+                      "cvc_check" : "STATE_INVALID",
+                      "address_line1_check" : "STATE_INVALID"
+                    },
+                    "country" : "COUNTRY_US",
+                    "exp_month" : 12,
+                    "funding" : "CREDIT",
+                    "preferred_network" : null,
+                    "program_details" : {
+                      "card_art_network_id" : "",
+                      "height" : 0,
+                      "program_name" : "",
+                      "width" : 0,
+                      "background_color" : "",
+                      "foreground_color" : "",
+                      "card_art_url" : ""
+                    },
+                    "brand" : "VISA",
+                    "last4" : "4242",
+                    "networks" : [
+                      "VISA"
+                    ],
+                    "exp_year" : 2030
+                  },
+                  "is_default" : false,
+                  "id" : "csmrpd_test_61QrpvXKaugSBvBsB41C40Oy4de1NQS8",
+                  "backup_ids" : [
+
+                  ],
+                  "is_us_debit_prepaid_or_bank_payment" : false,
+                  "billing_address" : {
+                    "line_1" : null,
+                    "line_2" : null,
+                    "locality" : null,
+                    "postal_code" : "55555",
+                    "sorting_code" : null,
+                    "country_code" : "US",
+                    "dependent_locality" : null,
+                    "administrative_area" : null,
+                    "name" : "Payments SDK CI"
+                  },
+                  "nickname" : "",
+                  "bank_account_details" : null,
+                  "type" : "CARD",
+                  "billing_email_address" : "mobile-payments-sdk-ci+874e9b29-df47-4a14-be39-be257a89dccb@stripe.com"
+                }
+              }
+            """
+
+            let response = try! JSONSerialization.jsonObject(
+                with: responseJSON.data(using: .utf8)!,
+                options: []
+            ) as! [AnyHashable: Any]
+
+            return HTTPStubsResponse(jsonObject: response, statusCode: 200, headers: nil)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
@@ -23,7 +23,7 @@ final class PaymentSheetLinkAccountTests: APIStubbedTestCase {
         let sut = makeSUT()
 
         let paymentDetails = makePaymentDetailsStub()
-        let result = sut.makePaymentMethodParams(from: paymentDetails, cvc: nil, billingPhoneNumber: nil)
+        let result = sut.makePaymentMethodParams(from: paymentDetails, cvc: nil, billingPhoneNumber: nil, allowRedisplay: nil)
 
         XCTAssertEqual(result?.type, .link)
         XCTAssertEqual(result?.link?.paymentDetailsID, "1")
@@ -40,7 +40,7 @@ final class PaymentSheetLinkAccountTests: APIStubbedTestCase {
         let sut = makeSUT()
 
         let paymentDetails = makePaymentDetailsStub()
-        let result = sut.makePaymentMethodParams(from: paymentDetails, cvc: "1234", billingPhoneNumber: nil)
+        let result = sut.makePaymentMethodParams(from: paymentDetails, cvc: "1234", billingPhoneNumber: nil, allowRedisplay: nil)
 
         XCTAssertEqual(
             result?.link?.additionalAPIParameters["card"] as? [String: String],
@@ -48,6 +48,15 @@ final class PaymentSheetLinkAccountTests: APIStubbedTestCase {
                 "cvc": "1234"
             ]
         )
+    }
+
+    func testMakePaymentMethodParams_withAllowRedisplay() {
+        let sut = makeSUT()
+
+        let paymentDetails = makePaymentDetailsStub()
+        let result = sut.makePaymentMethodParams(from: paymentDetails, cvc: "1234", billingPhoneNumber: nil, allowRedisplay: .always)
+
+        XCTAssertEqual(result?.allowRedisplay, .always)
     }
 
     func testRefreshesWhenNeeded() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetSnapshotTests.swift
@@ -54,12 +54,14 @@ class PaymentSheetSnapshotTests: STPSnapshotTestCase {
             APIStubbedTestCase.stubAllOutgoingRequests()
         }
         stubAllImageRequests()
+        PaymentSheet.resetCustomer()
     }
 
     public override func tearDown() {
         super.tearDown()
         HTTPStubs.removeAllStubs()
         configuration = PaymentSheet.Configuration()
+        PaymentSheet.resetCustomer()
     }
 
     private func stubbedAPIClient() -> STPAPIClient {

--- a/StripePayments/StripePayments.xcodeproj/project.pbxproj
+++ b/StripePayments/StripePayments.xcodeproj/project.pbxproj
@@ -226,6 +226,7 @@
 		CAC3A0302C2E127B007BC888 /* STPPaymentMethodSunbit.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC3A02F2C2E127B007BC888 /* STPPaymentMethodSunbit.swift */; };
 		CAC80EC32C333646001E3D0D /* STPPaymentMethodSatispay.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80EC22C333646001E3D0D /* STPPaymentMethodSatispay.swift */; };
 		CAC80EC52C33368E001E3D0D /* STPPaymentMethodSatispayParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAC80EC42C33368E001E3D0D /* STPPaymentMethodSatispayParams.swift */; };
+		CB28DBAD2DBD452A008DD7DF /* STPConfirmLinkOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB28DBAC2DBD452A008DD7DF /* STPConfirmLinkOptions.swift */; };
 		CB486DD02DB6B7580098A75D /* LinkPaymentDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB486DCF2DB6B7580098A75D /* LinkPaymentDetails.swift */; };
 		CB99BCA5D74904829DDF5A25 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 719D0377278FA11F93E19637 /* StripeCore.framework */; };
 		CBFB5A1330C916D5DC95F6FF /* STPLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 086AC53333729531A067E435 /* STPLocalizedString.swift */; };
@@ -645,6 +646,7 @@
 		CAC3A02F2C2E127B007BC888 /* STPPaymentMethodSunbit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodSunbit.swift; sourceTree = "<group>"; };
 		CAC80EC22C333646001E3D0D /* STPPaymentMethodSatispay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodSatispay.swift; sourceTree = "<group>"; };
 		CAC80EC42C33368E001E3D0D /* STPPaymentMethodSatispayParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodSatispayParams.swift; sourceTree = "<group>"; };
+		CB28DBAC2DBD452A008DD7DF /* STPConfirmLinkOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPConfirmLinkOptions.swift; sourceTree = "<group>"; };
 		CB486DCF2DB6B7580098A75D /* LinkPaymentDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPaymentDetails.swift; sourceTree = "<group>"; };
 		CEFD8715EEA4EECD411465FB /* STPPaymentMethodCardWallet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodCardWallet.swift; sourceTree = "<group>"; };
 		D07382674619AEF657397B21 /* STPThreeDSUICustomization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPThreeDSUICustomization.swift; sourceTree = "<group>"; };
@@ -971,6 +973,7 @@
 				7CE7DBFDCD8676DB9F60C96F /* STPConfirmBLIKOptions.swift */,
 				7B56A5D5A1ECF4C62BC2AE64 /* STPConfirmCardOptions.swift */,
 				B8157BD59DD68903FE728787 /* STPConfirmKonbiniOptions.swift */,
+				CB28DBAC2DBD452A008DD7DF /* STPConfirmLinkOptions.swift */,
 				535A112409DAB226749A688C /* STPConfirmPaymentMethodOptions.swift */,
 				34CB5AD8FDE347B19ED2D9CD /* STPConfirmUSBankAccountOptions.swift */,
 				030B54DF945D8ED922A55CDF /* STPConfirmWeChatPayOptions.swift */,
@@ -1881,6 +1884,7 @@
 				6BE5D7C3F86951E73DAAEB6B /* STPThreeDSCustomizationSettings.swift in Sources */,
 				E15AF2A98601482762212A18 /* STPThreeDSFooterCustomization.swift in Sources */,
 				31B7F54E2BD1D4E500BF1015 /* HCaptchaHtml.swift in Sources */,
+				CB28DBAD2DBD452A008DD7DF /* STPConfirmLinkOptions.swift in Sources */,
 				71A589E7CCAEA272B9CC37AB /* STPThreeDSLabelCustomization.swift in Sources */,
 				AC555A609E63E94BCAA468C5 /* STPThreeDSNavigationBarCustomization.swift in Sources */,
 				31B7F5582BD1D4E500BF1015 /* HCaptchaEvent.swift in Sources */,

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPConfirmLinkOptions.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPConfirmLinkOptions.swift
@@ -1,0 +1,36 @@
+//
+//  STPConfirmLinkOptions.swift
+//  StripePayments
+//
+//  Created by Till Hellmund on 4/26/25.
+//
+
+import Foundation
+
+// MARK: - STPConfirmLinkOptions
+/// Options to update a Link PaymentMethod during PaymentIntent confirmation.
+@_spi(STP) public class STPConfirmLinkOptions: NSObject {
+    /// Indicates that you intend to make future payments with this payment method.
+    /// Providing this parameter will attach the payment method to the PaymentIntent’s Customer, if present, after the Intent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be attached to a Customer after the transaction completes.
+    ///
+    /// If setup_future_usage is already set, you may only update the value from on_session to off_session.
+    @objc public var setupFutureUsage: STPPaymentIntentSetupFutureUsage = .none
+
+    @objc public var additionalAPIParameters: [AnyHashable: Any] = [:]
+}
+
+// MARK: - STPFormEncodable
+extension STPConfirmLinkOptions: STPFormEncodable {
+
+    @objc internal var setupFutureUsageRawString: String? {
+        return setupFutureUsage.stringValue
+    }
+
+    public static func rootObjectName() -> String? {
+        return "link"
+    }
+
+    public static func propertyNamesToFormFieldNamesMapping() -> [String: String] {
+        [NSStringFromSelector(#selector(getter: setupFutureUsageRawString)): "setup_future_usage"]
+    }
+}

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPConfirmPaymentMethodOptions.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPConfirmPaymentMethodOptions.swift
@@ -28,6 +28,9 @@ public class STPConfirmPaymentMethodOptions: NSObject {
     /// Options for a US Bank Account Payment Method.
     @objc public var usBankAccountOptions: STPConfirmUSBankAccountOptions?
 
+    /// Options for a Link Payment Method.
+    @_spi(STP) @objc public var linkOptions: STPConfirmLinkOptions?
+
     /// Options for a Konbini Payment Method.
     @objc public var konbiniOptions: STPConfirmKonbiniOptions?
 
@@ -45,6 +48,7 @@ public class STPConfirmPaymentMethodOptions: NSObject {
             "wechat_pay = \(String(describing: weChatPayOptions))",
             "us_bank_account = \(String(describing: usBankAccountOptions))",
             "konbini = \(String(describing: konbiniOptions))",
+            "link = \(String(describing: linkOptions))",
         ]
         return "<\(props.joined(separator: "; "))>"
     }
@@ -61,6 +65,7 @@ extension STPConfirmPaymentMethodOptions: STPFormEncodable {
             NSStringFromSelector(#selector(getter: weChatPayOptions)): "wechat_pay",
             NSStringFromSelector(#selector(getter: usBankAccountOptions)): "us_bank_account",
             NSStringFromSelector(#selector(getter: konbiniOptions)): "konbini",
+            NSStringFromSelector(#selector(getter: linkOptions)): "link",
         ]
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request makes sure that Link payment methods have the correct `allow_redisplay` and `setup_future_usage` values set on them when added via Link inline signup.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Link PMs in SPM.

## Testing
<!-- How was the code tested? Be as specific as possible. -->

Added a mock network test.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
