### PR TITLE
Add ability to create shop_pay pm type

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ShopPayECEPresenter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ShopPayECEPresenter.swift
@@ -245,9 +245,11 @@ extension ShopPayECEPresenter: ExpressCheckoutWebviewDelegate {
         }
 
         // Create Shop Pay payment method params
-        let paymentMethodParams = STPPaymentMethodParams()
-        paymentMethodParams.type = .unknown
-        paymentMethodParams.billingDetails = STPPaymentMethodBillingDetails()
+        let shopPayParams = STPPaymentMethodShopPayParams()
+        shopPayParams.externalSourceId = "TODO_12345" // TODO: Parse from paymentDetails when ready
+        let paymentMethodParams = STPPaymentMethodParams(shopPay: shopPayParams,
+                                                         billingDetails: STPPaymentMethodBillingDetails(),
+                                                         metadata: nil)
 
         // Add billing details
         if let email = billingDetails.email {
@@ -260,13 +262,10 @@ extension ShopPayECEPresenter: ExpressCheckoutWebviewDelegate {
             paymentMethodParams.billingDetails?.name = name
         }
 
-        // Create payment option
-        let confirmParams = IntentConfirmParams(type: .stripe(.unknown))
-        confirmParams.paymentMethodParams.billingDetails = paymentMethodParams.billingDetails
-
-        // TODO: Create a payment method here from the data (using STPAPIClient) once the API is available
-        // For now, use a mock STPPaymentMethod instead
-        let paymentMethod = STPPaymentMethod(stripeId: "pm_123abc", type: .unknown)
+        // Create payment method
+        // TODO: If this fails, then return a PaymentSheetResult failed?
+        let paymentMethod = try await flowController.configuration.apiClient.createPaymentMethod(with: paymentMethodParams,
+                                                                                                 additionalPaymentUserAgentValues: [])
 
         // Dismiss ECE and return the payment method ID on the main thread
         Task { @MainActor in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -313,7 +313,7 @@ extension PaymentSheet {
                     case .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .giropay, .przelewy24, .EPS,
                         .netBanking, .OXXO, .afterpayClearpay, .UPI, .link, .affirm, .paynow, .zip, .alma,
                         .mobilePay, .unknown, .alipay, .konbini, .promptPay, .swish, .twint, .multibanco,
-                        .sunbit, .billie, .satispay, .crypto:
+                        .sunbit, .billie, .satispay, .crypto, .shopPay:
                         return [.unsupportedForSetup]
                     @unknown default:
                         return [.unsupportedForSetup]
@@ -322,7 +322,7 @@ extension PaymentSheet {
             } else {
                 requirements = {
                     switch paymentMethod {
-                    case .blik, .card, .cardPresent, .UPI, .weChatPay, .paynow, .promptPay:
+                    case .blik, .card, .cardPresent, .UPI, .weChatPay, .paynow, .promptPay, .shopPay:
                         return []
                     case .alipay, .EPS, .FPX, .giropay, .grabPay, .netBanking, .payPal, .przelewy24, .klarna,
                             .bancontact, .iDEAL, .cashApp, .affirm, .zip, .revolutPay, .amazonPay, .alma,

--- a/StripePayments/StripePayments.xcodeproj/project.pbxproj
+++ b/StripePayments/StripePayments.xcodeproj/project.pbxproj
@@ -138,6 +138,8 @@
 		68F9810F66FB2D6B278429D7 /* STPAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740C01696C56E269129C86CF /* STPAddress.swift */; };
 		6AF719654B7BC4062C1AF65C /* STPPaymentMethodAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3403BA8AC9DAEAAEF288879 /* STPPaymentMethodAddress.swift */; };
 		6B55465E2BDAFEF900CA88F6 /* STPPaymentMethodAllowRedisplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B55465D2BDAFEF900CA88F6 /* STPPaymentMethodAllowRedisplay.swift */; };
+		6B80FB992E02440800830FD9 /* STPPaymentMethodShopPayParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B80FB982E02440800830FD9 /* STPPaymentMethodShopPayParams.swift */; };
+		6B80FB9B2E0266E700830FD9 /* STPPaymentMethodShopPay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B80FB9A2E0266E700830FD9 /* STPPaymentMethodShopPay.swift */; };
 		6BA4B9162BF3E0C900D1F21D /* STPPaymentMethodMobilePay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA4B9152BF3E0C900D1F21D /* STPPaymentMethodMobilePay.swift */; };
 		6BE5D7C3F86951E73DAAEB6B /* STPThreeDSCustomizationSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B458CF0D5A7EE56A02D750F2 /* STPThreeDSCustomizationSettings.swift */; };
 		6F09091B2E770D0072201C45 /* StripePayments+Export.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64C6DBBF4EED92890747C305 /* StripePayments+Export.swift */; };
