### PR TITLE
Fix flaky testLoaderStartShowsLoadingIndicator

### DIFF
--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
@@ -223,7 +223,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
         try await webVC.webView.evaluateOnLoaderStart(elementTagName: "payouts")
 
         // Wait for the animation state to settle after the async operation
-        await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        try await Task.sleep(nanoseconds: 100_000_000) // 100ms
         XCTAssertFalse(webVC.activityIndicator.isAnimating)
     }
 

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
@@ -222,13 +222,9 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
 
         try await webVC.webView.evaluateOnLoaderStart(elementTagName: "payouts")
 
-        if !webVC.activityIndicator.isAnimating {
-            XCTAssertFalse(webVC.activityIndicator.isAnimating)
-        } else {
-            // If it is animating, wait a second before we check.
-            sleep(1)
-            XCTAssertFalse(webVC.activityIndicator.isAnimating)
-        }
+        // Wait for the animation state to settle after the async operation
+        await Task.sleep(nanoseconds: 100_000_000) // 100ms
+        XCTAssertFalse(webVC.activityIndicator.isAnimating)
     }
 
     // MARK: - Errors


### PR DESCRIPTION
This is a weird test that keeps flaking, and the if branch here doesn't make sense. Going to try `await Task.sleep`, as I'm wondering if the main thread is being blocked by `sleep()` which would prevent `isAnimating` from updating.