### PR TITLE
Fix loading state when adding a bank account in Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-AddButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker-AddButton.swift
@@ -25,6 +25,20 @@ extension LinkPaymentMethodPicker {
             return label
         }()
 
+        private lazy var activityIndicator: ActivityIndicator = {
+            let indicator = ActivityIndicator(size: .medium)
+            // Lower the alpha since it will only be shown when the button is disabled.
+            indicator.alpha = 0.5
+            indicator.translatesAutoresizingMaskIntoConstraints = false
+            return indicator
+        }()
+
+        var isLoading: Bool = false {
+            didSet {
+                update()
+            }
+        }
+
         override var isHighlighted: Bool {
             didSet {
                 update()
@@ -62,22 +76,33 @@ extension LinkPaymentMethodPicker {
 
         private func setupUI() {
             addSubview(textLabel)
+            addSubview(activityIndicator)
 
             NSLayoutConstraint.activate([
                 textLabel.topAnchor.constraint(equalTo: layoutMarginsGuide.topAnchor),
                 textLabel.bottomAnchor.constraint(equalTo: layoutMarginsGuide.bottomAnchor),
                 textLabel.leadingAnchor.constraint(equalTo: layoutMarginsGuide.leadingAnchor),
-                textLabel.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
+                textLabel.trailingAnchor.constraint(lessThanOrEqualTo: activityIndicator.leadingAnchor, constant: -LinkUI.smallContentSpacing),
+
+                activityIndicator.centerYAnchor.constraint(equalTo: layoutMarginsGuide.centerYAnchor),
+                activityIndicator.trailingAnchor.constraint(equalTo: layoutMarginsGuide.trailingAnchor),
             ])
         }
 
         private func update() {
-            if isHighlighted {
-                textLabel.alpha = 0.7
-                backgroundColor = .linkSurfaceTertiary
-            } else {
-                textLabel.alpha = 1
+            if isLoading {
+                activityIndicator.startAnimating()
+                textLabel.alpha = 0.5
                 backgroundColor = .clear
+            } else {
+                activityIndicator.stopAnimating()
+                if isHighlighted {
+                    textLabel.alpha = 0.7
+                    backgroundColor = .linkSurfaceTertiary
+                } else {
+                    textLabel.alpha = 1
+                    backgroundColor = .clear
+                }
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
@@ -298,6 +298,10 @@ extension LinkPaymentMethodPicker {
         cell.isLoading = false
     }
 
+    func setAddButtonIsLoading(_ isLoading: Bool) {
+        addPaymentMethodButton.isLoading = isLoading
+    }
+
     private func reloadDataIfNeeded() {
         if needsDataReload {
             reloadData()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -723,16 +723,20 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
     }
 
     private func addBankAccount() {
-        confirmButton.update(state: .spinnerWithInteractionDisabled)
+        confirmButton.update(state: .disabled)
+        paymentPicker.setAddButtonIsLoading(true)
         coordinator?.startFinancialConnections { [weak self] result in
-            guard case .completed = result else {
+            let completion = {
                 self?.confirmButton.update(state: .enabled)
+                self?.paymentPicker.setAddButtonIsLoading(false)
+            }
+
+            guard case .completed = result else {
+                completion()
                 return
             }
 
-            self?.reloadPaymentDetails {
-                self?.confirmButton.update(state: .enabled)
-            }
+            self?.reloadPaymentDetails(completion: completion)
         }
     }
 


### PR DESCRIPTION
## Summary

While adding a bank account we show a loading state. Instead of showing a spinner on the payment confirmation button, this moves it to the `Add payment method` button.

## Motivation

💅 

## Testing

https://github.com/user-attachments/assets/72a9c36b-a925-4a25-b0a4-6373ac53448c

## Changelog

N/a
