### PR TITLE
Fix CMTime related potential crash in SelfieUploader+API.swift

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/API Bindings/SelfieUploader+API.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/SelfieUploader+API.swift
@@ -49,11 +49,11 @@ extension StripeAPI.VerificationPageDataFace {
             bestCameraLensModel: bestFrameExifMetadata?.lensModel,
             bestExposureDuration: capturedImages.bestMiddle.scannerOutput.cameraProperties.flatMap { properties in
                 let exposureDuration = properties.exposureDuration
-                
+
                 if exposureDuration.isNumeric {
                     return Int(properties.exposureDuration.seconds * 1000)
                 }
-                
+
                 return nil
             },
             bestExposureIso: capturedImages.bestMiddle.scannerOutput.cameraProperties.map {


### PR DESCRIPTION
## Summary

Validates the `exposureDuration` property before using it, to make sure it is not infinite or NaN.

## Motivation

This should prevent a potential crash that is similar to one reported in [https://github.com/stripe/stripe-ios/issues/3193](https://github.com/stripe/stripe-ios/issues/3193)

While investigating the above crash, we identified this line that is similar to it and could cause crashes that are similar.

## Testing

Run through the identity flow and verify no crash occurs and it completes successfully - specifically requiring selfie.



