### PR TITLE
Use `ios_crypto_onramp` request surface for CryptoOnrampCoordinator

### DIFF
--- a/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
+++ b/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
@@ -138,6 +138,7 @@ extension LinkInlineSignupElementSnapshotTests {
             withEmail email: String?,
             emailSource: StripePaymentSheet.EmailSource,
             doNotLogConsumerFunnelEvent: Bool,
+            requestSurface: StripePaymentSheet.LinkRequestSurface = .default,
             completion: @escaping (Result<PaymentSheetLinkAccount?, Error>) -> Void
         ) {
             completion(
@@ -147,7 +148,8 @@ extension LinkInlineSignupElementSnapshotTests {
                         session: nil,
                         publishableKey: nil,
                         displayablePaymentDetails: nil,
-                        useMobileEndpoints: false
+                        useMobileEndpoints: false,
+                        requestSurface: requestSurface
                     )
                 )
             )

--- a/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
+++ b/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
@@ -262,6 +262,7 @@ extension LinkInlineSignupViewModelTests {
             withEmail email: String?,
             emailSource: StripePaymentSheet.EmailSource,
             doNotLogConsumerFunnelEvent: Bool,
+            requestSurface: StripePaymentSheet.LinkRequestSurface = .default,
             completion: @escaping (Result<PaymentSheetLinkAccount?, Error>) -> Void
         ) {
             if shouldFailLookup {
@@ -274,7 +275,8 @@ extension LinkInlineSignupViewModelTests {
                             session: nil,
                             publishableKey: nil,
                             displayablePaymentDetails: nil,
-                            useMobileEndpoints: false
+                            useMobileEndpoints: false,
+                            requestSurface: requestSurface
                         )
                     )
                 )

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -106,7 +106,8 @@ public final class CryptoOnrampCoordinator: CryptoOnrampCoordinatorProtocol {
         let linkController = try await LinkController.create(
             apiClient: apiClient,
             mode: .payment,
-            appearance: appearance
+            appearance: appearance,
+            requestSurface: .cryptoOnramp
         )
 
         return CryptoOnrampCoordinator(

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		49909A332D8B48820031EC33 /* FCLiteErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49909A322D8B48820031EC33 /* FCLiteErrorView.swift */; };
 		49909A352D8B48D40031EC33 /* FCLiteError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49909A342D8B48D40031EC33 /* FCLiteError.swift */; };
 		49909A372D8B5AA30031EC33 /* FCLiteModalPresentationWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49909A362D8B5AA30031EC33 /* FCLiteModalPresentationWrapper.swift */; };
+		499E32A82E47982400575058 /* LinkRequestSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499E32A72E47982400575058 /* LinkRequestSurface.swift */; };
 		49B1F7CC2E1EC43300EA2593 /* LinkSignUpViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B1F7CB2E1EC43300EA2593 /* LinkSignUpViewController.swift */; };
 		49B1F7CE2E1EC44500EA2593 /* LinkSignUpViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B1F7CD2E1EC44500EA2593 /* LinkSignUpViewModel.swift */; };
 		49BCD44E2D9ECBEF003A6251 /* PaymentSheetAnalyticsExperimentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BCD44D2D9ECBEF003A6251 /* PaymentSheetAnalyticsExperimentsTests.swift */; };
@@ -671,6 +672,7 @@
 		49909A322D8B48820031EC33 /* FCLiteErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteErrorView.swift; sourceTree = "<group>"; };
 		49909A342D8B48D40031EC33 /* FCLiteError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteError.swift; sourceTree = "<group>"; };
 		49909A362D8B5AA30031EC33 /* FCLiteModalPresentationWrapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FCLiteModalPresentationWrapper.swift; sourceTree = "<group>"; };
+		499E32A72E47982400575058 /* LinkRequestSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkRequestSurface.swift; sourceTree = "<group>"; };
 		49B1F7CB2E1EC43300EA2593 /* LinkSignUpViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSignUpViewController.swift; sourceTree = "<group>"; };
 		49B1F7CD2E1EC44500EA2593 /* LinkSignUpViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkSignUpViewModel.swift; sourceTree = "<group>"; };
 		49BCD44D2D9ECBEF003A6251 /* PaymentSheetAnalyticsExperimentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetAnalyticsExperimentsTests.swift; sourceTree = "<group>"; };
@@ -1447,6 +1449,7 @@
 				F1E614E8481658A027599A92 /* STPAPIClient+Link.swift */,
 				B662953D2C63F6C2007B6B14 /* PaymentDetailsShareResponse.swift */,
 				441C3414745D483C9A47ED0B /* VerificationSession.swift */,
