### PR TITLE
Skip Link logout for verified merchants

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -366,7 +366,7 @@ extension PaymentSheet {
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
                         completion: { psResult, confirmationType in
-                            if shouldLogOutOfLink(result: psResult, elementsSession: elementsSession, intentConfig: intentConfig) {
+                            if shouldLogOutOfLink(result: psResult, elementsSession: elementsSession) {
                                 linkAccount?.logout()
                             }
                             completion(psResult, confirmationType)
@@ -428,7 +428,7 @@ extension PaymentSheet {
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
                         completion: { psResult, confirmationType in
-                            if shouldLogOutOfLink(result: psResult, elementsSession: elementsSession, intentConfig: intentConfig) {
+                            if shouldLogOutOfLink(result: psResult, elementsSession: elementsSession) {
                                 linkAccount?.logout()
                             }
                             completion(psResult, confirmationType)
@@ -778,13 +778,13 @@ extension PaymentSheet {
 
     private static func shouldLogOutOfLink(
         result: PaymentSheetResult,
-        elementsSession: STPElementsSession,
-        intentConfig: PaymentSheet.IntentConfiguration
+        elementsSession: STPElementsSession
     ) -> Bool {
         guard case .completed = result else {
             return false
         }
-        return elementsSession.linkSettings?.useAttestationEndpoints != true && intentConfig.preparePaymentMethodHandler == nil
+        // Only log out non-verified merchants.
+        return elementsSession.linkSettings?.useAttestationEndpoints != true
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -366,7 +366,7 @@ extension PaymentSheet {
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
                         completion: { psResult, confirmationType in
-                            if case .completed = psResult, intentConfig.preparePaymentMethodHandler == nil {
+                            if shouldLogOutOfLink(result: psResult, elementsSession: elementsSession, intentConfig: intentConfig) {
                                 linkAccount?.logout()
                             }
                             completion(psResult, confirmationType)
@@ -428,7 +428,7 @@ extension PaymentSheet {
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
                         completion: { psResult, confirmationType in
-                            if case .completed = psResult, intentConfig.preparePaymentMethodHandler == nil {
+                            if shouldLogOutOfLink(result: psResult, elementsSession: elementsSession, intentConfig: intentConfig) {
                                 linkAccount?.logout()
                             }
                             completion(psResult, confirmationType)
@@ -774,6 +774,17 @@ extension PaymentSheet {
         }
         params.returnURL = configuration.returnURL
         return params
+    }
+
+    private static func shouldLogOutOfLink(
+        result: PaymentSheetResult,
+        elementsSession: STPElementsSession,
+        intentConfig: PaymentSheet.IntentConfiguration
+    ) -> Bool {
+        guard case .completed = result else {
+            return false
+        }
+        return elementsSession.linkSettings?.useAttestationEndpoints != true && intentConfig.preparePaymentMethodHandler == nil
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -366,7 +366,7 @@ extension PaymentSheet {
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
                         completion: { psResult, confirmationType in
-                            if case .completed = psResult {
+                            if case .completed = psResult, intentConfig.preparePaymentMethodHandler == nil {
                                 linkAccount?.logout()
                             }
                             completion(psResult, confirmationType)
@@ -428,7 +428,7 @@ extension PaymentSheet {
                         paymentHandler: paymentHandler,
                         isFlowController: isFlowController,
                         completion: { psResult, confirmationType in
-                            if case .completed = psResult {
+                            if case .completed = psResult, intentConfig.preparePaymentMethodHandler == nil {
                                 linkAccount?.logout()
                             }
                             completion(psResult, confirmationType)


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request skips Link logout on `PaymentSheetResult.completed` for verified merchants.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
