### PR TITLE
Send SellerInfo to elements/sessions

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -48,7 +48,7 @@ extension STPAPIClient {
                 if let sellerDetails = intentConfig.sellerDetails {
                     deferredIntent["seller_details"] = [
                         "network_id": sellerDetails.networkId,
-                        "external_id": sellerDetails.externalId
+                        "external_id": sellerDetails.externalId,
                     ]
                 }
                 switch intentConfig.mode {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -38,18 +38,18 @@ extension STPAPIClient {
         case .deferredIntent(let intentConfig):
             parameters["type"] = "deferred_intent"
             parameters["key"] = publishableKey
+            if let sellerDetails = intentConfig.sellerDetails {
+                parameters["seller_details"] = [
+                    "network_id": sellerDetails.networkId,
+                    "external_id": sellerDetails.externalId,
+                ]
+            }
             parameters["deferred_intent"] = {
                 var deferredIntent = [String: Any]()
                 deferredIntent["payment_method_types"] = intentConfig.paymentMethodTypes
                 deferredIntent["on_behalf_of"] = intentConfig.onBehalfOf
                 if let paymentMethodConfigurationId = intentConfig.paymentMethodConfigurationId {
                     deferredIntent["payment_method_configuration"] = ["id": paymentMethodConfigurationId]
-                }
-                if let sellerDetails = intentConfig.sellerDetails {
-                    deferredIntent["seller_details"] = [
-                        "network_id": sellerDetails.networkId,
-                        "external_id": sellerDetails.externalId,
-                    ]
                 }
                 switch intentConfig.mode {
                 case .payment(let amount, let currency, let setupFutureUsage, let captureMethod, _):

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -45,6 +45,12 @@ extension STPAPIClient {
                 if let paymentMethodConfigurationId = intentConfig.paymentMethodConfigurationId {
                     deferredIntent["payment_method_configuration"] = ["id": paymentMethodConfigurationId]
                 }
+                if let sellerDetails = intentConfig.sellerDetails {
+                    deferredIntent["seller_details"] = [
+                        "network_id": sellerDetails.networkId,
+                        "external_id": sellerDetails.externalId
+                    ]
+                }
                 switch intentConfig.mode {
                 case .payment(let amount, let currency, let setupFutureUsage, let captureMethod, _):
                     deferredIntent["mode"] = "payment"

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -177,7 +177,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
 
         let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as? [String: Any])
         let sellerDetailsParams = try XCTUnwrap(deferredIntent["seller_details"] as? [String: Any])
-        
+
         XCTAssertEqual(sellerDetailsParams["network_id"] as? String, "network_123")
         XCTAssertEqual(sellerDetailsParams["external_id"] as? String, "external_456")
     }
@@ -198,7 +198,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         )
 
         let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as? [String: Any])
-        
+
         XCTAssertNil(deferredIntent["seller_details"])
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -158,7 +158,7 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         XCTAssertNil(parameters["customer_session_client_secret"])
     }
 
-    func testElementsSessionParameters_DeferredPayment_WithSellerDetails() throws {
+        func testElementsSessionParameters_DeferredPayment_WithSellerDetails() throws {
         let sellerDetails = PaymentSheet.IntentConfiguration.SellerDetails(networkId: "network_123", externalId: "external_456")
         let intentConfig = PaymentSheet.IntentConfiguration(
             sharedPaymentTokenSessionWithMode: .payment(amount: 2000, currency: "USD"),
@@ -175,14 +175,13 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
             customerAccessProvider: nil
         )
 
-        let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as? [String: Any])
-        let sellerDetailsParams = try XCTUnwrap(deferredIntent["seller_details"] as? [String: Any])
+        let sellerDetailsParams = try XCTUnwrap(parameters["seller_details"] as? [String: Any])
 
         XCTAssertEqual(sellerDetailsParams["network_id"] as? String, "network_123")
         XCTAssertEqual(sellerDetailsParams["external_id"] as? String, "external_456")
     }
 
-    func testElementsSessionParameters_DeferredPayment_WithoutSellerDetails() throws {
+        func testElementsSessionParameters_DeferredPayment_WithoutSellerDetails() throws {
         let intentConfig = PaymentSheet.IntentConfiguration(
             mode: .payment(amount: 2000, currency: "USD"),
             paymentMethodTypes: ["card"],
@@ -197,8 +196,6 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
             customerAccessProvider: nil
         )
 
-        let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as? [String: Any])
-
-        XCTAssertNil(deferredIntent["seller_details"])
+        XCTAssertNil(parameters["seller_details"])
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -11,7 +11,7 @@ import XCTest
 
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripePayments
-@testable@_spi(STP)@_spi(CustomerSessionBetaAccess)@_spi(CustomPaymentMethodsBeta) import StripePaymentSheet
+@testable@_spi(STP)@_spi(CustomerSessionBetaAccess)@_spi(CustomPaymentMethodsBeta)@_spi(SharedPaymentToken) import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsUI
 
 class STPAPIClient_PaymentSheetTest: XCTestCase {
@@ -156,5 +156,49 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         )
         XCTAssertNil(parameters["legacy_customer_ephemeral_key"])
         XCTAssertNil(parameters["customer_session_client_secret"])
+    }
+
+    func testElementsSessionParameters_DeferredPayment_WithSellerDetails() throws {
+        let sellerDetails = PaymentSheet.IntentConfiguration.SellerDetails(networkId: "network_123", externalId: "external_456")
+        let intentConfig = PaymentSheet.IntentConfiguration(
+            sharedPaymentTokenSessionWithMode: .payment(amount: 2000, currency: "USD"),
+            sellerDetails: sellerDetails,
+            paymentMethodTypes: ["card"],
+            preparePaymentMethodHandler: { _, _ in }
+        )
+
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(
+            mode: .deferredIntent(intentConfig),
+            epmConfiguration: nil,
+            cpmConfiguration: nil,
+            clientDefaultPaymentMethod: nil,
+            customerAccessProvider: nil
+        )
+
+        let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as? [String: Any])
+        let sellerDetailsParams = try XCTUnwrap(deferredIntent["seller_details"] as? [String: Any])
+        
+        XCTAssertEqual(sellerDetailsParams["network_id"] as? String, "network_123")
+        XCTAssertEqual(sellerDetailsParams["external_id"] as? String, "external_456")
+    }
+
+    func testElementsSessionParameters_DeferredPayment_WithoutSellerDetails() throws {
+        let intentConfig = PaymentSheet.IntentConfiguration(
+            mode: .payment(amount: 2000, currency: "USD"),
+            paymentMethodTypes: ["card"],
+            confirmHandler: { _, _, _ in }
+        )
+
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(
+            mode: .deferredIntent(intentConfig),
+            epmConfiguration: nil,
+            cpmConfiguration: nil,
+            clientDefaultPaymentMethod: nil,
+            customerAccessProvider: nil
+        )
+
+        let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as? [String: Any])
+        
+        XCTAssertNil(deferredIntent["seller_details"])
     }
 }


### PR DESCRIPTION
## Summary
Send the SellerInfo to the elements/sessions endpoint.

## Motivation
Enabling the SPT flow

## Testing
Added tests, tested in PS Example

## Changelog
N/A