### PR TITLE
[Link] Provide shipping address in `PaymentOptionDisplayData`

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -589,6 +589,15 @@ class PlaygroundController: ObservableObject {
     // Completion
 
     func onOptionsCompletion() {
+        if let shippingAddress = self.paymentSheetFlowController?.paymentOption?.shippingAddress {
+            self.addressViewController = .init(
+                configuration: .init(
+                    defaultValues: shippingAddress,
+                    additionalFields: .init(phone: .optional)
+                ),
+                delegate: self
+            )
+        }
         // Tell our observer to refresh
         objectWillChange.send()
     }
@@ -912,9 +921,8 @@ extension PlaygroundController {
                 let data = data,
                 let json = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
             else {
-                if let data = data,
-                   (response as? HTTPURLResponse)?.statusCode == 400,
-                   let errorMessage = String(data: data, encoding: .utf8) {
+                if let data, (response as? HTTPURLResponse)?.statusCode == 400 {
+                    let errorMessage = String(decoding: data, as: UTF8.self)
                     // read the error message
                     intentCreationCallback(.failure(ConfirmHandlerError.confirmError(errorMessage)))
                 } else {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -589,10 +589,10 @@ class PlaygroundController: ObservableObject {
     // Completion
 
     func onOptionsCompletion() {
-        if let shippingAddress = self.paymentSheetFlowController?.paymentOption?.shippingAddress {
+        if let shippingDetails = self.paymentSheetFlowController?.paymentOption?.shippingDetails {
             self.addressViewController = .init(
                 configuration: .init(
-                    defaultValues: shippingAddress,
+                    defaultValues: shippingDetails,
                     additionalFields: .init(phone: .optional)
                 ),
                 delegate: self

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		3EDFACA133567159875143C5 /* STPElementsSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA2D5E6CAA2990D88F64A4D /* STPElementsSession.swift */; };
 		401128A8DDC7B6E3CBB4381E /* PaymentSheetFormFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2363DF030555E62FDD3B1D42 /* PaymentSheetFormFactory.swift */; };
 		40806EF506CB719299FC90CC /* STPLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C9F8CED45EA4B66E770E3E /* STPLocalizedString.swift */; };
+		418007102DE0EB85000FEB87 /* ShippingAddressesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4180070F2DE0EB80000FEB87 /* ShippingAddressesResponse.swift */; };
 		429A68EA92C4101C9BC88269 /* TestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D658AC15478BF1E0A76B9D /* TestModeView.swift */; };
 		4313D6635F10EC460D2ED21E /* SavedPaymentMethodCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA26FF00FD57F6AA1A7CB83 /* SavedPaymentMethodCollectionView.swift */; };
 		436A212E364FD78C3745DDA3 /* CardScanningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D34B92439E9DC6E36D498312 /* CardScanningView.swift */; };
@@ -591,6 +592,7 @@
 		3F70E5F0FE6218715432D55A /* AddPaymentMethodViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPaymentMethodViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		3FBC7DC1A5EFF76C10D29DD6 /* LinkUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkUI.swift; sourceTree = "<group>"; };
 		40EDF386A07E1196FB043798 /* StripePaymentsObjcTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripePaymentsObjcTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4180070F2DE0EB80000FEB87 /* ShippingAddressesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingAddressesResponse.swift; sourceTree = "<group>"; };
 		4208AD2E0A737F5E0F00DE48 /* ConsumerSession+LookupResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConsumerSession+LookupResponse.swift"; sourceTree = "<group>"; };
 		441C3414745D483C9A47ED0B /* VerificationSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationSession.swift; sourceTree = "<group>"; };
 		446E3BBF316178C04343B193 /* STPApplePayContext+PaymentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPApplePayContext+PaymentSheet.swift"; sourceTree = "<group>"; };
@@ -1326,6 +1328,7 @@
 		6702628D1C9A293C2AA5A3EC /* Link */ = {
 			isa = PBXGroup;
 			children = (
+				4180070F2DE0EB80000FEB87 /* ShippingAddressesResponse.swift */,
 				D0CE026F53D10DA10D7BC4E7 /* ConsumerSession.swift */,
 				4208AD2E0A737F5E0F00DE48 /* ConsumerSession+LookupResponse.swift */,
 				E2D61B52BFA201D25E8F6428 /* ConsumerSession+PublishableKey.swift */,
@@ -2466,6 +2469,7 @@
 				ED75C8F47475E4BE5D496C93 /* STPPaymentIntentShippingDetailsParams+PaymentSheet.swift in Sources */,
 				4313D6635F10EC460D2ED21E /* SavedPaymentMethodCollectionView.swift in Sources */,
 				CF2AD2C7F761C46AE559E563 /* SavedPaymentOptionsViewController.swift in Sources */,
+				418007102DE0EB85000FEB87 /* ShippingAddressesResponse.swift in Sources */,
 				F4EA474D60D0889E7D48E1CF /* BankAccountInfoView.swift in Sources */,
 				057A899F4123F3716F2AC0FA /* USBankAccountPaymentMethodElement.swift in Sources */,
 				985DAA770BC0289D24A5999C /* AddressSearchResult.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -245,6 +245,17 @@ extension ConsumerSession {
             completion: completion)
     }
 
+    func listShippingAddress(
+        with apiClient: STPAPIClient = STPAPIClient.shared,
+        consumerAccountPublishableKey: String?,
+        completion: @escaping (Result<ShippingAddressesResponse, Error>) -> Void
+    ) {
+        apiClient.listShippingAddress(
+            for: clientSecret,
+            consumerAccountPublishableKey: consumerAccountPublishableKey,
+            completion: completion)
+    }
+
     func deletePaymentDetails(
         with apiClient: STPAPIClient = STPAPIClient.shared,
         id: String,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -359,6 +359,25 @@ extension STPAPIClient {
         }
     }
 
+    func listShippingAddress(
+        for consumerSessionClientSecret: String,
+        consumerAccountPublishableKey: String?,
+        completion: @escaping (Result<ShippingAddressesResponse, Error>) -> Void
+    ) {
+        let endPoint = "consumers/shipping_addresses/list"
+        let parameters: [String: Any] = [
+            "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
+            "request_surface": "ios_payment_element",
+        ]
+        post(
+            resource: endPoint,
+            parameters: parameters,
+            consumerPublishableKey: consumerAccountPublishableKey
+        ) { (result: Result<ShippingAddressesResponse, Error>) in
+            completion(result)
+        }
+    }
+
     func deletePaymentDetails(
         for consumerSessionClientSecret: String,
         id: String,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ShippingAddressesResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ShippingAddressesResponse.swift
@@ -1,0 +1,65 @@
+//
+//  ShippingAddressesResponse.swift
+//  StripePaymentSheet
+//
+//  Created by Chris Mays on 5/23/25.
+//
+
+struct ShippingAddressesResponse: Decodable {
+    struct ShippingAddress: Decodable {
+        let id: String
+        let address: Address
+        let isDefault: Bool?
+        let nickname: String?
+
+        private enum CodingKeys: String, CodingKey {
+            case id
+            case address
+            case isDefault = "is_default"
+            case nickname
+        }
+
+        struct Address: Decodable {
+            let administrativeArea: String?
+            let countryCode: String?
+            let dependentLocality: String?
+            let line1: String?
+            let line2: String?
+            let locality: String?
+            let name: String?
+            let postalCode: String?
+            let sortingCode: String?
+
+            private enum CodingKeys: String, CodingKey {
+                case administrativeArea = "administrative_area"
+                case countryCode = "country_code"
+                case dependentLocality = "dependent_locality"
+                case line1 = "line_1"
+                case line2 = "line_2"
+                case locality
+                case name
+                case postalCode = "postal_code"
+                case sortingCode = "sorting_code"
+            }
+        }
+    }
+
+    let shippingAddresses: [ShippingAddress]
+
+    private enum CodingKeys: String, CodingKey {
+        case shippingAddresses = "shipping_addresses"
+    }
+}
+
+extension ShippingAddressesResponse.ShippingAddress {
+    func toPaymentSheetAddress() -> PaymentSheet.Address {
+        .init(
+            city: address.locality,
+            country: address.countryCode,
+            line1: address.line1,
+            line2: address.line2,
+            postalCode: address.postalCode,
+            state: address.administrativeArea
+        )
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -138,6 +138,14 @@ final class PayWithLinkViewController: BottomSheetViewController {
 
     weak var payWithLinkDelegate: PayWithLinkViewControllerDelegate?
 
+    var shippingAddressResponse: ShippingAddressesResponse?
+
+    var defaultShippingAddress: ShippingAddressesResponse.ShippingAddress? {
+        shippingAddressResponse?.shippingAddresses.first {
+            $0.isDefault ?? false
+        } ?? shippingAddressResponse?.shippingAddresses.first
+    }
+
     private var isBailingToWebFlow: Bool = false
 
     convenience init(
@@ -305,36 +313,65 @@ private extension PayWithLinkViewController {
             .supportedPaymentDetailsTypes(for: context.elementsSession)
             .toSortedArray()
 
-        linkAccount.listPaymentDetails(
-            supportedTypes: supportedPaymentDetailsTypes
-        ) { result in
-            switch result {
-            case .success(let paymentDetails):
-                if paymentDetails.isEmpty {
-                    let addPaymentMethodVC = NewPaymentViewController(
-                        linkAccount: linkAccount,
-                        context: self.context,
-                        isAddingFirstPaymentMethod: true
-                    )
+        Task { @MainActor in
+            async let paymentDetailsResult = linkAccount.listPaymentDetails(
+                supportedTypes: supportedPaymentDetailsTypes
+            )
 
-                    self.setViewControllers([addPaymentMethodVC])
-                } else {
-                    let walletViewController = WalletViewController(
-                        linkAccount: linkAccount,
-                        context: self.context,
-                        paymentMethods: paymentDetails
-                    )
+            async let shippingAddressResult = fetchShippingAddress(
+                using: linkAccount,
+                shouldFetch: context.launchedFromFlowController
+            )
 
-                    self.setViewControllers([walletViewController])
-                }
-            case .failure(let error):
-                self.payWithLinkDelegate?.payWithLinkViewControllerDidFinish(
+            do {
+                let paymentDetails = try await paymentDetailsResult
+
+                // Ignore any errors that might happen here.
+                shippingAddressResponse = try? await shippingAddressResult
+
+                presentAppropriateViewController(
+                    with: linkAccount,
+                    paymentDetails: paymentDetails
+                )
+            } catch {
+                payWithLinkDelegate?.payWithLinkViewControllerDidFinish(
                     self,
                     result: PaymentSheetResult.failed(error: error),
                     deferredIntentConfirmationType: nil
                 )
             }
         }
+    }
+
+    private func fetchShippingAddress(
+        using account: PaymentSheetLinkAccount,
+        shouldFetch: Bool
+    ) async throws -> ShippingAddressesResponse? {
+        guard shouldFetch else { return nil }
+        return try await account.listShippingAddress()
+    }
+
+    private func presentAppropriateViewController(
+        with linkAccount: PaymentSheetLinkAccount,
+        paymentDetails: [ConsumerPaymentDetails]
+    ) {
+        let viewController: BottomSheetContentViewController
+        if paymentDetails.isEmpty {
+            let addPaymentMethodVC = NewPaymentViewController(
+                linkAccount: linkAccount,
+                context: context,
+                isAddingFirstPaymentMethod: true
+            )
+            viewController = addPaymentMethodVC
+        } else {
+            let walletViewController = WalletViewController(
+                linkAccount: linkAccount,
+                context: context,
+                paymentMethods: paymentDetails
+            )
+            viewController = walletViewController
+        }
+        setViewControllers([viewController])
     }
 
     func updateSupportedPaymentMethods() {
@@ -377,8 +414,10 @@ extension PayWithLinkViewController: PayWithLinkCoordinating {
         let confirmOption = PaymentSheet.LinkConfirmOption.withPaymentDetails(
             account: linkAccount,
             paymentDetails: paymentDetails,
-            confirmationExtras: confirmationExtras
+            confirmationExtras: confirmationExtras,
+            shippingAddress: defaultShippingAddress
         )
+
         payWithLinkDelegate?.payWithLinkViewControllerDidFinish(self, confirmOption: confirmOption)
     }
 
@@ -518,7 +557,8 @@ extension PayWithLinkViewController: PayWithLinkCoordinating {
                 option: .withPaymentDetails(
                     account: linkAccount,
                     paymentDetails: paymentDetails,
-                    confirmationExtras: confirmationExtras
+                    confirmationExtras: confirmationExtras,
+                    shippingAddress: defaultShippingAddress
                 )
             )
         ) { [weak self] result, confirmationType in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -34,7 +34,8 @@ extension PaymentSheet {
         case withPaymentDetails(
             account: PaymentSheetLinkAccount,
             paymentDetails: ConsumerPaymentDetails,
-            confirmationExtras: LinkConfirmationExtras?
+            confirmationExtras: LinkConfirmationExtras?,
+            shippingAddress: ShippingAddressesResponse.ShippingAddress?
         )
     }
 
@@ -52,7 +53,7 @@ extension PaymentSheet.LinkConfirmOption {
             return account
         case .withPaymentMethod:
             return nil
-        case .withPaymentDetails(let account, _, _):
+        case .withPaymentDetails(let account, _, _, _):
             return account
         }
     }
@@ -65,7 +66,7 @@ extension PaymentSheet.LinkConfirmOption {
             return intentConfirmParams.paymentMethodParams.paymentSheetLabel
         case .withPaymentMethod(let paymentMethod):
             return paymentMethod.paymentSheetLabel
-        case .withPaymentDetails(_, let paymentDetails, _):
+        case .withPaymentDetails(_, let paymentDetails, _, _):
             return paymentDetails.paymentSheetLabel
         }
     }
@@ -79,6 +80,20 @@ extension PaymentSheet.LinkConfirmOption {
         }
     }
 
+    var shippingAddress: AddressViewController.Configuration.DefaultAddressDetails? {
+        switch self {
+        case let .withPaymentDetails(linkAccount, _, _, shippingAddress):
+            guard let shippingAddress else { return nil }
+            return .init(
+                address: shippingAddress.toPaymentSheetAddress(),
+                name: shippingAddress.address.name,
+                phone: linkAccount.currentSession?.unredactedPhoneNumberWithPrefix
+            )
+        case .wallet, .withPaymentMethod, .signUp:
+            return nil
+        }
+    }
+
     var billingDetails: STPPaymentMethodBillingDetails? {
         switch self {
         case .wallet:
@@ -87,7 +102,7 @@ extension PaymentSheet.LinkConfirmOption {
             return intentConfirmParams.paymentMethodParams.billingDetails
         case .withPaymentMethod(let paymentMethod):
             return paymentMethod.billingDetails
-        case .withPaymentDetails(_, let paymentDetails, _):
+        case .withPaymentDetails(_, let paymentDetails, _, _):
             return STPPaymentMethodBillingDetails(billingAddress: paymentDetails.billingAddress, email: paymentDetails.billingEmailAddress)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -546,7 +546,7 @@ extension PaymentSheet {
                 }
             case .withPaymentMethod(let paymentMethod):
                 confirmWithPaymentMethod(paymentMethod, nil, false)
-            case .withPaymentDetails(let linkAccount, let paymentDetails, let confirmationExtras):
+            case .withPaymentDetails(let linkAccount, let paymentDetails, let confirmationExtras, _):
                 let shouldSave = false // always false, as we don't show a save-to-merchant checkbox in Link VC
 
                 if elementsSession.linkPassthroughModeEnabled {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -131,8 +131,8 @@ extension PaymentSheet {
             /// The billing details associated with the customer's desired payment method
             public let billingDetails: PaymentSheet.BillingDetails?
 
-            /// The shipping address associated with the current customer.
-            @_spi(STP) public let shippingAddress: AddressViewController.Configuration.DefaultAddressDetails?
+            /// The shipping details associated with the current customer.
+            @_spi(STP) public let shippingDetails: AddressViewController.Configuration.DefaultAddressDetails?
 
             /// A string representation of the customer's desired payment method
             /// - If this is a Stripe payment method, see https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for possible values.
@@ -147,27 +147,27 @@ extension PaymentSheet {
                     label = String.Localized.apple_pay
                     paymentMethodType = "apple_pay"
                     billingDetails = nil
-                    shippingAddress = nil
+                    shippingDetails = nil
                 case .saved(let paymentMethod, let confirmParams):
                     label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams)
                     paymentMethodType = paymentMethod.type.identifier
                     billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
-                    shippingAddress = nil
+                    shippingDetails = nil
                 case .new(let confirmParams):
                     label = confirmParams.paymentSheetLabel
                     paymentMethodType = confirmParams.paymentMethodType.identifier
                     billingDetails = confirmParams.paymentMethodParams.billingDetails?.toPaymentSheetBillingDetails()
-                    shippingAddress = nil
+                    shippingDetails = nil
                 case .link(let option):
                     label = option.paymentSheetLabel
                     paymentMethodType = option.paymentMethodType
                     billingDetails = option.billingDetails?.toPaymentSheetBillingDetails()
-                    shippingAddress = option.shippingAddress
+                    shippingDetails = option.shippingAddress
                 case .external(let paymentMethod, let stpBillingDetails):
                     label = paymentMethod.displayText
                     paymentMethodType = paymentMethod.type
                     billingDetails = stpBillingDetails.toPaymentSheetBillingDetails()
-                    shippingAddress = nil
+                    shippingDetails = nil
                 }
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -86,7 +86,7 @@ extension PaymentSheet {
         var linkUIAnalyticsValue: String? {
             if case .link(let option) = self {
                 switch option {
-                case .withPaymentDetails(let account, _, _):
+                case .withPaymentDetails(let account, _, _, _):
                     if account.hasCompletedSMSVerification {
                         // This was a returning user who logged in
                         return "native-returning"
@@ -131,6 +131,9 @@ extension PaymentSheet {
             /// The billing details associated with the customer's desired payment method
             public let billingDetails: PaymentSheet.BillingDetails?
 
+            /// The shipping address associated with the current customer.
+            @_spi(STP) public let shippingAddress: AddressViewController.Configuration.DefaultAddressDetails?
+
             /// A string representation of the customer's desired payment method
             /// - If this is a Stripe payment method, see https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for possible values.
             /// - If this is an external payment method, see https://stripe.com/docs/payments/external-payment-methods?platform=ios#available-external-payment-methods for possible values.
@@ -144,22 +147,27 @@ extension PaymentSheet {
                     label = String.Localized.apple_pay
                     paymentMethodType = "apple_pay"
                     billingDetails = nil
+                    shippingAddress = nil
                 case .saved(let paymentMethod, let confirmParams):
                     label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams)
                     paymentMethodType = paymentMethod.type.identifier
                     billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
+                    shippingAddress = nil
                 case .new(let confirmParams):
                     label = confirmParams.paymentSheetLabel
                     paymentMethodType = confirmParams.paymentMethodType.identifier
                     billingDetails = confirmParams.paymentMethodParams.billingDetails?.toPaymentSheetBillingDetails()
+                    shippingAddress = nil
                 case .link(let option):
                     label = option.paymentSheetLabel
                     paymentMethodType = option.paymentMethodType
                     billingDetails = option.billingDetails?.toPaymentSheetBillingDetails()
+                    shippingAddress = option.shippingAddress
                 case .external(let paymentMethod, let stpBillingDetails):
                     label = paymentMethod.displayText
                     paymentMethodType = paymentMethod.type
                     billingDetails = stpBillingDetails.toPaymentSheetBillingDetails()
+                    shippingAddress = nil
                 }
             }
         }
@@ -181,6 +189,7 @@ extension PaymentSheet {
         var elementsSession: STPElementsSession { viewController.elementsSession }
         lazy var paymentHandler: STPPaymentHandler = { STPPaymentHandler(apiClient: configuration.apiClient) }()
         var viewController: FlowControllerViewControllerProtocol
+
         private var presentPaymentOptionsCompletion: (() -> Void)?
 
         // If a WalletButtonsView is currently visible
@@ -727,7 +736,7 @@ extension PaymentOption {
             switch confirmOption {
             case .wallet, .signUp, .withPaymentMethod:
                 return nil
-            case .withPaymentDetails(_, let paymentDetails, _):
+            case .withPaymentDetails(_, let paymentDetails, _, _):
                 return paymentDetails.stripeID
             }
         case .applePay, .new, .external:

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
@@ -104,7 +104,8 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
                     nickname: nil,
                     isDefault: true
                 ),
-                confirmationExtras: nil
+                confirmationExtras: nil,
+                shippingAddress: nil
             )
             )
         }
@@ -207,7 +208,8 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
                         nickname: nil,
                         isDefault: true
                     ),
-                    confirmationExtras: nil
+                    confirmationExtras: nil,
+                    shippingAddress: nil
                 )
             ),
             paymentHandler: paymentHandler,
@@ -441,7 +443,7 @@ private extension PaymentSheetAPIMockTest {
         stub { urlRequest in
             guard let pathComponents = urlRequest.url?.pathComponents else { return false }
             return pathComponents.last == "payment_details"
-        } response: { [self] _ in
+        } response: { _ in
             defer { exp.fulfill() }
 
             let responseJSON = """


### PR DESCRIPTION
## Summary

This tweaks the `PaymentOptionDisplayData` object to include shipping address details that can be used in the `AddressViewController`.

## Motivation

https://docs.google.com/document/d/1jCj0A7agXCGC8xOn9cLKoGdOLoUwd7MjEGucjGzwEwA/edit?usp=sharing

## Testing

https://github.com/user-attachments/assets/cda51393-b11b-43f7-acb0-8930165109e4

## Changelog

N/a - no public API change yet.