### PR TITLE
StripeCryptoOnramp: Additional Setup & Begins Public API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -168,7 +168,7 @@ let package = Package(
         ),
         .target(
             name: "StripeCryptoOnramp",
-            dependencies: ["StripeCore"],
+            dependencies: ["StripeCore", "StripeUICore", "StripePaymentSheet", "StripeIdentity", "StripeFinancialConnections"],
             path: "StripeCryptoOnramp/StripeCryptoOnramp",
             resources: [
                 .process("Resources")

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -20,6 +20,11 @@
 		0B83D9922E1EF6EF004F0115 /* StripeCryptoOnramp.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B83D98D2E1EF6EF004F0115 /* StripeCryptoOnramp.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0B83D9962E1EF6F8004F0115 /* StripeCryptoOnrampTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B83D9932E1EF6F8004F0115 /* StripeCryptoOnrampTests.swift */; };
 		0B83D99A2E1EF8B7004F0115 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B83D9992E1EF8B7004F0115 /* XCTest.framework */; platformFilter = ios; };
+		0BED9B622E255BC2009FFF76 /* CryptoOnrampCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BED9B612E255BC2009FFF76 /* CryptoOnrampCoordinator.swift */; };
+		0BED9B642E255FB8009FFF76 /* StripeUICore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BED9B632E255FB8009FFF76 /* StripeUICore.framework */; };
+		0BED9B662E255FD7009FFF76 /* StripePaymentSheet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BED9B652E255FD7009FFF76 /* StripePaymentSheet.framework */; };
+		0BED9B682E255FE8009FFF76 /* StripeIdentity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BED9B672E255FE8009FFF76 /* StripeIdentity.framework */; };
+		0BED9B6A2E255FF1009FFF76 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BED9B692E255FF1009FFF76 /* StripeFinancialConnections.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -47,6 +52,11 @@
 		0B83D98E2E1EF6EF004F0115 /* Docs.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Docs.docc; sourceTree = "<group>"; };
 		0B83D9932E1EF6F8004F0115 /* StripeCryptoOnrampTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeCryptoOnrampTests.swift; sourceTree = "<group>"; };
 		0B83D9992E1EF8B7004F0115 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		0BED9B612E255BC2009FFF76 /* CryptoOnrampCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoOnrampCoordinator.swift; sourceTree = "<group>"; };
+		0BED9B632E255FB8009FFF76 /* StripeUICore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeUICore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0BED9B652E255FD7009FFF76 /* StripePaymentSheet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripePaymentSheet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0BED9B672E255FE8009FFF76 /* StripeIdentity.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeIdentity.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0BED9B692E255FF1009FFF76 /* StripeFinancialConnections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeFinancialConnections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -54,7 +64,11 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0BED9B642E255FB8009FFF76 /* StripeUICore.framework in Frameworks */,
+				0BED9B6A2E255FF1009FFF76 /* StripeFinancialConnections.framework in Frameworks */,
+				0BED9B682E255FE8009FFF76 /* StripeIdentity.framework in Frameworks */,
 				0B34E23F2E2020E20072FC89 /* StripeCore.framework in Frameworks */,
+				0BED9B662E255FD7009FFF76 /* StripePaymentSheet.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -112,6 +126,7 @@
 		0B83D98C2E1EF6EF004F0115 /* Source */ = {
 			isa = PBXGroup;
 			children = (
+				0BED9B602E255BB1009FFF76 /* Components */,
 				0B83D98B2E1EF6EF004F0115 /* StripeCryptoOnramp.swift */,
 			);
 			path = Source;
@@ -147,6 +162,10 @@
 		0B83D9982E1EF8B7004F0115 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0BED9B692E255FF1009FFF76 /* StripeFinancialConnections.framework */,
+				0BED9B672E255FE8009FFF76 /* StripeIdentity.framework */,
+				0BED9B652E255FD7009FFF76 /* StripePaymentSheet.framework */,
+				0BED9B632E255FB8009FFF76 /* StripeUICore.framework */,
 				0B34E23E2E2020E20072FC89 /* StripeCore.framework */,
 				0B83D9992E1EF8B7004F0115 /* XCTest.framework */,
 			);
@@ -161,6 +180,14 @@
 				0B83D9952E1EF6F8004F0115 /* StripeCryptoOnrampTests */,
 			);
 			name = Project;
