### PR TITLE
Reenable `testCustomerSheet_addUSBankAccount_MicroDeposit`

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -353,8 +353,7 @@ class CustomerSheetUITest: XCTestCase {
         dismissAlertView(alertBody: "Success: ••••6789, selected", alertTitle: "Complete", buttonToTap: "OK")
     }
 
-    // TODO(CONSUMERBANK-835): Reenable when Link is disabled
-    func disabled_testCustomerSheet_addUSBankAccount_MicroDeposit() throws {
+    func testCustomerSheet_addUSBankAccount_MicroDeposit() throws {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .new
         settings.applePay = .off
@@ -381,14 +380,6 @@ class CustomerSheetUITest: XCTestCase {
         // Go through connections flow
         app.otherElements["consent_manually_verify_label"].links.firstMatch.tap()
         try! fillUSBankData_microdeposits(app)
-
-        // Fill out Link
-        XCTAssertTrue(app.textFields["Email"].waitForExistence(timeout: timeout))
-        app.typeText("test-\(UUID().uuidString)@example.com")
-        XCTAssertTrue(app.textFields["Phone number"].waitForExistence(timeout: timeout))
-        app.typeText("3105551234")
-        app.toolbars.buttons["Done"].tap()
-        app.buttons["Save with Link"].waitForExistenceAndTap(timeout: timeout)
 
         let doneManualEntry = app.buttons["success_done_button"]
         XCTAssertTrue(doneManualEntry.waitForExistence(timeout: timeout))


### PR DESCRIPTION
## Summary

Reenables the `testCustomerSheet_addUSBankAccount_MicroDeposit` test, which was recently disabled while we removed the Link signup pane.

## Motivation

CONSUMERBANK-835

## Testing

Trust CI

## Changelog

N/a