@@ -527,6 +529,8 @@
 		69C77D6D92668C1E541E3C0F /* hu */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = hu; path = hu.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6A7CE39E853BD92ABE59F8EA /* StripeiOS-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS-Debug.xcconfig"; sourceTree = "<group>"; };
 		6B55465D2BDAFEF900CA88F6 /* STPPaymentMethodAllowRedisplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAllowRedisplay.swift; sourceTree = "<group>"; };
+		6B80FB982E02440800830FD9 /* STPPaymentMethodShopPayParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodShopPayParams.swift; sourceTree = "<group>"; };
+		6B80FB9A2E0266E700830FD9 /* STPPaymentMethodShopPay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodShopPay.swift; sourceTree = "<group>"; };
 		6BA4B9152BF3E0C900D1F21D /* STPPaymentMethodMobilePay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodMobilePay.swift; sourceTree = "<group>"; };
 		6BF260394EEC61199F0EABF8 /* STPPaymentMethodEnums.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodEnums.swift; sourceTree = "<group>"; };
 		6C360F4D54167F6A484B8D9F /* STPTestAPIClient+Swift.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPTestAPIClient+Swift.swift"; sourceTree = "<group>"; };
@@ -1306,6 +1310,8 @@
 				208127DD5118F21D896C0711 /* STPPaymentMethodUSBankAccountParams.swift */,
 				5C27780E7E42FDBE450941C0 /* STPPaymentMethodWeChatPay.swift */,
 				C740B96CCCC754A1CB19D44C /* STPPaymentMethodWeChatPayParams.swift */,
+				6B80FB9A2E0266E700830FD9 /* STPPaymentMethodShopPay.swift */,
+				6B80FB982E02440800830FD9 /* STPPaymentMethodShopPayParams.swift */,
 				CAC3A02F2C2E127B007BC888 /* STPPaymentMethodSunbit.swift */,
 				CAB989BA2C58771100DF9851 /* STPPaymentMethodSunbitParams.swift */,
 				CAB989BC2C58776100DF9851 /* STPPaymentMethodBillieParams.swift */,
@@ -1773,6 +1779,7 @@
 				F34C04E0C2A142C8CC05D902 /* STPPaymentMethodUPIParams.swift in Sources */,
 				7173E36D0A3EB23E68469BD1 /* STPPaymentMethodUSBankAccount.swift in Sources */,
 				CE5CCAF7BE93DF58A0922B90 /* STPPaymentMethodUSBankAccountParams.swift in Sources */,
+				6B80FB992E02440800830FD9 /* STPPaymentMethodShopPayParams.swift in Sources */,
 				DFC9C2AB405B2060BD1F2226 /* STPPaymentMethodWeChatPay.swift in Sources */,
 				B8C35DE8D237AA591ED70C9A /* STPPaymentMethodWeChatPayParams.swift in Sources */,
 				03A8995BD2286725969CDC9E /* STPPaymentMethodiDEAL.swift in Sources */,
@@ -1802,6 +1809,7 @@
 				ABDEED56ECE545675F5C3534 /* STPSetupIntent.swift in Sources */,
 				FDB1D6CBBF6A9BD4D53F3A82 /* STPSetupIntentConfirmParams.swift in Sources */,
 				64407AEF1246EE91037E4073 /* STPSetupIntentEnums.swift in Sources */,
+				6B80FB9B2E0266E700830FD9 /* STPPaymentMethodShopPay.swift in Sources */,
 				FBD81EE346071449583C8768 /* STPSetupIntentLastSetupError.swift in Sources */,
 				CAB989BD2C58776100DF9851 /* STPPaymentMethodBillieParams.swift in Sources */,
 				444AE95CBDC08E7B1C89B0AB /* LinkSettings.swift in Sources */,

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
@@ -98,6 +98,8 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
     @objc private(set) public var multibanco: STPPaymentMethodMultibanco?
     /// If this is a MobilePay PaymentMethod (i.e. `self.type == STPPaymentMethodTypeMobilePay`), this contains additional details.
     @objc private(set) public var mobilePay: STPPaymentMethodMobilePay?
