### PR TITLE
Crypto Onramp SDK: Payment Method Appearance Customization

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
@@ -99,9 +99,15 @@ struct CryptoOnrampExampleView: View {
         isLoading.wrappedValue = true
         Task {
             do {
+                let lavenderColor = UIColor(
+                    red: 171/255.0,
+                    green: 159/255.0,
+                    blue: 242/255.0,
+                    alpha: 1.0
+                )
                 let appearance = LinkAppearance(
-                    colors: .init(primary: .systemPurple, selectedBorder: .separator),
-                    primaryButton: .init(cornerRadius: 32, height: 80),
+                    colors: .init(primary: lavenderColor, selectedBorder: .label),
+                    primaryButton: .init(cornerRadius: 16, height: 56),
                     style: .automatic
                 )
                 let coordinator = try await CryptoOnrampCoordinator.create(appearance: appearance)

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
@@ -100,9 +100,9 @@ struct CryptoOnrampExampleView: View {
         Task {
             do {
                 let appearance = LinkAppearance(
-                    colors: .init(primary: .systemPink, selectedBorder: .white),
-                    primaryButton: .init(cornerRadius: 0, height: 200),
-                    style: .alwaysDark
+                    colors: .init(primary: .systemPurple, selectedBorder: .separator),
+                    primaryButton: .init(cornerRadius: 32, height: 80),
+                    style: .automatic
                 )
                 let coordinator = try await CryptoOnrampCoordinator.create(appearance: appearance)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
@@ -99,6 +99,12 @@ final class LinkPaymentMethodPicker: UIView {
         }
     }
 
+    var linkAppearance: LinkAppearance? {
+        didSet {
+            updateTintColors()
+        }
+    }
+
     /// Calculates the maximum width required for the header labels.
     static let widthForHeaderLabels: CGFloat = {
         let font = LinkUI.font(forTextStyle: .bodyEmphasized)
@@ -172,10 +178,8 @@ final class LinkPaymentMethodPicker: UIView {
 
         layer.cornerRadius = 16
         layer.borderColor = UIColor.linkBorderDefault.cgColor
-        tintColor = .linkIconBrand
+        updateTintColors()
         backgroundColor = .linkSurfaceSecondary
-
-        addPaymentMethodButton.tintColor = .linkTextBrand
 
         headerView.addTarget(self, action: #selector(onHeaderTapped(_:)), for: .touchUpInside)
         headerView.layer.zPosition = 1
@@ -217,6 +221,12 @@ final class LinkPaymentMethodPicker: UIView {
         } else {
             stackView.hideArrangedSubview(at: listViewIndex, animated: animated)
         }
+    }
+
+    private func updateTintColors() {
+        let linkAppearancePrimaryColor = linkAppearance?.colors?.primary
+        tintColor = linkAppearancePrimaryColor ?? .linkIconBrand
+        addPaymentMethodButton.tintColor = linkAppearancePrimaryColor ?? .linkTextBrand
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-LoaderViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-LoaderViewController.swift
@@ -19,7 +19,7 @@ extension PayWithLinkViewController {
         override func viewDidLoad() {
             super.viewDidLoad()
 
-            activityIndicator.tintColor = .linkIconBrand
+            activityIndicator.tintColor = context.linkAppearance?.colors?.primary ?? .linkIconBrand
             activityIndicator.translatesAutoresizingMaskIntoConstraints = false
             view.addSubview(activityIndicator)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -89,7 +89,8 @@ extension PayWithLinkViewController {
                 paymentMethodTypes: [.stripe(.card)],
                 formCache: .init(), // We don't want to share a form cache with the containing PaymentSheet
                 analyticsHelper: context.analyticsHelper,
-                delegate: self
+                delegate: self,
+                linkAppearance: context.linkAppearance
             )
         }()
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -31,7 +31,8 @@ extension PayWithLinkViewController {
         private lazy var confirmButton: ConfirmButton = .makeLinkButton(
             callToAction: context.callToAction,
             // Use a compact button if we are also displaying the Apple Pay button.
-            compact: shouldShowApplePayButton
+            compact: shouldShowApplePayButton,
+            linkAppearance: context.linkAppearance
         ) { [weak self] in
             self?.confirm()
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
@@ -46,7 +46,8 @@ extension PayWithLinkViewController {
         }()
 
         private lazy var updateButton: ConfirmButton = .makeLinkButton(
-            callToAction: isBillingDetailsUpdateFlow ? context.callToAction : .custom(title: String.Localized.update_card)
+            callToAction: isBillingDetailsUpdateFlow ? context.callToAction : .custom(title: String.Localized.update_card),
+            linkAppearance: context.linkAppearance
         ) { [weak self] in
             self?.updatePaymentMethod()
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -35,6 +35,7 @@ extension PayWithLinkViewController {
             paymentPicker.supportedPaymentMethodTypes = viewModel.supportedPaymentMethodTypes
             paymentPicker.billingDetails = context.configuration.defaultBillingDetails
             paymentPicker.billingDetailsCollectionConfiguration = context.configuration.billingDetailsCollectionConfiguration
+            paymentPicker.linkAppearance = viewModel.linkAppearance
             return paymentPicker
         }()
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -39,7 +39,7 @@ extension PayWithLinkViewController {
             return paymentPicker
         }()
 
-        private lazy var mandateView = LinkMandateView(delegate: self)
+        private lazy var mandateView = LinkMandateView(delegate: self, linkAppearance: viewModel.linkAppearance)
 
         private lazy var confirmButton = ConfirmButton.makeLinkButton(
             callToAction: viewModel.confirmButtonCallToAction,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -42,7 +42,8 @@ extension PayWithLinkViewController {
 
         private lazy var confirmButton = ConfirmButton.makeLinkButton(
             callToAction: viewModel.confirmButtonCallToAction,
-            compact: viewModel.shouldUseCompactConfirmButton
+            compact: viewModel.shouldUseCompactConfirmButton,
+            linkAppearance: viewModel.linkAppearance
         ) { [weak self] in
             guard let self else {
                 return

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -133,7 +133,7 @@ extension PayWithLinkViewController {
         }
 
         var cancelButtonConfiguration: Button.Configuration? {
-            context.shouldShowSecondaryCta ? .linkPlain() : nil
+            context.shouldShowSecondaryCta ? .linkPlain(foregroundColor: linkAppearance?.colors?.primary ?? .linkTextBrand) : nil
         }
 
         /// Whether or not we must re-collect the card CVC.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -128,6 +128,10 @@ extension PayWithLinkViewController {
             return shouldShowApplePayButton
         }
 
+        var linkAppearance: LinkAppearance? {
+            return context.linkAppearance
+        }
+
         var cancelButtonConfiguration: Button.Configuration? {
             context.shouldShowSecondaryCta ? .linkPlain() : nil
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -129,7 +129,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
             initiallySelectedPaymentDetailsID: String?,
             callToAction: ConfirmButton.CallToActionType?,
             analyticsHelper: PaymentSheetAnalyticsHelper,
-            linkAppearance: LinkAppearance?
+            linkAppearance: LinkAppearance? = nil
         ) {
             self.intent = intent
             self.elementsSession = elementsSession

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -91,6 +91,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         let callToAction: ConfirmButton.CallToActionType
         var lastAddedPaymentDetails: ConsumerPaymentDetails?
         var analyticsHelper: PaymentSheetAnalyticsHelper
+        let linkAppearance: LinkAppearance?
 
         var isDismissible: Bool = true
 
@@ -115,6 +116,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         ///   - initiallySelectedPaymentDetailsID: The ID of an initially selected payment method. This is set when opened instead of FlowController.
         ///   - callToAction: A custom CTA to display on the confirm button. If `nil`, will display `intent`'s default CTA.
         ///   - analyticsHelper: An instance of `AnalyticsHelper` to use for logging.
+        ///   - linkAppearance: Optional appearance overrides for Link UI.
         init(
             intent: Intent,
             elementsSession: STPElementsSession,
@@ -126,7 +128,8 @@ final class PayWithLinkViewController: BottomSheetViewController {
             canSkipWalletAfterVerification: Bool,
             initiallySelectedPaymentDetailsID: String?,
             callToAction: ConfirmButton.CallToActionType?,
-            analyticsHelper: PaymentSheetAnalyticsHelper
+            analyticsHelper: PaymentSheetAnalyticsHelper,
+            linkAppearance: LinkAppearance?
         ) {
             self.intent = intent
             self.elementsSession = elementsSession
@@ -139,6 +142,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
             self.initiallySelectedPaymentDetailsID = initiallySelectedPaymentDetailsID
             self.callToAction = callToAction ?? .makeDefaultTypeForLink(intent: intent)
             self.analyticsHelper = analyticsHelper
+            self.linkAppearance = linkAppearance
         }
     }
 
@@ -178,7 +182,8 @@ final class PayWithLinkViewController: BottomSheetViewController {
         initiallySelectedPaymentDetailsID: String? = nil,
         canSkipWalletAfterVerification: Bool,
         callToAction: ConfirmButton.CallToActionType? = nil,
-        analyticsHelper: PaymentSheetAnalyticsHelper
+        analyticsHelper: PaymentSheetAnalyticsHelper,
+        linkAppearance: LinkAppearance? = nil
     ) {
         self.init(
             context: Context(
@@ -192,7 +197,8 @@ final class PayWithLinkViewController: BottomSheetViewController {
                 canSkipWalletAfterVerification: canSkipWalletAfterVerification,
                 initiallySelectedPaymentDetailsID: initiallySelectedPaymentDetailsID,
                 callToAction: callToAction,
-                analyticsHelper: analyticsHelper
+                analyticsHelper: analyticsHelper,
+                linkAppearance: linkAppearance
             ),
             linkAccount: linkAccount
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
@@ -13,11 +13,31 @@ extension ConfirmButton {
     static func makeLinkButton(
         callToAction: CallToActionType,
         compact: Bool = false,
+        linkAppearance: LinkAppearance? = nil,
         didTap: @escaping () -> Void
     ) -> ConfirmButton {
-        let directionalLayoutMargins = compact ? LinkUI.compactButtonMargins : LinkUI.buttonMargins
+        var directionalLayoutMargins = compact ? LinkUI.compactButtonMargins : LinkUI.buttonMargins
 
         var appearance = LinkUI.appearance
+
+        if let linkAppearance {
+            if let colors = linkAppearance.colors {
+                appearance.primaryButton.backgroundColor = colors.primary
+            }
+
+            if let buttonConfiguration = linkAppearance.primaryButton {
+                appearance.primaryButton.cornerRadius = buttonConfiguration.cornerRadius
+
+                // Adjust the margins to back solve for the `LinkAppearance` customized height.
+                let desiredHeight = buttonConfiguration.height
+                let verticalMargin = LinkUI.verticalMarginForPrimaryButton(withDesiredHeight: desiredHeight)
+                directionalLayoutMargins.top = verticalMargin
+                directionalLayoutMargins.bottom = verticalMargin
+
+                appearance.primaryButton.cornerRadius = 2
+            }
+        }
+
         appearance.primaryButton.height = LinkUI.primaryButtonHeight(margins: directionalLayoutMargins)
 
         let button = ConfirmButton(

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
@@ -33,8 +33,6 @@ extension ConfirmButton {
                 let verticalMargin = LinkUI.verticalMarginForPrimaryButton(withDesiredHeight: desiredHeight)
                 directionalLayoutMargins.top = verticalMargin
                 directionalLayoutMargins.bottom = verticalMargin
-
-                appearance.primaryButton.cornerRadius = 2
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
@@ -54,6 +54,12 @@ enum LinkUI {
         return max(height, minimumButtonHeight)
     }
 
+    static func verticalMarginForPrimaryButton(withDesiredHeight height: CGFloat) -> CGFloat {
+        let desiredHeight = max(height, minimumButtonHeight)
+        let marginHeight = (desiredHeight - minimumLabelHeight) / 2.0
+        return max(0, marginHeight)
+    }
+
     // MARK: - Margins
 
     static let buttonMargins: NSDirectionalEdgeInsets = .insets(amount: 16)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMandateView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMandateView.swift
@@ -29,15 +29,17 @@ final class LinkMandateView: UIView {
     }
 
     weak var delegate: LinkMandateViewDelegate?
+    private let linkTextColor: UIColor
 
     private lazy var textView: UITextView = {
         let textView = UITextView()
         textView.delegate = self
-        textView.applyStyle()
+        textView.applyStyle(linkTextColor: linkTextColor)
         return textView
     }()
 
-    init(delegate: LinkMandateViewDelegate? = nil) {
+    init(delegate: LinkMandateViewDelegate? = nil, linkAppearance: LinkAppearance? = nil) {
+        linkTextColor = linkAppearance?.colors?.primary ?? .linkTextBrand
         super.init(frame: .zero)
         self.delegate = delegate
         addAndPinSubview(textView)
@@ -49,7 +51,7 @@ final class LinkMandateView: UIView {
 
     func setText(_ text: NSMutableAttributedString) {
         textView.attributedText = formattedLegalText(text)
-        textView.applyStyle()
+        textView.applyStyle(linkTextColor: linkTextColor)
     }
 
     private func formattedLegalText(_ formattedString: NSMutableAttributedString) -> NSAttributedString {
@@ -87,7 +89,7 @@ extension LinkMandateView: UITextViewDelegate {
 
 private extension UITextView {
 
-    func applyStyle() {
+    func applyStyle(linkTextColor: UIColor) {
         isScrollEnabled = false
         isEditable = false
         backgroundColor = .clear
@@ -98,7 +100,7 @@ private extension UITextView {
         clipsToBounds = false
         adjustsFontForContentSizeCategory = true
         linkTextAttributes = [
-            .foregroundColor: UIColor.linkTextBrand
+            .foregroundColor: linkTextColor
         ]
         font = LinkUI.font(forTextStyle: .caption)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
@@ -26,7 +26,7 @@ final class CardSectionElement: ContainerElement {
     lazy var view: UIView = {
         #if !os(visionOS)
         if #available(iOS 13.0, macCatalyst 14, *), STPCardScanner.cardScanningAvailable {
-            return CardSectionWithScannerView(cardSectionView: cardSection.view, delegate: self, theme: theme, analyticsHelper: analyticsHelper)
+            return CardSectionWithScannerView(cardSectionView: cardSection.view, delegate: self, theme: theme, analyticsHelper: analyticsHelper, linkAppearance: linkAppearance)
         } else {
             return cardSection.view
         }
@@ -37,6 +37,8 @@ final class CardSectionElement: ContainerElement {
     let cardSection: SectionElement
     let analyticsHelper: PaymentSheetAnalyticsHelper?
     let cardBrandFilter: CardBrandFilter
+
+    private let linkAppearance: LinkAppearance?
 
     struct DefaultValues {
         internal init(name: String? = nil, pan: String? = nil, cvc: String? = nil, expiry: String? = nil) {
@@ -70,7 +72,8 @@ final class CardSectionElement: ContainerElement {
         hostedSurface: HostedSurface,
         theme: ElementsAppearance = .default,
         analyticsHelper: PaymentSheetAnalyticsHelper?,
-        cardBrandFilter: CardBrandFilter = .default
+        cardBrandFilter: CardBrandFilter = .default,
+        linkAppearance: LinkAppearance? = nil
     ) {
         self.hostedSurface = hostedSurface
         self.theme = theme
@@ -149,6 +152,7 @@ final class CardSectionElement: ContainerElement {
         self.expiryElement = expiryElement.element
         self.preferredNetworks = preferredNetworks
         self.lastPanElementValidationState = panElement.validationState
+        self.linkAppearance = linkAppearance
         cardSection.delegate = self
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionWithScannerView.swift
@@ -24,7 +24,7 @@ final class CardSectionWithScannerView: UIView {
     let cardSectionView: UIView
     let analyticsHelper: PaymentSheetAnalyticsHelper?
     lazy var cardScanButton: UIButton = {
-        let button = UIButton.makeCardScanButton(theme: theme)
+        let button = UIButton.makeCardScanButton(theme: theme, linkAppearance: linkAppearance)
         button.addTarget(self, action: #selector(didTapCardScanButton), for: .touchUpInside)
         return button
     }()
@@ -36,12 +36,14 @@ final class CardSectionWithScannerView: UIView {
     }()
     weak var delegate: CardSectionWithScannerViewDelegate?
     private let theme: ElementsAppearance
+    private let linkAppearance: LinkAppearance?
 
-    init(cardSectionView: UIView, delegate: CardSectionWithScannerViewDelegate, theme: ElementsAppearance = .default, analyticsHelper: PaymentSheetAnalyticsHelper?) {
+    init(cardSectionView: UIView, delegate: CardSectionWithScannerViewDelegate, theme: ElementsAppearance = .default, analyticsHelper: PaymentSheetAnalyticsHelper?, linkAppearance: LinkAppearance? = nil) {
         self.cardSectionView = cardSectionView
         self.delegate = delegate
         self.theme = theme
         self.analyticsHelper = analyticsHelper
+        self.linkAppearance = linkAppearance
         super.init(frame: .zero)
         installConstraints()
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -276,7 +276,8 @@ import UIKit
             configuration: configuration,
             intent: intent,
             elementsSession: elementsSession,
-            analyticsHelper: analyticsHelper
+            analyticsHelper: analyticsHelper,
+            linkAppearance: appearance
         ) { [weak self] confirmOption, shouldClearSelection in
             guard let confirmOption else {
                 if shouldClearSelection {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -26,6 +26,7 @@ extension UIViewController {
         intent: Intent,
         elementsSession: STPElementsSession,
         analyticsHelper: PaymentSheetAnalyticsHelper,
+        linkAppearance: LinkAppearance? = nil,
         verificationDismissed: (() -> Void)? = nil,
         callback: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
     ) {
@@ -34,6 +35,7 @@ extension UIViewController {
                 mode: .inlineLogin,
                 linkAccount: linkAccount,
                 configuration: configuration,
+                appearance: linkAppearance,
                 allowLogoutInDialog: true
             )
 
@@ -55,6 +57,7 @@ extension UIViewController {
                     elementsSession: elementsSession,
                     configuration: configuration,
                     analyticsHelper: analyticsHelper,
+                    linkAppearance: linkAppearance,
                     callback: callback
                 )
             }
@@ -65,6 +68,7 @@ extension UIViewController {
                 elementsSession: elementsSession,
                 configuration: configuration,
                 analyticsHelper: analyticsHelper,
+                linkAppearance: linkAppearance,
                 callback: callback
             )
         }
@@ -76,6 +80,7 @@ extension UIViewController {
         elementsSession: STPElementsSession,
         configuration: PaymentElementConfiguration,
         analyticsHelper: PaymentSheetAnalyticsHelper,
+        linkAppearance: LinkAppearance? = nil,
         callback: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
     ) {
         let payWithLinkController = PayWithNativeLinkController(
@@ -84,7 +89,8 @@ extension UIViewController {
             elementsSession: elementsSession,
             configuration: configuration,
             logPayment: false,
-            analyticsHelper: analyticsHelper
+            analyticsHelper: analyticsHelper,
+            linkAppearance: linkAppearance
         )
 
         payWithLinkController.presentForPaymentMethodSelection(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -55,13 +55,16 @@ final class PayWithNativeLinkController {
     let logPayment: Bool
     let analyticsHelper: PaymentSheetAnalyticsHelper
 
+    private let linkAppearance: LinkAppearance?
+
     init(
         mode: Mode,
         intent: Intent,
         elementsSession: STPElementsSession,
         configuration: PaymentElementConfiguration,
         logPayment: Bool = true,
-        analyticsHelper: PaymentSheetAnalyticsHelper
+        analyticsHelper: PaymentSheetAnalyticsHelper,
+        linkAppearance: LinkAppearance? = nil
     ) {
         self.mode = mode
         self.intent = intent
@@ -70,6 +73,7 @@ final class PayWithNativeLinkController {
         self.configuration = configuration
         self.analyticsHelper = analyticsHelper
         self.paymentHandler = .init(apiClient: configuration.apiClient)
+        self.linkAppearance = linkAppearance
     }
 
     func presentAsBottomSheet(
@@ -150,7 +154,8 @@ final class PayWithNativeLinkController {
                 initiallySelectedPaymentDetailsID: initiallySelectedPaymentDetailsID,
                 canSkipWalletAfterVerification: canSkipWalletAfterVerification,
                 callToAction: callToAction,
-                analyticsHelper: self.analyticsHelper
+                analyticsHelper: self.analyticsHelper,
+                linkAppearance: self.linkAppearance
             )
 
             payWithLinkVC.payWithLinkDelegate = self

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/AddPaymentMethodViewController.swift
@@ -55,6 +55,7 @@ class AddPaymentMethodViewController: UIViewController {
     private let configuration: PaymentElementConfiguration
     private let formCache: PaymentMethodFormCache
     private let analyticsHelper: PaymentSheetAnalyticsHelper
+    private let linkAppearance: LinkAppearance?
     var previousCustomerInput: IntentConfirmParams?
 
     var paymentMethodFormElement: PaymentMethodElement {
@@ -63,7 +64,7 @@ class AddPaymentMethodViewController: UIViewController {
 
     // MARK: - Views
     private lazy var paymentMethodFormViewController: PaymentMethodFormViewController = {
-        let pmFormVC = PaymentMethodFormViewController(type: selectedPaymentMethodType, intent: intent, elementsSession: elementsSession, previousCustomerInput: previousCustomerInput, formCache: formCache, configuration: configuration, headerView: nil, analyticsHelper: analyticsHelper, delegate: self)
+        let pmFormVC = PaymentMethodFormViewController(type: selectedPaymentMethodType, intent: intent, elementsSession: elementsSession, previousCustomerInput: previousCustomerInput, formCache: formCache, configuration: configuration, headerView: nil, analyticsHelper: analyticsHelper, delegate: self, linkAppearance: linkAppearance)
         // Only use the previous customer input in the very first load, to avoid overwriting customer input
         previousCustomerInput = nil
         return pmFormVC
@@ -105,7 +106,8 @@ class AddPaymentMethodViewController: UIViewController {
         paymentMethodTypes: [PaymentSheet.PaymentMethodType],
         formCache: PaymentMethodFormCache,
         analyticsHelper: PaymentSheetAnalyticsHelper,
-        delegate: AddPaymentMethodViewControllerDelegate? = nil
+        delegate: AddPaymentMethodViewControllerDelegate? = nil,
+        linkAppearance: LinkAppearance? = nil,
     ) {
         if paymentMethodTypes.isEmpty {
             let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetError,
@@ -121,6 +123,7 @@ class AddPaymentMethodViewController: UIViewController {
         self.delegate = delegate
         self.formCache = formCache
         self.analyticsHelper = analyticsHelper
+        self.linkAppearance = linkAppearance
         super.init(nibName: nil, bundle: nil)
     }
 
@@ -185,7 +188,8 @@ class AddPaymentMethodViewController: UIViewController {
                 configuration: configuration,
                 headerView: nil,
                 analyticsHelper: analyticsHelper,
-                delegate: self
+                delegate: self,
+                linkAppearance: linkAppearance
             )
         }
         updateUI()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -14,7 +14,7 @@ import StripePayments
 import UIKit
 
 extension PaymentSheetFormFactory {
-    func makeCard() -> PaymentMethodElement {
+    func makeCard(linkAppearance: LinkAppearance? = nil) -> PaymentMethodElement {
         let showLinkInlineSignup = showLinkInlineCardSignup
         let defaultCheckbox: Element? = {
             guard allowsSetAsDefaultPM else {
@@ -60,7 +60,8 @@ extension PaymentSheetFormFactory {
             hostedSurface: .init(config: configuration),
             theme: theme,
             analyticsHelper: analyticsHelper,
-            cardBrandFilter: configuration.cardBrandFilter
+            cardBrandFilter: configuration.cardBrandFilter,
+            linkAppearance: linkAppearance
         )
 
         let shouldIncludeEmail = configuration.billingDetailsCollectionConfiguration.email == .always

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -28,6 +28,7 @@ class PaymentSheetFormFactory {
     let addressSpecProvider: AddressSpecProvider
     let showLinkInlineCardSignup: Bool
     let linkAccount: PaymentSheetLinkAccount?
+    let linkAppearance: LinkAppearance?
     let accountService: LinkAccountServiceProtocol?
     let previousCustomerInput: IntentConfirmParams?
 
@@ -86,7 +87,8 @@ class PaymentSheetFormFactory {
         addressSpecProvider: AddressSpecProvider = .shared,
         linkAccount: PaymentSheetLinkAccount? = nil,
         accountService: LinkAccountServiceProtocol,
-        analyticsHelper: PaymentSheetAnalyticsHelper?
+        analyticsHelper: PaymentSheetAnalyticsHelper?,
+        linkAppearance: LinkAppearance? = nil
     ) {
 
         /// Whether or not the card form should show the link inline signup checkbox
@@ -138,7 +140,9 @@ class PaymentSheetFormFactory {
                   signupOptInInitialValue: elementsSession.linkSignupOptInInitialValue,
                   isFirstSavedPaymentMethod: elementsSession.customer?.paymentMethods.isEmpty ?? true,
                   analyticsHelper: analyticsHelper,
-                  paymentMethodIncentive: elementsSession.incentive)
+                  paymentMethodIncentive: elementsSession.incentive,
+                  linkAppearance: linkAppearance
+        )
     }
 
     required init(
@@ -161,7 +165,8 @@ class PaymentSheetFormFactory {
         signupOptInInitialValue: Bool = false,
         isFirstSavedPaymentMethod: Bool = true,
         analyticsHelper: PaymentSheetAnalyticsHelper?,
-        paymentMethodIncentive: PaymentMethodIncentive?
+        paymentMethodIncentive: PaymentMethodIncentive?,
+        linkAppearance: LinkAppearance? = nil,
     ) {
         self.configuration = configuration
         self.paymentMethod = paymentMethod
@@ -188,6 +193,7 @@ class PaymentSheetFormFactory {
         self.isFirstSavedPaymentMethod = isFirstSavedPaymentMethod
         self.analyticsHelper = analyticsHelper
         self.paymentMethodIncentive = paymentMethodIncentive
+        self.linkAppearance = linkAppearance
     }
 
     func make() -> PaymentMethodElement {
@@ -203,7 +209,7 @@ class PaymentSheetFormFactory {
             // We have two ways to create the form for a payment method
             // 1. Custom, one-off forms
             if paymentMethod == .card {
-                return makeCard()
+                return makeCard(linkAppearance: linkAppearance)
             } else if paymentMethod == .USBankAccount {
                 return makeUSBankAccount(merchantName: configuration.merchantDisplayName)
             } else if paymentMethod == .UPI {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -166,7 +166,7 @@ class PaymentSheetFormFactory {
         isFirstSavedPaymentMethod: Bool = true,
         analyticsHelper: PaymentSheetAnalyticsHelper?,
         paymentMethodIncentive: PaymentMethodIncentive?,
-        linkAppearance: LinkAppearance? = nil,
+        linkAppearance: LinkAppearance? = nil
     ) {
         self.configuration = configuration
         self.paymentMethod = paymentMethod

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -99,7 +99,8 @@ class PaymentMethodFormViewController: UIViewController {
         configuration: PaymentElementConfiguration,
         headerView: UIView?,
         analyticsHelper: PaymentSheetAnalyticsHelper,
-        delegate: PaymentMethodFormViewControllerDelegate
+        delegate: PaymentMethodFormViewControllerDelegate,
+        linkAppearance: LinkAppearance? = nil
     ) {
         self.paymentMethodType = type
         self.intent = intent
@@ -119,7 +120,8 @@ class PaymentMethodFormViewController: UIViewController {
                 previousCustomerInput: previousCustomerInput,
                 linkAccount: LinkAccountContext.shared.account,
                 accountService: LinkAccountService(apiClient: configuration.apiClient, elementsSession: elementsSession),
-                analyticsHelper: analyticsHelper
+                analyticsHelper: analyticsHelper,
+                linkAppearance: linkAppearance,
             ).make()
             self.formCache[type] = form
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -122,7 +122,7 @@ class PaymentMethodFormViewController: UIViewController {
                 linkAccount: LinkAccountContext.shared.account,
                 accountService: LinkAccountService(apiClient: configuration.apiClient, elementsSession: elementsSession),
                 analyticsHelper: analyticsHelper,
-                linkAppearance: linkAppearance,
+                linkAppearance: linkAppearance
             ).make()
             self.formCache[type] = form
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanButton.swift
@@ -13,7 +13,7 @@ import CloudKit
 import UIKit
 
 extension UIButton {
-    static func makeCardScanButton(theme: ElementsAppearance = .default) -> UIButton {
+    static func makeCardScanButton(theme: ElementsAppearance = .default, linkAppearance: LinkAppearance? = nil) -> UIButton {
         let fontMetrics = UIFontMetrics(forTextStyle: .body)
         let iconConfig = UIImage.SymbolConfiguration(
             font: fontMetrics.scaledFont(for: UIFont.systemFont(ofSize: 9, weight: .semibold))
@@ -29,7 +29,7 @@ extension UIButton {
             scanButton.setImage(UIImage(systemName: "camera", withConfiguration: iconConfig), for: .normal)
         }
         scanButton.setContentSpacing(4, withEdgeInsets: .zero)
-        scanButton.tintColor = theme.colors.primary
+        scanButton.tintColor = linkAppearance?.colors?.primary ?? theme.colors.primary
         scanButton.titleLabel?.font = theme.fonts.sectionHeader
         scanButton.setContentHuggingPriority(.defaultLow + 1, for: .horizontal)
         return scanButton


### PR DESCRIPTION
## Summary
Makes use of `LinkAppearance` overrides in locations that we want to allow customization.

## Motivation
Required for Crypto Onramp.

## Testing
Navigated to the payment method selection UI, and tapped around, ensuring all green colored active elements were appropriately tinted to my customized color, and the primary button color + corner radius matched the custom values.

| Wallet | Update | New |
| --- | --- | --- |
| <img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-12 at 12 49 22" src="https://github.com/user-attachments/assets/dc22d1d4-a073-44e4-9814-489f3903cb38" /> | <img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-12 at 12 49 28" src="https://github.com/user-attachments/assets/61f18c71-7850-4690-8252-56e56af329d1" /> | <img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-12 at 12 49 36" src="https://github.com/user-attachments/assets/262056d6-9871-4e77-9d7e-d6304ff33a34" /> |

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
