### PR TITLE
Treat payment_method_remove=partial as enabled in CustomerSessions

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
@@ -49,7 +49,7 @@ struct CustomerSession: Equatable, Hashable {
 
             mobilePaymentElementComponent = MobilePaymentElementComponent(enabled: true,
                                                                           features: MobilePaymentElementComponentFeature(paymentMethodSave: paymentMethodSave == "enabled",
-                                                                                                                         paymentMethodRemove: paymentMethodRemove == "enabled",
+                                                                                                                         paymentMethodRemove: paymentMethodRemove == "enabled" || paymentMethodRemove == "partial",
                                                                                                                          paymentMethodRemoveLast: paymentMethodRemoveLast == "enabled",
                                                                                                                          paymentMethodSaveAllowRedisplayOverride: allowRedisplayOverrideValue,
                                                                                                                          paymentMethodSetAsDefault: paymentMethodSetAsDefault == "enabled"))
@@ -68,7 +68,7 @@ struct CustomerSession: Equatable, Hashable {
             let paymentMethodRemoveLast = customerSheetFeaturesDict["payment_method_remove_last"] as? String ?? "enabled"
             let paymentMethodSyncDefault = customerSheetFeaturesDict["payment_method_sync_default"] as? String ?? "disabled"
             customerSheetComponent = CustomerSheetComponent(enabled: true,
-                                                            features: CustomerSheetComponentFeature(paymentMethodRemove: paymentMethodRemove == "enabled",
+                                                            features: CustomerSheetComponentFeature(paymentMethodRemove: paymentMethodRemove == "enabled" || paymentMethodRemove == "partial",
                                                                                                     paymentMethodRemoveLast: paymentMethodRemoveLast == "enabled",
                                                                                                     paymentMethodSyncDefault: paymentMethodSyncDefault == "enabled"))
         } else {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -317,6 +317,48 @@ class STPElementsSessionTest: XCTestCase {
         XCTAssertFalse(allowsRemoval)
         XCTAssertEqual(.paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, savePaymentMethodConsentBehavior)
     }
+
+    func testSPMConsentAndRemoval_pmsE_pmrPartial() {
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
+                                                            customerSessionData: [
+                                                                "mobile_payment_element": [
+                                                                    "enabled": true,
+                                                                    "features": ["payment_method_save": "enabled",
+                                                                                 "payment_method_remove": "partial",
+                                                                                ],
+                                                                ],
+                                                                "customer_sheet": [
+                                                                    "enabled": false
+                                                                ],
+                                                            ])
+
+        let savePaymentMethodConsentBehavior = elementsSession.savePaymentMethodConsentBehavior
+        let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
+
+        XCTAssertTrue(allowsRemoval)
+        XCTAssertEqual(.paymentSheetWithCustomerSessionPaymentMethodSaveEnabled, savePaymentMethodConsentBehavior)
+    }
+
+    func testSPMConsentAndRemoval_pmsD_pmrPartial() {
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
+                                                            customerSessionData: [
+                                                                "mobile_payment_element": [
+                                                                    "enabled": true,
+                                                                    "features": ["payment_method_save": "disabled",
+                                                                                 "payment_method_remove": "partial",
+                                                                                ],
+                                                                ],
+                                                                "customer_sheet": [
+                                                                    "enabled": false
+                                                                ],
+                                                            ])
+
+        let savePaymentMethodConsentBehavior = elementsSession.savePaymentMethodConsentBehavior
+        let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
+
+        XCTAssertTrue(allowsRemoval)
+        XCTAssertEqual(.paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, savePaymentMethodConsentBehavior)
+    }
     func testPaymentMethodRemoveLast_enabled() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
                                                             customerSessionData: [
@@ -475,6 +517,25 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
 
         XCTAssertFalse(allowsRemoval)
+        XCTAssertTrue(elementsSession.paymentMethodRemoveLastForCustomerSheet)
+    }
+
+    func testAllowsRemovalOfPaymentMethodsForCustomerSheet_partial() {
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
+                                                            customerSessionData: [
+                                                                "mobile_payment_element": [
+                                                                    "enabled": false
+                                                                ],
+                                                                "customer_sheet": [
+                                                                    "enabled": true,
+                                                                    "features": ["payment_method_remove": "partial",
+                                                                                ],
+                                                                ],
+                                                              ])
+
+        let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
+
+        XCTAssertTrue(allowsRemoval)
         XCTAssertTrue(elementsSession.paymentMethodRemoveLastForCustomerSheet)
     }
     func testAllowsRemovalOfPaymentMethodsForCustomerSheet_removeLast_enabled() {


### PR DESCRIPTION
## Summary
- Update CustomerSession decoding to treat `payment_method_remove=partial` the same as `payment_method_remove=enabled`
- Apply this logic to both mobile payment element and customer sheet components  
- Add comprehensive tests covering all partial scenarios

## Test plan
- [x] Added unit tests for mobile payment element with `payment_method_remove=partial`
- [x] Added unit tests for customer sheet with `payment_method_remove=partial`  
- [x] Tests verify that partial behaves identically to enabled for payment method removal

🤖 Generated with [Claude Code](https://claude.ai/code)