### PR TITLE
Fix build on Xcode 26

### DIFF
--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPAUBECSDebitFormView.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPAUBECSDebitFormView.swift
@@ -514,20 +514,6 @@ public class STPAUBECSDebitFormView: STPMultiFormTextField, STPMultiFormFieldDel
         }
     }
 
-    // MARK: - UITextViewDelegate
-    /// :nodoc:
-#if compiler(<6.2) && !canImport(CompositorServices)
-    @objc
-    public func textView(
-        _ textView: UITextView,
-        shouldInteractWith URL: URL,
-        in characterRange: NSRange,
-        interaction: UITextItemInteraction
-    ) -> Bool {
-        return true
-    }
-#endif
-
     // MARK: - STPFormTextFieldContainer (Overrides)
     /// :nodoc:
     @objc public override var formFont: UIFont {

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPAUBECSDebitFormView.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPAUBECSDebitFormView.swift
@@ -516,7 +516,7 @@ public class STPAUBECSDebitFormView: STPMultiFormTextField, STPMultiFormFieldDel
 
     // MARK: - UITextViewDelegate
     /// :nodoc:
-#if !canImport(CompositorServices)
+#if compiler(<6.2) && !canImport(CompositorServices)
     @objc
     public func textView(
         _ textView: UITextView,


### PR DESCRIPTION
## Summary
Remove this override, as it breaks Objective-C header generation due to the deprecated method. It seems like the default answer is `true`, so the code to open the URL still functions: I'm not sure why it was even there.

## Motivation
Fix compiling on Xcode 26

## Testing
Locally in Xcode 26 beta and iOS 26

## Changelog
None