### PR TITLE
Add is_spt analytics parameter to track PreparePaymentMethodHandler usage

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -428,6 +428,7 @@ final class PaymentSheetAnalyticsHelper {
         additionalParams["mpe_config"] = configuration.analyticPayload
         additionalParams["currency"] = intent?.currency
         additionalParams["is_decoupled"] = intent?.intentConfig != nil
+        additionalParams["is_spt"] = intent?.intentConfig?.preparePaymentMethodHandler != nil
         additionalParams["deferred_intent_confirmation_type"] = deferredIntentConfirmationType?.rawValue
         additionalParams["require_cvc_recollection"] = intent?.cvcRecollectionEnabled
         additionalParams["selected_lpm"] = selectedLPM


### PR DESCRIPTION
## Summary

Adds a new `is_spt` boolean parameter to mc_ analytics events that tracks usage of PreparePaymentMethodHandler functionality.

- Appears alongside existing `is_decoupled` parameter in PaymentSheetAnalyticsHelper
- `true` when payment session uses `sharedPaymentTokenSessionWithMode` (Shared Payment Token sessions)
- `false` for regular PaymentIntents and standard deferred intents

## Changes

- **PaymentSheetAnalyticsHelper.swift**: Added `is_spt` parameter calculation
- **PaymentSheetAnalyticsHelperTest.swift**: Added comprehensive test coverage for all three scenarios:
  1. Regular PaymentIntent → `is_decoupled = false`, `is_spt = false`
  2. Deferred intent without preparePaymentMethodHandler → `is_decoupled = true`, `is_spt = false`  
  3. Deferred intent with preparePaymentMethodHandler → `is_decoupled = true`, `is_spt = true`

## Test plan

- [x] Added unit tests covering all parameter combinations
- [x] Verified project builds successfully
- [x] Code formatted and linted

🤖 Generated with [Claude Code](https://claude.ai/code)