+    /// If this is a ShopPay PaymentMethod (i.e. `self.type == STPPaymentMethodTypeShopPay`), this contains additional details.
+    @_spi(STP) @objc private(set) public var shopPay: STPPaymentMethodShopPay?
 
     /// This field indicates whether this payment method can be shown again to its customer in a checkout flow
     @objc private(set) public var allowRedisplay: STPPaymentMethodAllowRedisplay
@@ -175,6 +177,7 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
             "crypto = \(String(describing: crypto))",
             "multibanco = \(String(describing: multibanco))",
             "mobilePay = \(String(describing: mobilePay))",
+            "shopPay = \(String(describing: shopPay))",
             "liveMode = \(liveMode ? "YES" : "NO")",
             "allowRedisplay = \(allResponseFields["allow_redisplay"] as? String ?? "")",
             "type = \(allResponseFields["type"] as? String ?? "")",
@@ -370,7 +373,9 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
         paymentMethod.mobilePay = STPPaymentMethodMobilePay.decodedObject(
             fromAPIResponse: dict.stp_dictionary(forKey: "mobilepay")
         )
-
+        paymentMethod.shopPay = STPPaymentMethodShopPay.decodedObject(
+            fromAPIResponse: dict.stp_dictionary(forKey: "shop_pay")
+        )
         return paymentMethod
     }
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -96,6 +96,8 @@ import Foundation
     case twint
     /// A Multibanco payment method
     case multibanco
+    /// A ShopPay payment mehtod
+    case shopPay
     /// An unknown type.
     case unknown
 
@@ -190,6 +192,8 @@ import Foundation
             return "TWINT"
         case .multibanco:
             return "Multibanco"
+        case .shopPay:
+            return "ShopPay"
         case .cardPresent,
             .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
@@ -287,6 +291,8 @@ import Foundation
             return "twint"
         case .multibanco:
             return "multibanco"
+        case .shopPay:
+            return "shop_pay"
         }
     }
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -110,6 +110,8 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
     @objc public var crypto: STPPaymentMethodCryptoParams?
     /// If this is a Multibanco PaymentMethod, this contains additional details.
     @objc public var multibanco: STPPaymentMethodMultibancoParams?
+    /// If this is a ShopPay PaymentMethod, this contains additional details.
+    @_spi(STP) @objc public var shopPay: STPPaymentMethodShopPayParams?
 
     /// Set of key-value pairs that you can attach to the PaymentMethod. This can be useful for storing additional information about the PaymentMethod in a structured format.
     @objc public var metadata: [String: String]?
@@ -742,6 +744,23 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
         self.metadata = metadata
     }
 
+    /// Creates params for an ShopPay PaymentMethod.
+    /// - Parameters:
+    ///   - shopPay:          An object containing additional ShopPay details.
+    ///   - billingDetails:      An object containing the user's billing details.
+    ///   - metadata:            Additional information to attach to the PaymentMethod.
+    @_spi(STP) @objc
+    public convenience init(
+        shopPay: STPPaymentMethodShopPayParams,
+        billingDetails: STPPaymentMethodBillingDetails?,
+        metadata: [String: String]?
+    ) {
+        self.init()
+        self.type = .shopPay
+        self.shopPay = shopPay
+        self.billingDetails = billingDetails
+        self.metadata = metadata
+    }
     /// Creates params from a single-use PaymentMethod. This is useful for recreating a new payment method
     /// with similar settings. It will return nil if used with a reusable PaymentMethod.
     /// - Parameter paymentMethod:       An object containing the original single-use PaymentMethod.
@@ -832,6 +851,7 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             .USBankAccount,
             .cashApp,
             .revolutPay,
+            .shopPay,
             .unknown:
             return nil
         }
