### PR TITLE
[flakebot] Fix flaky test testSEPADebitPaymentMethod_PaymentSheet()

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLPMUITest.swift
@@ -554,6 +554,9 @@ class PaymentSheetStandardLPMUITwoTests: PaymentSheetStandardLPMUICase {
         app.typeText("AT611904300234573201" + XCUIKeyboardKey.return.rawValue)
 
         app.fillAddressWithAutocomplete()
+
+        // Dismiss keyboard before tapping pay button
+        app.toolbars.buttons["Done"].tap()
         app.buttons["Pay €50.99"].tap()
         let successText = app.staticTexts["Success!"]
         XCTAssertTrue(successText.waitForExistence(timeout: 10.0))


### PR DESCRIPTION
[testing a bot]

## Summary
Fixes flaky test `PaymentSheetStandardLPMUITwoTests/testSEPADebitPaymentMethod_PaymentSheet()` that was failing with `XCTAssertTrue failed` at line 559.

## Root Cause
After the recent autocomplete billing address changes (#5034), the autocomplete interaction leaves the keyboard visible, covering the "Pay €50.99" button. The test was unable to tap the pay button because it was not accessible behind the keyboard.

## Fix
Added `app.toolbars.buttons["Done"].tap()` to dismiss the keyboard before attempting to tap the pay button.

## Test Information
- **Test Identifier**: PaymentSheetStandardLPMUITwoTests/testSEPADebitPaymentMethod_PaymentSheet()
- **Failure Reason**: XCTAssertTrue failed at PaymentSheetLPMUITest.swift:559
- **Related to**: Autocomplete billing address changes in #5034 