### PR TITLE
Fix tap targeting on walletbuttonsview shoppay button

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/ShopPayButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/ShopPayButton.swift
@@ -22,6 +22,7 @@ struct ShopPayButton: View {
                 .resizable()
                 .scaledToFit()
                 .frame(height: Constants.contentHeight)
+                .frame(minWidth: 180, maxWidth: .infinity)
         }
         .frame(maxWidth: .infinity)
         .frame(height: Constants.buttonHeight)


### PR DESCRIPTION
## Summary
Fixes that tap targeting of the ShopPay WalletButtonsView

## Motivation
Currently, you can only tap the icon

## Testing
Manual

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
