### PR TITLE
Fix Link logo shown in PhoneNumberElement

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/PhoneNumber/PhoneNumberElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PhoneNumber/PhoneNumberElement.swift
@@ -26,6 +26,11 @@ import UIKit
         if let infoView = infoView {
             infoView.translatesAutoresizingMaskIntoConstraints = false
             hStackView.addArrangedSubview(infoView)
+
+            NSLayoutConstraint.activate([
+                infoView.trailingAnchor.constraint(equalTo: hStackView.trailingAnchor)
+            ])
+
             // Add some extra padding to the right side
             hStackView.isLayoutMarginsRelativeArrangement = true
             hStackView.directionalLayoutMargins = .insets(


### PR DESCRIPTION
## Summary

Fixes a visual issue in `PhoneNumberElement` where the `infoView` was not being properly constrained to the trailing edge.

## Motivation

✨ 

## Testing

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 16 - 2025-07-03 at 12 50 56](https://github.com/user-attachments/assets/37968a6a-f509-487a-a73b-a66dea0cfbe1) | ![Simulator Screenshot - iPhone 16 - 2025-07-03 at 14 42 19](https://github.com/user-attachments/assets/294942c0-2371-4bff-8e2e-087eab3a55a6) |

## Changelog

N/a
