### PR TITLE
Save Payment Sheet Playground Appearance config to UserDefaults

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		9F126696AD86BF2E861B5CC5 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16547B41C80B97FC2EFD0798 /* StripeFinancialConnections.framework */; };
 		A0037CC8E331CFF5CEE2D580 /* ExampleSwiftUICustomPaymentFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 447A394B34A55D5B1CD5C0C1 /* ExampleSwiftUICustomPaymentFlow.swift */; };
 		A03BF5292DD292B700B5122B /* EmbeddedPaymentElementWrapperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A03BF5282DD292A800B5122B /* EmbeddedPaymentElementWrapperViewController.swift */; };
+		A0640AA32E05992E0019A686 /* AppearanceCodableExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0640AA22E05992E0019A686 /* AppearanceCodableExtensions.swift */; };
 		A071C07B6FFACC5DEFC6AA01 /* ExampleSwiftUIViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = D20765908089ACB79B556592 /* ExampleSwiftUIViews.swift */; };
 		A262D76C3319002A2F6EE395 /* CustomerSheetTestPlaygroundSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C2A8BAE3842A0E892D06BB9 /* CustomerSheetTestPlaygroundSettings.swift */; };
 		A3884C372DA701A700CAE78E /* PaymentMethodOptionsSetupFutureUsagePlaygroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3884C362DA701A700CAE78E /* PaymentMethodOptionsSetupFutureUsagePlaygroundView.swift */; };
@@ -249,6 +250,7 @@
 		9D6F8659F31E23DF549E5057 /* el-GR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "el-GR"; path = "el-GR.lproj/Main.strings"; sourceTree = "<group>"; };
 		9F9C96D25ED549D6255FC274 /* StripeUICore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeUICore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A03BF5282DD292A800B5122B /* EmbeddedPaymentElementWrapperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedPaymentElementWrapperViewController.swift; sourceTree = "<group>"; };
+		A0640AA22E05992E0019A686 /* AppearanceCodableExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceCodableExtensions.swift; sourceTree = "<group>"; };
 		A10301FB96F08B8ADF93B2DB /* lv-LV */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "lv-LV"; path = "lv-LV.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		A10F554509B65711F00BE91C /* de */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = de; path = de.lproj/LaunchScreen.strings; sourceTree = "<group>"; };
 		A1D77C5D868315EAB494325C /* lv-LV */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "lv-LV"; path = "lv-LV.lproj/Main.strings"; sourceTree = "<group>"; };
