### PR TITLE
Show Link form validation errors inline

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -182,6 +182,12 @@ extension PayWithLinkViewController {
         }
 
         private func didTapWhenDisabled() {
+            // Clear any previous confirmation error
+            updateErrorLabel(for: nil)
+
+#if !os(visionOS)
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+#endif
             addPaymentMethodVC.paymentMethodFormElement.showAllValidationErrors()
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
@@ -54,12 +54,13 @@ extension PayWithLinkViewController {
         }
 
         private func didTapWhenDisabled() {
-            guard case let .invalid(error, _) = paymentMethodEditElement.validationState else {
-                return
-            }
+            // Clear any previous confirmation error
+            updateErrorLabel(for: nil)
 
-            errorLabel.text = error.localizedDescription
-            errorLabel.isHidden = false
+#if !os(visionOS)
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+#endif
+            paymentMethodEditElement.showAllValidationErrors()
         }
 
         private lazy var errorLabel: UILabel = {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
@@ -273,6 +273,9 @@ final class LinkPaymentMethodFormElement: Element {
         self.checkboxElement.checkboxButton.isHidden = true
     }
 
+    func showAllValidationErrors() {
+        formElement.showAllValidationErrors()
+    }
 }
 
 extension LinkPaymentMethodFormElement: ElementDelegate {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request updates the Link update card screen and shows validation errors inline instead of below the form.

| Before | After |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-14 at 11 36 51" src="https://github.com/user-attachments/assets/69fc1ab4-760f-4446-ab98-ea99cb43e362" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-14 at 11 35 31" src="https://github.com/user-attachments/assets/c5f9ee8e-02f7-48b8-b030-95ff0bf970ec" /> |

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
