### PR TITLE
Fix deletion issue for Link PMs in SPM

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -780,6 +780,20 @@ extension STPPaymentMethod {
                 ),
                 message: String(format: formattedMessage, brandString, last4)
             )
+        case .link:
+            let brandString = STPCardBrandUtilities.stringFrom(linkPaymentDetails?.brand ?? .unknown) ?? ""
+            let last4 = linkPaymentDetails?.last4 ?? ""
+            let formattedMessage = STPLocalizedString(
+                "%1$@ •••• %2$@",
+                "Content for alert popup prompting to confirm removing a saved card. {card brand} •••• {last 4} e.g. 'Visa •••• 3155'"
+            )
+            return (
+                title: STPLocalizedString(
+                    "Remove card?",
+                    "Title for confirmation alert to remove a card"
+                ),
+                message: String(format: formattedMessage, brandString, last4)
+            )
         case .SEPADebit:
             let last4 = sepaDebit?.last4 ?? ""
             let formattedMessage = String.Localized.bank_account_xxxx


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where showing the delete dialog for a Link saved payment method caused an assertion error.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Link PMs in SPM.

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
