### PR TITLE
Support validation errors in Link UI

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -31,7 +31,8 @@ extension PayWithLinkViewController {
         private lazy var confirmButton: ConfirmButton = .makeLinkButton(
             callToAction: context.callToAction,
             // Use a compact button if we are also displaying the Apple Pay button.
-            compact: shouldShowApplePayButton
+            compact: shouldShowApplePayButton,
+            didTapWhenDisabled: didTapWhenDisabled
         ) { [weak self] in
             self?.confirm()
         }
@@ -175,6 +176,10 @@ extension PayWithLinkViewController {
             ])
 
             didUpdate(addPaymentMethodVC)
+        }
+
+        private func didTapWhenDisabled() {
+            addPaymentMethodVC.paymentMethodFormElement.showAllValidationErrors()
         }
 
         func confirm() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
@@ -46,9 +46,19 @@ extension PayWithLinkViewController {
         }()
 
         private lazy var updateButton: ConfirmButton = .makeLinkButton(
-            callToAction: isBillingDetailsUpdateFlow ? context.callToAction : .custom(title: String.Localized.update_card)
+            callToAction: isBillingDetailsUpdateFlow ? context.callToAction : .custom(title: String.Localized.update_card),
+            didTapWhenDisabled: didTapWhenDisabled
         ) { [weak self] in
             self?.updatePaymentMethod()
+        }
+
+        private func didTapWhenDisabled() {
+            guard case let .invalid(error, _) = paymentMethodEditElement.validationState else {
+                return
+            }
+
+            errorLabel.text = error.localizedDescription
+            errorLabel.isHidden = false
         }
 
         private lazy var errorLabel: UILabel = {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
@@ -13,6 +13,7 @@ extension ConfirmButton {
     static func makeLinkButton(
         callToAction: CallToActionType,
         compact: Bool = false,
+        didTapWhenDisabled: @escaping () -> Void = {},
         didTap: @escaping () -> Void
     ) -> ConfirmButton {
         let directionalLayoutMargins = compact ? LinkUI.compactButtonMargins : LinkUI.buttonMargins
@@ -23,7 +24,8 @@ extension ConfirmButton {
         let button = ConfirmButton(
             callToAction: callToAction,
             appearance: appearance,
-            didTap: didTap
+            didTap: didTap,
+            didTapWhenDisabled: didTapWhenDisabled
         )
 
         button.directionalLayoutMargins = directionalLayoutMargins

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -57,7 +57,7 @@ class AddPaymentMethodViewController: UIViewController {
     private let analyticsHelper: PaymentSheetAnalyticsHelper
     var previousCustomerInput: IntentConfirmParams?
 
-    private var paymentMethodFormElement: PaymentMethodElement {
+    var paymentMethodFormElement: PaymentMethodElement {
         paymentMethodFormViewController.form
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request adopts the changes in https://github.com/stripe/stripe-ios/pull/5290 for the native Link UI, allowing us to show form validation errors if the user presses the disabled primary button.

We use this in the add-card and update-card screens for now, as these have the potential to grow quite big due to extensive billing details collection.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
