### PR TITLE
Tweak Link loader screen

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-LoaderViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-LoaderViewController.swift
@@ -21,12 +21,17 @@ extension PayWithLinkViewController {
 
             activityIndicator.tintColor = context.linkAppearance?.colors?.primary ?? .linkIconBrand
             activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-            view.addSubview(activityIndicator)
+
+            let containerView = UIView()
+            containerView.translatesAutoresizingMaskIntoConstraints = false
+            containerView.addSubview(activityIndicator)
+
+            contentView.addAndPinSubview(containerView, insets: .insets(bottom: LinkUI.bottomInset))
 
             NSLayoutConstraint.activate([
-                activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-                self.view.heightAnchor.constraint(equalToConstant: LoadingViewController.Constants.defaultLoadingViewHeight),
+                activityIndicator.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
+                activityIndicator.centerYAnchor.constraint(equalTo: containerView.centerYAnchor),
+                containerView.heightAnchor.constraint(equalToConstant: LoadingViewController.Constants.defaultLoadingViewHeight - LinkUI.bottomInset),
             ])
         }
 
@@ -34,7 +39,5 @@ extension PayWithLinkViewController {
             super.viewWillAppear(animated)
             activityIndicator.startAnimating()
         }
-
     }
-
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
@@ -128,7 +128,7 @@ extension PayWithLinkViewController {
             stackView.isLayoutMarginsRelativeArrangement = true
             stackView.directionalLayoutMargins = LinkUI.contentMargins
             stackView.translatesAutoresizingMaskIntoConstraints = false
-            contentView.addAndPinSubview(stackView, insets: .insets(bottom: 35))
+            contentView.addAndPinSubview(stackView, insets: .insets(bottom: LinkUI.bottomInset))
 
             if !paymentMethod.isDefault || isBillingDetailsUpdateFlow {
                 thisIsYourDefaultLabel.isHidden = true

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -202,7 +202,7 @@ extension PayWithLinkViewController {
                 containerView.addArrangedSubview(cancelButton)
             }
 
-            contentView.addAndPinSubview(containerView, insets: .insets(bottom: 35))
+            contentView.addAndPinSubview(containerView, insets: .insets(bottom: LinkUI.bottomInset))
 
             // If the initially selected payment method is not supported, we should automatically
             // expand the payment picker to hint the user to pick another payment method.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
@@ -80,6 +80,8 @@ enum LinkUI {
 
     static let tinyContentSpacing: CGFloat = 4
 
+    static let bottomInset: CGFloat = 35
+
     // MARK: - Navigation bar
 
     static let navigationBarHeight: CGFloat = 70


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request centers the activity indicator in the Link loader screen.

| Before | After |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-19 at 10 39 08" src="https://github.com/user-attachments/assets/8954195c-9156-49c8-9250-ce407c4ed17d" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-08-19 at 10 42 54" src="https://github.com/user-attachments/assets/0c72cce5-7fe6-44da-8386-482d9d478c90" /> | 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
