### PR TITLE
Add error message for incomplete generic text fields

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
@@ -105,7 +105,7 @@ final class LinkPaymentMethodFormElement: Element {
         guard configuration.billingDetailsCollectionConfiguration.name == .always else { return nil }
 
         return TextFieldElement.makeName(
-            label: STPLocalizedString("Name on card", "Label for name on card field"),
+            type: .onCard,
             defaultValue: paymentMethod.billingAddress?.name,
             theme: theme)
     }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
@@ -81,11 +81,11 @@ final class CardSectionElement: ContainerElement {
         self.cardBrandFilter = cardBrandFilter
         let nameElement = collectName
             ? PaymentMethodElementWrapper(
-                TextFieldElement.NameConfiguration(
-                    type: .full,
+                TextFieldElement.makeName(
+                    type: .onCard,
                     defaultValue: defaultValues.name,
-                    label: STPLocalizedString("Name on card", "Label for name on card field")),
-                theme: theme
+                    theme: theme
+                )
             ) { field, params in
                 params.paymentMethodParams.nonnil_billingDetails.name = field.text
                 return params

--- a/StripeUICore/StripeUICore/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/en.lproj/Localizable.strings
@@ -1,9 +1,6 @@
 /* The label of a text field that is optional. For example, 'Email (optional)' or 'Name (optional) */
 "%@ (optional)" = "%@ (optional)";
 
-/* Error message for a generic text field when the input is incomplete. E.g. 'Name on card is incomplete' */
-"%@ is incomplete." = "%@ is incomplete.";
-
 /* Shown in a dropdown picker next to a card brand that is not accepted by a merchant. E.g. \"Visa (not accepted)\" */
 "(not accepted)" = "(not accepted)";
 

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+Factory.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/TextFieldElement+Factory.swift
@@ -15,7 +15,7 @@ import UIKit
     // MARK: - Name
     struct NameConfiguration: TextFieldElementConfiguration {
         @frozen public enum NameType {
-            case given, family, full, onAccount
+            case given, family, full, onAccount, onCard
         }
 
         let type: NameType
@@ -29,8 +29,28 @@ import UIKit
                 return .givenName
             case .family:
                 return .familyName
-            case .full, .onAccount:
+            case .full, .onAccount, .onCard:
                 return .name
+            }
+        }
+
+        public var invalidInputErrorLabel: String {
+            switch type {
+            case .given:
+                // TODO: Localize
+                return "First name is incomplete."
+            case .family:
+                // TODO: Localize
+                return "Last name is incomplete."
+            case .full:
+                // TODO: Localize
+                return "Full name is incomplete."
+            case .onAccount:
+                // TODO: Localize
+                return "Name on account is incomplete."
+            case .onCard:
+                // TODO: Localize
+                return "Name on card is incomplete."
             }
         }
 
@@ -61,12 +81,19 @@ import UIKit
                 return String.Localized.full_name
             case .onAccount:
                 return String.Localized.nameOnAccount
+            case .onCard:
+                // TODO: Localize
+                return "Name on card"
             }
         }
     }
 
     static func makeName(label: String? = nil, defaultValue: String?, theme: ElementsAppearance = .default) -> TextFieldElement {
         return TextFieldElement(configuration: NameConfiguration(type: .full, defaultValue: defaultValue, label: label), theme: theme)
+    }
+
+    static func makeName(type: NameConfiguration.NameType, defaultValue: String?, theme: ElementsAppearance = .default) -> TextFieldElement {
+        return TextFieldElement(configuration: NameConfiguration(type: type, defaultValue: defaultValue), theme: theme)
     }
 
     // MARK: - Email

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElementConfiguration.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElementConfiguration.swift
@@ -41,6 +41,11 @@ import UIKit
     var editConfiguration: EditConfiguration { get }
 
     /**
+     Error label to use when the input is invalid.
+     */
+    var invalidInputErrorLabel: String { get }
+
+    /**
      Validate the text.
      
      - Parameter isOptional: Whether or not the text field's value is optional.
@@ -102,6 +107,10 @@ public extension TextFieldElementConfiguration {
         return nil
     }
 
+    var invalidInputErrorLabel: String {
+        return "Complete all required fields."
+    }
+
     // Hide clear button by default
     var shouldShowClearButton: Bool {
         return false
@@ -121,17 +130,7 @@ public extension TextFieldElementConfiguration {
 
     func validate(text: String, isOptional: Bool) -> TextFieldElement.ValidationState {
         if text.stp_stringByRemovingCharacters(from: .whitespacesAndNewlines).isEmpty {
-            return isOptional ? .valid : .invalid(
-                TextFieldElement.Error.empty(
-                    localizedDescription: String(
-                        format: STPLocalizedString(
-                            "%@ is incomplete.",
-                            "Error message for a generic text field when the input is incomplete. E.g. 'Name on card is incomplete'"
-                        ),
-                        label
-                    )
-                )
-            )
+            return isOptional ? .valid : .invalid(TextFieldElement.Error.empty(localizedDescription: invalidInputErrorLabel))
         }
         return .valid
     }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request adds a localized error message for incomplete generic text fields, as a follow-up to https://github.com/stripe/stripe-ios/pull/5290.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
