### PR TITLE
Attempt to deflake: testLoaderStartShowsLoadingIndicator

### DIFF
--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
@@ -222,8 +222,13 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
 
         try await webVC.webView.evaluateOnLoaderStart(elementTagName: "payouts")
 
-        // Loading indicator should stop
-        XCTAssertFalse(webVC.activityIndicator.isAnimating)
+        if !webVC.activityIndicator.isAnimating {
+            XCTAssertFalse(webVC.activityIndicator.isAnimating)
+        } else {
+            // If it is animating, wait a second before we check.
+            sleep(1)
+            XCTAssertFalse(webVC.activityIndicator.isAnimating)
+        }
     }
 
     // MARK: - Errors


### PR DESCRIPTION
## Summary
This test seems flakey -- i suspect it is because we are asserting too quickly. I wasn't able to repro but, the assertion failure was happening on the line, and it's probable we are just asserting too quickly.

Example:
https://app.bitrise.io/build/6a2542b2-773d-43e7-99ad-b813330fe086

## Motivation
Flakey tests are annoying

## Testing
Run locally.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
