### PR TITLE
Downgrade crypto onramp project files

### DIFF
--- a/.github/workflows/verify-public-interface.yml
+++ b/.github/workflows/verify-public-interface.yml
@@ -2,11 +2,6 @@ name: Verify public interface
 on:
   pull_request:
     types: [opened, labeled, unlabeled, synchronize]
-    paths:
-      - '**/*.swift'
-      - '!StripeFinancialConnections/**'
-      - '!StripeIdentity/**'
-      - '!StripeConnections/**'
 
 jobs:
   public-api-check:

--- a/Example/CryptoOnramp Example/CryptoOnramp Example.xcodeproj/project.pbxproj
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 70;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */

--- a/Example/CryptoOnramp Example/CryptoOnramp Example.xcodeproj/project.pbxproj
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example.xcodeproj/project.pbxproj
@@ -34,9 +34,15 @@
 		0BA5FE452E32AD5100D44BFE /* StripeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
-/* Begin PBXFileSystemSynchronizedRootGroup section */
-		0BA5FE342E32A11600D44BFE /* CryptoOnramp Example */ = {isa = PBXFileSystemSynchronizedRootGroup; explicitFileTypes = {}; explicitFolders = (); path = "CryptoOnramp Example"; sourceTree = "<group>"; };
-/* End PBXFileSystemSynchronizedRootGroup section */
+/* Begin PBXGroup section */
+		0BA5FE342E32A11600D44BFE /* CryptoOnramp Example */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = "CryptoOnramp Example";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		0BA5FE2F2E32A11600D44BFE /* Frameworks */ = {

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/ApplicationURLOpener.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/ApplicationURLOpener.swift
@@ -38,4 +38,20 @@ extension ApplicationURLOpener {
     }
 }
 
-extension UIApplication: ApplicationURLOpener {}
+extension UIApplication: ApplicationURLOpener {
+    func open(
+        _ url: URL,
+        options: [UIApplication.OpenExternalURLOptionsKey: Any],
+        completionHandler completion: OpenCompletionHandler?
+    ) {
+        let bridgedCompletion: ((Bool) -> Void)? = completion.map { handler in
+            { success in
+                Task { @MainActor in
+                    handler(success)
+                }
+            }
+        }
+
+        self.open(url, options: options, completionHandler: bridgedCompletion)
+    }
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -112,13 +112,15 @@
 		49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterWalletResponse.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
-/* Begin PBXFileSystemSynchronizedRootGroup section */
+/* Begin PBXGroup section */
 		0B7D05742E4A4D8200EE6BE2 /* Resources */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
+			isa = PBXGroup;
+			children = (
+			);
 			path = Resources;
 			sourceTree = "<group>";
 		};
-/* End PBXFileSystemSynchronizedRootGroup section */
+/* End PBXGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		0B4292822E1EC57600012FB8 /* Frameworks */ = {

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 77;
+	objectVersion = 55;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -366,7 +366,7 @@
 			);
 			mainGroup = 0B42927B2E1EC57600012FB8;
 			minimizedProjectReferenceProxies = 1;
-			preferredProjectObjectVersion = 77;
+			preferredProjectObjectVersion = 55;
 			productRefGroup = 0B4292862E1EC57600012FB8 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";


### PR DESCRIPTION
## Summary

Attempts to fix this issue: 

```
The project ‘StripeCryptoOnramp’ cannot be opened because it is in a future Xcode project file format (77). Adjust the project format using a compatible version of Xcode to allow it to be opened by this version of Xcode.” UserInfo={NSLocalizedDescription=The project ‘StripeCryptoOnramp’ cannot be opened because it is in a future Xcode project file format (77). Adjust the project format using a compatible version of Xcode to allow it to be opened by this version of Xcode.}
```

## Motivation

https://stripe.slack.com/archives/C02HQBW38JX/p1755278060742979

## Testing

Trust the GH Actions

## Changelog

N/a