### PR TITLE
Cleanup some CompositorServices references 2

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/DropdownFieldElement.swift
@@ -82,7 +82,7 @@ import UIKit
 
     /// A label displayed in the dropdown field UI e.g. "Country or region" for a country dropdown
     public let label: String?
-#if targetEnvironment(macCatalyst) || canImport(CompositorServices)
+#if targetEnvironment(macCatalyst) || canImport(visionOS)
     private(set) lazy var pickerView: UIButton = {
         let button = UIButton()
         let action = { (action: UIAction) in
@@ -239,7 +239,7 @@ import UIKit
 private extension DropdownFieldElement {
 
     func updatePickerField() {
-        #if targetEnvironment(macCatalyst) || canImport(CompositorServices)
+        #if targetEnvironment(macCatalyst) || canImport(visionOS)
         if #available(macCatalyst 14.0, *) {
             // Mark the enabled menu item as selected
             pickerView.menu?.children.forEach { ($0 as? UIAction)?.state = .off }

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/DropdownFieldElement+AddressFactory.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/DropdownFieldElement+AddressFactory.swift
@@ -27,7 +27,7 @@ import Foundation
             let dropdownItems: [DropdownItem] = countryCodes.map {
                 let flagEmoji = String.countryFlagEmoji(for: $0) ?? ""              // 🇺🇸
                 let countryName = locale.localizedString(forRegionCode: $0) ?? $0   // United States
-                #if targetEnvironment(macCatalyst) || canImport(CompositorServices)
+                #if targetEnvironment(macCatalyst) || canImport(visionOS)
                 // When using UIMenu with a keyboard, type-ahead search is based on the string name.
                 // This doesn't work if we prepend an emoji, so leave that out on macOS.
                 let pickerDisplayName = countryName

--- a/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerFieldView.swift
@@ -29,7 +29,7 @@ final class PickerFieldView: UIView {
     private lazy var textField: PickerTextField = {
         let textField = PickerTextField()
         // Input views are not supported on Catalyst (and are non-optimal on visionOS)
-#if !targetEnvironment(macCatalyst) && !canImport(CompositorServices)
+#if !targetEnvironment(macCatalyst) && !canImport(visionOS)
         textField.inputView = pickerView
 #endif
         textField.adjustsFontForContentSizeCategory = true
@@ -139,7 +139,7 @@ final class PickerFieldView: UIView {
         super.init(frame: .zero)
         addAndPinSubview(hStackView, directionalLayoutMargins: hasPadding ? theme.textFieldInsets : .zero)
 //      On Catalyst/visionOS, add the picker view as a subview instead of an input view.
-        #if targetEnvironment(macCatalyst) || canImport(CompositorServices)
+        #if targetEnvironment(macCatalyst) || canImport(visionOS)
         addAndPinSubview(pickerView, directionalLayoutMargins: theme.textFieldInsets)
         #endif
         layer.borderColor = theme.colors.border.cgColor
@@ -179,7 +179,7 @@ final class PickerFieldView: UIView {
         guard isUserInteractionEnabled, !isHidden, self.point(inside: point, with: event) else {
             return nil
         }
-        #if targetEnvironment(macCatalyst) || canImport(CompositorServices)
+        #if targetEnvironment(macCatalyst) || canImport(visionOS)
         // Forward all events within our bounds to the button
         return pickerView
         #else


### PR DESCRIPTION
## Summary
Cleaning up some references that were missed in https://github.com/stripe/stripe-ios/pull/5143

## Motivation
We no longer support the Xcode versions that required the hacky CompositorServices compiler check for conditional visionOS behavior and can now directly check.

## Testing
build

## Changelog
N/A