@@ -457,6 +459,7 @@
 		C4BE75A2EECEF0AC9EC24CD8 /* PaymentSheet Example */ = {
 			isa = PBXGroup;
 			children = (
+				A0640AA22E05992E0019A686 /* AppearanceCodableExtensions.swift */,
 				A03BF5282DD292A800B5122B /* EmbeddedPaymentElementWrapperViewController.swift */,
 				31CDFC2B2BA36F5B00B3DD91 /* PrivacyInfo.xcprivacy */,
 				132709C10C0114D239ED3FE9 /* Resources */,
@@ -729,6 +732,7 @@
 				56EF0879D7EAC041B147680C /* ExampleLinkPaymentCheckoutViewController.swift in Sources */,
 				A0037CC8E331CFF5CEE2D580 /* ExampleSwiftUICustomPaymentFlow.swift in Sources */,
 				27233E85B0B6E1114E9AF6E8 /* ExampleSwiftUICustomerSheet.swift in Sources */,
+				A0640AA32E05992E0019A686 /* AppearanceCodableExtensions.swift in Sources */,
 				432E82C3F5EC56E89D257563 /* ExampleSwiftUIPaymentSheet.swift in Sources */,
 				6BE115002DF8A6150024AC26 /* PlaygroundController+ApplePay.swift in Sources */,
 				A071C07B6FFACC5DEFC6AA01 /* ExampleSwiftUIViews.swift in Sources */,

--- a/Example/PaymentSheet Example/PaymentSheet Example/AppearanceCodableExtensions.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/AppearanceCodableExtensions.swift
@@ -1,0 +1,355 @@
+//
+//  AppearanceCodableExtensions.swift
+//  PaymentSheet Example
+//
+//  Created by Assistant on 2024-01-01.
+//  Copyright © 2024 stripe-ios. All rights reserved.
+//
+//  Codable extensions for PaymentSheet.Appearance to enable persistence in the playground app.
+//  These extensions are only for the example app and don't affect the public API.
+
+import Foundation
+@_spi(AppearanceAPIAdditionsPreview) import StripePaymentSheet
+import UIKit
+
+// Helper for encoding/decoding UIColor
+private struct CodableUIColor: Codable {
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+
+    init(color: UIColor) {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        color.getRed(&r, green: &g, blue: &b, alpha: &a)
+        self.red = r
+        self.green = g
+        self.blue = b
+        self.alpha = a
+    }
+
+    var uiColor: UIColor {
+        return UIColor(red: red, green: green, blue: blue, alpha: alpha)
+    }
+}
+
+private struct CodableUIFont: Codable {
+    let familyName: String
+    let pointSize: CGFloat
+
+    init(font: UIFont) {
+        self.familyName = font.familyName
+        self.pointSize = font.pointSize
+    }
+
+    var uiFont: UIFont {
+        return UIFont.systemFont(ofSize: pointSize)
+    }
+}
+
+extension UIFont.Weight: Codable {
+    enum CodingKeys: String, CodingKey {
+        case rawValue
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let rawValue = try container.decode(CGFloat.self, forKey: .rawValue)
+        self.init(rawValue: rawValue)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(rawValue, forKey: .rawValue)
+    }
+}
+
+extension PaymentSheet.Appearance: Codable {
+    private enum CodingKeys: String, CodingKey {
+        // Top-level properties
+        case cornerRadius, borderWidth, selectedBorderWidth, sheetCornerRadius
+        case sectionSpacing, verticalModeRowPadding, iconStyle
+        case textFieldInsets, formInsets
+
+        // Font properties
+        case fontSizeScaleFactor, fontBase, fontCustomHeadline
+
+        // Colors properties
+        case colorsPrimary, colorsBackground, colorsComponentBackground, colorsComponentBorder
+        case colorsSelectedComponentBorder, colorsComponentDivider, colorsText, colorsTextSecondary
+        case colorsComponentText, colorsComponentPlaceholderText, colorsIcon, colorsDanger
+
+        // Shadow properties
+        case shadowColor, shadowOpacity, shadowOffset, shadowRadius
+
+        // Primary Button properties
+        case primaryButtonBackgroundColor, primaryButtonTextColor, primaryButtonDisabledBackgroundColor
+        case primaryButtonDisabledTextColor, primaryButtonSuccessBackgroundColor, primaryButtonSuccessTextColor
+        case primaryButtonCornerRadius, primaryButtonBorderColor, primaryButtonBorderWidth
+        case primaryButtonFont, primaryButtonShadowColor, primaryButtonShadowOpacity
+        case primaryButtonShadowOffset, primaryButtonShadowRadius, primaryButtonHeight
+
+        // Embedded Payment Element properties
+        case embeddedRowStyle, embeddedRowAdditionalInsets
+        case embeddedFlatSeparatorThickness, embeddedFlatSeparatorColor, embeddedFlatSeparatorInsets
+        case embeddedFlatTopSeparatorEnabled, embeddedFlatBottomSeparatorEnabled
+        case embeddedFlatRadioSelectedColor, embeddedFlatRadioUnselectedColor
+        case embeddedFlatCheckmarkColor, embeddedFlatChevronColor
+        case embeddedFloatingSpacing
+    }
+
+    public init(from decoder: Decoder) throws {
+        self.init()
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // Top-level properties
+        self.cornerRadius = try container.decode(CGFloat.self, forKey: .cornerRadius)
+        self.borderWidth = try container.decode(CGFloat.self, forKey: .borderWidth)
+        self.selectedBorderWidth = try container.decodeIfPresent(CGFloat.self, forKey: .selectedBorderWidth)
+        self.sheetCornerRadius = try container.decode(CGFloat.self, forKey: .sheetCornerRadius)
+        self.sectionSpacing = try container.decode(CGFloat.self, forKey: .sectionSpacing)
+        self.verticalModeRowPadding = try container.decode(CGFloat.self, forKey: .verticalModeRowPadding)
+
+        let iconStyleString = try container.decode(String.self, forKey: .iconStyle)
+        self.iconStyle = iconStyleString == "filled" ? .filled : .outlined
+
+        self.textFieldInsets = try container.decode(NSDirectionalEdgeInsets.self, forKey: .textFieldInsets)
+        self.formInsets = try container.decode(NSDirectionalEdgeInsets.self, forKey: .formInsets)
+
+        // Font properties
+        self.font.sizeScaleFactor = try container.decode(CGFloat.self, forKey: .fontSizeScaleFactor)
+        self.font.base = try container.decode(CodableUIFont.self, forKey: .fontBase).uiFont
+        if let headlineFont = try container.decodeIfPresent(CodableUIFont.self, forKey: .fontCustomHeadline) {
+            self.font.custom.headline = headlineFont.uiFont
+        }
+
+        // Colors properties
+        self.colors.primary = try container.decode(CodableUIColor.self, forKey: .colorsPrimary).uiColor
+        self.colors.background = try container.decode(CodableUIColor.self, forKey: .colorsBackground).uiColor
+        self.colors.componentBackground = try container.decode(CodableUIColor.self, forKey: .colorsComponentBackground).uiColor
+        self.colors.componentBorder = try container.decode(CodableUIColor.self, forKey: .colorsComponentBorder).uiColor
+        if let selectedBorder = try container.decodeIfPresent(CodableUIColor.self, forKey: .colorsSelectedComponentBorder) {
+            self.colors.selectedComponentBorder = selectedBorder.uiColor
+        }
+        self.colors.componentDivider = try container.decode(CodableUIColor.self, forKey: .colorsComponentDivider).uiColor
+        self.colors.text = try container.decode(CodableUIColor.self, forKey: .colorsText).uiColor
+        self.colors.textSecondary = try container.decode(CodableUIColor.self, forKey: .colorsTextSecondary).uiColor
+        self.colors.componentText = try container.decode(CodableUIColor.self, forKey: .colorsComponentText).uiColor
+        self.colors.componentPlaceholderText = try container.decode(CodableUIColor.self, forKey: .colorsComponentPlaceholderText).uiColor
+        self.colors.icon = try container.decode(CodableUIColor.self, forKey: .colorsIcon).uiColor
+        self.colors.danger = try container.decode(CodableUIColor.self, forKey: .colorsDanger).uiColor
+
+        // Shadow properties
+        self.shadow.color = try container.decode(CodableUIColor.self, forKey: .shadowColor).uiColor
+        self.shadow.opacity = try container.decode(CGFloat.self, forKey: .shadowOpacity)
+        self.shadow.offset = try container.decode(CGSize.self, forKey: .shadowOffset)
+        self.shadow.radius = try container.decode(CGFloat.self, forKey: .shadowRadius)
+
+        // Primary Button properties
+        if let bgColor = try container.decodeIfPresent(CodableUIColor.self, forKey: .primaryButtonBackgroundColor) {
+            self.primaryButton.backgroundColor = bgColor.uiColor
+        }
+        if let txtColor = try container.decodeIfPresent(CodableUIColor.self, forKey: .primaryButtonTextColor) {
+            self.primaryButton.textColor = txtColor.uiColor
+        }
+        if let disabledBgColor = try container.decodeIfPresent(CodableUIColor.self, forKey: .primaryButtonDisabledBackgroundColor) {
+            self.primaryButton.disabledBackgroundColor = disabledBgColor.uiColor
+        }
+        if let disabledTxtColor = try container.decodeIfPresent(CodableUIColor.self, forKey: .primaryButtonDisabledTextColor) {
+            self.primaryButton.disabledTextColor = disabledTxtColor.uiColor
+        }
+        self.primaryButton.successBackgroundColor = try container.decode(CodableUIColor.self, forKey: .primaryButtonSuccessBackgroundColor).uiColor
+        if let successTxtColor = try container.decodeIfPresent(CodableUIColor.self, forKey: .primaryButtonSuccessTextColor) {
+            self.primaryButton.successTextColor = successTxtColor.uiColor
+        }
+        self.primaryButton.cornerRadius = try container.decodeIfPresent(CGFloat.self, forKey: .primaryButtonCornerRadius)
+        self.primaryButton.borderColor = try container.decode(CodableUIColor.self, forKey: .primaryButtonBorderColor).uiColor
+        self.primaryButton.borderWidth = try container.decode(CGFloat.self, forKey: .primaryButtonBorderWidth)
+        if let font = try container.decodeIfPresent(CodableUIFont.self, forKey: .primaryButtonFont) {
+            self.primaryButton.font = font.uiFont
+        }
+
+        // Primary Button Shadow
+        if let shadowColor = try container.decodeIfPresent(CodableUIColor.self, forKey: .primaryButtonShadowColor),
+           let shadowOpacity = try container.decodeIfPresent(CGFloat.self, forKey: .primaryButtonShadowOpacity),
+           let shadowOffset = try container.decodeIfPresent(CGSize.self, forKey: .primaryButtonShadowOffset),
+           let shadowRadius = try container.decodeIfPresent(CGFloat.self, forKey: .primaryButtonShadowRadius) {
+            self.primaryButton.shadow = PaymentSheet.Appearance.Shadow(
+                color: shadowColor.uiColor,
+                opacity: shadowOpacity,
+                offset: shadowOffset,
+                radius: shadowRadius
+            )
+        }
+        self.primaryButton.height = try container.decode(CGFloat.self, forKey: .primaryButtonHeight)
+
+        // Embedded Payment Element properties
+        let embeddedRowStyleString = try container.decode(String.self, forKey: .embeddedRowStyle)
+        switch embeddedRowStyleString {
+        case "floatingButton":
+            self.embeddedPaymentElement.row.style = .floatingButton
+        case "flatWithCheckmark":
+            self.embeddedPaymentElement.row.style = .flatWithCheckmark
+        case "flatWithChevron":
+            self.embeddedPaymentElement.row.style = .flatWithChevron
+        default:
+            self.embeddedPaymentElement.row.style = .flatWithRadio
+        }
+
+        self.embeddedPaymentElement.row.additionalInsets = try container.decode(CGFloat.self, forKey: .embeddedRowAdditionalInsets)
+
+        // Embedded Flat properties
+        self.embeddedPaymentElement.row.flat.separatorThickness = try container.decode(CGFloat.self, forKey: .embeddedFlatSeparatorThickness)
+        if let sepColor = try container.decodeIfPresent(CodableUIColor.self, forKey: .embeddedFlatSeparatorColor) {
+            self.embeddedPaymentElement.row.flat.separatorColor = sepColor.uiColor
+        }
+        self.embeddedPaymentElement.row.flat.separatorInsets = try container.decodeIfPresent(UIEdgeInsets.self, forKey: .embeddedFlatSeparatorInsets)
+        self.embeddedPaymentElement.row.flat.topSeparatorEnabled = try container.decode(Bool.self, forKey: .embeddedFlatTopSeparatorEnabled)
+        self.embeddedPaymentElement.row.flat.bottomSeparatorEnabled = try container.decode(Bool.self, forKey: .embeddedFlatBottomSeparatorEnabled)
+
+        // Radio colors
+        if let selectedColor = try container.decodeIfPresent(CodableUIColor.self, forKey: .embeddedFlatRadioSelectedColor) {
+            self.embeddedPaymentElement.row.flat.radio.selectedColor = selectedColor.uiColor
+        }
+        if let unselectedColor = try container.decodeIfPresent(CodableUIColor.self, forKey: .embeddedFlatRadioUnselectedColor) {
+            self.embeddedPaymentElement.row.flat.radio.unselectedColor = unselectedColor.uiColor
+        }
+
+        // Checkmark and chevron colors
+        if let checkmarkColor = try container.decodeIfPresent(CodableUIColor.self, forKey: .embeddedFlatCheckmarkColor) {
+            self.embeddedPaymentElement.row.flat.checkmark.color = checkmarkColor.uiColor
+        }
+        self.embeddedPaymentElement.row.flat.chevron.color = try container.decode(CodableUIColor.self, forKey: .embeddedFlatChevronColor).uiColor
+
+        // Floating properties
+        self.embeddedPaymentElement.row.floating.spacing = try container.decode(CGFloat.self, forKey: .embeddedFloatingSpacing)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+
+        // Top-level properties
+        try container.encode(cornerRadius, forKey: .cornerRadius)
+        try container.encode(borderWidth, forKey: .borderWidth)
+        try container.encodeIfPresent(selectedBorderWidth, forKey: .selectedBorderWidth)
+        try container.encode(sheetCornerRadius, forKey: .sheetCornerRadius)
+        try container.encode(sectionSpacing, forKey: .sectionSpacing)
+        try container.encode(verticalModeRowPadding, forKey: .verticalModeRowPadding)
+
+        let iconStyleString = iconStyle == .filled ? "filled" : "outlined"
+        try container.encode(iconStyleString, forKey: .iconStyle)
+
+        try container.encode(textFieldInsets, forKey: .textFieldInsets)
+        try container.encode(formInsets, forKey: .formInsets)
+
+        // Font properties
+        try container.encode(font.sizeScaleFactor, forKey: .fontSizeScaleFactor)
+        try container.encode(CodableUIFont(font: font.base), forKey: .fontBase)
+        if let headline = font.custom.headline {
+            try container.encode(CodableUIFont(font: headline), forKey: .fontCustomHeadline)
+        }
+
+        // Colors properties
+        try container.encode(CodableUIColor(color: colors.primary), forKey: .colorsPrimary)
+        try container.encode(CodableUIColor(color: colors.background), forKey: .colorsBackground)
+        try container.encode(CodableUIColor(color: colors.componentBackground), forKey: .colorsComponentBackground)
+        try container.encode(CodableUIColor(color: colors.componentBorder), forKey: .colorsComponentBorder)
+        if let selectedComponentBorder = colors.selectedComponentBorder {
+            try container.encode(CodableUIColor(color: selectedComponentBorder), forKey: .colorsSelectedComponentBorder)
+        }
+        try container.encode(CodableUIColor(color: colors.componentDivider), forKey: .colorsComponentDivider)
+        try container.encode(CodableUIColor(color: colors.text), forKey: .colorsText)
+        try container.encode(CodableUIColor(color: colors.textSecondary), forKey: .colorsTextSecondary)
+        try container.encode(CodableUIColor(color: colors.componentText), forKey: .colorsComponentText)
+        try container.encode(CodableUIColor(color: colors.componentPlaceholderText), forKey: .colorsComponentPlaceholderText)
+        try container.encode(CodableUIColor(color: colors.icon), forKey: .colorsIcon)
+        try container.encode(CodableUIColor(color: colors.danger), forKey: .colorsDanger)
+
+        // Shadow properties
+        try container.encode(CodableUIColor(color: shadow.color), forKey: .shadowColor)
+        try container.encode(shadow.opacity, forKey: .shadowOpacity)
+        try container.encode(shadow.offset, forKey: .shadowOffset)
+        try container.encode(shadow.radius, forKey: .shadowRadius)
+
+        // Primary Button properties
+        if let backgroundColor = primaryButton.backgroundColor {
+            try container.encode(CodableUIColor(color: backgroundColor), forKey: .primaryButtonBackgroundColor)
+        }
+        if let textColor = primaryButton.textColor {
+            try container.encode(CodableUIColor(color: textColor), forKey: .primaryButtonTextColor)
+        }
+        if let disabledBackgroundColor = primaryButton.disabledBackgroundColor {
+            try container.encode(CodableUIColor(color: disabledBackgroundColor), forKey: .primaryButtonDisabledBackgroundColor)
+        }
+        if let disabledTextColor = primaryButton.disabledTextColor {
+            try container.encode(CodableUIColor(color: disabledTextColor), forKey: .primaryButtonDisabledTextColor)
+        }
+        try container.encode(CodableUIColor(color: primaryButton.successBackgroundColor), forKey: .primaryButtonSuccessBackgroundColor)
+        if let successTextColor = primaryButton.successTextColor {
+            try container.encode(CodableUIColor(color: successTextColor), forKey: .primaryButtonSuccessTextColor)
+        }
+        try container.encodeIfPresent(primaryButton.cornerRadius, forKey: .primaryButtonCornerRadius)
+        try container.encode(CodableUIColor(color: primaryButton.borderColor), forKey: .primaryButtonBorderColor)
+        try container.encode(primaryButton.borderWidth, forKey: .primaryButtonBorderWidth)
+        if let font = primaryButton.font {
+            try container.encode(CodableUIFont(font: font), forKey: .primaryButtonFont)
+        }
+
+        // Primary Button Shadow
+        if let shadow = primaryButton.shadow {
+            try container.encode(CodableUIColor(color: shadow.color), forKey: .primaryButtonShadowColor)
+            try container.encode(shadow.opacity, forKey: .primaryButtonShadowOpacity)
+            try container.encode(shadow.offset, forKey: .primaryButtonShadowOffset)
+            try container.encode(shadow.radius, forKey: .primaryButtonShadowRadius)
+        }
+        try container.encode(primaryButton.height, forKey: .primaryButtonHeight)
+
+        // Embedded Payment Element properties
+        let embeddedRowStyleString: String
+        switch embeddedPaymentElement.row.style {
+        case .flatWithRadio:
+            embeddedRowStyleString = "flatWithRadio"
+        case .floatingButton:
+            embeddedRowStyleString = "floatingButton"
+        case .flatWithCheckmark:
+            embeddedRowStyleString = "flatWithCheckmark"
+        case .flatWithChevron:
+            embeddedRowStyleString = "flatWithChevron"
+        default:
+            throw AppearanceCodableError(description: "Implement encoding for new row styles in AppearanceCodableExtensions.swift")
+        }
+        try container.encode(embeddedRowStyleString, forKey: .embeddedRowStyle)
+        try container.encode(embeddedPaymentElement.row.additionalInsets, forKey: .embeddedRowAdditionalInsets)
+
+        // Embedded Flat properties
+        try container.encode(embeddedPaymentElement.row.flat.separatorThickness, forKey: .embeddedFlatSeparatorThickness)
+        if let separatorColor = embeddedPaymentElement.row.flat.separatorColor {
+            try container.encode(CodableUIColor(color: separatorColor), forKey: .embeddedFlatSeparatorColor)
+        }
+        try container.encodeIfPresent(embeddedPaymentElement.row.flat.separatorInsets, forKey: .embeddedFlatSeparatorInsets)
+        try container.encode(embeddedPaymentElement.row.flat.topSeparatorEnabled, forKey: .embeddedFlatTopSeparatorEnabled)
+        try container.encode(embeddedPaymentElement.row.flat.bottomSeparatorEnabled, forKey: .embeddedFlatBottomSeparatorEnabled)
+
+        // Radio colors
+        if let selectedColor = embeddedPaymentElement.row.flat.radio.selectedColor {
+            try container.encode(CodableUIColor(color: selectedColor), forKey: .embeddedFlatRadioSelectedColor)
+        }
+        if let unselectedColor = embeddedPaymentElement.row.flat.radio.unselectedColor {
+            try container.encode(CodableUIColor(color: unselectedColor), forKey: .embeddedFlatRadioUnselectedColor)
+        }
+
+        // Checkmark and chevron colors
+        if let checkmarkColor = embeddedPaymentElement.row.flat.checkmark.color {
+            try container.encode(CodableUIColor(color: checkmarkColor), forKey: .embeddedFlatCheckmarkColor)
+        }
+        try container.encode(CodableUIColor(color: embeddedPaymentElement.row.flat.chevron.color), forKey: .embeddedFlatChevronColor)
+
+        // Floating properties
+        try container.encode(embeddedPaymentElement.row.floating.spacing, forKey: .embeddedFloatingSpacing)
+    }
+}
+
+private struct AppearanceCodableError: Error {
+    let description: String
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/AppearanceCodableExtensions.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/AppearanceCodableExtensions.swift
@@ -79,11 +79,13 @@ extension PaymentSheet.Appearance: Codable {
         self.textFieldInsets = try container.decode(NSDirectionalEdgeInsets.self, forKey: .textFieldInsets)
         self.formInsets = try container.decode(NSDirectionalEdgeInsets.self, forKey: .formInsets)
         self.sectionSpacing = try container.decode(CGFloat.self, forKey: .sectionSpacing)
-        self.iconStyle = switch try container.decode(String.self, forKey: .iconStyle) {
-        case "filled": .filled
-        case "outlined": .outlined
-        default: throw AppearanceCodableError(description: "Unknown icon style")
-        }
+        self.iconStyle = try {
+            switch try container.decode(String.self, forKey: .iconStyle) {
+            case "filled": .filled
+            case "outlined": .outlined
+            default: throw AppearanceCodableError(description: "Unknown icon style")
+            }
+        }()
         self.verticalModeRowPadding = try container.decode(CGFloat.self, forKey: .verticalModeRowPadding)
 
         // Font properties - will need to be expanded if more options are added to the playground
@@ -220,7 +222,8 @@ extension PaymentSheet.Appearance: Codable {
         try container.encode(sectionSpacing, forKey: .sectionSpacing)
         try container.encode(verticalModeRowPadding, forKey: .verticalModeRowPadding)
 
-        let iconStyleString = switch iconStyle {
+        let iconStyleString =
+        switch iconStyle {
         case .filled: "filled"
         case .outlined: "outlined"
         default: throw AppearanceCodableError(description: "Unknown icon style")

--- a/Example/PaymentSheet Example/PaymentSheet Example/AppearancePlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/AppearancePlaygroundView.swift
@@ -487,61 +487,55 @@ struct AppearancePlaygroundView: View {
 
                 Section(header: Text("EmbeddedPaymentElement")) {
                     DisclosureGroup {
+                        Picker("Style", selection: $appearance.embeddedPaymentElement.row.style) {
+                            ForEach(PaymentSheet.Appearance.EmbeddedPaymentElement.Row.Style.allCases, id: \.self) {
+                                Text(String(describing: $0))
+                            }
+                        }
+
+                        Stepper("additionalInsets: \(Int(appearance.embeddedPaymentElement.row.additionalInsets))",
+                                value: $appearance.embeddedPaymentElement.row.additionalInsets, in: 0...40)
+
                         DisclosureGroup {
-                            Picker("Style", selection: $appearance.embeddedPaymentElement.row.style) {
-                                ForEach(PaymentSheet.Appearance.EmbeddedPaymentElement.Row.Style.allCases, id: \.self) {
-                                    Text(String(describing: $0))
-                                }
-                            }
-
-                            Stepper("additionalInsets: \(Int(appearance.embeddedPaymentElement.row.additionalInsets))",
-                                    value: $appearance.embeddedPaymentElement.row.additionalInsets, in: 0...40)
-
-                            DisclosureGroup {
-                                Stepper("separatorThickness: \(Int(appearance.embeddedPaymentElement.row.flat.separatorThickness))",
-                                        value: $appearance.embeddedPaymentElement.row.flat.separatorThickness, in: 0...10)
-                                ColorPicker("separatorColor", selection: embeddedPaymentElementFlatSeparatorColorBinding)
-                                Stepper("leftSeparatorInset: \(Int(appearance.embeddedPaymentElement.row.flat.separatorInsets?.left ?? 0))",
-                                        value: embeddedPaymentElementFlatLeftSeparatorInset, in: -40...40)
-                                Stepper("rightSeparatorInset: \(Int(appearance.embeddedPaymentElement.row.flat.separatorInsets?.right ?? 0))",
-                                        value: embeddedPaymentElementFlatRightSeparatorInset, in: -40...40)
-                                Toggle("topSeparatorEnabled", isOn: $appearance.embeddedPaymentElement.row.flat.topSeparatorEnabled)
-                                Toggle("bottomSeparatorEnabled", isOn: $appearance.embeddedPaymentElement.row.flat.bottomSeparatorEnabled)
-
-                                DisclosureGroup {
-                                    ColorPicker("selectedColor", selection: embeddedPaymentElementFlatRadioColorSelected)
-                                    ColorPicker("unselectedColor", selection: embeddedPaymentElementFlatRadioColorUnselected)
-                                } label: {
-                                    Text("Radio")
-                                }
-
-                            } label: {
-                                Text("FlatWithRadio")
-                            }
+                            Stepper("separatorThickness: \(Int(appearance.embeddedPaymentElement.row.flat.separatorThickness))",
+                                    value: $appearance.embeddedPaymentElement.row.flat.separatorThickness, in: 0...10)
+                            ColorPicker("separatorColor", selection: embeddedPaymentElementFlatSeparatorColorBinding)
+                            Stepper("leftSeparatorInset: \(Int(appearance.embeddedPaymentElement.row.flat.separatorInsets?.left ?? 0))",
+                                    value: embeddedPaymentElementFlatLeftSeparatorInset, in: -40...40)
+                            Stepper("rightSeparatorInset: \(Int(appearance.embeddedPaymentElement.row.flat.separatorInsets?.right ?? 0))",
+                                    value: embeddedPaymentElementFlatRightSeparatorInset, in: -40...40)
+                            Toggle("topSeparatorEnabled", isOn: $appearance.embeddedPaymentElement.row.flat.topSeparatorEnabled)
+                            Toggle("bottomSeparatorEnabled", isOn: $appearance.embeddedPaymentElement.row.flat.bottomSeparatorEnabled)
 
                             DisclosureGroup {
-                                Stepper("Spacing: \(Int(appearance.embeddedPaymentElement.row.floating.spacing))",
-                                        value: $appearance.embeddedPaymentElement.row.floating.spacing, in: 0...40)
-
+                                ColorPicker("selectedColor", selection: embeddedPaymentElementFlatRadioColorSelected)
+                                ColorPicker("unselectedColor", selection: embeddedPaymentElementFlatRadioColorUnselected)
                             } label: {
-                                Text("FloatingButton")
+                                Text("Radio")
                             }
                             DisclosureGroup {
                                 ColorPicker("checkmarkColor", selection: embeddedPaymentElementCheckmarkColorBinding)
                             } label: {
-                                Text("FlatWithCheckmark")
+                                Text("Checkmark")
                             }
                             DisclosureGroup {
                                 ColorPicker("chevronColor", selection: embeddedPaymentElementChevronColorBinding)
                             } label: {
-                                Text("FlatWithChevron")
+                                Text("Chevron")
                             }
                         } label: {
-                            Text("Row")
+                            Text("Flat")
                         }
 
+                        DisclosureGroup {
+                            Stepper("Spacing: \(Int(appearance.embeddedPaymentElement.row.floating.spacing))",
+                                    value: $appearance.embeddedPaymentElement.row.floating.spacing, in: 0...40)
+
+                        } label: {
+                            Text("FloatingButton")
+                        }
                     } label: {
-                        Text("EmbeddedPaymentElement")
+                        Text("EmbeddedPaymentElement.Row")
                     }
                 }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -14,8 +14,8 @@ struct PaymentSheetTestPlayground: View {
     @StateObject var analyticsLogObserver: AnalyticsLogObserver = .shared
     @State var showingQRSheet = false
 
-    init(settings: PaymentSheetTestPlaygroundSettings) {
-        _playgroundController = StateObject(wrappedValue: PlaygroundController(settings: settings))
+    init(settings: PaymentSheetTestPlaygroundSettings, appearance: PaymentSheet.Appearance) {
+        _playgroundController = StateObject(wrappedValue: PlaygroundController(settings: settings, appearance: appearance))
     }
 
     @ViewBuilder
@@ -618,6 +618,6 @@ struct SettingPickerView<S: PickerEnum>: View {
 @available(iOS 15.0, *)
 struct PaymentSheetTestPlayground_Previews: PreviewProvider {
     static var previews: some View {
-        PaymentSheetTestPlayground(settings: .defaultValues())
+        PaymentSheetTestPlayground(settings: .defaultValues(), appearance: PaymentSheet.Appearance.default)
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -711,6 +711,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
 
     static let nsUserDefaultsKey = "PaymentSheetTestPlaygroundSettings"
     static let nsUserDefaultsCustomerIDKey = "PaymentSheetTestPlaygroundCustomerId"
+    static let nsUserDefaultsAppearanceKey = "PaymentSheetTestPlaygroundAppearance"
 
     static let baseEndpoint = "https://stp-mobile-playground-backend-v7.stripedemos.com"
     static var endpointSelectorEndpoint: String {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -1027,8 +1027,8 @@ extension PlaygroundController {
         }
 
         // save appearance setting
-        let data = try! JSONEncoder().encode(appearance)
-        UserDefaults.standard.set(data, forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsAppearanceKey)
+        let appearanceData = try! JSONEncoder().encode(appearance)
+        UserDefaults.standard.set(appearanceData, forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsAppearanceKey)
     }
 
     static func settingsFromDefaults() -> PaymentSheetTestPlaygroundSettings? {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -273,6 +273,7 @@ class PlaygroundController: ObservableObject {
         configuration.formSheetAction = formSheetAction
         configuration.embeddedViewDisplaysMandateText = settings.embeddedViewDisplaysMandateText == .on
         configuration.rowSelectionBehavior = settings.rowSelectionBehavior == .default ? .default : .immediateAction { [weak self] in
+            print("immediateAction callback triggered")
             self?.embeddedPlaygroundViewController?.dismiss(animated: true)
             self?.embeddedPlaygroundViewController?.updatePaymentOptionView()
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/SceneDelegate.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/SceneDelegate.swift
@@ -41,7 +41,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     @available(iOS 15.0, *)
     func launchWith(base64String: String) {
         let settings = PaymentSheetTestPlaygroundSettings.fromBase64(base64: base64String, className: PaymentSheetTestPlaygroundSettings.self)!
-        let hvc = UIHostingController(rootView: PaymentSheetTestPlayground(settings: settings))
+        let hvc = UIHostingController(rootView: PaymentSheetTestPlayground(settings: settings, appearance: PaymentSheet.Appearance.default))
         let navController = UINavigationController(rootViewController: hvc)
         self.window!.rootViewController = navController
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/ViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import StripePaymentSheet
 import SwiftUI
 import UIKit
 
@@ -25,7 +26,7 @@ class ViewController: UIViewController {
     }
     @IBSegueAction func showSwiftUITestPlayground(_ coder: NSCoder) -> UIViewController? {
         if #available(iOS 15.0, *) {
-            return UIHostingController(coder: coder, rootView: PaymentSheetTestPlayground(settings: PlaygroundController.settingsFromDefaults() ?? .defaultValues()))
+            return UIHostingController(coder: coder, rootView: PaymentSheetTestPlayground(settings: PlaygroundController.settingsFromDefaults() ?? .defaultValues(), appearance: PlaygroundController.appearanceFromDefaults() ?? PaymentSheet.Appearance.default))
         } else {
             fatalError(">= iOS 15.0 required")
         }


### PR DESCRIPTION
## Summary
Propagate the PaymentSheet.Appearance settings to UserDefaults so that they are maintained between loads.

## Motivation
Ease of testing.

## Testing
Confirmed that settings are successfully saved between initializations.

## Changelog
N/A
