### PR TITLE
Tweak when Embedded didUpdateHeight is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [Added] Added `Appearance.EmbeddedPaymentElement.Row.paymentMethodIconLayoutMargins` to customize the spacing around payment method icons in EmbeddedPaymentElement payment method rows.
 * [Added] Added `Appearance.EmbeddedPaymentElement.Row.titleFont` to customize the font of EmbeddedPaymentElement payment method row titles.
 * [Changed] Renamed `PaymentSheet.Appearance.EmbeddedPaymentElement.Row.Style.flatWithChevron` to `PaymentSheet.Appearance.EmbeddedPaymentElement.Row.Style.flatWithDisclosure` and added an experimental `disclosureImage` property to customize the chevron icon displayed in EmbeddedPaymentElement payment method rows when the row style is flatWithDisclosure.
+* [Fixed] `EmbeddedPaymentElementDelegate` `didUpdateHeight` now accommodates cases where the embedded view can't change height until after `didUpdateHeight` is called, like inside a UITableViewCell.
 
 ### AddressElement
 * [Added] SwiftUI support for AddressElement.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -234,19 +234,24 @@ class EmbeddedPaymentMethodsView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        // to make sure that it doesn't log on height change
+        // Only log this once
         if !didLogRenderLPMs {
             logRenderLPMs()
             didLogRenderLPMs = true
         }
 
+        // Calculate our natural height
+        let desiredHeight = systemLayoutSizeFitting(CGSize(width: frame.width, height: UIView.layoutFittingExpandedSize.height)).height
+
+        // If we never recorded a height, this is our first layout; don't notify the delegate.
         guard let previousHeight else {
             previousHeight = frame.height
             return
         }
 
-        if frame.height != previousHeight {
-            self.previousHeight = frame.height
+        // If the desired height is different from our last recorded, notify the delegate that our height is updating.
+        if desiredHeight != previousHeight {
+            self.previousHeight = desiredHeight
             delegate?.embeddedPaymentMethodsViewDidUpdateHeight()
         }
     }
@@ -428,6 +433,7 @@ class EmbeddedPaymentMethodsView: UIView {
         case (false, true): // Showing mandate -> Showing mandate
             UIView.transition(with: self.mandateView, duration: 0.25, options: .transitionCrossDissolve) {
                 self.mandateView.attributedText = mandateText
+                self.setNeedsLayout()
                 self.layoutIfNeeded()
             }
         case (true, false): // Hidden -> Hidden


### PR DESCRIPTION
## Summary
Before, `didUpdateHeight` was called when the _frame_ changed after `layoutSubviews`.
Now, it's called when the "natural" height changed after `layoutSubviews`.

This accommodates usage in e.g. a UITableViewCell where embedded must inform its owner that the height changed _before_ it will be laid out with a new frame.

Does this change the `didUpdateHeight` delegate contract?
>   /// Called inside an animation block when the EmbeddedPaymentElement view is updating its height. Your implementation should call `setNeedsLayout()` and `layoutIfNeeded` on the scroll view that contains the EmbeddedPaymentElement view. This enables a smooth animation of the height change.

No, based on this description and intended usage, I don't think so.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
Manually tested the height change animation works as expected in:
- SwiftUI example 
- UIKit test playground
- A UITableView with a cell w/ embedded in it, that calls `tableView.beginUpdates() / endUpdates()` in `didUpdateHeight`

https://github.com/user-attachments/assets/91e5d414-cb68-4fc9-a262-8ff76505716b

## Changelog
See changelog
