### PR TITLE
Fix size test scripts on Xcode 16

### DIFF
--- a/Tests/installation_tests/size_test/SPMTest.xcodeproj/project.pbxproj
+++ b/Tests/installation_tests/size_test/SPMTest.xcodeproj/project.pbxproj
@@ -279,7 +279,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				INFOPLIST_FILE = SPMTestUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -303,7 +303,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				INFOPLIST_FILE = SPMTestUITests/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.SPMTestUITests;
@@ -432,7 +432,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = SPMTest/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.SPMTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -451,7 +451,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
 				INFOPLIST_FILE = SPMTest/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.SPMTest;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Tests/installation_tests/size_test/include_framework.patch
+++ b/Tests/installation_tests/size_test/include_framework.patch
@@ -35,7 +35,7 @@ index 25e5009784..ca719eb600 100644
 @@ -280,7 +283,11 @@
  				DEVELOPMENT_TEAM = Y28TH9SHX7;
  				INFOPLIST_FILE = SPMTestUITests/Info.plist;
- 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+ 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 -				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 +				LD_RUNPATH_SEARCH_PATHS = (
 +					"$(inherited)",
@@ -48,7 +48,7 @@ index 25e5009784..ca719eb600 100644
 @@ -304,11 +311,16 @@
  				DEVELOPMENT_TEAM = Y28TH9SHX7;
  				INFOPLIST_FILE = SPMTestUITests/Info.plist;
- 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+ 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 -				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 +				LD_RUNPATH_SEARCH_PATHS = (
 +					"$(inherited)",
@@ -69,7 +69,7 @@ index 25e5009784..ca719eb600 100644
  				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
  				INFOPLIST_FILE = SPMTest/Info.plist;
 +				INFOPLIST_KEY_CFBundleDisplayName = "{{SDK}}Size";
- 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+ 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 -				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 -				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.SPMTest;
 -				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -88,7 +88,7 @@ index 25e5009784..ca719eb600 100644
  				GCC_TREAT_WARNINGS_AS_ERRORS = YES;
  				INFOPLIST_FILE = SPMTest/Info.plist;
 +				INFOPLIST_KEY_CFBundleDisplayName = "{{SDK}}Size";
- 				IPHONEOS_DEPLOYMENT_TARGET = 14.5;
+ 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
 -				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 -				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.SPMTest;
 -				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/modules.yaml
+++ b/modules.yaml
@@ -156,6 +156,8 @@ modules:
     output: docs/stripeapplepay
     readme: StripeApplePay/README.md
   size_report:
+    max_compressed_size: 700
+    max_uncompressed_size: 1800
     max_incremental_uncompressed_size: 100
 
 - podspec: StripeCardScan.podspec
@@ -176,6 +178,8 @@ modules:
     include:
       - StripeCore
   size_report:
+    max_compressed_size: 3000
+    max_uncompressed_size: 5000
     max_incremental_uncompressed_size: 100
 
 - podspec: StripeUICore.podspec


### PR DESCRIPTION
## Summary
libSwiftConcurrency is *huge* with Xcode 16 (~7.7MB!). Targeting iOS 16 will give us a more realistic size estimate.