### PR TITLE
[Link] Minor UI tweaks

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-LoaderViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-LoaderViewController.swift
@@ -19,6 +19,7 @@ extension PayWithLinkViewController {
         override func viewDidLoad() {
             super.viewDidLoad()
 
+            activityIndicator.tintColor = .linkIconBrand
             activityIndicator.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview(activityIndicator)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
@@ -48,7 +48,11 @@ extension PayWithLinkViewController {
             return label
         }()
 
-        private lazy var emailElement = LinkEmailElement(defaultValue: viewModel.emailAddress, showLogo: false, theme: theme)
+        private lazy var emailElement = {
+            let element = LinkEmailElement(defaultValue: viewModel.emailAddress, showLogo: false, theme: theme)
+            element.indicatorTintColor = .linkIconBrand
+            return element
+        }()
 
         private lazy var phoneNumberElement = PhoneNumberElement(
             defaultCountryCode: context.configuration.defaultBillingDetails.address.country,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -197,7 +197,6 @@ final class PayWithLinkViewController: BottomSheetViewController {
         super.viewDidLoad()
 
         view.accessibilityIdentifier = "Stripe.Link.PayWithLinkViewController"
-        view.tintColor = .linkIconBrand
 
         context.configuration.style.configure(self)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
@@ -35,7 +35,7 @@ enum LinkUI {
 
     // MARK: - Border
 
-    static let borderWidth: CGFloat = 1.5
+    static let borderWidth: CGFloat = 1.0
 
     static let highlightBorderConfiguration = HighlightBorderConfiguration(
         width: borderWidth,


### PR DESCRIPTION
## Summary

This makes some minor tweaks to the Link UI to fix some small visual bugs.

Fixes the corner borders:

| Before | After |
|--------|--------|
| <img width="96" alt="Screenshot 2025-05-27 at 11 52 26 AM" src="https://github.com/user-attachments/assets/00cee3ff-b9e9-4b8c-8e3b-0a40cc5ec3e2" /> | <img width="114" alt="Screenshot 2025-06-02 at 4 07 01 PM" src="https://github.com/user-attachments/assets/d665e48c-12b4-4a1e-bcbf-80820d03e321" /> |

Fixes some tint color flashing that was happening on the sign up textfields. To do this, we remove the global tint color set on the `PayWithLinkViewController`, and instead apply it to individual view when needed.

Before:

https://github.com/user-attachments/assets/6e06aa2b-b362-4ee5-b830-31baab688e55

After:

https://github.com/user-attachments/assets/16c853e7-ac27-4dff-ab50-1b06ddecf51b


## Motivation

✨ 

## Testing

See above

## Changelog

N/a