### PR TITLE
Add `collectWalletAddress` API to CryptoOnrampCoordinator

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		0BED9B6A2E255FF1009FFF76 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BED9B692E255FF1009FFF76 /* StripeFinancialConnections.framework */; };
 		0BF41E892E3AB82E00CA4171 /* KycInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF41E882E3AB82E00CA4171 /* KycInfo.swift */; };
 		0BF41E8B2E3AB84800CA4171 /* IdType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF41E8A2E3AB84800CA4171 /* IdType.swift */; };
+		49D233A82E439EB900F51263 /* CryptoNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A72E439EB900F51263 /* CryptoNetwork.swift */; };
+		49D233AA2E439FAA00F51263 /* RegisterWalletRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */; };
+		49D233AC2E439FB200F51263 /* RegisterWalletResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -96,6 +99,9 @@
 		0BED9B692E255FF1009FFF76 /* StripeFinancialConnections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeFinancialConnections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BF41E882E3AB82E00CA4171 /* KycInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KycInfo.swift; sourceTree = "<group>"; };
 		0BF41E8A2E3AB84800CA4171 /* IdType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdType.swift; sourceTree = "<group>"; };
+		49D233A72E439EB900F51263 /* CryptoNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoNetwork.swift; sourceTree = "<group>"; };
+		49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterWalletRequest.swift; sourceTree = "<group>"; };
+		49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterWalletResponse.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -161,6 +167,8 @@
 				0BA7050B2E413DA40044B483 /* Credentials.swift */,
 				0B649EDD2E428F5A00AFAFB1 /* StartIdentityVerificationRequest.swift */,
 				0B649EDF2E428F6400AFAFB1 /* StartIdentityVerificationResponse.swift */,
+				49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */,
+				49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */,
 			);
 			path = "API Bindings";
 			sourceTree = "<group>";
@@ -246,6 +254,7 @@
 				0BF41E882E3AB82E00CA4171 /* KycInfo.swift */,
 				0BF41E8A2E3AB84800CA4171 /* IdType.swift */,
 				0B649EE12E4293AB00AFAFB1 /* IdentityVerificationResult.swift */,
+				49D233A72E439EB900F51263 /* CryptoNetwork.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -373,8 +382,10 @@
 			files = (
 				0B649EE22E4293AB00AFAFB1 /* IdentityVerificationResult.swift in Sources */,
 				0BED9B622E255BC2009FFF76 /* CryptoOnrampCoordinator.swift in Sources */,
+				49D233AA2E439FAA00F51263 /* RegisterWalletRequest.swift in Sources */,
 				0BF41E892E3AB82E00CA4171 /* KycInfo.swift in Sources */,
 				0BA705082E4132640044B483 /* KYCDataCollectionResponse.swift in Sources */,
+				49D233AC2E439FB200F51263 /* RegisterWalletResponse.swift in Sources */,
 				0B6DF34B2E297E0A008B1800 /* CustomerRequest.swift in Sources */,
 				0B6DF34D2E297E27008B1800 /* CustomerResponse.swift in Sources */,
 				0BF41E8B2E3AB84800CA4171 /* IdType.swift in Sources */,
@@ -384,6 +395,7 @@
 				0B649EDE2E428F5A00AFAFB1 /* StartIdentityVerificationRequest.swift in Sources */,
 				0BA7050A2E413D6B0044B483 /* KYCDataCollectionRequest.swift in Sources */,
 				0B649EE02E428F6400AFAFB1 /* StartIdentityVerificationResponse.swift in Sources */,
+				49D233A82E439EB900F51263 /* CryptoNetwork.swift in Sources */,
 				0BA7050A2E413D6B0044B483 /* KYCDataCollectionRequest.swift in Sources */,
 				0B20053F2E318235008FCF8D /* VerificationResult.swift in Sources */,
 			);

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoNetwork.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoNetwork.swift
@@ -1,0 +1,24 @@
+//
+//  CryptoNetwork.swift
+//  StripeCryptoOnramp
+//
+//  Created by Mat Schmid on 8/6/25.
+//
+
+import Foundation
+
+/// Supported crypto networks for wallet address registration.
+@_spi(CryptoOnrampSDKPreview)
+public enum CryptoNetwork: String, Codable {
+    case bitcoin = "bitcoin"
+    case ethereum = "ethereum"
+    case solana = "solana"
+    case polygon = "polygon"
+    case stellar = "stellar"
+    case avalanche = "avalanche"
+    case base = "base"
+    case aptos = "aptos"
+    case optimism = "optimism"
+    case worldchain = "worldchain"
+    case xrpl = "xrpl"
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -55,6 +55,12 @@ public protocol CryptoOnrampCoordinatorProtocol {
     ///
     /// - Returns: An `IdentityVerificationResult` representing the outcome of the verification process.
     func promptForIdentityVerification() async throws -> IdentityVerificationResult
+
+    /// Registers the given crypto wallet address to the current Link account.
+    ///
+    /// - Parameter walletAddress: The crypto wallet address to register.
+    /// - Parameter network: The crypto network for the wallet address.
+    func collectWalletAddress(walletAddress: String, network: CryptoNetwork) async throws
 }
 
 /// Coordinates headless Link user authentication and identity verification, leaving most of the UI to the client.
@@ -150,5 +156,13 @@ public final class CryptoOnrampCoordinator: CryptoOnrampCoordinatorProtocol {
         // TODO: use the response to initialize the Identity SDK and show its UI to perform document upload, returning the appropriate `completed` or `canceled` result.
         print(response)
         return .canceled
+    }
+
+    public func collectWalletAddress(walletAddress: String, network: CryptoNetwork) async throws {
+        try await apiClient.collectWalletAddress(
+            walletAddress: walletAddress,
+            network: network,
+            linkAccountInfo: linkAccountInfo
+        )
     }
 }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/RegisterWalletRequest.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/RegisterWalletRequest.swift
