### PR TITLE
Remove Link signup pane from FC in CustomerSheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -381,14 +381,6 @@ class CustomerSheetUITest: XCTestCase {
         app.otherElements["consent_manually_verify_label"].links.firstMatch.tap()
         try! fillUSBankData_microdeposits(app)
 
-        // Fill out Link
-        XCTAssertTrue(app.textFields["Email"].waitForExistence(timeout: timeout))
-        app.typeText("test-\(UUID().uuidString)@example.com")
-        XCTAssertTrue(app.textFields["Phone number"].waitForExistence(timeout: timeout))
-        app.typeText("3105551234")
-        app.toolbars.buttons["Done"].tap()
-        app.buttons["Save with Link"].waitForExistenceAndTap(timeout: timeout)
-
         let doneManualEntry = app.buttons["success_done_button"]
         XCTAssertTrue(doneManualEntry.waitForExistence(timeout: timeout))
         doneManualEntry.tap()


### PR DESCRIPTION
## Summary

Link signup will no longer be offered in Financial Connections when presented from the customer sheet. This updates our E2E test to no longer expect that pane.

## Motivation

https://stripe.slack.com/archives/C07TB59Q4HJ/p1752697481428249

## Testing

Trust CI

## Changelog

N/a