+			sourceTree = "<group>";
+		};
+		0BED9B602E255BB1009FFF76 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				0BED9B612E255BC2009FFF76 /* CryptoOnrampCoordinator.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -284,6 +311,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0B83D9902E1EF6EF004F0115 /* StripeCryptoOnramp.swift in Sources */,
+				0BED9B622E255BC2009FFF76 /* CryptoOnrampCoordinator.swift in Sources */,
 				0B83D9912E1EF6EF004F0115 /* Docs.docc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -15,7 +15,6 @@
 		0B83D9842E1EF6D2004F0115 /* StripeiOS Tests-Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0B83D9792E1EF6D2004F0115 /* StripeiOS Tests-Release.xcconfig */; };
 		0B83D9862E1EF6D2004F0115 /* StripeiOS-Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0B83D97B2E1EF6D2004F0115 /* StripeiOS-Debug.xcconfig */; };
 		0B83D9872E1EF6D2004F0115 /* StripeiOS-Release.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 0B83D97C2E1EF6D2004F0115 /* StripeiOS-Release.xcconfig */; };
-		0B83D9902E1EF6EF004F0115 /* StripeCryptoOnramp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B83D98B2E1EF6EF004F0115 /* StripeCryptoOnramp.swift */; };
 		0B83D9912E1EF6EF004F0115 /* Docs.docc in Sources */ = {isa = PBXBuildFile; fileRef = 0B83D98E2E1EF6EF004F0115 /* Docs.docc */; };
 		0B83D9922E1EF6EF004F0115 /* StripeCryptoOnramp.h in Headers */ = {isa = PBXBuildFile; fileRef = 0B83D98D2E1EF6EF004F0115 /* StripeCryptoOnramp.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0B83D9962E1EF6F8004F0115 /* StripeCryptoOnrampTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B83D9932E1EF6F8004F0115 /* StripeCryptoOnrampTests.swift */; };
@@ -47,7 +46,6 @@
 		0B83D9792E1EF6D2004F0115 /* StripeiOS Tests-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS Tests-Release.xcconfig"; sourceTree = "<group>"; };
 		0B83D97B2E1EF6D2004F0115 /* StripeiOS-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS-Debug.xcconfig"; sourceTree = "<group>"; };
 		0B83D97C2E1EF6D2004F0115 /* StripeiOS-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS-Release.xcconfig"; sourceTree = "<group>"; };
-		0B83D98B2E1EF6EF004F0115 /* StripeCryptoOnramp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeCryptoOnramp.swift; sourceTree = "<group>"; };
 		0B83D98D2E1EF6EF004F0115 /* StripeCryptoOnramp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = StripeCryptoOnramp.h; sourceTree = "<group>"; };
 		0B83D98E2E1EF6EF004F0115 /* Docs.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = Docs.docc; sourceTree = "<group>"; };
 		0B83D9932E1EF6F8004F0115 /* StripeCryptoOnrampTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeCryptoOnrampTests.swift; sourceTree = "<group>"; };
@@ -127,7 +125,6 @@
 			isa = PBXGroup;
 			children = (
 				0BED9B602E255BB1009FFF76 /* Components */,
-				0B83D98B2E1EF6EF004F0115 /* StripeCryptoOnramp.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -310,7 +307,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0B83D9902E1EF6EF004F0115 /* StripeCryptoOnramp.swift in Sources */,
 				0BED9B622E255BC2009FFF76 /* CryptoOnrampCoordinator.swift in Sources */,
 				0B83D9912E1EF6EF004F0115 /* Docs.docc in Sources */,
 			);

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		0BED9B662E255FD7009FFF76 /* StripePaymentSheet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BED9B652E255FD7009FFF76 /* StripePaymentSheet.framework */; };
 		0BED9B682E255FE8009FFF76 /* StripeIdentity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BED9B672E255FE8009FFF76 /* StripeIdentity.framework */; };
 		0BED9B6A2E255FF1009FFF76 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BED9B692E255FF1009FFF76 /* StripeFinancialConnections.framework */; };
