### PR TITLE
Add Shop Pay webview analytics events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,9 @@ fastlane/.env
 
 # Xcode Related files
 Stripe.xcworkspace/xcuserdata/*
+
+# Local LLM settings
+.claude
+
+# Simulator configuration cache
+.stripe-ios-config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,143 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Simulator Setup
+
+Before running tests or builds, ensure you have the correct simulator configured. The project requires an iPhone 12 mini with iOS 16.4 for consistent screenshot tests.
+
+### Automatic Simulator Detection
+
+**IMPORTANT**: Always check if `.stripe-ios-config` exists and contains a valid device ID before running tests or builds. Use the automated script to set up the simulator:
+
+```bash
+# Set up simulator (finds existing or creates new iPhone 12 mini with iOS 16.4)
+source <(./ci_scripts/setup_simulator.sh)
+```
+
+The script will:
+1. Check for cached simulator ID in `.stripe-ios-config`
+2. Validate the cached simulator still exists
+3. Find existing iPhone 12 mini with iOS 16.4 or create a new one
+4. Cache the result for future use
+
+**If simulator issues occur**: Clear the cache and retry:
+```bash
+./ci_scripts/setup_simulator.sh --clear-cache
+source <(./ci_scripts/setup_simulator.sh)
+```
+
+### Using the Device ID
+
+Once configured, you can use the device ID in build commands:
+```bash
+source <(./ci_scripts/setup_simulator.sh)
+xcodebuild -workspace Stripe.xcworkspace -scheme "StripePaymentSheet" -destination "id=$DEVICE_ID_FROM_USER_SETTINGS,arch=arm64" -quiet
+```
+
+### Quick Setup Check
+
+To verify the simulator is properly configured, run:
+```bash
+source <(./ci_scripts/setup_simulator.sh)
+echo "✅ Simulator configured: $DEVICE_ID_FROM_USER_SETTINGS"
+```
+
+## Build Commands
+
+### Core Testing Commands
+- **Run main tests**: `bundle exec fastlane stripeios_tests`
+- **Run StripeConnect tests**: `bundle exec fastlane stripeconnect_tests` 
+- **Run all integration tests**: `bundle exec fastlane integration_all`
+- **Run 3DS2 tests**: `bundle exec fastlane threeds2_tests`
+
+### Test with CI Script
+Use `./ci_scripts/test.rb` for more granular control:
+- **Build only**: `./ci_scripts/test.rb --build-only --scheme 'SCHEME_NAME'`
+- **Run specific scheme**: `./ci_scripts/test.rb --scheme 'SCHEME_NAME' --device 'iPhone 12 mini' --version 16.4 --retry-on-failure`
+
+### Standard Build Using Xcode
+For compilation testing, use this standard command:
+```bash
+source <(./ci_scripts/setup_simulator.sh)
+xcodebuild -workspace Stripe.xcworkspace -scheme "StripePaymentSheet" -destination "id=$DEVICE_ID_FROM_USER_SETTINGS,arch=arm64" -quiet
+```
+
+### Snapshot Tests
+- **Record snapshots**: Use `AllStripeFrameworks-RecordMode` scheme (will fail while recording)
+- **Run snapshots**: Use `AllStripeFrameworks` scheme to verify recorded snapshots
+- **Record via CLI**: `bundle exec ruby ci_scripts/snapshots.rb --record`
+
+## Code Quality
+
+### **IMPORTANT: Always Run Before Committing**
+Before any commit, ALWAYS run these commands in order: If you are on the `master` branch, you MUST check out a branch before running these commands.
+1. **Format modified files**: `ci_scripts/format_modified_files.sh`
+2. **Lint modified files**: `ci_scripts/lint_modified_files.sh`
+
+### Linting
+- **Format modified files**: `ci_scripts/format_modified_files.sh` 
+- **Lint modified files**: `ci_scripts/lint_modified_files.sh`
+
+### Filing PRs
+When using the GitHub `gh` command, ALWAYS set `GH_HOST=github.com`. For example: `GH_HOST=github.com gh pr create --title [...]`
+
+### Analysis
+- **Run static analyzer**: `bundle exec fastlane analyze`
+
+## Project Architecture
+
+### Module Structure
+The Stripe iOS SDK is organized as a multi-module framework with clear dependency hierarchies:
+
+**Core Dependencies:**
+- `StripeCore` - Foundational networking, utilities, analytics
+- `StripeUICore` - Shared UI components and themes
+- `Stripe3DS2` - 3D Secure 2.0 authentication
+
+**Payment Modules:**
+- `StripePayments` - Core payment APIs (depends on StripeCore, Stripe3DS2)
+- `StripePaymentsUI` - Payment UI components (depends on StripePayments, StripeUICore)
+- `StripePaymentSheet` - Prebuilt payment flow (depends on StripePaymentsUI, StripeApplePay)
+- `StripeApplePay` - Apple Pay integration (depends on StripeCore)
+
+**Specialized Modules:**
+- `StripeIdentity` - Identity verification (depends on StripeCore, StripeUICore, StripeCameraCore)
+- `StripeFinancialConnections` - Bank account linking (depends on StripeCore, StripeUICore)
+- `StripeConnect` - Connect embedded components (depends on StripeCore, StripeUICore, StripeFinancialConnections)
+- `StripeCardScan` - Card scanning functionality (depends on StripeCore)
+
+**Main Stripe Module:**
+- `Stripe` - Umbrella framework including most modules plus additional issuing features
+
+### Key Workspaces and Projects
+- **Main workspace**: `Stripe.xcworkspace` - Contains all modules and examples
+- **Individual projects**: Each module has its own `.xcodeproj` for focused development
+- **Test configurations**: Located in `BuildConfigurations/` directories
+
+### Package Manager Support
+- **Swift Package Manager**: Defined in `Package.swift` with iOS 13+ minimum deployment
+- **CocoaPods**: Individual `.podspec` files for each module
+- **Carthage**: Supported with proper framework linking
+
+## Development Workflow
+
+### Requirements
+- Xcode 15+ required
+- iOS 13+ minimum deployment target  
+- Carthage 0.37+ for dependency management
+- Bundle/Fastlane for automation
+
+### Testing Strategy
+- Comprehensive unit tests for each module in corresponding `*Tests/` directories
+- Snapshot tests for UI components using FBSnapshotTestCase
+- Integration tests with real backend APIs (marked as functional tests)
+- Example apps for manual testing in `Example/` directory
+
+### Dependencies Installation
+Run `bundle install && bundle exec fastlane stripeios_tests` initially to install test dependencies.
+
+### Special Testing Notes
+- E2E tests: Use `bundle exec fastlane e2e_only` for end-to-end testing
+- Legacy iOS versions: Separate fastlane lanes for iOS 13-16 compatibility testing
+- Network recording: Use `AllStripeFrameworks-NetworkRecordMode` scheme for network test recording

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,7 @@ Before running tests or builds, ensure you have the correct simulator configured
 
 ### Automatic Simulator Detection
 
-**IMPORTANT**: Always check if `.stripe-ios-config` exists and contains a valid device ID before running tests or builds. Use the automated script to set up the simulator:
-
-```bash
-# Set up simulator (finds existing or creates new iPhone 12 mini with iOS 16.4)
-source <(./ci_scripts/setup_simulator.sh)
-```
+**IMPORTANT**: Always include a `source` call to the automated script at `source <(./ci_scripts/setup_simulator.sh) && [...]` to set up the simulator and use the correct device ID:
 
 The script will:
 1. Check for cached simulator ID in `.stripe-ios-config`
@@ -29,19 +24,22 @@ source <(./ci_scripts/setup_simulator.sh)
 
 ### Using the Device ID
 
-Once configured, you can use the device ID in build commands:
+You must ALWAYS use the device ID in build commands:
 ```bash
-source <(./ci_scripts/setup_simulator.sh)
-xcodebuild -workspace Stripe.xcworkspace -scheme "StripePaymentSheet" -destination "id=$DEVICE_ID_FROM_USER_SETTINGS,arch=arm64" -quiet
+source <(./ci_scripts/setup_simulator.sh) && xcodebuild -workspace Stripe.xcworkspace -scheme "StripePaymentSheet" -destination "id=$DEVICE_ID_FROM_USER_SETTINGS,arch=arm64" -quiet
 ```
 
 ### Quick Setup Check
 
 To verify the simulator is properly configured, run:
 ```bash
-source <(./ci_scripts/setup_simulator.sh)
-echo "✅ Simulator configured: $DEVICE_ID_FROM_USER_SETTINGS"
+source <(./ci_scripts/setup_simulator.sh) && echo "✅ Simulator configured: $DEVICE_ID_FROM_USER_SETTINGS"
 ```
+
+## Adding new files
+If you create a new file, it MUST be added to the `.xcodeproj`. There is no reasonable way to do this on your own, you MUST ask the user to add the file manually before continuing.
+
+Ask the user to add the file to the `.xcodeproj`. Once they've completed this task, you can continue making progress.
 
 ## Build Commands
 
@@ -51,39 +49,39 @@ echo "✅ Simulator configured: $DEVICE_ID_FROM_USER_SETTINGS"
 - **Run all integration tests**: `bundle exec fastlane integration_all`
 - **Run 3DS2 tests**: `bundle exec fastlane threeds2_tests`
 
-### Test with CI Script
-Use `./ci_scripts/test.rb` for more granular control:
-- **Build only**: `./ci_scripts/test.rb --build-only --scheme 'SCHEME_NAME'`
-- **Run specific scheme**: `./ci_scripts/test.rb --scheme 'SCHEME_NAME' --device 'iPhone 12 mini' --version 16.4 --retry-on-failure`
-
 ### Standard Build Using Xcode
-For compilation testing, use this standard command:
+For testing, use this standard command:
 ```bash
-source <(./ci_scripts/setup_simulator.sh)
-xcodebuild -workspace Stripe.xcworkspace -scheme "StripePaymentSheet" -destination "id=$DEVICE_ID_FROM_USER_SETTINGS,arch=arm64" -quiet
+source <(./ci_scripts/setup_simulator.sh) && xcodebuild -workspace Stripe.xcworkspace -scheme "StripePaymentSheet" -destination "id=$DEVICE_ID_FROM_USER_SETTINGS,arch=arm64" -quiet SWIFT_SUPPRESS_WARNINGS=YES SWIFT_TREAT_WARNINGS_AS_ERRORS=NO
 ```
+(Replacing "StripePaymentSheet" with your desired test framework, or "AllStripeFrameworks" to test all frameworks.)
+
+### **IMPORTANT: Suppress Warnings for Test Targets**
+When building test targets, always suppress warnings to avoid distracting output. Use `SWIFT_SUPPRESS_WARNINGS=YES SWIFT_TREAT_WARNINGS_AS_ERRORS=NO` in xcodebuild commands for test schemes:
+```bash
+xcodebuild test -scheme StripePaymentSheet -workspace Stripe.xcworkspace -destination "id=$DEVICE_ID_FROM_USER_SETTINGS,arch=arm64" -quiet SWIFT_SUPPRESS_WARNINGS=YES SWIFT_TREAT_WARNINGS_AS_ERRORS=NO
+```
+(Replace "StripePaymentSheet" with the name of your scheme as needed.)
 
 ### Snapshot Tests
-- **Record snapshots**: Use `AllStripeFrameworks-RecordMode` scheme (will fail while recording)
+- **Record snapshots**: Use `AllStripeFrameworks-RecordMode` scheme (will fail while recording) and a specific test case
 - **Run snapshots**: Use `AllStripeFrameworks` scheme to verify recorded snapshots
-- **Record via CLI**: `bundle exec ruby ci_scripts/snapshots.rb --record`
+
+### Recorded network tests
+- **Record network tests**: Use `AllStripeFrameworks-NetworkRecordMode` scheme (will fail while recording) and a specific test case
+- **Run network tests**: Use `AllStripeFrameworks` scheme to verify recorded network tests
 
 ## Code Quality
 
-### **IMPORTANT: Always Run Before Committing**
-Before any commit, ALWAYS run these commands in order: If you are on the `master` branch, you MUST check out a branch before running these commands.
-1. **Format modified files**: `ci_scripts/format_modified_files.sh`
-2. **Lint modified files**: `ci_scripts/lint_modified_files.sh`
+### **IMPORTANT: Always Lint Before Committing**
+Before any commit, ALWAYS run these commands in order
 
-### Linting
-- **Format modified files**: `ci_scripts/format_modified_files.sh` 
-- **Lint modified files**: `ci_scripts/lint_modified_files.sh`
+1. **Check out a branch if needed**: If you are on the `master` branch, you MUST check out a new branch.
+2. **Format modified files**: `ci_scripts/format_modified_files.sh`
+3. **Lint modified files**: `ci_scripts/lint_modified_files.sh`
 
 ### Filing PRs
 When using the GitHub `gh` command, ALWAYS set `GH_HOST=github.com`. For example: `GH_HOST=github.com gh pr create --title [...]`
-
-### Analysis
-- **Run static analyzer**: `bundle exec fastlane analyze`
 
 ## Project Architecture
 
@@ -98,7 +96,7 @@ The Stripe iOS SDK is organized as a multi-module framework with clear dependenc
 **Payment Modules:**
 - `StripePayments` - Core payment APIs (depends on StripeCore, Stripe3DS2)
 - `StripePaymentsUI` - Payment UI components (depends on StripePayments, StripeUICore)
-- `StripePaymentSheet` - Prebuilt payment flow (depends on StripePaymentsUI, StripeApplePay)
+- `StripePaymentSheet` - Prebuilt payment flow (depends on StripePaymentsUI, StripeApplePay). (This is the main product we work on.)
 - `StripeApplePay` - Apple Pay integration (depends on StripeCore)
 
 **Specialized Modules:**
@@ -107,8 +105,8 @@ The Stripe iOS SDK is organized as a multi-module framework with clear dependenc
 - `StripeConnect` - Connect embedded components (depends on StripeCore, StripeUICore, StripeFinancialConnections)
 - `StripeCardScan` - Card scanning functionality (depends on StripeCore)
 
-**Main Stripe Module:**
-- `Stripe` - Umbrella framework including most modules plus additional issuing features
+**Legacy Stripe Module:**
+- `Stripe` - Legacy umbrella framework including most modules plus additional issuing features.
 
 ### Key Workspaces and Projects
 - **Main workspace**: `Stripe.xcworkspace` - Contains all modules and examples
@@ -138,6 +136,4 @@ The Stripe iOS SDK is organized as a multi-module framework with clear dependenc
 Run `bundle install && bundle exec fastlane stripeios_tests` initially to install test dependencies.
 
 ### Special Testing Notes
-- E2E tests: Use `bundle exec fastlane e2e_only` for end-to-end testing
 - Legacy iOS versions: Separate fastlane lanes for iOS 13-16 compatibility testing
-- Network recording: Use `AllStripeFrameworks-NetworkRecordMode` scheme for network test recording

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -294,4 +294,9 @@ import Foundation
 
     // MARK: - Custom Payment Methods
     case paymentSheetInvalidCPM = "mc_invalid_cpm"
+    
+    // MARK: - Shop Pay Webview
+    case shopPayWebviewLoadAttempt = "mc_shoppay_webview_load_attempt"
+    case shopPayWebviewConfirmSuccess = "mc_shoppay_webview_confirm_success"
+    case shopPayWebviewCancelled = "mc_shoppay_webview_cancelled"
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -387,6 +387,18 @@ final class PaymentSheetAnalyticsHelper {
         log(event: .mcUpdateFinishedEmbedded, duration: duration, error: error, params: ["status": result.analyticValue])
     }
 
+    func logShopPayWebviewLoadAttempt() {
+        log(event: .shopPayWebviewLoadAttempt)
+    }
+
+    func logShopPayWebviewConfirmSuccess() {
+        log(event: .shopPayWebviewConfirmSuccess)
+    }
+
+    func logShopPayWebviewCancelled(didReceiveECEClick: Bool) {
+        log(event: .shopPayWebviewCancelled, params: ["did_receive_ece_click": didReceiveECEClick])
+    }
+
     func log(
         event: STPAnalyticEvent,
         duration: TimeInterval? = nil,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -177,7 +177,8 @@ import WebKit
             // Present Shop Pay via ECE WebView
             let shopPayPresenter = ShopPayECEPresenter(
                 flowController: flowController,
-                configuration: shopPayConfig
+                configuration: shopPayConfig,
+                analyticsHelper: flowController.analyticsHelper
             )
             shopPayPresenter.present(from: WindowAuthenticationContext().authenticationPresentingViewController(),
                                      confirmHandler: confirmHandler)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEIntegrationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEIntegrationTests.swift
@@ -89,7 +89,8 @@ class ECEIntegrationTests: XCTestCase {
 
         presenter = ShopPayECEPresenter(
             flowController: flowController,
-            configuration: shopPayConfiguration
+            configuration: shopPayConfiguration,
+            analyticsHelper: analyticsHelper
         )
 
         presentingViewController = UIViewController()
@@ -250,7 +251,8 @@ class ECEIntegrationTests: XCTestCase {
 
         presenter = ShopPayECEPresenter(
             flowController: flowController,
-            configuration: configWithHandlers
+            configuration: configWithHandlers,
+            analyticsHelper: analyticsHelper
         )
         eceViewController.expressCheckoutWebviewDelegate = presenter
 
@@ -383,7 +385,8 @@ class ECEIntegrationTests: XCTestCase {
         )
         let presenterNoShipping = ShopPayECEPresenter(
             flowController: flowController2,
-            configuration: configNoShipping
+            configuration: configNoShipping,
+            analyticsHelper: analyticsHelper
         )
         let amount2 = presenterNoShipping.amountForECEView(eceViewController)
         XCTAssertEqual(amount2, 5000) // Just the item
@@ -411,7 +414,8 @@ class ECEIntegrationTests: XCTestCase {
         )
         let presenterMultiShipping = ShopPayECEPresenter(
             flowController: flowController3,
-            configuration: configMultiShipping
+            configuration: configMultiShipping,
+            analyticsHelper: analyticsHelper
         )
         let amount3 = presenterMultiShipping.amountForECEView(eceViewController)
         XCTAssertEqual(amount3, 1500) // 1000 + 500 (first shipping rate)
@@ -492,7 +496,8 @@ class ECEIntegrationTests: XCTestCase {
 
         let presenter = ShopPayECEPresenter(
             flowController: flowController,
-            configuration: shopPayConfiguration
+            configuration: shopPayConfiguration,
+            analyticsHelper: analyticsHelper
         )
 
         eceViewController.expressCheckoutWebviewDelegate = presenter
@@ -576,7 +581,8 @@ class ECEIntegrationTests: XCTestCase {
         )
         let presenterNoShipping = ShopPayECEPresenter(
             flowController: flowController2,
-            configuration: configNoShipping
+            configuration: configNoShipping,
+            analyticsHelper: analyticsHelper
         )
 
         // Configuration 3: Multiple shipping rates (should use first)
@@ -611,7 +617,8 @@ class ECEIntegrationTests: XCTestCase {
         )
         let presenterMultiShipping = ShopPayECEPresenter(
             flowController: flowController3,
-            configuration: configMultiShipping
+            configuration: configMultiShipping,
+            analyticsHelper: analyticsHelper
         )
 
         let mockECEVC = ECEViewController(apiClient: apiClient,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ShopPayECEPresenterTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ShopPayECEPresenterTests.swift
@@ -5,10 +5,13 @@
 
 @testable @_spi(STP) import StripeCore
 @testable @_spi(STP) import StripePayments
-@testable @_spi(STP) import StripePaymentSheet
+@testable @_spi(STP) @_spi(CustomerSessionBetaAccess) import StripePaymentSheet
 @testable @_spi(STP) import StripePaymentsTestUtils
 import UIKit
 import XCTest
+
+// We'll test analytics integration directly using the existing STPAnalyticsClient infrastructure
+// since PaymentSheetAnalyticsHelper is final and can't be subclassed for testing
 
 @available(iOS 16.0, *)
 @MainActor
@@ -19,6 +22,7 @@ class ShopPayECEPresenterTests: XCTestCase {
     var shopPayConfiguration: PaymentSheet.ShopPayConfiguration!
     var mockViewController: UIViewController!
     var mockFlowController: PaymentSheet.FlowController!
+    var analyticsHelper: PaymentSheetAnalyticsHelper!
 
     override func setUp() {
         super.setUp()
@@ -62,6 +66,7 @@ class ShopPayECEPresenterTests: XCTestCase {
         mockConfiguration.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
         mockConfiguration.merchantDisplayName = "Test Merchant"
         mockConfiguration.shopPay = shopPayConfiguration
+        mockConfiguration.customer = .init(id: "cus_123abc", customerSessionClientSecret: "cuss_123abc_secret_123")
 
         // Create mock flow controller
         let intentConfig = PaymentSheet.IntentConfiguration(
@@ -78,7 +83,7 @@ class ShopPayECEPresenterTests: XCTestCase {
             savedPaymentMethods: [],
             paymentMethodTypes: []
         )
-        let analyticsHelper = PaymentSheetAnalyticsHelper(
+        analyticsHelper = PaymentSheetAnalyticsHelper(
             integrationShape: .flowController,
             configuration: mockConfiguration
         )
@@ -92,7 +97,8 @@ class ShopPayECEPresenterTests: XCTestCase {
         // Create presenter
         sut = ShopPayECEPresenter(
             flowController: mockFlowController,
-            configuration: shopPayConfiguration
+            configuration: shopPayConfiguration,
+            analyticsHelper: analyticsHelper
         )
 
         mockViewController = UIViewController()
@@ -104,6 +110,7 @@ class ShopPayECEPresenterTests: XCTestCase {
         shopPayConfiguration = nil
         mockViewController = nil
         mockFlowController = nil
+        analyticsHelper = nil
         super.tearDown()
     }
 
@@ -145,7 +152,8 @@ class ShopPayECEPresenterTests: XCTestCase {
         )
         sut = ShopPayECEPresenter(
             flowController: mockFlowController,
-            configuration: noShippingConfig
+            configuration: noShippingConfig,
+            analyticsHelper: mockFlowController.analyticsHelper
         )
         let mockECEViewController = ECEViewController(apiClient: mockConfiguration.apiClient,
                                                       shopId: "shop_id_123",
@@ -251,7 +259,8 @@ class ShopPayECEPresenterTests: XCTestCase {
 
         sut = ShopPayECEPresenter(
             flowController: mockFlowController,
-            configuration: shopPayConfiguration
+            configuration: shopPayConfiguration,
+            analyticsHelper: mockFlowController.analyticsHelper
         )
 
         let shippingAddress: [String: Any] = [
@@ -309,7 +318,8 @@ class ShopPayECEPresenterTests: XCTestCase {
 
         sut = ShopPayECEPresenter(
             flowController: mockFlowController,
-            configuration: shopPayConfiguration
+            configuration: shopPayConfiguration,
+            analyticsHelper: mockFlowController.analyticsHelper
         )
 
         let shippingAddress: [String: Any] = [
@@ -398,7 +408,8 @@ class ShopPayECEPresenterTests: XCTestCase {
 
         sut = ShopPayECEPresenter(
             flowController: mockFlowController,
-            configuration: shopPayConfiguration
+            configuration: shopPayConfiguration,
+            analyticsHelper: mockFlowController.analyticsHelper
         )
 
         let shippingRate: [String: Any] = ["id": "express", "amount": 1000, "displayName": "Express Shipping"]
@@ -532,6 +543,92 @@ class ShopPayECEPresenterTests: XCTestCase {
             }
         } catch {
             XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    // MARK: - Analytics Tests
+
+    func testAnalytics_LoadAttemptLogged() {
+        // Given
+        STPAnalyticsClient.sharedClient._testLogHistory = []
+        
+        // When
+        sut.present(from: mockViewController) { _ in
+            // Do nothing, we'll log the event immediately
+        }
+        
+        // Then
+        let loggedEvents = STPAnalyticsClient.sharedClient._testLogHistory.compactMap { $0["event"] as? String }
+        XCTAssertTrue(loggedEvents.contains("mc_shoppay_webview_load_attempt"))
+    }
+
+    func testAnalytics_ECEClickTrackedForCancellation() async throws {
+        // Given
+        let mockECEViewController = ECEViewController(apiClient: mockConfiguration.apiClient,
+                                                      shopId: "shop_id_123",
+                                                      customerSessionClientSecret: "cuss_12345")
+        let event = [
+            "walletType": "shop_pay",
+            "expressPaymentType": "shop_pay",
+        ]
+
+        // When - First trigger ECE click to set the flag
+        _ = try await sut.eceView(mockECEViewController, didReceiveECEClick: event)
+        
+        // Reset analytics to only capture cancellation event
+        STPAnalyticsClient.sharedClient._testLogHistory = []
+        
+        // Then trigger cancellation
+        sut.didCancel()
+
+        // Then
+        let loggedEvents = STPAnalyticsClient.sharedClient._testLogHistory.compactMap { $0["event"] as? String }
+        XCTAssertTrue(loggedEvents.contains("mc_shoppay_webview_cancelled"))
+        
+        // Find the cancellation event and check parameters
+        if let cancelEvent = STPAnalyticsClient.sharedClient._testLogHistory.first(where: { ($0["event"] as? String) == "mc_shoppay_webview_cancelled" }) {
+            XCTAssertEqual(cancelEvent["did_receive_ece_click"] as? Bool, true)
+        } else {
+            XCTFail("Cancellation event not found")
+        }
+    }
+
+    func testAnalytics_CancellationWithoutECEClick() {
+        // Given
+        STPAnalyticsClient.sharedClient._testLogHistory = []
+        
+        // When - Cancel without triggering ECE click first
+        sut.didCancel()
+
+        // Then
+        let loggedEvents = STPAnalyticsClient.sharedClient._testLogHistory.compactMap { $0["event"] as? String }
+        XCTAssertTrue(loggedEvents.contains("mc_shoppay_webview_cancelled"))
+        
+        // Find the cancellation event and check parameters
+        if let cancelEvent = STPAnalyticsClient.sharedClient._testLogHistory.first(where: { ($0["event"] as? String) == "mc_shoppay_webview_cancelled" }) {
+            XCTAssertEqual(cancelEvent["did_receive_ece_click"] as? Bool, false)
+        } else {
+            XCTFail("Cancellation event not found")
+        }
+    }
+
+    func testAnalytics_PresentationControllerDismiss() {
+        // Given
+        STPAnalyticsClient.sharedClient._testLogHistory = []
+        let mockPresentationController = UIPresentationController(presentedViewController: UIViewController(), presenting: mockViewController)
+        
+        // When
+        sut.presentationControllerDidDismiss(mockPresentationController)
+
+        // Then
+        let loggedEvents = STPAnalyticsClient.sharedClient._testLogHistory.compactMap { $0["event"] as? String }
+        XCTAssertTrue(loggedEvents.contains("mc_shoppay_webview_cancelled"))
+        
+        // Verify the ECE click flag is correctly reported
+        if let cancelEvent = STPAnalyticsClient.sharedClient._testLogHistory.first(where: { ($0["event"] as? String) == "mc_shoppay_webview_cancelled" }) {
+            XCTAssertEqual(cancelEvent["did_receive_ece_click"] as? Bool, false)
+        } else {
+            XCTFail("Cancellation event not found")
         }
     }
 

--- a/ci_scripts/setup_simulator.sh
+++ b/ci_scripts/setup_simulator.sh
@@ -14,7 +14,6 @@ SIMULATOR_NAME="iPhone 12 mini (Stripe)"
 # Function to clear cache
 clear_cache() {
     if [ -f "$CONFIG_FILE" ]; then
-        echo "Clearing simulator cache..."
         rm "$CONFIG_FILE"
     fi
 }
@@ -26,7 +25,6 @@ find_existing_simulator() {
 
 # Function to create new simulator
 create_simulator() {
-    echo "Creating new $DEVICE_TYPE simulator with iOS $IOS_VERSION..."
     xcrun simctl create "$SIMULATOR_NAME" "com.apple.CoreSimulator.SimDeviceType.iPhone-12-mini" "com.apple.CoreSimulator.SimRuntime.iOS-16-4"
 }
 
@@ -41,7 +39,6 @@ main() {
     # Handle --clear-cache flag
     if [ "$1" = "--clear-cache" ]; then
         clear_cache
-        echo "Cache cleared. Run again to set up simulator."
         exit 0
     fi
     
@@ -51,11 +48,9 @@ main() {
         
         # Validate cached simulator still exists
         if validate_simulator "$DEVICE_ID_FROM_USER_SETTINGS"; then
-            echo "✅ Using cached simulator: $DEVICE_ID_FROM_USER_SETTINGS"
             echo "DEVICE_ID_FROM_USER_SETTINGS=$DEVICE_ID_FROM_USER_SETTINGS"
             exit 0
         else
-            echo "⚠️  Cached simulator no longer exists, finding new one..."
             clear_cache
         fi
     fi
@@ -64,20 +59,16 @@ main() {
     EXISTING_DEVICE=$(find_existing_simulator)
     
     if [ -n "$EXISTING_DEVICE" ]; then
-        echo "Found existing $DEVICE_TYPE: $EXISTING_DEVICE"
         DEVICE_ID="$EXISTING_DEVICE"
     else
         DEVICE_ID=$(create_simulator)
         if [ -z "$DEVICE_ID" ]; then
-            echo "❌ Failed to create simulator"
             exit 1
         fi
-        echo "Created simulator: $DEVICE_ID"
     fi
     
     # Save to config file
     echo "DEVICE_ID_FROM_USER_SETTINGS=$DEVICE_ID" > "$CONFIG_FILE"
-    echo "Simulator ID saved to $CONFIG_FILE: $DEVICE_ID"
     echo "DEVICE_ID_FROM_USER_SETTINGS=$DEVICE_ID"
 }
 

--- a/ci_scripts/setup_simulator.sh
+++ b/ci_scripts/setup_simulator.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# setup_simulator.sh
+# Automatically finds or creates an iPhone 12 mini with iOS 16.4 for testing
+# Caches the result to .stripe-ios-config for reuse
+
+set -e
+
+CONFIG_FILE=".stripe-ios-config"
+DEVICE_TYPE="iPhone 12 mini"
+IOS_VERSION="16.4"
+SIMULATOR_NAME="iPhone 12 mini (Stripe)"
+
+# Function to clear cache
+clear_cache() {
+    if [ -f "$CONFIG_FILE" ]; then
+        echo "Clearing simulator cache..."
+        rm "$CONFIG_FILE"
+    fi
+}
+
+# Function to find existing simulator
+find_existing_simulator() {
+    xcrun simctl list devices available | grep "$DEVICE_TYPE.*$IOS_VERSION" | head -1 | grep -o "([^)]*)" | tr -d "()"
+}
+
+# Function to create new simulator
+create_simulator() {
+    echo "Creating new $DEVICE_TYPE simulator with iOS $IOS_VERSION..."
+    xcrun simctl create "$SIMULATOR_NAME" "com.apple.CoreSimulator.SimDeviceType.iPhone-12-mini" "com.apple.CoreSimulator.SimRuntime.iOS-16-4"
+}
+
+# Function to validate simulator exists
+validate_simulator() {
+    local device_id="$1"
+    xcrun simctl list devices | grep -q "$device_id"
+}
+
+# Main logic
+main() {
+    # Handle --clear-cache flag
+    if [ "$1" = "--clear-cache" ]; then
+        clear_cache
+        echo "Cache cleared. Run again to set up simulator."
+        exit 0
+    fi
+    
+    # Check if cached config exists and is valid
+    if [ -f "$CONFIG_FILE" ] && grep -q "DEVICE_ID_FROM_USER_SETTINGS=" "$CONFIG_FILE"; then
+        source "$CONFIG_FILE"
+        
+        # Validate cached simulator still exists
+        if validate_simulator "$DEVICE_ID_FROM_USER_SETTINGS"; then
+            echo "✅ Using cached simulator: $DEVICE_ID_FROM_USER_SETTINGS"
+            echo "DEVICE_ID_FROM_USER_SETTINGS=$DEVICE_ID_FROM_USER_SETTINGS"
+            exit 0
+        else
+            echo "⚠️  Cached simulator no longer exists, finding new one..."
+            clear_cache
+        fi
+    fi
+    
+    # Look for existing simulator
+    EXISTING_DEVICE=$(find_existing_simulator)
+    
+    if [ -n "$EXISTING_DEVICE" ]; then
+        echo "Found existing $DEVICE_TYPE: $EXISTING_DEVICE"
+        DEVICE_ID="$EXISTING_DEVICE"
+    else
+        DEVICE_ID=$(create_simulator)
+        if [ -z "$DEVICE_ID" ]; then
+            echo "❌ Failed to create simulator"
+            exit 1
+        fi
+        echo "Created simulator: $DEVICE_ID"
+    fi
+    
+    # Save to config file
+    echo "DEVICE_ID_FROM_USER_SETTINGS=$DEVICE_ID" > "$CONFIG_FILE"
+    echo "Simulator ID saved to $CONFIG_FILE: $DEVICE_ID"
+    echo "DEVICE_ID_FROM_USER_SETTINGS=$DEVICE_ID"
+}
+
+# Show usage if requested
+if [ "$1" = "--help" ] || [ "$1" = "-h" ]; then
+    echo "Usage: $0 [--clear-cache] [--help]"
+    echo ""
+    echo "Automatically finds or creates an iPhone 12 mini with iOS 16.4 for testing."
+    echo "Caches the result to .stripe-ios-config for reuse."
+    echo ""
+    echo "Options:"
+    echo "  --clear-cache    Clear the cached simulator ID"
+    echo "  --help, -h       Show this help message"
+    echo ""
+    echo "Output:"
+    echo "  Prints DEVICE_ID_FROM_USER_SETTINGS=<device_id> for use with 'source' command"
+    exit 0
+fi
+
+main "$@"


### PR DESCRIPTION
## Summary
This PR adds comprehensive analytics tracking for the Shop Pay webview flow to provide visibility into user interactions and help identify issues.

**Analytics Events Added:**
- `shopPayWebviewLoadAttempt` - Tracks when Shop Pay webview loading begins
- `shopPayWebviewConfirmSuccess` - Tracks successful payment completion  
- `shopPayWebviewCancelled` - Tracks cancellations with ECE click context

**Key Features:**
- ECE click tracking distinguishes between users who cancelled after trying Shop Pay vs. those who cancelled before interacting
- Success events track meaningful payment completion (not just webview load)
- Integration with existing PaymentSheet analytics patterns
- Comprehensive test coverage using STPAnalyticsClient._testLogHistory

## Test plan
- [x] Added analytics tests in `ShopPayECEPresenterTests.swift`
- [x] Updated existing tests in `ECEIntegrationTests.swift` to work with analytics helper
- [x] Verified basic functionality with existing Shop Pay integration tests
- [x] Confirmed analytics events are logged at correct lifecycle points
- [x] Validated ECE click tracking works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)