### PR TITLE
Allow highlighting section borders on selection

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
@@ -20,6 +20,8 @@ extension PayWithLinkViewController {
     final class SignUpViewController: BaseViewController {
 
         private let viewModel: SignUpViewModel
+        private let selectionBehavior = SelectionBehavior.highlightBorder(configuration: LinkUI.highlightBorderConfiguration)
+        private let theme = LinkUI.appearance.asElementsTheme
 
         private let titleLabel: UILabel = {
             let label = UILabel()
@@ -46,12 +48,12 @@ extension PayWithLinkViewController {
             return label
         }()
 
-        private lazy var emailElement = LinkEmailElement(defaultValue: viewModel.emailAddress, showLogo: false, theme: LinkUI.appearance.asElementsTheme)
+        private lazy var emailElement = LinkEmailElement(defaultValue: viewModel.emailAddress, showLogo: false, theme: theme)
 
         private lazy var phoneNumberElement = PhoneNumberElement(
             defaultCountryCode: context.configuration.defaultBillingDetails.address.country,
             defaultPhoneNumber: context.configuration.defaultBillingDetails.phone,
-            theme: LinkUI.appearance.asElementsTheme
+            theme: theme
         )
 
         private lazy var nameElement = TextFieldElement(
@@ -59,14 +61,26 @@ extension PayWithLinkViewController {
                 type: .full,
                 defaultValue: viewModel.legalName
             ),
-            theme: LinkUI.appearance.asElementsTheme
+            theme: theme
         )
 
-        private lazy var emailSection = SectionElement(elements: [emailElement], theme: LinkUI.appearance.asElementsTheme)
+        private lazy var emailSection = SectionElement(
+            elements: [emailElement],
+            selectionBehavior: selectionBehavior,
+            theme: theme
+        )
 
-        private lazy var phoneNumberSection = SectionElement(elements: [phoneNumberElement], theme: LinkUI.appearance.asElementsTheme)
+        private lazy var phoneNumberSection = SectionElement(
+            elements: [phoneNumberElement],
+            selectionBehavior: selectionBehavior,
+            theme: theme
+        )
 
-        private lazy var nameSection = SectionElement(elements: [nameElement], theme: LinkUI.appearance.asElementsTheme)
+        private lazy var nameSection = SectionElement(
+            elements: [nameElement],
+            selectionBehavior: selectionBehavior,
+            theme: theme
+        )
 
         private lazy var legalTermsView: LinkLegalTermsView = {
             let legalTermsView = LinkLegalTermsView(textAlignment: .center, isStandalone: true)
@@ -76,7 +90,7 @@ extension PayWithLinkViewController {
         }()
 
         private lazy var errorLabel: UILabel = {
-            let label = ElementsUI.makeErrorLabel(theme: LinkUI.appearance.asElementsTheme)
+            let label = ElementsUI.makeErrorLabel(theme: theme)
             label.isHidden = true
             return label
         }()
@@ -269,6 +283,15 @@ extension PayWithLinkViewController.SignUpViewController: PayWithLinkSignUpViewM
 extension PayWithLinkViewController.SignUpViewController: ElementDelegate {
 
     func didUpdate(element: Element) {
+        // Forward delegate updates to the respective SectionElement
+        if element === emailElement {
+            emailSection.didUpdate(element: emailElement.emailAddressElement)
+        } else if element === phoneNumberElement {
+            phoneNumberSection.didUpdate(element: phoneNumberElement.lastUpdatedElement ?? element)
+        } else if element === nameElement {
+            nameSection.didUpdate(element: nameElement)
+        }
+
         switch emailElement.validationState {
         case .valid:
             viewModel.emailAddress = emailElement.emailAddressString

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkEmailElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkEmailElement.swift
@@ -14,7 +14,7 @@ class LinkEmailElement: Element {
 
     weak var delegate: ElementDelegate?
 
-    private let emailAddressElement: TextFieldElement
+    let emailAddressElement: TextFieldElement
 
     private let activityIndicator: ActivityIndicator = {
         // TODO: Consider adding the activity indicator to TextFieldView

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
@@ -37,6 +37,12 @@ enum LinkUI {
 
     static let borderWidth: CGFloat = 1.5
 
+    static let highlightBorderConfiguration = HighlightBorderConfiguration(
+        width: borderWidth,
+        color: UIColor.linkBorderSelected.cgColor,
+        animator: animator
+    )
+
     // MARK: - Margins
 
     static let buttonMargins: NSDirectionalEdgeInsets = .insets(amount: 16)
@@ -56,6 +62,19 @@ enum LinkUI {
     static let smallContentSpacing: CGFloat = 8
 
     static let tinyContentSpacing: CGFloat = 4
+
+    // MARK: - Animations
+
+    static let animator: UIViewPropertyAnimator = {
+        let params = UISpringTimingParameters(
+            mass: 1.0,
+            dampingRatio: 0.93,
+            frequencyResponse: 0.22
+        )
+        let animator = UIViewPropertyAnimator(duration: 0, timingParameters: params)
+        animator.isInterruptible = true
+        return animator
+    }()
 }
 
 // MARK: Development flags

--- a/StripeUICore/StripeUICore.xcodeproj/project.pbxproj
+++ b/StripeUICore/StripeUICore.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		39E61B5E6A88E5AF1922EE62 /* TextFieldFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34178B51599FDCB0D0D7475A /* TextFieldFormatter.swift */; };
 		4755A24604B396D5A25058CD /* StripeUICore.h in Headers */ = {isa = PBXBuildFile; fileRef = CB8A9F7B4B2E8AA5A7E4FE98 /* StripeUICore.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		48D3B7C2983A8A25C6599119 /* OneTimeCodeTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC2BFFB32C50AB4EECA90326 /* OneTimeCodeTextField.swift */; };
+		49377F042DE5F658005CA805 /* SectionSelectionBehavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49377F032DE5F658005CA805 /* SectionSelectionBehavior.swift */; };
 		4A5EADAF2F6514299BA4B8D8 /* FormElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB1FE2B6BCD6FC77117A2521 /* FormElement.swift */; };
 		4B05CF7F485F0AED498DAE49 /* OneTimeCodeTextField-TextStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 815DB8DE48AE3CE1609C8316 /* OneTimeCodeTextField-TextStorage.swift */; };
 		4B414F0A0E46D914C89B3741 /* StaticElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583B93BE0152CDF7383A37E7 /* StaticElement.swift */; };
@@ -189,6 +190,7 @@
 		4893E4B43FEFCE920D432F0C /* ContainerElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContainerElement.swift; sourceTree = "<group>"; };
 		48C9A13C4663EA8ACA6EA2E5 /* UIColor+StripeUICoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+StripeUICoreTests.swift"; sourceTree = "<group>"; };
 		48E2652D09C1A4EBBDE2FB61 /* DateFieldElementSnapshotTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFieldElementSnapshotTest.swift; sourceTree = "<group>"; };
+		49377F032DE5F658005CA805 /* SectionSelectionBehavior.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SectionSelectionBehavior.swift; sourceTree = "<group>"; };
 		4B66D666BB3EA733B92A60AA /* AddressSectionElement+DummyAddressLine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressSectionElement+DummyAddressLine.swift"; sourceTree = "<group>"; };
 		4CBAE2B07C5575F19470464D /* StripeiOS-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS-Release.xcconfig"; sourceTree = "<group>"; };
 		4D4BD46908791D2E4150C4DC /* TextFieldElement+Factory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextFieldElement+Factory.swift"; sourceTree = "<group>"; };
@@ -685,6 +687,7 @@
 				7BB17B284B6D063AF0329DAD /* SectionElement.swift */,
 				B6737026DF19C8D10AE8114A /* SectionElement+MultiElementRow.swift */,
 				CF3C9C0D2302B8E7F421EFBD /* SectionView.swift */,
+				49377F032DE5F658005CA805 /* SectionSelectionBehavior.swift */,
 			);
 			path = Section;
 			sourceTree = "<group>";
@@ -955,6 +958,7 @@
 				86427678E119E4AD22410E30 /* PhoneNumberElement.swift in Sources */,
 				019C76A03A30A67AE9F1FAEE /* PickerFieldView.swift in Sources */,
 				57C288DFD2CC2CFC216E47CC /* PickerTextField.swift in Sources */,
+				49377F042DE5F658005CA805 /* SectionSelectionBehavior.swift in Sources */,
 				32971AFF5D0DF9B28E9C464C /* SectionContainerView.swift in Sources */,
 				5A9B21FE5A6941713087B94B /* SectionElement+MultiElementRow.swift in Sources */,
 				336B882978CA47EE46260774 /* SectionElement.swift in Sources */,

--- a/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
@@ -71,6 +71,11 @@ import UIKit
             updatePickerField()
         }
     }
+    public private(set) var isEditing: Bool = false {
+        didSet {
+            delegate?.didUpdate(element: self)
+        }
+    }
     public var didUpdate: DidUpdateSelectedIndex?
     public let theme: ElementsAppearance
     public let hasPadding: Bool
@@ -282,9 +287,11 @@ extension DropdownFieldElement {
 
 extension DropdownFieldElement: PickerFieldViewDelegate {
     func didBeginEditing(_ pickerFieldView: PickerFieldView) {
+        isEditing = true
     }
 
     func didFinish(_ pickerFieldView: PickerFieldView, shouldAutoAdvance: Bool) {
+        isEditing = false
         if previouslySelectedIndex != selectedIndex {
             didUpdate?(selectedIndex)
         }

--- a/StripeUICore/StripeUICore/Source/Elements/PhoneNumber/PhoneNumberElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PhoneNumber/PhoneNumberElement.swift
@@ -15,6 +15,7 @@ import UIKit
 @_spi(STP) public class PhoneNumberElement: ContainerElement {
     // MARK: - ContainerElement protocol
     public lazy var elements: [Element] = { [countryDropdownElement, textFieldElement] }()
+    private(set) public var lastUpdatedElement: Element?
     public var delegate: ElementDelegate?
     public lazy var view: UIView = {
         countryDropdownElement.view.directionalLayoutMargins.trailing = 0
@@ -120,6 +121,8 @@ import UIKit
 
     // MARK: - ElementDelegate
     public func didUpdate(element: Element) {
+        lastUpdatedElement = element
+
         if element === textFieldElement && textFieldElement.didReceiveAutofill {
             // Autofilled numbers may already include the country code, so check if that's the case.
             // Note: We only validate against the currently selected country code, as an autofilled number _without_ a country code can trigger false positives, e.g. "2481234567" could be either "(248) 123-4567" (a phone number from Michigan, USA with no country code) or "+248 1 234 567" (a phone number from Seychelles with a country code). We can assume that generally, a user's autofilled phone number will match their phone's region setting.

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionElement.swift
@@ -19,6 +19,7 @@ import UIKit
         isViewInitialized = true
         return SectionView(viewModel: viewModel)
     }()
+    private let selectionBehavior: SelectionBehavior
     var isViewInitialized: Bool = false
     var errorText: String? {
         // Find the first element that's 1. invalid and 2. has a displayable error
@@ -35,6 +36,7 @@ import UIKit
             title: title,
             errorText: errorText,
             subLabel: subLabel,
+            selectionBehavior: selectionBehavior,
             theme: theme
         )
     }
@@ -64,14 +66,21 @@ import UIKit
         let title: String?
         let errorText: String?
         var subLabel: String?
+        let selectionBehavior: SelectionBehavior
         let theme: ElementsAppearance
     }
 
     // MARK: - Initializers
 
-    public init(title: String? = nil, elements: [Element], theme: ElementsAppearance = .default) {
+    public init(
+        title: String? = nil,
+        elements: [Element],
+        selectionBehavior: SelectionBehavior = .default,
+        theme: ElementsAppearance = .default
+    ) {
         self.title = title
         self.elements = elements
+        self.selectionBehavior = selectionBehavior
         self.theme = theme
         elements.forEach {
             $0.delegate = self
@@ -98,6 +107,7 @@ extension SectionElement: ElementDelegate {
         // Glue: Update the view and our delegate
         if isViewInitialized {
             sectionView.update(with: viewModel)
+            sectionView.updateBorder(for: element)
         }
         delegate?.didUpdate(element: self)
     }

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionSelectionBehavior.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionSelectionBehavior.swift
@@ -1,0 +1,25 @@
+//
+//  SectionSelectionBehavior.swift
+//  StripeUICore
+//
+//  Created by Mat Schmid on 5/27/25.
+//
+
+import UIKit
+
+@_spi(STP) public enum SelectionBehavior {
+    case `default`
+    case highlightBorder(configuration: HighlightBorderConfiguration)
+}
+
+@_spi(STP) public struct HighlightBorderConfiguration {
+    @_spi(STP) public let width: CGFloat
+    @_spi(STP) public let color: CGColor
+    @_spi(STP) public let animator: UIViewPropertyAnimator
+
+    @_spi(STP) public init(width: CGFloat, color: CGColor, animator: UIViewPropertyAnimator) {
+        self.width = width
+        self.color = color
+        self.animator = animator
+    }
+}

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionView.swift
@@ -70,4 +70,34 @@ final class SectionView: UIView {
             errorOrSubLabel.isHidden = true
         }
     }
+
+    func updateBorder(for element: Element) {
+        guard case .highlightBorder(let configuration) = viewModel.selectionBehavior else {
+            return
+        }
+
+        let isEditing: Bool = {
+            switch element {
+            case let textField as TextFieldElement:
+                return textField.isEditing
+            case let dropdown as DropdownFieldElement:
+                return dropdown.isEditing
+            default:
+                return false
+            }
+        }()
+
+        let borderChanges = {
+            if isEditing {
+                self.containerView.layer.borderWidth = configuration.width
+                self.containerView.layer.borderColor = configuration.color
+            } else {
+                self.containerView.layer.borderWidth = self.viewModel.theme.borderWidth
+                self.containerView.layer.borderColor = self.viewModel.theme.colors.border.cgColor
+            }
+        }
+
+        configuration.animator.addAnimations(borderChanges)
+        configuration.animator.startAnimation()
+    }
 }

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
@@ -30,7 +30,11 @@ import UIKit
     public private(set) lazy var text: String = {
         sanitize(text: configuration.defaultValue ?? "")
     }()
-    public private(set) var isEditing: Bool = false
+    public private(set) var isEditing: Bool = false {
+        didSet {
+            delegate?.didUpdate(element: self)
+        }
+    }
     private(set) var didReceiveAutofill: Bool = false
     public var validationState: ElementValidationState {
         return .init(


### PR DESCRIPTION
## Summary

This makes some changes to `SectionElement` and `SectionView` to support showing borders around the element when it is selected. To do this, we add a new configuration `SectionSelectionBehavior`, which we use to style and animate the border on selection.

This PR also applies this configuration to the fields in the `PayWithLinkSignUpViewController`.

## Motivation

https://www.figma.com/design/OGzRm5DunZ6ih4qHo73vEO/%F0%9F%8D%8F%F0%9F%93%B1-Mobile-Payment-Element?node-id=158-3864&t=Cj1NI1BnB2qFXKgl-0

## Testing

https://github.com/user-attachments/assets/ff7e2cf9-9f10-46a2-bc3b-5e7f8e9c8ec7

## Changelog

N/a
