### PR TITLE
Anchor logout dialog to menu button in Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
@@ -31,7 +31,10 @@ protocol LinkPaymentMethodPickerDelegate: AnyObject {
         sourceRect: CGRect
     )
 
-    func didTapOnAccountMenuItem(_ picker: LinkPaymentMethodPicker)
+    func didTapOnAccountMenuItem(
+        _ picker: LinkPaymentMethodPicker,
+        sourceRect: CGRect
+    )
 }
 
 protocol LinkPaymentMethodPickerDataSource: AnyObject {
@@ -233,7 +236,8 @@ private extension LinkPaymentMethodPicker {
     }
 
     @objc func didTapOnAccountMenuItem(_ sender: AddButton) {
-        delegate?.didTapOnAccountMenuItem(self)
+        let sourceRect = sender.convert(sender.bounds, to: self)
+        delegate?.didTapOnAccountMenuItem(self, sourceRect: sourceRect)
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -745,8 +745,14 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
         actions(for: index, includeCancelAction: false)
     }
 
-    func didTapOnAccountMenuItem(_ picker: LinkPaymentMethodPicker) {
+    func didTapOnAccountMenuItem(
+        _ picker: LinkPaymentMethodPicker,
+        sourceRect: CGRect
+    ) {
         let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        actionSheet.popoverPresentationController?.sourceView = picker
+        actionSheet.popoverPresentationController?.sourceRect = sourceRect
+
         actionSheet.addAction(UIAlertAction(
             title: STPLocalizedString("Log out of Link", "Title of the logout action."),
             style: .destructive,
@@ -755,10 +761,6 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
             }
         ))
         actionSheet.addAction(UIAlertAction(title: String.Localized.cancel, style: .cancel))
-
-        // iPad support
-        actionSheet.popoverPresentationController?.sourceView = picker
-        actionSheet.popoverPresentationController?.sourceRect = picker.bounds
 
         present(actionSheet, animated: true)
     }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request makes sure that the alert sheet displayed for logging out in native Link is anchored to the menu button.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
