### PR TITLE
Add US user country override to PaymentSheet Example app

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -393,6 +393,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         static var enumName: String { "UserOverrideCountry (debug only)" }
 
         case off
+        case US
         case GB
     }
 


### PR DESCRIPTION
## Summary

Allows overriding the user country to `US` in the `PaymentSheet Example` app

## Motivation

So that non-Americans can test US-only features

## Testing

<img width=40% src="https://github.com/user-attachments/assets/61521bad-fb47-455b-895f-51856ae8a9be" />

## Changelog

N/a