### PR TITLE
Fix Link bail to web flow

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewModel.swift
@@ -229,9 +229,10 @@ private extension PayWithLinkViewController.SignUpViewModel {
                     self.delegate?.viewModel(self, didLookupAccount: account)
                 case .failure(let error):
                     self.linkAccount = nil
-                    self.errorMessage = error.nonGenericDescription
                     if StripeAttest.isLinkAssertionError(error: error) {
                         self.delegate?.viewModelDidEncounterAttestationError(self)
+                    } else {
+                        self.errorMessage = error.nonGenericDescription
                     }
                 }
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -646,7 +646,7 @@ extension PayWithLinkViewController: PayWithLinkCoordinating {
             alwaysUseEphemeralSession: true
         )
         payWithLinkVC.payWithLinkDelegate = payWithLinkWebDelegate
-        // Dismis ourselves...
+        // Dismiss ourselves...
         self.dismiss(animated: false) {
             // ... and present the web controller. (This presentation will be handled by ASWebAuthenticationSession)
             payWithLinkVC.present(over: presentingViewController)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -647,9 +647,10 @@ extension PayWithLinkViewController: PayWithLinkCoordinating {
         )
         payWithLinkVC.payWithLinkDelegate = payWithLinkWebDelegate
         // Dismis ourselves...
-        self.dismiss(animated: false)
-        // ... and present the web controller. (This presentation will be handled by ASWebAuthenticationSession)
-        payWithLinkVC.present(over: presentingViewController)
+        self.dismiss(animated: false) {
+            // ... and present the web controller. (This presentation will be handled by ASWebAuthenticationSession)
+            payWithLinkVC.present(over: presentingViewController)
+        }
         STPAnalyticsClient.sharedClient.logLinkBailedToWebFlow()
     }
 


### PR DESCRIPTION
## Summary

Was testing Link's bail to web flow, which happens when an app attestation error occurs after a `/lookup` call, and noticed the flow crashed with error: 

```
Attempted to present SFAuthenticationViewController from a view controller that is being dismissed: <STP_Internal_PayWithLinkViewController: 0x107bf8800>
```

## Motivation

Fix things

## Testing

Before:

https://github.com/user-attachments/assets/0d148933-9de6-4dea-8bd5-bea776bbadd4

After:

https://github.com/user-attachments/assets/3bbe0e84-9b53-4d27-8d0e-8cf41a296a34

## Changelog

N/a
