### PR TITLE
Fix minor issues with billing details collection in Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
@@ -67,7 +67,7 @@ final class LinkPaymentMethodFormElement: Element {
         // This matches the object that was returned by CardDetailsEditView, but won't work
         // with `collectionMode: .all`, because extra fields won't match what expected by Link.
         let billingDetails = STPPaymentMethodBillingDetails()
-        billingDetails.name = billingAddressSection?.name?.text ?? nameElement?.text
+        billingDetails.name = billingAddressSection?.name?.text ?? nameOnCardElement?.text
         billingDetails.nonnil_address.country = billingAddressSection?.selectedCountryCode
         billingDetails.nonnil_address.line1 = billingAddressSection?.line1?.text
         billingDetails.nonnil_address.line2 = billingAddressSection?.line2?.text
@@ -101,13 +101,14 @@ final class LinkPaymentMethodFormElement: Element {
         return !isCard && collectsName
     }
 
-    private lazy var nameElement: TextFieldElement? = {
+    private lazy var nameOnCardElement: TextFieldElement? = {
         guard configuration.billingDetailsCollectionConfiguration.name == .always else { return nil }
 
         return TextFieldElement.makeName(
             label: STPLocalizedString("Name on card", "Label for name on card field"),
-            defaultValue: paymentMethod.billingAddress?.name,
-            theme: theme)
+            defaultValue: paymentMethod.billingAddress?.name ?? configuration.defaultBillingDetails.name,
+            theme: theme
+        )
     }()
 
     private lazy var cardBrandDropdownElement: PaymentMethodElementWrapper<DropdownFieldElement>? = {
@@ -204,7 +205,7 @@ final class LinkPaymentMethodFormElement: Element {
 
     private lazy var cardSection: SectionElement = {
         let allElements: [Element?] = [
-            nameElement,
+            nameOnCardElement,
             panElement, SectionElement.HiddenElement(cardBrandDropdownElement),
             SectionElement.MultiElementRow([expiryDateElement, cvcElement], theme: theme),
         ]
@@ -238,10 +239,12 @@ final class LinkPaymentMethodFormElement: Element {
             nil
         }
 
+        let name = paymentMethod.billingAddress?.name ?? configuration.defaultBillingDetails.name
+
         let defaultBillingAddress = AddressSectionElement.AddressDetails(
             billingAddress: paymentMethod.billingAddress ?? .init(),
             phone: phone,
-            name: paymentMethod.billingAddress?.name,
+            name: name,
             email: email
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
@@ -218,10 +218,13 @@ final class LinkPaymentMethodFormElement: Element {
     }()
 
     private lazy var billingAddressSection: AddressSectionElement? = {
-        guard configuration.billingDetailsCollectionConfiguration.address != .never else { return nil }
-
         let collectPhone = configuration.billingDetailsCollectionConfiguration.phone == .always && isBillingDetailsUpdateFlow
         let collectEmail = configuration.billingDetailsCollectionConfiguration.email == .always
+        let collectAddress = configuration.billingDetailsCollectionConfiguration.address != .never || paymentMethod.type == .card
+
+        guard collectPhone || collectEmail || collectAddress else {
+            return nil
+        }
 
         let phone: String? = if collectPhone {
             configuration.defaultBillingDetails.phone


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a minor issue in the Link update card screen and ensures that the billing details section is displayed correctly. It also makes sure that the name is correctly prefilled from any merchant-provided billing details.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
