### PR TITLE
Fix Link UI opening after Card selection

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -501,10 +501,12 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     }
 
     private var canPresentLinkOnPrimaryButton: Bool {
+        // Presenting Link as the primary action should only happen when selecting Link
+        // as the payment method (i.e. LinkConfirmOptions == .wallet) from the FlowController.
         guard elementsSession.enableFlowControllerRUX(for: configuration) else {
             return false
         }
-        guard case .link = selectedPaymentOption else {
+        guard case .link(.wallet) = selectedPaymentOption else {
             return false
         }
         return isFlowController


### PR DESCRIPTION
## Summary

Fixes an issue where the Link UI was opening after a card selection in the FlowController. It should only open if Link was selected as the payment method.

## Motivation

https://stripe.slack.com/archives/C01QWD93HUP/p1752612441996929

## Testing

Before:

https://github.com/user-attachments/assets/6c0d3fdc-2867-4e02-a312-d8e3042bed4e

After:

https://github.com/user-attachments/assets/5bc135ee-cce8-4cf3-97ec-f26b23f4eda7

## Changelog

N/a
