### PR TITLE
Use Link branding for PTM payment methods in SPM

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
@@ -71,7 +71,7 @@ extension STPPaymentMethod {
     var expandedPaymentSheetLabel: String {
         switch type {
         case .card:
-            if isLinkPaymentMethod || isLinkOrigin {
+            if isLinkPaymentMethod || isLinkPassthroughMode {
                 return STPPaymentMethodType.link.displayName
             } else if let card {
                 return STPCardBrandUtilities.stringFrom(card.preferredDisplayBrand) ?? STPPaymentMethodType.card.displayName
@@ -79,7 +79,7 @@ extension STPPaymentMethod {
                 return STPPaymentMethodType.card.displayName
             }
         case .USBankAccount:
-            if isLinkOrigin {
+            if isLinkPassthroughMode {
                 return STPPaymentMethodType.link.displayName
             } else {
                 return usBankAccount?.bankName ?? type.displayName

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
@@ -71,7 +71,7 @@ extension STPPaymentMethod {
     var expandedPaymentSheetLabel: String {
         switch type {
         case .card:
-            if isLinkPaymentMethod {
+            if isLinkPaymentMethod || isLinkOrigin {
                 return STPPaymentMethodType.link.displayName
             } else if let card {
                 return STPCardBrandUtilities.stringFrom(card.preferredDisplayBrand) ?? STPPaymentMethodType.card.displayName
@@ -79,7 +79,11 @@ extension STPPaymentMethod {
                 return STPPaymentMethodType.card.displayName
             }
         case .USBankAccount:
-            return usBankAccount?.bankName ?? type.displayName
+            if isLinkOrigin {
+                return STPPaymentMethodType.link.displayName
+            } else {
+                return usBankAccount?.bankName ?? type.displayName
+            }
         default:
             return type.displayName
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
@@ -57,9 +57,10 @@ struct ElementsCustomer: Equatable, Hashable {
             if enableLinkInSPM {
                 if let paymentMethodWithLinkDetails = PaymentMethodWithLinkDetails.decodedObject(fromAPIResponse: json) {
                     let paymentMethod = paymentMethodWithLinkDetails.paymentMethod
-                    paymentMethod.isLinkOrigin = paymentMethodWithLinkDetails.isLinkOrigin
                     if let linkDetails = paymentMethodWithLinkDetails.linkDetails {
                         paymentMethod.setLinkPaymentDetails(from: linkDetails)
+                    } else {
+                        paymentMethod.isLinkPassthroughMode = paymentMethodWithLinkDetails.isLinkOrigin
                     }
                     paymentMethods.append(paymentMethod)
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
@@ -57,6 +57,7 @@ struct ElementsCustomer: Equatable, Hashable {
             if enableLinkInSPM {
                 if let paymentMethodWithLinkDetails = PaymentMethodWithLinkDetails.decodedObject(fromAPIResponse: json) {
                     let paymentMethod = paymentMethodWithLinkDetails.paymentMethod
+                    paymentMethod.isLinkOrigin = paymentMethodWithLinkDetails.isLinkOrigin
                     if let linkDetails = paymentMethodWithLinkDetails.linkDetails {
                         paymentMethod.setLinkPaymentDetails(from: linkDetails)
                     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/PaymentMethodWithLinkDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/PaymentMethodWithLinkDetails.swift
@@ -9,13 +9,20 @@ import Foundation
 
 class PaymentMethodWithLinkDetails: NSObject, STPAPIResponseDecodable {
     let paymentMethod: STPPaymentMethod
+    let isLinkOrigin: Bool
     let linkDetails: ConsumerPaymentDetails?
     var allResponseFields: [AnyHashable: Any]
 
     // MARK: - STPAPIResponseDecodable
 
-    required init(paymentMethod: STPPaymentMethod, linkDetails: ConsumerPaymentDetails?, allResponseFields: [AnyHashable: Any]) {
+    required init(
+        paymentMethod: STPPaymentMethod,
+        isLinkOrigin: Bool,
+        linkDetails: ConsumerPaymentDetails?,
+        allResponseFields: [AnyHashable: Any]
+    ) {
         self.paymentMethod = paymentMethod
+        self.isLinkOrigin = isLinkOrigin
         self.linkDetails = linkDetails
         self.allResponseFields = allResponseFields
     }
@@ -28,6 +35,8 @@ class PaymentMethodWithLinkDetails: NSObject, STPAPIResponseDecodable {
         else {
             return nil
         }
+
+        let isLinkOrigin = response["is_link_origin"] as? Bool ?? false
 
         var linkDetails: ConsumerPaymentDetails?
 
@@ -47,6 +56,7 @@ class PaymentMethodWithLinkDetails: NSObject, STPAPIResponseDecodable {
 
         return self.init(
             paymentMethod: paymentMethod,
+            isLinkOrigin: isLinkOrigin,
             linkDetails: linkDetails,
             allResponseFields: response
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -81,13 +81,13 @@ extension STPPaymentMethod {
     func makeIcon(iconStyle: PaymentSheet.Appearance.IconStyle = .filled) -> UIImage {
         switch type {
         case .card:
-            return isLinkPaymentMethod
+            return (isLinkPaymentMethod || isLinkOrigin)
                 ? Image.link_icon.makeImage()
                 : STPImageLibrary.cardBrandImage(for: calculateCardBrandToDisplay())
         case .USBankAccount:
-            return PaymentSheetImageLibrary.bankIcon(
-                for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName), iconStyle: iconStyle
-            )
+            return isLinkOrigin
+                ? Image.link_icon.makeImage()
+                : PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName), iconStyle: iconStyle)
         case .link:
             return Image.link_icon.makeImage()
         default:
@@ -109,13 +109,13 @@ extension STPPaymentMethod {
     func makeSavedPaymentMethodCellImage(overrideUserInterfaceStyle: UIUserInterfaceStyle?, iconStyle: PaymentSheet.Appearance.IconStyle) -> UIImage {
         switch type {
         case .card:
-            return isLinkPaymentMethod
+            return (isLinkPaymentMethod || isLinkOrigin)
                 ? Image.link_logo.makeImage()
                 : calculateCardBrandToDisplay().makeSavedPaymentMethodCellImage(overrideUserInterfaceStyle: overrideUserInterfaceStyle)
         case .USBankAccount:
-            return PaymentSheetImageLibrary.bankIcon(
-                for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName), iconStyle: iconStyle
-            )
+            return isLinkOrigin
+                ? Image.link_logo.makeImage()
+                : PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName), iconStyle: iconStyle)
         case .SEPADebit:
             return Image.carousel_sepa.makeImage(overrideUserInterfaceStyle: overrideUserInterfaceStyle).withRenderingMode(.alwaysOriginal)
         case .link:
@@ -130,13 +130,13 @@ extension STPPaymentMethod {
     func makeSavedPaymentMethodRowImage(iconStyle: PaymentSheet.Appearance.IconStyle) -> UIImage {
         switch type {
         case .card:
-            return isLinkPaymentMethod
+            return (isLinkPaymentMethod || isLinkOrigin)
                 ? Image.link_icon.makeImage()
                 : STPImageLibrary.unpaddedCardBrandImage(for: calculateCardBrandToDisplay())
         case .USBankAccount:
-            return PaymentSheetImageLibrary.bankIcon(
-                for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName), iconStyle: iconStyle
-            ).rounded(radius: 3)
+            return isLinkOrigin
+                ? Image.link_icon.makeImage()
+                : PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName), iconStyle: iconStyle).rounded(radius: 3)
         case .SEPADebit:
             return Image.pm_type_sepa.makeImage().withRenderingMode(.alwaysOriginal)
         case .link:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -81,11 +81,11 @@ extension STPPaymentMethod {
     func makeIcon(iconStyle: PaymentSheet.Appearance.IconStyle = .filled) -> UIImage {
         switch type {
         case .card:
-            return (isLinkPaymentMethod || isLinkOrigin)
+            return (isLinkPaymentMethod || isLinkPassthroughMode)
                 ? Image.link_icon.makeImage()
                 : STPImageLibrary.cardBrandImage(for: calculateCardBrandToDisplay())
         case .USBankAccount:
-            return isLinkOrigin
+            return isLinkPassthroughMode
                 ? Image.link_icon.makeImage()
                 : PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName), iconStyle: iconStyle)
         case .link:
@@ -109,11 +109,11 @@ extension STPPaymentMethod {
     func makeSavedPaymentMethodCellImage(overrideUserInterfaceStyle: UIUserInterfaceStyle?, iconStyle: PaymentSheet.Appearance.IconStyle) -> UIImage {
         switch type {
         case .card:
-            return (isLinkPaymentMethod || isLinkOrigin)
+            return (isLinkPaymentMethod || isLinkPassthroughMode)
                 ? Image.link_logo.makeImage()
                 : calculateCardBrandToDisplay().makeSavedPaymentMethodCellImage(overrideUserInterfaceStyle: overrideUserInterfaceStyle)
         case .USBankAccount:
-            return isLinkOrigin
+            return isLinkPassthroughMode
                 ? Image.link_logo.makeImage()
                 : PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName), iconStyle: iconStyle)
         case .SEPADebit:
@@ -130,11 +130,11 @@ extension STPPaymentMethod {
     func makeSavedPaymentMethodRowImage(iconStyle: PaymentSheet.Appearance.IconStyle) -> UIImage {
         switch type {
         case .card:
-            return (isLinkPaymentMethod || isLinkOrigin)
+            return (isLinkPaymentMethod || isLinkPassthroughMode)
                 ? Image.link_icon.makeImage()
                 : STPImageLibrary.unpaddedCardBrandImage(for: calculateCardBrandToDisplay())
         case .USBankAccount:
-            return isLinkOrigin
+            return isLinkPassthroughMode
                 ? Image.link_icon.makeImage()
                 : PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: usBankAccount?.bankName), iconStyle: iconStyle).rounded(radius: 3)
         case .SEPADebit:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -779,7 +779,7 @@ extension PaymentOption {
         let hasLinkAccount = LinkAccountContext.shared.account?.isRegistered ?? false
         switch self {
         case .saved(let paymentMethod, _):
-            return (paymentMethod.isLinkPaymentMethod || paymentMethod.isLinkOrigin) && hasLinkAccount
+            return (paymentMethod.isLinkPaymentMethod || paymentMethod.isLinkPassthroughMode) && hasLinkAccount
         case .link(let confirmOption):
             switch confirmOption {
             case .signUp, .withPaymentMethod:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -779,7 +779,7 @@ extension PaymentOption {
         let hasLinkAccount = LinkAccountContext.shared.account?.isRegistered ?? false
         switch self {
         case .saved(let paymentMethod, _):
-            return paymentMethod.isLinkPaymentMethod && hasLinkAccount
+            return (paymentMethod.isLinkPaymentMethod || paymentMethod.isLinkOrigin) && hasLinkAccount
         case .link(let confirmOption):
             switch confirmOption {
             case .signUp, .withPaymentMethod:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -531,11 +531,15 @@ extension RowButton {
         let imageView = UIImageView(image: paymentMethod.makeSavedPaymentMethodRowImage(iconStyle: appearance.iconStyle))
         imageView.contentMode = .scaleAspectFit
 
+        let text = paymentMethod.isLinkPassthroughMode
+            ? STPPaymentMethodType.link.displayName
+            : paymentMethod.paymentSheetLabel
+
         let button = RowButton.create(
             appearance: appearance,
             type: .saved(paymentMethod: paymentMethod),
             imageView: imageView,
-            text: paymentMethod.isLinkPassthroughMode ? "Link" : paymentMethod.paymentSheetLabel,
+            text: text,
             subtext: paymentMethod.linkSpecificSublabel ?? subtext,
             badgeText: badgeText,
             accessoryView: accessoryView,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -535,8 +535,8 @@ extension RowButton {
             appearance: appearance,
             type: .saved(paymentMethod: paymentMethod),
             imageView: imageView,
-            text: paymentMethod.paymentSheetLabel,
-            subtext: paymentMethod.linkPaymentDetails?.sublabel ?? subtext,
+            text: paymentMethod.isLinkPassthroughMode ? "Link" : paymentMethod.paymentSheetLabel,
+            subtext: paymentMethod.linkSpecificSublabel ?? subtext,
             badgeText: badgeText,
             accessoryView: accessoryView,
             isEmbedded: isEmbedded,
@@ -628,5 +628,20 @@ extension PaymentSheet.Appearance {
 
     var defaultBadgeFont: UIFont {
         return scaledFont(for: font.base.regular, style: .caption1, maximumPointSize: 20)
+    }
+}
+
+private extension STPPaymentMethod {
+
+    var linkSpecificSublabel: String? {
+        if let linkPaymentDetails {
+            return linkPaymentDetails.sublabel
+        }
+        if isLinkPassthroughMode {
+            // We render "Link" as the label, so use the original label
+            // as the sublabel.
+            return paymentSheetLabel
+        }
+        return nil
     }
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
@@ -121,9 +121,15 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
 
     /// The payment details of a PaymentMethod that was created using Link.
     @_spi(STP) public var linkPaymentDetails: LinkPaymentDetails?
+    /// Whether this payment method is coming from Link.
+    @_spi(STP) public var isLinkOrigin: Bool = false
 
     @_spi(STP) public var isLinkPaymentMethod: Bool {
         linkPaymentDetails != nil
+    }
+
+    @_spi(STP) public var isLinkPassthroughMode: Bool {
+        isLinkOrigin && linkPaymentDetails == nil
     }
 
     /// :nodoc:

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
@@ -122,14 +122,10 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
     /// The payment details of a PaymentMethod that was created using Link.
     @_spi(STP) public var linkPaymentDetails: LinkPaymentDetails?
     /// Whether this payment method is coming from Link.
-    @_spi(STP) public var isLinkOrigin: Bool = false
+    @_spi(STP) public var isLinkPassthroughMode: Bool = false
 
     @_spi(STP) public var isLinkPaymentMethod: Bool {
         linkPaymentDetails != nil
-    }
-
-    @_spi(STP) public var isLinkPassthroughMode: Bool {
-        isLinkOrigin && linkPaymentDetails == nil
     }
 
     /// :nodoc:


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request extends the Link branding beyond payment methods of type `link` to payment methods that were created in passthrough mode.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
