### PR TITLE
Add exposure logging for Link AB test

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -159,6 +159,8 @@
 		49909A372D8B5AA30031EC33 /* FCLiteModalPresentationWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49909A362D8B5AA30031EC33 /* FCLiteModalPresentationWrapper.swift */; };
 		49BCD44E2D9ECBEF003A6251 /* PaymentSheetAnalyticsExperimentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BCD44D2D9ECBEF003A6251 /* PaymentSheetAnalyticsExperimentsTests.swift */; };
 		49DBCAFB2DCA9BB400DB3ACB /* LinkSignUpViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DBCAFA2DCA9BB400DB3ACB /* LinkSignUpViewControllerSnapshotTests.swift */; };
+		49E908B32DDE107600D5BDBF /* LinkABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E908B22DDE107600D5BDBF /* LinkABTest.swift */; };
+		49E908B52DDE11FD00D5BDBF /* BaseLinkExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E908B42DDE11FD00D5BDBF /* BaseLinkExperiment.swift */; };
 		49F62EDF394F18E5BB201D53 /* StripePaymentSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA6166F234C3A2129CBD573 /* StripePaymentSheet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4A1A0A542B824C830A200BE0 /* StubbedBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF8498CCD12A5190F9267CD /* StubbedBackend.swift */; };
 		4A8C7B2AFB290567C961DAB0 /* StripePaymentsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F22354BD25171B8DC2B922D2 /* StripePaymentsUI.framework */; };
@@ -617,6 +619,8 @@
 		49909A362D8B5AA30031EC33 /* FCLiteModalPresentationWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteModalPresentationWrapper.swift; sourceTree = "<group>"; };
 		49BCD44D2D9ECBEF003A6251 /* PaymentSheetAnalyticsExperimentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetAnalyticsExperimentsTests.swift; sourceTree = "<group>"; };
 		49DBCAFA2DCA9BB400DB3ACB /* LinkSignUpViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSignUpViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
+		49E908B22DDE107600D5BDBF /* LinkABTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkABTest.swift; sourceTree = "<group>"; };
+		49E908B42DDE11FD00D5BDBF /* BaseLinkExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseLinkExperiment.swift; sourceTree = "<group>"; };
 		4BEFE8C0CFEAE73F9FD736D3 /* STPStringUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPStringUtils.swift; sourceTree = "<group>"; };
 		4C6AA41454A6757B3E26AE67 /* StripePaymentSheetTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StripePaymentSheetTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D595AA033BC84CB4E1C277F /* PaymentSheetFormFactorySnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetFormFactorySnapshotTest.swift; sourceTree = "<group>"; };
@@ -1179,8 +1183,10 @@
 		497713022D9D8E0000DB5CB2 /* Experiments */ = {
 			isa = PBXGroup;
 			children = (
-				4965A7122D9D8D3700DC2E3C /* LinkGlobalHoldback.swift */,
 				497713032D9D8E1200DB5CB2 /* PaymentSheetAnalytics+Experiments.swift */,
+				49E908B42DDE11FD00D5BDBF /* BaseLinkExperiment.swift */,
+				4965A7122D9D8D3700DC2E3C /* LinkGlobalHoldback.swift */,
+				49E908B22DDE107600D5BDBF /* LinkABTest.swift */,
 			);
 			path = Experiments;
 			sourceTree = "<group>";
@@ -2270,12 +2276,14 @@
 				05B61641310A9775D40C1775 /* String+Localized.swift in Sources */,
 				AAF2AFF4B9A935B2A3FD52EA /* String+StripePaymentSheet.swift in Sources */,
 				F70BCDEECB5863244085F12F /* BoolReference.swift in Sources */,
+				49E908B32DDE107600D5BDBF /* LinkABTest.swift in Sources */,
 				8B1D7A7CE7D50382E9FA77E3 /* Images.swift in Sources */,
 				D3CC2489468E3288FD34C160 /* IntentStatusPoller.swift in Sources */,
 				CB46EF492CED1A2E00E9A7F2 /* PaymentMethodIncentive.swift in Sources */,
 				96C307CDEE7028B12D9CB69B /* PaymentSheetLinkAccount.swift in Sources */,
 				623C2D9F87929D6DA9C09E23 /* STPCameraView.swift in Sources */,
 				599337DB99E9E7017EF47BCE /* STPCardScanner.swift in Sources */,
+				49E908B52DDE11FD00D5BDBF /* BaseLinkExperiment.swift in Sources */,
 				EB190E908B567CD90D5B0645 /* STPImageLibrary.swift in Sources */,
 				6180A5C72C824377009D1536 /* RadioButton.swift in Sources */,
 				6180A5C12C8222A9009D1536 /* EmbeddedPaymentMethodsView.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -140,6 +140,7 @@
 		4926B9E22D9C66250049A43E /* ExperimentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4926B9E12D9C66250049A43E /* ExperimentData.swift */; };
 		4930D8D52DB92CDC0091FBFE /* LinkPaymentMethodPicker-Email.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4930D8D42DB92CDC0091FBFE /* LinkPaymentMethodPicker-Email.swift */; };
 		4930D8D72DB93F060091FBFE /* LinkSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4930D8D62DB93F060091FBFE /* LinkSeparatorView.swift */; };
