### PR TITLE
Add new user signup API for Link in FlowController

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
@@ -176,7 +176,7 @@ struct WalletButtonsFlowControllerView: View {
                 paymentOptionDisplayData: flowController.paymentOption)
         }
 
-        if case let .visible(title, description, _) = flowController.linkNewUserSignupState {
+        if case let .visible(title, description, _) = flowController.linkSignupOptInState {
             Toggle(isOn: $linkSignUpOptIn) {
                 VStack(alignment: .leading) {
                     Text(title)
@@ -199,7 +199,7 @@ struct WalletButtonsFlowControllerView: View {
             .padding(.horizontal)
         }
 
-        if case let .visible(_, _, termsAndConditions) = flowController.linkNewUserSignupState {
+        if case let .visible(_, _, termsAndConditions) = flowController.linkSignupOptInState {
             Text(AttributedString(termsAndConditions))
                 .foregroundStyle(Color.secondary)
                 .font(.footnote)

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
@@ -176,13 +176,15 @@ struct WalletButtonsFlowControllerView: View {
                 paymentOptionDisplayData: flowController.paymentOption)
         }
 
-        Toggle(isOn: $linkSignUpOptIn) {
-            Text("Sign up to Link")
+        if flowController.linkAccountRecognitionStatus == .notRecognized {
+            Toggle(isOn: $linkSignUpOptIn) {
+                Text("Sign up to Link")
+            }
+            .onChange(of: linkSignUpOptIn) { newValue in
+                flowController.linkSignUpOptIn = newValue
+            }
+            .padding(.horizontal)
         }
-        .onChange(of: linkSignUpOptIn) { newValue in
-            flowController.linkSignUpOptIn = newValue
-        }
-        .padding(.horizontal)
 
         Button(action: {
             // If you need to update the PaymentIntent's amount, you should do it here and

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
@@ -176,9 +176,22 @@ struct WalletButtonsFlowControllerView: View {
                 paymentOptionDisplayData: flowController.paymentOption)
         }
 
-        if flowController.linkAccountRecognitionStatus == .notRecognized {
+        if case let .visible(title, description, termsAndConditions) = flowController.linkNewUserSignupState {
             Toggle(isOn: $linkSignUpOptIn) {
-                Text("Sign up to Link")
+                VStack(alignment: .leading) {
+                    Text(title)
+                        .bold()
+                        .foregroundStyle(Color.primary)
+                    Text(AttributedString(description))
+                        .foregroundStyle(Color.secondary)
+                    Text(AttributedString(termsAndConditions))
+                        .foregroundStyle(Color.secondary)
+                        .font(.footnote)
+                }
+                .frame(maxWidth: .infinity)
+            }
+            .onAppear {
+                linkSignUpOptIn = flowController.linkSignUpOptIn
             }
             .onChange(of: linkSignUpOptIn) { newValue in
                 flowController.linkSignUpOptIn = newValue

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
@@ -161,8 +161,6 @@ struct WalletButtonsFlowControllerView: View {
     @Binding var isConfirmingPayment: Bool
     let onCompletion: (PaymentSheetResult) -> Void
 
-    @State var linkSignUpOptIn: Bool = false
-
     var body: some View {
         if flowController.paymentOption == nil {
             WalletButtonsView(flowController: flowController) { _ in }
@@ -177,7 +175,7 @@ struct WalletButtonsFlowControllerView: View {
         }
 
         if case let .visible(title, description, _) = flowController.linkSignupOptInState {
-            Toggle(isOn: $linkSignUpOptIn) {
+            Toggle(isOn: $flowController.linkSignUpOptIn) {
                 VStack(alignment: .leading) {
                     Text(title)
                         .foregroundStyle(Color.primary)
@@ -188,12 +186,6 @@ struct WalletButtonsFlowControllerView: View {
                         .font(.system(size: 13))
                 }
                 .frame(maxWidth: .infinity)
-            }
-            .onAppear {
-                linkSignUpOptIn = flowController.linkSignUpOptIn
-            }
-            .onChange(of: linkSignUpOptIn) { newValue in
-                flowController.linkSignUpOptIn = newValue
             }
             .frame(maxWidth: .infinity)
             .padding(.horizontal)

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
@@ -161,6 +161,8 @@ struct WalletButtonsFlowControllerView: View {
     @Binding var isConfirmingPayment: Bool
     let onCompletion: (PaymentSheetResult) -> Void
 
+    @State var linkSignUpOptIn: Bool = false
+
     var body: some View {
         if flowController.paymentOption == nil {
             WalletButtonsView(flowController: flowController) { _ in }
@@ -173,6 +175,15 @@ struct WalletButtonsFlowControllerView: View {
             ExamplePaymentOptionView(
                 paymentOptionDisplayData: flowController.paymentOption)
         }
+
+        Toggle(isOn: $linkSignUpOptIn) {
+            Text("Sign up to Link")
+        }
+        .onChange(of: linkSignUpOptIn) { newValue in
+            flowController.linkSignUpOptIn = newValue
+        }
+        .padding(.horizontal)
+
         Button(action: {
             // If you need to update the PaymentIntent's amount, you should do it here and
             // set the `isConfirmingPayment` binding after your update completes.
@@ -310,6 +321,9 @@ class ExampleWalletButtonsModel: ObservableObject {
                 configuration.returnURL = "payments-example://stripe-redirect"
                 configuration.willUseWalletButtonsView = true
                 configuration.appearance = self?.appearance ?? PaymentSheet.Appearance()
+
+                configuration.billingDetailsCollectionConfiguration.email = .always
+                configuration.billingDetailsCollectionConfiguration.phone = .always
 
                 self?.addDebugLog("Creating PaymentSheet FlowController with original backend...")
                 PaymentSheet.FlowController.create(

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
@@ -176,17 +176,16 @@ struct WalletButtonsFlowControllerView: View {
                 paymentOptionDisplayData: flowController.paymentOption)
         }
 
-        if case let .visible(title, description, termsAndConditions) = flowController.linkNewUserSignupState {
+        if case let .visible(title, description, _) = flowController.linkNewUserSignupState {
             Toggle(isOn: $linkSignUpOptIn) {
                 VStack(alignment: .leading) {
                     Text(title)
-                        .bold()
                         .foregroundStyle(Color.primary)
+                        .font(.system(size: 14))
+
                     Text(AttributedString(description))
                         .foregroundStyle(Color.secondary)
-                    Text(AttributedString(termsAndConditions))
-                        .foregroundStyle(Color.secondary)
-                        .font(.footnote)
+                        .font(.system(size: 13))
                 }
                 .frame(maxWidth: .infinity)
             }
@@ -196,7 +195,17 @@ struct WalletButtonsFlowControllerView: View {
             .onChange(of: linkSignUpOptIn) { newValue in
                 flowController.linkSignUpOptIn = newValue
             }
+            .frame(maxWidth: .infinity)
             .padding(.horizontal)
+        }
+
+        if case let .visible(_, _, termsAndConditions) = flowController.linkNewUserSignupState {
+            Text(AttributedString(termsAndConditions))
+                .foregroundStyle(Color.secondary)
+                .font(.footnote)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal)
         }
 
         Button(action: {

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
@@ -182,7 +182,7 @@ struct WalletButtonsFlowControllerView: View {
         }
 
         if case let .visible(title, description, _) = flowController.linkSignupOptInState {
-            Toggle(isOn: $flowController.linkSignUpOptIn) {
+            Toggle(isOn: $flowController.linkSignUpOptedIn) {
                 VStack(alignment: .leading) {
                     Text(title)
                         .foregroundStyle(Color.primary)

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -163,6 +163,12 @@ import Foundation
     case link2FAFailure = "link.2fa.failure"
     case linkNativeBailed = "link.native.bailed"
 
+    // MARK: - Link New User Signup API
+    case linkNewUserSignupViaApiSuccess = "link.new_user_signup_api.signup_success"
+    case linkNewUserSignupViaApiFailure = "link.new_user_signup_api.signup_failure"
+    case linkNewUserPaymentDetailCreationViaApiSuccess = "link.new_user_signup_api.payment_detail_creation_success"
+    case linkNewUserPaymentDetailCreationViaApiFailure = "link.new_user_signup_api.payment_detail_creation_failure"
+
     // MARK: - Link Misc
     case linkAccountLookupComplete = "link.account_lookup.complete"
     case linkAccountLookupFailure = "link.account_lookup.failure"

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -399,6 +399,24 @@ final class PaymentSheetAnalyticsHelper {
         log(event: .shopPayWebviewCancelled, params: ["did_receive_ece_click": didReceiveECEClick])
     }
 
+    func logLinkUserSignupSucceeded() {
+        log(event: .linkNewUserSignupViaApiSuccess)
+    }
+
+    func logLinkUserSignupFailed(error: Error) {
+        let params = error.serializeForV1Analytics()
+        log(event: .linkNewUserSignupViaApiFailure, params: params)
+    }
+
+    func logLinkUserPaymentDetailCreationCompleted(error: Error?) {
+        let event: STPAnalyticEvent = error == nil
+            ? .linkNewUserPaymentDetailCreationViaApiSuccess
+            : .linkNewUserPaymentDetailCreationViaApiFailure
+
+        let params = error?.serializeForV1Analytics() ?? [:]
+        log(event: event, params: params)
+    }
+
     func log(
         event: STPAnalyticEvent,
         duration: TimeInterval? = nil,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -537,4 +537,34 @@ extension String.Localized {
     static var use_billing_address_for_shipping: String {
         STPLocalizedString("Use billing address for shipping", "Label for checkbox in address form allowing user to use billing address")
     }
+
+    static var save_my_info_for_faster_checkout_with_link: String {
+        STPLocalizedString(
+            "Save my info for faster checkout with Link",
+            """
+            Label for a checkbox that when checked allows the payment information
+            to be saved and used in future checkout sessions.
+            """
+        )
+    }
+
+    static var pay_faster_everywhere_link_is_accepted: String {
+        STPLocalizedString(
+            "Pay faster everywhere Link is accepted.",
+            """
+            Sublabel for a checkbox that when checked allows the payment information
+            to be saved and used in future checkout sessions.
+            """
+        )
+    }
+
+    static var your_information_will_be_saved_to_link_see_terms: String {
+        STPLocalizedString(
+            "Your information will be saved to Link, see <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+            """
+            Disclaimer for a checkbox that when checked allows the payment information
+            to be saved and used in future checkout sessions.
+            """
+        )
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -120,22 +120,22 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
     }
 
     func signUp(
-        with phoneNumber: PhoneNumber,
+        with phoneNumber: PhoneNumber?,
         legalName: String?,
         consentAction: ConsentAction,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         signUp(
-            with: phoneNumber.string(as: .e164),
+            with: phoneNumber?.string(as: .e164),
             legalName: legalName,
-            countryCode: phoneNumber.countryCode,
+            countryCode: phoneNumber?.countryCode,
             consentAction: consentAction,
             completion: completion
         )
     }
 
     func signUp(
-        with phoneNumber: String,
+        with phoneNumber: String?,
         legalName: String?,
         countryCode: String?,
         consentAction: ConsentAction,
@@ -265,6 +265,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
 
     func createPaymentDetails(
         with paymentMethodParams: STPPaymentMethodParams,
+        isDefault: Bool,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         retryingOnAuthError(completion: completion) { completionRetryingOnAuthErrors in
@@ -280,6 +281,7 @@ class PaymentSheetLinkAccount: PaymentSheetLinkAccountInfoProtocol {
                 paymentMethodParams: paymentMethodParams,
                 with: self.apiClient,
                 consumerAccountPublishableKey: self.publishableKey,
+                isDefault: isDefault,
                 completion: completionRetryingOnAuthErrors
             )
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -144,7 +144,7 @@ extension ConsumerSession {
         paymentMethodParams: STPPaymentMethodParams,
         with apiClient: STPAPIClient = STPAPIClient.shared,
         consumerAccountPublishableKey: String?,
-        isDefault: Bool,
+        isDefault: Bool = false,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         guard paymentMethodParams.type == .card,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -119,7 +119,7 @@ extension ConsumerSession {
 
     class func signUp(
         email: String,
-        phoneNumber: String,
+        phoneNumber: String?,
         locale: Locale = .autoupdatingCurrent,
         legalName: String?,
         countryCode: String?,
@@ -144,6 +144,7 @@ extension ConsumerSession {
         paymentMethodParams: STPPaymentMethodParams,
         with apiClient: STPAPIClient = STPAPIClient.shared,
         consumerAccountPublishableKey: String?,
+        isDefault: Bool,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         guard paymentMethodParams.type == .card,
@@ -168,6 +169,7 @@ extension ConsumerSession {
             cardParams: cardParams,
             billingEmailAddress: billingEmailAddress,
             billingDetails: paymentMethodParams.nonnil_billingDetails,
+            isDefault: isDefault,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -83,7 +83,7 @@ extension STPAPIClient {
 
     func createConsumer(
         for email: String,
-        with phoneNumber: String,
+        with phoneNumber: String?,
         locale: Locale,
         legalName: String?,
         countryCode: String?,
@@ -98,10 +98,13 @@ extension STPAPIClient {
             var parameters: [String: Any] = [
                 "request_surface": "ios_payment_element",
                 "email_address": email.lowercased(),
-                "phone_number": phoneNumber,
                 "locale": locale.toLanguageTag(),
                 "country_inferring_method": "PHONE_NUMBER",
             ]
+
+            if let phoneNumber {
+                parameters["phone_number"] = phoneNumber
+            }
 
             if let legalName = legalName {
                 parameters["legal_name"] = legalName
@@ -167,6 +170,7 @@ extension STPAPIClient {
         cardParams: STPPaymentMethodCardParams,
         billingEmailAddress: String,
         billingDetails: STPPaymentMethodBillingDetails,
+        isDefault: Bool,
         consumerAccountPublishableKey: String?,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
@@ -175,6 +179,7 @@ extension STPAPIClient {
             rawCardParams: cardParams.consumersAPIParams,
             billingEmailAddress: billingEmailAddress,
             billingDetails: billingDetails,
+            isDefault: isDefault,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion
         )
@@ -185,6 +190,7 @@ extension STPAPIClient {
         rawCardParams: [String: Any],
         billingEmailAddress: String,
         billingDetails: STPPaymentMethodBillingDetails,
+        isDefault: Bool,
         consumerAccountPublishableKey: String?,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
@@ -200,6 +206,7 @@ extension STPAPIClient {
             "billing_email_address": billingEmailAddress,
             "billing_address": billingParams,
             "active": true, // card details are created with active true so they can be shared for passthrough mode
+            "is_default": isDefault,
         ]
 
         makePaymentDetailsRequest(

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -184,7 +184,10 @@ extension PayWithLinkViewController {
             confirmButton.update(state: .processing)
             coordinator?.allowSheetDismissal(false)
 
-            linkAccount.createPaymentDetails(with: confirmParams.paymentMethodParams) { [weak self] result in
+            linkAccount.createPaymentDetails(
+                with: confirmParams.paymentMethodParams,
+                isDefault: isAddingFirstPaymentMethod
+            ) { [weak self] result in
                 guard let self = self else {
                     return
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
@@ -46,13 +46,7 @@ extension LinkInlineSignupView {
             let text = {
                 switch mode {
                 case .checkboxWithDefaultOptIn:
-                    return STPLocalizedString(
-                        "Save my info for faster checkout with Link",
-                        """
-                        Label for a checkbox that when checked allows the payment information
-                        to be saved and used in future checkout sessions.
-                        """
-                    )
+                    return String.Localized.save_my_info_for_faster_checkout_with_link
                 case .checkbox, .textFieldsOnlyEmailFirst, .textFieldsOnlyPhoneFirst:
                     return STPLocalizedString(
                         "Save your info for secure 1-click checkout with Link",

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -154,14 +154,21 @@ extension PaymentSheet {
             return
         }
 
-        let billingDetails = confirmParams.paymentMethodParams.billingDetails
-        let email = billingDetails?.email ?? LinkAccountContext.shared.account?.email
+        let linkAccount = LinkAccountContext.shared.account
 
-        let phoneNumber = billingDetails?.phone.flatMap { PhoneNumber.fromE164($0) }
+        guard linkAccount?.isRegistered != true else {
+            // The user already has a Link account
+            return
+        }
+
+        let billingDetails = confirmParams.paymentMethodParams.billingDetails
+        let email = linkAccount?.email ?? billingDetails?.email
 
         guard let email else {
             return
         }
+
+        let phoneNumber = billingDetails?.phone.flatMap { PhoneNumber.fromE164($0) }
 
         ConsumerSession.signUp(
             email: email,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -214,12 +214,18 @@ extension PaymentSheet {
         /// You can use this to e.g. display the payment option in your UI.
         @Published public private(set) var paymentOption: PaymentOptionDisplayData?
 
+        /// The current recognition status of the Link account.
+        /// You can use this to render any “Sign up to Link” messaging in your own UI.
         @Published public private(set) var linkAccountRecognitionStatus: LinkAccountRecognitionStatus?
 
+        /// Whether your customer has chosen to sign up to Link in your UI.
         public var linkSignUpOptIn: Bool = false
 
+        /// The recognition status of the current user's Link account.
         public enum LinkAccountRecognitionStatus {
+            /// The current user has been recognized as a Link consumer.
             case recognized
+            /// The current user has not been recognized as a Link consumer.
             case notRecognized
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -214,19 +214,30 @@ extension PaymentSheet {
         /// You can use this to e.g. display the payment option in your UI.
         @Published public private(set) var paymentOption: PaymentOptionDisplayData?
 
-        /// The current recognition status of the Link account.
-        /// You can use this to render any “Sign up to Link” messaging in your own UI.
-        @Published public private(set) var linkAccountRecognitionStatus: LinkAccountRecognitionStatus?
+        /// The current state of the Link new user signup.
+        @Published public private(set) var linkNewUserSignupState: LinkNewUserSignupState = .hidden
 
         /// Whether your customer has chosen to sign up to Link in your UI.
          public var linkSignUpOptIn: Bool = false
 
+//        /// The recognition status of the current user's Link account.
+//        public enum LinkAccountRecognitionStatus {
+//            /// The current user has been recognized as a Link consumer.
+//            case recognized
+//            /// The current user has not been recognized as a Link consumer.
+//            case notRecognized
+//        }
+
         /// The recognition status of the current user's Link account.
-        public enum LinkAccountRecognitionStatus {
+        public enum LinkNewUserSignupState {
             /// The current user has been recognized as a Link consumer.
-            case recognized
+            case hidden
             /// The current user has not been recognized as a Link consumer.
-            case notRecognized
+            case visible(
+                title: String,
+                description: NSAttributedString,
+                termsAndConditions: NSAttributedString
+            )
         }
 
         // MARK: - Private properties
@@ -318,7 +329,17 @@ extension PaymentSheet {
 
         private func updateLinkAccountRecognitionStatus(for linkAccount: PaymentSheetLinkAccount?) {
             let isLinkConsumer = linkAccount?.isRegistered == true
-            linkAccountRecognitionStatus = isLinkConsumer ? .recognized : .notRecognized
+            linkNewUserSignupState = isLinkConsumer ? .hidden : .visible(
+                title: "Save my info for faster checkout with Link",
+                description: NSAttributedString(string: "Pay faster everywhere Link is accepted."),
+                termsAndConditions: NSAttributedString(string: "Your information will be saved to Link, see Terms and Privacy Policy.")
+            )
+
+            if case .visible = linkNewUserSignupState {
+                // Default to opt-in for US users
+                linkSignUpOptIn = elementsSession.countryCode == "CA"
+            }
+//            linkAccountRecognitionStatus = isLinkConsumer ? .recognized : .notRecognized
         }
 
         // MARK: - Public methods

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -332,7 +332,15 @@ extension PaymentSheet {
             linkNewUserSignupState = isLinkConsumer ? .hidden : .visible(
                 title: "Save my info for faster checkout with Link",
                 description: NSAttributedString(string: "Pay faster everywhere Link is accepted."),
-                termsAndConditions: NSAttributedString(string: "Your information will be saved to Link, see Terms and Privacy Policy.")
+                termsAndConditions: NSAttributedString(
+                    attributedString: STPStringUtils.applyLinksToString(
+                        template: "Your information will be saved to Link, see <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+                        links: [
+                            "terms": URL(string: "https://link.co/terms")!,
+                            "privacy": URL(string: "https://link.co/privacy")!,
+                        ]
+                    )
+                )
             )
 
             if case .visible = linkNewUserSignupState {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -215,13 +215,13 @@ extension PaymentSheet {
         @Published public private(set) var paymentOption: PaymentOptionDisplayData?
 
         /// The current state of the Link new user signup.
-        @Published public private(set) var linkSignupOptInState: LinkSignupOptInState = .hidden
+        @Published @_spi(STP) public private(set) var linkSignupOptInState: LinkSignupOptInState = .hidden
 
         /// Whether your customer has chosen to sign up to Link in your UI.
-        public var linkSignUpOptIn: Bool = false
+        @_spi(STP) public var linkSignUpOptIn: Bool = false
 
         /// The state of the Link signup opt-in. Use this to present the appropriate UI to the user.
-        public enum LinkSignupOptInState {
+        @_spi(STP) public enum LinkSignupOptInState {
             /// The current user has been recognized as a Link consumer. No signup opt-in UI should be shown.
             case hidden
             /// The current user has not been recognized as a Link consumer. Display signup opt-in UI.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -334,11 +334,11 @@ extension PaymentSheet {
             }
 
             return .visible(
-                title: "Save my info for faster checkout with Link",
-                description: NSAttributedString(string: "Pay faster everywhere Link is accepted."),
+                title: .Localized.save_my_info_for_faster_checkout_with_link,
+                description: NSAttributedString(string: .Localized.pay_faster_everywhere_link_is_accepted),
                 termsAndConditions: NSAttributedString(
                     attributedString: STPStringUtils.applyLinksToString(
-                        template: "Your information will be saved to Link, see <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+                        template: .Localized.your_information_will_be_saved_to_link_see_terms,
                         links: [
                             "terms": URL(string: "https://link.com/terms")!,
                             "privacy": URL(string: "https://link.com/privacy")!,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -220,14 +220,6 @@ extension PaymentSheet {
         /// Whether your customer has chosen to sign up to Link in your UI.
         public var linkSignUpOptIn: Bool = false
 
-//        /// The recognition status of the current user's Link account.
-//        public enum LinkAccountRecognitionStatus {
-//            /// The current user has been recognized as a Link consumer.
-//            case recognized
-//            /// The current user has not been recognized as a Link consumer.
-//            case notRecognized
-//        }
-
         /// The state of the Link signup opt-in. Use this to present the appropriate UI to the user.
         public enum LinkSignupOptInState {
             /// The current user has been recognized as a Link consumer. No signup opt-in UI should be shown.
@@ -328,25 +320,28 @@ extension PaymentSheet {
         }
 
         private func updateLinkAccountRecognitionStatus(for linkAccount: PaymentSheetLinkAccount?) {
-            let hideSignupOptIn = linkAccount?.isRegistered == true
-            linkSignupOptInState = hideSignupOptIn ? .hidden : .visible(
+            linkSignUpOptIn = elementsSession.linkSettings?.newUserSignupInitialValue ?? false
+            linkSignupOptInState = makeVisibleLinkSignupOptInState(for: linkAccount)
+        }
+
+        private func makeVisibleLinkSignupOptInState(for linkAccount: PaymentSheetLinkAccount?) -> LinkSignupOptInState {
+            guard linkAccount?.isRegistered != true && elementsSession.linkSettings?.enableNewUserSignupAPI == true else {
+                return .hidden
+            }
+
+            return .visible(
                 title: "Save my info for faster checkout with Link",
                 description: NSAttributedString(string: "Pay faster everywhere Link is accepted."),
                 termsAndConditions: NSAttributedString(
                     attributedString: STPStringUtils.applyLinksToString(
                         template: "Your information will be saved to Link, see <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
                         links: [
-                            "terms": URL(string: "https://link.co/terms")!,
-                            "privacy": URL(string: "https://link.co/privacy")!,
+                            "terms": URL(string: "https://link.com/terms")!,
+                            "privacy": URL(string: "https://link.com/privacy")!,
                         ]
                     )
                 )
             )
-
-            if !hideSignupOptIn {
-                // Default to opt-in for US users
-                linkSignUpOptIn = elementsSession.countryCode == "US"
-            }
         }
 
         // MARK: - Public methods

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -329,6 +329,10 @@ extension PaymentSheet {
                 return .hidden
             }
 
+            let hasExistingLinkPaymentMethod = elementsSession.customer?.paymentMethods.contains { paymentMethod in
+                paymentMethod.isLinkPaymentMethod || paymentMethod.isLinkPassthroughMode
+            }
+
             return .visible(
                 title: "Save my info for faster checkout with Link",
                 description: NSAttributedString(string: "Pay faster everywhere Link is accepted."),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -219,7 +219,7 @@ extension PaymentSheet {
         @Published public private(set) var linkAccountRecognitionStatus: LinkAccountRecognitionStatus?
 
         /// Whether your customer has chosen to sign up to Link in your UI.
-        public var linkSignUpOptIn: Bool = false
+         public var linkSignUpOptIn: Bool = false
 
         /// The recognition status of the current user's Link account.
         public enum LinkAccountRecognitionStatus {
@@ -304,7 +304,7 @@ extension PaymentSheet {
             self.viewController = Self.makeViewController(configuration: configuration, loadResult: loadResult, analyticsHelper: analyticsHelper, walletButtonsShownExternally: self.walletButtonsShownExternally)
             self.viewController.flowControllerDelegate = self
             updatePaymentOption()
-
+            updateLinkAccountRecognitionStatus(for: LinkAccountContext.shared.account)
             LinkAccountContext.shared.addObserver(self, selector: #selector(onAccountChange(_:)))
         }
 
@@ -312,9 +312,13 @@ extension PaymentSheet {
         func onAccountChange(_ notification: Notification) {
             DispatchQueue.main.async { [weak self] in
                 let linkAccount = notification.object as? PaymentSheetLinkAccount
-                let isLinkConsumer = linkAccount?.isRegistered == true
-                self?.linkAccountRecognitionStatus = isLinkConsumer ? .recognized : .notRecognized
+                self?.updateLinkAccountRecognitionStatus(for: linkAccount)
             }
+        }
+
+        private func updateLinkAccountRecognitionStatus(for linkAccount: PaymentSheetLinkAccount?) {
+            let isLinkConsumer = linkAccount?.isRegistered == true
+            linkAccountRecognitionStatus = isLinkConsumer ? .recognized : .notRecognized
         }
 
         // MARK: - Public methods

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -218,7 +218,7 @@ extension PaymentSheet {
         @Published public private(set) var linkSignupOptInState: LinkSignupOptInState = .hidden
 
         /// Whether your customer has chosen to sign up to Link in your UI.
-         public var linkSignUpOptIn: Bool = false
+        public var linkSignUpOptIn: Bool = false
 
 //        /// The recognition status of the current user's Link account.
 //        public enum LinkAccountRecognitionStatus {
@@ -328,8 +328,8 @@ extension PaymentSheet {
         }
 
         private func updateLinkAccountRecognitionStatus(for linkAccount: PaymentSheetLinkAccount?) {
-            let canShowSignupOptIn = linkAccount?.isRegistered == true
-            linkSignupOptInState = canShowSignupOptIn ? .hidden : .visible(
+            let hideSignupOptIn = linkAccount?.isRegistered == true
+            linkSignupOptInState = hideSignupOptIn ? .hidden : .visible(
                 title: "Save my info for faster checkout with Link",
                 description: NSAttributedString(string: "Pay faster everywhere Link is accepted."),
                 termsAndConditions: NSAttributedString(
@@ -343,7 +343,7 @@ extension PaymentSheet {
                 )
             )
 
-            if !canShowSignupOptIn {
+            if !hideSignupOptIn {
                 // Default to opt-in for US users
                 linkSignUpOptIn = elementsSession.countryCode == "US"
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -215,7 +215,7 @@ extension PaymentSheet {
         @Published public private(set) var paymentOption: PaymentOptionDisplayData?
 
         /// The current state of the Link new user signup.
-        @Published public private(set) var linkNewUserSignupState: LinkNewUserSignupState = .hidden
+        @Published public private(set) var linkSignupOptInState: LinkSignupOptInState = .hidden
 
         /// Whether your customer has chosen to sign up to Link in your UI.
          public var linkSignUpOptIn: Bool = false
@@ -228,11 +228,11 @@ extension PaymentSheet {
 //            case notRecognized
 //        }
 
-        /// The recognition status of the current user's Link account.
-        public enum LinkNewUserSignupState {
-            /// The current user has been recognized as a Link consumer.
+        /// The state of the Link signup opt-in. Use this to present the appropriate UI to the user.
+        public enum LinkSignupOptInState {
+            /// The current user has been recognized as a Link consumer. No signup opt-in UI should be shown.
             case hidden
-            /// The current user has not been recognized as a Link consumer.
+            /// The current user has not been recognized as a Link consumer. Display signup opt-in UI.
             case visible(
                 title: String,
                 description: NSAttributedString,
@@ -328,8 +328,8 @@ extension PaymentSheet {
         }
 
         private func updateLinkAccountRecognitionStatus(for linkAccount: PaymentSheetLinkAccount?) {
-            let isLinkConsumer = linkAccount?.isRegistered == true
-            linkNewUserSignupState = isLinkConsumer ? .hidden : .visible(
+            let canShowSignupOptIn = linkAccount?.isRegistered == true
+            linkSignupOptInState = canShowSignupOptIn ? .hidden : .visible(
                 title: "Save my info for faster checkout with Link",
                 description: NSAttributedString(string: "Pay faster everywhere Link is accepted."),
                 termsAndConditions: NSAttributedString(
@@ -343,11 +343,10 @@ extension PaymentSheet {
                 )
             )
 
-            if case .visible = linkNewUserSignupState {
+            if !canShowSignupOptIn {
                 // Default to opt-in for US users
-                linkSignUpOptIn = elementsSession.countryCode == "CA"
+                linkSignUpOptIn = elementsSession.countryCode == "US"
             }
-//            linkAccountRecognitionStatus = isLinkConsumer ? .recognized : .notRecognized
         }
 
         // MARK: - Public methods

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -80,11 +80,16 @@ class PaymentSheetFormFactory {
         addressSpecProvider: AddressSpecProvider = .shared,
         linkAccount: PaymentSheetLinkAccount? = nil,
         accountService: LinkAccountServiceProtocol,
-        analyticsHelper: PaymentSheetAnalyticsHelper?
+        analyticsHelper: PaymentSheetAnalyticsHelper?,
+        forceHideLinkInlineSignup: Bool = false
     ) {
 
         /// Whether or not the card form should show the link inline signup checkbox
         let showLinkInlineCardSignup: Bool = {
+            guard !forceHideLinkInlineSignup else {
+                return false
+            }
+
             guard case .paymentElement(let configuration) = configuration else {
                 return false
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -99,7 +99,8 @@ class PaymentMethodFormViewController: UIViewController {
         configuration: PaymentElementConfiguration,
         headerView: UIView?,
         analyticsHelper: PaymentSheetAnalyticsHelper,
-        delegate: PaymentMethodFormViewControllerDelegate
+        delegate: PaymentMethodFormViewControllerDelegate,
+        forceHideLinkInlineSignup: Bool = false
     ) {
         self.paymentMethodType = type
         self.intent = intent
@@ -119,7 +120,8 @@ class PaymentMethodFormViewController: UIViewController {
                 previousCustomerInput: previousCustomerInput,
                 linkAccount: LinkAccountContext.shared.account,
                 accountService: LinkAccountService(apiClient: configuration.apiClient, elementsSession: elementsSession),
-                analyticsHelper: analyticsHelper
+                analyticsHelper: analyticsHelper,
+                forceHideLinkInlineSignup: forceHideLinkInlineSignup
             ).make()
             self.formCache[type] = form
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -893,7 +893,8 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
             configuration: configuration,
             headerView: headerView,
             analyticsHelper: analyticsHelper,
-            delegate: self
+            delegate: self,
+            forceHideLinkInlineSignup: walletButtonsShownExternally
         )
     }
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
@@ -42,6 +42,14 @@ import Foundation
 
     @_spi(STP) public let allResponseFields: [AnyHashable: Any]
 
+    @_spi(STP) public var enableNewUserSignupAPI: Bool {
+        linkFlags?["link_enable_new_user_signup_api"] ?? false
+    }
+
+    @_spi(STP) public var newUserSignupInitialValue: Bool {
+        linkFlags?["link_new_user_signup_api_initial_value"] ?? false
+    }
+
     @_spi(STP) public init(
         fundingSources: Set<FundingSource>,
         popupWebviewOption: PopupWebviewOption?,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request updates `FlowController` to enable the Link new user signup API. It allows merchants to render a Link signup opt-in and notify `FlowController` about it, so that we can sign up the consumer.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
