### PR TITLE
Fix legacy iOS tests

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewControllerRepresentableSnapshotTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewControllerRepresentableSnapshotTest.swift
@@ -1,5 +1,5 @@
 //
-//  AddressElementRepresentableSnapshotTest.swift
+//  AddressViewControllerRepresentableSnapshotTest.swift
 //  StripePaymentSheetTests
 //
 //  Created by Nick Porter on 7/11/25.
@@ -15,7 +15,7 @@ import XCTest
 
 @available(iOS 15.0, *)
 @MainActor
-class AddressElementRepresentableSnapshotTest: STPSnapshotTestCase {
+class AddressViewControllerRepresentableSnapshotTest: STPSnapshotTestCase {
 
     func testAddressElementView() async throws {
         var configuration = AddressElement.Configuration()


### PR DESCRIPTION
## Summary
Fix the legacy tests 15 nightly job: The filename and class name needs to match, or these snapshot tests won't be excluded correctly. 

## Testing
CI

## Changelog
None