### PR TITLE
Send `customerEmail` in wallet buttons playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
@@ -243,7 +243,8 @@ class ExampleWalletButtonsModel: ObservableObject {
         // First, create customer and get customer session
         self.addDebugLog("Creating customer with SPT test backend...")
         let body = [
-            "customerId": nil, // Let backend create a new customer
+            "customerId": nil, // Let backend create a new customer if no email is passed
+            "customerEmail": email.nonEmpty,
             "isMobile": true,
         ] as [String: Any?]
         let json = try! JSONSerialization.data(withJSONObject: body, options: [])


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request updates the wallet buttons playground to allow passing a customer email to the backend.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