@@ -872,6 +892,7 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             NSStringFromSelector(#selector(getter: usBankAccount)): "us_bank_account",
             NSStringFromSelector(#selector(getter: cashApp)): "cashapp",
             NSStringFromSelector(#selector(getter: revolutPay)): "revolut_pay",
+            NSStringFromSelector(#selector(getter: shopPay)): "shop_pay",
             NSStringFromSelector(#selector(getter: swish)): "swish",
             NSStringFromSelector(#selector(getter: mobilePay)): "mobilepay",
             NSStringFromSelector(#selector(getter: amazonPay)): "amazon_pay",
@@ -1360,6 +1381,8 @@ extension STPPaymentMethodParams {
             crypto = STPPaymentMethodCryptoParams()
         case .multibanco:
             multibanco = STPPaymentMethodMultibancoParams()
+        case .shopPay:
+            shopPay = STPPaymentMethodShopPayParams()
         case .cardPresent, .paynow, .zip, .konbini, .promptPay, .twint:
             // These payment methods don't have any params
             break

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodShopPay.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodShopPay.swift
@@ -1,0 +1,45 @@
+//
+//  STPPaymentMethodShopPay.swift
+//  StripePayments
+//
+
+import Foundation
+/// ShopPay Payment Method.
+@_spi(STP) public class STPPaymentMethodShopPay: NSObject, STPAPIResponseDecodable {
+    @objc private(set) public var allResponseFields: [AnyHashable: Any] = [:]
+
+    /// Associated external source Id
+    @objc public private(set) var externalSourceId: String
+
+    // MARK: - Description
+    /// :nodoc:
+    @objc public override var description: String {
+        let props = [
+            // Object
+            String(format: "%@: %p", NSStringFromClass(STPPaymentMethodShopPay.self), self),
+            "externalSourceId = \(externalSourceId)",
+        ]
+
+        return "<\(props.joined(separator: "; "))>"
+    }
+
+    // MARK: - STPAPIResponseDecodable
+    @objc
+    public class func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
+        guard let response = response else {
+            return nil
+        }
+        return self.init(dictionary: response)
+    }
+
+    required init?(dictionary dict: [AnyHashable: Any]) {
+        guard let externalSourceId = dict.stp_string(forKey: "external_source_id") else {
+            return nil
+        }
+
+        self.externalSourceId = externalSourceId
+
+        super.init()
+        allResponseFields = dict
+    }
+}

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodShopPayParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodShopPayParams.swift
@@ -1,0 +1,27 @@
+//
+//  STPPaymentMethodShopPayParams.swift
+//  StripePayments
+//
+
+import Foundation
+
+/// An object representing parameters used to create a ShopPay Payment Method
+@_spi(STP) public class STPPaymentMethodShopPayParams: NSObject, STPFormEncodable {
+    @objc public var additionalAPIParameters: [AnyHashable: Any] = [:]
+
+    /// Corresponding externalSourceId. Required.
+    @objc public var externalSourceId: String?
+
+    // MARK: - STPFormEncodable
+    @objc
+    public class func rootObjectName() -> String? {
+        return "shop_pay"
+    }
+
+    @objc
+    public class func propertyNamesToFormFieldNamesMapping() -> [String: String] {
+       return [
+            NSStringFromSelector(#selector(getter: externalSourceId)): "external_source_id"
+            ]
+    }
+}

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -525,7 +525,7 @@ extension STPPaymentMethodType: CustomStringConvertible {
             return "swish"
         case .twint:
             return "TWINT"
-        case .paynow, .zip, .revolutPay, .mobilePay, .amazonPay, .alma, .konbini, .promptPay, .sunbit, .billie, .satispay, .crypto:
+        case .paynow, .zip, .revolutPay, .mobilePay, .amazonPay, .alma, .konbini, .promptPay, .sunbit, .billie, .satispay, .crypto, .shopPay:
             // `description` is the value used when this type is converted to a string for debugging purposes, just use the display name.
             return displayName
         case .multibanco:

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -740,7 +740,8 @@ public class STPPaymentHandler: NSObject {
             .promptPay,
             .swish,
             .twint,
-            .multibanco:
+            .multibanco,
+            .shopPay:
             return false
 
         case .unknown:


### PR DESCRIPTION
## Summary
Adds plumbing for creating PM for on WalletButtonsView shopPay confirmation

## Motivation
Support ShopPay via WalletButtonsView

## Testing
Manually wrote some code which instrumented the creation of a PM. Inspected with object explorer.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
