### PR TITLE
Update deserilization logic to allow deserilization independent between ps and cs

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
@@ -25,17 +25,15 @@ struct CustomerSession: Equatable, Hashable {
               let apiKey = response["api_key"] as? String,
               let apiKeyExpiry = response["api_key_expiry"] as? Int,
               let customer = response["customer"] as? String,
-              let componentsDict = response["components"] as? [AnyHashable: Any],
-              let mobilePaymentElementDict = componentsDict["mobile_payment_element"] as? [AnyHashable: Any],
-              let mobilePaymentElementEnabled = mobilePaymentElementDict["enabled"] as? Bool,
-              let customerSheetDict = componentsDict["customer_sheet"] as? [AnyHashable: Any],
-              let customerSheetEnabled = customerSheetDict["enabled"] as? Bool
+              let componentsDict = response["components"] as? [AnyHashable: Any]
         else {
             return nil
         }
 
         var mobilePaymentElementComponent: MobilePaymentElementComponent
-        if mobilePaymentElementEnabled {
+        if let mobilePaymentElementDict = componentsDict["mobile_payment_element"] as? [AnyHashable: Any],
+           let mobilePaymentElementEnabled = mobilePaymentElementDict["enabled"] as? Bool,
+           mobilePaymentElementEnabled {
             guard let mobilePaymentElementFeaturesDict = mobilePaymentElementDict["features"] as? [AnyHashable: Any],
                   let paymentMethodSave = mobilePaymentElementFeaturesDict["payment_method_save"] as? String,
                   let paymentMethodRemove = mobilePaymentElementFeaturesDict["payment_method_remove"] as? String else {
@@ -60,7 +58,9 @@ struct CustomerSession: Equatable, Hashable {
         }
 
         var customerSheetComponent: CustomerSheetComponent
-        if customerSheetEnabled {
+        if let customerSheetDict = componentsDict["customer_sheet"] as? [AnyHashable: Any],
+            let customerSheetEnabled = customerSheetDict["enabled"] as? Bool,
+           customerSheetEnabled {
             guard let customerSheetFeaturesDict = customerSheetDict["features"] as? [AnyHashable: Any],
                   let paymentMethodRemove = customerSheetFeaturesDict["payment_method_remove"] as? String else {
                 return nil

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -531,8 +531,7 @@ class STPElementsSessionTest: XCTestCase {
                                                                 ],
                                                             ])
 
-        let allowsSetAsDefault = elementsSession.paymentMethodSyncDefaultForCustomerSheet
-        XCTAssertTrue(allowsSetAsDefault)
+        XCTAssertTrue(elementsSession.paymentMethodSyncDefaultForCustomerSheet)
     }
 
     private let testCardJSON = [

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -504,6 +504,37 @@ class STPElementsSessionTest: XCTestCase {
         let allowsSetAsDefault = elementsSession.paymentMethodSyncDefaultForCustomerSheet
         XCTAssertFalse(allowsSetAsDefault)
     }
+    func testCanDeserializeMPEWithoutCS() {
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
+                                                            customerSessionData: [
+                                                                "mobile_payment_element": [
+                                                                    "enabled": true,
+                                                                    "features": ["payment_method_save": "enabled",
+                                                                                 "payment_method_remove": "enabled",
+                                                                                 "payment_method_set_as_default": "enabled",
+                                                                                ],
+                                                                ],
+                                                            ])
+
+        let allowsSetAsDefault = elementsSession.paymentMethodSetAsDefaultForPaymentSheet
+        XCTAssertTrue(allowsSetAsDefault)
+    }
+    func testCanDeserializeCSWithoutMPE() {
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
+                                                            customerSessionData: [
+                                                                "customer_sheet": [
+                                                                    "enabled": true,
+                                                                    "features": [
+                                                                        "payment_method_remove": "enabled",
+                                                                        "payment_method_sync_default": "enabled",
+                                                                    ],
+                                                                ],
+                                                            ])
+
+        let allowsSetAsDefault = elementsSession.paymentMethodSyncDefaultForCustomerSheet
+        XCTAssertTrue(allowsSetAsDefault)
+    }
+
     private let testCardJSON = [
         "id": "pm_123card",
         "type": "card",


### PR DESCRIPTION
## Summary
Make deserialization indepenent between ps and cs -- currently merchant is REQUIRED to be in both gates

## Motivation
Reduce operational overhead to onboard a merchant to both gates

## Testing
Added tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
