### PR TITLE
Fix embedded not showing forms in SwiftUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## x.x.x x-x-x
+
+### PaymentSheet
+* [Fixed] A bug where the EmbeddedPaymentElement failed to display forms when tapped in SwiftUI.
+
 ## 24.15.0 2025-06-02
 
 ### Connect

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
@@ -187,5 +187,6 @@ public struct EmbeddedPaymentElementView: View {
     public var body: some View {
         EmbeddedViewRepresentable(viewModel: viewModel)
             .frame(height: viewModel.height)
+            .onAppear { viewModel.objectWillChange.send() } // Re-trigger SwiftUI’s update cycle to ensure correct ViewController is set as presentingViewcontroller
     }
 }


### PR DESCRIPTION
## Summary
- Fixes an issue where the embedded element would not present VC's when tapped in some navigation stacks in SwiftUI. Fixed this by always updating the presenting VC when it's displayed.

## Motivation
https://stripe.slack.com/archives/CFA2HJ99A/p1749077475813589

## Testing
- Manual (we could create a new example to test this but a little overkill)

## Changelog
See diff