### PR TITLE
Crypto Onramp SDK: Apple Pay Integration

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -94,7 +94,7 @@ struct AuthenticatedView: View {
                 }
 
                 VStack(alignment: .leading, spacing: 12) {
-                    Text("Checkout")
+                    Text("Check Out")
                         .font(.headline)
                         .foregroundColor(.secondary)
 
@@ -126,6 +126,7 @@ struct AuthenticatedView: View {
                         }
                     }
                 }
+                .frame(maxWidth: .infinity)
                 .padding()
                 .background(Color.secondary.opacity(0.1))
                 .cornerRadius(8)

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -113,12 +113,12 @@ struct AuthenticatedView: View {
                                 .cornerRadius(8)
                                 .disabled(shouldDisableButtons)
                                 .opacity(shouldDisableButtons ? 0.5 : 1)
-                            }
 
-                            Text("or")
-                                .font(.footnote)
-                                .bold()
-                                .foregroundColor(.secondary)
+                                Text("or")
+                                    .font(.footnote)
+                                    .bold()
+                                    .foregroundColor(.secondary)
+                            }
 
                             Button("Select Payment Method") {
                                 presentPaymentMethodSelector()

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -102,6 +102,10 @@ struct AuthenticatedView: View {
                         PaymentMethodCardView(preview: selectedPaymentMethod)
                     } else {
                         VStack(spacing: 8) {
+                            // Note: Apple Pay does not require iOS 16, but the native SwiftUI
+                            // `PayWithApplePayButton` does, which we're using in this example.
+                            // For earlier OS versions, use `PKPaymentButton` in UIKit, optionally
+                            // wrapping it in a `UIViewRepresentable` for SwiftUI.
                             if #available(iOS 16.0, *), StripeAPI.deviceSupportsApplePay() {
                                 PayWithApplePayButton(.plain) {
                                     presentApplePay()
@@ -209,7 +213,7 @@ struct AuthenticatedView: View {
 
         Task {
             do {
-                let result = try await coordinator.selectApplePay(using: request, from: viewController)
+                let result = try await coordinator.presentApplePay(using: request, from: viewController)
                 await MainActor.run {
                     isLoading.wrappedValue = false
 

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -39,66 +39,92 @@ struct AuthenticatedView: View {
     var body: some View {
         ScrollView {
             VStack(spacing: 20) {
-                if isIdentityVerificationComplete {
-                    Text("Identity Verification Complete")
-                        .foregroundColor(.green)
-                        .frame(maxWidth: .infinity)
-                        .padding()
-                        .background {
-                            RoundedRectangle(cornerRadius: 8)
-                                .foregroundColor(.green.opacity(0.1))
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Customer Information")
+                        .font(.headline)
+                        .foregroundColor(.secondary)
+
+                    // Identity and KYC actions within the section
+                    if isIdentityVerificationComplete {
+                        Text("Identity Verification Complete")
+                            .foregroundColor(.green)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background {
+                                RoundedRectangle(cornerRadius: 8)
+                                    .foregroundColor(.green.opacity(0.1))
+                            }
+                    } else {
+                        Button("Verify Identity") {
+                            verifyIdentity()
                         }
-                } else {
-                    Button("Verify Identity") {
-                        verifyIdentity()
+                        .buttonStyle(PrimaryButtonStyle())
+                        .disabled(shouldDisableButtons)
+                        .opacity(shouldDisableButtons ? 0.5 : 1)
+                    }
+
+                    Button("Submit KYC Information") {
+                        showKYCView = true
                     }
                     .buttonStyle(PrimaryButtonStyle())
                     .disabled(shouldDisableButtons)
                     .opacity(shouldDisableButtons ? 0.5 : 1)
-                }
 
-                Button("Submit KYC Information") {
-                    showKYCView = true
+                    HStack(spacing: 4) {
+                        Spacer()
+
+                        Text("Customer ID:")
+                            .font(.footnote)
+                            .bold()
+                            .foregroundColor(.secondary)
+                        Text(customerId)
+                            .font(.footnote.monospaced())
+                            .foregroundColor(.secondary)
+
+                        Spacer()
+                    }
                 }
-                .buttonStyle(PrimaryButtonStyle())
-                .disabled(shouldDisableButtons)
-                .opacity(shouldDisableButtons ? 0.5 : 1)
+                .padding()
+                .background(Color.secondary.opacity(0.1))
+                .cornerRadius(8)
+
 
                 if let errorMessage {
                     ErrorMessageView(message: errorMessage)
                 }
 
-                if let selectedPaymentMethod {
-                    PaymentMethodCardView(preview: selectedPaymentMethod)
-                } else {
-                    Button("Select Payment Method") {
-                        presentPaymentMethodSelector()
-                    }
-                    .buttonStyle(PrimaryButtonStyle())
-                    .disabled(shouldDisableButtons)
-                    .opacity(shouldDisableButtons ? 0.5 : 1)
-
-                    if #available(iOS 16.0, *), StripeAPI.deviceSupportsApplePay() {
-                        PayWithApplePayButton(.plain) {
-                            presentApplePay()
-                        }
-                        .frame(height: 45)
-                        .frame(maxWidth: .infinity)
-                        .disabled(shouldDisableButtons)
-                        .opacity(shouldDisableButtons ? 0.5 : 1)
-                    }
-                }
-
-                VStack(spacing: 8) {
-                    Text("Customer ID")
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Payment Method")
                         .font(.headline)
                         .foregroundColor(.secondary)
-                        .padding(.horizontal)
 
-                    Text(customerId)
-                        .font(.subheadline.monospaced())
-                        .foregroundColor(.secondary)
-                        .padding(.horizontal)
+                    if let selectedPaymentMethod {
+                        PaymentMethodCardView(preview: selectedPaymentMethod)
+                    } else {
+                        VStack(spacing: 8) {
+                            if #available(iOS 16.0, *), StripeAPI.deviceSupportsApplePay() {
+                                PayWithApplePayButton(.plain) {
+                                    presentApplePay()
+                                }
+                                .frame(height: 52)
+                                .cornerRadius(8)
+                                .disabled(shouldDisableButtons)
+                                .opacity(shouldDisableButtons ? 0.5 : 1)
+                            }
+
+                            Text("or")
+                                .font(.footnote)
+                                .bold()
+                                .foregroundColor(.secondary)
+
+                            Button("Select Payment Method") {
+                                presentPaymentMethodSelector()
+                            }
+                            .buttonStyle(PrimaryButtonStyle())
+                            .disabled(shouldDisableButtons)
+                            .opacity(shouldDisableButtons ? 0.5 : 1)
+                        }
+                    }
                 }
                 .padding()
                 .background(Color.secondary.opacity(0.1))

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -88,7 +88,6 @@ struct AuthenticatedView: View {
                 .background(Color.secondary.opacity(0.1))
                 .cornerRadius(8)
 
-
                 if let errorMessage {
                     ErrorMessageView(message: errorMessage)
                 }

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -94,7 +94,7 @@ struct AuthenticatedView: View {
                 }
 
                 VStack(alignment: .leading, spacing: 12) {
-                    Text("Payment Method")
+                    Text("Checkout")
                         .font(.headline)
                         .foregroundColor(.secondary)
 

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/PaymentMethodCardView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/PaymentMethodCardView.swift
@@ -27,6 +27,7 @@ struct PaymentMethodCardView: View {
                     .frame(width: 24, height: 24)
                     .padding(8)
                     .background(.white.opacity(0.3))
+                    .foregroundColor(.white)
                     .clipShape(RoundedRectangle(cornerRadius: 6))
 
                 Text(preview.label)

--- a/StripeCryptoOnramp/README.md
+++ b/StripeCryptoOnramp/README.md
@@ -35,6 +35,7 @@ Placeholder
 ## Manual linking
 
 If you link the Stripe Crypto Onramp library manually, use a version from our [releases](https://github.com/stripe/stripe-ios/releases) page and make sure to embed <ins>all</ins> of the following frameworks:
+- `Stripe.xcframework`
 - `StripeCryptoOnramp.xcframework`
 - `StripeCore.xcframework`
 - `StripeUICore.xcframework`

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -11,6 +11,8 @@
 		0B34E23F2E2020E20072FC89 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B34E23E2E2020E20072FC89 /* StripeCore.framework */; };
 		0B4292912E1EC57700012FB8 /* StripeCryptoOnramp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B4292852E1EC57600012FB8 /* StripeCryptoOnramp.framework */; };
 		0B49B6B52E4A9213003E6393 /* PaymentMethodPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B49B6B42E4A9213003E6393 /* PaymentMethodPreview.swift */; };
+		0B63C98A2E4CEE04005D8BD2 /* Stripe.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B63C9892E4CEE04005D8BD2 /* Stripe.framework */; };
+		0B63C98E2E4CF8CD005D8BD2 /* ApplePayPaymentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B63C98D2E4CF8C1005D8BD2 /* ApplePayPaymentStatus.swift */; };
 		0B649EDE2E428F5A00AFAFB1 /* StartIdentityVerificationRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B649EDD2E428F5A00AFAFB1 /* StartIdentityVerificationRequest.swift */; };
 		0B649EE02E428F6400AFAFB1 /* StartIdentityVerificationResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B649EDF2E428F6400AFAFB1 /* StartIdentityVerificationResponse.swift */; };
 		0B649EE22E4293AB00AFAFB1 /* IdentityVerificationResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B649EE12E4293AB00AFAFB1 /* IdentityVerificationResult.swift */; };
@@ -75,6 +77,8 @@
 		0B4292852E1EC57600012FB8 /* StripeCryptoOnramp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCryptoOnramp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B4292902E1EC57700012FB8 /* StripeCryptoOnrampTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StripeCryptoOnrampTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B49B6B42E4A9213003E6393 /* PaymentMethodPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodPreview.swift; sourceTree = "<group>"; };
+		0B63C9892E4CEE04005D8BD2 /* Stripe.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Stripe.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0B63C98D2E4CF8C1005D8BD2 /* ApplePayPaymentStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplePayPaymentStatus.swift; sourceTree = "<group>"; };
 		0B649EDD2E428F5A00AFAFB1 /* StartIdentityVerificationRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartIdentityVerificationRequest.swift; sourceTree = "<group>"; };
 		0B649EDF2E428F6400AFAFB1 /* StartIdentityVerificationResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartIdentityVerificationResponse.swift; sourceTree = "<group>"; };
 		0B649EE12E4293AB00AFAFB1 /* IdentityVerificationResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentityVerificationResult.swift; sourceTree = "<group>"; };
@@ -126,6 +130,7 @@
 				0BED9B682E255FE8009FFF76 /* StripeIdentity.framework in Frameworks */,
 				0B34E23F2E2020E20072FC89 /* StripeCore.framework in Frameworks */,
 				0BED9B662E255FD7009FFF76 /* StripePaymentSheet.framework in Frameworks */,
+				0B63C98A2E4CEE04005D8BD2 /* Stripe.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -238,6 +243,7 @@
 		0B83D9982E1EF8B7004F0115 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0B63C9892E4CEE04005D8BD2 /* Stripe.framework */,
 				0B6DF3502E298AB6008B1800 /* StripeCoreTestUtils.framework */,
 				0BED9B692E255FF1009FFF76 /* StripeFinancialConnections.framework */,
 				0BED9B672E255FE8009FFF76 /* StripeIdentity.framework */,
@@ -262,6 +268,7 @@
 		0BED9B602E255BB1009FFF76 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				0B63C98D2E4CF8C1005D8BD2 /* ApplePayPaymentStatus.swift */,
 				0B20053E2E318231008FCF8D /* VerificationResult.swift */,
 				0BED9B612E255BC2009FFF76 /* CryptoOnrampCoordinator.swift */,
 				0BF41E882E3AB82E00CA4171 /* KycInfo.swift */,
@@ -402,6 +409,7 @@
 				0B649EE22E4293AB00AFAFB1 /* IdentityVerificationResult.swift in Sources */,
 				0BED9B622E255BC2009FFF76 /* CryptoOnrampCoordinator.swift in Sources */,
 				49D233AA2E439FAA00F51263 /* RegisterWalletRequest.swift in Sources */,
+				0B63C98E2E4CF8CD005D8BD2 /* ApplePayPaymentStatus.swift in Sources */,
 				0BF41E892E3AB82E00CA4171 /* KycInfo.swift in Sources */,
 				0BA705082E4132640044B483 /* KYCDataCollectionResponse.swift in Sources */,
 				49D233AC2E439FB200F51263 /* RegisterWalletResponse.swift in Sources */,

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/ApplePayPaymentStatus.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/ApplePayPaymentStatus.swift
@@ -1,0 +1,27 @@
+//
+//  ApplePayPaymentStatus.swift
+//  StripeCryptoOnramp
+//
+//  Created by Michael Liberatore on 8/13/25.
+//
+
+/// Possible return statuses from `CryptoOnrampCoordinator.selectApplePay(using:from)`.
+@_spi(CryptoOnrampSDKPreview)
+public enum ApplePayPaymentStatus {
+
+    /// Attempt to use Apple Pay resulted in success.
+    case success
+
+    /// The user canceled payment using Apple Pay.
+    case canceled
+}
+
+public extension ApplePayPaymentStatus {
+
+    /// Encapsulates a fallback error in the unlikely event that Apple Pay fails without a specified error.
+    enum Error: Swift.Error {
+
+        /// A fallback error case in the unlikely event that Apple Pay fails without a specified error.
+        case applePayFallbackError
+    }
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/ApplePayPaymentStatus.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/ApplePayPaymentStatus.swift
@@ -5,7 +5,7 @@
 //  Created by Michael Liberatore on 8/13/25.
 //
 
-/// Possible return statuses from `CryptoOnrampCoordinator.selectApplePay(using:from)`.
+/// Possible return statuses from `CryptoOnrampCoordinator.presentApplePay(using:from)`.
 @_spi(CryptoOnrampSDKPreview)
 public enum ApplePayPaymentStatus {
 

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -74,7 +74,13 @@ public protocol CryptoOnrampCoordinatorProtocol {
     /// - Returns: A `PaymentMethodPreview` if the user selected a payment method, or `nil` otherwise.
     func collectPaymentMethod(from viewController: UIViewController) async -> PaymentMethodPreview?
 
-    func selectApplePay(using paymentRequest: PKPaymentRequest, from viewController: UIViewController) async throws -> ApplePayPaymentStatus
+    /// Presents the Apple Pay interface to initiate checkout. Intended to be called in response to tapping a `PKPaymentButton` or `PayWithApplePayButton`.
+    /// - Parameters:
+    ///   - paymentRequest: Represents the request for payment using Apple Pay.
+    ///   - viewController: The view controller from which to present the Apple Pay interface.
+    /// - Returns: A payment status indicating whether the payment request was successful or canceled.
+    /// Throws if an error occurs accepting the payment request.
+    func presentApplePay(using paymentRequest: PKPaymentRequest, from viewController: UIViewController) async throws -> ApplePayPaymentStatus
 }
 
 /// Coordinates headless Link user authentication and identity verification, leaving most of the UI to the client.
@@ -219,7 +225,7 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
     }
 
     @MainActor
-    public func selectApplePay(using paymentRequest: PKPaymentRequest, from viewController: UIViewController) async throws -> ApplePayPaymentStatus {
+    public func presentApplePay(using paymentRequest: PKPaymentRequest, from viewController: UIViewController) async throws -> ApplePayPaymentStatus {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<ApplePayPaymentStatus, Swift.Error>) in
             guard let context = STPApplePayContext(paymentRequest: paymentRequest, delegate: self) else {
                 continuation.resume(throwing: ApplePayPaymentStatus.Error.applePayFallbackError)


### PR DESCRIPTION
## Summary
Adds the ability to present Apple Pay from CryptoOnramp

## Motivation
To ensure Apple Pay is offered prominently alongside other payment methods.

## Testing

1. Using the Example app, I verified my account.
2. On the Authenticated view, I tapped the Apple Pay button.
3. I canceled from the Apple Pay sheet, and saw the sheet dismiss.
4. I tapped it again.
5. I completed payment.
6. I saw the card UI replace the payment option buttons.

Here’s a video of the happy path without steps 3+4:

https://github.com/user-attachments/assets/6fdc242b-c041-439a-82be-f9c95e1ae6a7

## Changelog
N/A