@@ -1,0 +1,31 @@
+//
+//  RegisterWalletRequest.swift
+//  StripeCryptoOnramp
+//
+//  Created by Mat Schmid on 8/6/25.
+//
+
+import Foundation
+
+/// Encodable model passed to the `/v1/crypto/internal/wallet` endpoint.
+struct RegisterWalletRequest: Encodable {
+    /// The crypto wallet address to register.
+    let walletAddress: String
+
+    /// The crypto network for the wallet address.
+    let network: CryptoNetwork
+
+    /// Contains credentials required to make the request.
+    let credentials: Credentials
+
+    /// Creates a new `RegisterWalletRequest` instance.
+    /// - Parameters:
+    ///   - walletAddress: The crypto wallet address to register.
+    ///   - network: The crypto network for the wallet address.
+    ///   - consumerSessionClientSecret: Contains credentials required to make the request.
+    init(walletAddress: String, network: CryptoNetwork, consumerSessionClientSecret: String) {
+        self.walletAddress = walletAddress
+        self.network = network
+        self.credentials = Credentials(consumerSessionClientSecret: consumerSessionClientSecret)
+    }
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/RegisterWalletResponse.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/RegisterWalletResponse.swift
@@ -1,0 +1,14 @@
+//
+//  RegisterWalletResponse.swift
+//  StripeCryptoOnramp
+//
+//  Created by Mat Schmid on 8/6/25.
+//
+
+import Foundation
+
+struct RegisterWalletResponse: Codable {
+
+    /// The created crypto wallet's unique identifier.
+    let id: String
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -38,11 +38,7 @@ extension STPAPIClient {
 
         let endpoint = "crypto/internal/customers"
         let requestObject = CustomerRequest(consumerSessionClientSecret: consumerSessionClientSecret)
-        return try await withCheckedThrowingContinuation { continuation in
-            post(resource: endpoint, object: requestObject) { result in
-                continuation.resume(with: result)
-            }
-        }
+        return try await post(resource: endpoint, object: requestObject)
     }
 
     /// Attaches the specific KYC info to the current Link user on the backend.
@@ -67,11 +63,7 @@ extension STPAPIClient {
             calendar: calendar
         )
 
-        return try await withCheckedThrowingContinuation { continuation in
-            post(resource: endpoint, object: requestObject) { result in
-                continuation.resume(with: result)
-            }
-        }
+        return try await post(resource: endpoint, object: requestObject)
     }
 
     /// Begins an identity verification session, providing the necessary data used to initialize the Identity SDK.
@@ -89,16 +81,50 @@ extension STPAPIClient {
             consumerSessionClientSecret: consumerSessionClientSecret
         )
 
-        return try await withCheckedThrowingContinuation { continuation in
-            post(resource: endpoint, object: requestObject) { result in
-                continuation.resume(with: result)
-            }
+        return try await post(resource: endpoint, object: requestObject)
+    }
+
+    /// Registers the given crypto wallet address to the current Link account.
+    /// - Parameters:
+    ///   - linkAccountInfo: Information associated with the link account including the client secret and whether the account has been verified.
+    ///   -  walletAddress: The crypto wallet address to register.
+    ///   - network: The crypto network for the wallet address.
+    @discardableResult
+    func collectWalletAddress(
+        walletAddress: String,
+        network: CryptoNetwork,
+        linkAccountInfo: PaymentSheetLinkAccountInfoProtocol
+    ) async throws -> RegisterWalletResponse {
+        guard let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret else {
+            throw CryptoOnrampAPIError.missingConsumerSessionClientSecret
         }
+
+        try validateSessionState(using: linkAccountInfo)
+
+        let endpoint = "crypto/internal/wallet"
+        let requestObject = RegisterWalletRequest(
+            walletAddress: walletAddress,
+            network: network,
+            consumerSessionClientSecret: consumerSessionClientSecret
+        )
+
+        return try await post(resource: endpoint, object: requestObject)
     }
 
     private func validateSessionState(using linkAccountInfo: PaymentSheetLinkAccountInfoProtocol) throws {
         guard case .verified = linkAccountInfo.sessionState else {
             throw CryptoOnrampAPIError.linkAccountNotVerified
+        }
+    }
+}
+
+private extension STPAPIClient {
+    /// Helper method to wrap the closure-based post method for Swift concurrency.
+    func post<T: Decodable>(resource: String, object: Encodable) async throws -> T {
+        return try await withCheckedThrowingContinuation { continuation in
+            post(resource: resource, object: object) { (result: Result<T, Error>) in
+                continuation.resume(with: result)
+            }
         }
     }
 }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -87,7 +87,7 @@ extension STPAPIClient {
     /// Registers the given crypto wallet address to the current Link account.
     /// - Parameters:
     ///   - linkAccountInfo: Information associated with the link account including the client secret and whether the account has been verified.
-    ///   -  walletAddress: The crypto wallet address to register.
+    ///   - walletAddress: The crypto wallet address to register.
     ///   - network: The crypto network for the wallet address.
     @discardableResult
     func collectWalletAddress(


### PR DESCRIPTION
## Summary

Adds the `collectWalletAddress` API to the `CryptoOnrampCoordinator`.

<img width="978" height="394" alt="Screenshot 2025-08-06 at 12 08 30 PM" src="https://github.com/user-attachments/assets/5c820da5-2834-404b-a04c-b6bb150f1874" />

## Motivation

https://docs.google.com/document/d/1owKwHgD5s8u75EWDOny2bp6rlNZq1aI4NNUr43PKdVA/edit?usp=sharing

## Testing

Unit tests added

## Changelog

N/a