### PR TITLE
Always allow user interaction when presenting 3DS

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -507,6 +507,15 @@ extension BottomSheetViewController: PaymentSheetAuthenticationContext {
         let threeDS2ViewController = BottomSheet3DS2ViewController(
             challengeViewController: authenticationViewController, appearance: appearance, isTestMode: isTestMode)
         threeDS2ViewController.delegate = self
+
+        // Re-enable user interaction when presenting the 3DS controller.
+        // This fixes an issue where the PayWithLinkViewController disables user interaction
+        // during payment confirmation but the 3DS controller needs to be interactable.
+        let wasUserInteractionEnabled = view.isUserInteractionEnabled
+        if !wasUserInteractionEnabled {
+            view.isUserInteractionEnabled = true
+        }
+
         pushContentViewController(threeDS2ViewController)
         // Remove a blur effect, if any
         self.removeBlurEffect(animated: true, completion: completion)


### PR DESCRIPTION
## Summary

This fixes an issue where user interaction was disabled when presenting 3DS from the Pay with Link controller. In BottomSheetViewController we can force-enable user interaction when the 3DS controller is being presented.

## Motivation

https://stripe.slack.com/archives/C08G211PLER/p1751885395251659

## Testing

Before:

https://github.com/user-attachments/assets/87c75d62-7aed-456e-928d-ab33e17ea9b2

After:

https://github.com/user-attachments/assets/0e852f91-9099-4cb4-9cec-3a38e6e551f0

## Changelog

N/a
