### PR TITLE
Remove ASCS fields from models

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession+PublishableKey.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession+PublishableKey.swift
@@ -12,16 +12,13 @@ extension ConsumerSession {
     final class SessionWithPublishableKey: Decodable {
         let consumerSession: ConsumerSession
         let publishableKey: String
-        let authSessionClientSecret: String?
 
         init(
             consumerSession: ConsumerSession,
-            publishableKey: String,
-            authSessionClientSecret: String? = nil
+            publishableKey: String
         ) {
             self.consumerSession = consumerSession
             self.publishableKey = publishableKey
-            self.authSessionClientSecret = authSessionClientSecret
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -596,7 +596,6 @@ private extension STPAPIClient {
     }
 
     struct SessionResponse: Decodable {
-        let authSessionClientSecret: String?
         let consumerSession: ConsumerSession
     }
 }


### PR DESCRIPTION
## Summary

Removes the `auth_session_client_secret` field from models. We don't use it anywhere.

## Motivation

Cleanup

## Testing

Project still builds

## Changelog

N/a