### PR TITLE
Undo changes to `testCustomerSheet_addUSBankAccount_MicroDeposit`

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -381,6 +381,14 @@ class CustomerSheetUITest: XCTestCase {
         app.otherElements["consent_manually_verify_label"].links.firstMatch.tap()
         try! fillUSBankData_microdeposits(app)
 
+        // Fill out Link
+        XCTAssertTrue(app.textFields["Email"].waitForExistence(timeout: timeout))
+        app.typeText("test-\(UUID().uuidString)@example.com")
+        XCTAssertTrue(app.textFields["Phone number"].waitForExistence(timeout: timeout))
+        app.typeText("3105551234")
+        app.toolbars.buttons["Done"].tap()
+        app.buttons["Save with Link"].waitForExistenceAndTap(timeout: timeout)
+
         let doneManualEntry = app.buttons["success_done_button"]
         XCTAssertTrue(doneManualEntry.waitForExistence(timeout: timeout))
         doneManualEntry.tap()


### PR DESCRIPTION
## Summary

There was a brief period of time where the networking Link signup pane was no longer being shown in this scenario, but now it's back. This reverts the changes done to this test in https://github.com/stripe/stripe-ios/pull/5164 

## Motivation

Fix CI

## Testing

Trust CI

## Changelog

N/a