### PR TITLE
Hide secondary Link CTA when shown from the LinkController

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -311,7 +311,8 @@ import UIKit
             analyticsHelper: analyticsHelper,
             supportedPaymentMethodTypes: supportedPaymentMethodTypes,
             linkAppearance: appearance,
-            linkConfiguration: linkConfiguration
+            linkConfiguration: linkConfiguration,
+            shouldShowSecondaryCta: false
         ) { [weak self] confirmOption, shouldClearSelection in
             guard let confirmOption else {
                 if shouldClearSelection {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -29,6 +29,7 @@ extension UIViewController {
         supportedPaymentMethodTypes: [LinkPaymentMethodType] = LinkPaymentMethodType.allCases,
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
+        shouldShowSecondaryCta: Bool = true,
         verificationDismissed: (() -> Void)? = nil,
         callback: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
     ) {
@@ -75,6 +76,7 @@ extension UIViewController {
                 supportedPaymentMethodTypes: supportedPaymentMethodTypes,
                 linkAppearance: linkAppearance,
                 linkConfiguration: linkConfiguration,
+                shouldShowSecondaryCta: shouldShowSecondaryCta,
                 callback: callback
             )
         }
@@ -89,6 +91,7 @@ extension UIViewController {
         supportedPaymentMethodTypes: [LinkPaymentMethodType],
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
+        shouldShowSecondaryCta: Bool = true,
         callback: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
     ) {
         let payWithLinkController = PayWithNativeLinkController(
@@ -106,6 +109,7 @@ extension UIViewController {
         payWithLinkController.presentForPaymentMethodSelection(
             from: self,
             initiallySelectedPaymentDetailsID: selectedPaymentDetailsID,
+            shouldShowSecondaryCta: shouldShowSecondaryCta,
             canSkipWalletAfterVerification: false,
             completion: callback
         )


### PR DESCRIPTION
## Summary

We don't want the `Continue another way` button to be shown when Link is presented from the LinkController. It should still show that button if it is presented from flow controller.

## Motivation

https://stripe.slack.com/archives/C094P3BRBL1/p1755269239094089

## Testing

| FlowController | LinkController |
|--------|--------|
| <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-18 at 10 47 59" src="https://github.com/user-attachments/assets/6de47cb6-0f32-4da3-8504-ad1f14010dad" /> | <img width="1179" height="2556" alt="Simulator Screenshot - iPhone 16 - 2025-08-18 at 10 47 24" src="https://github.com/user-attachments/assets/1de6bd42-f597-4f31-b9c1-e0adaaff4cd8" /> |

## Changelog

N/a