### PR TITLE
Add context menus for payment method picker in Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
@@ -17,6 +17,11 @@ protocol LinkPaymentMethodPickerDelegate: AnyObject {
 
     func paymentMethodPicker(
         _ picker: LinkPaymentMethodPicker,
+        menuActionsForItemAt index: Int
+    ) -> [PayWithLinkViewController.WalletViewController.Action]
+
+    func paymentMethodPicker(
+        _ picker: LinkPaymentMethodPicker,
         showMenuForItemAt index: Int,
         sourceRect: CGRect
     )
@@ -471,4 +476,8 @@ extension LinkPaymentMethodPicker: LinkPaymentMethodPickerCellDelegate {
         delegate?.paymentMethodPicker(self, showMenuForItemAt: index, sourceRect: sourceRect)
     }
 
+    func savedPaymentPickerCellMenuActions(for cell: Cell) -> [PayWithLinkViewController.WalletViewController.Action]? {
+        guard let index = index(for: cell) else { return nil }
+        return delegate?.paymentMethodPicker(self, menuActionsForItemAt: index)
+    }
 }


### PR DESCRIPTION
## Summary

Adds context menus when available (iOS 14+) to the payment method rows in the Link wallet screen. It uses the same actions as the three-dots menu.

## Motivation

Just adds a little bit of ✨ 

## Testing

https://github.com/user-attachments/assets/ea3ab248-a8f1-4804-b74b-88e3c892be04

## Changelog

N/a