### PR TITLE
Refactor collapsing list view to be reusable.

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -72,11 +72,11 @@
 		3147CEC12CC080570067B5E4 /* LinkCookieStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEBC2CC080570067B5E4 /* LinkCookieStore.swift */; };
 		3147CEC22CC080570067B5E4 /* LinkSecureCookieStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEBE2CC080570067B5E4 /* LinkSecureCookieStore.swift */; };
 		3147CECA2CC1BF550067B5E4 /* LinkPaymentMethodPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEC32CC1BF550067B5E4 /* LinkPaymentMethodPicker.swift */; };
-		3147CECB2CC1BF550067B5E4 /* LinkPaymentMethodPicker-CellContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEC62CC1BF550067B5E4 /* LinkPaymentMethodPicker-CellContentView.swift */; };
-		3147CECC2CC1BF550067B5E4 /* LinkPaymentMethodPicker-Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEC52CC1BF550067B5E4 /* LinkPaymentMethodPicker-Cell.swift */; };
-		3147CECD2CC1BF550067B5E4 /* LinkPaymentMethodPicker-Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEC72CC1BF550067B5E4 /* LinkPaymentMethodPicker-Header.swift */; };
-		3147CECE2CC1BF550067B5E4 /* LinkPaymentMethodPicker-RadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEC82CC1BF550067B5E4 /* LinkPaymentMethodPicker-RadioButton.swift */; };
-		3147CECF2CC1BF550067B5E4 /* LinkPaymentMethodPicker-AddButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEC42CC1BF550067B5E4 /* LinkPaymentMethodPicker-AddButton.swift */; };
+		3147CECB2CC1BF550067B5E4 /* LinkPaymentMethodListView-CellContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEC62CC1BF550067B5E4 /* LinkPaymentMethodListView-CellContentView.swift */; };
+		3147CECC2CC1BF550067B5E4 /* LinkPaymentMethodListView-Cell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEC52CC1BF550067B5E4 /* LinkPaymentMethodListView-Cell.swift */; };
+		3147CECD2CC1BF550067B5E4 /* LinkCollapsingListView-Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEC72CC1BF550067B5E4 /* LinkCollapsingListView-Header.swift */; };
+		3147CECE2CC1BF550067B5E4 /* LinkCollapsingListView-RadioButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEC82CC1BF550067B5E4 /* LinkCollapsingListView-RadioButton.swift */; };
+		3147CECF2CC1BF550067B5E4 /* LinkCollapsingListView-AddButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CEC42CC1BF550067B5E4 /* LinkCollapsingListView-AddButton.swift */; };
 		3147CED12CC1BF6E0067B5E4 /* LinkCardEditElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CED02CC1BF6E0067B5E4 /* LinkCardEditElement.swift */; };
 		3147CED82CC1BF860067B5E4 /* LinkVerificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CED62CC1BF860067B5E4 /* LinkVerificationViewController.swift */; };
 		3147CED92CC1BF860067B5E4 /* LinkVerificationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3147CED22CC1BF860067B5E4 /* LinkVerificationController.swift */; };
@@ -136,6 +136,9 @@
 		3EDFACA133567159875143C5 /* STPElementsSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CA2D5E6CAA2990D88F64A4D /* STPElementsSession.swift */; };
 		401128A8DDC7B6E3CBB4381E /* PaymentSheetFormFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2363DF030555E62FDD3B1D42 /* PaymentSheetFormFactory.swift */; };
 		40806EF506CB719299FC90CC /* STPLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 96C9F8CED45EA4B66E770E3E /* STPLocalizedString.swift */; };
+		411242602E0C53F4005B9B19 /* LinkCollapsingListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4112425F2E0C53F0005B9B19 /* LinkCollapsingListView.swift */; };
+		411242622E0C586E005B9B19 /* LinkPaymentMethodListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 411242612E0C586A005B9B19 /* LinkPaymentMethodListView.swift */; };
+		41124BF62E0C7E53005B9B19 /* LinkPaymentMethodListView+Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41124BF52E0C7E4E005B9B19 /* LinkPaymentMethodListView+Header.swift */; };
 		418007102DE0EB85000FEB87 /* ShippingAddressesResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4180070F2DE0EB80000FEB87 /* ShippingAddressesResponse.swift */; };
 		429A68EA92C4101C9BC88269 /* TestModeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64D658AC15478BF1E0A76B9D /* TestModeView.swift */; };
 		4313D6635F10EC460D2ED21E /* SavedPaymentMethodCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AA26FF00FD57F6AA1A7CB83 /* SavedPaymentMethodCollectionView.swift */; };
