### PR TITLE
Fix issue with swiftUIcardformView with high prioirty views

### DIFF
--- a/Example/UI Examples/UI Examples/Source/SwiftUICardFormView.swift
+++ b/Example/UI Examples/UI Examples/Source/SwiftUICardFormView.swift
@@ -16,6 +16,7 @@ struct SwiftUICardFormView: View {
 
     var body: some View {
         VStack {
+            Spacer().layoutPriority(1)
             STPCardFormView.Representable(paymentMethodParams: $paymentMethodParams,
                                           isComplete: $cardFormIsComplete)
                 .padding()
@@ -25,6 +26,7 @@ struct SwiftUICardFormView: View {
                 Text("Buy")
             }).disabled(!cardFormIsComplete)
             .padding()
+            Spacer().layoutPriority(1)
         }
     }
 }

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPCardFormView+SwiftUI.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPCardFormView+SwiftUI.swift
@@ -46,6 +46,16 @@ extension STPCardFormView {
         public func updateUIView(_ cardFormView: STPCardFormView, context: Context) {
             cardFormView.cardParams = paymentMethodParams
         }
+
+        @available(iOS 16.0, *)
+        public func sizeThatFits(_ proposal: ProposedViewSize, uiView: STPCardFormView, context: Context) -> CGSize? {
+            let width = proposal.width ?? UIView.layoutFittingExpandedSize.width
+            let height = proposal.height ?? UIView.layoutFittingExpandedSize.height
+            let targetSize = CGSize(width: width, height: height)
+            return uiView.systemLayoutSizeFitting(targetSize,
+                                                   withHorizontalFittingPriority: .defaultHigh,
+                                                   verticalFittingPriority: .fittingSizeLevel)
+        }
     }
 
     /// :nodoc:


### PR DESCRIPTION
## Summary
This is a much better approach than:
https://github.com/stripe/stripe-ios/pull/5134

## Motivation
CardFormView basically shrinks down to nothing if surrounded by high priority views.

## Testing
Relying on existing screenshot tests and manual testing

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