+		0BED9B6C2E25796B009FFF76 /* Appearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BED9B6B2E257965009FFF76 /* Appearance.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +56,7 @@
 		0BED9B652E255FD7009FFF76 /* StripePaymentSheet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripePaymentSheet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BED9B672E255FE8009FFF76 /* StripeIdentity.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeIdentity.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BED9B692E255FF1009FFF76 /* StripeFinancialConnections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeFinancialConnections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0BED9B6B2E257965009FFF76 /* Appearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Appearance.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -182,6 +184,7 @@
 		0BED9B602E255BB1009FFF76 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				0BED9B6B2E257965009FFF76 /* Appearance.swift */,
 				0BED9B612E255BC2009FFF76 /* CryptoOnrampCoordinator.swift */,
 			);
 			path = Components;
@@ -308,6 +311,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0BED9B622E255BC2009FFF76 /* CryptoOnrampCoordinator.swift in Sources */,
+				0BED9B6C2E25796B009FFF76 /* Appearance.swift in Sources */,
 				0B83D9912E1EF6EF004F0115 /* Docs.docc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/Appearance.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/Appearance.swift
@@ -5,7 +5,9 @@
 //  Created by Michael Liberatore on 7/14/25.
 //
 
+// Placeholder type which will eventually hold appearance-related
+// properties for customizable UI that we’ll fill out as we make use of them.
 @_spi(CryptoOnrampSDKPreview)
 public struct Appearance {
-    
+    public init() {}
 }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/Appearance.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/Appearance.swift
@@ -1,0 +1,11 @@
+//
+//  Appearance.swift
+//  StripeCryptoOnramp
+//
+//  Created by Michael Liberatore on 7/14/25.
+//
+
+@_spi(CryptoOnrampSDKPreview)
+public struct Appearance {
+    
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -31,17 +31,23 @@ public protocol CryptoOnrampCoordinatorProtocol {
 public final class CryptoOnrampCoordinator: CryptoOnrampCoordinatorProtocol {
     private let linkController: LinkController
     private let apiClient: STPAPIClient
+    private let appearance: Appearance
 
-    private init(linkController: LinkController, apiClient: STPAPIClient = .shared) {
+    private init(linkController: LinkController, apiClient: STPAPIClient = .shared, appearance: Appearance) {
         self.linkController = linkController
         self.apiClient = apiClient
+        self.appearance = appearance
     }
 
     // MARK: - CryptoOnrampCoordinatorProtocol
 
-    public static func create(apiClient: STPAPIClient, appearance: Appearance) async throws -> CryptoOnrampCoordinator {
+    public static func create(apiClient: STPAPIClient = .shared, appearance: Appearance) async throws -> CryptoOnrampCoordinator {
         let linkController = try await LinkController.create(apiClient: apiClient, mode: .payment)
-        return CryptoOnrampCoordinator(linkController: linkController)
+        return CryptoOnrampCoordinator(
+            linkController: linkController,
+            apiClient: apiClient,
+            appearance: appearance
+        )
     }
 
     public func isLinkUser(email: String) async throws -> Bool {

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -1,0 +1,10 @@
+//
+//  CryptoOnrampCoordinator.swift
+//  StripeCryptoOnramp
+//
+//  Created by Michael Liberatore on 7/14/25.
+//
+
+import Foundation
+
+

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -26,7 +26,7 @@ public protocol CryptoOnrampCoordinatorProtocol {
     func isLinkUser(email: String) async throws -> Bool
 }
 
-///Coordinates headless Link user authentication and identity verification, leaving most of the UI to the client.
+/// Coordinates headless Link user authentication and identity verification, leaving most of the UI to the client.
 @_spi(CryptoOnrampSDKPreview)
 public final class CryptoOnrampCoordinator: CryptoOnrampCoordinatorProtocol {
     private let linkController: LinkController

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -6,5 +6,45 @@
 //
 
 import Foundation
+@_spi(STP) import StripePaymentSheet
 
+/// Protocol describing a type that coordinates headless Link user authentication, identity verification, and payment, leaving most of the associated UI up to the client.
+@_spi(CryptoOnrampSDKPreview)
+public protocol CryptoOnrampCoordinatorProtocol {
+    
+    /// Creates a `CryptoOnrampCoordinator` to facilitate authentication, identity verification, and payment.
+    ///
+    /// - Parameter apiClient: The `STPAPIClient` instance for this coordinator. Defaults to `.shared`.
+    /// - Parameter appearance: Customizable appearance-related configuration for any Stripe-provided UI.
+    /// - Returns: A configured `CryptoOnrampCoordinator`.
+    static func create(apiClient: STPAPIClient, appearance: Appearance) async throws -> Self
+    
+    /// Determines whether the user with the specified email is already a Link user.
+    ///
+    /// - Parameter email: The email address of the user in question.
+    /// - Returns: Whether the email corresponds to an already registered Link user.
+    func isLinkUser(email: String) async throws -> Bool
+}
 
+///Coordinates headless Link user authentication and identity verification, leaving most of the UI to the client.
+@_spi(CryptoOnrampSDKPreview)
+public final class CryptoOnrampCoordinator: CryptoOnrampCoordinatorProtocol {
+    private let linkController: LinkController
+    private let apiClient: STPAPIClient
+    
+    private init(linkController: LinkController, apiClient: STPAPIClient = .shared) {
+        self.linkController = linkController
+        self.apiClient = apiClient
+    }
+    
+    // MARK: - CryptoOnrampCoordinatorProtocol
+    
+    public static func create(apiClient: STPAPIClient, appearance: Appearance) async throws -> CryptoOnrampCoordinator {
+        let linkController = try await LinkController.create(apiClient: apiClient, mode: .payment)
+        return CryptoOnrampCoordinator(linkController: linkController)
+    }
+    
+    public func isLinkUser(email: String) async throws -> Bool {
+        return try await linkController.lookupConsumer(with: email)
+    }
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -11,14 +11,14 @@ import Foundation
 /// Protocol describing a type that coordinates headless Link user authentication, identity verification, and payment, leaving most of the associated UI up to the client.
 @_spi(CryptoOnrampSDKPreview)
 public protocol CryptoOnrampCoordinatorProtocol {
-    
+
     /// Creates a `CryptoOnrampCoordinator` to facilitate authentication, identity verification, and payment.
     ///
     /// - Parameter apiClient: The `STPAPIClient` instance for this coordinator. Defaults to `.shared`.
     /// - Parameter appearance: Customizable appearance-related configuration for any Stripe-provided UI.
     /// - Returns: A configured `CryptoOnrampCoordinator`.
     static func create(apiClient: STPAPIClient, appearance: Appearance) async throws -> Self
-    
+
     /// Determines whether the user with the specified email is already a Link user.
     ///
     /// - Parameter email: The email address of the user in question.
@@ -31,19 +31,19 @@ public protocol CryptoOnrampCoordinatorProtocol {
 public final class CryptoOnrampCoordinator: CryptoOnrampCoordinatorProtocol {
     private let linkController: LinkController
     private let apiClient: STPAPIClient
-    
+
     private init(linkController: LinkController, apiClient: STPAPIClient = .shared) {
         self.linkController = linkController
         self.apiClient = apiClient
     }
-    
+
     // MARK: - CryptoOnrampCoordinatorProtocol
-    
+
     public static func create(apiClient: STPAPIClient, appearance: Appearance) async throws -> CryptoOnrampCoordinator {
         let linkController = try await LinkController.create(apiClient: apiClient, mode: .payment)
         return CryptoOnrampCoordinator(linkController: linkController)
     }
-    
+
     public func isLinkUser(email: String) async throws -> Bool {
         return try await linkController.lookupConsumer(with: email)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -95,9 +95,11 @@ import UIKit
 
     /// Creates a `LinkController` for the specified `mode`.
     ///
+    /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
     /// - Parameter mode: The mode in which the Link payment method controller should operate, either `payment` or `setup`.
     /// - Parameter completion: A closure that is called with the result of the creation. It returns a `LinkController` if successful, or an error if the creation failed.
     @_spi(STP) public static func create(
+        apiClient: STPAPIClient = .shared,
         mode: LinkController.Mode,
         completion: @escaping (Result<LinkController, Error>) -> Void
     ) {
@@ -117,6 +119,7 @@ import UIKit
                 }
 
                 let controller = LinkController(
+                    apiClient: apiClient,
                     mode: mode,
                     elementsSession: loadResult.elementsSession,
                     intent: loadResult.intent,
@@ -319,11 +322,12 @@ import UIKit
 
     /// Creates a `LinkController` for the specified `mode`.
     ///
+    /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
     /// - Parameter mode: The mode in which the Link payment method controller should operate, either `payment` or `setup`.
     /// - Returns: A `LinkController` if successful, or throws an error if the creation failed.
-    static func create(mode: LinkController.Mode) async throws -> LinkController {
+    static func create(apiClient: STPAPIClient = .shared, mode: LinkController.Mode) async throws -> LinkController {
         return try await withCheckedThrowingContinuation { continuation in
-            create(mode: mode) { result in
+            create(apiClient: apiClient, mode: mode) { result in
                 switch result {
                 case .success(let controller):
                     continuation.resume(returning: controller)


### PR DESCRIPTION
## Summary
- Added remaining dependencies listed in the [Onramp tech spec under iOS > SDK Setup](https://docs.google.com/document/d/1owKwHgD5s8u75EWDOny2bp6rlNZq1aI4NNUr43PKdVA/edit?tab=t.0#heading=h.vqz32ccsplag) to reduce noise in future PRs. Will remove any if we end up not using them.
- Adds the very beginnings of the public API, which is still being finalized in some aspects.
- Addresses the inability to pass in an `STPAPIClient` to `LinkController`.

## Motivation

Necessary for the Crypto Onramp project.

Looking to keep moving forward and getting early feedback as I continue coming up to speed. I thought opening small changes like this would give a good opportunity for feedback, notes on approach, and the ability to ask others questions regarding conventions.

## Testing
No tests yet. I tried the API out manually by wiring up a button to the payment sheet example app. I navigated to another example first to establish a test `publishableKey`.

```swift
@_spi(CryptoOnrampSDKPreview) import StripeCryptoOnramp

// …

Button("CryptoOnramp isLinkUser") {
    Task {
        do {
            let coordinator = try await CryptoOnrampCoordinator.create(apiClient: .shared, appearance: .init())
            let result1 = try await coordinator.isLinkUser(email: "michael@lickability.net")
            print("Result 1: \(result1)")
            
            let result2 = try await coordinator.isLinkUser(email: "michael@lickability.com")
            print("Result 2: \(result2)")
            
            let result3 = try await coordinator.isLinkUser(email: "michael")
            print("Result 3: \(result3)")
        } catch {
            print("Error: \(error)")
        }
    }
}
```

Here are the raw logs, annotated with comments prefixed by `#`.
```
[Stripe SDK]: POST "/v1/consumers/mobile/sessions/lookup" 200 req_bvC98S4NDmgQ6D
LOG ANALYTICS: link.account_lookup.complete - [(key: "pay_var", value: "paymentsheet"), (key: "ocr_type", value: "none"), (key: "lookupResult", value: "found"), (key: "apple_pay_enabled", value: 1)]

# Expected true (I signed up with this address)
Result 1: true

LOG ANALYTICS: stripeios.attest.assertion.failed - [(key: "error_type", value: "StripeCore.StripeAttest.AttestationError"), (key: "error_code", value: "attestationNotSupported")]
[Stripe SDK]: POST "/v1/consumers/mobile/sessions/lookup" 200 req_Js3HRaWFYbqNak
LOG ANALYTICS: link.account_lookup.complete - [(key: "pay_var", value: "paymentsheet"), (key: "ocr_type", value: "none"), (key: "lookupResult", value: "notFound"), (key: "apple_pay_enabled", value: 1)]

# Expected false (I’ve never signed up)
Result 2: false

LOG ANALYTICS: stripeios.attest.assertion.failed - [(key: "error_type", value: "StripeCore.StripeAttest.AttestationError"), (key: "error_code", value: "attestationNotSupported")]
[Stripe SDK]: POST "/v1/consumers/mobile/sessions/lookup" 400 req_m7G0msGkl0sWPk
LOG ANALYTICS: link.account_lookup.failure - [(key: "request_id", value: "req_m7G0msGkl0sWPk"), (key: "pay_var", value: "paymentsheet"), (key: "ocr_type", value: "none"), (key: "error_type", value: "invalid_request_error"), (key: "error_code", value: "email_invalid"), (key: "apple_pay_enabled", value: 1)]

# Expected error (bad input)
Error: apiError(StripeCore.StripeAPIError(type: StripeCore.StripeAPIError.ErrorType.invalidRequestError, code: Optional("email_invalid"), docUrl: Optional(https://stripe.com/docs/error-codes/email-invalid), message: Optional("Invalid email address."), param: nil, statusCode: Optional(400), requestID: Optional("req_m7G0msGkl0sWPk"), _allResponseFieldsStorage: Optional(4 fields)))
```

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A