### PR TITLE
Stripe-mobile-payment-sheet-test-playground-v6 glitch migration

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetSnapshotTests.swift
@@ -19,7 +19,7 @@ import XCTest
 class PaymentSheetSnapshotTests: STPSnapshotTestCase {
 
     private let backendCheckoutUrl = URL(
-        string: "https://stripe-mobile-payment-sheet-test-playground-v6.glitch.me/checkout"
+        string: "https://stripe-mobile-test-playground-v6.stripedemos.com/checkout"
     )!
 
     private var paymentSheet: PaymentSheet!


### PR DESCRIPTION
Summary
Changed glitch url to stripedemos

Motivation
Glitch is going down July 8th 2025

Testing
N.A.

Changelog
N.A.