### PR TITLE
ShopPay updates for shipping and auto click

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
@@ -228,6 +228,11 @@ class ExampleWalletButtonsModel: ObservableObject {
         let fiveBusinessDays = PaymentSheet.ShopPayConfiguration.DeliveryEstimate.DeliveryEstimateUnit(value: 5, unit: .business_day)
         let sevenBusinessDays = PaymentSheet.ShopPayConfiguration.DeliveryEstimate.DeliveryEstimateUnit(value: 7, unit: .business_day)
 
+        let shippingRates: [PaymentSheet.ShopPayConfiguration.ShippingRate] = [
+            .init(id: "express", amount: 1099, displayName: "Overnight", deliveryEstimate: .init(minimum: singleBusinessDay, maximum: singleBusinessDay)),
+            .init(id: "standard", amount: 0, displayName: "Free", deliveryEstimate: .init(minimum: fiveBusinessDays, maximum: sevenBusinessDays)),
+        ]
+
         let handlers = PaymentSheet.ShopPayConfiguration.Handlers(
             shippingMethodUpdateHandler: { shippingRateSelected, completion in
                 // Process the selected shipping method
@@ -237,29 +242,11 @@ class ExampleWalletButtonsModel: ObservableObject {
 
                 // Create the update with the new line items and available shipping rates
                 let update = PaymentSheet.ShopPayConfiguration.ShippingRateUpdate(
-                    lineItems: [.init(name: "Subtotal", amount: 200),
+                    lineItems: [.init(name: "Golden Potato", amount: 500),
+                                .init(name: "Silver Potato", amount: 345),
                                 .init(name: "Tax", amount: 200),
                                 .init(name: "Shipping", amount: selectedRate.amount), ],
-                    shippingRates: [
-                        PaymentSheet.ShopPayConfiguration.ShippingRate(
-                            id: "standard",
-                            amount: 500,
-                            displayName: "Standard Shipping",
-                            deliveryEstimate: PaymentSheet.ShopPayConfiguration.DeliveryEstimate(
-                                minimum: .init(value: 3, unit: .business_day),
-                                maximum: .init(value: 5, unit: .business_day)
-                            )
-                        ),
-                        PaymentSheet.ShopPayConfiguration.ShippingRate(
-                            id: "express",
-                            amount: 1000,
-                            displayName: "Express Shipping",
-                            deliveryEstimate: .init(
-                                minimum: .init(value: 1, unit: .business_day),
-                                maximum: .init(value: 2, unit: .business_day)
-                            )
-                        ),
-                    ]
+                    shippingRates: shippingRates
                 )
 
                 // Return the update to the Shop Pay UI
@@ -276,11 +263,10 @@ class ExampleWalletButtonsModel: ObservableObject {
 
                 if canShipToLocation {
                     // Create available shipping rates based on the location
-                    let shippingRates = self.getShippingRatesForLocation(address)
-
                     // Return the update with new line items and shipping rates
                     let update = PaymentSheet.ShopPayConfiguration.ShippingContactUpdate(
-                        lineItems: [.init(name: "Subtotal", amount: 200),
+                        lineItems: [.init(name: "Golden Potato", amount: 500),
+                                    .init(name: "Silver Potato", amount: 345),
                                     .init(name: "Tax", amount: 200),
                                     .init(name: "Shipping", amount: shippingRates.first!.amount), ],
                         shippingRates: shippingRates
@@ -295,37 +281,16 @@ class ExampleWalletButtonsModel: ObservableObject {
         )
 
         return PaymentSheet.ShopPayConfiguration(shippingAddressRequired: true,
-                                                 lineItems: [.init(name: "Golden Potato", amount: 500), .init(name: "Silver Potato", amount: 345), .init(name: "Tax", amount: 200)],
-                                                 shippingRates: [.init(id: "express", amount: 1099, displayName: "Overnight", deliveryEstimate: .init(minimum: singleBusinessDay, maximum: singleBusinessDay)),
-                                                                 .init(id: "standard", amount: 0, displayName: "Free", deliveryEstimate: .init(minimum: fiveBusinessDays, maximum: sevenBusinessDays)),
-                                                                ],
+                                                 lineItems: [.init(name: "Golden Potato", amount: 500),
+                                                             .init(name: "Silver Potato", amount: 345),
+                                                             .init(name: "Tax", amount: 200),
+                                                             .init(name: "Shipping", amount: shippingRates.first!.amount), ],
+                                                 shippingRates: shippingRates,
                                                  shopId: self.shopId,
                                                  handlers: handlers)
     }
     func isValidShippingLocation(_ address: PaymentSheet.ShopPayConfiguration.PartialAddress) -> Bool {
         return true
-    }
-    func getShippingRatesForLocation(_ address: PaymentSheet.ShopPayConfiguration.PartialAddress) -> [PaymentSheet.ShopPayConfiguration.ShippingRate] {
-        return [
-            PaymentSheet.ShopPayConfiguration.ShippingRate(
-                id: "standard",
-                amount: 500,
-                displayName: "Standard Shipping",
-                deliveryEstimate: .init(
-                    minimum: .init(value: 3, unit: .business_day),
-                    maximum: .init(value: 5, unit: .business_day)
-                )
-            ),
-            PaymentSheet.ShopPayConfiguration.ShippingRate(
-                id: "express",
-                amount: 1000,
-                displayName: "Express Shipping",
-                deliveryEstimate: .init(
-                    minimum: .init(value: 1, unit: .business_day),
-                    maximum: .init(value: 2, unit: .business_day)
-                )
-            ),
-        ]
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEBridgeTypes.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEBridgeTypes.swift
@@ -4,6 +4,7 @@
 //
 
 import Foundation
+import StripePayments
 
 // MARK: - Shipping Address Types
 
@@ -137,6 +138,13 @@ struct ECEDeliveryEstimateUnit: Codable {
     }
 }
 
+struct ECEPaymentMethodOptions: Codable {
+    struct ShopPay: Codable {
+        let externalSourceId: String
+    }
+    let shopPay: ShopPay?
+}
+
 // MARK: - Line Item Types
 
 /// Line item shown in the payment interface
@@ -219,6 +227,9 @@ struct ECEConfirmEventData: Codable {
 
     /// Selected shipping rate
     let shippingRate: ECEShippingRate?
+
+    /// Payment method options
+    let paymentMethodOptions: ECEPaymentMethodOptions?
 }
 
 /// Shipping address data from confirm event
@@ -228,6 +239,19 @@ struct ECEShippingAddressData: Codable {
 
     /// The full shipping address
     let address: ECEFullAddress?
+}
+extension ECEShippingAddressData {
+    func toSTPAddress() -> STPAddress {
+        let stpAddress = STPAddress()
+        stpAddress.name = name
+        stpAddress.line1 = address?.line1
+        stpAddress.line2 = address?.line2
+        stpAddress.city = address?.city
+        stpAddress.state = address?.state
+        stpAddress.postalCode = address?.postalCode
+        stpAddress.country = address?.country
+        return stpAddress
+    }
 }
 
 // MARK: - Express Payment Type

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEIndexHtml.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEIndexHtml.swift
@@ -3,7 +3,12 @@
 //  StripePaymentSheet
 //
 
-let ECEHTML = """
+struct ECEIndexHTML {
+    let shopId: String
+    let customerSessionClientSecret: String
+
+    var ECEHTML: String {
+"""
 <!DOCTYPE html>
 <html>
   <head>
@@ -36,6 +41,13 @@ let ECEHTML = """
           amount: window.NATIVE_AMOUNT_TOTAL,
           currency: "usd",
           payment_method_types: ["card", "link", "shop_pay"],
+          customerSessionClientSecret: "\(customerSessionClientSecret)",
+          paymentMethodOptions: {
+            shop_pay: {
+              shop_id: "\(shopId)",
+            },
+          },
+          __elementsInitSource: 'native_sdk',
         };
 
       console.log("Initializing stripe elements with options", options);
@@ -84,6 +96,7 @@ let ECEHTML = """
         } else {
           expressCheckoutDiv.style.visibility = "initial";
         }
+        expressCheckoutElement._sendNativeSdkClick({paymentMethodType: 'shop_pay'})
       });
 
       expressCheckoutElement.on("click", async function (event) {
@@ -215,7 +228,7 @@ let ECEHTML = """
               shippingRate: event.shippingRate,
               mode: mode,
               captureMethod: captureMethod,
-              //paymentMethod: paymentMethod,
+              paymentMethodOptions: event._paymentMethodOptions,
             };
 
             const response = await window.NativeStripeECE.confirmPayment(paymentDetails);
@@ -245,3 +258,5 @@ let ECEHTML = """
   </body>
 </html>
 """
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEViewController.swift
@@ -36,9 +36,15 @@ enum ExpressCheckoutError: LocalizedError {
 @available(iOS 16.0, *)
 class ECEViewController: UIViewController {
     let apiClient: STPAPIClient
+    let shopId: String
+    let customerSessionClientSecret: String
 
-    init(apiClient: STPAPIClient) {
+    init(apiClient: STPAPIClient,
+         shopId: String,
+         customerSessionClientSecret: String) {
         self.apiClient = apiClient
+        self.shopId = shopId
+        self.customerSessionClientSecret = customerSessionClientSecret
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -216,7 +222,8 @@ class ECEViewController: UIViewController {
     }
 
     private func loadECE() {
-        webView.loadHTMLString(ECEHTML, baseURL: URL(string: "https://pay.stripe.com")!)
+        let staticHTML = ECEIndexHTML(shopId: shopId, customerSessionClientSecret: customerSessionClientSecret)
+        webView.loadHTMLString(staticHTML.ECEHTML, baseURL: URL(string: "https://pay.stripe.com")!)
     }
 
     @objc private func refreshWebView() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ShopPayECEPresenter.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ShopPayECEPresenter.swift
@@ -14,16 +14,19 @@ import WebKit
 class ShopPayECEPresenter: NSObject, UIAdaptivePresentationControllerDelegate {
     private let flowController: PaymentSheet.FlowController
     private let shopPayConfiguration: PaymentSheet.ShopPayConfiguration
+    private let customerSessionClientSecret: String
     private var confirmHandler: ((PaymentSheetResult) -> Void)?
     private var eceViewController: ECEViewController?
     private weak var presentingViewController: UIViewController?
 
     init(
         flowController: PaymentSheet.FlowController,
-        configuration: PaymentSheet.ShopPayConfiguration
+        configuration: PaymentSheet.ShopPayConfiguration,
+        customerSessionClientSecret: String
     ) {
         self.flowController = flowController
         self.shopPayConfiguration = configuration
+        self.customerSessionClientSecret = customerSessionClientSecret
         super.init()
     }
 
@@ -31,12 +34,15 @@ class ShopPayECEPresenter: NSObject, UIAdaptivePresentationControllerDelegate {
                  confirmHandler: @escaping (PaymentSheetResult) -> Void) {
         self.presentingViewController = viewController
 
-        let eceVC = ECEViewController(apiClient: flowController.configuration.apiClient)
-         eceVC.expressCheckoutWebviewDelegate = self
-         self.eceViewController = eceVC
+        let eceVC = ECEViewController(apiClient: flowController.configuration.apiClient,
+                                      shopId: shopPayConfiguration.shopId,
+                                      customerSessionClientSecret: customerSessionClientSecret)
+
+        eceVC.expressCheckoutWebviewDelegate = self
+        self.eceViewController = eceVC
         let navController = UINavigationController(rootViewController: eceVC)
-         navController.modalPresentationStyle = .pageSheet
-         viewController.present(navController, animated: true)
+        navController.modalPresentationStyle = .pageSheet
+        viewController.present(navController, animated: true)
         eceVC.presentationController?.delegate = self
         // retain self while presented
         self.confirmHandler = { result in
@@ -101,7 +107,7 @@ extension ShopPayECEPresenter: ExpressCheckoutWebviewDelegate {
                                 )
                             },
                             applePay: nil,
-                            totalAmount: self.calculateTotal(lineItems: update.lineItems, shippingRates: update.shippingRates)
+                            totalAmount: self.calculateTotal(lineItems: update.lineItems)
                         )
 
                         // Convert to dictionary for JavaScript
@@ -132,7 +138,7 @@ extension ShopPayECEPresenter: ExpressCheckoutWebviewDelegate {
                     )
                 },
                 applePay: nil,
-                totalAmount: calculateTotal(lineItems: shopPayConfiguration.lineItems, shippingRates: shopPayConfiguration.shippingRates)
+                totalAmount: calculateTotal(lineItems: shopPayConfiguration.lineItems)
             )
 
             return try ECEBridgeTypes.encode(response)
@@ -168,7 +174,7 @@ extension ShopPayECEPresenter: ExpressCheckoutWebviewDelegate {
                                 )
                             },
                             applePay: nil,
-                            totalAmount: self.calculateTotal(lineItems: update.lineItems, selectedShippingRate: matchingRate)
+                            totalAmount: self.calculateTotal(lineItems: update.lineItems)
                         )
 
                         // Convert to dictionary for JavaScript
@@ -199,7 +205,7 @@ extension ShopPayECEPresenter: ExpressCheckoutWebviewDelegate {
                     )
                 },
                 applePay: nil,
-                totalAmount: calculateTotal(lineItems: shopPayConfiguration.lineItems, selectedShippingRate: matchingRate)
+                totalAmount: calculateTotal(lineItems: shopPayConfiguration.lineItems)
             )
 
             return try ECEBridgeTypes.encode(response)
@@ -241,12 +247,25 @@ extension ShopPayECEPresenter: ExpressCheckoutWebviewDelegate {
         let confirmData = try ECEBridgeTypes.decode(ECEConfirmEventData.self, from: paymentDetails)
 
         guard let billingDetails = confirmData.billingDetails else {
-            throw ExpressCheckoutError.missingRequiredField(field: "billingDetails")
+            let error = ExpressCheckoutError.missingRequiredField(field: "billingDetails")
+            dismissECE { [weak self] in
+                guard let self = self else { return }
+                self.confirmHandler?(.failed(error: error))
+            }
+            throw error
+        }
+        guard let externalSourceId = confirmData.paymentMethodOptions?.shopPay?.externalSourceId else {
+            let error = ExpressCheckoutError.missingRequiredField(field: "externalSourceId")
+            dismissECE { [weak self] in
+                guard let self = self else { return }
+                self.confirmHandler?(.failed(error: error))
+            }
+            throw error
         }
 
         // Create Shop Pay payment method params
         let shopPayParams = STPPaymentMethodShopPayParams()
-        shopPayParams.externalSourceId = "TODO_12345" // TODO: Parse from paymentDetails when ready
+        shopPayParams.externalSourceId = externalSourceId
         let paymentMethodParams = STPPaymentMethodParams(shopPay: shopPayParams,
                                                          billingDetails: STPPaymentMethodBillingDetails(),
                                                          metadata: nil)
@@ -263,26 +282,35 @@ extension ShopPayECEPresenter: ExpressCheckoutWebviewDelegate {
         }
 
         // Create payment method
-        // TODO: If this fails, then return a PaymentSheetResult failed?
-        let paymentMethod = try await flowController.configuration.apiClient.createPaymentMethod(with: paymentMethodParams,
+        do {
+            let paymentMethod = try await flowController.configuration.apiClient.createPaymentMethod(with: paymentMethodParams,
                                                                                                  additionalPaymentUserAgentValues: [])
+            // Dismiss ECE and return the payment method ID on the main thread
+            Task { @MainActor in
+                dismissECE { [weak self] in
+                    guard let self = self else { return }
 
-        // Dismiss ECE and return the payment method ID on the main thread
-        Task { @MainActor in
-
+                    guard case .deferredIntent(let intentConfig) = self.flowController.intent else  {
+                        stpAssertionFailure("Integration Error: Shop Pay ECE flow requires a deferred intent.")
+                        return
+                    }
+                    // Call the intent config confirm handler first
+                    guard let preparePaymentMethodHandler = intentConfig.preparePaymentMethodHandler else {
+                        stpAssertionFailure("Integration Error: Shop Pay ECE flow requires a preparePaymentMethodHandler")
+                        return
+                    }
+                    preparePaymentMethodHandler(paymentMethod,
+                                                confirmData.shippingAddress?.toSTPAddress())
+                    // And then the PaymentSheet presentation handler
+                    self.confirmHandler?(.completed)
+                }
+            }
+        } catch {
             dismissECE { [weak self] in
                 guard let self = self else { return }
-
-                guard case .deferredIntent(let intentConfig) = self.flowController.intent else  {
-                    stpAssertionFailure("Integration Error: Shop Pay ECE flow requires a deferred intent.")
-                    return
-                }
-                // TODO: Replace this to use the new facilitatedPaymentSession confirmation handler when ready
-                // Call the intent config confirm handler first
-                intentConfig.confirmHandler(paymentMethod, false, { _ in })
-                // And then the PaymentSheet presentation handler
-                self.confirmHandler?(.completed)
+                self.confirmHandler?(.failed(error: error))
             }
+            throw error
         }
 
         // Return success response to webview
@@ -324,14 +352,7 @@ extension ShopPayECEPresenter: ExpressCheckoutWebviewDelegate {
         }
     }
 
-    private func calculateTotal(lineItems: [PaymentSheet.ShopPayConfiguration.LineItem], shippingRates: [PaymentSheet.ShopPayConfiguration.ShippingRate]) -> Int {
-        let itemsTotal = lineItems.reduce(0) { $0 + $1.amount }
-        let defaultShippingAmount = shippingRates.first?.amount ?? 0
-        return itemsTotal + defaultShippingAmount
-    }
-
-    private func calculateTotal(lineItems: [PaymentSheet.ShopPayConfiguration.LineItem], selectedShippingRate: PaymentSheet.ShopPayConfiguration.ShippingRate) -> Int {
-        let itemsTotal = lineItems.reduce(0) { $0 + $1.amount }
-        return itemsTotal + selectedShippingRate.amount
+    private func calculateTotal(lineItems: [PaymentSheet.ShopPayConfiguration.LineItem]) -> Int {
+        return lineItems.reduce(0) { $0 + $1.amount }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -162,11 +162,17 @@ import WebKit
                 confirmHandler(.failed(error: error))
                 return
             }
+            guard case .customerSession(let customerSessionClientSecret) = flowController.configuration.customer?.customerAccessProvider else {
+                let error = PaymentSheetError.integrationError(nonPIIDebugDescription: "CustomerSession client secret is missing")
+                confirmHandler(.failed(error: error))
+                return
+            }
 
             // Present Shop Pay via ECE WebView
             let shopPayPresenter = ShopPayECEPresenter(
                 flowController: flowController,
-                configuration: shopPayConfig
+                configuration: shopPayConfig,
+                customerSessionClientSecret: customerSessionClientSecret
             )
             shopPayPresenter.present(from: WindowAuthenticationContext().authenticationPresentingViewController(),
                                      confirmHandler: confirmHandler)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -162,17 +162,11 @@ import WebKit
                 confirmHandler(.failed(error: error))
                 return
             }
-            guard case .customerSession(let customerSessionClientSecret) = flowController.configuration.customer?.customerAccessProvider else {
-                let error = PaymentSheetError.integrationError(nonPIIDebugDescription: "CustomerSession client secret is missing")
-                confirmHandler(.failed(error: error))
-                return
-            }
 
             // Present Shop Pay via ECE WebView
             let shopPayPresenter = ShopPayECEPresenter(
                 flowController: flowController,
-                configuration: shopPayConfig,
-                customerSessionClientSecret: customerSessionClientSecret
+                configuration: shopPayConfig
             )
             shopPayPresenter.present(from: WindowAuthenticationContext().authenticationPresentingViewController(),
                                      confirmHandler: confirmHandler)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEViewControllerSnapshotTests.swift
@@ -25,7 +25,9 @@ class ECEViewControllerSnapshotTests: STPSnapshotTestCase {
 
         mockAPIClient = STPAPIClient(publishableKey: "pk_test_123")
         mockDelegate = MockExpressCheckoutWebviewDelegate()
-        sut = ECEViewController(apiClient: mockAPIClient)
+        sut = ECEViewController(apiClient: mockAPIClient,
+                                shopId: "shop_id_123",
+                                customerSessionClientSecret: "cuss_12345")
         sut.expressCheckoutWebviewDelegate = mockDelegate
 
         navigationController = UINavigationController(rootViewController: sut)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEViewControllerTests.swift
@@ -22,7 +22,9 @@ class ECEViewControllerTests: XCTestCase {
         super.setUp()
         mockAPIClient = STPAPIClient(publishableKey: "pk_test_123")
         mockDelegate = MockExpressCheckoutWebviewDelegate()
-        sut = ECEViewController(apiClient: mockAPIClient)
+        sut = ECEViewController(apiClient: mockAPIClient,
+                                shopId: "shop_id_123",
+                                customerSessionClientSecret: "cuss_12345")
         sut.expressCheckoutWebviewDelegate = mockDelegate
     }
 


### PR DESCRIPTION
## Summary
ECE Additions: 
* Passes additional params - __elementsInitSource, customersessionclientsecret, paymentOptions
* Executes expressCheckoutElement._sendNativeSdkClick({paymentMethodType: 'shop_pay'})

Native Additions:
* Calculate total amount based on what is listed in lineItems
* Parse external source id from confirm message and route through preparePaymentMethodHandler
* Parse shipping information from confirm message and route through preparePaymentMethodHandler

## Motivation
Basic end to end flow working with basic error handling.


## Testing
Happy path seems to work, and will work on edge cases/jank next

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