+				499E32A72E47982400575058 /* LinkRequestSurface.swift */,
 			);
 			path = Link;
 			sourceTree = "<group>";
@@ -2422,6 +2425,7 @@
 				6180A5C72C824377009D1536 /* RadioButton.swift in Sources */,
 				495D53122DF10A7B008B92F9 /* LinkProgressIndicatorView.swift in Sources */,
 				6180A5C12C8222A9009D1536 /* EmbeddedPaymentMethodsView.swift in Sources */,
+				499E32A82E47982400575058 /* LinkRequestSurface.swift in Sources */,
 				61C87E1B2CB818ED001B7DA9 /* CardBrandFilter.swift in Sources */,
 				49377F022DE4E4FD005CA805 /* BaseLinkHoldbackExperiment.swift in Sources */,
 				610EAAF02C0F5D9400124AB2 /* FormHeaderView.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -75,6 +75,7 @@ struct LinkPMDisplayDetails {
     let cookieStore: LinkCookieStore
 
     let useMobileEndpoints: Bool
+    let requestSurface: LinkRequestSurface
 
     /// Publishable key of the Consumer Account.
     private(set) var publishableKey: String?
@@ -130,7 +131,8 @@ struct LinkPMDisplayDetails {
         displayablePaymentDetails: ConsumerSession.DisplayablePaymentDetails?,
         apiClient: STPAPIClient = .shared,
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
-        useMobileEndpoints: Bool
+        useMobileEndpoints: Bool,
+        requestSurface: LinkRequestSurface = .default
     ) {
         self.email = email
         self.currentSession = session
@@ -139,6 +141,7 @@ struct LinkPMDisplayDetails {
         self.apiClient = apiClient
         self.cookieStore = cookieStore
         self.useMobileEndpoints = useMobileEndpoints
+        self.requestSurface = requestSurface
     }
 
     func signUp(
@@ -183,7 +186,8 @@ struct LinkPMDisplayDetails {
             countryCode: countryCode,
             consentAction: consentAction.rawValue,
             useMobileEndpoints: useMobileEndpoints,
-            with: apiClient
+            with: apiClient,
+            requestSurface: requestSurface
         ) { [weak self] result in
             switch result {
             case .success(let signupResponse):
@@ -219,7 +223,8 @@ struct LinkPMDisplayDetails {
         session.startVerification(
             with: apiClient,
             cookieStore: cookieStore,
-            consumerAccountPublishableKey: publishableKey
+            consumerAccountPublishableKey: publishableKey,
+            requestSurface: requestSurface
         ) { [weak self] result in
             switch result {
             case .success(let newSession):
@@ -251,7 +256,8 @@ struct LinkPMDisplayDetails {
             with: oneTimePasscode,
             with: apiClient,
             cookieStore: cookieStore,
-            consumerAccountPublishableKey: publishableKey
+            consumerAccountPublishableKey: publishableKey,
+            requestSurface: requestSurface
         ) { [weak self] result in
             switch result {
             case .success(let verifiedSession):
@@ -281,6 +287,7 @@ struct LinkPMDisplayDetails {
 
             session.createLinkAccountSession(
                 consumerAccountPublishableKey: self.publishableKey,
+                requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
         }
@@ -305,6 +312,7 @@ struct LinkPMDisplayDetails {
                 with: self.apiClient,
                 consumerAccountPublishableKey: self.publishableKey,
                 isDefault: isDefault,
+                requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
         }
@@ -326,6 +334,7 @@ struct LinkPMDisplayDetails {
                 linkedAccountId: linkedAccountId,
                 consumerAccountPublishableKey: self.publishableKey,
                 isDefault: isDefault,
+                requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
         }
@@ -361,6 +370,7 @@ struct LinkPMDisplayDetails {
                 with: self.apiClient,
                 supportedPaymentDetailsTypes: supportedTypes,
                 consumerAccountPublishableKey: self.publishableKey,
+                requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
         }
@@ -389,7 +399,7 @@ struct LinkPMDisplayDetails {
                 return
             }
 
-            session.listShippingAddress(with: self.apiClient, consumerAccountPublishableKey: self.publishableKey, completion: completionRetryingOnAuthErrors)
+            session.listShippingAddress(with: self.apiClient, consumerAccountPublishableKey: self.publishableKey, requestSurface: self.requestSurface, completion: completionRetryingOnAuthErrors)
         }
     }
 
@@ -410,6 +420,7 @@ struct LinkPMDisplayDetails {
                 with: self.apiClient,
                 id: id,
                 consumerAccountPublishableKey: self.publishableKey,
+                requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
         }
@@ -437,6 +448,7 @@ struct LinkPMDisplayDetails {
                 id: id,
                 updateParams: updateParams,
                 consumerAccountPublishableKey: publishableKey,
+                requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
         }
@@ -470,6 +482,7 @@ struct LinkPMDisplayDetails {
                 billingPhoneNumber: billingPhoneNumber,
                 consumerAccountPublishableKey: publishableKey,
                 clientAttributionMetadata: clientAttributionMetadata,
+                requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
         }
@@ -479,7 +492,7 @@ struct LinkPMDisplayDetails {
         guard let session = currentSession else {
             return
         }
-        session.logout(with: apiClient, consumerAccountPublishableKey: publishableKey) { _ in
+        session.logout(with: apiClient, consumerAccountPublishableKey: publishableKey, requestSurface: requestSurface) { _ in
             // We don't need to do anything if this fails, the key will expire automatically.
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -105,6 +105,7 @@ extension ConsumerSession {
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         useMobileEndpoints: Bool,
         doNotLogConsumerFunnelEvent: Bool,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
     ) {
         apiClient.lookupConsumerSession(
@@ -115,6 +116,7 @@ extension ConsumerSession {
             cookieStore: cookieStore,
             useMobileEndpoints: useMobileEndpoints,
             doNotLogConsumerFunnelEvent: doNotLogConsumerFunnelEvent,
+            requestSurface: requestSurface,
             completion: completion
         )
     }
@@ -128,6 +130,7 @@ extension ConsumerSession {
         consentAction: String?,
         useMobileEndpoints: Bool,
         with apiClient: STPAPIClient = STPAPIClient.shared,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<SessionWithPublishableKey, Error>) -> Void
     ) {
         apiClient.createConsumer(
@@ -138,6 +141,7 @@ extension ConsumerSession {
             countryCode: countryCode,
             consentAction: consentAction,
             useMobileEndpoints: useMobileEndpoints,
+            requestSurface: requestSurface,
             completion: completion
         )
     }
@@ -147,6 +151,7 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         consumerAccountPublishableKey: String?,
         isDefault: Bool = false,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         guard paymentMethodParams.type == .card,
@@ -173,6 +178,7 @@ extension ConsumerSession {
             billingDetails: paymentMethodParams.nonnil_billingDetails,
             isDefault: isDefault,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
+            requestSurface: requestSurface,
             completion: completion)
     }
 
@@ -181,6 +187,7 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         consumerAccountPublishableKey: String?,
         isDefault: Bool,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         apiClient.createPaymentDetails(
@@ -188,6 +195,7 @@ extension ConsumerSession {
             linkedAccountId: linkedAccountId,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             isDefault: isDefault,
+            requestSurface: requestSurface,
             completion: completion)
     }
 
@@ -197,6 +205,7 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
         apiClient.startVerification(
@@ -205,6 +214,7 @@ extension ConsumerSession {
             locale: locale,
             cookieStore: cookieStore,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
+            requestSurface: requestSurface,
             completion: completion)
     }
 
@@ -213,6 +223,7 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
         apiClient.confirmSMSVerification(
@@ -220,6 +231,7 @@ extension ConsumerSession {
             with: code,
             cookieStore: cookieStore,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
+            requestSurface: requestSurface,
             completion: completion)
     }
 
@@ -228,6 +240,7 @@ extension ConsumerSession {
         consumerAccountPublishableKey: String?,
         linkMode: LinkMode? = nil,
         intentToken: String? = nil,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<LinkAccountSession, Error>) -> Void
     ) {
         apiClient.createLinkAccountSession(
@@ -235,6 +248,7 @@ extension ConsumerSession {
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             linkMode: linkMode,
             intentToken: intentToken,
+            requestSurface: requestSurface,
             completion: completion)
     }
 
@@ -242,23 +256,27 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         supportedPaymentDetailsTypes: [ConsumerPaymentDetails.DetailsType],
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<[ConsumerPaymentDetails], Error>) -> Void
     ) {
         apiClient.listPaymentDetails(
             for: clientSecret,
             supportedPaymentDetailsTypes: supportedPaymentDetailsTypes,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
+            requestSurface: requestSurface,
             completion: completion)
     }
 
     func listShippingAddress(
         with apiClient: STPAPIClient = STPAPIClient.shared,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ShippingAddressesResponse, Error>) -> Void
     ) {
         apiClient.listShippingAddress(
             for: clientSecret,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
+            requestSurface: requestSurface,
             completion: completion)
     }
 
@@ -266,12 +284,14 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         id: String,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         apiClient.deletePaymentDetails(
             for: clientSecret,
             id: id,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
+            requestSurface: requestSurface,
             completion: completion)
     }
 
@@ -280,12 +300,14 @@ extension ConsumerSession {
         id: String,
         updateParams: UpdatePaymentDetailsParams,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         apiClient.updatePaymentDetails(
             for: clientSecret, id: id,
             updateParams: updateParams,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
+            requestSurface: requestSurface,
             completion: completion)
     }
 
@@ -298,6 +320,7 @@ extension ConsumerSession {
         billingPhoneNumber: String?,
         consumerAccountPublishableKey: String?,
         clientAttributionMetadata: STPClientAttributionMetadata,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<PaymentDetailsShareResponse, Error>) -> Void
     ) {
         apiClient.sharePaymentDetails(
@@ -309,6 +332,7 @@ extension ConsumerSession {
             expectedPaymentMethodType: expectedPaymentMethodType,
             billingPhoneNumber: billingPhoneNumber,
             clientAttributionMetadata: clientAttributionMetadata,
+            requestSurface: requestSurface,
             completion: completion)
     }
 
@@ -316,12 +340,14 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
         apiClient.logout(
             consumerSessionClientSecret: clientSecret,
             cookieStore: cookieStore,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
+            requestSurface: requestSurface,
             completion: completion)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/LinkRequestSurface.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/LinkRequestSurface.swift
@@ -1,0 +1,19 @@
+//
+//  LinkRequestSurface.swift
+//  StripePaymentSheet
+//
+//  Created by Mat Schmid on 8/9/25.
+//
+
+import Foundation
+
+@_spi(STP) public enum LinkRequestSurface: String {
+    /// Used for requests from the `StripePaymentSheet` SDK.
+    case paymentElement = "ios_payment_element"
+    /// Used for requests from the `StripeCryptoOnramp` SDK.
+    case cryptoOnramp = "ios_crypto_onramp"
+}
+
+@_spi(STP) public extension LinkRequestSurface {
+    static let `default`: LinkRequestSurface = .paymentElement
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -23,6 +23,7 @@ extension STPAPIClient {
         cookieStore: LinkCookieStore,
         useMobileEndpoints: Bool,
         doNotLogConsumerFunnelEvent: Bool,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
     ) {
         Task {
@@ -30,7 +31,7 @@ extension STPAPIClient {
             let mobileEndpoint = "consumers/mobile/sessions/lookup"
 
             var parameters: [String: Any] = [
-                "request_surface": "ios_payment_element",
+                "request_surface": requestSurface.rawValue,
                 "session_id": sessionID,
             ]
             parameters["customer_id"] = customerID
@@ -91,6 +92,7 @@ extension STPAPIClient {
         countryCode: String?,
         consentAction: String?,
         useMobileEndpoints: Bool,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.SessionWithPublishableKey, Error>) -> Void
     ) {
         Task {
@@ -98,7 +100,7 @@ extension STPAPIClient {
             let modernEndpoint = "consumers/mobile/sign_up"
 
             var parameters: [String: Any] = [
-                "request_surface": "ios_payment_element",
+                "request_surface": requestSurface.rawValue,
                 "email_address": email.lowercased(),
                 "locale": locale.toLanguageTag(),
             ]
@@ -174,6 +176,7 @@ extension STPAPIClient {
         billingDetails: STPPaymentMethodBillingDetails,
         isDefault: Bool,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         createPaymentDetails(
@@ -183,6 +186,7 @@ extension STPAPIClient {
             billingDetails: billingDetails,
             isDefault: isDefault,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
+            requestSurface: requestSurface,
             completion: completion
         )
     }
@@ -194,6 +198,7 @@ extension STPAPIClient {
         billingDetails: STPPaymentMethodBillingDetails,
         isDefault: Bool,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         let endpoint: String = "consumers/payment_details"
@@ -202,7 +207,7 @@ extension STPAPIClient {
 
         let parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
-            "request_surface": "ios_payment_element",
+            "request_surface": requestSurface.rawValue,
             "type": "card",
             "card": rawCardParams,
             "billing_email_address": billingEmailAddress,
@@ -224,13 +229,14 @@ extension STPAPIClient {
         linkedAccountId: String,
         consumerAccountPublishableKey: String?,
         isDefault: Bool,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         let endpoint: String = "consumers/payment_details"
 
         let parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
-            "request_surface": "ios_payment_element",
+            "request_surface": requestSurface.rawValue,
             "bank_account": [
                 "account": linkedAccountId,
             ],
@@ -294,6 +300,7 @@ extension STPAPIClient {
         consumerAccountPublishableKey: String?,
         linkMode: LinkMode? = nil,
         intentToken: String? = nil,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<LinkAccountSession, Error>) -> Void
     ) {
         let endpoint: String = "consumers/link_account_sessions"
@@ -302,7 +309,7 @@ extension STPAPIClient {
             "credentials": [
                 "consumer_session_client_secret": consumerSessionClientSecret,
             ],
-            "request_surface": "ios_payment_element",
+            "request_surface": requestSurface.rawValue,
         ]
         parameters["link_mode"] = linkMode?.rawValue
         parameters["intent_token"] = intentToken
@@ -325,13 +332,14 @@ extension STPAPIClient {
         expectedPaymentMethodType: String?,
         billingPhoneNumber: String?,
         clientAttributionMetadata: STPClientAttributionMetadata,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<PaymentDetailsShareResponse, Error>) -> Void
     ) {
         let endpoint: String = "consumers/payment_details/share"
 
         var parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
-            "request_surface": "ios_payment_element",
+            "request_surface": requestSurface.rawValue,
             "expand": ["payment_method"],
             "id": id,
         ]
@@ -371,13 +379,14 @@ extension STPAPIClient {
         for consumerSessionClientSecret: String,
         supportedPaymentDetailsTypes: [ConsumerPaymentDetails.DetailsType],
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<[ConsumerPaymentDetails], Error>) -> Void
     ) {
         let endpoint: String = "consumers/payment_details/list"
 
         let parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
-            "request_surface": "ios_payment_element",
+            "request_surface": requestSurface.rawValue,
             "types": supportedPaymentDetailsTypes.map(\.rawValue),
         ]
 
@@ -393,12 +402,13 @@ extension STPAPIClient {
     func listShippingAddress(
         for consumerSessionClientSecret: String,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ShippingAddressesResponse, Error>) -> Void
     ) {
         let endPoint = "consumers/shipping_addresses/list"
         let parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
-            "request_surface": "ios_payment_element",
+            "request_surface": requestSurface.rawValue,
         ]
         post(
             resource: endPoint,
@@ -413,13 +423,14 @@ extension STPAPIClient {
         for consumerSessionClientSecret: String,
         id: String,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         let endpoint: String = "consumers/payment_details/\(id)"
 
         let parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
-            "request_surface": "ios_payment_element",
+            "request_surface": requestSurface.rawValue,
         ]
 
         APIRequest<STPEmptyStripeResponse>.delete(
@@ -437,13 +448,14 @@ extension STPAPIClient {
         id: String,
         updateParams: UpdatePaymentDetailsParams,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         let endpoint: String = "consumers/payment_details/\(id)"
 
         var parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
-            "request_surface": "ios_payment_element",
+            "request_surface": requestSurface.rawValue,
         ]
 
         if let details = updateParams.details, case .card(let expiryDate, let billingDetails, let preferredNetwork) = details {
@@ -491,6 +503,7 @@ extension STPAPIClient {
         consumerSessionClientSecret: String,
         cookieStore: LinkCookieStore,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
         let endpoint: String = "consumers/sessions/log_out"
@@ -499,7 +512,7 @@ extension STPAPIClient {
             "credentials": [
                 "consumer_session_client_secret": consumerSessionClientSecret,
             ],
-            "request_surface": "ios_payment_element",
+            "request_surface": requestSurface.rawValue,
         ]
 
         makeConsumerSessionRequest(
@@ -517,6 +530,7 @@ extension STPAPIClient {
         locale: Locale,
         cookieStore: LinkCookieStore,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
 
@@ -535,6 +549,7 @@ extension STPAPIClient {
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
             "type": typeString,
             "locale": locale.toLanguageTag(),
+            "request_surface": requestSurface.rawValue,
         ]
 
         makeConsumerSessionRequest(
@@ -551,6 +566,7 @@ extension STPAPIClient {
         with code: String,
         cookieStore: LinkCookieStore,
         consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
         let endpoint: String = "consumers/sessions/confirm_verification"
@@ -559,7 +575,7 @@ extension STPAPIClient {
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
             "type": "SMS",
             "code": code,
-            "request_surface": "ios_payment_element",
+            "request_surface": requestSurface.rawValue,
         ]
 
         makeConsumerSessionRequest(

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
@@ -26,11 +26,13 @@ protocol LinkAccountServiceProtocol {
     ///   - email: Email address associated with the account.
     ///   - emailSource: Details on the source of the email used.
     ///   - doNotLogConsumerFunnelEvent: Whether or not this lookup call should be logged backend side.
+    ///   - requestSurface: The request surface to use for the API call. `.default` will map to `ios_payment_element`.
     ///   - completion: Completion block.
     func lookupAccount(
         withEmail email: String?,
         emailSource: EmailSource,
         doNotLogConsumerFunnelEvent: Bool,
+        requestSurface: LinkRequestSurface,
         completion: @escaping (Result<PaymentSheetLinkAccount?, Error>) -> Void
     )
 }
@@ -82,6 +84,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
         withEmail email: String?,
         emailSource: EmailSource,
         doNotLogConsumerFunnelEvent: Bool,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<PaymentSheetLinkAccount?, Error>) -> Void
     ) {
         guard LinkEmailHelper.canLookupEmail(email) else {
@@ -96,7 +99,8 @@ final class LinkAccountService: LinkAccountServiceProtocol {
             customerID: customerID,
             with: apiClient,
             useMobileEndpoints: useMobileEndpoints,
-            doNotLogConsumerFunnelEvent: doNotLogConsumerFunnelEvent
+            doNotLogConsumerFunnelEvent: doNotLogConsumerFunnelEvent,
+            requestSurface: requestSurface
         ) { [apiClient] result in
             switch result {
             case .success(let lookupResponse):
@@ -110,7 +114,8 @@ final class LinkAccountService: LinkAccountServiceProtocol {
                             publishableKey: session.publishableKey,
                             displayablePaymentDetails: session.displayablePaymentDetails,
                             apiClient: apiClient,
-                            useMobileEndpoints: self.useMobileEndpoints
+                            useMobileEndpoints: self.useMobileEndpoints,
+                            requestSurface: requestSurface
                         )
                     ))
                 case .notFound:
@@ -122,7 +127,8 @@ final class LinkAccountService: LinkAccountServiceProtocol {
                                 publishableKey: nil,
                                 displayablePaymentDetails: nil,
                                 apiClient: self.apiClient,
-                                useMobileEndpoints: self.useMobileEndpoints
+                                useMobileEndpoints: self.useMobileEndpoints,
+                                requestSurface: requestSurface
                             )
                         ))
                     } else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewModel.swift
@@ -202,7 +202,8 @@ private extension LinkSignUpViewModel {
             self?.accountService.lookupAccount(
                 withEmail: emailAddress,
                 emailSource: .userAction,
-                doNotLogConsumerFunnelEvent: false
+                doNotLogConsumerFunnelEvent: false,
+                requestSurface: .default
             ) { result in
                 guard let self = self else { return }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
@@ -434,7 +434,8 @@ private extension LinkInlineSignupViewModel {
             self?.accountService.lookupAccount(
                 withEmail: emailAddress,
                 emailSource: .userAction,
-                doNotLogConsumerFunnelEvent: false
+                doNotLogConsumerFunnelEvent: false,
+                requestSurface: .default
             ) { result in
                 // Check the requested email address against the current one. Handle
                 // email address changes while a lookup is in-flight.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -55,6 +55,7 @@ import UIKit
     private let configuration: PaymentElementConfiguration
     private let appearance: LinkAppearance?
     private let analyticsHelper: PaymentSheetAnalyticsHelper
+    private let requestSurface: LinkRequestSurface
 
     private lazy var linkAccountService: LinkAccountServiceProtocol = {
         LinkAccountService(elementsSession: elementsSession)
@@ -102,7 +103,8 @@ import UIKit
         intent: Intent,
         configuration: PaymentElementConfiguration,
         appearance: LinkAppearance?,
-        analyticsHelper: PaymentSheetAnalyticsHelper
+        analyticsHelper: PaymentSheetAnalyticsHelper,
+        requestSurface: LinkRequestSurface
     ) {
         self.apiClient = apiClient
         self.mode = mode
@@ -111,6 +113,7 @@ import UIKit
         self.configuration = configuration
         self.appearance = appearance
         self.analyticsHelper = analyticsHelper
+        self.requestSurface = requestSurface
 
         LinkAccountContext.shared.addObserver(self, selector: #selector(onLinkAccountChange))
     }
@@ -127,11 +130,13 @@ import UIKit
     /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
     /// - Parameter mode: The mode in which the Link payment method controller should operate, either `payment` or `setup`.
     /// - Parameter appearance: Link UI-specific appearance overrides. If not specified, `PaymentSheet.Appearance` defaults are used.
+    /// - Parameter requestSurface: The request surface to use for API calls. Defaults to `ios_payment_element`.
     /// - Parameter completion: A closure that is called with the result of the creation. It returns a `LinkController` if successful, or an error if the creation failed.
     @_spi(STP) public static func create(
         apiClient: STPAPIClient = .shared,
         mode: LinkController.Mode,
         appearance: LinkAppearance? = nil,
+        requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<LinkController, Error>) -> Void
     ) {
         Task {
@@ -160,7 +165,8 @@ import UIKit
                     intent: loadResult.intent,
                     configuration: configuration,
                     appearance: appearance,
-                    analyticsHelper: analyticsHelper
+                    analyticsHelper: analyticsHelper,
+                    requestSurface: requestSurface
                 )
                 completion(.success(controller))
             } catch {
@@ -176,7 +182,8 @@ import UIKit
     @_spi(STP) public func lookupConsumer(with email: String, completion: @escaping (Result<Bool, Error>) -> Void) {
         Self.lookupConsumer(
             email: email,
-            linkAccountService: linkAccountService
+            linkAccountService: linkAccountService,
+            requestSurface: requestSurface
         ) { result in
             switch result {
             case .success(let linkAccount):
@@ -409,6 +416,7 @@ import UIKit
     private static func lookupConsumer(
         email: String,
         linkAccountService: any LinkAccountServiceProtocol,
+        requestSurface: LinkRequestSurface,
         completion: @escaping (Result<PaymentSheetLinkAccount?, Error>) -> Void
     ) {
         linkAccountService.lookupAccount(
@@ -417,6 +425,7 @@ import UIKit
             emailSource: .customerEmail,
             // TODO: Confirm which value to pass here to not cause experiment issues
             doNotLogConsumerFunnelEvent: false,
+            requestSurface: requestSurface,
             completion: completion
         )
     }
@@ -437,14 +446,16 @@ import UIKit
     /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
     /// - Parameter mode: The mode in which the Link payment method controller should operate, either `payment` or `setup`.
     /// - Parameter appearance: Link UI-specific appearance overrides. If not specified, `PaymentSheet.Configuration` defaults are used.
+    /// - Parameter requestSurface: The request surface to use for API calls. Defaults to `ios_payment_element`.
     /// - Returns: A `LinkController` if successful, or throws an error if the creation failed.
     static func create(
         apiClient: STPAPIClient = .shared,
         mode: LinkController.Mode,
-        appearance: LinkAppearance? = nil
+        appearance: LinkAppearance? = nil,
+        requestSurface: LinkRequestSurface = .default
     ) async throws -> LinkController {
         return try await withCheckedThrowingContinuation { continuation in
-            create(apiClient: apiClient, mode: mode, appearance: appearance) { result in
+            create(apiClient: apiClient, mode: mode, appearance: appearance, requestSurface: requestSurface) { result in
                 switch result {
                 case .success(let controller):
                     continuation.resume(returning: controller)


### PR DESCRIPTION
## Summary

This makes changes across various Link API layers such that an `ios_crypto_onramp` `request_surface` can be used in the Link consumer API calls when the requests come from the `StripeCryptoOnramp` SDK. A default value of `ios_payment_element` is used everywhere.

## Motivation

https://stripe.slack.com/archives/C08G211PLER/p1754591826013449

## Testing

API requests from the Onramp SDK still work:

<img width="726" height="392" alt="image" src="https://github.com/user-attachments/assets/ae1fa3fd-9705-4731-967e-36a45e100fa8" />

## Changelog

N/a
