### PR TITLE
Fix issue with selected payment method when Flow Controller is launched from Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -461,7 +461,6 @@ extension PaymentSheet {
                 }
 
                 if shouldReturnToPaymentSheet {
-                    self.viewController.linkConfirmOption = nil
                     self.updatePaymentOption()
                     returnToPaymentSheet()
                     return


### PR DESCRIPTION
## Summary

Fixes an issue where the selected payment method was lost when the FlowController was launched by the PayWithNativeLinkController.

## Motivation

Bug fix

## Testing

Before:

https://github.com/user-attachments/assets/3b182014-f0f6-4300-ac51-a4b6292cad19

After:

https://github.com/user-attachments/assets/bef1abbb-95bb-4a52-b157-435451b7f4f9


https://github.com/user-attachments/assets/f594aaf0-c143-4c67-ba15-1f56ce8888d6

## Changelog

N/a
