### PR TITLE
Add signup opt-in toggle for Link

### DIFF
--- a/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
+++ b/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
@@ -191,6 +191,8 @@ extension LinkInlineSignupElementSnapshotTests {
             showCheckbox: showCheckbox,
             accountService: MockAccountService(),
             allowsDefaultOptIn: allowsDefaultOptIn,
+            signupOptInFeatureEnabled: false,
+            signupOptInInitialValue: false,
             linkAccount: linkAccount,
             country: country
         )

--- a/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
+++ b/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
@@ -253,7 +253,9 @@ extension LinkInlineSignupViewModelTests {
         showCheckbox: Bool,
         hasAccountObject: Bool = false,
         shouldFailLookup: Bool = false,
-        allowsDefaultOptIn: Bool = false
+        allowsDefaultOptIn: Bool = false,
+        signupOptInFeatureEnabled: Bool = false,
+        signupOptInInitialValue: Bool = false
     ) -> LinkInlineSignupViewModel {
         let linkAccount: PaymentSheetLinkAccount? = hasAccountObject
         ? PaymentSheetLinkAccount(
@@ -270,6 +272,8 @@ extension LinkInlineSignupViewModelTests {
             showCheckbox: showCheckbox,
             accountService: MockAccountService(shouldFailLookup: shouldFailLookup),
             allowsDefaultOptIn: allowsDefaultOptIn,
+            signupOptInFeatureEnabled: signupOptInFeatureEnabled,
+            signupOptInInitialValue: signupOptInInitialValue,
             linkAccount: linkAccount,
             country: country
         )

--- a/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
+++ b/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
@@ -212,6 +212,45 @@ class LinkInlineSignupViewModelTests: STPNetworkStubbingTestCase {
         XCTAssertTrue(sut.shouldShowEmailField)
         XCTAssertTrue(sut.shouldShowPhoneField)
     }
+
+    func test_signupOptIn_shows_no_fields() {
+        let sut = makeSUT(
+            country: "US",
+            showCheckbox: true,
+            hasAccountObject: true,
+            allowsDefaultOptIn: true,
+            signupOptInFeatureEnabled: true,
+            signupOptInInitialValue: true
+        )
+        XCTAssertFalse(sut.shouldShowDefaultOptInView)
+        XCTAssertFalse(sut.shouldShowEmailField)
+        XCTAssertFalse(sut.shouldShowPhoneField)
+        XCTAssertFalse(sut.shouldShowNameField)
+    }
+
+    func test_signupOptIn_prechecked() {
+        let sut = makeSUT(
+            country: "US",
+            showCheckbox: true,
+            hasAccountObject: true,
+            allowsDefaultOptIn: true,
+            signupOptInFeatureEnabled: true,
+            signupOptInInitialValue: true
+        )
+        XCTAssertTrue(sut.saveCheckboxChecked)
+    }
+
+    func test_signupOptIn_not_prechecked() {
+        let sut = makeSUT(
+            country: "US",
+            showCheckbox: true,
+            hasAccountObject: true,
+            allowsDefaultOptIn: true,
+            signupOptInFeatureEnabled: true,
+            signupOptInInitialValue: false
+        )
+        XCTAssertFalse(sut.saveCheckboxChecked)
+    }
 }
 
 extension LinkInlineSignupViewModelTests {

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -92,6 +92,12 @@
 /* Text providing link to terms for ACH payments */
 "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>." = "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.";
 
+/* Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. */
+"By continuing, you agree to save your information for future purchases with %@ and <link>Link</link>. You also agree to Link's <terms>Terms</terms> and <privacy>Privacy</privacy>." = "By continuing, you agree to save your information for future purchases with %@ and <link>Link</link>. You also agree to Link's <terms>Terms</terms> and <privacy>Privacy</privacy>.";
+
+/* Text displayed below a credit card entry form when the card will be saved with the merchant. */
+"By continuing, you agree to save your information for future purchases with %@." = "By continuing, you agree to save your information for future purchases with %@.";
+
 /* Satispay mandate text */
 "By continuing, you authorize %@ to automatically debit your Satispay Balance on a recurring basis in accordance with your purchase or subscription plan." = "By continuing, you authorize %@ to automatically debit your Satispay Balance on a recurring basis in accordance with your purchase or subscription plan.";
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -471,6 +471,20 @@ extension String.Localized {
         )
     }
 
+    static var by_continuing_you_agree_to_save_your_information_to_merchant: String {
+        STPLocalizedString(
+            "By continuing, you agree to save your information for future purchases with %@.",
+            "Text displayed below a credit card entry form when the card will be saved with the merchant."
+        )
+    }
+
+    static var by_continuing_you_agree_to_save_your_information_to_merchant_and_link: String {
+        STPLocalizedString(
+            "By continuing, you agree to save your information for future purchases with %@ and <link>Link</link>. You also agree to Link's <terms>Terms</terms> and <privacy>Privacy</privacy>.",
+            "Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link."
+        )
+    }
+
     static var confirm_your_cvc: String {
         STPLocalizedString("Confirm your CVC", "Title for prompting for a card's CVC on confirming the payment")
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -62,6 +62,12 @@ struct LinkPMDisplayDetails {
 
         // Crypto onramp, email and phone number are entered, a sign up button is tapped
         case entered_phone_number_email_clicked_signup_crypto_onramp = "entered_phone_number_email_clicked_signup_crypto_onramp"
+
+        // Checkbox pre-checked, signup data inferred from billing details or customer information
+        case sign_up_opt_in_mobile_prechecked = "sign_up_opt_in_mobile_prechecked"
+
+        // Checkbox checked, signup data inferred from billing details or customer information
+        case sign_up_opt_in_mobile_checked = "sign_up_opt_in_mobile_checked"
     }
 
     // Dependencies
@@ -132,22 +138,23 @@ struct LinkPMDisplayDetails {
     }
 
     func signUp(
-        with phoneNumber: PhoneNumber,
+        with phoneNumber: PhoneNumber?,
         legalName: String?,
+        countryCode: String?,
         consentAction: ConsentAction,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         signUp(
-            with: phoneNumber.string(as: .e164),
+            with: phoneNumber?.string(as: .e164),
             legalName: legalName,
-            countryCode: phoneNumber.countryCode,
+            countryCode: phoneNumber?.countryCode ?? countryCode,
             consentAction: consentAction,
             completion: completion
         )
     }
 
     func signUp(
-        with phoneNumber: String,
+        with phoneNumber: String?,
         legalName: String?,
         countryCode: String?,
         consentAction: ConsentAction,
@@ -277,6 +284,7 @@ struct LinkPMDisplayDetails {
 
     func createPaymentDetails(
         with paymentMethodParams: STPPaymentMethodParams,
+        isDefault: Bool,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         retryingOnAuthError(completion: completion) { completionRetryingOnAuthErrors in
@@ -292,6 +300,7 @@ struct LinkPMDisplayDetails {
                 paymentMethodParams: paymentMethodParams,
                 with: self.apiClient,
                 consumerAccountPublishableKey: self.publishableKey,
+                isDefault: isDefault,
                 completion: completionRetryingOnAuthErrors
             )
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -121,7 +121,7 @@ extension ConsumerSession {
 
     class func signUp(
         email: String,
-        phoneNumber: String,
+        phoneNumber: String?,
         locale: Locale = .autoupdatingCurrent,
         legalName: String?,
         countryCode: String?,
@@ -146,6 +146,7 @@ extension ConsumerSession {
         paymentMethodParams: STPPaymentMethodParams,
         with apiClient: STPAPIClient = STPAPIClient.shared,
         consumerAccountPublishableKey: String?,
+        isDefault: Bool = false,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         guard paymentMethodParams.type == .card,
@@ -170,6 +171,7 @@ extension ConsumerSession {
             cardParams: cardParams,
             billingEmailAddress: billingEmailAddress,
             billingDetails: paymentMethodParams.nonnil_billingDetails,
+            isDefault: isDefault,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -85,7 +85,7 @@ extension STPAPIClient {
 
     func createConsumer(
         for email: String,
-        with phoneNumber: String,
+        with phoneNumber: String?,
         locale: Locale,
         legalName: String?,
         countryCode: String?,
@@ -100,10 +100,13 @@ extension STPAPIClient {
             var parameters: [String: Any] = [
                 "request_surface": "ios_payment_element",
                 "email_address": email.lowercased(),
-                "phone_number": phoneNumber,
                 "locale": locale.toLanguageTag(),
                 "country_inferring_method": "PHONE_NUMBER",
             ]
+
+            if let phoneNumber {
+                parameters["phone_number"] = phoneNumber
+            }
 
             if let legalName = legalName {
                 parameters["legal_name"] = legalName
@@ -169,6 +172,7 @@ extension STPAPIClient {
         cardParams: STPPaymentMethodCardParams,
         billingEmailAddress: String,
         billingDetails: STPPaymentMethodBillingDetails,
+        isDefault: Bool,
         consumerAccountPublishableKey: String?,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
@@ -177,6 +181,7 @@ extension STPAPIClient {
             rawCardParams: cardParams.consumersAPIParams,
             billingEmailAddress: billingEmailAddress,
             billingDetails: billingDetails,
+            isDefault: isDefault,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion
         )
@@ -187,6 +192,7 @@ extension STPAPIClient {
         rawCardParams: [String: Any],
         billingEmailAddress: String,
         billingDetails: STPPaymentMethodBillingDetails,
+        isDefault: Bool,
         consumerAccountPublishableKey: String?,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
@@ -202,6 +208,7 @@ extension STPAPIClient {
             "billing_email_address": billingEmailAddress,
             "billing_address": billingParams,
             "active": true, // card details are created with active true so they can be shared for passthrough mode
+            "is_default": isDefault,
         ]
 
         makePaymentDetailsRequest(

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -101,11 +101,11 @@ extension STPAPIClient {
                 "request_surface": "ios_payment_element",
                 "email_address": email.lowercased(),
                 "locale": locale.toLanguageTag(),
-                "country_inferring_method": "PHONE_NUMBER",
             ]
 
             if let phoneNumber {
                 parameters["phone_number"] = phoneNumber
+                parameters["country_inferring_method"] = "PHONE_NUMBER"
             }
 
             if let legalName = legalName {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -320,6 +320,14 @@ extension STPElementsSession {
     var allowsLinkDefaultOptIn: Bool {
         linkFlags["link_mobile_disable_default_opt_in"] != true
     }
+
+    var linkSignupOptInFeatureEnabled: Bool {
+        linkFlags["link_sign_up_opt_in_feature_enabled"] == true
+    }
+
+    var linkSignupOptInInitialValue: Bool {
+        linkFlags["link_sign_up_opt_in_initial_value"] == true
+    }
 }
 
 extension STPElementsSession {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -184,7 +184,10 @@ extension PayWithLinkViewController {
             confirmButton.update(state: .processing)
             coordinator?.allowSheetDismissal(false)
 
-            linkAccount.createPaymentDetails(with: confirmParams.paymentMethodParams) { [weak self] result in
+            linkAccount.createPaymentDetails(
+                with: confirmParams.paymentMethodParams,
+                isDefault: isAddingFirstPaymentMethod
+            ) { [weak self] result in
                 guard let self = self else {
                     return
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupElement.swift
@@ -41,13 +41,17 @@ final class LinkInlineSignupElement: Element {
         country: String?,
         showCheckbox: Bool,
         accountService: LinkAccountServiceProtocol,
-        allowsDefaultOptIn: Bool
+        allowsDefaultOptIn: Bool,
+        signupOptInFeatureEnabled: Bool,
+        signupOptInInitialValue: Bool
     ) {
         self.init(viewModel: LinkInlineSignupViewModel(
             configuration: configuration,
             showCheckbox: showCheckbox,
             accountService: accountService,
             allowsDefaultOptIn: allowsDefaultOptIn,
+            signupOptInFeatureEnabled: signupOptInFeatureEnabled,
+            signupOptInInitialValue: signupOptInInitialValue,
             linkAccount: linkAccount,
             country: country
         ))

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
@@ -45,7 +45,7 @@ extension LinkInlineSignupView {
 
             let text = {
                 switch mode {
-                case .checkboxWithDefaultOptIn:
+                case .checkboxWithDefaultOptIn, .signupOptIn:
                     return STPLocalizedString(
                         "Save my info for faster checkout with Link",
                         """
@@ -70,7 +70,7 @@ extension LinkInlineSignupView {
                     return String.Localized.pay_faster_at_$merchant_and_thousands_of_merchants(
                         merchantDisplayName: merchantName
                     )
-                case .checkboxWithDefaultOptIn:
+                case .checkboxWithDefaultOptIn, .signupOptIn:
                     return nil
                 }
             }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewModel.swift
@@ -169,6 +169,7 @@ final class LinkSignUpViewModel: NSObject {
         linkAccount.signUp(
             with: phoneNumber,
             legalName: requiresNameCollection ? legalName : nil,
+            countryCode: nil,
             consentAction: .clicked_button_mobile_v1
         ) { [weak self] result in
             switch result {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
@@ -17,7 +17,7 @@ protocol LinkInlineSignupViewModelDelegate: AnyObject {
 
 final class LinkInlineSignupViewModel {
     enum Action: Equatable {
-        case signupAndPay(account: PaymentSheetLinkAccount, phoneNumber: PhoneNumber, legalName: String?)
+        case signupAndPay(account: PaymentSheetLinkAccount, phoneNumber: PhoneNumber?, legalName: String?)
         case continueWithoutLink
     }
 
@@ -26,6 +26,7 @@ final class LinkInlineSignupViewModel {
         case checkboxWithDefaultOptIn // shows the Link inline signup with a pre-checked checkbox and a label showing the used signup data
         case textFieldsOnlyEmailFirst // shows the Link inline signup without the checkbox, email field first
         case textFieldsOnlyPhoneFirst // shows the Link inline signup without the checkbox, phone number field first
+        case signupOptIn // shows the Link signup opt-in with a checkbox
     }
 
     weak var delegate: LinkInlineSignupViewModelDelegate?
@@ -43,6 +44,7 @@ final class LinkInlineSignupViewModel {
     var saveCheckboxChecked: Bool = false {
         didSet {
             if saveCheckboxChecked != oldValue {
+                didInteractWithSaveCheckbox = true
                 notifyUpdate()
 
                 if saveCheckboxChecked, mode == .checkbox {
@@ -51,6 +53,8 @@ final class LinkInlineSignupViewModel {
             }
         }
     }
+
+    private var didInteractWithSaveCheckbox = false
 
     var emailAddress: String? {
         didSet {
@@ -105,6 +109,12 @@ final class LinkInlineSignupViewModel {
             return .implied_v0
         case .textFieldsOnlyPhoneFirst:
             return .implied_v0_0
+        case .signupOptIn:
+            if didInteractWithSaveCheckbox {
+                return .sign_up_opt_in_mobile_checked
+            } else {
+                return .sign_up_opt_in_mobile_prechecked
+            }
         }
     }
 
@@ -172,6 +182,8 @@ final class LinkInlineSignupViewModel {
         case .textFieldsOnlyPhoneFirst:
             // Only show email if the phone number field has contents
             return (phoneNumber?.isComplete ?? false)
+        case .signupOptIn:
+            return false
         }
     }
 
@@ -187,6 +199,8 @@ final class LinkInlineSignupViewModel {
             return false
         case .textFieldsOnlyPhoneFirst:
             return requiresNameCollection && phoneNumber?.isComplete ?? false
+        case .signupOptIn:
+            return false
         }
     }
 
@@ -205,6 +219,8 @@ final class LinkInlineSignupViewModel {
             return saveCheckboxChecked && (!defaultOptInInfoWasPrefilled || didAskToChangeSignupData) && !isExistingConsumer
         case .textFieldsOnlyPhoneFirst:
             return true
+        case .signupOptIn:
+            return false
         }
     }
 
@@ -216,6 +232,8 @@ final class LinkInlineSignupViewModel {
             return saveCheckboxChecked
         case .textFieldsOnlyPhoneFirst, .textFieldsOnlyEmailFirst:
             return true
+        case .signupOptIn:
+            return false
         }
     }
 
@@ -249,18 +267,19 @@ final class LinkInlineSignupViewModel {
 
         switch linkAccount.sessionState {
         case .requiresSignUp:
-            guard let phoneNumber = phoneNumber,
-                  phoneNumber.isComplete else {
+            guard phoneNumber?.isComplete == true || mode == .signupOptIn else {
                 return nil
             }
 
-            if requiresNameCollection && !legalNameProvided {
+            if mode != .signupOptIn && requiresNameCollection && !legalNameProvided {
                 return nil
             }
+
+            let phone = phoneNumber?.isComplete == true ? phoneNumber : nil
 
             return .signupAndPay(
                 account: linkAccount,
-                phoneNumber: phoneNumber,
+                phoneNumber: phone,
                 legalName: requiresNameCollection ? legalName : nil
             )
         case .verified, .requiresVerification:
@@ -274,14 +293,14 @@ final class LinkInlineSignupViewModel {
         switch mode {
         case .checkbox:
             return 16
-        case .checkboxWithDefaultOptIn, .textFieldsOnlyEmailFirst, .textFieldsOnlyPhoneFirst:
+        case .checkboxWithDefaultOptIn, .textFieldsOnlyEmailFirst, .textFieldsOnlyPhoneFirst, .signupOptIn:
             return 0
         }
     }
 
     var showCheckbox: Bool {
         switch mode {
-        case .checkbox, .checkboxWithDefaultOptIn:
+        case .checkbox, .checkboxWithDefaultOptIn, .signupOptIn:
             return true
         case .textFieldsOnlyEmailFirst, .textFieldsOnlyPhoneFirst:
             return false
@@ -292,7 +311,7 @@ final class LinkInlineSignupViewModel {
         switch mode {
         case .checkbox:
             return true
-        case .checkboxWithDefaultOptIn, .textFieldsOnlyEmailFirst, .textFieldsOnlyPhoneFirst:
+        case .checkboxWithDefaultOptIn, .textFieldsOnlyEmailFirst, .textFieldsOnlyPhoneFirst, .signupOptIn:
             return false
         }
     }
@@ -305,6 +324,9 @@ final class LinkInlineSignupViewModel {
             return true
         case .textFieldsOnlyPhoneFirst:
             return false
+        case .signupOptIn:
+            // Not applicable
+            return true
         }
     }
 
@@ -317,6 +339,9 @@ final class LinkInlineSignupViewModel {
         case .textFieldsOnlyEmailFirst:
             return false
         case .textFieldsOnlyPhoneFirst:
+            return true
+        case .signupOptIn:
+            // Not applicable
             return true
         }
     }
@@ -331,6 +356,9 @@ final class LinkInlineSignupViewModel {
         case .textFieldsOnlyPhoneFirst:
             // Already shown in the phone number field
             return false
+        case .signupOptIn:
+            // Not applicable
+            return false
         }
     }
 
@@ -339,6 +367,8 @@ final class LinkInlineSignupViewModel {
         showCheckbox: Bool,
         accountService: LinkAccountServiceProtocol,
         allowsDefaultOptIn: Bool,
+        signupOptInFeatureEnabled: Bool,
+        signupOptInInitialValue: Bool,
         linkAccount: PaymentSheetLinkAccount? = nil,
         country: String? = nil
     ) {
@@ -350,7 +380,9 @@ final class LinkInlineSignupViewModel {
            !email.isEmpty {
             emailWasPrefilled = true
         }
-        if showCheckbox {
+        if signupOptInFeatureEnabled && emailWasPrefilled {
+            self.mode = .signupOptIn
+        } else if showCheckbox {
             let allowsDefaultOptIn = allowsDefaultOptIn && country == "US"
             self.mode = allowsDefaultOptIn ? .checkboxWithDefaultOptIn : .checkbox
         } else {
@@ -360,7 +392,16 @@ final class LinkInlineSignupViewModel {
         self.legalName = configuration.defaultBillingDetails.name
         self.country = country
 
-        self.saveCheckboxChecked = mode == .checkboxWithDefaultOptIn
+        self.saveCheckboxChecked = {
+            switch mode {
+            case .checkbox, .textFieldsOnlyEmailFirst, .textFieldsOnlyPhoneFirst:
+                return false
+            case .checkboxWithDefaultOptIn:
+                return true
+            case .signupOptIn:
+                return signupOptInInitialValue
+            }
+        }()
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
@@ -95,8 +95,8 @@ final class LinkLegalTermsView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func formattedLegalText() -> NSAttributedString {
-        let string: String = {
+    private func formattedLegalText() -> NSAttributedString? {
+        let string: String? = {
             if isStandalone {
                 return STPLocalizedString(
                     "By continuing you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
@@ -124,8 +124,15 @@ final class LinkLegalTermsView: UIView {
                     "By providing your phone number, you agree to create a Link account and save your payment info to Link, according to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
                     "Legal text shown when creating a Link account."
                 )
+            case .signupOptIn:
+                stpAssertionFailure("LinkLegalTermsView should not be available in signup opt-in mode")
+                return nil
             }
         }()
+
+        guard let string else {
+            return nil
+        }
 
         let leadingIcon: NSTextAttachment? = {
             guard mode == .checkboxWithDefaultOptIn else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
@@ -5,6 +5,7 @@
 //  Created by Yuki Tokuhiro on 3/26/23.
 //
 
+@_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripeUICore
 import UIKit
 
@@ -38,6 +39,11 @@ class SimpleMandateElement: PaymentMethodElement {
     let customerAlreadySawMandate: Bool
 
     init(mandateText: String, customerAlreadySawMandate: Bool, theme: ElementsAppearance = .default) {
+        mandateTextView = SimpleMandateTextView(mandateText: mandateText, theme: theme)
+        self.customerAlreadySawMandate = customerAlreadySawMandate
+    }
+
+    init(mandateText: NSAttributedString, customerAlreadySawMandate: Bool, theme: ElementsAppearance = .default) {
         mandateTextView = SimpleMandateTextView(mandateText: mandateText, theme: theme)
         self.customerAlreadySawMandate = customerAlreadySawMandate
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/SimpleMandateElement.swift
@@ -5,7 +5,6 @@
 //  Created by Yuki Tokuhiro on 3/26/23.
 //
 
-@_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripeUICore
 import UIKit
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -19,7 +19,7 @@ extension PaymentSheet {
         /// Signup for Link then pay.
         case signUp(
             account: PaymentSheetLinkAccount,
-            phoneNumber: PhoneNumber,
+            phoneNumber: PhoneNumber?,
             consentAction: PaymentSheetLinkAccount.ConsentAction,
             legalName: String?,
             intentConfirmParams: IntentConfirmParams

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -77,8 +77,11 @@ extension PaymentSheet {
         guard isLinkEnabled(elementsSession: elementsSession, configuration: configuration) else {
             return false
         }
-        let enableSignupOrOptIn = !elementsSession.disableLinkSignup || elementsSession.linkSignupOptInFeatureEnabled
-        return enableSignupOrOptIn && elementsSession.supportsLinkCard
+        // A non-nil account indicates that a consumer lookup has taken place, meaning that we have a customer email
+        // via the billing details or customer session.
+        let enableOptIn = elementsSession.linkSignupOptInFeatureEnabled && LinkAccountContext.shared.account != nil
+        let enableSignup = !elementsSession.disableLinkSignup
+        return (enableSignup || enableOptIn) && elementsSession.supportsLinkCard
     }
 
     /// An unordered list of paymentMethodTypes that can be used with Link in PaymentSheet

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -73,6 +73,14 @@ extension PaymentSheet {
         return true
     }
 
+    static func isLinkSignupEnabled(elementsSession: STPElementsSession, configuration: PaymentElementConfiguration) -> Bool {
+        guard isLinkEnabled(elementsSession: elementsSession, configuration: configuration) else {
+            return false
+        }
+        let enableSignupOrOptIn = !elementsSession.disableLinkSignup || elementsSession.linkSignupOptInFeatureEnabled
+        return enableSignupOrOptIn && elementsSession.supportsLinkCard
+    }
+
     /// An unordered list of paymentMethodTypes that can be used with Link in PaymentSheet
     /// - Note: This is a var because it depends on the authenticated Link user
     ///

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -14,12 +14,7 @@ import StripePayments
 import UIKit
 
 extension PaymentSheetFormFactory {
-    func makeCard(
-        cardBrandChoiceEligible: Bool = false,
-        allowsLinkDefaultOptIn: Bool,
-        signupOptInFeatureEnabled: Bool,
-        signupOptInInitialValue: Bool
-    ) -> PaymentMethodElement {
+    func makeCard() -> PaymentMethodElement {
         let showLinkInlineSignup = showLinkInlineCardSignup
         let defaultCheckbox: Element? = {
             guard allowsSetAsDefaultPM else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -123,10 +123,7 @@ extension PaymentSheetFormFactory {
 
         let mandate: SimpleMandateElement? = {
             if isSettingUp || signupOptInFeatureEnabled {
-                return makeMandate(
-                    linkSignupOptInFeatureEnabled: signupOptInFeatureEnabled,
-                    linkSignupOptInInitialValue: signupOptInInitialValue
-                )
+                return makeMandate()
             }
             return nil
         }()
@@ -143,13 +140,10 @@ extension PaymentSheetFormFactory {
             customSpacing: customSpacing)
     }
 
-    private func makeMandate(
-        linkSignupOptInFeatureEnabled: Bool,
-        linkSignupOptInInitialValue: Bool
-    ) -> SimpleMandateElement {
+    private func makeMandate() -> SimpleMandateElement {
         let mandateText = Self.makeMandateText(
             linkSignupOptInFeatureEnabled: signupOptInFeatureEnabled,
-            shouldSaveToLink: linkSignupOptInInitialValue,
+            shouldSaveToLink: signupOptInInitialValue,
             merchantName: configuration.merchantDisplayName
         )
         return makeMandate(mandateText: mandateText)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Mandates.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Mandates.swift
@@ -16,6 +16,12 @@ extension PaymentSheetFormFactory {
         return SimpleMandateElement(mandateText: mandateText, customerAlreadySawMandate: customerAlreadySawMandate, theme: theme)
     }
 
+    func makeMandate(mandateText: NSAttributedString) -> SimpleMandateElement {
+        // If there was previous customer input, check if it displayed the mandate for this payment method
+        let customerAlreadySawMandate = previousCustomerInput?.didDisplayMandate ?? false
+        return SimpleMandateElement(mandateText: mandateText, customerAlreadySawMandate: customerAlreadySawMandate, theme: theme)
+    }
+
     func makeAUBECSMandate() -> StaticElement {
         return StaticElement(view: AUBECSLegalTermsView(configuration: configuration))
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -39,6 +39,8 @@ class PaymentSheetFormFactory {
     let savePaymentMethodConsentBehavior: SavePaymentMethodConsentBehavior
     let allowsSetAsDefaultPM: Bool
     let allowsLinkDefaultOptIn: Bool
+    let signupOptInFeatureEnabled: Bool
+    let signupOptInInitialValue: Bool
     let isFirstSavedPaymentMethod: Bool
     let analyticsHelper: PaymentSheetAnalyticsHelper?
     let paymentMethodIncentive: PaymentMethodIncentive?
@@ -89,8 +91,7 @@ class PaymentSheetFormFactory {
                 return false
             }
 
-            let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
-            guard isLinkEnabled && !elementsSession.disableLinkSignup && elementsSession.supportsLinkCard else {
+            guard PaymentSheet.isLinkSignupEnabled(elementsSession: elementsSession, configuration: configuration) else {
                 return false
             }
 
@@ -129,6 +130,8 @@ class PaymentSheetFormFactory {
                   savePaymentMethodConsentBehavior: elementsSession.savePaymentMethodConsentBehavior,
                   allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
                   allowsLinkDefaultOptIn: elementsSession.allowsLinkDefaultOptIn,
+                  signupOptInFeatureEnabled: elementsSession.linkSignupOptInFeatureEnabled,
+                  signupOptInInitialValue: elementsSession.linkSignupOptInInitialValue,
                   isFirstSavedPaymentMethod: elementsSession.customer?.paymentMethods.isEmpty ?? true,
                   analyticsHelper: analyticsHelper,
                   paymentMethodIncentive: elementsSession.incentive)
@@ -150,6 +153,8 @@ class PaymentSheetFormFactory {
         savePaymentMethodConsentBehavior: SavePaymentMethodConsentBehavior,
         allowsSetAsDefaultPM: Bool = false,
         allowsLinkDefaultOptIn: Bool = false,
+        signupOptInFeatureEnabled: Bool = false,
+        signupOptInInitialValue: Bool = false,
         isFirstSavedPaymentMethod: Bool = true,
         analyticsHelper: PaymentSheetAnalyticsHelper?,
         paymentMethodIncentive: PaymentMethodIncentive?
@@ -174,6 +179,8 @@ class PaymentSheetFormFactory {
         self.savePaymentMethodConsentBehavior = savePaymentMethodConsentBehavior
         self.allowsSetAsDefaultPM = allowsSetAsDefaultPM
         self.allowsLinkDefaultOptIn = allowsLinkDefaultOptIn
+        self.signupOptInFeatureEnabled = signupOptInFeatureEnabled
+        self.signupOptInInitialValue = signupOptInInitialValue
         self.isFirstSavedPaymentMethod = isFirstSavedPaymentMethod
         self.analyticsHelper = analyticsHelper
         self.paymentMethodIncentive = paymentMethodIncentive
@@ -192,7 +199,12 @@ class PaymentSheetFormFactory {
             // We have two ways to create the form for a payment method
             // 1. Custom, one-off forms
             if paymentMethod == .card {
-                return makeCard(cardBrandChoiceEligible: cardBrandChoiceEligible, allowsLinkDefaultOptIn: allowsLinkDefaultOptIn)
+                return makeCard(
+                    cardBrandChoiceEligible: cardBrandChoiceEligible,
+                    allowsLinkDefaultOptIn: allowsLinkDefaultOptIn,
+                    signupOptInFeatureEnabled: signupOptInFeatureEnabled,
+                    signupOptInInitialValue: signupOptInInitialValue
+                )
             } else if paymentMethod == .USBankAccount {
                 return makeUSBankAccount(merchantName: configuration.merchantDisplayName)
             } else if paymentMethod == .UPI {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -199,12 +199,7 @@ class PaymentSheetFormFactory {
             // We have two ways to create the form for a payment method
             // 1. Custom, one-off forms
             if paymentMethod == .card {
-                return makeCard(
-                    cardBrandChoiceEligible: cardBrandChoiceEligible,
-                    allowsLinkDefaultOptIn: allowsLinkDefaultOptIn,
-                    signupOptInFeatureEnabled: signupOptInFeatureEnabled,
-                    signupOptInInitialValue: signupOptInInitialValue
-                )
+                return makeCard()
             } else if paymentMethod == .USBankAccount {
                 return makeUSBankAccount(merchantName: configuration.merchantDisplayName)
             } else if paymentMethod == .UPI {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SimpleMandateTextView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SimpleMandateTextView.swift
@@ -29,6 +29,7 @@ class SimpleMandateTextView: UIView {
     convenience init(mandateText: NSAttributedString, theme: ElementsAppearance) {
         self.init(theme: theme)
         textView.attributedText = mandateText
+        applyTextViewStyle()
     }
 
     convenience init(mandateText: String, theme: ElementsAppearance) {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
@@ -115,4 +115,72 @@ final class PaymentMethodAvailabilityTest: XCTestCase {
 
         XCTAssertFalse(isLinkEnabled, "Link should be disabled when display is set to .never")
     }
+
+    func testIsLinkSignupEnabled_enabled_for_linkSignupOptInFeatureEnabled_if_general_signup_disabled() {
+        // Lookup happened during initialization and an email was provided
+        LinkAccountContext.shared.account = ._testValue(email: "john@doe.com", isRegistered: false)
+
+        let elementsSession = STPElementsSession._testValue(
+            linkSettings: ._testValue(
+                disableSignup: true,
+                flags: ["link_sign_up_opt_in_feature_enabled": true]
+            )
+        )
+        let configuration = PaymentSheet.Configuration()
+        let isLinkSignupEnabled = PaymentSheet.isLinkSignupEnabled(elementsSession: elementsSession, configuration: configuration)
+
+        XCTAssertTrue(isLinkSignupEnabled, "Link inline signup should be enabled for linkSignupOptInFeatureEnabled even if general signup disabled")
+    }
+
+    func testIsLinkSignupEnabled_enabled_for_linkSignupOptInFeatureEnabled_if_email_provided() {
+        // Lookup happened during initialization and an email was provided
+        LinkAccountContext.shared.account = ._testValue(email: "john@doe.com", isRegistered: false)
+
+        let elementsSession = STPElementsSession._testValue(
+            linkSettings: ._testValue(flags: ["link_sign_up_opt_in_feature_enabled": true])
+        )
+        let configuration = PaymentSheet.Configuration()
+        let isLinkSignupEnabled = PaymentSheet.isLinkSignupEnabled(elementsSession: elementsSession, configuration: configuration)
+
+        XCTAssertTrue(isLinkSignupEnabled, "Link inline signup should be enabled for linkSignupOptInFeatureEnabled if an email was provided")
+    }
+
+    func testIsLinkSignupEnabled_disabled_for_linkSignupOptInFeatureEnabled_if_no_email_provided() {
+        // Lookup happened during initialization and no email was provided
+        LinkAccountContext.shared.account = nil
+
+        let elementsSession = STPElementsSession._testValue(
+            linkSettings: ._testValue(
+                disableSignup: true,
+                flags: ["link_sign_up_opt_in_feature_enabled": true]
+            )
+        )
+        let configuration = PaymentSheet.Configuration()
+        let isLinkSignupEnabled = PaymentSheet.isLinkSignupEnabled(elementsSession: elementsSession, configuration: configuration)
+
+        XCTAssertFalse(isLinkSignupEnabled, "Link inline signup should be disabled for linkSignupOptInFeatureEnabled if no email was provided")
+    }
+}
+
+private extension LinkSettings {
+    static func _testValue(
+        disableSignup: Bool = false,
+        flags: [String: Bool]? = nil
+    ) -> LinkSettings {
+        return .init(
+            fundingSources: [.card, .bankAccount],
+            popupWebviewOption: nil,
+            passthroughModeEnabled: true,
+            disableSignup: disableSignup,
+            suppress2FAModal: false,
+            disableFlowControllerRUX: true,
+            useAttestationEndpoints: true,
+            linkMode: .passthrough,
+            linkFlags: flags,
+            linkConsumerIncentive: nil,
+            linkDefaultOptIn: nil,
+            linkEnableDisplayableDefaultValuesInECE: nil,
+            allResponseFields: [:]
+        )
+    }
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request adds the new signup opt-in toggle for Link in the card form.

| **On** | **Off** |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-01 at 12 33 30" src="https://github.com/user-attachments/assets/a6552e81-d674-41f5-874a-90c15ae84d29" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-01 at 12 33 32" src="https://github.com/user-attachments/assets/d25c3dd6-99e6-45a0-b198-3540ec51b5ba" /> |

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
