### PR TITLE
Show email in Link wallet button

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -144,6 +144,8 @@
 		49377F022DE4E4FD005CA805 /* BaseLinkHoldbackExperiment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49377F012DE4E4FD005CA805 /* BaseLinkHoldbackExperiment.swift */; };
 		4954E9712D96FA0C0061585F /* FCLiteImplementationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4954E9702D96FA0C0061585F /* FCLiteImplementationTests.swift */; };
 		495C04692DCAA1AB006D8F1A /* PayWithLinkTestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495C04682DCAA1AB006D8F1A /* PayWithLinkTestHelpers.swift */; };
+		495D531E2DF7640D008B92F9 /* LinkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495D531D2DF7640D008B92F9 /* LinkButton.swift */; };
+		495D53202DF7678A008B92F9 /* LinkButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495D531F2DF7678A008B92F9 /* LinkButtonViewModel.swift */; };
 		4965A7132D9D8D3700DC2E3C /* LinkGlobalHoldback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4965A7122D9D8D3700DC2E3C /* LinkGlobalHoldback.swift */; };
 		497713042D9D8E1200DB5CB2 /* PaymentSheetAnalytics+Experiments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497713032D9D8E1200DB5CB2 /* PaymentSheetAnalytics+Experiments.swift */; };
 		49803444CD948F1ED28FF021 /* PaymentSheetFormFactory+FormSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7A1EFF100C589FDFF4D516 /* PaymentSheetFormFactory+FormSpec.swift */; };
@@ -608,6 +610,8 @@
 		49377F012DE4E4FD005CA805 /* BaseLinkHoldbackExperiment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseLinkHoldbackExperiment.swift; sourceTree = "<group>"; };
 		4954E9702D96FA0C0061585F /* FCLiteImplementationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteImplementationTests.swift; sourceTree = "<group>"; };
 		495C04682DCAA1AB006D8F1A /* PayWithLinkTestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PayWithLinkTestHelpers.swift; sourceTree = "<group>"; };
+		495D531D2DF7640D008B92F9 /* LinkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkButton.swift; sourceTree = "<group>"; };
+		495D531F2DF7678A008B92F9 /* LinkButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkButtonViewModel.swift; sourceTree = "<group>"; };
 		4965A7122D9D8D3700DC2E3C /* LinkGlobalHoldback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkGlobalHoldback.swift; sourceTree = "<group>"; };
 		497713032D9D8E1200DB5CB2 /* PaymentSheetAnalytics+Experiments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PaymentSheetAnalytics+Experiments.swift"; sourceTree = "<group>"; };
 		498BF1712D92FF6A006E866B /* FCLiteImplementation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteImplementation.swift; sourceTree = "<group>"; };
@@ -1019,6 +1023,8 @@
 			isa = PBXGroup;
 			children = (
 				31005B592DD4F99B00639F13 /* WalletButtonsView.swift */,
+				495D531D2DF7640D008B92F9 /* LinkButton.swift */,
+				495D531F2DF7678A008B92F9 /* LinkButtonViewModel.swift */,
 			);
 			path = WalletButtonsView;
 			sourceTree = "<group>";
@@ -2392,10 +2398,12 @@
 				68E3CF21A7E1525CA05BA260 /* ConnectionsElement.swift in Sources */,
 				46DB5D39B3B76C08AE2C83C8 /* PaymentMethodElement.swift in Sources */,
 				335A19D93A5979557DB4CA4D /* PaymentMethodElementWrapper.swift in Sources */,
+				495D53202DF7678A008B92F9 /* LinkButtonViewModel.swift in Sources */,
 				B615E8732CA4CC04007D684C /* EmbeddedPaymentElementConfiguration.swift in Sources */,
 				6123E94D2D4A84800088FBE8 /* EmbeddedPaymentElement+SwiftUI.swift in Sources */,
 				00A3805F91E6F903FA677393 /* SimpleMandateElement.swift in Sources */,
 				DFA10770E494AFB895BA4EE2 /* TextFieldElement+Card.swift in Sources */,
