### PR TITLE
Use Onramp merchant key in example LinkController

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
@@ -273,7 +273,7 @@ struct ExampleLinkControllerView: View {
     }
 
     private func initializeLinkController() {
-        STPAPIClient.shared.publishableKey = "pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFfB7cY9WG4a00ZnDtiC2C"
+        STPAPIClient.shared.publishableKey = "pk_test_51K9W3OHMaDsveWq0oLP0ZjldetyfHIqyJcz27k2BpMGHxu9v9Cei2tofzoHncPyk3A49jMkFEgTOBQyAMTUffRLa00xzzARtZO"
 
         isLoading = true
         errorMessage = nil


### PR DESCRIPTION
## Summary

Switches to our test Onramp merchant in the example LinkController app.

## Motivation

Ensures we're using a merchant with all gates / features enabled.

## Testing

Manual testing

## Changelog

N/a
