### PR TITLE
Hide secondary Link CTA for inline verification flow

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -54,9 +54,12 @@ extension PayWithLinkViewController {
             self.confirm(confirmationExtras: confirmationExtras)
         }
 
-        private lazy var cancelButton: Button = {
+        private lazy var cancelButton: Button? = {
+            guard let cancelButtonConfiguration = viewModel.cancelButtonConfiguration else {
+                return nil
+            }
             let button = Button(
-                configuration: viewModel.cancelButtonConfiguration,
+                configuration: cancelButtonConfiguration,
                 title: viewModel.context.secondaryButtonLabel
             )
             button.addTarget(self, action: #selector(cancelButtonTapped(_:)), for: .touchUpInside)
@@ -176,7 +179,9 @@ extension PayWithLinkViewController {
                 containerView.addArrangedSubview(applePayButton)
             }
 
-            containerView.addArrangedSubview(cancelButton)
+            if let cancelButton {
+                containerView.addArrangedSubview(cancelButton)
+            }
 
             contentView.addAndPinSubview(containerView)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -128,7 +128,8 @@ extension PayWithLinkViewController {
             return shouldShowApplePayButton
         }
 
-        var cancelButtonConfiguration: Button.Configuration {
+        var cancelButtonConfiguration: Button.Configuration? {
+            guard context.shouldShowSecondaryCta else { return nil }
             return shouldShowApplePayButton ? .linkPlain() : .linkSecondary()
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -79,6 +79,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         let configuration: PaymentElementConfiguration
         let shouldOfferApplePay: Bool
         let shouldFinishOnClose: Bool
+        let shouldShowSecondaryCta: Bool
         let launchedFromFlowController: Bool
         let initiallySelectedPaymentDetailsID: String?
         let callToAction: ConfirmButton.CallToActionType
@@ -102,6 +103,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         ///   - configuration: PaymentSheet configuration.
         ///   - shouldOfferApplePay: Whether or not to show Apple Pay as a payment option.
         ///   - shouldFinishOnClose: Whether or not Link should finish with `.canceled` result instead of returning to Payment Sheet when the close button is tapped.
+        ///   - shouldShowSecondaryCta: Whether or not a secondary CTA to pay another way should be shown.
         ///   - launchedFromFlowController: Whether the flow was opened from `FlowController`.
         ///   - initiallySelectedPaymentDetailsID: The ID of an initially selected payment method. This is set when opened instead of FlowController.
         ///   - callToAction: A custom CTA to display on the confirm button. If `nil`, will display `intent`'s default CTA.
@@ -112,6 +114,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
             configuration: PaymentElementConfiguration,
             shouldOfferApplePay: Bool,
             shouldFinishOnClose: Bool,
+            shouldShowSecondaryCta: Bool = true,
             launchedFromFlowController: Bool = false,
             initiallySelectedPaymentDetailsID: String?,
             callToAction: ConfirmButton.CallToActionType?,
@@ -122,6 +125,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
             self.configuration = configuration
             self.shouldOfferApplePay = shouldOfferApplePay
             self.shouldFinishOnClose = shouldFinishOnClose
+            self.shouldShowSecondaryCta = shouldShowSecondaryCta
             self.launchedFromFlowController = launchedFromFlowController
             self.initiallySelectedPaymentDetailsID = initiallySelectedPaymentDetailsID
             self.callToAction = callToAction ?? .makeDefaultTypeForLink(intent: intent)
@@ -156,6 +160,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         configuration: PaymentElementConfiguration,
         shouldOfferApplePay: Bool = false,
         shouldFinishOnClose: Bool = false,
+        shouldShowSecondaryCta: Bool = true,
         launchedFromFlowController: Bool = false,
         initiallySelectedPaymentDetailsID: String? = nil,
         callToAction: ConfirmButton.CallToActionType? = nil,
@@ -168,6 +173,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
                 configuration: configuration,
                 shouldOfferApplePay: shouldOfferApplePay,
                 shouldFinishOnClose: shouldFinishOnClose,
+                shouldShowSecondaryCta: shouldShowSecondaryCta,
                 launchedFromFlowController: launchedFromFlowController,
                 initiallySelectedPaymentDetailsID: initiallySelectedPaymentDetailsID,
                 callToAction: callToAction,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -96,6 +96,7 @@ final class PayWithNativeLinkController {
     func presentForPaymentMethodSelection(
         from presentingController: UIViewController,
         initiallySelectedPaymentDetailsID: String?,
+        shouldShowSecondaryCta: Bool = true,
         completion: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
     ) {
         presentAsBottomSheetInternal(
@@ -105,7 +106,8 @@ final class PayWithNativeLinkController {
             launchedFromFlowController: true,
             initiallySelectedPaymentDetailsID: initiallySelectedPaymentDetailsID,
             callToAction: .continue,
-            shouldFinishOnClose: false
+            shouldFinishOnClose: false,
+            shouldShowSecondaryCta: shouldShowSecondaryCta
         ) { completionResult in
             guard case .paymentMethodSelection(let confirmOption, let shouldReturnToPaymentSheet) = completionResult else {
                 return
@@ -123,6 +125,7 @@ final class PayWithNativeLinkController {
         initiallySelectedPaymentDetailsID: String? = nil,
         callToAction: ConfirmButton.CallToActionType? = nil,
         shouldFinishOnClose: Bool,
+        shouldShowSecondaryCta: Bool = true,
         completion: @escaping (CompletionResult) -> Void
     ) {
         self.selfRetainer = self
@@ -138,6 +141,7 @@ final class PayWithNativeLinkController {
                 configuration: self.configuration,
                 shouldOfferApplePay: shouldOfferApplePay,
                 shouldFinishOnClose: shouldFinishOnClose,
+                shouldShowSecondaryCta: shouldShowSecondaryCta,
                 launchedFromFlowController: launchedFromFlowController,
                 initiallySelectedPaymentDetailsID: initiallySelectedPaymentDetailsID,
                 callToAction: callToAction,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -135,6 +135,7 @@ import SwiftUI
             linkController.presentForPaymentMethodSelection(
                 from: WindowAuthenticationContext().authenticationPresentingViewController(),
                 initiallySelectedPaymentDetailsID: nil,
+                shouldShowSecondaryCta: false,
                 completion: { confirmOptions, _ in
                     guard let confirmOptions else {
                         self.orderedWallets = WalletButtonsView.determineAvailableWallets(for: flowController)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
@@ -223,6 +223,16 @@ class PayWithLinkViewController_WalletViewModelTests: XCTestCase {
             "Selected payment method should be bank account when cards are disabled"
         )
     }
+
+    func testShouldShowSecondaryButtonEnabled() throws {
+        let sut = try makeSUT(shouldShowSecondaryCta: true)
+        XCTAssertNotNil(sut.cancelButtonConfiguration)
+    }
+
+    func testShouldShowSecondaryButtonDisabled() throws {
+        let sut = try makeSUT(shouldShowSecondaryCta: false)
+        XCTAssertNil(sut.cancelButtonConfiguration)
+    }
 }
 
 extension PayWithLinkViewController_WalletViewModelTests {
@@ -234,7 +244,8 @@ extension PayWithLinkViewController_WalletViewModelTests {
         cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = .all,
         linkPassthroughModeEnabled: Bool? = nil,
         isSettingUp: Bool = false,
-        linkPMOSFU: Bool? = nil
+        linkPMOSFU: Bool? = nil,
+        shouldShowSecondaryCta: Bool = true
     ) throws -> PayWithLinkViewController.WalletViewModel {
         let (intent, elementsSession) = try isSettingUp
         ? PayWithLinkTestHelpers.makeSetupIntentAndElementsSession(
@@ -265,6 +276,7 @@ extension PayWithLinkViewController_WalletViewModelTests {
                 configuration: paymentSheetConfiguration,
                 shouldOfferApplePay: false,
                 shouldFinishOnClose: false,
+                shouldShowSecondaryCta: shouldShowSecondaryCta,
                 initiallySelectedPaymentDetailsID: nil,
                 callToAction: nil,
                 analyticsHelper: ._testValue()


### PR DESCRIPTION
## Summary

This removes the secondary `Pay another way` CTA shown in the Link wallet view when launched by inline verification since it does the same thing as the close button.

## Motivation

💅 

## Testing

https://github.com/user-attachments/assets/2b591746-b69f-4c3a-9927-0190237e8708


## Changelog

N/a