### PR TITLE
Rename flat_with_chevron analytic value to flat_with_disclosure

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -156,7 +156,7 @@ extension PaymentSheet.Appearance.EmbeddedPaymentElement.Row.Style {
         case .flatWithCheckmark:
             return "flat_with_checkmark"
         case .flatWithDisclosure:
-            return "flat_with_chevron"
+            return "flat_with_disclosure"
         }
     }
 }


### PR DESCRIPTION
Missed this when renaming flatWithChevron to flatWithDisclosure