### PR TITLE
Update payment option before triggering immediateAction

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -443,10 +443,10 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
             }
         }
         embeddedFormViewController.dismiss(animated: true)
+        informDelegateIfPaymentOptionUpdated()
         if case .immediateAction(let didSelectPaymentOption) = configuration.rowSelectionBehavior {
             didSelectPaymentOption()
         }
-        informDelegateIfPaymentOptionUpdated()
     }
 
     func getChangeButtonState(for type: RowButtonType) -> (shouldShowChangeButton: Bool, sublabel: String?) {


### PR DESCRIPTION
## Summary
- Makes sure we are updating the payment option before we trigger the immediateAction callback

## Motivation
- [Bug fix](https://stripe.slack.com/archives/CFA2HJ99A/p1748456921612389)

## Testing
- Added a new unit test

## Changelog
N/A
