### PR TITLE
skip dead code check

### DIFF
--- a/.github/workflows/find-dead-code.yml
+++ b/.github/workflows/find-dead-code.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   dead-code-check:
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip dead code check') }}
+    if: false
     runs-on: macos-15
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary
- Skip dead code check due to simulators not being able to be ran on github actions currently
