### PR TITLE
[Onramp] Use Stripe's MoR keys for payment method creation requests

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -27,6 +27,7 @@ struct AuthenticatedView: View {
     @State private var isIdentityVerificationComplete = false
     @State private var showKYCView = false
     @State private var selectedPaymentMethod: PaymentMethodPreview?
+    @State private var cryptoPaymentToken: String?
 
     @Environment(\.isLoading) private var isLoading
 
@@ -99,6 +100,11 @@ struct AuthenticatedView: View {
 
                     if let selectedPaymentMethod {
                         PaymentMethodCardView(preview: selectedPaymentMethod)
+
+                        Button("Create crypto payment token") {
+                            createCryptoPaymentToken()
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
                     } else {
                         VStack(spacing: 8) {
                             // Note: Apple Pay does not require iOS 16, but the native SwiftUI
@@ -230,6 +236,26 @@ struct AuthenticatedView: View {
                 await MainActor.run {
                     isLoading.wrappedValue = false
                     errorMessage = "Apple Pay failed: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    private func createCryptoPaymentToken() {
+        isLoading.wrappedValue = true
+        errorMessage = nil
+
+        Task {
+            do {
+                let token = try await coordinator.createCryptoPaymentToken()
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    cryptoPaymentToken = token
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    errorMessage = "Create crypto payment token failed: \(error.localizedDescription)"
                 }
             }
         }

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -72,8 +72,6 @@ struct AuthenticatedView: View {
                     .opacity(shouldDisableButtons ? 0.5 : 1)
 
                     HStack(spacing: 4) {
-                        Spacer()
-
                         Text("Customer ID:")
                             .font(.footnote)
                             .bold()
@@ -81,8 +79,6 @@ struct AuthenticatedView: View {
                         Text(customerId)
                             .font(.footnote.monospaced())
                             .foregroundColor(.secondary)
-
-                        Spacer()
                     }
                 }
                 .padding()
@@ -105,6 +101,18 @@ struct AuthenticatedView: View {
                             createCryptoPaymentToken()
                         }
                         .buttonStyle(PrimaryButtonStyle())
+
+                        if let cryptoPaymentToken {
+                            HStack(spacing: 4) {
+                                Text("Crypto payment token:")
+                                    .font(.footnote)
+                                    .bold()
+                                    .foregroundColor(.secondary)
+                                Text(cryptoPaymentToken)
+                                    .font(.footnote.monospaced())
+                                    .foregroundColor(.secondary)
+                            }
+                        }
                     } else {
                         VStack(spacing: 8) {
                             // Note: Apple Pay does not require iOS 16, but the native SwiftUI
@@ -141,23 +149,6 @@ struct AuthenticatedView: View {
                 .padding()
                 .background(Color.secondary.opacity(0.1))
                 .cornerRadius(8)
-
-                if let cryptoPaymentToken {
-                    VStack(spacing: 8) {
-                        Text("Crypto Payment Token")
-                            .font(.headline)
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal)
-
-                        Text(cryptoPaymentToken)
-                            .font(.subheadline.monospaced())
-                            .foregroundColor(.secondary)
-                            .padding(.horizontal)
-                    }
-                    .padding()
-                    .background(Color.blue.opacity(0.1))
-                    .cornerRadius(8)
-                }
 
                 HiddenNavigationLink(
                     destination: KYCInfoView(coordinator: coordinator),

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -95,7 +95,11 @@ struct AuthenticatedView: View {
                         .foregroundColor(.secondary)
 
                     if let selectedPaymentMethod {
-                        PaymentMethodCardView(preview: selectedPaymentMethod)
+                        HStack {
+                            Spacer()
+                            PaymentMethodCardView(preview: selectedPaymentMethod)
+                            Spacer()
+                        }
 
                         Button("Create crypto payment token") {
                             createCryptoPaymentToken()

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -142,6 +142,23 @@ struct AuthenticatedView: View {
                 .background(Color.secondary.opacity(0.1))
                 .cornerRadius(8)
 
+                if let cryptoPaymentToken {
+                    VStack(spacing: 8) {
+                        Text("Crypto Payment Token")
+                            .font(.headline)
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal)
+
+                        Text(cryptoPaymentToken)
+                            .font(.subheadline.monospaced())
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal)
+                    }
+                    .padding()
+                    .background(Color.blue.opacity(0.1))
+                    .cornerRadius(8)
+                }
+
                 HiddenNavigationLink(
                     destination: KYCInfoView(coordinator: coordinator),
                     isActive: $showKYCView

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/PaymentMethodCardView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/PaymentMethodCardView.swift
@@ -46,7 +46,6 @@ struct PaymentMethodCardView: View {
             }
         }
         .aspectRatio(1.6 / 1, contentMode: .fit)
-        .frame(maxWidth: 280)
         .padding()
         .background(
             LinearGradient(

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/PaymentMethodCardView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/PaymentMethodCardView.swift
@@ -46,6 +46,7 @@ struct PaymentMethodCardView: View {
             }
         }
         .aspectRatio(1.6 / 1, contentMode: .fit)
+        .frame(maxHeight: 180)
         .padding()
         .background(
             LinearGradient(

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -192,6 +192,9 @@
 				49D73DF82E4E49EC00E35F1F /* String+Localized.swift */,
 				0B089E6E2E53935B007D160E /* CheckoutError.swift */,
 				0B6DF3472E296E2F008B1800 /* API Bindings */,
+				49D73DF22E4E499F00E35F1F /* StripeCryptoOnrampBundleLocator.swift */,
+				49D73DF42E4E49C300E35F1F /* STPLocalizedString+StripeCryptoOnramp.swift */,
+				49D73DF82E4E49EC00E35F1F /* String+Localized.swift */,
 			);
 			path = Internal;
 			sourceTree = "<group>";

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -202,9 +202,9 @@
 		0B6DF3472E296E2F008B1800 /* API Bindings */ = {
 			isa = PBXGroup;
 			children = (
+				0B6DF3482E296E38008B1800 /* STPAPIClient+CryptoOnramp.swift */,
 				0B089E822E53B254007D160E /* CreatePaymentTokenResponse.swift */,
 				490D4AC62E5541A600FAF4FF /* CreatePaymentTokenRequest.swift */,
-				0B6DF3482E296E38008B1800 /* STPAPIClient+CryptoOnramp.swift */,
 				0B6DF34C2E297E22008B1800 /* CustomerResponse.swift */,
 				0B6DF34A2E297E0A008B1800 /* CustomerRequest.swift */,
 				0BA705072E4132640044B483 /* KYCDataCollectionResponse.swift */,

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		0BED9B6A2E255FF1009FFF76 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BED9B692E255FF1009FFF76 /* StripeFinancialConnections.framework */; };
 		0BF41E892E3AB82E00CA4171 /* KycInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF41E882E3AB82E00CA4171 /* KycInfo.swift */; };
 		0BF41E8B2E3AB84800CA4171 /* IdType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF41E8A2E3AB84800CA4171 /* IdType.swift */; };
+		4907AF512E54B80000F0C49D /* PlatformSettingsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4907AF502E54B80000F0C49D /* PlatformSettingsResponse.swift */; };
 		49D233A82E439EB900F51263 /* CryptoNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A72E439EB900F51263 /* CryptoNetwork.swift */; };
 		49D233AA2E439FAA00F51263 /* RegisterWalletRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */; };
 		49D233AC2E439FB200F51263 /* RegisterWalletResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */; };
@@ -120,6 +121,7 @@
 		0BED9B692E255FF1009FFF76 /* StripeFinancialConnections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeFinancialConnections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0BF41E882E3AB82E00CA4171 /* KycInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KycInfo.swift; sourceTree = "<group>"; };
 		0BF41E8A2E3AB84800CA4171 /* IdType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdType.swift; sourceTree = "<group>"; };
+		4907AF502E54B80000F0C49D /* PlatformSettingsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsResponse.swift; sourceTree = "<group>"; };
 		49D233A72E439EB900F51263 /* CryptoNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoNetwork.swift; sourceTree = "<group>"; };
 		49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterWalletRequest.swift; sourceTree = "<group>"; };
 		49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterWalletResponse.swift; sourceTree = "<group>"; };
@@ -213,6 +215,7 @@
 				0B649EDF2E428F6400AFAFB1 /* StartIdentityVerificationResponse.swift */,
 				49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */,
 				49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */,
+				4907AF502E54B80000F0C49D /* PlatformSettingsResponse.swift */,
 			);
 			path = "API Bindings";
 			sourceTree = "<group>";

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		0BF41E892E3AB82E00CA4171 /* KycInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF41E882E3AB82E00CA4171 /* KycInfo.swift */; };
 		0BF41E8B2E3AB84800CA4171 /* IdType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF41E8A2E3AB84800CA4171 /* IdType.swift */; };
 		490D4AAE2E552D6F00FAF4FF /* PlatformSettingsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4907AF502E54B80000F0C49D /* PlatformSettingsResponse.swift */; };
+		490D4AC72E5541A600FAF4FF /* CreatePaymentTokenRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490D4AC62E5541A600FAF4FF /* CreatePaymentTokenRequest.swift */; };
 		49D233A82E439EB900F51263 /* CryptoNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A72E439EB900F51263 /* CryptoNetwork.swift */; };
 		49D233AA2E439FAA00F51263 /* RegisterWalletRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */; };
 		49D233AC2E439FB200F51263 /* RegisterWalletResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */; };
