### PR TITLE
Use remote killswitch for Link inline verification

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
@@ -20,7 +20,6 @@ struct ShopPayTestingOptions {
 struct ExampleWalletButtonsContainerView: View {
     @State private var email: String = ""
     @State private var shopId: String = "69293637654"
-    @State private var linkInlineVerificationEnabled: Bool = PaymentSheet.LinkFeatureFlags.enableLinkInlineVerification
     @State private var useSPTTestBackend: Bool = false
     @State private var appearance: PaymentSheet.Appearance = PaymentSheet.Appearance()
     @State private var showingAppearancePlayground = false
@@ -45,11 +44,6 @@ struct ExampleWalletButtonsContainerView: View {
                     TextField("ShopId", text: $shopId)
                         .textContentType(.emailAddress)
                         .textInputAutocapitalization(.never)
-
-                    Toggle("Enable inline verification", isOn: $linkInlineVerificationEnabled)
-                        .onChange(of: linkInlineVerificationEnabled) { newValue in
-                            PaymentSheet.LinkFeatureFlags.enableLinkInlineVerification = newValue
-                        }
 
                     Toggle("Use SPT test backend", isOn: $useSPTTestBackend)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -114,14 +114,3 @@ func deviceCanUseNativeLink(elementsSession: STPElementsSession, configuration: 
 
     return configuration.apiClient.stripeAttest.isSupported
 }
-
-// MARK: - Link features
-
-extension PaymentSheet {
-
-    @_spi(STP) public enum LinkFeatureFlags {
-
-        /// Decides whether Link inline verification is shown in the `WalletButtonsView`.
-        @_spi(STP) public static var enableLinkInlineVerification: Bool = false
-    }
-}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -99,12 +99,13 @@ import WebKit
             configuration: flowController.configuration
         ) {
             let canUseLinkInlineVerification: Bool = {
-                let featureFlagEnabled = PaymentSheet.LinkFeatureFlags.enableLinkInlineVerification
+                let inlineVerificationKillswitch = "link_mobile_express_checkout_element_inline_otp_killswitch"
+                let killswitchEnabled = flowController.elementsSession.flags[inlineVerificationKillswitch] == true
                 let canUseNativeLink = deviceCanUseNativeLink(
                     elementsSession: flowController.elementsSession,
                     configuration: flowController.configuration
                 )
-                return featureFlagEnabled && canUseNativeLink
+                return canUseNativeLink && !killswitchEnabled
             }()
 
             if canUseLinkInlineVerification,


### PR DESCRIPTION
## Summary

This enables Link inline verification by default in the `WalletButtonsView`, and respects a remote killswitch (`link_mobile_express_checkout_element_inline_otp_killswitch`) to allow disabling the feature.

## Motivation

https://stripe.slack.com/archives/C08QFJDQHQD/p1753476677044329?thread_ts=1753462906.273789&cid=C08QFJDQHQD

## Testing

Manual testing

<img width="699" height="105" alt="image" src="https://github.com/user-attachments/assets/afdc7321-f0c8-44cb-8706-8fce415c12f3" />

## Changelog

N/a
