### PR TITLE
Small fixes to the Link signup / verification screen

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
@@ -152,6 +152,7 @@ extension PayWithLinkViewController {
 
         override func viewDidLoad() {
             super.viewDidLoad()
+            view.tintColor = .linkTextPrimary
 
             contentView.addSubview(stackView)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
@@ -35,11 +35,11 @@ enum LinkUI {
 
     // MARK: - Border
 
-    static let borderWidth: CGFloat = 1.0
+    static let borderWidth: CGFloat = 1.5
 
     static let highlightBorderConfiguration = HighlightBorderConfiguration(
         width: borderWidth,
-        color: UIColor.linkBorderSelected.cgColor,
+        color: .linkBorderSelected,
         animator: animator
     )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationView.swift
@@ -84,6 +84,7 @@ final class LinkVerificationView: UIView {
             configuration: .init(
                 numberOfDigits: 6,
                 enableDigitGrouping: false,
+                font: LinkUI.font(forTextStyle: .title),
                 itemCornerRadius: LinkUI.cornerRadius,
                 itemHeight: 56,
                 itemFocusRingThickness: LinkUI.borderWidth

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionSelectionBehavior.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionSelectionBehavior.swift
@@ -14,10 +14,10 @@ import UIKit
 
 @_spi(STP) public struct HighlightBorderConfiguration {
     @_spi(STP) public let width: CGFloat
-    @_spi(STP) public let color: CGColor
+    @_spi(STP) public let color: UIColor
     @_spi(STP) public let animator: UIViewPropertyAnimator
 
-    @_spi(STP) public init(width: CGFloat, color: CGColor, animator: UIViewPropertyAnimator) {
+    @_spi(STP) public init(width: CGFloat, color: UIColor, animator: UIViewPropertyAnimator) {
         self.width = width
         self.color = color
         self.animator = animator

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionView.swift
@@ -45,7 +45,6 @@ final class SectionView: UIView {
 
         setupBorderLayer()
         update(with: viewModel)
-        applyDefaultBorder()
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
## Summary

This makes a few small UI adjustments to the Link signup / verification screen:

- Use `.title` font for OTP digits
- Fix janky corner radius on selected `SectionView`s
- Update order color when device theme changes
- Update cursor color in textfields on signup screen

## Motivation

✨ 

## Testing

Corner radius changes:

| Before | After |
|--------|--------|
| <img width="552" alt="Screenshot 2025-06-10 at 12 41 37 PM" src="https://github.com/user-attachments/assets/9319c538-e611-429a-8f71-d69a6a01f70c" /> | <img width="552" alt="Screenshot 2025-06-10 at 1 02 17 PM" src="https://github.com/user-attachments/assets/ab35f934-48b5-4cab-918c-6ddf2caa44a5" /> |

Color adjustments with theme: 

https://github.com/user-attachments/assets/ba84de5b-5cae-41f2-a507-6bdc8790cee1

## Changelog

N/a