@@ -122,6 +123,7 @@
 		0BF41E882E3AB82E00CA4171 /* KycInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KycInfo.swift; sourceTree = "<group>"; };
 		0BF41E8A2E3AB84800CA4171 /* IdType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdType.swift; sourceTree = "<group>"; };
 		4907AF502E54B80000F0C49D /* PlatformSettingsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsResponse.swift; sourceTree = "<group>"; };
+		490D4AC62E5541A600FAF4FF /* CreatePaymentTokenRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentTokenRequest.swift; sourceTree = "<group>"; };
 		49D233A72E439EB900F51263 /* CryptoNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoNetwork.swift; sourceTree = "<group>"; };
 		49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterWalletRequest.swift; sourceTree = "<group>"; };
 		49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterWalletResponse.swift; sourceTree = "<group>"; };
@@ -188,10 +190,6 @@
 			children = (
 				0B63C98D2E4CF8C1005D8BD2 /* ApplePayPaymentStatus.swift */,
 				0B089E6A2E5386C9007D160E /* SelectedPaymentSource.swift */,
-				0B6DF3472E296E2F008B1800 /* API Bindings */,
-				49D73DF22E4E499F00E35F1F /* StripeCryptoOnrampBundleLocator.swift */,
-				49D73DF42E4E49C300E35F1F /* STPLocalizedString+StripeCryptoOnramp.swift */,
-				49D73DF82E4E49EC00E35F1F /* String+Localized.swift */,
 				0B089E6E2E53935B007D160E /* CheckoutError.swift */,
 				0B6DF3472E296E2F008B1800 /* API Bindings */,
 				49D73DF22E4E499F00E35F1F /* StripeCryptoOnrampBundleLocator.swift */,
