### PR TITLE
Fix Link view controller jank

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
@@ -117,7 +117,7 @@ extension PayWithLinkViewController {
                 contentView.topAnchor.constraint(equalTo: stackView.topAnchor),
                 contentView.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
                 contentView.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
-                contentView.bottomAnchor.constraint(greaterThanOrEqualTo: stackView.bottomAnchor),
+                contentView.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
             ])
 
             if !paymentMethod.isDefault || isBillingDetailsUpdateFlow {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -221,6 +221,9 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
         contentContainerView.addArrangedSubview(self.contentViewController.view)
         if let presentationController = rootParent.presentationController as? BottomSheetPresentationController {
             presentationController.forceFullHeight = newContentViewController.requiresFullScreen
+
+            // Force layout pass to apply safe area insets
+            presentationController.containerView?.layoutIfNeeded()
         }
 
         contentContainerView.layoutIfNeeded()


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an animation issue when opening the `Add payment method` and `Update card` screens in the native Link UI, where the bottom sheet height would suddenly change at the end of the animation.

### Before

https://github.com/user-attachments/assets/7a80b5d8-3b07-44df-9938-88121f8ae16b

### After

https://github.com/user-attachments/assets/1219b357-f5f7-4e8a-90e9-c183b2a20fcf


## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
