### PR TITLE
Use visionOS checks instead of CompositorServices

### DIFF
--- a/StripeConnect/StripeConnect/Source/Internal/ConnectActivityIndicator.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/ConnectActivityIndicator.swift
@@ -103,7 +103,7 @@ import UIKit
         updateColor()
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateColor()
@@ -129,7 +129,7 @@ import UIKit
 
         if let window = newWindow {
             contentLayer.shouldRasterize = true
-#if !canImport(CompositorServices)
+#if !os(visionOS)
             contentLayer.rasterizationScale = window.screen.scale
 #endif
         }

--- a/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/StripeAPI.swift
@@ -163,7 +163,7 @@ import PassKit
         let paymentRequest = PKPaymentRequest()
         paymentRequest.merchantIdentifier = merchantIdentifier
         paymentRequest.supportedNetworks = self.supportedPKPaymentNetworks()
-        #if canImport(CompositorServices)
+        #if os(visionOS)
         paymentRequest.merchantCapabilities = .threeDSecure
         #else
         paymentRequest.merchantCapabilities = .capability3DS

--- a/StripeCore/StripeCore/Source/Categories/Locale+StripeCore.swift
+++ b/StripeCore/StripeCore/Source/Categories/Locale+StripeCore.swift
@@ -11,7 +11,7 @@ import Foundation
     /// Returns the regionCode, for visionOS compatibility
     /// We can remove this once we drop iOS 16
     var stp_regionCode: String? {
-#if canImport(CompositorServices)
+#if os(visionOS)
         return self.region?.identifier
         #else
         return self.regionCode
@@ -19,7 +19,7 @@ import Foundation
     }
 
     var stp_currencyCode: String? {
-        #if canImport(CompositorServices)
+        #if os(visionOS)
         return self.currency?.identifier
         #else
         return self.currencyCode
@@ -27,7 +27,7 @@ import Foundation
     }
 
     var stp_languageCode: String? {
-#if canImport(CompositorServices)
+#if os(visionOS)
         return self.language.languageCode?.identifier
         #else
         return self.languageCode
@@ -35,7 +35,7 @@ import Foundation
     }
 
     static var stp_isoRegionCodes: [String] {
-#if canImport(CompositorServices)
+#if os(visionOS)
         return self.Region.isoRegions.map { $0.identifier }
 #else
         return self.isoRegionCodes

--- a/StripeCore/StripeCore/Source/Telemetry/STPTelemetryClient.swift
+++ b/StripeCore/StripeCore/Source/Telemetry/STPTelemetryClient.swift
@@ -83,7 +83,7 @@ private let TelemetryURL = URL(string: "https://m.stripe.com/6")!
 
     private let urlSession: URLSession
 
-    @_spi(STP) public class func shouldSendTelemetry() -> Bool {
+    @_spi(STP) public static func shouldSendTelemetry() -> Bool {
         #if targetEnvironment(simulator)
             return false
         #else
@@ -121,7 +121,7 @@ private let TelemetryURL = URL(string: "https://m.stripe.com/6")!
     private var osVersion = UIDevice.current.systemVersion
 
     private var screenSize: String {
-        #if canImport(CompositorServices)
+        #if os(visionOS)
         return "visionOS"
         #else
         let screen = UIScreen.main

--- a/StripeCore/StripeCoreTestUtils/STPSnapshotTestCase.swift
+++ b/StripeCore/StripeCoreTestUtils/STPSnapshotTestCase.swift
@@ -5,7 +5,7 @@
 //  Created by David Estes on 4/13/22.
 //
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
 import Foundation
 import iOSSnapshotTestCase
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/ScreenNativeScale.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/ScreenNativeScale.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 var stp_screenNativeScale: CGFloat {
-    #if canImport(CompositorServices)
+    #if os(visionOS)
     return 1.0
     #else
     return UIScreen.main.nativeScale

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -122,7 +122,7 @@ final class LinkLoginViewController: UIViewController {
 
         paneLayoutView?.addTo(view: view)
 
-        #if !canImport(CompositorServices)
+        #if !os(visionOS)
         // if user drags, dismiss keyboard so the CTA buttons can be shown
         paneLayoutView?.scrollView.keyboardDismissMode = .onDrag
         #endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/ManualEntry/ManualEntryViewController.swift
@@ -103,7 +103,7 @@ final class ManualEntryViewController: UIViewController {
             keepFooterAboveKeyboard: true
         )
         paneLayoutView?.addTo(view: view)
-        #if !canImport(CompositorServices)
+        #if !os(visionOS)
         paneLayoutView?.scrollView.keyboardDismissMode = .onDrag
         #endif
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -168,7 +168,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
         )
         paneLayoutView.addTo(view: view)
 
-        #if !canImport(CompositorServices)
+        #if !os(visionOS)
         // if user drags, dismiss keyboard so the CTA buttons can be shown
         paneLayoutView.scrollView.keyboardDismissMode = .onDrag
         #endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedTextView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AttributedTextView.swift
@@ -158,7 +158,7 @@ final class AttributedTextView: HitTestView {
 
 extension AttributedTextView: UITextViewDelegate {
 
-    #if !canImport(CompositorServices)
+    #if !os(visionOS)
     func textView(
         _ textView: UITextView,
         shouldInteractWith URL: URL,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/UIApplication+StripePaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/UIApplication+StripePaymentSheet.swift
@@ -11,7 +11,7 @@ import UIKit
 extension UIApplication {
     func stp_hackilyFumbleAroundUntilYouFindAKeyWindow() -> UIWindow? {
         // We really shouldn't do this: Try to find a way to get the user to pass us a window instead.
-        #if canImport(CompositorServices)
+        #if os(visionOS)
         let windows = connectedScenes
             .compactMap { ($0 as? UIWindowScene)?.windows }
             .flatMap { $0 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/DownloadManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/DownloadManager.swift
@@ -138,7 +138,7 @@ private extension UIImage {
     }
 
     static func from(imageData: Data) throws -> UIImage {
-        #if canImport(CompositorServices)
+        #if os(visionOS)
         let scale = 1.0
         #else
         let scale = UIScreen.main.scale

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCameraView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCameraView.swift
@@ -5,7 +5,7 @@
 //  Created by David Estes on 8/17/20.
 //  Copyright © 2020 Stripe, Inc. All rights reserved.
 //
-#if !canImport(CompositorServices)
+#if !os(visionOS)
 
 import AVFoundation
 import UIKit

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPCardScanner.swift
@@ -5,7 +5,7 @@
 //  Created by David Estes on 8/17/20.
 //  Copyright © 2020 Stripe, Inc. All rights reserved.
 //
-#if !canImport(CompositorServices)
+#if !os(visionOS)
 
 import AVFoundation
 import Foundation

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
@@ -244,7 +244,7 @@ final class LinkInlineSignupView: UIView {
         }
     }
 
-    #if !canImport(CompositorServices)
+    #if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateAppearance()
@@ -319,7 +319,7 @@ extension LinkInlineSignupView: LinkLegalTermsViewDelegate {
     func legalTermsView(_ legalTermsView: LinkLegalTermsView, didTapOnLinkWithURL url: URL) -> Bool {
         let safariVC = SFSafariViewController(url: url)
 
-        #if !canImport(CompositorServices)
+        #if !os(visionOS)
         safariVC.dismissButtonStyle = .close
         safariVC.preferredControlTintColor = window?.tintColor ?? viewModel.configuration.appearance.colors.primary
         #endif

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/UIColor+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/UIColor+Link.swift
@@ -130,7 +130,7 @@ extension UIColor {
         forBackgroundColor backgroundColor: UIColor,
         traitCollection: UITraitCollection = .current
     ) -> UIColor {
-        #if canImport(CompositorServices)
+        #if os(visionOS)
         let resolvedLightModeColor = resolvedColor(
             with: traitCollection.modifyingTraits({ mutableTraits in
                 mutableTraits.userInterfaceStyle = .light

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
@@ -173,7 +173,7 @@ extension LinkLegalTermsView: UITextViewDelegate {
         case linkLegalTermsViewUITextViewDelegate
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     func textView(
         _ textView: UITextView,
         shouldInteractWith URL: URL,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationController.swift
@@ -78,7 +78,7 @@ class BottomSheetPresentationController: UIPresentationController {
 
         coordinator.animate(alongsideTransition: { [weak self] _ in
             self?.backgroundView.alpha = 1
-            #if !canImport(CompositorServices)
+            #if !os(visionOS)
             self?.presentedViewController.setNeedsStatusBarAppearanceUpdate()
             #endif
         })
@@ -98,7 +98,7 @@ class BottomSheetPresentationController: UIPresentationController {
 
         coordinator.animate(alongsideTransition: { [weak self] _ in
             self?.backgroundView.alpha = 0
-            #if !canImport(CompositorServices)
+            #if !os(visionOS)
             self?.presentingViewController.setNeedsStatusBarAppearanceUpdate()
             #endif
         })

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
@@ -15,7 +15,7 @@ extension UIViewController {
         completion: (() -> Void)? = nil
     ) {
         var presentAsFormSheet: Bool {
-            #if canImport(CompositorServices)
+            #if os(visionOS)
             return true
             #else
             // Present as form sheet in larger devices (iPad/Mac).

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -211,7 +211,7 @@ class CustomerAddPaymentMethodViewController: UIViewController {
             paymentMethodDetailsContainerView.layoutIfNeeded()
             newView.alpha = 0
 
-            #if !canImport(CompositorServices)
+            #if !os(visionOS)
             UISelectionFeedbackGenerator().selectionChanged()
             #endif
             // Fade the new one in and the old one out

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
@@ -24,7 +24,7 @@ final class CardSectionElement: ContainerElement {
 
     weak var delegate: ElementDelegate?
     lazy var view: UIView = {
-        #if !canImport(CompositorServices)
+        #if !os(visionOS)
         if #available(iOS 13.0, macCatalyst 14, *), STPCardScanner.cardScanningAvailable {
             return CardSectionWithScannerView(cardSectionView: cardSection.view, delegate: self, theme: theme, analyticsHelper: analyticsHelper)
         } else {
@@ -306,7 +306,7 @@ internal func cardParams(for intentParams: IntentConfirmParams) -> STPPaymentMet
     return cardParams
 }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
 // MARK: - CardSectionWithScannerViewDelegate
 
 extension CardSectionElement: CardSectionWithScannerViewDelegate {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
 import Foundation
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
@@ -322,7 +322,7 @@ class EmbeddedFormViewController: UIViewController {
                     self.updatePrimaryButton()
                     self.isUserInteractionEnabled = true
                 case .failed(let error):
-#if !canImport(CompositorServices)
+#if !os(visionOS)
                     UINotificationFeedbackGenerator().notificationOccurred(.error)
 #endif
                     // Update state
@@ -337,7 +337,7 @@ class EmbeddedFormViewController: UIViewController {
                     self.presentedViewController?.isBeingDismissed == true ? 1 : 0
                     // Hack: PaymentHandler calls the completion block while SafariVC is still being dismissed - "wait" until it's finished before updating UI
                     DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-#if !canImport(CompositorServices)
+#if !os(visionOS)
                         UINotificationFeedbackGenerator().notificationOccurred(.success)
 #endif
                         self.primaryButton.update(state: .succeeded, animated: true) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/RadioButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/RadioButton.swift
@@ -70,7 +70,7 @@ class RadioButton: UIView {
         outerCircle.position = CGPoint(x: bounds.midX, y: bounds.midY)
         innerCircle.position = CGPoint(x: bounds.midX, y: bounds.midY)
     }
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         update()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -207,7 +207,7 @@ class AddPaymentMethodViewController: UIViewController {
 extension AddPaymentMethodViewController: PaymentMethodTypeCollectionViewDelegate {
     func didUpdateSelection(_ paymentMethodTypeCollectionView: PaymentMethodTypeCollectionView) {
         analyticsHelper.logNewPaymentMethodSelected(paymentMethodTypeIdentifier: selectedPaymentMethodType.identifier)
-#if !canImport(CompositorServices)
+#if !os(visionOS)
             UISelectionFeedbackGenerator().selectionChanged()
 #endif
         updateFormElement()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -147,7 +147,7 @@ extension PaymentMethodTypeCollectionView: UICollectionViewDataSource, UICollect
 
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         var useFixedSizeCells: Bool {
-            #if canImport(CompositorServices)
+            #if os(visionOS)
             return true
             #else
             // Prefer fixed size cells for iPads and Mac.
@@ -288,7 +288,7 @@ extension PaymentMethodTypeCollectionView {
             fatalError("init(coder:) has not been implemented")
         }
 
-        #if !canImport(CompositorServices)
+        #if !os(visionOS)
         override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
             super.traitCollectionDidChange(previousTraitCollection)
             update()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
@@ -133,14 +133,14 @@ public extension PaymentSheet {
             public init() {}
 
             /// The primary color used throughout PaymentSheet
-            #if canImport(CompositorServices)
+            #if os(visionOS)
             public var primary: UIColor = .label
             #else
             public var primary: UIColor = .systemBlue
             #endif
 
             /// The color used for the background of PaymentSheet
-            #if canImport(CompositorServices)
+            #if os(visionOS)
             public var background: UIColor = .clear
             #else
             public var background: UIColor = .systemBackground
@@ -232,7 +232,7 @@ public extension PaymentSheet {
 
             /// The background color of the primary button
             /// - Note: If `nil`, `appearance.colors.primary` will be used as the primary button background color
-            #if canImport(CompositorServices)
+            #if os(visionOS)
             public var backgroundColor: UIColor? = .systemBlue
             #else
             public var backgroundColor: UIColor?

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -231,7 +231,7 @@ extension SavedPaymentMethodCollectionView {
             fatalError("init(coder:) has not been implemented")
         }
 
-        #if !canImport(CompositorServices)
+        #if !os(visionOS)
         override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
             super.traitCollectionDidChange(previousTraitCollection)
             update()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -124,7 +124,7 @@ class RowButton: UIView, EventHandler {
 
     // MARK: Overrides
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         // If the font size changes, make this RowButton the same height as the tallest variant if necessary
         heightConstraint?.isActive = false

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
@@ -71,7 +71,7 @@ class AutoCompleteViewController: UIViewController {
         let tableView = UITableView()
         tableView.delegate = self
         tableView.dataSource = self
-        #if !canImport(CompositorServices)
+        #if !os(visionOS)
         tableView.keyboardDismissMode = .onDrag
         #endif
         tableView.backgroundColor = configuration.appearance.colors.background

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -601,7 +601,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                     self.updatePrimaryButton()
                     self.isUserInteractionEnabled = true
                 case .failed(let error):
-#if !canImport(CompositorServices)
+#if !os(visionOS)
                     UINotificationFeedbackGenerator().notificationOccurred(.error)
 #endif
 
@@ -625,7 +625,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                     self.presentedViewController?.isBeingDismissed == true ? 1 : 0
                     // Hack: PaymentHandler calls the completion block while SafariVC is still being dismissed - "wait" until it's finished before updating UI
                     DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-#if !canImport(CompositorServices)
+#if !os(visionOS)
                         UINotificationFeedbackGenerator().notificationOccurred(.success)
 #endif
                         self.primaryButton.update(state: .succeeded, animated: true) {
@@ -789,7 +789,7 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
     func didTapPaymentMethod(_ selection: RowButtonType) {
         analyticsHelper.logNewPaymentMethodSelected(paymentMethodTypeIdentifier: selection.analyticsIdentifier)
         error = nil
-#if !canImport(CompositorServices)
+#if !os(visionOS)
         UISelectionFeedbackGenerator().selectionChanged()
 #endif
         switch selection {
@@ -813,7 +813,7 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
     }
 
     func didTapSavedPaymentMethodAccessoryButton() {
-#if !canImport(CompositorServices)
+#if !os(visionOS)
         UISelectionFeedbackGenerator().selectionChanged()
 #endif
         presentManageScreen()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -466,7 +466,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                     // Do nothing, keep customer on payment sheet
                     self.updateUI()
                 case .failed(let error):
-                    #if !canImport(CompositorServices)
+                    #if !os(visionOS)
                     UINotificationFeedbackGenerator().notificationOccurred(.error)
                     #endif
                     // Update state
@@ -478,7 +478,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                     let delay: TimeInterval = self.presentedViewController?.isBeingDismissed == true ? 1 : 0
                     // Hack: PaymentHandler calls the completion block while SafariVC is still being dismissed - "wait" until it's finished before updating UI
                     DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-#if !canImport(CompositorServices)
+#if !os(visionOS)
                         UINotificationFeedbackGenerator().notificationOccurred(.success)
 #endif
                         self.buyButton.update(state: .succeeded, animated: true) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PollingViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PollingViewController.swift
@@ -177,7 +177,7 @@ class PollingViewController: UIViewController {
         // disable swipe to dismiss
         isModalInPresentation = true
 
-        #if canImport(CompositorServices)
+        #if os(visionOS)
         let height = parent?.view.frame.size.height ?? 600 // An arbitrary value for visionOS
         #else
         // Height of the polling view controller is either the height of the parent, or the height of the screen (flow controller use case)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AUBECSMandate.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AUBECSMandate.swift
@@ -49,7 +49,7 @@ final class AUBECSLegalTermsView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         textView.font = .preferredFont(forTextStyle: .caption1)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AffirmCopyLabel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AffirmCopyLabel.swift
@@ -30,7 +30,7 @@ class AffirmCopyLabel: UIView {
         addAndPinSubview(affirmLabel)
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         logo.image = PaymentSheetImageLibrary.affirmLogo()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AfterpayPriceBreakdownView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AfterpayPriceBreakdownView.swift
@@ -130,7 +130,7 @@ class AfterpayPriceBreakdownView: UIView {
         }
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         afterPayClearPayLabel.attributedText = makeAfterPayClearPayString()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CVCPaymentMethodInformationView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CVCPaymentMethodInformationView.swift
@@ -84,7 +84,7 @@ class CVCPaymentMethodInformationView: UIView {
         ])
     }
 
-    #if !canImport(CompositorServices)
+    #if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         self.transparentMaskView.backgroundColor = appearance.colors.componentBackground.translucentMaskColor

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CVCRecollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CVCRecollectionView.swift
@@ -76,7 +76,7 @@ class CVCRecollectionView: UIView {
         addAndPinSubview(stack)
 
     }
-    #if !canImport(CompositorServices)
+    #if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         self.stackView.layer.borderColor = appearance.colors.componentBorder.cgColor

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2020 Stripe, Inc. All rights reserved.
 //
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
 
 import Foundation
 @_spi(STP) import StripeCore

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CircularButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CircularButton.swift
@@ -150,7 +150,7 @@ class CircularButton: UIControl {
         imageView.tintColor = isEnabled ? iconColor : .tertiaryLabel
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateShadow()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
@@ -154,7 +154,7 @@ class ConfirmButton: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         self.buyButton.update(status: state, callToAction: callToAction, animated: false)
@@ -393,7 +393,7 @@ class ConfirmButton: UIView {
             overriddenForegroundColor = appearance.primaryButton.textColor
         }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
         override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
             super.traitCollectionDidChange(previousTraitCollection)
             layer.borderColor = appearance.primaryButton.borderColor.cgColor

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentMethodTypeImageView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentMethodTypeImageView.swift
@@ -34,7 +34,7 @@ class PaymentMethodTypeImageView: UIImageView {
         fatalError("init(coder:) has not been implemented")
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateImage()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
@@ -19,7 +19,7 @@ enum PaymentSheetUI {
     /// The padding between views in the sheet e.g., between the bottom of the form and the Pay button
     static let defaultPadding: CGFloat = 20
 
-#if canImport(CompositorServices)
+#if os(visionOS)
     static let navBarPadding: CGFloat = 30
 #else
     static let navBarPadding = defaultPadding

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ShadowedRoundedRectangleView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ShadowedRoundedRectangleView.swift
@@ -72,7 +72,7 @@ class ShadowedRoundedRectangle: UIView {
         update()
     }
 
-    #if !canImport(CompositorServices)
+    #if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         update()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
@@ -84,7 +84,7 @@ class SheetNavigationBar: UIView {
         testModeView.isHidden = !isTestMode
         self.appearance = appearance
         super.init(frame: .zero)
-        #if !canImport(CompositorServices)
+        #if !os(visionOS)
         backgroundColor = appearance.colors.background.withAlphaComponent(0.9)
         #endif
         [leftItemsStackView, closeButtonRight, additionalButton].forEach {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddPaymentMethodViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddPaymentMethodViewControllerSnapshotTests.swift
@@ -5,7 +5,7 @@
 //  Created by Yuki Tokuhiro on 3/22/23.
 //
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
 import iOSSnapshotTestCase
 import StripeCoreTestUtils
 @_spi(STP) @_spi(CustomerSessionBetaAccess) @testable import StripePaymentSheet

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEIntegrationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEIntegrationTests.swift
@@ -11,7 +11,7 @@ import StripePaymentsTestUtils
 import WebKit
 import XCTest
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
 @available(iOS 16.0, *)
 @MainActor
 class ECEIntegrationTests: XCTestCase {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEViewControllerTests.swift
@@ -9,7 +9,7 @@
 import WebKit
 import XCTest
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
 @available(iOS 16.0, *)
 @MainActor
 class ECEViewControllerTests: XCTestCase {

--- a/StripePayments/StripePayments/Source/API Bindings/STPRedirectContext.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPRedirectContext.swift
@@ -274,7 +274,7 @@ public class STPRedirectContext: NSObject,
             lastKnownSafariVCURL = redirectURL
             let safariVC = SFSafariViewController(url: lastKnownSafariVCURL!)
             safariVC.transitioningDelegate = self
-            #if !canImport(CompositorServices)
+            #if !os(visionOS)
             safariVC.delegate = self
             #endif
             safariVC.modalPresentationStyle = .custom
@@ -561,7 +561,7 @@ extension UIApplication: UIApplicationProtocol {
     }
 }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
 extension STPRedirectContext: SFSafariViewControllerDelegate {
     // MARK: - SFSafariViewControllerDelegate -
     /// :nodoc:

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1811,7 +1811,7 @@ public class STPPaymentHandler: NSObject {
                     } else {
                         let safariViewController = SFSafariViewController(url: fallbackURL)
                         safariViewController.modalPresentationStyle = .overFullScreen
-#if !canImport(CompositorServices)
+#if !os(visionOS)
                         safariViewController.dismissButtonStyle = .close
                         safariViewController.delegate = self
 #endif
@@ -2282,7 +2282,7 @@ struct STPPaymentHandlerError: Error, CustomNSError, AnalyticLoggableError {
     }
 }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
 extension STPPaymentHandler: SFSafariViewControllerDelegate {
     // MARK: - SFSafariViewControllerDelegate
     /// :nodoc:

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/Categories/UIButton+Stripe.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/Categories/UIButton+Stripe.swift
@@ -20,7 +20,7 @@ extension UIButton {
         withEdgeInsets edgeInsets: NSDirectionalEdgeInsets
     ) {
 // TODO: Rewrite this for visionOS & iOS 17.
-        #if canImport(CompositorServices)
+        #if os(visionOS)
         #else
         // UIButton doesn't have support for directional edge insets. We should
         // apply insets depending on the layout direction.

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/CardBrandView.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/CardBrandView.swift
@@ -104,7 +104,7 @@ import UIKit
             targetSize.height
             / (Self.legacyIconSize.height - Self.iconPadding.top - Self.iconPadding.bottom)
         // We could adapt this for multiple screens, but probably not worth it (better solution is to remove padding from images)
-        #if canImport(CompositorServices)
+        #if os(visionOS)
         let screenScale = 1.0
         #else
         let screenScale = UIScreen.main.scale
@@ -251,7 +251,7 @@ import UIKit
     }
 
     // MARK: - Callbacks
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     @_spi(STP) public override func traitCollectionDidChange(
         _ previousTraitCollection: UITraitCollection?
     ) {

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/STPGenericInputPickerField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/STPGenericInputPickerField.swift
@@ -103,7 +103,7 @@ import UIKit
         pickerView.dataSource = wrappedDataSource
         inputView = pickerView
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
         inputAccessoryView = DoneButtonToolbar(delegate: self)
 #endif
 

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPViewWithSeparator.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPViewWithSeparator.swift
@@ -75,7 +75,7 @@ class STPViewWithSeparator: UIView {
     }
 
     func _currentPixelHeight() -> CGFloat {
-        #if canImport(CompositorServices)
+        #if os(visionOS)
         return 1.0
         #else
         let screen = window?.screen ?? UIScreen.main

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPPaymentCardTextField.swift
@@ -228,7 +228,7 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
         }
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     private var _inputAccessoryView: UIView?
     /// This behaves identically to setting the inputAccessoryView for each child text field.
     @objc open override var inputAccessoryView: UIView? {
@@ -971,7 +971,7 @@ open class STPPaymentCardTextField: UIControl, UIKeyInput, STPFormTextFieldDeleg
 
     static let placeholderGrayColor: UIColor = .systemGray2
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     open override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         if previousTraitCollection?.preferredContentSizeCategory

--- a/StripeUICore/StripeUICore/Source/Controls/ActivityIndicator.swift
+++ b/StripeUICore/StripeUICore/Source/Controls/ActivityIndicator.swift
@@ -140,7 +140,7 @@ import UIKit
         updateColor()
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateColor()
@@ -166,7 +166,7 @@ import UIKit
 
         if let window = newWindow {
             contentLayer.shouldRasterize = true
-#if !canImport(CompositorServices)
+#if !os(visionOS)
             contentLayer.rasterizationScale = window.screen.scale
 #endif
         }

--- a/StripeUICore/StripeUICore/Source/Controls/Button.swift
+++ b/StripeUICore/StripeUICore/Source/Controls/Button.swift
@@ -295,7 +295,7 @@ import UIKit
         updateColors()
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         invalidateIntrinsicContentSize()

--- a/StripeUICore/StripeUICore/Source/Controls/OneTimeCodeTextField.swift
+++ b/StripeUICore/StripeUICore/Source/Controls/OneTimeCodeTextField.swift
@@ -111,7 +111,7 @@ import UIKit
         )
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     private let feedbackGenerator = UINotificationFeedbackGenerator()
 #endif
 
@@ -199,7 +199,7 @@ import UIKit
         let result = super.resignFirstResponder()
 
         if result {
-            #if !canImport(CompositorServices)
+            #if !os(visionOS)
             hideMenu()
             #endif
             update()
@@ -217,7 +217,7 @@ import UIKit
         }
 
         if isFirstResponder {
-            #if !canImport(CompositorServices)
+            #if !os(visionOS)
             toggleMenu()
             #endif
         } else {
@@ -287,7 +287,7 @@ private extension OneTimeCodeTextField {
             : STPLocalizedString("Double tap to edit", "Accessibility hint for a text field")
     }
 
-    #if !canImport(CompositorServices) // Don't mess with the UIMenuController on visionOS
+    #if !os(visionOS) // Don't mess with the UIMenuController on visionOS
     func toggleMenu() {
         if UIMenuController.shared.isMenuVisible {
             hideMenu()
@@ -375,7 +375,7 @@ public extension OneTimeCodeTextField {
             digitView.borderLayer.add(borderColorAnimation, forKey: "borderColor")
         }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
         feedbackGenerator.notificationOccurred(.error)
 #endif
 
@@ -414,7 +414,7 @@ extension OneTimeCodeTextField: UIKeyInput {
         inputDelegate?.textDidChange(self)
 
         sendActions(for: [.editingChanged, .valueChanged])
-        #if !canImport(CompositorServices)
+        #if !os(visionOS)
         hideMenu()
         #endif
         update()
@@ -430,7 +430,7 @@ extension OneTimeCodeTextField: UIKeyInput {
         inputDelegate?.textDidChange(self)
 
         sendActions(for: [.editingChanged, .valueChanged])
-        #if !canImport(CompositorServices)
+        #if !os(visionOS)
         hideMenu()
         #endif
         update()
@@ -865,7 +865,7 @@ private extension OneTimeCodeTextField {
             updateColors()
         }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
         override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
             super.traitCollectionDidChange(previousTraitCollection)
             updateColors()

--- a/StripeUICore/StripeUICore/Source/Elements/Checkbox/CheckboxButton.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Checkbox/CheckboxButton.swift
@@ -164,7 +164,7 @@ import UIKit
         textView.invalidateIntrinsicContentSize()
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateLabels()
@@ -276,7 +276,7 @@ extension CheckboxButton: EventHandler {
 
 // MARK: - UITextViewDelegate
 extension CheckboxButton: UITextViewDelegate {
-    #if !canImport(CompositorServices)
+    #if !os(visionOS)
     // This is only used by StripeIdentity, which does not support visionOS.
     public func textView(_ textView: UITextView, shouldInteractWith url: URL, in characterRange: NSRange) -> Bool {
         return delegate?.checkboxButton(self, shouldOpen: url) ?? true

--- a/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
@@ -34,7 +34,7 @@ final class PickerFieldView: UIView {
 #endif
         textField.adjustsFontForContentSizeCategory = true
         textField.font = theme.fonts.subheadline
-#if !canImport(CompositorServices)
+#if !os(visionOS)
         textField.inputAccessoryView = toolbar
 #endif
         textField.delegate = self
@@ -166,7 +166,7 @@ final class PickerFieldView: UIView {
         }
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         layer.borderColor = theme.colors.border.cgColor

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionContainerView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionContainerView.swift
@@ -103,7 +103,7 @@ class SectionContainerView: UIView {
         )
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         updateUI()

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionView.swift
@@ -154,7 +154,7 @@ final class SectionView: UIView {
         updateBorderPath()
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         guard previousTraitCollection?.userInterfaceStyle != traitCollection.userInterfaceStyle else { return }

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
@@ -45,7 +45,7 @@ import UIKit
 
     private let theme: ElementsAppearance
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     public var inputAccessoryView: UIView? {
         get {
             return textFieldView.textField.inputAccessoryView

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
@@ -232,7 +232,7 @@ class TextFieldView: UIView {
         textField.textContentType = viewModel.keyboardProperties.textContentType
         if viewModel.keyboardProperties.type != textField.keyboardType {
             textField.keyboardType = viewModel.keyboardProperties.type
-#if !canImport(CompositorServices)
+#if !os(visionOS)
             textField.inputAccessoryView = textField.keyboardType.hasReturnKey ? nil : toolbar
 #endif
             textField.reloadInputViews()
@@ -264,7 +264,7 @@ class TextFieldView: UIView {
         layoutIfNeeded()
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         self.transparentMaskView.backgroundColor = viewModel.theme.colors.componentBackground.translucentMaskColor

--- a/StripeUICore/StripeUICore/Source/Helpers/StackViewWithSeparator.swift
+++ b/StripeUICore/StripeUICore/Source/Helpers/StackViewWithSeparator.swift
@@ -203,7 +203,7 @@ import UIKit
             UIBezierPath(roundedRect: bounds, cornerRadius: borderCornerRadius).cgPath
     }
 
-#if !canImport(CompositorServices)
+#if !os(visionOS)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         // CGColor's must be manually updated when the trait collection changes

--- a/StripeUICore/StripeUICore/Source/Views/DynamicImageView.swift
+++ b/StripeUICore/StripeUICore/Source/Views/DynamicImageView.swift
@@ -43,7 +43,7 @@ import UIKit
         fatalError("init(coder:) has not been implemented")
     }
 
-    #if !canImport(CompositorServices)
+    #if !os(visionOS)
     public override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
         image = Self.makeImage(for: traitCollection, dynamicImage: dynamicImage, pairedColor: pairedColor)


### PR DESCRIPTION
## Summary
No no longer support the Xcode versions that required the hacky CompositorServices compiler check for conditional visionOS behavior and can now directly check.

## Motivation
- less hacky code
- https://github.com/stripe/stripe-ios/issues/5000

## Testing
Builds :)

## Changelog
N/A