### PR TITLE
Crypto Onramp SDK: Example Backend Crypto APIs Part 1

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Crypto.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Crypto.swift
@@ -17,7 +17,7 @@ extension APIClient {
         guard let token = authToken else { throw APIError.missingAuthToken }
         return try await request("customer_wallets", bearerToken: token, queryItems: [
             .cryptoCustomerToken(cryptoCustomerToken),
-            .pageSize(50)
+            .pageSize(50),
         ])
     }
 
@@ -25,7 +25,7 @@ extension APIClient {
         guard let token = authToken else { throw APIError.missingAuthToken }
         return try await request("payment_tokens", bearerToken: token, queryItems: [
             .cryptoCustomerToken(cryptoCustomerToken),
-            .pageSize(50)
+            .pageSize(50),
         ])
     }
 }
@@ -39,4 +39,3 @@ private extension URLQueryItem {
         URLQueryItem(name: "limit", value: String(value))
     }
 }
-

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Crypto.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Crypto.swift
@@ -14,5 +14,12 @@ extension APIClient {
             URLQueryItem(name: "crypto_customer_token", value: cryptoCustomerToken)
         ])
     }
+
+    func fetchCustomerWallets(cryptoCustomerToken: String) async throws -> CustomerWalletsResponse {
+        guard let token = authToken else { throw APIError.missingAuthToken }
+        return try await request("customer_wallets", bearerToken: token, queryItems: [
+            URLQueryItem(name: "crypto_customer_token", value: cryptoCustomerToken)
+        ])
+    }
 }
 

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Crypto.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Crypto.swift
@@ -10,16 +10,33 @@ import Foundation
 extension APIClient {
     func fetchCustomerInfo(cryptoCustomerToken: String) async throws -> CustomerInformationResponse {
         guard let token = authToken else { throw APIError.missingAuthToken }
-        return try await request("customer_info", bearerToken: token, queryItems: [
-            URLQueryItem(name: "crypto_customer_token", value: cryptoCustomerToken)
-        ])
+        return try await request("customer_info", bearerToken: token, queryItems: [.cryptoCustomerToken(cryptoCustomerToken)])
     }
 
     func fetchCustomerWallets(cryptoCustomerToken: String) async throws -> CustomerWalletsResponse {
         guard let token = authToken else { throw APIError.missingAuthToken }
         return try await request("customer_wallets", bearerToken: token, queryItems: [
-            URLQueryItem(name: "crypto_customer_token", value: cryptoCustomerToken)
+            .cryptoCustomerToken(cryptoCustomerToken),
+            .pageSize(50)
         ])
+    }
+
+    func fetchPaymentTokens(cryptoCustomerToken: String) async throws -> PaymentTokensResponse {
+        guard let token = authToken else { throw APIError.missingAuthToken }
+        return try await request("payment_tokens", bearerToken: token, queryItems: [
+            .cryptoCustomerToken(cryptoCustomerToken),
+            .pageSize(50)
+        ])
+    }
+}
+
+private extension URLQueryItem {
+    static func cryptoCustomerToken(_ value: String) -> URLQueryItem {
+        URLQueryItem(name: "crypto_customer_token", value: value)
+    }
+
+    static func pageSize(_ value: Int) -> URLQueryItem {
+        URLQueryItem(name: "limit", value: String(value))
     }
 }
 

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Crypto.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Crypto.swift
@@ -1,0 +1,18 @@
+//
+//  APIClient+Crypto.swift
+//  CryptoOnramp Example
+//
+//  Created by Michael Liberatore on 8/19/25.
+//
+
+import Foundation
+
+extension APIClient {
+    func fetchCustomerInfo(cryptoCustomerToken: String) async throws -> CustomerInformationResponse {
+        guard let token = authToken else { throw APIError.missingAuthToken }
+        return try await request("customer_info", bearerToken: token, queryItems: [
+            URLQueryItem(name: "crypto_customer_token", value: cryptoCustomerToken)
+        ])
+    }
+}
+

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient.swift
@@ -12,7 +12,7 @@ final class APIClient {
     static let shared = APIClient()
 
     private let session: URLSession
-    private let baseURL = URL(string: "https://crypto-onramp-example.stripedemos.com")!
+    private let baseURL = URL(string: "https://crypto-onramp-example.stripedemos.com")
     private let jsonDecoder: JSONDecoder
     private let jsonEncoder: JSONEncoder
     private(set) var authToken: String?
@@ -59,47 +59,65 @@ final class APIClient {
         method: HTTPMethod = .GET,
         body: Body? = nil,
         bearerToken: String? = nil,
-        headers: [String: String] = [:]
+        headers: [String: String] = [:],
+        queryItems: [URLQueryItem]? = nil
     ) async throws -> T {
-        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(path))
-        urlRequest.httpMethod = method.rawValue
-        urlRequest.addValue("application/json", forHTTPHeaderField: "Accept")
-
-        if let body = body {
-            urlRequest.httpBody = try jsonEncoder.encode(body)
-            urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
-        }
-
-        headers.forEach { key, value in
-            urlRequest.addValue(value, forHTTPHeaderField: key)
-        }
-
-        if let bearerToken {
-            urlRequest.addValue("Bearer \(bearerToken)", forHTTPHeaderField: "Authorization")
-        }
-
-        let (data, response) = try await session.data(for: urlRequest)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw URLError(.badServerResponse)
-        }
-
-        guard (200...299).contains(httpResponse.statusCode) else {
-            let message = String(data: data, encoding: .utf8) ?? "Unknown error"
-            throw APIError.httpError(status: httpResponse.statusCode, message: message)
-        }
-
-        return try jsonDecoder.decode(T.self, from: data)
+        let data = try body.map { try jsonEncoder.encode($0) }
+        return try await performRequest(
+            path,
+            method: method,
+            bodyData: data,
+            bearerToken: bearerToken,
+            headers: headers,
+            queryItems: queryItems
+        )
     }
 
     func request<T: Decodable>(
         _ path: String,
         method: HTTPMethod = .GET,
         bearerToken: String? = nil,
-        headers: [String: String] = [:]
+        headers: [String: String] = [:],
+        queryItems: [URLQueryItem]? = nil
     ) async throws -> T {
-        var urlRequest = URLRequest(url: baseURL.appendingPathComponent(path))
+        try await performRequest(
+            path,
+            method: method,
+            bodyData: nil,
+            bearerToken: bearerToken,
+            headers: headers,
+            queryItems: queryItems
+        )
+    }
+
+    private func performRequest<T: Decodable>(
+        _ path: String,
+        method: HTTPMethod,
+        bodyData: Data?,
+        bearerToken: String?,
+        headers: [String: String],
+        queryItems: [URLQueryItem]?
+    ) async throws -> T {
+        guard let baseURL = baseURL, var components = URLComponents(url: baseURL.appendingPathComponent(path), resolvingAgainstBaseURL: false) else {
+            throw URLError(.badURL)
+        }
+
+        if let queryItems {
+            components.queryItems = queryItems
+        }
+
+        guard let url = components.url else {
+            throw URLError(.badURL)
+        }
+
+        var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = method.rawValue
         urlRequest.addValue("application/json", forHTTPHeaderField: "Accept")
+
+        if let bodyData {
+            urlRequest.httpBody = bodyData
+            urlRequest.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        }
 
         headers.forEach { key, value in
             urlRequest.addValue(value, forHTTPHeaderField: key)

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/CustomerInformationResponse.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/CustomerInformationResponse.swift
@@ -5,6 +5,8 @@
 //  Created by Michael Liberatore on 8/19/25.
 //
 
+import Foundation
+
 struct CustomerInformationResponse: Decodable {
     struct Verification: Decodable {
         let errors: [String]

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/CustomerInformationResponse.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/CustomerInformationResponse.swift
@@ -1,0 +1,19 @@
+//
+//  CustomerInformationResponse.swift
+//  CryptoOnramp Example
+//
+//  Created by Michael Liberatore on 8/19/25.
+//
+
+struct CustomerInformationResponse: Decodable {
+    struct Verification: Decodable {
+        let errors: [String]
+        let name: String
+        let status: String
+    }
+
+    let id: String
+    let object: String
+    let providedFields: [String]
+    let verifications: [Verification]
+}

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/CustomerWalletsResponse.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/CustomerWalletsResponse.swift
@@ -1,0 +1,22 @@
+//
+//  CustomerWalletsResponse.swift
+//  CryptoOnramp Example
+//
+//  Created by Michael Liberatore on 8/19/25.
+//
+
+import Foundation
+
+struct CustomerWalletsResponse: Decodable {
+    struct Wallet: Decodable {
+        let id: String
+        let object: String
+        let livemode: Bool
+        let network: String
+        let walletAddress: String
+    }
+
+    let object: String
+    let count: Int
+    let data: [Wallet]
+}

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/PaymentTokensResponse.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/PaymentTokensResponse.swift
@@ -1,0 +1,30 @@
+//
+//  PaymentTokensResponse.swift
+//  CryptoOnramp Example
+//
+//  Created by Michael Liberatore on 8/19/25.
+//
+
+import Foundation
+
+struct PaymentTokensResponse: Decodable {
+    struct Card: Decodable {
+        let brand: String
+        let expMonth: Int
+        let expYear: Int
+        let funding: String
+        let last4: String
+        let wallet: String?
+    }
+
+    struct PaymentToken: Decodable {
+        let id: String
+        let object: String
+        let card: Card?
+        let type: String
+        let usBankAccount: String?
+    }
+
+    let object: String
+    let data: [PaymentToken]
+}


### PR DESCRIPTION
## Summary
1. Adds 3 more example backend APIs, a continuation of #5364.
2. Deduplicates `APIClient` code shared between the two `request` methods.

## Motivation
Required to demonstrate an end-to-end payment flow.

## Testing
Ran the following test code in a `Task`+ `do`/`catch`:

```swift
let authResult = try await APIClient.shared.authenticateUser(with: "mike@lickability.net")
print("LAI_ID: \(authResult.data.id)")

// ---<breakpoint>---

let customerInfo = try await APIClient.shared.fetchCustomerInfo(cryptoCustomerToken: customerId)
print("Customer info: \(customerInfo)")

let wallets = try await APIClient.shared.fetchCustomerWallets(cryptoCustomerToken: customerId)
print("Wallets: \(wallets)")

let paymentTokens = try await APIClient.shared.fetchPaymentTokens(cryptoCustomerToken: customerId)
print("Payment tokens: \(paymentTokens)")
```

At the breakpoint, I called the script referenced from [this doc](https://docs.google.com/document/d/10_JMkZnNJ9Zjx59e8JKiJNbMnd93mW7d0OV1FKi2NWk/edit?tab=t.0#heading=h.mf146dgggjwp) using the printed `LAI_ID`). I then continued execution, resulting in the output:

```
Customer info: CustomerInformationResponse(id: "crc_REDACTED", object: "crypto.customer", providedFields: ["first_name", "last_name", "id_type", "id_number", "dob", "address_line_1", "address_city", "address_state", "address_postal_code", "address_country"], verifications: [CryptoOnramp_Example.CustomerInformationResponse.Verification(errors: [], name: "kyc_verified", status: "verified"), CryptoOnramp_Example.CustomerInformationResponse.Verification(errors: ["id_document_verification_failed"], name: "id_document_verified", status: "rejected")])
Wallets: CustomerWalletsResponse(object: "list", count: 0, data: [])
Payment tokens: PaymentTokensResponse(object: "list", data: [])
```

Note that my account does not yet have wallets or tokens, so the response object types are modeled based on the documentation in the doc linked above. I’ll come back to modify those in the event that the resulting JSON ends up being different.

## Changelog
N/A
