### PR TITLE
Temporarily remove buildMenu override

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerTextField.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/PickerField/PickerTextField.swift
@@ -35,11 +35,12 @@ class PickerTextField: UITextField {
         false
     }
 
-    override func buildMenu(with builder: any UIMenuBuilder) {
+    // TODO(gbirch) temporarily removed to fix an Xcode 26 beta 5 bug that causes the availability check to not work and the code to crash on iOS <17
+//    override func buildMenu(with builder: any UIMenuBuilder) {
         // autoFill bypasses the canPerformAction check, so we have to directly remove it from the UIMenuBuilder
         // enumerating every possible menu to remove them would be too tedious and require too much updating with newer iOS versions, so the others are left to the canPerformAction check
-        if #available(iOS 17.0, *) {
-            builder.remove(menu: .autoFill)
-        }
-    }
+//        if #available(iOS 17.0, *) {
+//            builder.remove(menu: .autoFill)
+//        }
+//    }
 }


### PR DESCRIPTION
## Summary
The iOS 17 availability check appears to not work on Xcode 26 beta 5, causing the example apps (and presumably other host apps) to crash instantly on launch on devices/sim running iOS < 17. This change should hopefully be able to be reinstated with future Xcode versions.

## Motivation
Avoid user app crashes when building with Xcode 26

## Testing
Doesn't crash!

## Changelog
N/A
