### PR TITLE
Attempt to fix potential race condition in image scanning session's concurrency manager 

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/ImageScanningConcurrencyManager.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/ImageScanningConcurrencyManager.swift
@@ -59,7 +59,7 @@ final class ImageScanningConcurrencyManager: ImageScanningConcurrencyManagerProt
 
     private var amountOfFutures = 0
     private var futureQueue: DispatchQueue = DispatchQueue(label: "com.stripe.identity.concurrent-image-scanner.futures")
-    
+
     private let analyticsClient: IdentityAnalyticsClient
     private let sheetController: VerificationSheetControllerProtocol
 
@@ -71,7 +71,7 @@ final class ImageScanningConcurrencyManager: ImageScanningConcurrencyManagerProt
         self.sheetController = sheetController
         self.semaphore = DispatchSemaphore(value: maxConcurrentScans)
     }
-    
+
     deinit {
         futureQueue.sync {
             for _ in 0..<amountOfFutures {
@@ -136,7 +136,7 @@ final class ImageScanningConcurrencyManager: ImageScanningConcurrencyManagerProt
         futureQueue.sync {
             self.amountOfFutures += 1
         }
-        
+
         future.observe(on: concurrentQueue) { result in
             switch result {
             case .success(let scannerOutput):
@@ -153,12 +153,12 @@ final class ImageScanningConcurrencyManager: ImageScanningConcurrencyManagerProt
                 self?.perfLastScanEndTime = scanEndTime
                 self?.perfNumFramesScanned += 1
             }
-            
+
             self.futureQueue.sync {
                 self.amountOfFutures -= 1
                 self.semaphore.signal()
             }
-            
+
         }
     }
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/ImageScanningConcurrencyManager.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/ImageScanningConcurrencyManager.swift
@@ -57,6 +57,9 @@ final class ImageScanningConcurrencyManager: ImageScanningConcurrencyManagerProt
     /// Semaphore used to block the current thread until detectors have completed
     private let semaphore: DispatchSemaphore
 
+    private var amountOfFutures = 0
+    private var futureQueue: DispatchQueue = DispatchQueue(label: "com.stripe.identity.concurrent-image-scanner.futures")
+    
     private let analyticsClient: IdentityAnalyticsClient
     private let sheetController: VerificationSheetControllerProtocol
 
@@ -67,6 +70,14 @@ final class ImageScanningConcurrencyManager: ImageScanningConcurrencyManagerProt
         self.analyticsClient = sheetController.analyticsClient
         self.sheetController = sheetController
         self.semaphore = DispatchSemaphore(value: maxConcurrentScans)
+    }
+    
+    deinit {
+        futureQueue.sync {
+            for _ in 0..<amountOfFutures {
+                self.semaphore.signal()
+            }
+        }
     }
 
     /// Scans a camera frame and calls a completion block with the scanned output
@@ -116,12 +127,17 @@ final class ImageScanningConcurrencyManager: ImageScanningConcurrencyManagerProt
         }
 
         semaphore.wait()
-
-        scanner.scanImage(
+        let future = scanner.scanImage(
             pixelBuffer: pixelBuffer,
             sampleBuffer: sampleBuffer,
             cameraProperties: cameraProperties
-        ).observe(on: concurrentQueue) { result in
+        )
+
+        futureQueue.sync {
+            self.amountOfFutures += 1
+        }
+        
+        future.observe(on: concurrentQueue) { result in
             switch result {
             case .success(let scannerOutput):
                 wrappedCompletion(scannerOutput)
@@ -137,8 +153,12 @@ final class ImageScanningConcurrencyManager: ImageScanningConcurrencyManagerProt
                 self?.perfLastScanEndTime = scanEndTime
                 self?.perfNumFramesScanned += 1
             }
-
-            self.semaphore.signal()
+            
+            self.futureQueue.sync {
+                self.amountOfFutures -= 1
+                self.semaphore.signal()
+            }
+            
         }
     }
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/ImageScanningConcurrencyManager.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/ImageScanningConcurrencyManager.swift
@@ -111,7 +111,6 @@ final class ImageScanningConcurrencyManager: ImageScanningConcurrencyManagerProt
     ) {
         assert(!Thread.isMainThread, "`scanImage` should not be called from the main thread")
 
-        
         // Get camera session properties immediately before the camera state changes
         let cameraProperties = cameraSession.getCameraProperties()
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/ImageScanningConcurrencyManager.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/ImageScanningConcurrencyManager.swift
@@ -111,6 +111,7 @@ final class ImageScanningConcurrencyManager: ImageScanningConcurrencyManagerProt
     ) {
         assert(!Thread.isMainThread, "`scanImage` should not be called from the main thread")
 
+        
         // Get camera session properties immediately before the camera state changes
         let cameraProperties = cameraSession.getCameraProperties()
 


### PR DESCRIPTION
## Summary

Tracks the balance of a semaphore in the scanning session concurrency code. If that is unbalanced by the time it goes out of memory, it will resolve it. I do not see a way this crash happens, but this should resolve it in any circumstance.

## Motivation

Fixes [#2670](https://github.com/stripe/stripe-ios/issues/2670)

## Testing

I went through the identity flow a handful of times, and cancelling mid flow as well during scanning.