### PR TITLE
Update LinkController with new APIs and published LinkAccount

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkStandaloneComponent.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkStandaloneComponent.swift
@@ -213,7 +213,7 @@ struct ExampleLinkStandaloneComponentContent: View {
         }
 
         Task {
-            let paymentMethodPreview = await linkController.present(from: viewController, with: email)
+            let paymentMethodPreview = await linkController.collectPaymentMethod(from: viewController, with: email)
             self.paymentMethodPreview = paymentMethodPreview
         }
     }
@@ -497,7 +497,7 @@ struct PaymentMethodSheet: View {
         STPAPIClient.shared.publishableKey = "pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFfB7cY9WG4a00ZnDtiC2C"
 
         Task {
-            let paymentMethodPreview = await linkController.present(from: viewController, with: email)
+            let paymentMethodPreview = await linkController.collectPaymentMethod(from: viewController, with: email)
             if paymentMethodPreview != nil {
                 DispatchQueue.main.async {
                     dismiss()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -22,8 +22,8 @@ struct LinkPMDisplayDetails {
     let brand: STPCardBrand
 }
 
-class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
-    enum SessionState: String {
+@_spi(STP) public class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
+    @_spi(STP) public enum SessionState: String {
         case requiresSignUp
         case requiresVerification
         case verified
@@ -73,17 +73,17 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
     var phoneNumberUsedInSignup: String?
     var nameUsedInSignup: String?
 
-    let email: String
+    @_spi(STP) public let email: String
 
-    var redactedPhoneNumber: String? {
+    @_spi(STP) public var redactedPhoneNumber: String? {
         return currentSession?.redactedFormattedPhoneNumber.replacingOccurrences(of: "*", with: "•")
     }
 
-    var isRegistered: Bool {
+    @_spi(STP) public var isRegistered: Bool {
         return currentSession != nil
     }
 
-    var sessionState: SessionState {
+    @_spi(STP) public var sessionState: SessionState {
         if let currentSession = currentSession {
             // sms verification is not required if we are in the signup flow
             return currentSession.hasVerifiedSMSSession || currentSession.isVerifiedForSignup
@@ -91,6 +91,10 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
         } else {
             return .requiresSignUp
         }
+    }
+
+    @_spi(STP) public var consumerSessionClientSecret: String? {
+        currentSession?.clientSecret
     }
 
     var hasStartedSMSVerification: Bool {
@@ -471,7 +475,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
 
 extension PaymentSheetLinkAccount: Equatable {
 
-    static func == (lhs: PaymentSheetLinkAccount, rhs: PaymentSheetLinkAccount) -> Bool {
+    @_spi(STP) public static func == (lhs: PaymentSheetLinkAccount, rhs: PaymentSheetLinkAccount) -> Bool {
         return
             (lhs.email == rhs.email && lhs.currentSession == rhs.currentSession
             && lhs.publishableKey == rhs.publishableKey)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -30,7 +30,7 @@ struct LinkPMDisplayDetails {
     }
 
     // More information: go/link-signup-consent-action-log
-    enum ConsentAction: String {
+    @_spi(STP) public enum ConsentAction: String {
         // Checkbox, no fields prefilled
         case checkbox_v0 = "clicked_checkbox_nospm_mobile_v0"
 
@@ -57,6 +57,9 @@ struct LinkPMDisplayDetails {
 
         // Checkbox pre-checked, no fields prefilled
         case prechecked_opt_in_box_prefilled_none = "prechecked_opt_in_box_prefilled_none"
+
+        // Crypto onramp, email and phone number are entered, a sign up button is tapped
+        case entered_phone_number_email_clicked_signup_crypto_onramp = "entered_phone_number_email_clicked_signup_crypto_onramp"
     }
 
     // Dependencies

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -35,7 +35,7 @@ extension STPAPIClient {
             if doNotLogConsumerFunnelEvent {
                 parameters["do_not_log_consumer_funnel_event"] = true
             }
-            if let email, let emailSource {
+            if let email, !email.isEmpty, let emailSource {
                 parameters["email_address"] = email.lowercased()
                 parameters["email_source"] = emailSource.rawValue
             } else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -28,10 +28,10 @@ import UIKit
         @_spi(STP) public let sublabel: String?
     }
 
-    @frozen @_spi(STP) public enum AuthenticationResult {
-        /// Authentication was completed successfully.
+    @frozen @_spi(STP) public enum VerificationResult {
+        /// Verification was completed successfully.
         case completed
-        /// Authentication was canceled by the user.
+        /// Verification was canceled by the user.
         case canceled
     }
 
@@ -211,11 +211,11 @@ import UIKit
     /// Presents the Link verification flow for an existing user which requires verification.
     /// `lookupConsumer` must be called before this.
     ///
-    /// - Parameter viewController: The view controller from which to present the authentication flow.
-    /// - Parameter completion: A closure that is called with the result of the authentication. It returns an `AuthenticationResult` if successful, or an error if the verification failed.
+    /// - Parameter viewController: The view controller from which to present the verification flow.
+    /// - Parameter completion: A closure that is called with the result of the verification. It returns a `VerificationResult` if successful, or an error if the verification failed.
     @_spi(STP) public func presentForVerification(
         from viewController: UIViewController,
-        completion: @escaping (Result<AuthenticationResult, Error>) -> Void
+        completion: @escaping (Result<VerificationResult, Error>) -> Void
     ) {
         guard let linkAccount, linkAccount.sessionState == .requiresVerification else {
             let error = IntegrationError.noActiveLinkConsumer
@@ -480,10 +480,10 @@ import UIKit
     /// Presents the Link verification flow for an existing user.
     /// `lookupConsumer` must be called before this.
     ///
-    /// - Parameter viewController: The view controller from which to present the authentication flow.
-    /// - Returns: An `AuthenticationResult` indicating whether authentication was completed or canceled.
+    /// - Parameter viewController: The view controller from which to present the verification flow.
+    /// - Returns: A `VerificationResult` indicating whether verification was completed or canceled.
     /// Throws if `lookupConsumer` was not called prior to this, or an API error occurs.
-    func presentForVerification(from viewController: UIViewController) async throws -> AuthenticationResult {
+    func presentForVerification(from viewController: UIViewController) async throws -> VerificationResult {
         try await withCheckedThrowingContinuation { continuation in
             presentForVerification(from: viewController) { result in
                 switch result {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -28,6 +28,13 @@ import UIKit
         @_spi(STP) public let sublabel: String?
     }
 
+    @frozen @_spi(STP) public enum AuthenticationResult {
+        /// Authentication was completed successfully.
+        case completed
+        /// Authentication was canceled by the user.
+        case canceled
+    }
+
     /// Errors specific incorrect integrations with LinkController
     @_spi(STP) public enum IntegrationError: Error {
         case noPaymentMethodSelected
@@ -47,6 +54,13 @@ import UIKit
     private let intent: Intent
     private let configuration: PaymentElementConfiguration
     private let analyticsHelper: PaymentSheetAnalyticsHelper
+
+    private lazy var linkAccountService: LinkAccountServiceProtocol = {
+        LinkAccountService(
+            useMobileEndpoints: elementsSession.linkSettings?.useAttestationEndpoints ?? false,
+            sessionID: elementsSession.sessionID
+        )
+    }()
 
     private var selectedPaymentDetails: ConsumerPaymentDetails? {
         guard case .link(let confirmOption) = internalPaymentOption else {
@@ -72,6 +86,9 @@ import UIKit
         }
     }
 
+    /// Details on the current Link account.
+    @Published @_spi(STP) public private(set) var linkAccount: PaymentSheetLinkAccount?
+
     /// A preview of the currently selected Link payment method.
     @Published @_spi(STP) public private(set) var paymentMethodPreview: PaymentMethodPreview?
 
@@ -89,6 +106,13 @@ import UIKit
         self.intent = intent
         self.configuration = configuration
         self.analyticsHelper = analyticsHelper
+
+        LinkAccountContext.shared.addObserver(self, selector: #selector(onLinkAccountChange))
+    }
+
+    deinit {
+        // Just to make sure no observers stay around
+        LinkAccountContext.shared.removeObserver(self)
     }
 
     @_spi(STP) public static var linkIcon: UIImage = Image.link_icon.makeImage()
@@ -140,8 +164,7 @@ import UIKit
     @_spi(STP) public func lookupConsumer(with email: String, completion: @escaping (Result<Bool, Error>) -> Void) {
         Self.lookupConsumer(
             email: email,
-            useMobileEndpoints: elementsSession.linkSettings?.useAttestationEndpoints ?? false,
-            sessionID: elementsSession.sessionID
+            linkAccountService: linkAccountService
         ) { result in
             switch result {
             case .success(let linkAccount):
@@ -153,12 +176,75 @@ import UIKit
         }
     }
 
+    /// Registers a new Link user with the provided details.
+    /// `lookupConsumer` must be called before this.
+    ///
+    /// - Parameter fullName: The full name of the user.
+    /// - Parameter phone: The phone number of the user. Expected to be in E.164 format.
+    /// - Parameter country: The country code of the user.
+    /// - Parameter completion: A closure that is called with the result of the sign up.
+    @_spi(STP) public func registerNewLinkUser(
+        fullName: String?,
+        phone: String,
+        country: String,
+        completion: @escaping (Result<Void, Error>) -> Void
+    ) {
+        guard let linkAccount else {
+            let error = IntegrationError.noActiveLinkConsumer
+            completion(.failure(error))
+            return
+        }
+        linkAccount.signUp(
+            with: phone,
+            legalName: fullName,
+            countryCode: country,
+            consentAction: .clicked_button_mobile_v1,
+            completion: { [weak self] result in
+                LinkAccountContext.shared.account = self?.linkAccount
+                completion(result)
+            }
+        )
+    }
+
+    /// Presents the Link verification flow for an existing user which requires verification.
+    /// `lookupConsumer` must be called before this.
+    ///
+    /// - Parameter viewController: The view controller from which to present the authentication flow.
+    /// - Parameter completion: A closure that is called with the result of the authentication. It returns an `AuthenticationResult` if successful, or an error if the verification failed.
+    @_spi(STP) public func presentForVerification(
+        from viewController: UIViewController,
+        completion: @escaping (Result<AuthenticationResult, Error>) -> Void
+    ) {
+        guard let linkAccount, linkAccount.sessionState == .requiresVerification else {
+            let error = IntegrationError.noActiveLinkConsumer
+            completion(.failure(error))
+            return
+        }
+
+        let verificationController = LinkVerificationController(
+            mode: .modal,
+            linkAccount: linkAccount,
+            configuration: configuration
+        )
+
+        verificationController.present(from: viewController) { result in
+            switch result {
+            case .completed:
+                completion(.success(.completed))
+            case .canceled:
+                completion(.success(.canceled))
+            case .failed(let error):
+                completion(.failure(error))
+            }
+        }
+    }
+
     /// Presents the Link sheet to collect a customer's payment method.
     ///
     /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
     /// - Parameter email: The email address to pre-fill in the Link sheet. If `nil`, the email field will be empty.
     /// - Parameter completion: A closure that is called when the user has selected a payment method or canceled the sheet. If the user selects a payment method, the `paymentMethodPreview` will be updated accordingly.
-    @_spi(STP) public func present(
+    @_spi(STP) public func collectPaymentMethod(
         from presentingViewController: UIViewController,
         with email: String?,
         completion: @escaping () -> Void
@@ -298,15 +384,9 @@ import UIKit
 
     private static func lookupConsumer(
         email: String,
-        useMobileEndpoints: Bool,
-        sessionID: String,
+        linkAccountService: LinkAccountServiceProtocol,
         completion: @escaping (Result<PaymentSheetLinkAccount?, Error>) -> Void
     ) {
-        let linkAccountService = LinkAccountService(
-            useMobileEndpoints: useMobileEndpoints,
-            sessionID: sessionID
-        )
-
         linkAccountService.lookupAccount(
             withEmail: email,
             // TODO: Check that this is the right email source to pass in
@@ -315,6 +395,14 @@ import UIKit
             doNotLogConsumerFunnelEvent: false,
             completion: completion
         )
+    }
+
+    @objc
+    private func onLinkAccountChange(_ notification: Notification) {
+        DispatchQueue.main.async { [weak self] in
+            let linkAccount = notification.object as? PaymentSheetLinkAccount
+            self?.linkAccount = linkAccount
+        }
     }
 }
 
@@ -343,13 +431,56 @@ import UIKit
     /// - Parameter email: The email address to look up.
     /// - Returns: Returns `true` if the email is associated with an existing Link consumer, or `false` otherwise.
     func lookupConsumer(with email: String) async throws -> Bool {
-        return try await withCheckedThrowingContinuation { continuation in
+        try await withCheckedThrowingContinuation { continuation in
             lookupConsumer(with: email) { result in
                 switch result {
                 case .success(let isExistingLinkConsumer):
                     continuation.resume(returning: isExistingLinkConsumer)
-                case .failure(let failure):
-                    continuation.resume(throwing: failure)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Registers a new Link user with the provided details.
+    /// `lookupConsumer` must be called before this.
+    ///
+    /// - Parameter fullName: The full name of the user.
+    /// - Parameter phone: The phone number of the user. Expected to be in E.164 format.
+    /// - Parameter country: The country code of the user.
+    /// Throws if `lookupConsumer` was not called prior to this, or an API error occurs.
+    func registerNewLinkUser(
+        fullName: String?,
+        phone: String,
+        country: String
+    ) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            registerNewLinkUser(fullName: fullName, phone: phone, country: country) { result in
+                switch result {
+                case .success:
+                    continuation.resume(returning: ())
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Presents the Link verification flow for an existing user.
+    /// `lookupConsumer` must be called before this.
+    ///
+    /// - Parameter viewController: The view controller from which to present the authentication flow.
+    /// - Returns: An `AuthenticationResult` indicating whether authentication was completed or canceled.
+    /// Throws if `lookupConsumer` was not called prior to this, or an API error occurs.
+    func presentForVerification(from viewController: UIViewController) async throws -> AuthenticationResult {
+        try await withCheckedThrowingContinuation { continuation in
+            presentForVerification(from: viewController) { result in
+                switch result {
+                case .success(let result):
+                    continuation.resume(returning: result)
+                case .failure(let error):
+                    continuation.resume(throwing: error)
                 }
             }
         }
@@ -360,10 +491,10 @@ import UIKit
     /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
     /// - Parameter email: The email address to pre-fill in the Link sheet. If `nil`, the email field will be empty.
     /// - Returns: A `PaymentMethodPreview` if the user selected a payment method, or `nil` otherwise.
-    func present(from presentingViewController: UIViewController, with email: String?) async -> LinkController.PaymentMethodPreview? {
+    func collectPaymentMethod(from presentingViewController: UIViewController, with email: String?) async -> LinkController.PaymentMethodPreview? {
         return await withCheckedContinuation { continuation in
             DispatchQueue.main.async {
-                self.present(from: presentingViewController, with: email) { [weak self] in
+                self.collectPaymentMethod(from: presentingViewController, with: email) { [weak self] in
                     guard let self else { return }
                     continuation.resume(returning: self.paymentMethodPreview)
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -182,11 +182,13 @@ import UIKit
     /// - Parameter fullName: The full name of the user.
     /// - Parameter phone: The phone number of the user. Expected to be in E.164 format.
     /// - Parameter country: The country code of the user.
+    /// - Parameter consentAction: The action taken by the user in order to register for Link.
     /// - Parameter completion: A closure that is called with the result of the sign up.
     @_spi(STP) public func registerLinkUser(
         fullName: String?,
         phone: String,
         country: String,
+        consentAction: PaymentSheetLinkAccount.ConsentAction,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         guard let linkAccount else {
@@ -198,7 +200,7 @@ import UIKit
             with: phone,
             legalName: fullName,
             countryCode: country,
-            consentAction: .clicked_button_mobile_v1,
+            consentAction: consentAction,
             completion: { [weak self] result in
                 LinkAccountContext.shared.account = self?.linkAccount
                 completion(result)
@@ -450,14 +452,21 @@ import UIKit
     /// - Parameter fullName: The full name of the user.
     /// - Parameter phone: The phone number of the user. Expected to be in E.164 format.
     /// - Parameter country: The country code of the user.
+    /// - Parameter consentAction: The action taken by the user in order to register for Link.
     /// Throws if `lookupConsumer` was not called prior to this, or an API error occurs.
     func registerLinkUser(
         fullName: String?,
         phone: String,
-        country: String
+        country: String,
+        consentAction: PaymentSheetLinkAccount.ConsentAction
     ) async throws {
         try await withCheckedThrowingContinuation { continuation in
-            registerLinkUser(fullName: fullName, phone: phone, country: country) { result in
+            registerLinkUser(
+                fullName: fullName,
+                phone: phone,
+                country: country,
+                consentAction: consentAction
+            ) { result in
                 switch result {
                 case .success:
                     continuation.resume(returning: ())

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -183,7 +183,7 @@ import UIKit
     /// - Parameter phone: The phone number of the user. Expected to be in E.164 format.
     /// - Parameter country: The country code of the user.
     /// - Parameter completion: A closure that is called with the result of the sign up.
-    @_spi(STP) public func registerNewLinkUser(
+    @_spi(STP) public func registerLinkUser(
         fullName: String?,
         phone: String,
         country: String,
@@ -257,6 +257,7 @@ import UIKit
 
         presentingViewController.presentNativeLink(
             selectedPaymentDetailsID: selectedPaymentDetails?.stripeID,
+            linkAccount: linkAccount,
             configuration: configuration,
             intent: intent,
             elementsSession: elementsSession,
@@ -450,13 +451,13 @@ import UIKit
     /// - Parameter phone: The phone number of the user. Expected to be in E.164 format.
     /// - Parameter country: The country code of the user.
     /// Throws if `lookupConsumer` was not called prior to this, or an API error occurs.
-    func registerNewLinkUser(
+    func registerLinkUser(
         fullName: String?,
         phone: String,
         country: String
     ) async throws {
         try await withCheckedThrowingContinuation { continuation in
-            registerNewLinkUser(fullName: fullName, phone: phone, country: country) { result in
+            registerLinkUser(fullName: fullName, phone: phone, country: country) { result in
                 switch result {
                 case .success:
                     continuation.resume(returning: ())

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -21,6 +21,7 @@ extension UIViewController {
 
     func presentNativeLink(
         selectedPaymentDetailsID: String?,
+        linkAccount: PaymentSheetLinkAccount? = LinkAccountContext.shared.account,
         configuration: PaymentElementConfiguration,
         intent: Intent,
         elementsSession: STPElementsSession,
@@ -28,8 +29,6 @@ extension UIViewController {
         verificationDismissed: (() -> Void)? = nil,
         callback: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
     ) {
-        let linkAccount = LinkAccountContext.shared.account
-
         if let linkAccount, linkAccount.sessionState == .requiresVerification {
             let verificationController = LinkVerificationController(
                 mode: .inlineLogin,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -221,7 +221,7 @@ class WindowAuthenticationContext: NSObject, STPAuthenticationContext {
 }
 
 extension PaymentSheetLinkAccount: Hashable {
-    func hash(into hasher: inout Hasher) {
+    @_spi(STP) public func hash(into hasher: inout Hasher) {
         hasher.combine(ObjectIdentifier(self))
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
@@ -7,7 +7,7 @@
 
 import StripeCoreTestUtils
 @_spi(STP) @testable import StripePayments
-@_spi(CustomPaymentMethodsBeta) @_spi(AppearanceAPIAdditionsPreview) @_spi(CustomEmbeddedDisclosureImagePreview) @testable import StripePaymentSheet
+@_spi(STP) @_spi(CustomPaymentMethodsBeta) @_spi(AppearanceAPIAdditionsPreview) @_spi(CustomEmbeddedDisclosureImagePreview) @testable import StripePaymentSheet
 @testable import StripePaymentsTestUtils
 @_spi(STP) @testable import StripeUICore
 import XCTest


### PR DESCRIPTION
## Summary

Makes the following changes to `LinkController`:

1. Adds `registerNewLinkUser` API. Headlessly registers a new Link account.
2. Adds `presentForVerification` API. Presents the Link UI to verify an existing Link user.
3. Renames `present` to `collectPaymentMethod`.
4. Adds an `@Published` `linkAccount` property, and marks certain fields on the `PaymentSheetLinkAccount` object as internally public.

## Motivation

https://docs.google.com/document/d/1owKwHgD5s8u75EWDOny2bp6rlNZq1aI4NNUr43PKdVA/edit?usp=sharing

## Testing

Follow-up PR will include a new demo app to play around with the LinkController.

## Changelog

N/a
