### PR TITLE
Fix embedded spamming broken constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## XX.YY.ZZ 2025-XX-YY
+
+### PaymentSheet
+* [Fixed] Fixed an issue that caused EmbeddedPaymentElement to log broken layout constraints.
+
 ## 24.18.1 2025-07-29
 * [Fixed] Improved Klarna payments when using Universal Links.
 

--- a/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
@@ -258,7 +258,6 @@ private extension DropdownFieldElement {
 
         // Ensure the floating placeholder view updates immediately so the label doesn't overlap.
         pickerFieldView.setNeedsLayout()
-        pickerFieldView.layoutIfNeeded()
     }
 
 }


### PR DESCRIPTION
## Summary
Embedded started spamming broken constraint warnings in https://github.com/stripe/stripe-ios/pull/5128/files#diff-0dadbd4db308020182ab78a41cc6f0abd48dd1adb2507ccf6c23ab40868c60efR261 


## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4500

## Testing
I manually tested the 'label overlap' behavior that caused us to add `layoutIfNeeded()` in the first place. It's only triggered by removing `setNeedsLayout()`; `layoutIfNeeded()` is not necessary to prevent the overlap behavior.

## Changelog
see changelog