@@ -205,6 +203,7 @@
 			isa = PBXGroup;
 			children = (
 				0B089E822E53B254007D160E /* CreatePaymentTokenResponse.swift */,
+				490D4AC62E5541A600FAF4FF /* CreatePaymentTokenRequest.swift */,
 				0B6DF3482E296E38008B1800 /* STPAPIClient+CryptoOnramp.swift */,
 				0B6DF34C2E297E22008B1800 /* CustomerResponse.swift */,
 				0B6DF34A2E297E0A008B1800 /* CustomerRequest.swift */,
@@ -448,6 +447,7 @@
 				0B6DF34B2E297E0A008B1800 /* CustomerRequest.swift in Sources */,
 				0B089E692E5378F7007D160E /* PaymentMethodType.swift in Sources */,
 				0B089E6B2E5386C9007D160E /* SelectedPaymentSource.swift in Sources */,
+				490D4AC72E5541A600FAF4FF /* CreatePaymentTokenRequest.swift in Sources */,
 				49D73DF52E4E49C300E35F1F /* STPLocalizedString+StripeCryptoOnramp.swift in Sources */,
 				0B6DF34D2E297E27008B1800 /* CustomerResponse.swift in Sources */,
 				0BF41E8B2E3AB84800CA4171 /* IdType.swift in Sources */,

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -47,7 +47,7 @@
 		0BED9B6A2E255FF1009FFF76 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0BED9B692E255FF1009FFF76 /* StripeFinancialConnections.framework */; };
 		0BF41E892E3AB82E00CA4171 /* KycInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF41E882E3AB82E00CA4171 /* KycInfo.swift */; };
 		0BF41E8B2E3AB84800CA4171 /* IdType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF41E8A2E3AB84800CA4171 /* IdType.swift */; };
