### PR TITLE
[Identity] Use caches direcotry not temp directory for downloaded ML models in Identity

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ML/IdentityMLModelLoader.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ML/IdentityMLModelLoader.swift
@@ -89,14 +89,18 @@ final class IdentityMLModelLoader: IdentityMLModelLoaderProtocol {
         // Since the models are unlikely to be used after the user has finished
         // verifying their identity, cache them to a temp directory so the
         // system will delete them when it needs the space.
-        let tempDirectory = URL(
-            fileURLWithPath: NSTemporaryDirectory(),
-            isDirectory: true
-        )
+        
+        let cachesDirectory: URL
+        if #available(iOS 16.0, *) {
+            cachesDirectory = URL.cachesDirectory
+        } else {
+            let paths = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask)
+            cachesDirectory = paths.first ?? URL(fileURLWithPath: NSTemporaryDirectory())
+        }
 
         // Create a name-spaced subdirectory inside the temp directory so
         // we don't clash with any other files the app is storing here.
-        let cacheDirectory = tempDirectory.appendingPathComponent(
+        let cacheDirectory = cachesDirectory.appendingPathComponent(
             IdentityMLModelLoader.cacheDirectoryName
         )
 
@@ -109,7 +113,7 @@ final class IdentityMLModelLoader: IdentityMLModelLoaderProtocol {
             return cacheDirectory
         } catch {
             // If creating the subdirectory fails, use temp directory directly
-            return tempDirectory
+            return cacheDirectory
         }
     }
 


### PR DESCRIPTION
## Summary

Rules out temporary directory being prematurely cleared leading to errors as described in [#5229](https://github.com/stripe/stripe-ios/issues/5229)

## Motivation

It is possible that the IO error we are seeing is because these models are not accessible, this is _possible_ in theory because of them being in the temporary directory. I do not know how likely that is, but this will rule it out.

## Testing

I ran through the playground example in the identity example app.

I tried an existing install, and new install -- using both caches directory code paths (although both tests on iOS 18+)

