### PR TITLE
Provide payment method icons in LinkController

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
@@ -108,7 +108,8 @@ struct CryptoOnrampExampleView: View {
                 let appearance = LinkAppearance(
                     colors: .init(primary: lavenderColor, selectedBorder: .label),
                     primaryButton: .init(cornerRadius: 16, height: 56),
-                    style: .automatic
+                    style: .automatic,
+                    reduceLinkBranding: true
                 )
                 let coordinator = try await CryptoOnrampCoordinator.create(appearance: appearance)
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkAppearance.swift
@@ -57,18 +57,25 @@ public struct LinkAppearance {
     /// Style options for colors in the Link UI.
     public let style: PaymentSheet.UserInterfaceStyle
 
+    /// When true, reduces Link branding in payment method previews by showing payment
+    /// method-specific icons (e.g., Visa, Mastercard) instead of the Link icon.
+    public let reduceLinkBranding: Bool
+
     /// Creates a new instance of `LinkAppearance`.
     /// - Parameters:
     ///   - colors: Custom colors used throughout the Link UI. Defaults to Link colors.
     ///   - primaryButton: Configuration values for the primary button. Uses reasonable defaults if nothing is provided.
     ///   - style: Style options for colors in the Link UI.
+    ///   - reduceLinkBranding: When true, reduces Link branding by showing payment method-specific icons. Defaults to false.
     public init(
         colors: Colors? = nil,
         primaryButton: PrimaryButtonConfiguration? = nil,
-        style: PaymentSheet.UserInterfaceStyle = .automatic
+        style: PaymentSheet.UserInterfaceStyle = .automatic,
+        reduceLinkBranding: Bool = false
     ) {
         self.colors = colors
         self.primaryButton = primaryButton
         self.style = style
+        self.reduceLinkBranding = reduceLinkBranding
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -10,6 +10,7 @@ import UIKit
 
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripeUICore
 
 /// A controller that presents a Link sheet to collect a customer's payment method.
@@ -78,7 +79,7 @@ import UIKit
                 return
             }
             paymentMethodPreview = .init(
-                icon: Self.linkIcon,
+                icon: iconForPaymentDetails(selectedPaymentDetails),
                 label: STPPaymentMethodType.link.displayName,
                 sublabel: selectedPaymentDetails.linkPaymentDetailsFormattedString
             )
@@ -124,6 +125,22 @@ import UIKit
     }
 
     @_spi(STP) public static var linkIcon: UIImage = Image.link_icon.makeImage()
+
+    private func iconForPaymentDetails(_ paymentDetails: ConsumerPaymentDetails) -> UIImage {
+        guard let appearance, appearance.reduceLinkBranding else {
+            return Self.linkIcon
+        }
+
+        switch paymentDetails.details {
+        case .card(let card):
+            return STPImageLibrary.cardBrandImage(for: card.stpBrand)
+        case .bankAccount(let bankAccount):
+            let iconCode = PaymentSheetImageLibrary.bankIconCode(for: bankAccount.name)
+            return PaymentSheetImageLibrary.bankIcon(for: iconCode, iconStyle: .filled)
+        case .unparsable:
+            return Self.linkIcon
+        }
+    }
 
     /// Creates a `LinkController` for the specified `mode`.
     ///


### PR DESCRIPTION
## Summary

Adds a new field to the `LinkAppearance`, `reduceLinkBranding`, which allows returning the appropriate payment method icon in `LinkController`'s `paymentMethodPreview`

## Motivation

🎨 

## Testing

| Visa | Mastercard | Bank |
|--------|--------|--------|
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-14 at 11 39 46" src="https://github.com/user-attachments/assets/b2481d4a-dc4a-4ba9-b20b-444bc7972980" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-14 at 11 39 21" src="https://github.com/user-attachments/assets/cff71e8e-bd88-48af-b627-9d84abeda67b" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-14 at 11 38 35" src="https://github.com/user-attachments/assets/888b70df-6712-4bb2-bd4b-18880d87efda" /> | 

## Changelog

N/a