-		4907AF512E54B80000F0C49D /* PlatformSettingsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4907AF502E54B80000F0C49D /* PlatformSettingsResponse.swift */; };
+		490D4AAE2E552D6F00FAF4FF /* PlatformSettingsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4907AF502E54B80000F0C49D /* PlatformSettingsResponse.swift */; };
 		49D233A82E439EB900F51263 /* CryptoNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A72E439EB900F51263 /* CryptoNetwork.swift */; };
 		49D233AA2E439FAA00F51263 /* RegisterWalletRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */; };
 		49D233AC2E439FB200F51263 /* RegisterWalletResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */; };
@@ -458,6 +458,7 @@
 				49D73DF92E4E49EC00E35F1F /* String+Localized.swift in Sources */,
 				0B649EDE2E428F5A00AFAFB1 /* StartIdentityVerificationRequest.swift in Sources */,
 				0BA7050A2E413D6B0044B483 /* KYCDataCollectionRequest.swift in Sources */,
+				490D4AAE2E552D6F00FAF4FF /* PlatformSettingsResponse.swift in Sources */,
 				49D73DF32E4E499F00E35F1F /* StripeCryptoOnrampBundleLocator.swift in Sources */,
 				0B649EE02E428F6400AFAFB1 /* StartIdentityVerificationResponse.swift in Sources */,
 				49D233A82E439EB900F51263 /* CryptoNetwork.swift in Sources */,

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -160,9 +160,6 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
             requestSurface: .cryptoOnramp
         )
 
-        let platformSettings = try await apiClient.getPlatformSettings()
-        apiClient.publishableKey = platformSettings.publishableKey
-
         return CryptoOnrampCoordinator(
             linkController: linkController,
             apiClient: apiClient,

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -123,11 +123,6 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
         case invalidSelectedPaymentSource
     }
 
-    private enum SelectedPaymentSource {
-        case link
-        case applePay(STPPaymentMethod)
-    }
-
     private let linkController: LinkController
     private let apiClient: STPAPIClient
     private let appearance: LinkAppearance

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -160,6 +160,9 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
             requestSurface: .cryptoOnramp
         )
 
+        let platformSettings = try await apiClient.getPlatformSettings()
+        apiClient.publishableKey = platformSettings.publishableKey
+
         return CryptoOnrampCoordinator(
             linkController: linkController,
             apiClient: apiClient,

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -314,16 +314,17 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
             throw Error.invalidSelectedPaymentSource
         }
 
-        let paymentMethod: STPPaymentMethod
-        switch selectedPaymentSource {
-        case .link:
-            let platformPublishableKey = try await getPlatformKey()
-            paymentMethod = try await linkController.createPaymentMethod(
-                overridePublishableKey: platformPublishableKey
-            )
-        case .applePay(let applePayPaymentMethod):
-            paymentMethod = applePayPaymentMethod
-        }
+        let paymentMethod: STPPaymentMethod = try await {
+            switch selectedPaymentSource {
+            case .link:
+                let platformPublishableKey = try await getPlatformKey()
+                return try await linkController.createPaymentMethod(
+                    overridePublishableKey: platformPublishableKey
+                )
+            case .applePay(let applePayPaymentMethod):
+                return applePayPaymentMethod
+            }
+        }()
 
         let token = try await apiClient.createPaymentToken(
             for: paymentMethod.stripeId,

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -123,6 +123,11 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
         case invalidSelectedPaymentSource
     }
 
