### PR TITLE
Respect backend flag for Link RUX in FlowController

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -5,7 +5,17 @@
 //  Created by Till Hellmund on 5/14/25.
 //
 
+@_spi(STP) import StripePayments
 import UIKit
+
+extension STPElementsSession {
+
+    func enableFlowControllerRUX(for configuration: PaymentElementConfiguration) -> Bool {
+        let usesNative = deviceCanUseNativeLink(elementsSession: self, configuration: configuration)
+        let disableFlowControllerRUX = linkSettings?.disableFlowControllerRUX ?? false
+        return PaymentSheet.LinkFeatureFlags.enableLinkFlowControllerChanges && !disableFlowControllerRUX && usesNative
+    }
+}
 
 extension UIViewController {
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -210,16 +210,9 @@ extension PaymentSheet {
         }
 
         private var canPresentLinkInPlaceOfFlowController: Bool {
-            guard PaymentSheet.LinkFeatureFlags.enableLinkFlowControllerChanges else {
-                // Only allow if the feature flag is enabled
+            guard elementsSession.enableFlowControllerRUX(for: configuration) else {
                 return false
             }
-
-            guard deviceCanUseNativeLink(elementsSession: elementsSession, configuration: configuration) else {
-                // We only allow this with native Link
-                return false
-            }
-
             return _paymentOption?.canLaunchLink ?? false
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -287,8 +287,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
     }
 
     private var canPresentLinkOnWalletButton: Bool {
-        let usesNative = deviceCanUseNativeLink(elementsSession: elementsSession, configuration: configuration)
-        return PaymentSheet.LinkFeatureFlags.enableLinkFlowControllerChanges && usesNative
+        elementsSession.enableFlowControllerRUX(for: configuration)
     }
 
     private func presentLink() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -469,16 +469,20 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     }
 
     private var canPresentLinkOnPrimaryButton: Bool {
+        guard elementsSession.enableFlowControllerRUX(for: configuration) else {
+            return false
+        }
         guard case .link = selectedPaymentOption else {
             return false
         }
-        let usesNative = deviceCanUseNativeLink(elementsSession: elementsSession, configuration: configuration)
-        return PaymentSheet.LinkFeatureFlags.enableLinkFlowControllerChanges && isFlowController && usesNative
+        return isFlowController
     }
 
     private var canPresentLinkOnWalletButton: Bool {
-        let usesNative = deviceCanUseNativeLink(elementsSession: elementsSession, configuration: configuration)
-        return PaymentSheet.LinkFeatureFlags.enableLinkFlowControllerChanges && isFlowController && usesNative
+        guard elementsSession.enableFlowControllerRUX(for: configuration) else {
+            return false
+        }
+        return isFlowController
     }
 
     private func presentLinkInFlowController() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
@@ -78,6 +78,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             passthroughModeEnabled: true,
             disableSignup: nil,
             suppress2FAModal: nil,
+            disableFlowControllerRUX: nil,
             useAttestationEndpoints: true,
             linkMode: .passthrough,
             linkFlags: nil,

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
@@ -33,6 +33,7 @@ import Foundation
     @_spi(STP) public let passthroughModeEnabled: Bool?
     @_spi(STP) public let disableSignup: Bool?
     @_spi(STP) public let suppress2FAModal: Bool?
+    @_spi(STP) public let disableFlowControllerRUX: Bool?
     @_spi(STP) public let useAttestationEndpoints: Bool?
     @_spi(STP) public let linkMode: LinkMode?
     @_spi(STP) public let linkFlags: [String: Bool]?
@@ -47,6 +48,7 @@ import Foundation
         passthroughModeEnabled: Bool?,
         disableSignup: Bool?,
         suppress2FAModal: Bool?,
+        disableFlowControllerRUX: Bool?,
         useAttestationEndpoints: Bool?,
         linkMode: LinkMode?,
         linkFlags: [String: Bool]?,
@@ -59,6 +61,7 @@ import Foundation
         self.passthroughModeEnabled = passthroughModeEnabled
         self.disableSignup = disableSignup
         self.suppress2FAModal = suppress2FAModal
+        self.disableFlowControllerRUX = disableFlowControllerRUX
         self.useAttestationEndpoints = useAttestationEndpoints
         self.linkMode = linkMode
         self.linkFlags = linkFlags
@@ -83,6 +86,7 @@ import Foundation
         let webviewOption = PopupWebviewOption(rawValue: response["link_popup_webview_option"] as? String ?? "")
         let passthroughModeEnabled = response["link_passthrough_mode_enabled"] as? Bool ?? false
         let disableSignup = response["link_mobile_disable_signup"] as? Bool ?? false
+        let disableFlowControllerRUX = response["link_mobile_disable_rux_in_flow_controller"] as? Bool ?? false
         let useAttestationEndpoints = response["link_mobile_use_attestation_endpoints"] as? Bool ?? false
         let suppress2FAModal = response["link_mobile_suppress_2fa_modal"] as? Bool ?? false
         let linkMode = (response["link_mode"] as? String).flatMap { LinkMode(rawValue: $0) }
@@ -110,6 +114,7 @@ import Foundation
             passthroughModeEnabled: passthroughModeEnabled,
             disableSignup: disableSignup,
             suppress2FAModal: suppress2FAModal,
+            disableFlowControllerRUX: disableFlowControllerRUX,
             useAttestationEndpoints: useAttestationEndpoints,
             linkMode: linkMode,
             linkFlags: linkFlags,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull requests makes the client respect the backend feature flag that controls whether the Link return-user experience should be enabled in FlowController.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
