### PR TITLE
Removes native close button in favor of web rendered one

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEIndexHtml.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEIndexHtml.swift
@@ -42,6 +42,7 @@ struct ECEIndexHTML {
           currency: "usd",
           payment_method_types: ["card", "link", "shop_pay"],
           customerSessionClientSecret: "\(customerSessionClientSecret)",
+          __elementsInitSource: 'native_sdk',
         };
 
       console.log("Initializing stripe elements with options", options);

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEIndexHtml.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEIndexHtml.swift
@@ -42,7 +42,6 @@ struct ECEIndexHTML {
           currency: "usd",
           payment_method_types: ["card", "link", "shop_pay"],
           customerSessionClientSecret: "\(customerSessionClientSecret)",
-          __elementsInitSource: 'native_sdk',
         };
 
       console.log("Initializing stripe elements with options", options);

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEViewController.swift
@@ -151,38 +151,6 @@ class ECEViewController: UIViewController {
             type: 'bridgeReady'
         });
 
-        (function() {
-            function hideReturnButtons() {
-                const returnButtons = document.querySelectorAll('button[aria-label="Return to store"]');
-                returnButtons.forEach(button => {
-                    if (!button.hasAttribute('data-hidden')) {
-                        button.style.display = 'none';
-                        button.style.visibility = 'hidden';
-                        button.style.opacity = '0';
-                        button.style.pointerEvents = 'none';
-                        button.setAttribute('data-hidden', 'true');
-                    }
-                });
-            }
-
-            // Initial hiding
-            hideReturnButtons();
-
-            // Set up a mutation observer to watch for DOM changes
-            const observer = new MutationObserver(function(mutations) {
-                mutations.forEach(function() {
-                    hideReturnButtons();
-                });
-            });
-
-            // Start observing the document with the configured parameters
-            observer.observe(document.body, { childList: true, subtree: true });
-
-            // Also check periodically (as a fallback)
-            setInterval(hideReturnButtons, 500);
-
-            console.log('Return button hiding observer initialized');
-        })();
         """
 
         // Intercept console logs
@@ -462,27 +430,6 @@ extension ECEViewController: WKUIDelegate {
         // Add the popup webview as a fullscreen overlay
         if let popupWebView = popupWebView {
             view.addSubview(popupWebView)
-
-            // Add a close button overlay
-            let closeButton = UIButton(type: .custom)
-            closeButton.setImage(UIImage(systemName: "xmark.circle.fill"), for: .normal)
-            closeButton.tintColor = .systemGray
-            closeButton.backgroundColor = .systemBackground.withAlphaComponent(0.9)
-            closeButton.layer.cornerRadius = 20
-            closeButton.translatesAutoresizingMaskIntoConstraints = false
-            closeButton.addTarget(self, action: #selector(closePopup), for: .touchUpInside)
-
-            popupWebView.addSubview(closeButton)
-
-            NSLayoutConstraint.activate([
-                closeButton.topAnchor.constraint(equalTo: popupWebView.safeAreaLayoutGuide.topAnchor, constant: 16),
-                closeButton.trailingAnchor.constraint(equalTo: popupWebView.trailingAnchor, constant: -16),
-                closeButton.widthAnchor.constraint(equalToConstant: 44),
-                closeButton.heightAnchor.constraint(equalToConstant: 44),
-            ])
-
-            // Store reference to close button so we can remove it later
-            closeButton.tag = 999
         }
 
         return popupWebView

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEViewControllerTests.swift
@@ -212,10 +212,6 @@ class ECEViewControllerTests: XCTestCase {
         XCTAssertNotNil(popupWebView)
         XCTAssertEqual(popupWebView?.frame, sut.view.bounds)
         XCTAssertEqual(popupWebView?.customUserAgent, ECEViewController.FakeSafariUserAgent)
-
-        // Check close button was added
-        let closeButton = popupWebView?.subviews.first { $0.tag == 999 } as? UIButton
-        XCTAssertNotNil(closeButton)
     }
 }
 #endif


### PR DESCRIPTION
## Summary
Close button was fixed on shoppay's webview, so we can use that instead of this native one

## Motivation
No need to render our own native button, which tbh, was a bit hack

## Testing
Manual testing.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