@@ -554,11 +557,11 @@
 		3147CEBD2CC080570067B5E4 /* LinkInMemoryCookieStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkInMemoryCookieStore.swift; sourceTree = "<group>"; };
 		3147CEBE2CC080570067B5E4 /* LinkSecureCookieStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSecureCookieStore.swift; sourceTree = "<group>"; };
 		3147CEC32CC1BF550067B5E4 /* LinkPaymentMethodPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPaymentMethodPicker.swift; sourceTree = "<group>"; };
-		3147CEC42CC1BF550067B5E4 /* LinkPaymentMethodPicker-AddButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkPaymentMethodPicker-AddButton.swift"; sourceTree = "<group>"; };
-		3147CEC52CC1BF550067B5E4 /* LinkPaymentMethodPicker-Cell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkPaymentMethodPicker-Cell.swift"; sourceTree = "<group>"; };
-		3147CEC62CC1BF550067B5E4 /* LinkPaymentMethodPicker-CellContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkPaymentMethodPicker-CellContentView.swift"; sourceTree = "<group>"; };
-		3147CEC72CC1BF550067B5E4 /* LinkPaymentMethodPicker-Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkPaymentMethodPicker-Header.swift"; sourceTree = "<group>"; };
-		3147CEC82CC1BF550067B5E4 /* LinkPaymentMethodPicker-RadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkPaymentMethodPicker-RadioButton.swift"; sourceTree = "<group>"; };
+		3147CEC42CC1BF550067B5E4 /* LinkCollapsingListView-AddButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkCollapsingListView-AddButton.swift"; sourceTree = "<group>"; };
+		3147CEC52CC1BF550067B5E4 /* LinkPaymentMethodListView-Cell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkPaymentMethodListView-Cell.swift"; sourceTree = "<group>"; };
+		3147CEC62CC1BF550067B5E4 /* LinkPaymentMethodListView-CellContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkPaymentMethodListView-CellContentView.swift"; sourceTree = "<group>"; };
+		3147CEC72CC1BF550067B5E4 /* LinkCollapsingListView-Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkCollapsingListView-Header.swift"; sourceTree = "<group>"; };
+		3147CEC82CC1BF550067B5E4 /* LinkCollapsingListView-RadioButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkCollapsingListView-RadioButton.swift"; sourceTree = "<group>"; };
 		3147CED02CC1BF6E0067B5E4 /* LinkCardEditElement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkCardEditElement.swift; sourceTree = "<group>"; };
 		3147CED22CC1BF860067B5E4 /* LinkVerificationController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkVerificationController.swift; sourceTree = "<group>"; };
 		3147CED32CC1BF860067B5E4 /* LinkVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkVerificationView.swift; sourceTree = "<group>"; };
@@ -623,6 +626,9 @@
 		3F70E5F0FE6218715432D55A /* AddPaymentMethodViewControllerSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddPaymentMethodViewControllerSnapshotTests.swift; sourceTree = "<group>"; };
 		3FBC7DC1A5EFF76C10D29DD6 /* LinkUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkUI.swift; sourceTree = "<group>"; };
 		40EDF386A07E1196FB043798 /* StripePaymentsObjcTestUtils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripePaymentsObjcTestUtils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		4112425F2E0C53F0005B9B19 /* LinkCollapsingListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkCollapsingListView.swift; sourceTree = "<group>"; };
+		411242612E0C586A005B9B19 /* LinkPaymentMethodListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkPaymentMethodListView.swift; sourceTree = "<group>"; };
+		41124BF52E0C7E4E005B9B19 /* LinkPaymentMethodListView+Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkPaymentMethodListView+Header.swift"; sourceTree = "<group>"; };
 		4180070F2DE0EB80000FEB87 /* ShippingAddressesResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingAddressesResponse.swift; sourceTree = "<group>"; };
 		4208AD2E0A737F5E0F00DE48 /* ConsumerSession+LookupResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConsumerSession+LookupResponse.swift"; sourceTree = "<group>"; };
 		441C3414745D483C9A47ED0B /* VerificationSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VerificationSession.swift; sourceTree = "<group>"; };
@@ -1101,12 +1107,9 @@
 		3147CEC92CC1BF550067B5E4 /* PaymentMethodPicker */ = {
 			isa = PBXGroup;
 			children = (
+				41124BF42E0C7E44005B9B19 /* PaymentMethodListView */,
+				41124BF32E0C6ED2005B9B19 /* CollapsingListView */,
 				3147CEC32CC1BF550067B5E4 /* LinkPaymentMethodPicker.swift */,
-				3147CEC42CC1BF550067B5E4 /* LinkPaymentMethodPicker-AddButton.swift */,
-				3147CEC52CC1BF550067B5E4 /* LinkPaymentMethodPicker-Cell.swift */,
-				3147CEC62CC1BF550067B5E4 /* LinkPaymentMethodPicker-CellContentView.swift */,
-				3147CEC72CC1BF550067B5E4 /* LinkPaymentMethodPicker-Header.swift */,
-				3147CEC82CC1BF550067B5E4 /* LinkPaymentMethodPicker-RadioButton.swift */,
 				4930D8D42DB92CDC0091FBFE /* LinkPaymentMethodPicker-Email.swift */,
 			);
 			path = PaymentMethodPicker;
@@ -1187,6 +1190,28 @@
 				8FF44D69B2A917BF700496C9 /* CustomerSheetError.swift */,
 			);
 			path = CustomerSheet;