+		49377F022DE4E4FD005CA805 /* BaseLinkHoldbackExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49377F012DE4E4FD005CA805 /* BaseLinkHoldbackExperiment.swift */; };
 		4954E9712D96FA0C0061585F /* FCLiteImplementationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4954E9702D96FA0C0061585F /* FCLiteImplementationTests.swift */; };
 		495C04692DCAA1AB006D8F1A /* PayWithLinkTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495C04682DCAA1AB006D8F1A /* PayWithLinkTestHelpers.swift */; };
 		4965A7132D9D8D3700DC2E3C /* LinkGlobalHoldback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4965A7122D9D8D3700DC2E3C /* LinkGlobalHoldback.swift */; };
@@ -160,7 +161,6 @@
 		49BCD44E2D9ECBEF003A6251 /* PaymentSheetAnalyticsExperimentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BCD44D2D9ECBEF003A6251 /* PaymentSheetAnalyticsExperimentsTests.swift */; };
 		49DBCAFB2DCA9BB400DB3ACB /* LinkSignUpViewControllerSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DBCAFA2DCA9BB400DB3ACB /* LinkSignUpViewControllerSnapshotTests.swift */; };
 		49E908B32DDE107600D5BDBF /* LinkABTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E908B22DDE107600D5BDBF /* LinkABTest.swift */; };
-		49E908B52DDE11FD00D5BDBF /* BaseLinkExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E908B42DDE11FD00D5BDBF /* BaseLinkExperiment.swift */; };
 		49F62EDF394F18E5BB201D53 /* StripePaymentSheet.h in Headers */ = {isa = PBXBuildFile; fileRef = 7AA6166F234C3A2129CBD573 /* StripePaymentSheet.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4A1A0A542B824C830A200BE0 /* StubbedBackend.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBF8498CCD12A5190F9267CD /* StubbedBackend.swift */; };
 		4A8C7B2AFB290567C961DAB0 /* StripePaymentsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F22354BD25171B8DC2B922D2 /* StripePaymentsUI.framework */; };
@@ -601,6 +601,7 @@
 		492B254E43F3BB9F9CEAEA06 /* PaymentSheetLoaderStubbedTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetLoaderStubbedTest.swift; sourceTree = "<group>"; };
 		4930D8D42DB92CDC0091FBFE /* LinkPaymentMethodPicker-Email.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkPaymentMethodPicker-Email.swift"; sourceTree = "<group>"; };
 		4930D8D62DB93F060091FBFE /* LinkSeparatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSeparatorView.swift; sourceTree = "<group>"; };
+		49377F012DE4E4FD005CA805 /* BaseLinkHoldbackExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseLinkHoldbackExperiment.swift; sourceTree = "<group>"; };
 		4954E9702D96FA0C0061585F /* FCLiteImplementationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteImplementationTests.swift; sourceTree = "<group>"; };
 		495C04682DCAA1AB006D8F1A /* PayWithLinkTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayWithLinkTestHelpers.swift; sourceTree = "<group>"; };
 		4965A7122D9D8D3700DC2E3C /* LinkGlobalHoldback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkGlobalHoldback.swift; sourceTree = "<group>"; };
@@ -620,7 +621,6 @@
 		49BCD44D2D9ECBEF003A6251 /* PaymentSheetAnalyticsExperimentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetAnalyticsExperimentsTests.swift; sourceTree = "<group>"; };
 		49DBCAFA2DCA9BB400DB3ACB /* LinkSignUpViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSignUpViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		49E908B22DDE107600D5BDBF /* LinkABTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkABTest.swift; sourceTree = "<group>"; };
-		49E908B42DDE11FD00D5BDBF /* BaseLinkExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseLinkExperiment.swift; sourceTree = "<group>"; };
 		4BEFE8C0CFEAE73F9FD736D3 /* STPStringUtils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPStringUtils.swift; sourceTree = "<group>"; };
 		4C6AA41454A6757B3E26AE67 /* StripePaymentSheetTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StripePaymentSheetTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		4D595AA033BC84CB4E1C277F /* PaymentSheetFormFactorySnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetFormFactorySnapshotTest.swift; sourceTree = "<group>"; };
@@ -1184,7 +1184,7 @@
 			isa = PBXGroup;
 			children = (
 				497713032D9D8E1200DB5CB2 /* PaymentSheetAnalytics+Experiments.swift */,
