### PR TITLE
Prevent another Link signup toggle edge case

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -126,7 +126,7 @@ extension PaymentSheetFormFactory {
             case .never:
                 return nil
             case .automatic:
-                if isSettingUp || (showLinkInlineSignup && signupOptInFeatureEnabled)  {
+                if isSettingUp || shouldShowLinkSignupOptIn  {
                     return makeMandate()
                 }
             }
@@ -147,7 +147,7 @@ extension PaymentSheetFormFactory {
 
     private func makeMandate() -> SimpleMandateElement {
         let mandateText = Self.makeMandateText(
-            linkSignupOptInFeatureEnabled: signupOptInFeatureEnabled,
+            linkSignupOptInFeatureEnabled: shouldShowLinkSignupOptIn,
             shouldSaveToLink: signupOptInInitialValue,
             merchantName: configuration.merchantDisplayName
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -50,11 +50,11 @@ class PaymentSheetFormFactory {
         guard !configuration.linkPaymentMethodsOnly else { return false }
         switch savePaymentMethodConsentBehavior {
         case .legacy:
-            return !isSettingUp && configuration.hasCustomer && paymentMethod.supportsSaveForFutureUseCheckbox()
+            return !shouldShowLinkSignupOptIn && !isSettingUp && configuration.hasCustomer && paymentMethod.supportsSaveForFutureUseCheckbox()
         case .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled:
             return false
         case .paymentSheetWithCustomerSessionPaymentMethodSaveEnabled:
-            return configuration.hasCustomer && paymentMethod.supportsSaveForFutureUseCheckbox()
+            return !shouldShowLinkSignupOptIn && configuration.hasCustomer && paymentMethod.supportsSaveForFutureUseCheckbox()
         case .customerSheetWithCustomerSession:
             return false
         }
@@ -66,6 +66,10 @@ class PaymentSheetFormFactory {
 
     var theme: ElementsAppearance {
         return configuration.appearance.asElementsTheme
+    }
+
+    var shouldShowLinkSignupOptIn: Bool {
+        showLinkInlineCardSignup && signupOptInFeatureEnabled
     }
 
     private static let PayByBankDescriptionText = STPLocalizedString(


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request makes the display of the Link signup opt-in toggle more resilient to lookup failures, making sure that we don't show any terms without the accompanying checkbox.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
