### PR TITLE
Call cancel in formSheetAction.confirm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## x.x.x x-x-x
+
+### EmbeddedPaymentElement
+* [Changed] When using `EmbeddedPaymentElement.Configuration.FormSheetAction.confirm`, the completion block is now called with a `canceled` result if the user closes the form sheet without completing the transaction.
+
 ## 24.19.0 2025-08-04
 
 ### CustomerSheet

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -436,7 +436,11 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
             }
         }
 
-        embeddedFormViewController.dismiss(animated: true)
+        embeddedFormViewController.dismiss(animated: true) {
+            if case let .confirm(completion) = self.configuration.formSheetAction {
+                completion(.canceled)
+            }
+        }
     }
 
     func embeddedFormViewControllerDidContinue(_ embeddedFormViewController: EmbeddedFormViewController) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElementConfiguration.swift
@@ -144,7 +144,7 @@ extension EmbeddedPaymentElement {
         /// The view can display payment methods like “Card” that, when tapped, open a form sheet where customers enter their payment method details. The sheet has a button at the bottom. `FormSheetAction` enumerates the actions the button can perform.
         public enum FormSheetAction {
             /// The button says “Pay” or “Setup”. When tapped, we confirm the payment or setup in the form sheet.
-            /// - Parameter completion: Called with the result of the payment or setup.
+            /// - Parameter completion: Called with the result of the payment or setup when the sheet is closed.
             case confirm(
                 completion: (EmbeddedPaymentElementResult) -> Void
             )


### PR DESCRIPTION
## Summary
- Now when the user cancels the transaction we call the completion block with canceled 

## Motivation
- Bug fix

## Testing
Manual

## Changelog
See diff
