### PR TITLE
Add Link RUX in Embedded MPE

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -58,6 +58,7 @@ struct PaymentSheetTestPlayground: View {
         SettingView(setting: $playgroundController.settings.instantDebitsIncentives)
         SettingView(setting: $playgroundController.settings.fcLiteEnabled)
         SettingView(setting: $playgroundController.settings.linkFlowControllerChanges)
+        SettingView(setting: $playgroundController.settings.linkEmbeddedChanges)
     }
 
     var body: some View {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -598,6 +598,12 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
+    enum LinkEmbeddedChanges: String, PickerEnum {
+        static let enumName: String = "Link Embedded RUX"
+        case on
+        case off
+    }
+
     enum ConfigurationStyle: String, PickerEnum {
         static let enumName: String = "Style"
         case automatic
@@ -659,6 +665,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var rowSelectionBehavior: RowSelectionBehavior
     var cardBrandAcceptance: CardBrandAcceptance
     var linkFlowControllerChanges: LinkFlowControllerChanges
+    var linkEmbeddedChanges: LinkEmbeddedChanges
 
     static func defaultValues() -> PaymentSheetTestPlaygroundSettings {
         return PaymentSheetTestPlaygroundSettings(
@@ -712,7 +719,8 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             embeddedViewDisplaysMandateText: .on,
             rowSelectionBehavior: .default,
             cardBrandAcceptance: .all,
-            linkFlowControllerChanges: .off
+            linkFlowControllerChanges: .off,
+            linkEmbeddedChanges: .off
         )
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -503,6 +503,7 @@ class PlaygroundController: ObservableObject {
             FinancialConnectionsSDKAvailability.shouldPreferFCLite = enableFcLite
 
             PaymentSheet.LinkFeatureFlags.enableLinkFlowControllerChanges = newValue.linkFlowControllerChanges == .on
+            PaymentSheet.LinkFeatureFlags.enableLinkEmbeddedChanges = newValue.linkEmbeddedChanges == .on
         }.store(in: &subscribers)
 
         // Listen for analytics

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -65,6 +65,7 @@ extension EmbeddedPaymentElement {
             initialSelectedRowChangeButtonState: previousSelectedRowChangeButtonState,
             paymentMethodTypes: loadResult.paymentMethodTypes,
             savedPaymentMethod: loadResult.savedPaymentMethods.first,
+            configuration: configuration,
             appearance: configuration.appearance,
             shouldShowApplePay: shouldShowApplePay,
             shouldShowLink: shouldShowLink,
@@ -76,7 +77,9 @@ extension EmbeddedPaymentElement {
             currency: loadResult.intent.currency,
             incentive: loadResult.elementsSession.incentive,
             analyticsHelper: analyticsHelper,
-            delegate: delegate
+            delegate: delegate,
+            elementsSession: loadResult.elementsSession,
+            intent: loadResult.intent
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -328,7 +328,11 @@ public final class EmbeddedPaymentElement {
         case .applePay:
             return .applePay
         case .link:
-            return .link(option: .wallet)
+            if let linkConfirmOption = embeddedPaymentMethodsView.selectedRowButton?.linkConfirmOption {
+                return .link(option: linkConfirmOption)
+            } else {
+                return .link(option: .wallet)
+            }
         case let .new(paymentMethodType: paymentMethodType):
             let params = IntentConfirmParams(type: paymentMethodType)
             params.setDefaultBillingDetailsIfNecessary(for: configuration)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -321,6 +321,7 @@ class EmbeddedPaymentMethodsView: UIView {
             intent: intent,
             elementsSession: elementsSession,
             analyticsHelper: analyticsHelper,
+            verificationRejected: resetSelectionToLastSelection,
             callback: { [weak self] confirmOption, shouldReturnToPaymentSheet in
                 self?.updateLinkRow(with: confirmOption, resetPaymentSelection: shouldReturnToPaymentSheet)
             }
@@ -370,6 +371,7 @@ class EmbeddedPaymentMethodsView: UIView {
         if resetPaymentSelection {
             linkRowButton.linkConfirmOption = nil
             linkRowButton.accessoryView?.isHidden = true
+            resetSelectionToLastSelection()
         }
 
         let sublabel = linkRowButton.linkConfirmOption?.paymentSheetLabel ?? .Localized.link_subtitle_text

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -262,7 +262,7 @@ class EmbeddedPaymentMethodsView: UIView {
         LinkAccountContext.shared.addObserver(self, selector: #selector(onLinkAccountChange(_:)))
 
         if let linkAccount = LinkAccountContext.shared.account, linkAccount.isRegistered {
-            updateLinkRow(for: linkAccount)
+            updateLinkRow(for: linkAccount, animated: false)
         }
     }
 
@@ -297,13 +297,18 @@ class EmbeddedPaymentMethodsView: UIView {
         delegate?.embeddedPaymentMethodsViewDidTapViewMoreSavedPaymentMethods(selectedSavedPaymentMethod: selectedRowButton?.type.savedPaymentMethod)
     }
 
-    func updateLinkRow(for linkAccount: PaymentSheetLinkAccount?) {
+    func updateLinkRow(for linkAccount: PaymentSheetLinkAccount?, animated: Bool = true) {
         guard let linkRowButton else {
             return
         }
 
-        let sublabel = linkAccount?.email ?? .Localized.link_subtitle_text
-        linkRowButton.setSublabel(text: sublabel)
+        var sublabel = String.Localized.link_subtitle_text
+
+        if let linkAccount, linkAccount.isRegistered {
+            sublabel = linkAccount.email
+        }
+
+        linkRowButton.setSublabel(text: sublabel, animated: animated)
     }
 
     func updateSavedPaymentMethodRow(_ savedPaymentMethods: [STPPaymentMethod],

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -124,5 +124,9 @@ extension PaymentSheet {
         /// Decides whether Link shows more actively in FlowController.
         /// Only enable this in the PaymentSheet playground.
         @_spi(STP) public static var enableLinkFlowControllerChanges: Bool = false
+
+        /// Decides whether Link shows more actively in Embedded.
+        /// Only enable this in the PaymentSheet playground.
+        @_spi(STP) public static var enableLinkEmbeddedChanges: Bool = false
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -167,9 +167,13 @@ class RowButton: UIView, EventHandler {
         stpAssertionFailure("RowButton init not called from subclass, use RowButton.create() instead of RowButton(...).")
     }
 
-    func setSublabel(text: String?) {
+    func setSublabel(text: String?, animated: Bool = true) {
+        guard text != sublabel.text else {
+            return
+        }
+        let duration = animated ? 0.2 : 0
         guard let text else {
-            UIView.animate(withDuration: 0.2) { [self] in
+            UIView.animate(withDuration: duration) { [self] in
                 self.sublabel.text = nil
                 self.sublabel.isHidden = true
                 self.setNeedsLayout()
@@ -179,10 +183,10 @@ class RowButton: UIView, EventHandler {
         }
         self.sublabel.text = text
         self.sublabel.alpha = 0
-        UIView.animate(withDuration: 0.2) { [self] in
+        UIView.animate(withDuration: duration) { [self] in
             self.sublabel.isHidden = text.isEmpty
         }
-        UIView.animate(withDuration: 0.1, delay: 0.1) { [self] in
+        UIView.animate(withDuration: duration / 2, delay: duration / 2) { [self] in
             self.sublabel.alpha = 1
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -541,21 +541,7 @@ extension RowButton {
         )
         accessoryView.isHidden = true
 
-//        let linkAccount = LinkAccountContext.shared.account
-//        let subtext = linkAccount?.email ?? .Localized.link_subtitle_text
-
-        let button = RowButton.create(appearance: appearance, type: .link, imageView: imageView, text: STPPaymentMethodType.link.displayName, subtext: .Localized.link_subtitle_text, isEmbedded: isEmbedded, didTap: didTap)
-
-//        let button = RowButton.create(
-//            appearance: appearance,
-//            type: .link,
-//            imageView: imageView,
-//            text: STPPaymentMethodType.link.displayName,
-//            subtext: subtext,
-//            accessoryView: accessoryView,
-//            isEmbedded: isEmbedded,
-//            didTap: didTap
-//        )
+        let button = RowButton.create(appearance: appearance, type: .link, imageView: imageView, text: STPPaymentMethodType.link.displayName, subtext: .Localized.link_subtitle_text, accessoryView: accessoryView, isEmbedded: isEmbedded, didTap: didTap)
         button.accessibilityHelperView.accessibilityLabel = String.Localized.pay_with_link
         return button
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
@@ -183,4 +183,7 @@ private class MockEmbeddedPaymentMethodsViewDelegate: EmbeddedPaymentMethodsView
     func shouldAnimateOnPress(_ paymentMethodType: PaymentSheet.PaymentMethodType) -> Bool {
         return false
     }
+
+    func embeddedPaymentMethodsViewDidTapChangeLinkPaymentMethod() {
+    }
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request adds a return-user experience for Link in the Embedded MPE. The feature is currently behind a local feature flag.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
