### PR TITLE
Show Link signup opt-in regardless of terms display

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -122,11 +122,15 @@ extension PaymentSheetFormFactory {
         }
 
         let mandate: SimpleMandateElement? = {
+            if shouldShowLinkSignupOptIn {
+                // Respect this over all other configurations.
+                return makeMandate()
+            }
             switch configuration.termsDisplayFor(paymentMethodType: .stripe(.card)) {
             case .never:
                 return nil
             case .automatic:
-                if isSettingUp || shouldShowLinkSignupOptIn  {
+                if isSettingUp {
                     return makeMandate()
                 }
             }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request makes sure that the Link signup opt-in toggle is displayed regardless of card terms.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://github.com/stripe/stripe-android/pull/11291

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
