### PR TITLE
fix dynamic actor isolation crash on CustomerSheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 24.19.1 2025-08-06
+
+### CustomerSheet
+* [Fixed] Crash when opening CustomerSheet in SwiftUI with Dynamic Actor Isolation feature flag enabled
+
 ## 24.19.0 2025-08-04
 
 ### CustomerSheet

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet+SwiftUI.swift
@@ -15,7 +15,7 @@ extension View {
     public func customerSheet(
         isPresented: Binding<Bool>,
         customerSheet: CustomerSheet,
-        onCompletion: @escaping (CustomerSheet.CustomerSheetResult) -> Void
+        onCompletion: @escaping @MainActor (CustomerSheet.CustomerSheetResult) -> Void
     ) -> some View {
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: SwiftUIProduct.self)
         return self.modifier(
@@ -32,7 +32,7 @@ extension CustomerSheet {
     struct CustomerSheetPresentationModifier: ViewModifier {
         @Binding var isPresented: Bool
         let customerSheet: CustomerSheet
-        let onCompletion: (CustomerSheet.CustomerSheetResult) -> Void
+        let onCompletion: @MainActor (CustomerSheet.CustomerSheetResult) -> Void
 
         func body(content: Content) -> some View {
             content.background(
@@ -48,7 +48,7 @@ extension CustomerSheet {
     struct CustomerSheetPresenter: UIViewRepresentable {
         @Binding var presented: Bool
         weak var customerSheet: CustomerSheet?
-        let onCompletion: (CustomerSheet.CustomerSheetResult) -> Void
+        let onCompletion: @MainActor (CustomerSheet.CustomerSheetResult) -> Void
 
         func makeCoordinator() -> Coordinator {
             return Coordinator(parent: self)


### PR DESCRIPTION
## Summary
Fix for #5269

## Motivation
Fixes a crash when calling the onCompletion block in the CustomerSheet when codebase has Dynamic actor isolation enabled.

## Testing
- My project is running swift 6 with Dynamic actor isolation feature flag enabled
- Tried to call the CustomerSheet from SwiftUI app crashes with a dispatch_queue_assertion
- after the fix, repeating same scenario, app no longer crashes

## Changelog
- added to changelog.md