+    private enum SelectedPaymentSource {
+        case link
+        case applePay(STPPaymentMethod)
+    }
+
     private let linkController: LinkController
     private let apiClient: STPAPIClient
     private let appearance: LinkAppearance

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -393,6 +393,11 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
             return .failed(error)
         }
     }
+
+    private func getPlatformKey() async throws -> String {
+        let platformSettings = try await apiClient.getPlatformSettings(linkAccountInfo: linkAccountInfo)
+        return platformSettings.publishableKey
+    }
 }
 
 extension CryptoOnrampCoordinator: STPApplePayContextDelegate {

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/CreatePaymentTokenRequest.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/CreatePaymentTokenRequest.swift
@@ -1,0 +1,22 @@
+//
+//  CreatePaymentTokenRequest.swift
+//  StripeCryptoOnramp
+//
+//  Created by Mat Schmid on 8/19/25.
+//
+
+import Foundation
+
+/// Encodable model passed to the `/v1/crypto/internal/payment_token` endpoint.
+struct CreatePaymentTokenRequest: Encodable {
+    /// The crypto wallet address to register.
+    let paymentMethod: String
+
+    /// Contains credentials required to make the request.
+    let credentials: Credentials
+
+    init(paymentMethod: String, consumerSessionClientSecret: String) {
+        self.paymentMethod = paymentMethod
+        self.credentials = Credentials(consumerSessionClientSecret: consumerSessionClientSecret)
+    }
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/CreatePaymentTokenResponse.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/CreatePaymentTokenResponse.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// Codable model representing a response from the `/v1/crypto/internal/payment_token` endpoint.
 struct CreatePaymentTokenResponse: Codable {
 
     /// The created crypto wallet's unique identifier.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/PlatformSettingsResponse.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/PlatformSettingsResponse.swift
@@ -1,0 +1,14 @@
+//
+//  PlatformSettingsResponse.swift
+//  StripeCryptoOnramp
+//
+//  Created by Mat Schmid on 8/19/25.
+//
+
+import Foundation
+
+struct PlatformSettingsResponse: Codable {
+
+    /// The publishable key associated with the current platform.
+    let publishableKey: String
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -125,6 +125,12 @@ extension STPAPIClient {
         return try await APIRequest<STPPaymentIntent>.getWith(self, endpoint: endpoint, parameters: parameters)
     }
 
+    /// Creates a crypto payment token from a given payment method and consumer.
+    /// - Parameters:
+    ///   - paymentMethodId: The originating payment method ID.
+    ///   - linkAccountInfo: Information associated with the link account including the client secret.
+    /// - Returns: The created crypto payment token.
+    /// Throws if an API error occurs.
     func createPaymentToken(
         for paymentMethodId: String,
         linkAccountInfo: PaymentSheetLinkAccountInfoProtocol
@@ -142,21 +148,15 @@ extension STPAPIClient {
     }
 
     /// Retrieves platform settings for the crypto onramp service.
-    /// - Parameters:
-    ///   - linkAccountInfo: Information associated with the link account including the client secret.
-    ///   - countryHint: Country code hint if the caller knows the user's KYC region.
+    /// - Parameter linkAccountInfo: Information associated with the link account including the client secret.
     /// - Returns: Platform settings including the publishable key.
     /// Throws if an API error occurs.
     func getPlatformSettings(
-        linkAccountInfo: PaymentSheetLinkAccountInfoProtocol,
-        countryHint: String = "US"
+        linkAccountInfo: PaymentSheetLinkAccountInfoProtocol
     ) async throws -> PlatformSettingsResponse {
         let endpoint = "crypto/internal/platform_settings"
 
-        var parameters: [String: Any] = [
-            "country_hint": countryHint
-        ]
-
+        var parameters: [String: Any] = [:]
         if let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret {
             parameters["credentials"] = ["consumer_session_client_secret": consumerSessionClientSecret]
         }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -125,9 +125,20 @@ extension STPAPIClient {
         return try await APIRequest<STPPaymentIntent>.getWith(self, endpoint: endpoint, parameters: parameters)
     }
 
-    func createPaymentToken(for paymentMethodId: String, linkAccountInfo: PaymentSheetLinkAccountInfoProtocol) async throws -> CreatePaymentTokenResponse {
-        // TODO: incorporate the implementation found at https://github.com/stripe/stripe-ios/pull/5302 once merged.
-        return CreatePaymentTokenResponse(id: "todo_123")
+    func createPaymentToken(
+        for paymentMethodId: String,
+        linkAccountInfo: PaymentSheetLinkAccountInfoProtocol
+    ) async throws -> CreatePaymentTokenResponse {
+        guard let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret else {
+            throw CryptoOnrampAPIError.missingConsumerSessionClientSecret
+        }
+
+        let endpoint = "crypto/internal/payment_token"
+        let requestObject = CreatePaymentTokenRequest(
+            paymentMethod: paymentMethodId,
+            consumerSessionClientSecret: consumerSessionClientSecret
+        )
+        return try await post(resource: endpoint, object: requestObject)
     }
 
     /// Retrieves platform settings for the crypto onramp service.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -130,6 +130,14 @@ extension STPAPIClient {
         return CreatePaymentTokenResponse(id: "todo_123")
     }
 
+    /// Retrieves platform settings for the crypto onramp service.
+    /// - Returns: Platform settings including the publishable key.
+    /// Throws if an API error occurs.
+    func getPlatformSettings() async throws -> PlatformSettingsResponse {
+        let endpoint = "crypto/internal/platform_settings"
+        return try await get(resource: endpoint)
+    }
+
     private func validateSessionState(using linkAccountInfo: PaymentSheetLinkAccountInfoProtocol) throws {
         guard case .verified = linkAccountInfo.sessionState else {
             throw CryptoOnrampAPIError.linkAccountNotVerified
@@ -142,6 +150,15 @@ private extension STPAPIClient {
     func post<T: Decodable>(resource: String, object: Encodable) async throws -> T {
         return try await withCheckedThrowingContinuation { continuation in
             post(resource: resource, object: object) { (result: Result<T, Error>) in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+    /// Helper method to wrap the closure-based get method for Swift concurrency.
+    func get<T: Decodable>(resource: String, parameters: [String: Any] = [:]) async throws -> T {
+        return try await withCheckedThrowingContinuation { continuation in
+            get(resource: resource, parameters: parameters) { (result: Result<T, Error>) in
                 continuation.resume(with: result)
             }
         }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -131,11 +131,26 @@ extension STPAPIClient {
     }
 
     /// Retrieves platform settings for the crypto onramp service.
+    /// - Parameters:
+    ///   - linkAccountInfo: Information associated with the link account including the client secret.
+    ///   - countryHint: Country code hint if the caller knows the user's KYC region.
     /// - Returns: Platform settings including the publishable key.
     /// Throws if an API error occurs.
-    func getPlatformSettings() async throws -> PlatformSettingsResponse {
+    func getPlatformSettings(
+        linkAccountInfo: PaymentSheetLinkAccountInfoProtocol,
+        countryHint: String = "US"
+    ) async throws -> PlatformSettingsResponse {
         let endpoint = "crypto/internal/platform_settings"
-        return try await get(resource: endpoint)
+
+        var parameters: [String: Any] = [
+            "country_hint": countryHint
+        ]
+
+        if let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret {
+            parameters["credentials"] = ["consumer_session_client_secret": consumerSessionClientSecret]
+        }
+
+        return try await get(resource: endpoint, parameters: parameters)
     }
 
     private func validateSessionState(using linkAccountInfo: PaymentSheetLinkAccountInfoProtocol) throws {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -327,6 +327,7 @@ extension STPAPIClient {
         for consumerSessionClientSecret: String,
         id: String,
         consumerAccountPublishableKey: String?,
+        overridePublishableKey: String? = nil,
         allowRedisplay: STPPaymentMethodAllowRedisplay?,
         cvc: String?,
         expectedPaymentMethodType: String?,
@@ -361,11 +362,10 @@ extension STPAPIClient {
             parameters["billing_phone"] = billingPhoneNumber
         }
 
-        let additionalHeaders: [String: String] = if let consumerAccountPublishableKey {
-            authorizationHeader(using: consumerAccountPublishableKey)
-        } else {
-            [:]
-        }
+        let additionalHeaders = overridePublishableKey != nil
+            ? authorizationHeader(using: overridePublishableKey)
+            : [:]
+
         APIRequest<PaymentDetailsShareResponse>.post(
             with: self,
             endpoint: endpoint,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -361,13 +361,16 @@ extension STPAPIClient {
             parameters["billing_phone"] = billingPhoneNumber
         }
 
+        let customHeaders: [String: String] = consumerAccountPublishableKey != nil
+            ? authorizationHeader(using: consumerAccountPublishableKey)
+            : [:]
         APIRequest<PaymentDetailsShareResponse>.post(
             with: self,
             endpoint: endpoint,
+            additionalHeaders: customHeaders,
             parameters: parameters
         ) { paymentDetailsShareResponse, _, error in
             guard let paymentDetailsShareResponse else {
-                stpAssert(error != nil)
                 completion(.failure(error ?? NSError.stp_genericConnectionError()))
                 return
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -361,16 +361,19 @@ extension STPAPIClient {
             parameters["billing_phone"] = billingPhoneNumber
         }
 
-        let customHeaders: [String: String] = consumerAccountPublishableKey != nil
-            ? authorizationHeader(using: consumerAccountPublishableKey)
-            : [:]
+        let additionalHeaders: [String: String] = if let consumerAccountPublishableKey {
+            authorizationHeader(using: consumerAccountPublishableKey)
+        } else {
+            [:]
+        }
         APIRequest<PaymentDetailsShareResponse>.post(
             with: self,
             endpoint: endpoint,
-            additionalHeaders: customHeaders,
+            additionalHeaders: additionalHeaders,
             parameters: parameters
         ) { paymentDetailsShareResponse, _, error in
             guard let paymentDetailsShareResponse else {
+                stpAssert(error != nil)
                 completion(.failure(error ?? NSError.stp_genericConnectionError()))
                 return
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -380,7 +380,8 @@ import UIKit
         apiClient.sharePaymentDetails(
             for: consumerSessionClientSecret,
             id: paymentDetails.stripeID,
-            consumerAccountPublishableKey: overridePublishableKey,
+            consumerAccountPublishableKey: nil,
+            overridePublishableKey: overridePublishableKey,
             allowRedisplay: nil,
             cvc: paymentDetails.cvc,
             expectedPaymentMethodType: nil,

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -853,8 +853,8 @@ extension STPAPIClient {
     /// Creates a PaymentMethod object with the provided params object.
     /// - seealso: https://stripe.com/docs/api/payment_methods/create
     /// - Parameters:
-    ///   - paymentMethodParams:  The `STPPaymentMethodParams` to pass to `/v1/payment_methods`.  Cannot be nil.
-    ///   - additionalPaymentUserAgentValues:  A list of values to append to the `payment_user_agent` parameter sent in the request. e.g. `["deferred-intent", "autopm"]` will append "; deferred-intent; autopm" to the `payment_user_agent`.
+    ///   - paymentMethodParams: The `STPPaymentMethodParams` to pass to `/v1/payment_methods`.  Cannot be nil.
+    ///   - additionalPaymentUserAgentValues: A list of values to append to the `payment_user_agent` parameter sent in the request. e.g. `["deferred-intent", "autopm"]` will append "; deferred-intent; autopm" to the `payment_user_agent`.
     /// - Returns: the returned PaymentMethod object.
     public func createPaymentMethod(with paymentMethodParams: STPPaymentMethodParams, additionalPaymentUserAgentValues: [String]) async throws -> STPPaymentMethod {
         return try await createPaymentMethod(
@@ -867,8 +867,8 @@ extension STPAPIClient {
     /// Creates a PaymentMethod object with the provided params object and optional override publishable key.
     /// - seealso: https://stripe.com/docs/api/payment_methods/create
     /// - Parameters:
-    ///   - paymentMethodParams:  The `STPPaymentMethodParams` to pass to `/v1/payment_methods`.  Cannot be nil.
-    ///   - additionalPaymentUserAgentValues:  A list of values to append to the `payment_user_agent` parameter sent in the request. e.g. `["deferred-intent", "autopm"]` will append "; deferred-intent; autopm" to the `payment_user_agent`.
+    ///   - paymentMethodParams: The `STPPaymentMethodParams` to pass to `/v1/payment_methods`.  Cannot be nil.
+    ///   - additionalPaymentUserAgentValues: A list of values to append to the `payment_user_agent` parameter sent in the request. e.g. `["deferred-intent", "autopm"]` will append "; deferred-intent; autopm" to the `payment_user_agent`.
     ///   - overridePublishableKey: Optional publishable key to use for this request instead of the default key.
     /// - Returns: the returned PaymentMethod object.
     @_spi(STP) public func createPaymentMethod(

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -820,7 +820,7 @@ extension STPAPIClient {
     }
 
     /// - Parameter additionalPaymentUserAgentValues: A list of values to append to the `payment_user_agent` parameter sent in the request. e.g. `["deferred-intent", "autopm"]` will append "; deferred-intent; autopm" to the `payment_user_agent`.
-    /// - Parameter overridePublishableKey: Optional publishable key to use for this request instead of the client's default key.
+    /// - Parameter overridePublishableKey: Optional publishable key to use for this request instead of the default key.
     func createPaymentMethod(
         with paymentMethodParams: STPPaymentMethodParams,
         additionalPaymentUserAgentValues: [String] = [],
@@ -869,7 +869,7 @@ extension STPAPIClient {
     /// - Parameters:
     ///   - paymentMethodParams:  The `STPPaymentMethodParams` to pass to `/v1/payment_methods`.  Cannot be nil.
     ///   - additionalPaymentUserAgentValues:  A list of values to append to the `payment_user_agent` parameter sent in the request. e.g. `["deferred-intent", "autopm"]` will append "; deferred-intent; autopm" to the `payment_user_agent`.
-    ///   - overridePublishableKey: Optional publishable key to use for this request instead of the client's default key.
+    ///   - overridePublishableKey: Optional publishable key to use for this request instead of the default key.
     /// - Returns: the returned PaymentMethod object.
     @_spi(STP) public func createPaymentMethod(
         with paymentMethodParams: STPPaymentMethodParams,
@@ -883,9 +883,9 @@ extension STPAPIClient {
                 overridePublishableKey: overridePublishableKey
             ) { paymentMethod, error in
                 if let paymentMethod = paymentMethod {
-                    continuation.resume(returning: paymentMethod)
+                    continuation.resume(with: .success(paymentMethod))
                 } else {
-                    continuation.resume(throwing: error ?? NSError.stp_genericFailedToParseResponseError())
+                    continuation.resume(with: .failure(error ?? NSError.stp_genericFailedToParseResponseError()))
                 }
             }
         }


### PR DESCRIPTION
## Summary

This does a few things;
- Adds an API call to `GET /v1/crypto/internal/platform_settings`, which gets us the platform merchant's publishable key
- Uses the platform's PK in payment method creation requests from the Onramp SDK (`/share` & `/payment_method`). It also uses this key for Apple Pay payment methods.
- Adds API call to `POST /v1/crypto/internal/payment_token`, which creates the crypto payment token for the associated payment method.

## Motivation

https://docs.google.com/document/d/1Ky83xVOPzBVsgnJ3KI4d477tISXdyVW502sWD41OQAE/edit?usp=sharing

## Testing

Link (card):

https://github.com/user-attachments/assets/be26987f-86e2-414d-afcb-f16f4bc9665a

Apple Pay:

https://github.com/user-attachments/assets/37a8b7b5-082f-48b7-83dd-3bffd04829b8

## Changelog

N/a