### PR TITLE
Fix `testNativeNetworkingManualEntryTestMode`

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsNetworkingUITests.swift
@@ -371,7 +371,10 @@ final class FinancialConnectionsNetworkingUITests: XCTestCase {
         // auto-fill manual entry screen
         app.fc_nativeTestModeAutofillButton.waitForExistenceAndTap()
 
-        app.fc_nativeSaveToLinkButton.waitForExistenceAndTap()
+        // Wait a moment for the consumer session lookup to complete before tapping `Save to Link`.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            app.fc_nativeSaveToLinkButton.waitForExistenceAndTap()
+        }
 
         app.fc_nativeSuccessDoneButton.waitForExistenceAndTap()
 


### PR DESCRIPTION
## Summary

This fixes `testNativeNetworkingManualEntryTestMode` by delaying the tap top `Save with Link` in order to eliminate a race condition between creating a Link account and looking up the Link account.

The failure was happening when:
1. We reach the Networking Link Signup pane, and an email is prefilled.
2. The UI test immediately taps `Save with Link`, meanwhile the consumer session lookup call was fired due to the email being prefilled.
3. We push to the Success pane.
4. Almost immediately after we get the consumer session lookup response, which results in an existing Link user
5. The Link Verification pane is pushed
6. :boom:

## Motivation

Fix CI

## Testing

Failing test:

https://github.com/user-attachments/assets/85defb9f-0e49-45df-9422-0c530d91c5bb

Fixed test:

https://github.com/user-attachments/assets/7afde6a0-110c-41d8-9443-3caf44f9a323

## Changelog

N/a