### PR TITLE
Support adding bank accounts in Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -43,7 +43,8 @@
 /* Text for back button */
 "Back" = "Back";
 
-/* A label used in various UIs, including a button that represents a payment method type 'Bank' - where a user can pay with their bank account instead of, say, a credit card. */
+/* A label used in various UIs, including a button that represents a payment method type 'Bank' - where a user can pay with their bank account instead of, say, a credit card.
+   Label shown in the payment type picker describing a bank payment */
 "Bank" = "Bank";
 
 /* Title for collected bank account information */
@@ -160,6 +161,9 @@ with the transaction. */
 
 /* Label for CPF/CPNJ (Brazil tax ID) field */
 "CPF/CPNJ" = "CPF/CPNJ";
+
+/* Label shown in the payment type picker describing a card payment */
+"Debit or credit card" = "Debit or credit card";
 
 /* Label for identifying the default payment method. */
 "Default" = "Default";

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -220,11 +220,15 @@ extension ConsumerSession {
     func createLinkAccountSession(
         with apiClient: STPAPIClient = STPAPIClient.shared,
         consumerAccountPublishableKey: String?,
+        linkMode: LinkMode? = nil,
+        intentToken: String? = nil,
         completion: @escaping (Result<LinkAccountSession, Error>) -> Void
     ) {
         apiClient.createLinkAccountSession(
             for: clientSecret,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
+            linkMode: linkMode,
+            intentToken: intentToken,
             completion: completion)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -266,16 +266,20 @@ extension STPAPIClient {
     func createLinkAccountSession(
         for consumerSessionClientSecret: String,
         consumerAccountPublishableKey: String?,
+        linkMode: LinkMode? = nil,
+        intentToken: String? = nil,
         completion: @escaping (Result<LinkAccountSession, Error>) -> Void
     ) {
         let endpoint: String = "consumers/link_account_sessions"
 
-        let parameters: [String: Any] = [
+        var parameters: [String: Any] = [
             "credentials": [
                 "consumer_session_client_secret": consumerSessionClientSecret,
             ],
             "request_surface": "ios_payment_element",
         ]
+        parameters["link_mode"] = linkMode?.rawValue
+        parameters["intent_token"] = intentToken
 
         APIRequest<LinkAccountSession>.post(
             with: self,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
@@ -69,12 +69,7 @@ final class LinkPaymentMethodPicker: UIView {
         return selectedPaymentMethod.map { dataSource.isPaymentMethodSupported($0) } ?? false
     }
 
-    var supportedPaymentMethodTypes = Set(ConsumerPaymentDetails.DetailsType.allCases) {
-        didSet {
-            // TODO(tillh-stripe) Update this as soon as adding bank accounts is supported
-            addPaymentMethodButton.isHidden = !supportedPaymentMethodTypes.contains(.card)
-        }
-    }
+    var supportedPaymentMethodTypes = Set(ConsumerPaymentDetails.DetailsType.allCases)
 
     var selectedPaymentMethod: ConsumerPaymentDetails? {
         let count = dataSource?.numberOfPaymentMethods(in: self) ?? 0
@@ -293,10 +288,6 @@ extension LinkPaymentMethodPicker {
         }
 
         cell.isLoading = false
-    }
-
-    func setAddPaymentMethodButtonEnabled(_ enabled: Bool) {
-        addPaymentMethodButton.isEnabled = enabled
     }
 
     private func reloadDataIfNeeded() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -284,6 +284,21 @@ extension PayWithLinkViewController {
             }
         }
 
+        // Updates the list of payment methods, and selects the newly added payment method, if supported.
+        func updatePaymentMethods(_ paymentMethods: [ConsumerPaymentDetails]) {
+            let existingIDs = Set(self.paymentMethods.map { $0.stripeID })
+            let newPaymentMethod = paymentMethods.first { !existingIDs.contains($0.stripeID) }
+
+            self.paymentMethods = paymentMethods
+
+            if let newPaymentMethod, isPaymentMethodSupported(paymentMethod: newPaymentMethod),
+               let newIndex = paymentMethods.firstIndex(where: { $0.stripeID == newPaymentMethod.stripeID }) {
+                selectedPaymentMethodIndex = newIndex
+            }
+
+            delegate?.viewModelDidChange(self)
+        }
+
         func updatePaymentMethod(_ paymentMethod: ConsumerPaymentDetails) {
             guard let index = paymentMethods.firstIndex(where: { $0.stripeID == paymentMethod.stripeID }) else {
                 return

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -26,10 +26,6 @@ extension STPElementsSession {
         supportsLink && (linkFundingSources?.contains(.card) ?? false) || linkPassthroughModeEnabled
     }
 
-    var onlySupportsLinkBank: Bool {
-        return supportsLink && (linkFundingSources == [.bankAccount])
-    }
-
     var linkFundingSources: Set<LinkSettings.FundingSource>? {
         linkSettings?.fundingSources
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
@@ -23,6 +23,14 @@ enum Intent {
     case setupIntent(STPSetupIntent)
     case deferredIntent(intentConfig: PaymentSheet.IntentConfiguration)
 
+    var stripeId: String? {
+        switch self {
+        case .paymentIntent(let intent): intent.stripeId
+        case .setupIntent(let intent): intent.stripeID
+        case .deferredIntent: nil
+        }
+    }
+
     var isPaymentIntent: Bool {
         switch self {
         case .paymentIntent:

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -69,7 +69,7 @@ import UIKit
         }
     }
 
-    static func financialConnections() -> FinancialConnectionsSDKInterface? {
+    @_spi(STP) public static func financialConnections() -> FinancialConnectionsSDKInterface? {
         let financialConnectionsStubbedResult = ProcessInfo.processInfo.environment["FinancialConnectionsStubbedResult"] == "true"
         if isUnitTest || (isUITest && financialConnectionsStubbedResult) {
             return StubbedConnectionsSDKInterface()


### PR DESCRIPTION
## Summary

This wires up the changes introduced in the upstream branch for adding bank accounts to Link. It uses the Financial Connections SDK if available, and otherwise uses FC Lite. The general flow is;

1. Create a Link Account Session
2. Launch Financial Connections using the client secret we get in step 1
3. Create the payment details using the account ID we get in step 2
4. Refresh the Link payment method list

## Motivation

Part 2 of 2 of https://docs.google.com/document/d/1S7OyhUuqi7ESFO4rZDt71exHCyyZwGBWKQPr7m9LLJs/edit?usp=sharing

## Testing

Native SDK:

https://github.com/user-attachments/assets/6766aed1-21d2-4a5b-b963-52f0b0f0055f

Web SDK:

https://github.com/user-attachments/assets/13b17538-c6af-4c45-843c-26561e22da24

FC Lite

https://github.com/user-attachments/assets/3d63f0ec-9905-44e7-9635-9ce5c2d9887c

## Changelog

N/a
