### PR TITLE
Deferred validator check against payment methods on the intent

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
@@ -116,7 +116,7 @@ struct PaymentSheetDeferredValidator {
             }
             return result
         }()
-        // Validate that the IntentConfiguration and PaymentIntent PMO SFU values match for all values present in the PaymentIntent. Don't validate the particular values are the same (off_session vs on_session) but if none, check that both are none.
+        // Validate that the IntentConfiguration and PaymentIntent PMO SFU values match for all paymentMethodTypes present on the PaymentIntent. Don't validate the particular values are the same (off_session vs on_session) but if none, check that both are none.
         // Some values set in the IntentConfiguration could be filtered out on the PaymentIntent if the payment methods are not applicable, so we only check the ones present in the PaymentIntent.
         let doesPMOSFUMatch = paymentIntent.paymentMethodTypes.allSatisfy { paymentMethodTypeNSNumber in
             let paymentMethodType: String = STPPaymentMethodType.fromNSNumber(paymentMethodTypeNSNumber).identifier

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
@@ -29,7 +29,7 @@ struct PaymentSheetDeferredValidator {
         guard isPaymentIntentSFUSet == isIntentConfigurationSFUSet else {
            throw PaymentSheetError.deferredIntentValidationFailed(message: "Your PaymentIntent setupFutureUsage (\(paymentIntent.setupFutureUsage)) does not match the PaymentSheet.IntentConfiguration setupFutureUsage (\(String(describing: setupFutureUsage))).")
         }
-        try validatePaymentMethodOptions(paymentIntentPaymentMethodOptions: paymentIntent.paymentMethodOptions?.allResponseFields as? [String: Any], paymentMethodOptions: paymentMethodOptions)
+        try validatePaymentMethodOptions(paymentIntent: paymentIntent, paymentMethodOptions: paymentMethodOptions)
         try validatePaymentMethod(intentPaymentMethod: paymentIntent.paymentMethod, paymentMethod: paymentMethod)
         /*
          Manual confirmation is only available using FlowController because merchants own the final step of confirmation.
@@ -95,7 +95,8 @@ struct PaymentSheetDeferredValidator {
         }
     }
 
-    static func validatePaymentMethodOptions(paymentIntentPaymentMethodOptions: [String: Any]?, paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions?) throws {
+    static func validatePaymentMethodOptions(paymentIntent: STPPaymentIntent, paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions?) throws {
+        let paymentIntentPaymentMethodOptions: [String: Any]? = paymentIntent.paymentMethodOptions?.allResponseFields as? [String: Any]
         // Parse the response into a [String: String] dictionary [paymentMethodType: setupFutureUsage]
         let paymentIntentPMOSFU: [String: String] = {
             var result: [String: String] = [:]
@@ -117,15 +118,24 @@ struct PaymentSheetDeferredValidator {
         }()
         // Validate that the IntentConfiguration and PaymentIntent PMO SFU values match for all values present in the PaymentIntent. Don't validate the particular values are the same (off_session vs on_session) but if none, check that both are none.
         // Some values set in the IntentConfiguration could be filtered out on the PaymentIntent if the payment methods are not applicable, so we only check the ones present in the PaymentIntent.
-        let doesPMOSFUMatch = paymentIntentPMOSFU.allSatisfy { paymentMethodType, setupFutureUsage in
-                if setupFutureUsage == "none" {
-                    return intentConfigurationPMOSFU[paymentMethodType] == "none"
-                }
-                if intentConfigurationPMOSFU[paymentMethodType] == "none" {
-                    return setupFutureUsage == "none"
-                }
-                return intentConfigurationPMOSFU[paymentMethodType] != nil
+        let doesPMOSFUMatch = paymentIntent.paymentMethodTypes.allSatisfy { paymentMethodTypeNSNumber in
+            let paymentMethodType: String = STPPaymentMethodType.fromNSNumber(paymentMethodTypeNSNumber).identifier
+            let paymentIntentSetupFutureUsage = paymentIntentPMOSFU[paymentMethodType]
+            let intentConfigurationSetupFutureUsage = intentConfigurationPMOSFU[paymentMethodType]
+            guard let paymentIntentSetupFutureUsage, let intentConfigurationSetupFutureUsage else {
+                // if one is nil, both must be nil
+                return paymentIntentSetupFutureUsage == intentConfigurationSetupFutureUsage
             }
+            // if one is none, both must be none
+            if paymentIntentSetupFutureUsage == "none" {
+                return intentConfigurationSetupFutureUsage == "none"
+            }
+            if intentConfigurationSetupFutureUsage == "none" {
+                return paymentIntentSetupFutureUsage == "none"
+            }
+            // if both non-nil and not none, we consider them to be the same
+            return true
+        }
         guard doesPMOSFUMatch else {
             throw PaymentSheetError.deferredIntentValidationFailed(message: "Your PaymentIntent paymentMethodOptions setupFutureUsage (\(paymentIntentPMOSFU)) does not match the PaymentSheet.IntentConfiguration paymentMethodOptions setupFutureUsage (\(intentConfigurationPMOSFU)).")
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -780,6 +780,20 @@ extension STPPaymentMethod {
                 ),
                 message: String(format: formattedMessage, brandString, last4)
             )
+        case .link:
+            let brandString = STPCardBrandUtilities.stringFrom(linkPaymentDetails?.brand ?? .unknown) ?? ""
+            let last4 = linkPaymentDetails?.last4 ?? ""
+            let formattedMessage = STPLocalizedString(
+                "%1$@ •••• %2$@",
+                "Content for alert popup prompting to confirm removing a saved card. {card brand} •••• {last 4} e.g. 'Visa •••• 3155'"
+            )
+            return (
+                title: STPLocalizedString(
+                    "Remove card?",
+                    "Title for confirmation alert to remove a card"
+                ),
+                message: String(format: formattedMessage, brandString, last4)
+            )
         case .SEPADebit:
             let last4 = sepaDebit?.last4 ?? ""
             let formattedMessage = String.Localized.bank_account_xxxx

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
@@ -76,21 +76,21 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
 
     func testPaymentIntentMismatchedPaymentMethodOptionsSetupFutureUsage() throws {
         // payment method types with pmo sfu do not match
-        var pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"], "amazon_pay": ["setup_future_usage": "off_session"]]))
+        var pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodTypes: [.card, .amazonPay], paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"], "amazon_pay": ["setup_future_usage": "off_session"]]))
         var intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.card: .offSession, .USBankAccount: .offSession])), confirmHandler: confirmHandler)
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
                                                                         paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
         // even if payment method type pmo sfu value non-nil on both, if one is .none, both must be .none
-        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"]]))
+        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodTypes: [.card], paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"]]))
         intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.card: .none])), confirmHandler: confirmHandler)
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
                                                                         paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
         // intent config pmo nil but intent pmo is non-nil
-        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"]]))
+        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodTypes: [.card], paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"]]))
         intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD"), confirmHandler: confirmHandler)
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
@@ -108,7 +108,7 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
 
     func testPaymentIntentConfigurationPaymentMethodOptionsSetupFutureUsage() throws {
         // different order
-        var pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"], "us_bank_account": ["setup_future_usage": "off_session"]]))
+        var pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodTypes: [.card, .USBankAccount], paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"], "us_bank_account": ["setup_future_usage": "off_session"]]))
         var intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.USBankAccount: .offSession, .card: .offSession])), confirmHandler: confirmHandler)
         XCTAssertNoThrow(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
@@ -122,14 +122,14 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
                                                                         paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
         // pi pmo non-nil but not sfu-related
-        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: .init(requireCvcRecollection: true, allResponseFields: ["require_cvc_recollection": true]), allResponseFields: ["card": ["require_cvc_recollection": true]]))
+        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodTypes: [.card], paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: .init(requireCvcRecollection: true, allResponseFields: ["require_cvc_recollection": true]), allResponseFields: ["card": ["require_cvc_recollection": true]]))
         intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD"), confirmHandler: confirmHandler)
         XCTAssertNoThrow(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
                                                                         paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
         // pi sepa_debit got filtered out, but sepa_debit pmo sfu set on the IntentConfiguration
-        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"], "us_bank_account": ["setup_future_usage": "off_session"]]))
+        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodTypes: [.card, .USBankAccount], paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"], "us_bank_account": ["setup_future_usage": "off_session"]]))
         intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.USBankAccount: .offSession, .card: .offSession, .SEPADebit: .offSession])), confirmHandler: confirmHandler)
         XCTAssertNoThrow(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
@@ -96,6 +96,14 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
                                                                         intentConfiguration: intentConfig,
                                                                         paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
+
+        // intent config pmo has something that intent pmo doesn't AND that payment type is on the intent
+        pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodTypes: [.card])
+        intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.card: .offSession])), confirmHandler: confirmHandler)
+        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
+                                                                        intentConfiguration: intentConfig,
+                                                                        paymentMethod: STPPaymentMethod._testCard(),
+                                                                        isFlowController: false))
     }
 
     func testPaymentIntentConfigurationPaymentMethodOptionsSetupFutureUsage() throws {

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -294,6 +294,10 @@ import Foundation
         return allCases.first(where: { $0.identifier == identifier }) ?? .unknown
     }
 
+    @_spi(STP) public static func fromNSNumber(_ nsNumber: NSNumber) -> STPPaymentMethodType {
+        return allCases.first(where: { NSNumber(value: $0.rawValue) == nsNumber }) ?? .unknown
+    }
+
 }
 
 extension STPPaymentMethodType: CaseIterable { }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Previously: check to make sure pmo sfu on the intent config matches pmo sfu on the intent
Now: check all available payment method types on the intent, and if pmo sfu is set on either the intent config or on the intent, then it must also be set on the other.

An example case that the previous validator wouldn't catch:
Intent: paymentMethodTypes [card], paymentMethodOptions nil
IntentConfig: paymentMethodOptions card: .offSession

Since card is one of the paymentMethodTypes on the Intent, then its PMO SFU must match the PMO SFU on the config
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
PMO SFU
More context here: https://stripe.slack.com/archives/C08FQ6WNYHW/p1747605434561129?thread_ts=1747425613.464559&cid=C08FQ6WNYHW
## Testing
<!-- How was the code tested? Be as specific as possible. -->
Updated unit test
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A