### PR TITLE
[flakebot] Fix flaky test testSEPADebitPaymentMethod_PaymentSheet()

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
@@ -560,7 +560,7 @@ class PaymentSheetStandardLPMUITwoTests: PaymentSheetStandardLPMUICase {
         app.typeText("94102" + XCUIKeyboardKey.return.rawValue)
         app.buttons["Pay €50.99"].tap()
         let successText = app.staticTexts["Success!"]
-        XCTAssertTrue(successText.waitForExistence(timeout: 10.0))
+        XCTAssertTrue(successText.waitForExistence(timeout: 15.0))
     }
 
     func testSavedSEPADebitPaymentMethod_FlowController_ShowsMandate() {


### PR DESCRIPTION
## Summary
- Increased timeout for Success\! text assertion from 10s to 15s in `testSEPADebitPaymentMethod_PaymentSheet()` test
- Aligns timeout with other similar payment method tests that use 15s or longer timeouts
- SEPA Debit is a delayed payment method that can take longer to process

## Test plan
- [x] Verified that most other tests in the same file use 15s timeout for Success\! text assertions
- [x] Confirmed that SEPA Debit uses `allowsDelayedPMs = .on` setting which indicates longer processing times
- [x] Applied consistent timeout pattern used by other delayed payment methods
- [x] Ran linting and formatting to ensure code quality

**Test Details:**
- Test identifier: `PaymentSheetStandardLPMUITwoTests/testSEPADebitPaymentMethod_PaymentSheet()`
- Failure reason: XCTAssertTrue failed on Success\! text existence check at line 563
- Fix: Changed `waitForExistence(timeout: 10.0)` to `waitForExistence(timeout: 15.0)`

🤖 Generated with [Claude Code](https://claude.ai/code)