### PR TITLE
Fix race condition in Async.swift by putting Future `result` property…

### DIFF
--- a/StripeCore/StripeCoreTests/Helpers/AsyncTests.swift
+++ b/StripeCore/StripeCoreTests/Helpers/AsyncTests.swift
@@ -139,6 +139,16 @@ class AsyncTests: XCTestCase {
         promise.fullfill(with: .success(42))
         wait(for: [expectation], timeout: 1.0)
     }
+    
+    func testPromiseResolvedImmediatelyEdgecase() {
+        // This caused an EXC_BAD_ACCESS in a previous implementation of Async.swift that didn't make the Future's `result` property threadsafe
+        var i = 0
+        while i < 1000 {
+            let promise = Promise<Int>(error: NSError(domain: "", code: 0))
+            promise.resolve(with: 42)
+            i += 1
+        }
+    }
 }
 
 private extension Result {


### PR DESCRIPTION
… behind a queue

## Summary
Builds off https://github.com/stripe/stripe-ios/pull/5066 - reading the `result` property was not properly synchronized.

## Testing
I'm not sure if it's a good test but the test I added failed consistently before and is a minimal repro of the issue with VerificationSheetFlowControllerTest. 

## Changelog
I don't think this happened in production
