### PR TITLE
Always log Link AB test exposures

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -107,20 +107,14 @@ final class PaymentSheetLoader {
                     )
                     analyticsHelper.logExposure(experiment: linkGlobalHoldbackExperiment)
 
-                    // Only log Link AB Test if Link is enabled
-                    if PaymentSheet.isLinkEnabled(
-                        elementsSession: elementsSession,
-                        configuration: configuration
-                    ) {
-                        let linkAbTestExperiment = LinkABTest(
-                            arbId: arbId,
-                            session: elementsSession,
-                            configuration: configuration,
-                            linkAccount: linkAccount,
-                            integrationShape: analyticsHelper.integrationShape
-                        )
-                        analyticsHelper.logExposure(experiment: linkAbTestExperiment)
-                    }
+                    let linkAbTestExperiment = LinkABTest(
+                        arbId: arbId,
+                        session: elementsSession,
+                        configuration: configuration,
+                        linkAccount: linkAccount,
+                        integrationShape: analyticsHelper.integrationShape
+                    )
+                    analyticsHelper.logExposure(experiment: linkAbTestExperiment)
                 }
 
                 // Filter out payment methods that the PI/SI or PaymentSheet doesn't support


### PR DESCRIPTION
## Summary

Always log Link AB test exposures, instead of only when Link is enabled.

## Motivation

https://stripe.slack.com/archives/C08P60QCL1W/p1754362038470109

## Testing

N/a

## Changelog

N/a