+				495D531E2DF7640D008B92F9 /* LinkButton.swift in Sources */,
 				B6B3481CBA798CF22EE8411A /* TextFieldElement+IBAN.swift in Sources */,
 				F90B7028426261188B66C834 /* Error+PaymentSheet.swift in Sources */,
 				3147CECA2CC1BF550067B5E4 /* LinkPaymentMethodPicker.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/LinkButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/LinkButton.swift
@@ -1,0 +1,130 @@
+//
+//  LinkButton.swift
+//  StripePaymentSheet
+//
+//  Created by Mat Schmid on 6/9/25.
+//
+
+@_spi(STP) import StripeUICore
+import SwiftUI
+
+@available(iOS 16.0, *)
+struct LinkButton: View {
+    private enum Constants {
+        static let buttonHeight: CGFloat = 44
+        static let contentHeight: CGFloat = 18
+        static let separatorWidth: CGFloat = 1
+        static let contentSpacing: CGFloat = 10
+        static let cornerRadius = buttonHeight / 2
+        static let emailFont: UIFont = .systemFont(ofSize: 15, weight: .medium)
+            .scaled(withTextStyle: .callout, maximumPointSize: 16)
+    }
+
+    @StateObject private var viewModel: LinkButtonViewModel
+    private let action: () -> Void
+
+    init(viewModel: LinkButtonViewModel = LinkButtonViewModel(), action: @escaping () -> Void) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: Constants.contentSpacing) {
+                SwiftUI.Image(uiImage: Image.link_logo_bw.makeImage(template: false))
+                    .resizable()
+                    .scaledToFit()
+                    .frame(height: Constants.contentHeight)
+
+                if let account = viewModel.account {
+                    Rectangle()
+                        .fill(Color(uiColor: .linkSeparatorOnPrimaryButton))
+                        .frame(width: Constants.separatorWidth, height: Constants.contentHeight)
+
+                    Text(account.email)
+                        .font(Font(Constants.emailFont))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+            }
+            .padding(.horizontal, LinkUI.contentSpacing)
+            .frame(maxWidth: .infinity)
+            .frame(height: Constants.buttonHeight)
+            .background(Color(uiColor: .linkIconBrand))
+            .foregroundColor(Color(uiColor: .linkTextPrimary))
+            .cornerRadius(Constants.cornerRadius)
+        }
+    }
+}
+
+#if DEBUG
+private enum Stubs {
+    static let consumerSession: ConsumerSession = .init(
+        clientSecret: "cs_123",
+        emailAddress: "jane.diaz@gmail.com",
+        redactedFormattedPhoneNumber: "(•••) ••• ••70",
+        unredactedPhoneNumber: "+17070707070",
+        phoneNumberCountry: "US",
+        verificationSessions: [],
+        supportedPaymentDetailsTypes: [.card]
+    )
+
+    static func linkAccount(
+        email: String = "jane.diaz@gmail.com",
+        isRegistered: Bool = true
+    ) -> PaymentSheetLinkAccount {
+        .init(
+            email: email,
+            session: isRegistered ? Self.consumerSession : nil,
+            publishableKey: "pk_test_123",
+            useMobileEndpoints: true
+        )
+    }
+}
+
+@available(iOS 16.0, *)
+private struct LinkButtonPreview: View {
+    private let viewModel = LinkButtonViewModel()
+
+    init(
+        email: String? = "jane.diaz@gmail.com",
+        isRegistered: Bool = true
+    ) {
+        // Setup the view model with appropriate account
+        if let email {
+            viewModel.setAccount(Stubs.linkAccount(
+                email: email,
+                isRegistered: isRegistered
+            ))
+        } else {
+            viewModel.setAccount(nil)
+        }
+    }
+
+    var body: some View {
+        LinkButton(viewModel: viewModel, action: {})
+            .padding(.horizontal)
+    }
+}
+
+@available(iOS 16.0, *)
+#Preview {
+    VStack(spacing: 20) {
+        // Standard registered user
+        LinkButtonPreview()
+
+        // Moderately long email
+        LinkButtonPreview(email: "thisemailislong@company.com")
+
+        // Very long email
+        LinkButtonPreview(email: "thisemailisreallyreallylong@company.com")
+
+        // Unregistered user (won't show email)
+        LinkButtonPreview(isRegistered: false)
+
+        // No account
+        LinkButtonPreview(email: nil)
+    }
+}
+
+#endif

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/LinkButtonViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/LinkButtonViewModel.swift
@@ -1,0 +1,39 @@
+//
+//  LinkButtonViewModel.swift
+//  StripePaymentSheet
+//
+//  Created by Mat Schmid on 6/9/25.
+//
+
+import SwiftUI
+
+class LinkButtonViewModel: NSObject, ObservableObject {
+    @Published private(set) var account: PaymentSheetLinkAccountInfoProtocol?
+
+    override init() {
+        super.init()
+        updateAccountFromContext()
+        LinkAccountContext.shared.addObserver(self, selector: #selector(updateAccountFromContext))
+    }
+
+    deinit {
+        LinkAccountContext.shared.removeObserver(self)
+    }
+
+    func setAccount(_ newAccount: PaymentSheetLinkAccountInfoProtocol?) {
+        setAccountIfRegistered(newAccount)
+    }
+
+    @objc private func updateAccountFromContext() {
+        setAccountIfRegistered(LinkAccountContext.shared.account)
+    }
+
+    /// Sets the account only if it exists and is registered
+    private func setAccountIfRegistered(_ newAccount: PaymentSheetLinkAccountInfoProtocol?) {
+        if let newAccount, newAccount.isRegistered {
+            self.account = newAccount
+        } else {
+            self.account = nil
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -4,9 +4,7 @@
 //
 
 import PassKit
-@_spi(STP) import StripeUICore
 import SwiftUI
-import UIKit
 
 @available(iOS 16.0, *)
 @_spi(STP) public struct WalletButtonsView: View {
@@ -120,26 +118,6 @@ import UIKit
                 .frame(maxWidth: .infinity)
                 .frame(height: 44)
                 .cornerRadius(100)
-        }
-    }
-
-    private struct LinkButton: View {
-        let action: () -> Void
-
-        var body: some View {
-            Button(action: action) {
-                HStack(spacing: 4) {
-                    SwiftUI.Image(uiImage: Image.link_logo_bw.makeImage(template: false))
-                        .resizable()
-                        .scaledToFit()
-                        .frame(height: 18)
-                }
-                .frame(maxWidth: .infinity)
-                .frame(height: 44)
-                .background(Color(uiColor: .linkIconBrand))
-                .foregroundColor(.black)
-                .cornerRadius(100)
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary

This updates the `WalletButtonsView`'s `LinkButton` to show the user's email when available, and when the user is registered.

## Motivation

🎨 👨‍🎨 

## Testing

https://github.com/user-attachments/assets/bde08b7d-f28d-42b1-9d32-331a627a810c

## Changelog

N/a