### PR TITLE
Fix error code bridging in Link

### DIFF
--- a/Stripe/StripeiOSTests/StripeErrorTest.swift
+++ b/Stripe/StripeiOSTests/StripeErrorTest.swift
@@ -272,12 +272,8 @@ class StripeErrorTest: XCTestCase {
 
     func testStpErrorCodeExtension() {
         let modernAPIError = StripeError.apiError(StripeAPIError(
-            message: "Test message",
-            type: .invalidRequest,
-            code: "test_code",
-            param: nil,
-            declineCode: nil,
-            paymentIntent: nil
+            type: .invalidRequestError, code: "test_code", message: "Test message",
+            param: nil
         ))
         XCTAssertEqual(modernAPIError._stp_error_code, "test_code")
 

--- a/Stripe/StripeiOSTests/StripeErrorTest.swift
+++ b/Stripe/StripeiOSTests/StripeErrorTest.swift
@@ -269,4 +269,28 @@ class StripeErrorTest: XCTestCase {
             "req_123"
         )
     }
+
+    func testStpErrorCodeExtension() {
+        let modernAPIError = StripeError.apiError(StripeAPIError(
+            message: "Test message",
+            type: .invalidRequest,
+            code: "test_code",
+            param: nil,
+            declineCode: nil,
+            paymentIntent: nil
+        ))
+        XCTAssertEqual(modernAPIError._stp_error_code, "test_code")
+
+        let response = [
+            "error": [
+                "type": "card_error",
+                "code": "card_declined",
+            ],
+        ]
+        let legacyError = NSError.stp_error(fromStripeResponse: response)!
+        XCTAssertEqual(legacyError._stp_error_code, "card_declined")
+
+        let genericError = NSError(domain: "test", code: 1, userInfo: nil)
+        XCTAssertNil(genericError._stp_error_code)
+    }
 }

--- a/StripeCore/StripeCore/Source/API Bindings/StripeError.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/StripeError.swift
@@ -84,3 +84,19 @@ extension StripeError: LocalizedError {
         }
     }
 }
+
+extension Error {
+    /// Returns the Stripe error code, if available. Works with modern and legacy Stripe API errors.
+    @_spi(STP) public var _stp_error_code: String? {
+        if let stripeError = self as? StripeError,
+              case let .apiError(stripeAPIError) = stripeError {
+            return stripeAPIError.code
+        }
+
+        if let errorCodeString = (self as NSError).userInfo[STPError.stripeErrorCodeKey] as? String {
+            return errorCodeString
+        }
+
+        return nil
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkUtils.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkUtils.swift
@@ -40,7 +40,7 @@ final class LinkUtils {
     }
 
     static func getLocalizedErrorMessage(from error: Error) -> String {
-        guard let errorCodeString = (error as NSError).userInfo[STPError.stripeErrorCodeKey] as? String,
+        guard let errorCodeString = error._stp_error_code,
               let errorCode = ConsumerErrorCode(rawValue: errorCodeString) else {
             return error.localizedDescription
         }


### PR DESCRIPTION
## Summary
This code in Link wasn't working, as it was using the modern API bindings. We should have a helper to bridge both modern and legacy error codes.

## Motivation
Fixing a "an unknown error occurred" message when using Link.

## Testing
Added a test for the bridge, tested Link's error handling manually in PS Example.

## Changelog
None