### PR TITLE
Enable default opt-in for Link inline signup

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -58,7 +58,6 @@ struct PaymentSheetTestPlayground: View {
         SettingView(setting: $playgroundController.settings.instantDebitsIncentives)
         SettingView(setting: $playgroundController.settings.fcLiteEnabled)
         SettingView(setting: $playgroundController.settings.linkFlowControllerChanges)
-        SettingView(setting: $playgroundController.settings.linkDefaultOptIn)
     }
 
     var body: some View {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -598,12 +598,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
-    enum LinkDefaultOptIn: String, PickerEnum {
-        static let enumName: String = "Link DOI"
-        case on
-        case off
-    }
-
     enum ConfigurationStyle: String, PickerEnum {
         static let enumName: String = "Style"
         case automatic
@@ -665,7 +659,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var rowSelectionBehavior: RowSelectionBehavior
     var cardBrandAcceptance: CardBrandAcceptance
     var linkFlowControllerChanges: LinkFlowControllerChanges
-    var linkDefaultOptIn: LinkDefaultOptIn
 
     static func defaultValues() -> PaymentSheetTestPlaygroundSettings {
         return PaymentSheetTestPlaygroundSettings(
@@ -719,8 +712,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             embeddedViewDisplaysMandateText: .on,
             rowSelectionBehavior: .default,
             cardBrandAcceptance: .all,
-            linkFlowControllerChanges: .off,
-            linkDefaultOptIn: .off
+            linkFlowControllerChanges: .off
         )
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -503,7 +503,6 @@ class PlaygroundController: ObservableObject {
             FinancialConnectionsSDKAvailability.shouldPreferFCLite = enableFcLite
 
             PaymentSheet.LinkFeatureFlags.enableLinkFlowControllerChanges = newValue.linkFlowControllerChanges == .on
-            PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = newValue.linkDefaultOptIn == .on
         }.store(in: &subscribers)
 
         // Listen for analytics

--- a/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
+++ b/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
@@ -53,7 +53,6 @@ class LinkInlineSignupElementSnapshotTests: STPSnapshotTestCase {
     // MARK: Default opt-in
 
     func testDefaultOptIn_fully_preFilled() {
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = true
         let sut = makeSUT(
             saveCheckboxChecked: true,
             linkAccountEmailAddress: "user@example.com",
@@ -61,11 +60,9 @@ class LinkInlineSignupElementSnapshotTests: STPSnapshotTestCase {
             allowsDefaultOptIn: true
         )
         verify(sut)
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = false
     }
 
     func testDefaultOptIn_fully_preFilled_longEmail() {
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = true
         let sut = makeSUT(
             saveCheckboxChecked: true,
             linkAccountEmailAddress: "user_with_a_super_long_email_address@example.com",
@@ -73,18 +70,15 @@ class LinkInlineSignupElementSnapshotTests: STPSnapshotTestCase {
             allowsDefaultOptIn: true
         )
         verify(sut)
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = false
     }
 
     func testDefaultOptIn_partially_preFilled() {
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = true
         let sut = makeSUT(
             saveCheckboxChecked: true,
             preFillPhone: "+13105551234",
             allowsDefaultOptIn: true
         )
         verify(sut)
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = false
     }
 
     // MARK: Textfield only mode

--- a/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
+++ b/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
@@ -163,52 +163,35 @@ class LinkInlineSignupViewModelTests: STPNetworkStubbingTestCase {
     }
 
     func test_defaultOptIn_allowed_for_eligible_merchant() {
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = true
         let sut = makeSUT(country: "US", showCheckbox: true, allowsDefaultOptIn: true)
         XCTAssertEqual(sut.mode, .checkboxWithDefaultOptIn)
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = false
-    }
-
-    func test_defaultOptIn_not_allowed_if_feature_flag_off() {
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = false
-        let sut = makeSUT(country: "US", showCheckbox: true, allowsDefaultOptIn: true)
-        XCTAssertNotEqual(sut.mode, .checkboxWithDefaultOptIn)
     }
 
     func test_defaultOptIn_not_allowed_for_ineligible_merchant() {
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = true
         let sut = makeSUT(country: "US", showCheckbox: true, allowsDefaultOptIn: false)
         XCTAssertNotEqual(sut.mode, .checkboxWithDefaultOptIn)
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = false
     }
 
     func test_defaultOptIn_not_allowed_outside_US() {
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = true
         let sut = makeSUT(country: "CA", showCheckbox: true, allowsDefaultOptIn: true)
         XCTAssertNotEqual(sut.mode, .checkboxWithDefaultOptIn)
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = false
     }
 
     func test_defaultOptIn_not_allowed_if_showing_checkbox() {
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = true
         let sut = makeSUT(country: "US", showCheckbox: false, allowsDefaultOptIn: true)
         XCTAssertNotEqual(sut.mode, .checkboxWithDefaultOptIn)
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = false
     }
 
     func test_defaultOptIn_shows_readonly_view_if_completely_prefilled() {
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = true
         let sut = makeSUT(country: "US", showCheckbox: true, allowsDefaultOptIn: true)
         sut.emailWasPrefilled = true
         sut.phoneNumberWasPrefilled = true
         XCTAssertTrue(sut.shouldShowDefaultOptInView)
         XCTAssertFalse(sut.shouldShowEmailField)
         XCTAssertFalse(sut.shouldShowPhoneField)
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = false
     }
 
     func test_defaultOptIn_shows_fields_if_user_asked_to_change_signup_data() {
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = true
         let sut = makeSUT(country: "US", showCheckbox: true, allowsDefaultOptIn: true)
         sut.emailWasPrefilled = true
         sut.phoneNumberWasPrefilled = true
@@ -219,18 +202,15 @@ class LinkInlineSignupViewModelTests: STPNetworkStubbingTestCase {
         XCTAssertFalse(sut.shouldShowDefaultOptInView)
         XCTAssertTrue(sut.shouldShowEmailField)
         XCTAssertTrue(sut.shouldShowPhoneField)
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = false
     }
 
     func test_defaultOptIn_shows_fields_if_not_completely_prefilled() {
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = true
         let sut = makeSUT(country: "US", showCheckbox: true, allowsDefaultOptIn: true)
         sut.emailWasPrefilled = true
         sut.phoneNumberWasPrefilled = false
         XCTAssertFalse(sut.shouldShowDefaultOptInView)
         XCTAssertTrue(sut.shouldShowEmailField)
         XCTAssertTrue(sut.shouldShowPhoneField)
-        PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn = false
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
@@ -351,7 +351,7 @@ final class LinkInlineSignupViewModel {
             emailWasPrefilled = true
         }
         if showCheckbox {
-            let allowsDefaultOptIn = PaymentSheet.LinkFeatureFlags.enableLinkDefaultOptIn && allowsDefaultOptIn && country == "US"
+            let allowsDefaultOptIn = allowsDefaultOptIn && country == "US"
             self.mode = allowsDefaultOptIn ? .checkboxWithDefaultOptIn : .checkbox
         } else {
             // If we don't show a checkbox *and* we have a prefilled email, show the phone field first.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -124,9 +124,5 @@ extension PaymentSheet {
         /// Decides whether Link shows more actively in FlowController.
         /// Only enable this in the PaymentSheet playground.
         @_spi(STP) public static var enableLinkFlowControllerChanges: Bool = false
-
-        /// Decides whether Link default opt-in should be available.
-        /// Only enable this in the PaymentSheet playground.
-        @_spi(STP) public static var enableLinkDefaultOptIn: Bool = false
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/elements_sessions_paymentMethod_link_200.json
+++ b/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/elements_sessions_paymentMethod_link_200.json
@@ -18,7 +18,8 @@
     "link_funding_sources": [
         "CARD"
     ],
-    "link_local_storage_login_enabled": true
+    "link_local_storage_login_enabled": true,
+    "link_mobile_disable_default_opt_in": true
   },
   "merchant_country": "US",
   "merchant_currency": "usd",


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request enables default opt-in for Link inline signup in production.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
