### PR TITLE
[flakebot] Fix flaky test EmbeddedUITests/testSwiftUI()

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -1012,7 +1012,16 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.launch()
         XCTAssertTrue(app.buttons["EmbeddedPaymentElement (SwiftUI)"].waitForExistenceAndTap())
 
-        app.buttons["Card"].waitForExistenceAndTap(timeout: 10)
+        // Wait for the SwiftUI embedded payment element to fully load
+        // The loading screen shows "Preparing Payment..." while the element loads asynchronously
+        let cardButton = app.buttons["Card"]
+        XCTAssertTrue(cardButton.waitForExistence(timeout: 30), "Card button should appear after embedded payment element loads")
+        cardButton.waitForExistenceAndTap(timeout: 10)
+        
+        // Additional wait to ensure the card form is fully rendered before trying to fill data
+        let cardNumberField = app.textFields["Card number"]
+        XCTAssertTrue(cardNumberField.waitForExistence(timeout: 15), "Card number field should be available after tapping Card button")
+        
         try fillCardData(app)
         let continueButton = app.buttons["Continue"]
         XCTAssertTrue(continueButton.isEnabled)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -1017,11 +1017,11 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         let cardButton = app.buttons["Card"]
         XCTAssertTrue(cardButton.waitForExistence(timeout: 30), "Card button should appear after embedded payment element loads")
         cardButton.waitForExistenceAndTap(timeout: 10)
-        
+
         // Additional wait to ensure the card form is fully rendered before trying to fill data
         let cardNumberField = app.textFields["Card number"]
         XCTAssertTrue(cardNumberField.waitForExistence(timeout: 15), "Card number field should be available after tapping Card button")
-        
+
         try fillCardData(app)
         let continueButton = app.buttons["Continue"]
         XCTAssertTrue(continueButton.isEnabled)


### PR DESCRIPTION
[testing a fixbot]

## Summary

Fixes flaky test `EmbeddedUITests/testSwiftUI()` that was failing with timeout errors when trying to interact with the "Card number" TextField.

- **Test identifier**: `EmbeddedUITests/testSwiftUI()`
- **Failure reason**: `XCUITest+Utilities.swift:37: Asynchronous wait failed: Exceeded timeout of 15 seconds, with unfulfilled expectations: "Expect predicate 'hittable == 1' for object "Card number" TextField"`

## Root Cause

The test was failing because it attempted to interact with UI elements before the SwiftUI embedded payment element finished loading asynchronously:

1. Test taps "EmbeddedPaymentElement (SwiftUI)" button
2. SwiftUI view shows "Preparing Payment..." loading screen while making async network calls
3. Test immediately tries to tap "Card" button and fill card data
4. `fillCardData()` calls `forceTapWhenHittableInTestCase()` with 15s timeout on "Card number" field
5. Field never becomes hittable because the embedded payment element is still loading

## Solution

Added proper wait conditions to ensure the embedded payment element is fully loaded before UI interactions:

- **Increased Card button timeout** to 30 seconds to accommodate async loading
- **Added explicit wait** for "Card number" field existence before calling `fillCardData()`
- **Added descriptive error messages** for better debugging if timeouts still occur

## Test Plan

- [x] Test now waits for SwiftUI embedded payment element to fully load
- [x] Ensures card form is rendered before attempting to fill data
- [x] Maintains existing test logic and assertions
- [x] Applied automatic code formatting per project standards

The fix is minimal and targeted to the specific timing issue without changing the test's intent or coverage.