### PR TITLE
Temporarily disable Customer Sheet test that uses FC

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -353,7 +353,8 @@ class CustomerSheetUITest: XCTestCase {
         dismissAlertView(alertBody: "Success: ••••6789, selected", alertTitle: "Complete", buttonToTap: "OK")
     }
 
-    func testCustomerSheet_addUSBankAccount_MicroDeposit() throws {
+    // TODO(CONSUMERBANK-835): Reenable when Link is disabled
+    func disabled_testCustomerSheet_addUSBankAccount_MicroDeposit() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
         settings.applePay = .off


### PR DESCRIPTION
## Summary

Link is being disabled in Financial Connections when presented from the customer sheet. This test will be reenabled after that rollout. This is to prevent any breakages.

## Motivation

https://jira.corp.stripe.com/browse/CONSUMERBANK-835

## Testing

N/a

## Changelog

N/a
