### PR TITLE
Hide mandate in signup opt-in feature edge case

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -123,7 +123,7 @@ extension PaymentSheetFormFactory {
         }
 
         let mandate: SimpleMandateElement? = {
-            if isSettingUp || signupOptInFeatureEnabled {
+            if isSettingUp || (showLinkInlineSignup && signupOptInFeatureEnabled) {
                 return makeMandate()
             }
             return nil


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request makes [the Link signup opt-in toggle](https://github.com/stripe/stripe-ios/pull/5248) more reliable by hiding the mandate if `showLinkInlineSignup` is false. The feature is behind a remote feature flag and only expected to be used by merchants who reliably pass an email address into MPE, but still feels right to add this additional check.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
