### PR TITLE
Add additional APIs to LinkController

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -122,7 +122,7 @@ struct LinkPMDisplayDetails {
     func signUp(
         with phoneNumber: PhoneNumber,
         legalName: String?,
-        consentAction: ConsentAction?,
+        consentAction: ConsentAction,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         signUp(
@@ -138,7 +138,7 @@ struct LinkPMDisplayDetails {
         with phoneNumber: String,
         legalName: String?,
         countryCode: String?,
-        consentAction: ConsentAction?,
+        consentAction: ConsentAction,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         guard case .requiresSignUp = sessionState else {
@@ -158,7 +158,7 @@ struct LinkPMDisplayDetails {
             phoneNumber: phoneNumber,
             legalName: legalName,
             countryCode: countryCode,
-            consentAction: consentAction?.rawValue,
+            consentAction: consentAction.rawValue,
             useMobileEndpoints: useMobileEndpoints,
             with: apiClient
         ) { [weak self] result in

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -122,7 +122,7 @@ struct LinkPMDisplayDetails {
     func signUp(
         with phoneNumber: PhoneNumber,
         legalName: String?,
-        consentAction: ConsentAction,
+        consentAction: ConsentAction?,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         signUp(
@@ -138,7 +138,7 @@ struct LinkPMDisplayDetails {
         with phoneNumber: String,
         legalName: String?,
         countryCode: String?,
-        consentAction: ConsentAction,
+        consentAction: ConsentAction?,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         guard case .requiresSignUp = sessionState else {
@@ -158,7 +158,7 @@ struct LinkPMDisplayDetails {
             phoneNumber: phoneNumber,
             legalName: legalName,
             countryCode: countryCode,
-            consentAction: consentAction.rawValue,
+            consentAction: consentAction?.rawValue,
             useMobileEndpoints: useMobileEndpoints,
             with: apiClient
         ) { [weak self] result in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -206,7 +206,7 @@ import UIKit
         )
     }
 
-    /// Presents the Link verification flow for an existing user.
+    /// Presents the Link verification flow for an existing user which requires verification.
     ///
     /// - Parameter viewController: The view controller from which to present the authentication flow.
     /// - Parameter completion: A closure that is called with the result of the authentication. It returns an `AuthenticationResult` if successful, or an error if the verification failed.
@@ -214,7 +214,7 @@ import UIKit
         from viewController: UIViewController,
         completion: @escaping (Result<AuthenticationResult, Error>) -> Void
     ) {
-        guard let linkAccount, linkAccount.isRegistered else {
+        guard let linkAccount, linkAccount.sessionState == .requiresVerification else {
             let error = IntegrationError.noActiveLinkConsumer
             completion(.failure(error))
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -207,6 +207,7 @@ import UIKit
     }
 
     /// Presents the Link verification flow for an existing user which requires verification.
+    /// `lookupConsumer` must be called before this.
     ///
     /// - Parameter viewController: The view controller from which to present the authentication flow.
     /// - Parameter completion: A closure that is called with the result of the authentication. It returns an `AuthenticationResult` if successful, or an error if the verification failed.
@@ -490,9 +491,11 @@ import UIKit
     }
 
     /// Presents the Link verification flow for an existing user.
+    /// `lookupConsumer` must be called before this.
     ///
     /// - Parameter viewController: The view controller from which to present the authentication flow.
     /// - Returns: An `AuthenticationResult` indicating whether authentication was completed or canceled.
+    /// Throws if `lookupConsumer` was not called prior to this, or an API error occurs.
     func presentForVerification(from viewController: UIViewController) async throws -> AuthenticationResult {
         try await withCheckedThrowingContinuation { continuation in
             presentForVerification(from: viewController) { result in


### PR DESCRIPTION
## Summary

This adds two new internally-public APIs to `LinkController`:

- `registerNewLinkUser`: Headless (no UI) API to create a new Link account.
- `presentForVerification`: Presents the standalone verification flow. Throws an error if no Link account exists

## Motivation

👻 

## Testing

Updated the demo app to use the new APIs:

https://github.com/user-attachments/assets/f85492a8-5dba-4e1c-a170-2dc773312c5b

## Changelog

N/a
