### PR TITLE
Fix missing mandate for Link signup opt-in toggle

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -128,7 +128,7 @@ extension PaymentSheetFormFactory {
         }
 
         let mandate: SimpleMandateElement? = {
-            if shouldShowLinkSignupOptIn {
+            if signupOptInFeatureEnabled {
                 // Respect this over all other configurations.
                 return makeMandate()
             }
@@ -156,9 +156,14 @@ extension PaymentSheetFormFactory {
     }
 
     private func makeMandate() -> SimpleMandateElement {
+        // It's possible that `signupOptInFeatureEnabled` is true, but the user has already used Link.
+        // This user would not see the signup opt-in toggle, but we still want to show the mandate.
+        // Therefore, always show the mandate if `signupOptInFeatureEnabled` is true, but only add
+        // the Link-specific terms if the signup opt-in toggle is actually visible via `shouldShowLinkSignupOptIn`.
+        let shouldSaveToLink = shouldShowLinkSignupOptIn && signupOptInInitialValue
         let mandateText = Self.makeMandateText(
-            linkSignupOptInFeatureEnabled: shouldShowLinkSignupOptIn,
-            shouldSaveToLink: signupOptInInitialValue,
+            linkSignupOptInFeatureEnabled: signupOptInFeatureEnabled,
+            shouldSaveToLink: shouldSaveToLink,
             merchantName: configuration.merchantDisplayName
         )
         return makeMandate(mandateText: mandateText)


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where merchants using `link_sign_up_opt_in_feature_enabled` would not see the standard mandate if the user had used Link before on their device.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