-				49E908B42DDE11FD00D5BDBF /* BaseLinkExperiment.swift */,
+				49377F012DE4E4FD005CA805 /* BaseLinkHoldbackExperiment.swift */,
 				4965A7122D9D8D3700DC2E3C /* LinkGlobalHoldback.swift */,
 				49E908B22DDE107600D5BDBF /* LinkABTest.swift */,
 			);
@@ -2283,11 +2283,11 @@
 				96C307CDEE7028B12D9CB69B /* PaymentSheetLinkAccount.swift in Sources */,
 				623C2D9F87929D6DA9C09E23 /* STPCameraView.swift in Sources */,
 				599337DB99E9E7017EF47BCE /* STPCardScanner.swift in Sources */,
-				49E908B52DDE11FD00D5BDBF /* BaseLinkExperiment.swift in Sources */,
 				EB190E908B567CD90D5B0645 /* STPImageLibrary.swift in Sources */,
 				6180A5C72C824377009D1536 /* RadioButton.swift in Sources */,
 				6180A5C12C8222A9009D1536 /* EmbeddedPaymentMethodsView.swift in Sources */,
 				61C87E1B2CB818ED001B7DA9 /* CardBrandFilter.swift in Sources */,
+				49377F022DE4E4FD005CA805 /* BaseLinkHoldbackExperiment.swift in Sources */,
 				610EAAF02C0F5D9400124AB2 /* FormHeaderView.swift in Sources */,
 				40806EF506CB719299FC90CC /* STPLocalizedString.swift in Sources */,
 				71132CE036C3EE0655ECD2DB /* STPStringUtils.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/BaseLinkExperiment.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/BaseLinkExperiment.swift
@@ -9,7 +9,6 @@ import Foundation
 @_spi(STP) import StripePayments
 
 struct BaseLinkExperiment {
-    let arbId: String
     let group: ExperimentGroup
 
     let defaultValuesProvided: String
@@ -36,14 +35,11 @@ struct BaseLinkExperiment {
 
     init(
         experimentName: String,
-        arbId: String,
         elementsSession: STPElementsSession,
         configuration: PaymentElementConfiguration,
         linkAccount: PaymentSheetLinkAccount?,
         integrationShape: PaymentSheetAnalyticsHelper.IntegrationShape
     ) {
-        self.arbId = arbId
-
         let isLinkEnabled = PaymentSheet.isLinkEnabled(
             elementsSession: elementsSession,
             configuration: configuration

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/BaseLinkExperiment.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/BaseLinkExperiment.swift
@@ -1,0 +1,85 @@
+//
+//  BaseLinkExperiment.swift
+//  StripePaymentSheet
+//
+//  Created by Mat Schmid on 5/21/25.
+//
+
+import Foundation
+@_spi(STP) import StripePayments
+
+struct BaseLinkExperiment {
+    let arbId: String
+    let group: ExperimentGroup
+
+    let defaultValuesProvided: String
+    let hasSPMs: Bool
+    let integrationShape: String
+    let isReturningLinkUser: Bool
+    let linkDefaultOptIn: String
+    let linkDisplayed: Bool
+    let linkNative: Bool
+
+    var dimensionsDictionary: [String: Any] {
+        [
+            "dvs_provided": defaultValuesProvided,
+            "has_spms": hasSPMs,
+            "integration_shape": integrationShape,
+            "integration_type": "mpe_ios",
+            "is_returning_link_user": isReturningLinkUser,
+            "link_default_opt_in": linkDefaultOptIn,
+            "link_displayed": linkDisplayed,
+            "link_native": linkNative,
+            "recognition_type": "email",
+        ]
+    }
+
+    init(
+        experimentName: String,
+        arbId: String,
+        elementsSession: STPElementsSession,
+        configuration: PaymentElementConfiguration,
+        linkAccount: PaymentSheetLinkAccount?,
+        integrationShape: PaymentSheetAnalyticsHelper.IntegrationShape
+    ) {
+        self.arbId = arbId
+
+        let isLinkEnabled = PaymentSheet.isLinkEnabled(
+            elementsSession: elementsSession,
+            configuration: configuration
+        )
+
+        // In some scenarios (i.e. testmode) there will be no group assignment.
+        // Treat these scenarios as though we're in the control group.
+        let assignment = elementsSession.experimentsData?.experimentAssignments[experimentName]
+        self.group = assignment ?? .control
+
+        // A non-nil consumer session represents an existing Link user.
+        self.isReturningLinkUser = linkAccount?.currentSession != nil
+        self.linkNative = linkAccount?.useMobileEndpoints == true
+        self.linkDefaultOptIn = (elementsSession.linkSettings?.linkDefaultOptIn ?? .none).rawValue
+        self.integrationShape = integrationShape.analyticsValue
+        self.linkDisplayed = isLinkEnabled
+
+        var defaultValuesProvided: [String] = []
+        if configuration.defaultBillingDetails.email != nil {
+            defaultValuesProvided.append("email")
+        }
+        if configuration.defaultBillingDetails.name != nil {
+            defaultValuesProvided.append("name")
+        }
+        if configuration.defaultBillingDetails.phone != nil {
+            defaultValuesProvided.append("phone")
+        }
+        self.defaultValuesProvided = defaultValuesProvided.joined(separator: " ")
+
+        // SPM is enabled when:
+        // 1. Session has a valid customer
+        // 2. Payment Method Save is enabled
+        // 3. Link is not enabled (unless an additional beta flag is enabled)
+        let hasCustomer = elementsSession.customer != nil
+        let paymentMethodSaveEnabled = elementsSession.customerSessionMobilePaymentElementFeatures?.paymentMethodSave == true
+        let linkNotEnabledOrEnableLinkSPMFlag = !isLinkEnabled || elementsSession.flags["elements_enable_link_spm"] == true
+        self.hasSPMs = hasCustomer && paymentMethodSaveEnabled && linkNotEnabledOrEnableLinkSPMFlag
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/BaseLinkHoldbackExperiment.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/BaseLinkHoldbackExperiment.swift
@@ -1,5 +1,5 @@
 //
-//  BaseLinkExperiment.swift
+//  BaseLinkHoldbackExperiment.swift
 //  StripePaymentSheet
 //
 //  Created by Mat Schmid on 5/21/25.
@@ -8,7 +8,7 @@
 import Foundation
 @_spi(STP) import StripePayments
 
-struct BaseLinkExperiment {
+struct BaseLinkHoldbackExperiment {
     let group: ExperimentGroup
 
     let defaultValuesProvided: String

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkABTest.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkABTest.swift
@@ -1,14 +1,14 @@
 //
-//  LinkGlobalHoldback.swift
+//  LinkABTest.swift
 //  StripePaymentSheet
 //
-//  Created by Mat Schmid on 2025-04-02.
+//  Created by Mat Schmid on 5/21/25.
 //
 
 import Foundation
 
-struct LinkGlobalHoldback: LoggableExperiment {
-    private static let experimentName = "link_global_holdback"
+struct LinkABTest: LoggableExperiment {
+    private static let experimentName = "link_ab_test"
     private let baseExperiment: BaseLinkExperiment
 
     let name: String = experimentName

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkABTest.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkABTest.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct LinkABTest: LoggableExperiment {
     private static let experimentName = "link_ab_test"
-    private let baseExperiment: BaseLinkExperiment
+    private let baseExperiment: BaseLinkHoldbackExperiment
 
     let name: String = experimentName
     let arbId: String
@@ -29,7 +29,7 @@ struct LinkABTest: LoggableExperiment {
         linkAccount: PaymentSheetLinkAccount?,
         integrationShape: PaymentSheetAnalyticsHelper.IntegrationShape
     ) {
-        let baseExperiment = BaseLinkExperiment(
+        let baseExperiment = BaseLinkHoldbackExperiment(
             experimentName: Self.experimentName,
             elementsSession: elementsSession,
             configuration: configuration,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkABTest.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkABTest.swift
@@ -13,10 +13,13 @@ struct LinkABTest: LoggableExperiment {
 
     let name: String = experimentName
     let arbId: String
-    let group: ExperimentGroup
+
+    var group: ExperimentGroup {
+        baseExperiment.group
+    }
 
     var dimensions: [String: Any] {
-        return baseExperiment.dimensionsDictionary
+        baseExperiment.dimensionsDictionary
     }
 
     init(
@@ -28,15 +31,13 @@ struct LinkABTest: LoggableExperiment {
     ) {
         let baseExperiment = BaseLinkExperiment(
             experimentName: Self.experimentName,
-            arbId: arbId,
             elementsSession: elementsSession,
             configuration: configuration,
             linkAccount: linkAccount,
             integrationShape: integrationShape
         )
 
-        self.baseExperiment = baseExperiment
         self.arbId = arbId
-        self.group = baseExperiment.group
+        self.baseExperiment = baseExperiment
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkGlobalHoldback.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkGlobalHoldback.swift
@@ -9,7 +9,7 @@ import Foundation
 
 struct LinkGlobalHoldback: LoggableExperiment {
     private static let experimentName = "link_global_holdback"
-    private let baseExperiment: BaseLinkExperiment
+    private let baseExperiment: BaseLinkHoldbackExperiment
 
     let name: String = experimentName
     let arbId: String
@@ -29,7 +29,7 @@ struct LinkGlobalHoldback: LoggableExperiment {
         linkAccount: PaymentSheetLinkAccount?,
         integrationShape: PaymentSheetAnalyticsHelper.IntegrationShape
     ) {
-        let baseExperiment = BaseLinkExperiment(
+        let baseExperiment = BaseLinkHoldbackExperiment(
             experimentName: Self.experimentName,
             elementsSession: elementsSession,
             configuration: configuration,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkGlobalHoldback.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/LinkGlobalHoldback.swift
@@ -13,10 +13,13 @@ struct LinkGlobalHoldback: LoggableExperiment {
 
     let name: String = experimentName
     let arbId: String
-    let group: ExperimentGroup
+
+    var group: ExperimentGroup {
+        baseExperiment.group
+    }
 
     var dimensions: [String: Any] {
-        return baseExperiment.dimensionsDictionary
+        baseExperiment.dimensionsDictionary
     }
 
     init(
@@ -28,15 +31,13 @@ struct LinkGlobalHoldback: LoggableExperiment {
     ) {
         let baseExperiment = BaseLinkExperiment(
             experimentName: Self.experimentName,
-            arbId: arbId,
             elementsSession: elementsSession,
             configuration: configuration,
             linkAccount: linkAccount,
             integrationShape: integrationShape
         )
 
-        self.baseExperiment = baseExperiment
         self.arbId = arbId
-        self.group = baseExperiment.group
+        self.baseExperiment = baseExperiment
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
@@ -72,6 +72,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
     }
 
     func testLinkGlobalHoldback() {
+        let arbId = "arb_id_123"
         let linkSettings: LinkSettings = .init(
             fundingSources: [],
             popupWebviewOption: nil,
@@ -86,7 +87,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             allResponseFields: [:]
         )
         let experimentsData = ExperimentsData(
-            arbId: "arb_id_123",
+            arbId: arbId,
             experimentAssignments: [
                 "link_global_holdback": .treatment
             ],
@@ -106,21 +107,21 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             publishableKey: nil,
             useMobileEndpoints: true
         )
-        guard let experiment = LinkGlobalHoldback(
+
+        let experiment = LinkGlobalHoldback(
+            arbId: arbId,
             session: session,
             configuration: configuration,
             linkAccount: linkAccount,
             integrationShape: .complete
-        ) else {
-            return XCTFail("Initializing a `LinkGlobalHoldback` should not fail here.")
-        }
-
+        )
         analyticsClient.logExposure(experiment: experiment)
+
         guard let payload = analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName).first else {
             return XCTFail("Expected event logged with name \(PaymentSheetAnalyticsHelper.eventName)")
         }
 
-        XCTAssertEqual(payload["arb_id"] as? String, "arb_id_123")
+        XCTAssertEqual(payload["arb_id"] as? String, arbId)
         XCTAssertEqual(payload["experiment_retrieved"] as? String, "link_global_holdback")
         XCTAssertEqual(payload["assignment_group"] as? String, ExperimentGroup.treatment.rawValue)
 
@@ -132,6 +133,70 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
         XCTAssertEqual(payload["dimensions-is_returning_link_user"] as? Bool, false)
         XCTAssertEqual(payload["dimensions-link_displayed"] as? Bool, PaymentSheet.isLinkEnabled(elementsSession: session, configuration: configuration))
         XCTAssertEqual(payload["dimensions-integration_shape"] as? String, "paymentsheet")
+        XCTAssertEqual(payload["dimensions-has_spms"] as? Bool, false)
+    }
+
+    func testLinkABTest() {
+        let arbId = "arb_id_321"
+        let linkSettings: LinkSettings = .init(
+            fundingSources: [],
+            popupWebviewOption: nil,
+            passthroughModeEnabled: true,
+            disableSignup: nil,
+            suppress2FAModal: nil,
+            useAttestationEndpoints: true,
+            linkMode: .passthrough,
+            linkFlags: nil,
+            linkConsumerIncentive: nil,
+            linkDefaultOptIn: .optional,
+            allResponseFields: [:]
+        )
+        let experimentsData = ExperimentsData(
+            arbId: arbId,
+            experimentAssignments: [
+                "link_ab_test": .holdback
+            ],
+            allResponseFields: [:]
+        )
+        let session = STPElementsSession._testValue(
+            linkSettings: linkSettings,
+            experimentsData: experimentsData,
+            customer: nil
+        )
+        var configuration = PaymentSheet.Configuration()
+        configuration.defaultBillingDetails.phone = "(707) 707-7070"
+        let linkAccount = PaymentSheetLinkAccount(
+            email: "email",
+            session: LinkStubs.consumerSession(),
+            publishableKey: nil,
+            useMobileEndpoints: true
+        )
+
+        let experiment = LinkABTest(
+            arbId: arbId,
+            session: session,
+            configuration: configuration,
+            linkAccount: linkAccount,
+            integrationShape: .flowController
+        )
+        analyticsClient.logExposure(experiment: experiment)
+
+        guard let payload = analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName).first else {
+            return XCTFail("Expected event logged with name \(PaymentSheetAnalyticsHelper.eventName)")
+        }
+
+        XCTAssertEqual(payload["arb_id"] as? String, arbId)
+        XCTAssertEqual(payload["experiment_retrieved"] as? String, "link_ab_test")
+        XCTAssertEqual(payload["assignment_group"] as? String, ExperimentGroup.holdback.rawValue)
+
+        XCTAssertEqual(payload["dimensions-recognition_type"] as? String, "email")
+        XCTAssertEqual(payload["dimensions-link_native"] as? Bool, true)
+        XCTAssertEqual(payload["dimensions-link_default_opt_in"] as? String, "OPTIONAL")
+        XCTAssertEqual(payload["dimensions-integration_type"] as? String, "mpe_ios")
+        XCTAssertEqual(payload["dimensions-dvs_provided"] as? String, "phone")
+        XCTAssertEqual(payload["dimensions-is_returning_link_user"] as? Bool, true)
+        XCTAssertEqual(payload["dimensions-link_displayed"] as? Bool, PaymentSheet.isLinkEnabled(elementsSession: session, configuration: configuration))
+        XCTAssertEqual(payload["dimensions-integration_shape"] as? String, "flowcontroller")
         XCTAssertEqual(payload["dimensions-has_spms"] as? Bool, false)
     }
 }


### PR DESCRIPTION
## Summary

This adds exposure logging for a new experiment, `link_ab_test`. It has the same dimensions as `link_global_holdback`, so I've extracted those params into `BaseLinkExperiment`. We only want to log exposure of this experiment if Link is enabled.

## Motivation

Doc: https://docs.google.com/document/d/16GFiEFFO_vkJD_BdnH7AaGCbsKnF0HAN5ZN-2gzTrzk/edit?tab=t.0

## Testing

Unit test added

## Changelog

N/a