### PR TITLE
Fix highlighted color of Link payment method header

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-Header.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-Header.swift
@@ -50,7 +50,7 @@ extension LinkPaymentMethodPicker {
         override var isHighlighted: Bool {
             didSet {
                 if isHighlighted && !isExpanded {
-                    backgroundColor = .linkIconCritical
+                    backgroundColor = .linkSurfaceTertiary
                 } else {
                     backgroundColor = .clear
                 }


### PR DESCRIPTION
## Summary

Fixes a small color issue when the Link Payment Method Picker header is highlighted.

## Motivation

✨ 

## Testing

| Before | After |
|--------|--------|
| ![simulator_screenshot_-_iphone_12_mini_-_2025-05-21_at_13 10 42](https://github.com/user-attachments/assets/5ab8acd0-fb27-4b34-9a47-24514ca58549) | ![simulator_screenshot_-_iphone_12_mini_-_2025-05-21_at_13 10 43](https://github.com/user-attachments/assets/8d012b15-9343-4769-97da-92a0510e4acd) |

## Changelog

N/a
