### PR TITLE
Tweak behavior of combined reuse and Link mandate

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -340,6 +340,11 @@ extension STPElementsSession {
         linkFlags["link_mobile_disable_default_opt_in"] != true
     }
 
+    var combinedReuseAndLinkMandateEnabled: Bool {
+        // This (now poorly named) feature flag impacts whether the combined mandate is supposed to be used.
+        linkSignupOptInFeatureEnabled
+    }
+
     var linkSignupOptInFeatureEnabled: Bool {
         linkFlags["link_sign_up_opt_in_feature_enabled"] == true
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -87,6 +87,7 @@ extension PayWithLinkViewController {
                 paymentMethodTypes: [.stripe(.card)],
                 formCache: .init(), // We don't want to share a form cache with the containing PaymentSheet
                 analyticsHelper: context.analyticsHelper,
+                isLinkUI: true,
                 delegate: self
             )
         }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -64,10 +64,21 @@ extension PayWithLinkViewController {
         }
 
         /// The mandate text to show.
-        var mandate: NSMutableAttributedString? {
+        var mandate: NSAttributedString? {
             switch selectedPaymentMethod?.details {
             case .card:
-                guard context.intent.isSetupFutureUsageSet(for: context.elementsSession.linkPassthroughModeEnabled ? .card : .link) else { return nil }
+                if context.elementsSession.combinedReuseAndLinkMandateEnabled {
+                    // Use the updated mandate text that can mention both payment method reuse and Link signup.
+                    // Since the user is already signed up for Link, we don't need to save to Link.
+                    return PaymentSheetFormFactory.makeMandateText(
+                        useCombinedReuseAndLinkSignupText: true,
+                        shouldSaveToLink: false,
+                        merchantName: context.configuration.merchantDisplayName
+                    )
+                }
+                guard context.intent.isSetupFutureUsageSet(for: context.elementsSession.linkPassthroughModeEnabled ? .card : .link) else {
+                    return nil
+                }
                 let string = String(format: .Localized.by_providing_your_card_information_text, context.configuration.merchantDisplayName)
                 return NSMutableAttributedString(string: string)
             case .bankAccount:

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMandateView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMandateView.swift
@@ -47,12 +47,13 @@ final class LinkMandateView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func setText(_ text: NSMutableAttributedString) {
+    func setText(_ text: NSAttributedString) {
         textView.attributedText = formattedLegalText(text)
         textView.applyStyle()
     }
 
-    private func formattedLegalText(_ formattedString: NSMutableAttributedString) -> NSAttributedString {
+    private func formattedLegalText(_ formattedString: NSAttributedString) -> NSAttributedString {
+        let mutableString = NSMutableAttributedString(attributedString: formattedString)
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
         paragraphStyle.lineSpacing = LinkUI.lineSpacing(
@@ -60,7 +61,7 @@ final class LinkMandateView: UIView {
             textStyle: .caption
         )
 
-        formattedString.addAttributes([.paragraphStyle: paragraphStyle], range: formattedString.extent)
+        mutableString.addAttributes([.paragraphStyle: paragraphStyle], range: mutableString.extent)
 
         return formattedString
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
@@ -150,6 +150,7 @@ class EmbeddedFormViewController: UIViewController {
             configuration: configuration,
             headerView: headerView,
             analyticsHelper: analyticsHelper,
+            isLinkUI: false,
             delegate: self
         )
     }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/MandateTextProvider.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/MandateTextProvider.swift
@@ -62,7 +62,7 @@ class VerticalListMandateProvider: MandateTextProvider {
             let form = PaymentSheetFormFactory(
                 intent: intent,
                 elementsSession: elementsSession,
-                configuration: .paymentElement(configuration),
+                configuration: .paymentElement(configuration, isLinkUI: false),
                 paymentMethod: paymentMethodType,
                 previousCustomerInput: nil,
                 linkAccount: LinkAccountContext.shared.account,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -55,6 +55,7 @@ class AddPaymentMethodViewController: UIViewController {
     private let configuration: PaymentElementConfiguration
     private let formCache: PaymentMethodFormCache
     private let analyticsHelper: PaymentSheetAnalyticsHelper
+    private let isLinkUI: Bool
     var previousCustomerInput: IntentConfirmParams?
 
     private var paymentMethodFormElement: PaymentMethodElement {
@@ -63,7 +64,7 @@ class AddPaymentMethodViewController: UIViewController {
 
     // MARK: - Views
     private lazy var paymentMethodFormViewController: PaymentMethodFormViewController = {
-        let pmFormVC = PaymentMethodFormViewController(type: selectedPaymentMethodType, intent: intent, elementsSession: elementsSession, previousCustomerInput: previousCustomerInput, formCache: formCache, configuration: configuration, headerView: nil, analyticsHelper: analyticsHelper, delegate: self)
+        let pmFormVC = PaymentMethodFormViewController(type: selectedPaymentMethodType, intent: intent, elementsSession: elementsSession, previousCustomerInput: previousCustomerInput, formCache: formCache, configuration: configuration, headerView: nil, analyticsHelper: analyticsHelper, isLinkUI: isLinkUI, delegate: self)
         // Only use the previous customer input in the very first load, to avoid overwriting customer input
         previousCustomerInput = nil
         return pmFormVC
@@ -105,6 +106,7 @@ class AddPaymentMethodViewController: UIViewController {
         paymentMethodTypes: [PaymentSheet.PaymentMethodType],
         formCache: PaymentMethodFormCache,
         analyticsHelper: PaymentSheetAnalyticsHelper,
+        isLinkUI: Bool = false,
         delegate: AddPaymentMethodViewControllerDelegate? = nil
     ) {
         if paymentMethodTypes.isEmpty {
@@ -121,6 +123,7 @@ class AddPaymentMethodViewController: UIViewController {
         self.delegate = delegate
         self.formCache = formCache
         self.analyticsHelper = analyticsHelper
+        self.isLinkUI = isLinkUI
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -185,6 +188,7 @@ class AddPaymentMethodViewController: UIViewController {
                 configuration: configuration,
                 headerView: nil,
                 analyticsHelper: analyticsHelper,
+                isLinkUI: isLinkUI,
                 delegate: self
             )
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -91,7 +91,7 @@ class PaymentSheetFormFactory {
 
         /// Whether or not the card form should show the link inline signup checkbox
         let showLinkInlineCardSignup: Bool = {
-            guard case .paymentElement(let configuration) = configuration else {
+            guard case .paymentElement(let configuration, _) = configuration else {
                 return false
             }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -9,12 +9,12 @@ import UIKit
 @_spi(STP) import StripePayments
 
 enum PaymentSheetFormFactoryConfig {
-    case paymentElement(PaymentElementConfiguration)
+    case paymentElement(PaymentElementConfiguration, isLinkUI: Bool = false)
     case customerSheet(CustomerSheet.Configuration)
 
     var hasCustomer: Bool {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.customer != nil
         case .customerSheet:
             return true
@@ -22,7 +22,7 @@ enum PaymentSheetFormFactoryConfig {
     }
     var merchantDisplayName: String {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.merchantDisplayName
         case .customerSheet(let config):
             return config.merchantDisplayName
@@ -30,7 +30,7 @@ enum PaymentSheetFormFactoryConfig {
     }
     var overrideCountry: String? {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.userOverrideCountry
         case .customerSheet:
             return nil
@@ -38,7 +38,7 @@ enum PaymentSheetFormFactoryConfig {
     }
     var billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.billingDetailsCollectionConfiguration
         case .customerSheet(let config):
             return config.billingDetailsCollectionConfiguration
@@ -46,7 +46,7 @@ enum PaymentSheetFormFactoryConfig {
     }
     var appearance: PaymentSheet.Appearance {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.appearance
         case .customerSheet(let config):
             return config.appearance
@@ -54,7 +54,7 @@ enum PaymentSheetFormFactoryConfig {
     }
     var defaultBillingDetails: PaymentSheet.BillingDetails {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.defaultBillingDetails
         case .customerSheet(let config):
             return config.defaultBillingDetails
@@ -62,7 +62,7 @@ enum PaymentSheetFormFactoryConfig {
     }
     var shippingDetails: () -> AddressViewController.AddressDetails? {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.shippingDetails
         case .customerSheet:
             return { return nil }
@@ -70,7 +70,7 @@ enum PaymentSheetFormFactoryConfig {
     }
     var savePaymentMethodOptInBehavior: PaymentSheet.SavePaymentMethodOptInBehavior {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.savePaymentMethodOptInBehavior
         case .customerSheet:
             return .automatic
@@ -79,7 +79,7 @@ enum PaymentSheetFormFactoryConfig {
 
     var preferredNetworks: [STPCardBrand]? {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.preferredNetworks
         case .customerSheet(let config):
             return config.preferredNetworks
@@ -88,7 +88,7 @@ enum PaymentSheetFormFactoryConfig {
 
     var isUsingBillingAddressCollection: Bool {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.requiresBillingDetailCollection()
         case .customerSheet(let config):
             return config.isUsingBillingAddressCollection()
@@ -97,7 +97,7 @@ enum PaymentSheetFormFactoryConfig {
 
     var cardBrandFilter: CardBrandFilter {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.cardBrandFilter
         case .customerSheet(let config):
             return config.cardBrandFilter
@@ -106,7 +106,7 @@ enum PaymentSheetFormFactoryConfig {
 
     var linkPaymentMethodsOnly: Bool {
         switch self {
-        case .paymentElement(let config):
+        case .paymentElement(let config, _):
             return config.linkPaymentMethodsOnly
         case .customerSheet:
             return false
@@ -115,7 +115,7 @@ enum PaymentSheetFormFactoryConfig {
 
     var isHorizontalMode: Bool {
         switch self {
-        case .paymentElement(let paymentElementConfiguration):
+        case .paymentElement(let paymentElementConfiguration, _):
             switch paymentElementConfiguration.paymentMethodLayout {
             case .horizontal:
                 return true
@@ -129,7 +129,7 @@ enum PaymentSheetFormFactoryConfig {
 
     func termsDisplayFor(paymentMethodType: PaymentSheet.PaymentMethodType) -> PaymentSheet.TermsDisplay {
         switch self {
-        case .paymentElement(let configuration):
+        case .paymentElement(let configuration, _):
             return configuration.termsDisplayFor(paymentMethodType: paymentMethodType)
         case .customerSheet:
             return .automatic

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -99,6 +99,7 @@ class PaymentMethodFormViewController: UIViewController {
         configuration: PaymentElementConfiguration,
         headerView: UIView?,
         analyticsHelper: PaymentSheetAnalyticsHelper,
+        isLinkUI: Bool,
         delegate: PaymentMethodFormViewControllerDelegate
     ) {
         self.paymentMethodType = type
@@ -114,7 +115,7 @@ class PaymentMethodFormViewController: UIViewController {
             self.form = PaymentSheetFormFactory(
                 intent: intent,
                 elementsSession: elementsSession,
-                configuration: .paymentElement(configuration),
+                configuration: .paymentElement(configuration, isLinkUI: isLinkUI),
                 paymentMethod: paymentMethodType,
                 previousCustomerInput: previousCustomerInput,
                 linkAccount: LinkAccountContext.shared.account,
@@ -233,7 +234,7 @@ extension PaymentMethodFormViewController: ElementDelegate {
         if let linkSignup = form.linkInlineSignupElement, let mandateElement = form.mandateElement {
             // Update the mandate with or without Link
             let text = PaymentSheetFormFactory.makeMandateText(
-                linkSignupOptInFeatureEnabled: linkSignup.viewModel.mode == .signupOptIn,
+                useCombinedReuseAndLinkSignupText: linkSignup.viewModel.mode == .signupOptIn,
                 shouldSaveToLink: linkSignup.viewModel.saveCheckboxChecked,
                 merchantName: configuration.merchantDisplayName
             )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -99,7 +99,7 @@ class PaymentMethodFormViewController: UIViewController {
         configuration: PaymentElementConfiguration,
         headerView: UIView?,
         analyticsHelper: PaymentSheetAnalyticsHelper,
-        isLinkUI: Bool,
+        isLinkUI: Bool = false,
         delegate: PaymentMethodFormViewControllerDelegate
     ) {
         self.paymentMethodType = type

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -894,6 +894,7 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
             configuration: configuration,
             headerView: headerView,
             analyticsHelper: analyticsHelper,
+            isLinkUI: false,
             delegate: self
         )
     }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request tweaks the behavior of the combined reuse and Link mandate, making sure that the reuse part is now also shown in the native Link UI.

<details><summary>Screenshot</summary>
<p>

<img width="1206" height="1424" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-12 at 13 15 45" src="https://github.com/user-attachments/assets/7ec182d6-ecd3-4a29-9bcb-7a4c87c25867" />

</p>
</details> 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
