### PR TITLE
Fix “Continue another way” label in Link UI

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -74,10 +74,10 @@ final class PayWithLinkViewController: UINavigationController {
         var analyticsHelper: PaymentSheetAnalyticsHelper
 
         var secondaryButtonLabel: String {
-            if intent.isSettingUp {
-                String.Localized.continue_another_way
-            } else {
+            if intent.isPaymentIntent {
                 String.Localized.pay_another_way
+            } else {
+                String.Localized.continue_another_way
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
@@ -133,23 +133,6 @@ enum Intent {
         }
     }
 
-    /// True if this is a PaymentIntent with sfu not equal to none or a SetupIntent
-    var isSettingUp: Bool {
-        switch self {
-        case .paymentIntent(let paymentIntent):
-            return paymentIntent.setupFutureUsage != .none
-        case .setupIntent:
-            return true
-        case .deferredIntent(let intentConfig):
-            switch intentConfig.mode {
-            case .payment(_, _, let setupFutureUsage, _, _):
-                return setupFutureUsage != nil
-            case .setup:
-                return true
-            }
-        }
-    }
-
     /// Whether the intent has setup for future usage set for a payment method type.
     func isSetupFutureUsageSet(for paymentMethodType: STPPaymentMethodType) -> Bool {
         switch self {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -196,7 +196,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
         // ...should cancel the 1st update
         XCTAssertEqual(updateResult, .canceled)
         XCTAssertEqual(updateResult2, .succeeded)
-        XCTAssertTrue(sut.intent.isSettingUp)
+        XCTAssertFalse(sut.intent.isPaymentIntent)
     }
 
     func testConfirmHandlesInflightUpdateThatSucceeds() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
@@ -61,7 +61,7 @@ class PayWithLinkViewController_WalletViewModelTests: XCTestCase {
 
     func test_showCorrectMandateForPayment() throws {
         let sut = try makeSUT(isSettingUp: false)
-        XCTAssertFalse(sut.context.intent.isSettingUp)
+        XCTAssertFalse(sut.context.intent.isSetupFutureUsageSet(for: .link))
 
         // Card
         sut.selectedPaymentMethodIndex = LinkStubs.PaymentMethodIndices.card
@@ -74,7 +74,6 @@ class PayWithLinkViewController_WalletViewModelTests: XCTestCase {
 
     func test_showCorrectMandateForPaymentWithLinkPMOSFUPaymentMethodMode() throws {
         let sut = try makeSUT(linkPassthroughModeEnabled: false, isSettingUp: false, linkPMOSFU: true)
-        XCTAssertFalse(sut.context.intent.isSettingUp)
         XCTAssertTrue(sut.context.intent.isSetupFutureUsageSet(for: .link))
 
         // Card
@@ -88,7 +87,6 @@ class PayWithLinkViewController_WalletViewModelTests: XCTestCase {
 
     func test_showCorrectMandateForPaymentWithLinkPMOSFUPassthroughMode() throws {
         let sut = try makeSUT(linkPassthroughModeEnabled: true, isSettingUp: false, linkPMOSFU: true)
-        XCTAssertFalse(sut.context.intent.isSettingUp)
         XCTAssertTrue(sut.context.intent.isSetupFutureUsageSet(for: .card))
 
         // Card
@@ -102,7 +100,7 @@ class PayWithLinkViewController_WalletViewModelTests: XCTestCase {
 
     func test_showCorrectMandateForSetup() throws {
         let sut = try makeSUT(isSettingUp: true)
-        XCTAssertTrue(sut.context.intent.isSettingUp)
+        XCTAssertTrue(sut.context.intent.isSetupFutureUsageSet(for: .link))
 
         // Card
         sut.selectedPaymentMethodIndex = LinkStubs.PaymentMethodIndices.card

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -1045,14 +1045,12 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
             switch result {
             case .success(let sut):
                 // ...the vc's intent should match the initial intent config...
-                XCTAssertFalse(sut.intent.isSettingUp)
                 XCTAssertTrue(sut.intent.isPaymentIntent)
                 // ...and updating the intent config should succeed...
                 intentConfig.mode = .setup(currency: nil, setupFutureUsage: .offSession)
                 sut.update(intentConfiguration: intentConfig) { error in
                     XCTAssertNil(error)
                     XCTAssertNil(sut.paymentOption)
-                    XCTAssertTrue(sut.intent.isSettingUp)
                     XCTAssertFalse(sut.intent.isPaymentIntent)
                     firstUpdateExpectation.fulfill()
 
@@ -1061,7 +1059,6 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
                     sut.update(intentConfiguration: intentConfig) { error in
                         XCTAssertNil(error)
                         XCTAssertNil(sut.paymentOption)
-                        XCTAssertFalse(sut.intent.isSettingUp)
                         XCTAssertTrue(sut.intent.isPaymentIntent)
 
                         // Sanity check that the analytics...


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where the Link UI would show a `Continue another way` button for Pay+SFU, when a `Pay another way` would be more appropriate.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
