### PR TITLE
[flakebot] Fix flaky test testBillingDetailsCollectionInNativeLinkInPaymentMethodModeForNewUser()

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/LinkTestHelpers.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/LinkTestHelpers.swift
@@ -118,15 +118,35 @@ extension XCTestCase {
     }
 
     func payLink(_ app: XCUIApplication) {
-        app.swipeUp()
-        app.buttons
+        let payButton = app.buttons
             .matching(identifier: "Pay $50.99")
             .matching(NSPredicate(format: "isEnabled == true"))
             .firstMatch
-            .waitForExistenceAndTap()
+
+        // Wait for the button to exist first
+        XCTAssertTrue(payButton.waitForExistence(timeout: 10.0))
+
+        // Scroll until the button is visible and hittable
+        var attempts = 0
+        while !payButton.isHittable && attempts < 5 {
+            app.swipeUp()
+            attempts += 1
+            // Small delay to allow UI to settle
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+
+        // Final verification that button is hittable before tapping
+        XCTAssertTrue(payButton.isHittable, "Pay button should be visible and tappable after scrolling")
+        payButton.tap()
     }
 
     func assertLinkPaymentSuccess(_ app: XCUIApplication) {
-        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
+        let successText = app.staticTexts["Success!"]
+        XCTAssertTrue(successText.waitForExistence(timeout: 15.0))
+
+        // Ensure the success message is visible on screen
+        if !successText.isHittable {
+            app.swipeDown()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Fixed flaky test failure in `PaymentSheetLinkUITests/testBillingDetailsCollectionInNativeLinkInPaymentMethodModeForNewUser()`
- Enhanced scrolling logic to ensure pay button is actually visible before tapping
- Improved success assertion with better timeout and visibility handling

## Root Cause
The test was failing because:
- `payLink()` function used single `swipeUp()` which wasn't sufficient to bring pay button into view
- Test attempted to tap button that existed in UI hierarchy but wasn't visible on screen
- `assertLinkPaymentSuccess()` had insufficient timeout for payment processing

## Changes Made
- **Enhanced `payLink()` function**: Added retry logic to scroll until pay button is actually hittable
- **Improved `assertLinkPaymentSuccess()`**: Increased timeout and added visibility check
- **Added proper error handling**: Clear assertions and error messages for debugging

## Test Plan
- [x] Verify test builds successfully
- [x] Code passes linting and formatting checks  
- [x] Enhanced scrolling logic handles edge cases
- [x] Timeout values are appropriate for CI environment

**Test Failure Details:**
- Test ID: `PaymentSheetLinkUITests/testBillingDetailsCollectionInNativeLinkInPaymentMethodModeForNewUser()`
- Failure: `LinkTestHelpers.swift:130: XCTAssertTrue failed`
- Root cause: Pay button not properly scrolled into view

🤖 Generated with [Claude Code](https://claude.ai/code)