### PR TITLE
[flake] Fix flaky Apple Pay test by ensuring publishable key is loaded

### DIFF
--- a/Testers/IntegrationTester/IntegrationTester/Source/Models/ApplePayModel.swift
+++ b/Testers/IntegrationTester/IntegrationTester/Source/Models/ApplePayModel.swift
@@ -50,6 +50,17 @@ class MyApplePayBackendModel: NSObject, ObservableObject, STPApplePayContextDele
 
   func applePayContext(_ context: STPApplePayContext, didCreatePaymentMethod paymentMethod: STPPaymentMethod, paymentInformation: PKPayment, completion: @escaping STPIntentClientSecretCompletionBlock) {
     // When the Apple Pay sheet is confirmed, create a PaymentIntent on your backend from the provided PKPayment information.
+    // Ensure publishable key is loaded before proceeding
+    if STPAPIClient.shared.publishableKey == nil {
+      BackendModel.shared.loadPublishableKey { _ in
+        self.fetchPaymentIntentForApplePay(completion: completion)
+      }
+    } else {
+      fetchPaymentIntentForApplePay(completion: completion)
+    }
+  }
+  
+  private func fetchPaymentIntentForApplePay(completion: @escaping STPIntentClientSecretCompletionBlock) {
     BackendModel.shared.fetchPaymentIntent(integrationMethod: .card) { pip in
       if let clientSecret = pip?.clientSecret {
         // Call the completion block with the PaymentIntent's client secret.


### PR DESCRIPTION
Fixes race condition where Apple Pay payment could start before the publishable key finished loading asynchronously, causing intermittent "You did not provide an API key" errors.

## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
