### PR TITLE
Check feature flag to use FC Lite by default

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -278,7 +278,7 @@ final class PlaygroundViewModel: ObservableObject {
 
     func didSelectShow() {
         let useFCLite = playgroundConfiguration.sdkType == .fcLite
-        FinancialConnectionsSDKAvailability.shouldPreferFCLite = useFCLite
+        FinancialConnectionsSDKAvailability.localFcLiteOverride = useFCLite
 
         switch playgroundConfiguration.integrationType {
         case .standalone:

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -551,7 +551,7 @@ class PlaygroundController: ObservableObject {
             UserDefaults.standard.set(enableInstantDebitsIncentives, forKey: "FINANCIAL_CONNECTIONS_INSTANT_DEBITS_INCENTIVES")
 
             let enableFcLite = newValue.fcLiteEnabled == .on
-            FinancialConnectionsSDKAvailability.shouldPreferFCLite = enableFcLite
+            FinancialConnectionsSDKAvailability.localFcLiteOverride = enableFcLite
         }.store(in: &subscribers)
 
         // Listen for analytics

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -141,6 +141,9 @@ final class PaymentSheetLoader {
                 let isFcLiteKillswitchEnabled = elementsSession.flags["elements_disable_fc_lite"] == true
                 FinancialConnectionsSDKAvailability.fcLiteKillswitchEnabled = isFcLiteKillswitchEnabled
 
+                let shouldPreferFcLite = elementsSession.flags["elements_prefer_fc_lite"] == true
+                FinancialConnectionsSDKAvailability.shouldPreferFCLite = shouldPreferFcLite
+
                 // Send load finished analytic
                 // This is hacky; the logic to determine the default selected payment method belongs to the SavedPaymentOptionsViewController. We invoke it here just to report it to analytics before that VC loads.
                 let (defaultSelectedIndex, paymentOptionsViewModels) = SavedPaymentOptionsViewController.makeViewModels(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -141,8 +141,8 @@ final class PaymentSheetLoader {
                 let isFcLiteKillswitchEnabled = elementsSession.flags["elements_disable_fc_lite"] == true
                 FinancialConnectionsSDKAvailability.fcLiteKillswitchEnabled = isFcLiteKillswitchEnabled
 
-                let shouldPreferFcLite = elementsSession.flags["elements_prefer_fc_lite"] == true
-                FinancialConnectionsSDKAvailability.shouldPreferFCLite = shouldPreferFcLite
+                let remoteFcLiteOverrideEnabled = elementsSession.flags["elements_prefer_fc_lite"] == true
+                FinancialConnectionsSDKAvailability.remoteFcLiteOverride = remoteFcLiteOverrideEnabled
 
                 // Send load finished analytic
                 // This is hacky; the logic to determine the default selected payment method belongs to the SavedPaymentOptionsViewController. We invoke it here just to report it to analytics before that VC loads.

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -20,7 +20,8 @@ import UIKit
         as? FinancialConnectionsSDKInterface.Type
 
     @_spi(STP) public static var fcLiteKillswitchEnabled: Bool = false
-    @_spi(STP) public static var shouldPreferFCLite: Bool = false
+    @_spi(STP) public static var localFcLiteOverride: Bool = false
+    @_spi(STP) public static var remoteFcLiteOverride: Bool = false
 
     private static var FCLiteClassIfEnabled: FinancialConnectionsSDKInterface.Type? {
         guard !fcLiteKillswitchEnabled else {
@@ -75,7 +76,8 @@ import UIKit
             return StubbedConnectionsSDKInterface()
         }
 
-        let klass: FinancialConnectionsSDKInterface.Type? = shouldPreferFCLite
+        let fcLiteOverrideEnabled = localFcLiteOverride || remoteFcLiteOverride
+        let klass: FinancialConnectionsSDKInterface.Type? = fcLiteOverrideEnabled
             ? (FCLiteClassIfEnabled ?? FinancialConnectionsSDKClass)
             : (FinancialConnectionsSDKClass ?? FCLiteClassIfEnabled) // Default
 


### PR DESCRIPTION
## Summary

Checks the value of the `elements_prefer_fc_lite` feature flag to determine if we should use FC Lite as the preffered Financial Connections implementation.

## Motivation

We'll roll out this feature flag slowly to start collecting more FC Lite usage.

## Testing

N/a

## Changelog

N/a