+			sourceTree = "<group>";
+		};
+		41124BF32E0C6ED2005B9B19 /* CollapsingListView */ = {
+			isa = PBXGroup;
+			children = (
+				3147CEC72CC1BF550067B5E4 /* LinkCollapsingListView-Header.swift */,
+				4112425F2E0C53F0005B9B19 /* LinkCollapsingListView.swift */,
+				3147CEC82CC1BF550067B5E4 /* LinkCollapsingListView-RadioButton.swift */,
+				3147CEC42CC1BF550067B5E4 /* LinkCollapsingListView-AddButton.swift */,
+			);
+			path = CollapsingListView;
+			sourceTree = "<group>";
+		};
+		41124BF42E0C7E44005B9B19 /* PaymentMethodListView */ = {
+			isa = PBXGroup;
+			children = (
+				41124BF52E0C7E4E005B9B19 /* LinkPaymentMethodListView+Header.swift */,
+				411242612E0C586A005B9B19 /* LinkPaymentMethodListView.swift */,
+				3147CEC52CC1BF550067B5E4 /* LinkPaymentMethodListView-Cell.swift */,
+				3147CEC62CC1BF550067B5E4 /* LinkPaymentMethodListView-CellContentView.swift */,
+			);
+			path = PaymentMethodListView;
 			sourceTree = "<group>";
 		};
 		417CC7FB8A8E73B6E1E16FE8 /* PaymentSheet */ = {
@@ -2353,6 +2378,7 @@
 				31CC9B972CB5F74A00E84A38 /* LinkSheetNavigationBar.swift in Sources */,
 				31CC9B982CB5F74A00E84A38 /* LinkNoticeView.swift in Sources */,
 				315673E72CD3024F00BA08BC /* PaymentSheet+Link.swift in Sources */,
+				41124BF62E0C7E53005B9B19 /* LinkPaymentMethodListView+Header.swift in Sources */,
 				31CC9B9A2CB5F74A00E84A38 /* LinkToast.swift in Sources */,
 				31CC9B9C2CB5F74A00E84A38 /* LinkBadgeView.swift in Sources */,
 				108846A3D8EFD1D4DCC0DDBC /* NSAttributedString+Stripe.swift in Sources */,
@@ -2436,6 +2462,7 @@
 				B615E8752CA4CC38007D684C /* EmbeddedPaymentElementDelegate.swift in Sources */,
 				4965A7132D9D8D3700DC2E3C /* LinkGlobalHoldback.swift in Sources */,
 				6B28A6B92BE9712500B47DBF /* CustomerSessionAdapter.swift in Sources */,
+				411242602E0C53F4005B9B19 /* LinkCollapsingListView.swift in Sources */,
 				B306EA3F66D07CCABF17CB9C /* LinkInlineSignupViewModel.swift in Sources */,
 				235687C1FBE7417C48F99EE3 /* LinkLegalTermsView.swift in Sources */,
 				262850706DA3ECCDC0E5E38F /* LinkMoreInfoView.swift in Sources */,
@@ -2483,13 +2510,13 @@
 				B6B3481CBA798CF22EE8411A /* TextFieldElement+IBAN.swift in Sources */,
 				F90B7028426261188B66C834 /* Error+PaymentSheet.swift in Sources */,
 				3147CECA2CC1BF550067B5E4 /* LinkPaymentMethodPicker.swift in Sources */,
-				3147CECB2CC1BF550067B5E4 /* LinkPaymentMethodPicker-CellContentView.swift in Sources */,
-				3147CECC2CC1BF550067B5E4 /* LinkPaymentMethodPicker-Cell.swift in Sources */,
-				3147CECD2CC1BF550067B5E4 /* LinkPaymentMethodPicker-Header.swift in Sources */,
+				3147CECB2CC1BF550067B5E4 /* LinkPaymentMethodListView-CellContentView.swift in Sources */,
+				3147CECC2CC1BF550067B5E4 /* LinkPaymentMethodListView-Cell.swift in Sources */,
+				3147CECD2CC1BF550067B5E4 /* LinkCollapsingListView-Header.swift in Sources */,
 				A36949C52CE7D72300739E5D /* UpdatePaymentMethodViewController+Configuration.swift in Sources */,
 				313D00C82CD9972F00A8E6B0 /* PayWithNativeLinkController.swift in Sources */,
-				3147CECE2CC1BF550067B5E4 /* LinkPaymentMethodPicker-RadioButton.swift in Sources */,
-				3147CECF2CC1BF550067B5E4 /* LinkPaymentMethodPicker-AddButton.swift in Sources */,
+				3147CECE2CC1BF550067B5E4 /* LinkCollapsingListView-RadioButton.swift in Sources */,
+				3147CECF2CC1BF550067B5E4 /* LinkCollapsingListView-AddButton.swift in Sources */,
 				FB653AA92B68F73344835A50 /* Intent.swift in Sources */,
 				253EED99635621AC0E788EBC /* IntentConfirmParams.swift in Sources */,
 				313F5F832B0BE5FD00BD98A9 /* Docs.docc in Sources */,
@@ -2528,6 +2555,7 @@
 				CBC98E222DD53F9D00458788 /* LinkFlowControllerHelpers.swift in Sources */,
 				F003E2D0185F1FC4FEC7D126 /* PaymentSheetAppearance.swift in Sources */,
 				E672F7F306C9D2BC941AE8C9 /* PaymentSheetConfiguration.swift in Sources */,
+				411242622E0C586E005B9B19 /* LinkPaymentMethodListView.swift in Sources */,
 				3147CF012CC1D4350067B5E4 /* PaymentSheet-Configuration+Link.swift in Sources */,
 				5867A512E488F5325CF38DD2 /* PaymentSheetDeferredValidator.swift in Sources */,
 				727874C468C0E1CD3653C91A /* PaymentSheetError.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/CollapsingListView/LinkCollapsingListView-AddButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/CollapsingListView/LinkCollapsingListView-AddButton.swift
@@ -1,22 +1,19 @@
 //
-//  LinkPaymentMethodPicker-AddButton.swift
+//  LinkCollapsingListView-AddButton.swift
 //  StripePaymentSheet
 //
 //  Created by Ramon Torres on 10/20/21.
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
-@_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
 import UIKit
 
-extension LinkPaymentMethodPicker {
+extension LinkCollapsingListView {
 
     final class AddButton: UIControl {
-
         private lazy var textLabel: UILabel = {
             let label = UILabel()
-            label.text = String.Localized.add_a_payment_method
             label.numberOfLines = 0
             label.textColor = tintColor
             label.font = LinkUI.font(forTextStyle: .bodyEmphasized)
@@ -45,13 +42,14 @@ extension LinkPaymentMethodPicker {
             }
         }
 
-        init() {
+        init(text: String) {
             super.init(frame: .zero)
 
             isAccessibilityElement = true
             accessibilityTraits = .button
+            textLabel.text = text
             accessibilityLabel = textLabel.text
-            directionalLayoutMargins = Cell.Constants.margins
+            directionalLayoutMargins = LinkCollapsingListView.Constants.margins
 
             setupUI()
             update()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/CollapsingListView/LinkCollapsingListView-Header.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/CollapsingListView/LinkCollapsingListView-Header.swift
@@ -1,5 +1,5 @@
 //
-//  LinkPaymentMethodPicker-Header.swift
+//  LinkCollapsingListView-Header.swift
 //  StripePaymentSheet
 //
 //  Created by Ramon Torres on 10/22/21.
@@ -9,9 +9,9 @@
 @_spi(STP) import StripeUICore
 import UIKit
 
-extension LinkPaymentMethodPicker {
+extension LinkCollapsingListView {
 
-    final class Header: UIControl {
+    class Header: UIControl {
         struct Constants {
             static let contentSpacing: CGFloat = 16
             static let chevronSize: CGSize = .init(width: 24, height: 24)
@@ -26,18 +26,9 @@ extension LinkPaymentMethodPicker {
             )
         }
 
-        /// The selected payment method.
-        private(set) var selectedPaymentMethod: ConsumerPaymentDetails? {
-            didSet {
-                updateChevron()
-                contentView.paymentMethod = selectedPaymentMethod
-                updateAccessibilityContent()
-            }
-        }
-
         // Indicates whether the header should appear collapsable or not.
         // The header is collapsable when the currently selected payment method is supported.
-        private(set) var collapsable: Bool = false
+        var collapsable: Bool = false
 
         var isExpanded: Bool = false {
             didSet {
@@ -57,34 +48,21 @@ extension LinkPaymentMethodPicker {
             }
         }
 
-        private let payWithLabel: UILabel = {
+        let collapsedLabel: UILabel = {
             let label = UILabel()
-            label.font = LinkUI.font(forTextStyle: .body)
             label.textColor = .linkTextTertiary
-            label.text = Strings.payment
+            label.font = LinkUI.font(forTextStyle: .body)
             label.adjustsFontForContentSizeCategory = true
             label.translatesAutoresizingMaskIntoConstraints = false
             return label
         }()
 
-        private let headingLabel: UILabel = {
+        let headingLabel: UILabel = {
             let label = UILabel()
             label.font = LinkUI.font(forTextStyle: .body)
             label.textColor = .linkTextTertiary
-            label.text = STPLocalizedString(
-                "Payment methods",
-                "Title for a section listing one or more payment methods."
-            )
+
             label.adjustsFontForContentSizeCategory = true
-            return label
-        }()
-
-        private let contentView = CellContentView()
-
-        private let cardNumberLabel: UILabel = {
-            let label = UILabel()
-            label.font = UIFont.monospacedDigitSystemFont(ofSize: 14, weight: .medium)
-                .scaled(withTextStyle: .body, maximumPointSize: 20)
             return label
         }()
 
@@ -100,17 +78,16 @@ extension LinkPaymentMethodPicker {
             return chevron
         }()
 
-        private lazy var paymentInfoStackView: UIStackView = {
+        lazy var collapsedStackView: UIStackView = {
             let stackView = UIStackView(arrangedSubviews: [
-                payWithLabel,
-                contentView,
+                collapsedLabel,
             ])
 
             stackView.alignment = .center
-            stackView.setCustomSpacing(Constants.contentSpacing, after: payWithLabel)
+            stackView.setCustomSpacing(Constants.contentSpacing, after: collapsedLabel)
             stackView.translatesAutoresizingMaskIntoConstraints = false
 
-            let payWithLabelWidth = payWithLabel.widthAnchor.constraint(equalToConstant: LinkPaymentMethodPicker.widthForHeaderLabels)
+            let payWithLabelWidth = collapsedLabel.widthAnchor.constraint(equalToConstant: LinkPaymentMethodPicker.widthForHeaderLabels)
             payWithLabelWidth.priority = .defaultLow
 
             NSLayoutConstraint.activate([
@@ -122,7 +99,7 @@ extension LinkPaymentMethodPicker {
 
         private lazy var stackView: UIStackView = {
             let stackView = UIStackView(arrangedSubviews: [
-                paymentInfoStackView,
+                collapsedStackView,
                 headingLabel,
                 chevron,
             ])
@@ -161,12 +138,7 @@ extension LinkPaymentMethodPicker {
             fatalError("init(coder:) has not been implemented")
         }
 
-        func setSelectedPaymentMethod(selectedPaymentMethod: ConsumerPaymentDetails?, supported: Bool) {
-            self.collapsable = supported
-            self.selectedPaymentMethod = selectedPaymentMethod
-        }
-
-        private func updateChevron() {
+        func updateChevron() {
             if isExpanded {
                 chevron.transform = CGAffineTransform(rotationAngle: .pi)
             } else {
@@ -176,15 +148,13 @@ extension LinkPaymentMethodPicker {
             chevron.isHidden = !collapsable
         }
 
-        private func updateAccessibilityContent() {
+        func updateAccessibilityContent() {
             if isExpanded {
-                accessibilityLabel = headingLabel.text
                 accessibilityHint = STPLocalizedString(
                     "Tap to close",
                     "Accessibility hint to tell the user that they can tap to hide additional content."
                 )
             } else {
-                accessibilityLabel = selectedPaymentMethod?.accessibilityDescription
                 accessibilityHint = STPLocalizedString(
                     "Tap to expand",
                     "Accessibility hint to tell the user that they can tap to reveal additional content."
@@ -196,11 +166,11 @@ extension LinkPaymentMethodPicker {
             super.layoutSubviews()
 
             if isExpanded {
-                paymentInfoStackView.isHidden = true
+                collapsedStackView.isHidden = true
                 headingLabel.isHidden = false
                 stackView.directionalLayoutMargins = Constants.expandedInsets
             } else {
-                paymentInfoStackView.isHidden = false
+                collapsedStackView.isHidden = false
                 headingLabel.isHidden = true
                 stackView.directionalLayoutMargins = Constants.collapsedInsets
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/CollapsingListView/LinkCollapsingListView-RadioButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/CollapsingListView/LinkCollapsingListView-RadioButton.swift
@@ -1,5 +1,5 @@
 //
-//  LinkPaymentMethodPicker-RadioButton.swift
+//  LinkCollapsingListView-RadioButton.swift
 //  StripePaymentSheet
 //
 //  Created by Ramon Torres on 11/15/21.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-extension LinkPaymentMethodPicker {
+extension LinkCollapsingListView {
 
     final class RadioButton: UIView {
         struct Constants {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/CollapsingListView/LinkCollapsingListView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/CollapsingListView/LinkCollapsingListView.swift
@@ -1,0 +1,106 @@
+//
+//  LinkCollapsingListView.swift
+//  StripePaymentSheet
+//
+//  Created by Chris Mays on 6/25/25.
+//
+
+@_spi(STP) import StripeUICore
+
+import UIKit
+
+class LinkCollapsingListView: UIView {
+
+    struct Constants {
+        static let margins = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20)
+    }
+
+    private(set) var collapsable: Bool = true
+
+#if !os(visionOS)
+let impactFeedbackGenerator = UIImpactFeedbackGenerator(style: .medium)
+let selectionFeedbackGenerator = UISelectionFeedbackGenerator()
+#endif
+
+    let headerView = LinkPaymentMethodListView.PaymentListHeader()
+
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [
+            headerView,
+            listView,
+        ])
+
+        stackView.axis = .vertical
+        stackView.clipsToBounds = true
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    lazy var listView: UIStackView = {
+        let stackView = UIStackView(arrangedSubviews: [
+        ])
+
+        stackView.axis = .vertical
+        stackView.distribution = .equalSpacing
+        stackView.clipsToBounds = true
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        return stackView
+    }()
+
+    init() {
+        super.init(frame: .zero)
+        setup()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(frame: .zero)
+        setup()
+    }
+
+    func setup() {
+        addAndPinSubview(stackView)
+
+        clipsToBounds = true
+
+        layer.cornerRadius = 16
+        layer.borderColor = UIColor.linkBorderDefault.cgColor
+        tintColor = .linkIconBrand
+        backgroundColor = .linkSurfaceSecondary
+
+
+        headerView.addTarget(self, action: #selector(onHeaderTapped(_:)), for: .touchUpInside)
+        headerView.layer.zPosition = 1
+
+        listView.isHidden = true
+        listView.layer.zPosition = 0
+    }
+
+    func setExpanded(_ expanded: Bool, animated: Bool) {
+        headerView.isExpanded = collapsable ? expanded : true
+
+        // Prevent double header animation
+        if headerView.isExpanded {
+            // TODO(link): revise layout margin placement and remove conditional
+            setNeedsLayout()
+            layoutIfNeeded()
+        } else {
+            headerView.layoutIfNeeded()
+        }
+
+        guard let listViewIndex = stackView.arrangedSubviews.firstIndex(of: listView) else { return }
+        if headerView.isExpanded {
+            stackView.showArrangedSubview(at: listViewIndex, animated: animated)
+        } else {
+            stackView.hideArrangedSubview(at: listViewIndex, animated: animated)
+        }
+    }
+
+    @objc func onHeaderTapped(_ sender: UIView) {
+        guard collapsable || !headerView.isExpanded else { return }
+        setExpanded(!headerView.isExpanded, animated: true)
+#if !os(visionOS)
+        impactFeedbackGenerator.impactOccurred()
+#endif
+    }
+
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/PaymentMethodListView/LinkPaymentMethodListView+Header.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/PaymentMethodListView/LinkPaymentMethodListView+Header.swift
@@ -1,0 +1,51 @@
+//
+//  LinkPaymentMethodListView+Header.swift
+//  StripePaymentSheet
+//
+//  Created by Chris Mays on 6/25/25.
+//
+
+extension LinkPaymentMethodListView {
+    class PaymentListHeader: LinkCollapsingListView.Header {
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            collapsedLabel.text = Strings.payment
+            headingLabel.text = STPLocalizedString(
+                "Payment methods",
+                "Title for a section listing one or more payment methods."
+            )
+            collapsedStackView.addArrangedSubview(collapsedContent)
+        }
+
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        let collapsedContent = CellContentView()
+
+        /// The selected payment method.
+        private(set) var selectedPaymentMethod: ConsumerPaymentDetails? {
+            didSet {
+                updateChevron()
+                collapsedContent.paymentMethod = selectedPaymentMethod
+                updateAccessibilityContent()
+            }
+        }
+
+        func setSelectedPaymentMethod(selectedPaymentMethod: ConsumerPaymentDetails?, supported: Bool) {
+            self.collapsable = supported
+            self.selectedPaymentMethod = selectedPaymentMethod
+        }
+
+        override func updateAccessibilityContent() {
+            super.updateAccessibilityContent()
+            if isExpanded {
+                accessibilityLabel = collapsedLabel.text
+            } else {
+                accessibilityLabel = selectedPaymentMethod?.accessibilityDescription
+            }
+        }
+
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/PaymentMethodListView/LinkPaymentMethodListView-Cell.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/PaymentMethodListView/LinkPaymentMethodListView-Cell.swift
@@ -1,5 +1,5 @@
 //
-//  LinkPaymentMethodPicker-Cell.swift
+//  LinkPaymentMethodListView-Cell.swift
 //  StripePaymentSheet
 //
 //  Created by Ramon Torres on 10/19/21.
@@ -11,21 +11,19 @@
 import UIKit
 
 protocol LinkPaymentMethodPickerCellDelegate: AnyObject {
-    func savedPaymentPickerCellDidSelect(_ cell: LinkPaymentMethodPicker.Cell)
-    func savedPaymentPickerCell(_ cell: LinkPaymentMethodPicker.Cell, didTapMenuButton button: UIButton)
+    func savedPaymentPickerCellDidSelect(_ cell: LinkPaymentMethodListView.Cell)
+    func savedPaymentPickerCell(_ cell: LinkPaymentMethodListView.Cell, didTapMenuButton button: UIButton)
     func savedPaymentPickerCellMenuActions(
-        for cell: LinkPaymentMethodPicker.Cell
+        for cell: LinkPaymentMethodListView.Cell
     ) -> [PayWithLinkViewController.WalletViewController.Action]?
 }
 
-extension LinkPaymentMethodPicker {
+extension LinkPaymentMethodListView {
 
     final class Cell: UIControl {
         struct Constants {
-            static let margins = NSDirectionalEdgeInsets(top: 16, leading: 20, bottom: 16, trailing: 20)
             static let contentSpacing: CGFloat = 12
             static let contentIndentation: CGFloat = 34
-            static let menuSpacing: CGFloat = 8
             static let menuButtonSize: CGSize = .init(width: 24, height: 24)
             static let separatorHeight: CGFloat = 0.5
             static let iconViewSize: CGSize = .init(width: 14, height: 20)
@@ -68,7 +66,7 @@ extension LinkPaymentMethodPicker {
 
         weak var delegate: LinkPaymentMethodPickerCellDelegate?
 
-        private let radioButton = RadioButton()
+        private let radioButton = LinkCollapsingListView.RadioButton()
 
         private let contentView = CellContentView()
 
@@ -126,7 +124,7 @@ extension LinkPaymentMethodPicker {
             super.init(frame: frame)
 
             isAccessibilityElement = true
-            directionalLayoutMargins = Constants.margins
+            directionalLayoutMargins = LinkPaymentMethodListView.Constants.margins
 
             setupUI()
 
@@ -287,7 +285,7 @@ extension LinkPaymentMethodPicker {
 
 }
 
-extension LinkPaymentMethodPicker.Cell {
+extension LinkPaymentMethodListView.Cell {
     override func contextMenuInteraction(
         _ interaction: UIContextMenuInteraction,
         configurationForMenuAtLocation location: CGPoint

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/PaymentMethodListView/LinkPaymentMethodListView-CellContentView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/PaymentMethodListView/LinkPaymentMethodListView-CellContentView.swift
@@ -11,7 +11,7 @@
 @_spi(STP) import StripeUICore
 import UIKit
 
-extension LinkPaymentMethodPicker {
+extension LinkPaymentMethodListView {
 
     final class CellContentView: UIView {
         struct Constants {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/PaymentMethodListView/LinkPaymentMethodListView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/PaymentMethodListView/LinkPaymentMethodListView.swift
@@ -1,0 +1,174 @@
+//
+//  LinkPaymentMethodListView.swift
+//  StripePaymentSheet
+//
+//  Created by Chris Mays on 6/25/25.
+//
+
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+
+import UIKit
+
+class LinkPaymentMethodListView: LinkCollapsingListView {
+    private var needsDataReload: Bool = true
+
+    private let addPaymentMethodButton = LinkCollapsingListView.AddButton(text:  String.Localized.add_a_payment_method)
+
+    weak var dataSource: LinkPaymentMethodPickerDataSource?
+
+    weak var delegate: LinkPaymentMethodPickerDelegate?
+
+    var selectedIndex: Int {
+        dataSource?.selectedIndex ?? 0
+    }
+
+    override var collapsable: Bool {
+        guard let dataSource else { return false }
+        return selectedPaymentMethod.map { dataSource.isPaymentMethodSupported($0) } ?? false
+    }
+
+    var selectedPaymentMethod: ConsumerPaymentDetails? {
+        let count = dataSource?.numberOfPaymentMethods() ?? 0
+
+        guard selectedIndex >= 0 && selectedIndex < count else {
+            return nil
+        }
+
+        return dataSource?.paymentPicker(paymentMethodAt: selectedIndex)
+    }
+
+    override func setup() {
+        super.setup()
+        listView.addArrangedSubview(addPaymentMethodButton)
+        addPaymentMethodButton.tintColor = .linkTextBrand
+        addPaymentMethodButton.addTarget(self, action: #selector(onAddPaymentButtonTapped(_:)), for: .touchUpInside)
+    }
+
+    func reloadData() {
+        needsDataReload = false
+
+        addMissingPaymentMethodCells()
+
+        let count = dataSource?.numberOfPaymentMethods() ?? 0
+        if count == 0 {
+            headerView.isHidden = true
+            listView.isHidden = false
+        }
+
+        for index in 0..<count {
+            reloadCell(at: index)
+        }
+    }
+
+    func reloadCell(at index: Int) {
+        guard let cell = listView.arrangedSubviews[index] as? Cell else {
+            stpAssertionFailure("Cell not found at index: \(index)")
+            return
+        }
+
+        guard let dataSource = dataSource else {
+            stpAssertionFailure("Data source not configured.")
+            return
+        }
+
+        let paymentMethod = dataSource.paymentPicker(paymentMethodAt: index)
+
+        cell.paymentMethod = paymentMethod
+        cell.isSelected = selectedIndex == index
+        cell.isSupported = dataSource.isPaymentMethodSupported(paymentMethod)
+    }
+
+    func showLoaderForPaymentMethod(at index: Int) {
+        guard let cell = listView.arrangedSubviews[index] as? Cell else {
+            stpAssertionFailure("Cell not found at index: \(index)")
+            return
+        }
+
+        cell.isLoading = true
+    }
+
+    func hideLoaderForPaymentMethod(at index: Int) {
+        guard let cell = listView.arrangedSubviews[index] as? Cell else {
+            stpAssertionFailure("Cell not found at index: \(index)")
+            return
+        }
+
+        cell.isLoading = false
+    }
+
+    func setAddButtonIsLoading(_ isLoading: Bool) {
+        addPaymentMethodButton.isLoading = isLoading
+    }
+
+    func reloadDataIfNeeded() {
+        if needsDataReload {
+            reloadData()
+        }
+    }
+
+    private func addMissingPaymentMethodCells() {
+        let count = dataSource?.numberOfPaymentMethods() ?? 0
+
+        while count > listView.arrangedSubviews.count - 1 {
+            let cell = Cell()
+            cell.delegate = self
+
+            let index = listView.arrangedSubviews.count - 1
+            listView.insertArrangedSubview(cell, at: index)
+        }
+
+        for (index, subview) in listView.arrangedSubviews.enumerated() {
+            subview.layer.zPosition = CGFloat(-index)
+        }
+
+        headerView.setSelectedPaymentMethod(selectedPaymentMethod: selectedPaymentMethod, supported: dataSource?.isPaymentMethodSupported(selectedPaymentMethod) ?? false)
+    }
+
+    func index(for cell: Cell) -> Int? {
+        return listView.arrangedSubviews.firstIndex(of: cell)
+    }
+
+    func removePaymentMethod(at index: Int, animated: Bool) {
+        isUserInteractionEnabled = false
+
+        listView.removeArrangedSubview(at: index, animated: true) {
+            self.isUserInteractionEnabled = true
+            self.reloadData()
+        }
+    }
+
+    @objc func onAddPaymentButtonTapped(_ sender: AddButton) {
+        let sourceRect = sender.convert(sender.bounds, to: self)
+        delegate?.paymentDetailsPickerDidTapOnAddPayment(sourceRect: sourceRect)
+    }
+}
+
+extension LinkPaymentMethodListView: LinkPaymentMethodPickerCellDelegate {
+
+    func savedPaymentPickerCellDidSelect(_ savedCardView: Cell) {
+        if let newIndex = index(for: savedCardView), savedCardView.isSupported {
+#if !os(visionOS)
+            selectionFeedbackGenerator.selectionChanged()
+#endif
+
+            delegate?.paymentMethodPicker(didSelectIndex: newIndex)
+        }
+    }
+
+    func savedPaymentPickerCell(_ cell: Cell, didTapMenuButton button: UIButton) {
+        guard let index = index(for: cell) else {
+            stpAssertionFailure("Index not found")
+            return
+        }
+
+        let sourceRect = button.convert(button.bounds, to: self)
+
+        delegate?.paymentMethodPicker(showMenuForItemAt: index, sourceRect: sourceRect)
+    }
+
+    func savedPaymentPickerCellMenuActions(for cell: Cell) -> [PayWithLinkViewController.WalletViewController.Action]? {
+        guard let index = index(for: cell) else { return nil }
+        return delegate?.paymentMethodPicker(menuActionsForItemAt: index)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -22,6 +22,7 @@ extension PayWithLinkViewController {
         let context: Context
         let linkAccount: PaymentSheetLinkAccount
         private(set) var paymentMethods: [ConsumerPaymentDetails]
+        private(set) var shippingAddresses: [ShippingAddressesResponse.ShippingAddress]
 
         weak var delegate: PayWithLinkWalletViewModelDelegate?
 
@@ -191,7 +192,8 @@ extension PayWithLinkViewController {
         init(
             linkAccount: PaymentSheetLinkAccount,
             context: Context,
-            paymentMethods: [ConsumerPaymentDetails]
+            paymentMethods: [ConsumerPaymentDetails],
+            shippingAddresses: [ShippingAddressesResponse.ShippingAddress]
         ) {
             self.linkAccount = linkAccount
             self.context = context
@@ -200,6 +202,7 @@ extension PayWithLinkViewController {
                 context: context,
                 paymentMethods: paymentMethods
             )
+            self.shippingAddresses = shippingAddresses
         }
 
         func deletePaymentMethod(at index: Int, completion: @escaping (Result<Void, Error>) -> Void) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -341,7 +341,8 @@ private extension PayWithLinkViewController {
 
                 presentAppropriateViewController(
                     with: linkAccount,
-                    paymentDetails: paymentDetails
+                    paymentDetails: paymentDetails,
+                    shippingAddresses: shippingAddressResponse?.shippingAddresses ?? []
                 )
             } catch {
                 payWithLinkDelegate?.payWithLinkViewControllerDidFinish(
@@ -363,7 +364,8 @@ private extension PayWithLinkViewController {
 
     private func presentAppropriateViewController(
         with linkAccount: PaymentSheetLinkAccount,
-        paymentDetails: [ConsumerPaymentDetails]
+        paymentDetails: [ConsumerPaymentDetails],
+        shippingAddresses: [ShippingAddressesResponse.ShippingAddress]
     ) {
         let viewController: BottomSheetContentViewController
         if paymentDetails.isEmpty {
@@ -377,7 +379,8 @@ private extension PayWithLinkViewController {
             let walletViewController = WalletViewController(
                 linkAccount: linkAccount,
                 context: context,
-                paymentMethods: paymentDetails
+                paymentMethods: paymentDetails,
+                shippingAddresses: shippingAddresses
             )
             viewController = walletViewController
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkPaymentMethodPickerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkPaymentMethodPickerSnapshotTests.swift
@@ -150,7 +150,7 @@ extension LinkPaymentMethodPickerSnapshotTests {
             self.accountEmail = email
         }
 
-        func numberOfPaymentMethods(in picker: LinkPaymentMethodPicker) -> Int {
+        func numberOfPaymentMethods() -> Int {
             return paymentMethods.count
         }
 
@@ -159,7 +159,6 @@ extension LinkPaymentMethodPickerSnapshotTests {
         }
 
         func paymentPicker(
-            _ picker: LinkPaymentMethodPicker,
             paymentMethodAt index: Int
         ) -> ConsumerPaymentDetails {
             return paymentMethods[index]


### PR DESCRIPTION
## Summary
This change refactors the collapsing list functionality to be reusable. This is in preparation to display shipping addresses in the native link view.

## Demo

https://github.com/user-attachments/assets/30cdc8c1-1758-48b6-a65a-232f1af1f30c

