### PR TITLE
Fix macOS builds on master — add macCatalyst available check

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
@@ -272,6 +272,7 @@ class CardScanningView: UIView {
     }
 }
 
+@available(macCatalyst 14.0, *)
 extension CardScanningView: STPCardScannerDelegate {
 
     func cardScanner(_ scanner: STPCardScanner, didFinishWith cardParams: STPPaymentMethodCardParams?) {


### PR DESCRIPTION
## Summary
Add macCatalyst available check on STPCardScanner extension to match main class

## Motivation
Fix macOS builds on master

## Testing
Builds

## Changelog
N/A
