### PR TITLE
Don't use Link's bailToWebFlow in payment method selection mode

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -627,6 +627,13 @@ extension PayWithLinkViewController: PayWithLinkCoordinating {
             // Multiple things can kick off bailing to web flow, but we only want to do it once
             return
         }
+        guard !context.launchedFromFlowController else {
+            // If we're launched from FlowController, then just finish with a wallet confirm option.
+            // The wallet confirm option will trigger Link at the time of confirmation, where we can
+            // use the web flow without issue.
+            payWithLinkDelegate?.payWithLinkViewControllerDidFinish(self, confirmOption: .wallet)
+            return
+        }
         isBailingToWebFlow = true
         // Make sure we're presenting over a VC
         guard let presentingViewController else {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request updates the native Link experience to _not_ bail to the web flow when launched for payment method selection.

Payment method selection happens before the intent confirmation, which is something that the web flow isn't compatible with. Therefore, if we encounter an attestation error, we simply close the native Link experience and set `LinkConfirmOption.wallet` as the current payment option. This will open the web flow on intent confirmation.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
