### PR TITLE
[flakebot] Fix flaky test testMissingDocFrontNoType()

### DIFF
--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
@@ -160,6 +160,9 @@ final class VerificationSheetFlowControllerTest: XCTestCase {
 
     // Requires document photo without type - should return DocumentTypeSelectViewController
     func testMissingDocFrontNoType() throws {
+        // Mock that user has selected document type
+        mockSheetController.collectedData = .init()
+
         // Mock that document ML models successfully loaded
         mockMLModelLoader.documentModelsPromise.resolve(with: .init(DocumentScannerMock()))
 

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
@@ -160,12 +160,6 @@ final class VerificationSheetFlowControllerTest: XCTestCase {
 
     // Requires document photo without type - should return DocumentTypeSelectViewController
     func testMissingDocFrontNoType() throws {
-        // Mock that user has selected document type
-        mockSheetController.collectedData = .init()
-
-        // Mock that document ML models successfully loaded
-        mockMLModelLoader.documentModelsPromise.resolve(with: .init(DocumentScannerMock()))
-
         let exp = expectation(description: "testMissingDocFrontNoType")
         try nextViewController(
             missingRequirements: [.idDocumentFront],
@@ -174,6 +168,12 @@ final class VerificationSheetFlowControllerTest: XCTestCase {
                 exp.fulfill()
             }
         )
+
+        // Resolve the promise after setting up the observation to avoid race condition
+        DispatchQueue.main.async {
+            self.mockMLModelLoader.documentModelsPromise.resolve(with: .init(DocumentScannerMock()))
+        }
+
         wait(for: [exp], timeout: 1)
     }
 
@@ -324,9 +324,6 @@ final class VerificationSheetFlowControllerTest: XCTestCase {
         // Mock that user has selected document type
         mockSheetController.collectedData = .init()
 
-        // Mock that document ML models successfully loaded
-        mockMLModelLoader.documentModelsPromise.resolve(with: .init(DocumentScannerMock()))
-
         let frontExp = expectation(description: "front")
         try nextViewController(
             missingRequirements: [.idDocumentFront],
@@ -344,6 +341,11 @@ final class VerificationSheetFlowControllerTest: XCTestCase {
                 backExp.fulfill()
             }
         )
+
+        // Resolve the promise after setting up the observations to avoid race condition
+        DispatchQueue.main.async {
+            self.mockMLModelLoader.documentModelsPromise.resolve(with: .init(DocumentScannerMock()))
+        }
 
         wait(for: [frontExp, backExp], timeout: 1)
     }


### PR DESCRIPTION
## Summary
- Fixed segmentation faults in `testMissingDocFrontNoType()` and `testNextViewControllerDocumentWarmup()` 
- Root cause: Race condition between main thread and FutureQueue thread accessing the same memory
- Both tests were crashing with `EXC_BAD_ACCESS` in `objc_retain` during `Result<AnyDocumentScanner, Error>` copy operations

## Root Cause Analysis
The crashes occurred due to a race condition between two concurrent operations:

1. **Main thread**: Loading MockData via `VerificationPageMock.response200.make()` and setting up Future observations in `nextViewController()`
2. **FutureQueue thread**: Processing promise resolution from `mockMLModelLoader.documentModelsPromise.resolve()` and copying Result objects

When both threads accessed the same `Result<AnyDocumentScanner, Error>` memory simultaneously, it caused memory corruption during Swift's copy operations, leading to segmentation faults in `objc_retain`.

## Solution
Deferred promise resolution using `DispatchQueue.main.async` to ensure:
- All test setup (including Future observations) completes on the main thread first
- Promise resolution only triggers FutureQueue async work after setup is complete  
- Eliminates concurrent memory access that caused the crashes

## Test plan
- [x] Identified the race condition through detailed crash log analysis
- [x] Applied the fix to both failing tests using async deferral pattern
- [x] Verified the fix follows async testing best practices
- [ ] Run the specific tests to confirm they no longer crash
- [ ] Run the full StripeIdentity test suite to ensure no regressions

**Test identifiers:** 
- `VerificationSheetFlowControllerTest/testMissingDocFrontNoType()`
- `VerificationSheetFlowControllerTest/testNextViewControllerDocumentWarmup()`

**Original failure:** Crash: xctest (SIGSEGV) on FutureQueue thread

🤖 Generated with [Claude Code](https://claude.ai/code)