### PR TITLE
Duplicate card scanner implementations, branch which one to use

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -323,6 +323,9 @@
 		9E77F1E9F801AE970F1A5BE1 /* CustomerSheetConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7768E4377A7D7495A02655D /* CustomerSheetConfiguration.swift */; };
 		9F750611C4E8EAABE9F0B460 /* CustomerSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED7ABCE56539213DCE501C54 /* CustomerSheetTests.swift */; };
 		A0317DBB2DC2CD88003EF979 /* RowButtonFlatWithDisclosure.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0317DBA2DC2CD7D003EF979 /* RowButtonFlatWithDisclosure.swift */; };
+		A097B1A22E553B5C00B92803 /* OldSTPCardScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A097B1A12E553B5C00B92803 /* OldSTPCardScanner.swift */; };
+		A097B1A42E553B7200B92803 /* OldCardScanningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A097B1A32E553B7200B92803 /* OldCardScanningView.swift */; };
+		A097B1A62E553B8600B92803 /* OldCardSectionWithScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A097B1A52E553B8600B92803 /* OldCardSectionWithScannerView.swift */; };
 		A1AC7034E778F81B8758A653 /* OHHTTPStubsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 20076FBD56C42E259EF62F2B /* OHHTTPStubsSwift */; };
 		A36949C52CE7D72300739E5D /* UpdatePaymentMethodViewController+Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A36949C42CE7D72300739E5D /* UpdatePaymentMethodViewController+Configuration.swift */; };
 		A3B2F2B22CEE689C00C0E88C /* TextFieldElement+USBankAccount.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B2F2B12CEE689C00C0E88C /* TextFieldElement+USBankAccount.swift */; };
@@ -836,6 +839,9 @@
 		9A0D887C5AC6EFFAFE1AFD77 /* PaymentMethodType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodType.swift; sourceTree = "<group>"; };
 		9E3905FE9F40E82EAEF49CD2 /* ro-RO */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "ro-RO"; path = "ro-RO.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		A0317DBA2DC2CD7D003EF979 /* RowButtonFlatWithDisclosure.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowButtonFlatWithDisclosure.swift; sourceTree = "<group>"; };
+		A097B1A12E553B5C00B92803 /* OldSTPCardScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldSTPCardScanner.swift; sourceTree = "<group>"; };
+		A097B1A32E553B7200B92803 /* OldCardScanningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldCardScanningView.swift; sourceTree = "<group>"; };
+		A097B1A52E553B8600B92803 /* OldCardSectionWithScannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OldCardSectionWithScannerView.swift; sourceTree = "<group>"; };
 		A09CCD0ED44336B23450A995 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		A1928BE9DFF116368B1A19DC /* LinkCookieKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkCookieKey.swift; sourceTree = "<group>"; };
 		A36949C42CE7D72300739E5D /* UpdatePaymentMethodViewController+Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UpdatePaymentMethodViewController+Configuration.swift"; sourceTree = "<group>"; };
@@ -1521,6 +1527,7 @@
 				70ED08B0F303B7C2334602C3 /* StripePaymentSheetBundleLocator.swift */,
 				6103F2BB2BE45990002D67F8 /* SavedPaymentMethodManager.swift */,
 				49909A2B2D8B0C860031EC33 /* URL+Extensions.swift */,
+				A097B1A12E553B5C00B92803 /* OldSTPCardScanner.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1573,6 +1580,7 @@
 				32BDC53A88FB17F378C6B413 /* CardSectionWithScannerView.swift */,
 				6BA8D3332B0C1F79008C51FF /* CVCRecollectionElement.swift */,
 				B66D70F92C54086600DECB3D /* HostedSurface.swift */,
+				A097B1A52E553B8600B92803 /* OldCardSectionWithScannerView.swift */,
 			);
 			path = CardSection;
 			sourceTree = "<group>";
@@ -1678,6 +1686,7 @@
 				B8A49995CE949176F7A8C71F /* SimpleMandateTextView.swift */,
 				64D658AC15478BF1E0A76B9D /* TestModeView.swift */,
 				A3BE1C232D4161DC0061632C /* RemoveButton.swift */,
+				A097B1A32E553B7200B92803 /* OldCardScanningView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -2493,6 +2502,7 @@
 				3147CEC22CC080570067B5E4 /* LinkSecureCookieStore.swift in Sources */,
 				258A75AF2E5393186C8850CA /* LinkEmailElement.swift in Sources */,
 				A0317DBB2DC2CD88003EF979 /* RowButtonFlatWithDisclosure.swift in Sources */,
+				A097B1A62E553B8600B92803 /* OldCardSectionWithScannerView.swift in Sources */,
 				EDE71E0BEDD94FB1101F3C10 /* FormElement+Link.swift in Sources */,
 				C346B534D57A952D4415ADFD /* Intent+Link.swift in Sources */,
 				A3B2F2B62CF1149200C0E88C /* SavedPaymentMethodFormFactory+Card.swift in Sources */,
@@ -2628,6 +2638,7 @@
 				B61E2C202C5C44FE0045B5CF /* PaymentSheetAnalyticsHelper.swift in Sources */,
 				CB6F8F892E0455D9003551D5 /* LinkController.swift in Sources */,
 				C5E3750BBCA700CF364F7578 /* PaymentSheetFormFactory+OXXO.swift in Sources */,
+				A097B1A42E553B7200B92803 /* OldCardScanningView.swift in Sources */,
 				49909A352D8B48D40031EC33 /* FCLiteError.swift in Sources */,
 				4930D8D52DB92CDC0091FBFE /* LinkPaymentMethodPicker-Email.swift in Sources */,
 				49679F6D2E3963460077112E /* LinkPaymentMethodPreview.swift in Sources */,
@@ -2692,6 +2703,7 @@
 				BBA94A936D05C7DA2721F557 /* BacsDDMandateView.swift in Sources */,
 				B8A217F26AAEC592B9B0D2E1 /* CardScanButton.swift in Sources */,
 				436A212E364FD78C3745DDA3 /* CardScanningView.swift in Sources */,
+				A097B1A22E553B5C00B92803 /* OldSTPCardScanner.swift in Sources */,
 				19A6D9D9951E13377F305263 /* CircularButton.swift in Sources */,
 				49909A282D8B05F90031EC33 /* FCLiteAuthFlowViewController.swift in Sources */,
 				3147CEBB2CC07E960067B5E4 /* LinkUtils.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/OldSTPCardScanner.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/OldSTPCardScanner.swift
@@ -1,0 +1,503 @@
+//
+//  STPCardScanner.swift
+//  StripePaymentSheet
+//
+//  Created by David Estes on 8/17/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+#if !os(visionOS)
+
+import AVFoundation
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
+@_spi(STP) import StripePaymentsUI
+import UIKit
+import Vision
+
+enum OldSTPCardScannerError: Int {
+    /// Camera not available.
+    case cameraNotAvailable
+}
+
+@available(macCatalyst 14.0, *)
+@objc protocol OldSTPCardScannerDelegate: NSObjectProtocol {
+    @objc(cardScanner:didFinishWithCardParams:error:) func cardScanner(
+        _ scanner: OldSTPCardScanner,
+        didFinishWith cardParams:
+        STPPaymentMethodCardParams?,
+        error: Error?)
+}
+
+@available(macCatalyst 14.0, *)
+@objc(OldSTPCardScanner)
+class OldSTPCardScanner: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate {
+    // iOS will kill the app if it tries to request the camera without an NSCameraUsageDescription
+    static let cardScanningAvailableCameraHasUsageDescription = {
+        return
+            (Bundle.main.infoDictionary?["NSCameraUsageDescription"] != nil
+            || Bundle.main.localizedInfoDictionary?["NSCameraUsageDescription"] != nil)
+    }()
+
+    static var cardScanningAvailable: Bool {
+        // Always allow in tests:
+        if NSClassFromString("XCTest") != nil {
+            return true
+        }
+        return cardScanningAvailableCameraHasUsageDescription
+    }
+
+    weak var cameraView: STPCameraView?
+
+    var feedbackGenerator: UINotificationFeedbackGenerator?
+
+    @objc public var deviceOrientation: UIDeviceOrientation {
+        get {
+            return stp_deviceOrientation
+        }
+        set(newDeviceOrientation) {
+            stp_deviceOrientation = newDeviceOrientation
+
+            // This is an optimization for portrait mode: The card will be centered in the screen,
+            // so we can ignore the top and bottom. We'll use the whole frame in landscape.
+            let kSTPCardScanningScreenCenter = CGRect(
+                x: 0, y: CGFloat(0.3), width: 1, height: CGFloat(0.4))
+
+            // iOS camera image data is returned in LandcapeLeft orientation by default. We'll flip it as needed:
+            switch newDeviceOrientation {
+            case .portraitUpsideDown:
+                videoOrientation = .portraitUpsideDown
+                textOrientation = .left
+                regionOfInterest = kSTPCardScanningScreenCenter
+            case .landscapeLeft:
+                videoOrientation = .landscapeRight
+                textOrientation = .up
+                regionOfInterest = CGRect(x: 0, y: 0, width: 1, height: 1)
+            case .landscapeRight:
+                videoOrientation = .landscapeLeft
+                textOrientation = .down
+                regionOfInterest = CGRect(x: 0, y: 0, width: 1, height: 1)
+            case .portrait, .faceUp, .faceDown, .unknown:
+                fallthrough
+            default:
+                videoOrientation = .portrait
+                textOrientation = .right
+                regionOfInterest = kSTPCardScanningScreenCenter
+            }
+            cameraView?.videoPreviewLayer.connection?.videoOrientation = videoOrientation
+        }
+    }
+
+    override init() {
+    }
+
+    init(delegate: OldSTPCardScannerDelegate?) {
+        super.init()
+        self.delegate = delegate
+        captureSessionQueue = DispatchQueue(label: "com.stripe.CardScanning.CaptureSessionQueue")
+        deviceOrientation = UIDevice.current.orientation
+    }
+
+    func start() {
+        if isScanning {
+            return
+        }
+        STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: OldSTPCardScanner.self)
+        startTime = Date()
+
+        isScanning = true
+        timeoutTime = nil
+        feedbackGenerator = UINotificationFeedbackGenerator()
+        feedbackGenerator?.prepare()
+
+        captureSessionQueue?.async(execute: {
+            #if targetEnvironment(simulator)
+                // Camera not supported on Simulator
+                self.stopWithError(STPCardScanner.stp_cardScanningError())
+                return
+            #else
+                self.detectedNumbers = NSCountedSet()
+                self.detectedExpirations = NSCountedSet()
+                self.setupCamera()
+                DispatchQueue.main.async(execute: {
+                    self.cameraView?.captureSession = self.captureSession
+                    self.cameraView?.videoPreviewLayer.connection?.videoOrientation =
+                        self.videoOrientation
+                })
+            #endif
+        })
+    }
+
+    func stop() {
+        stopWithError(nil)
+    }
+
+    private weak var delegate: OldSTPCardScannerDelegate?
+    private var captureDevice: AVCaptureDevice?
+    private var captureSession: AVCaptureSession?
+    private var captureSessionQueue: DispatchQueue?
+    private var videoDataOutput: AVCaptureVideoDataOutput?
+    private var videoDataOutputQueue: DispatchQueue?
+    private var textRequest: VNRecognizeTextRequest?
+    private var isScanning = false
+
+    private var timeoutTime: Date?
+    private var didTimeout: Bool {
+        if let timeoutTime = timeoutTime {
+            return timeoutTime <= Date()
+        }
+        return false
+    }
+
+    private var stp_deviceOrientation: UIDeviceOrientation!
+    private var videoOrientation: AVCaptureVideoOrientation!
+    private var textOrientation: CGImagePropertyOrientation!
+    private var regionOfInterest = CGRect.zero
+    private var detectedNumbers = NSCountedSet()
+    private var detectedExpirations = NSCountedSet()
+    private var startTime: Date?
+
+    // MARK: Public
+
+    class func stp_cardScanningError() -> Error {
+        let userInfo = [
+            NSLocalizedDescriptionKey: String.Localized.allow_camera_access,
+            STPError.errorMessageKey: "The camera couldn't be used.",
+        ]
+        return NSError(
+            domain: OldSTPCardScannerErrorDomain,
+            code: OldSTPCardScannerError.cameraNotAvailable.rawValue,
+            userInfo: userInfo)
+    }
+
+    deinit {
+        if isScanning {
+            captureDevice?.unlockForConfiguration()
+            captureSession?.stopRunning()
+        }
+    }
+
+    func stopWithError(_ error: Error?) {
+        if isScanning {
+            finish(with: nil, error: error)
+        }
+    }
+
+    // MARK: Setup
+    func setupCamera() {
+        weak var weakSelf = self
+        textRequest = VNRecognizeTextRequest(completionHandler: { request, error in
+            let strongSelf = weakSelf
+            if !(strongSelf?.isScanning ?? false) {
+                return
+            }
+            if error != nil {
+                strongSelf?.stopWithError(OldSTPCardScanner.stp_cardScanningError())
+                return
+            }
+            strongSelf?.processVNRequest(request)
+        })
+
+        // The triple and dualWide cameras have a 0.5x lens for better macro focus.
+        // If neither are available, use the default wide angle camera.
+        let discoverySession = AVCaptureDevice.DiscoverySession(deviceTypes:
+                                                                    [.builtInTripleCamera, .builtInDualWideCamera, .builtInWideAngleCamera],
+                                                                mediaType: .video, position: .back)
+        guard let captureDevice = discoverySession.devices.first else {
+            stopWithError(OldSTPCardScanner.stp_cardScanningError())
+            return
+        }
+        self.captureDevice = captureDevice
+
+        captureSession = AVCaptureSession()
+        captureSession?.sessionPreset = .hd1920x1080
+
+        var deviceInput: AVCaptureDeviceInput?
+        do {
+            deviceInput = try AVCaptureDeviceInput(device: captureDevice)
+        } catch {
+            stopWithError(OldSTPCardScanner.stp_cardScanningError())
+            return
+        }
+
+        if let deviceInput = deviceInput {
+            if captureSession?.canAddInput(deviceInput) ?? false {
+                captureSession?.addInput(deviceInput)
+            } else {
+                stopWithError(OldSTPCardScanner.stp_cardScanningError())
+                return
+            }
+        }
+
+        videoDataOutputQueue = DispatchQueue(label: "com.stripe.CardScanning.VideoDataOutputQueue")
+        videoDataOutput = AVCaptureVideoDataOutput()
+        videoDataOutput?.alwaysDiscardsLateVideoFrames = true
+        videoDataOutput?.setSampleBufferDelegate(self, queue: videoDataOutputQueue)
+
+        // This is the recommended pixel buffer format for Vision:
+        videoDataOutput?.videoSettings = [
+            kCVPixelBufferPixelFormatTypeKey as String:
+                kCVPixelFormatType_420YpCbCr8BiPlanarFullRange,
+        ]
+
+        if let videoDataOutput = videoDataOutput {
+            if captureSession?.canAddOutput(videoDataOutput) ?? false {
+                captureSession?.addOutput(videoDataOutput)
+            } else {
+                stopWithError(OldSTPCardScanner.stp_cardScanningError())
+                return
+            }
+        }
+
+        // This improves recognition quality, but means the VideoDataOutput buffers won't match what we're seeing on screen.
+        videoDataOutput?.connection(with: .video)?.preferredVideoStabilizationMode = .auto
+
+        captureSession?.startRunning()
+
+        do {
+            try self.captureDevice?.lockForConfiguration()
+            self.captureDevice?.autoFocusRangeRestriction = .near
+        } catch {
+        }
+    }
+
+    // MARK: Processing
+    func captureOutput(
+        _ output: AVCaptureOutput,
+        didOutput sampleBuffer: CMSampleBuffer,
+        from connection: AVCaptureConnection
+    ) {
+        if !isScanning {
+            return
+        }
+        let pixelBuffer = CMSampleBufferGetImageBuffer(sampleBuffer)
+        if pixelBuffer == nil {
+            return
+        }
+        textRequest?.recognitionLevel = .accurate
+        textRequest?.usesLanguageCorrection = false
+        textRequest?.regionOfInterest = regionOfInterest
+        var handler: VNImageRequestHandler?
+        if let pixelBuffer = pixelBuffer {
+            handler = VNImageRequestHandler(
+                cvPixelBuffer: pixelBuffer, orientation: textOrientation, options: [:])
+        }
+        do {
+            try handler?.perform([textRequest].compactMap { $0 })
+        } catch {
+        }
+    }
+
+    func processVNRequest(_ request: VNRequest) {
+        var allNumbers: [String] = []
+        for observation in request.results ?? [] {
+            guard let observation = observation as? VNRecognizedTextObservation else {
+                continue
+            }
+            let candidates = observation.topCandidates(5)
+            let topCandidate = candidates.first?.string
+            if STPCardValidator.sanitizedNumericString(for: topCandidate ?? "").count >= 4 {
+                allNumbers.append(topCandidate ?? "")
+            }
+            for recognizedText in candidates {
+                let possibleNumber = STPCardValidator.sanitizedNumericString(
+                    for: recognizedText.string)
+                if possibleNumber.count < 4 {
+                    continue  // This probably isn't something we're interested in, so don't bother processing it.
+                }
+
+                // First strategy: We check if Vision sent us a number in a group on its own. If that fails, we'll try
+                // to catch it later when we iterate over all the numbers.
+                if STPCardValidator.validationState(
+                    forNumber: possibleNumber, validatingCardBrand: true)
+                    == .valid
+                {
+                    addDetectedNumber(possibleNumber)
+                } else if let sanitizedExpiration = STPStringUtils.sanitizedExpirationDateFromOCRString(recognizedText.string) {
+                    handlePossibleExpirationDate(sanitizedExpiration)
+                } else if possibleNumber.count >= 4 && possibleNumber.count <= 6
+                    && STPStringUtils.stringMayContainExpirationDate(recognizedText.string)
+                {
+                    // Try to parse anything that looks like an expiration date.
+                    let expirationString = STPStringUtils.expirationDateString(
+                        from: recognizedText.string)
+                    let sanitizedExpiration = STPCardValidator.sanitizedNumericString(
+                        for: expirationString ?? "")
+                    handlePossibleExpirationDate(sanitizedExpiration)
+                }
+            }
+        }
+        // Second strategy: We look for consecutive groups of 4/4/4/4 or 4/6/5
+        // Vision is sending us groups like ["1234 565", "1234 1"], so we'll normalize these into groups with spaces:
+        let allGroups = allNumbers.joined(separator: " ").components(separatedBy: " ")
+        if allGroups.count < 3 {
+            return
+        }
+        for i in 0..<(allGroups.count - 3) {
+            let string1 = allGroups[i]
+            let string2 = allGroups[i + 1]
+            let string3 = allGroups[i + 2]
+            var string4 = ""
+            if i + 3 < allGroups.count {
+                string4 = allGroups[i + 3]
+            }
+            // Then we'll go through each group and build a potential match:
+            let potentialCardString = "\(string1)\(string2)\(string3)\(string4)"
+            let potentialAmexString = "\(string1)\(string2)\(string3)"
+
+            // Then we'll add valid matches. It's okay if we add a number a second time after doing so above, as the success of that first pass means it's more likely to be a good match.
+            if STPCardValidator.validationState(
+                forNumber: potentialCardString, validatingCardBrand: true)
+                == .valid
+            {
+                addDetectedNumber(potentialCardString)
+            } else if STPCardValidator.validationState(
+                forNumber: potentialAmexString, validatingCardBrand: true) == .valid
+            {
+                addDetectedNumber(potentialAmexString)
+            }
+        }
+    }
+
+    private func handlePossibleExpirationDate(_ sanitizedExpiration: String) {
+        let month = (sanitizedExpiration as NSString).substring(to: 2)
+        let year = (sanitizedExpiration as NSString).substring(from: 2)
+
+        // Ignore expiration dates 10+ years in the future, as they're likely to be incorrect recognitions
+        let calendar = Calendar(identifier: .gregorian)
+        let presentYear = calendar.component(.year, from: Date())
+        let maxYear = (presentYear % 100) + 10
+
+        if STPCardValidator.validationState(forExpirationYear: year, inMonth: month)
+            == .valid
+            && Int(year) ?? 0 < maxYear
+        {
+            addDetectedExpiration(sanitizedExpiration)
+        }
+    }
+
+    func addDetectedNumber(_ number: String) {
+        detectedNumbers.add(number)
+
+        // Set a timeout: If we don't get enough scans in the next 0.6 seconds, we'll use the best option we have.
+        if timeoutTime == nil {
+            self.timeoutTime = Date().addingTimeInterval(kSTPCardScanningTimeout)
+            weak var weakSelf = self
+            DispatchQueue.main.async(execute: {
+                let strongSelf = weakSelf
+                strongSelf?.cameraView?.playSnapshotAnimation()
+                strongSelf?.feedbackGenerator?.notificationOccurred(.success)
+            })
+            // Just in case we don't get any frames, add another call to `finishIfReady` after timeoutTime to check
+            videoDataOutputQueue?.asyncAfter(
+                deadline: DispatchTime.now() + kSTPCardScanningTimeout,
+                execute: {
+                    let strongSelf = weakSelf
+                    if strongSelf?.isScanning ?? false {
+                        strongSelf?.finishIfReady()
+                    }
+                })
+        }
+
+        if (detectedNumbers.count(for: number)) >= kSTPCardScanningMinimumValidScans {
+            finishIfReady()
+        }
+    }
+
+    func addDetectedExpiration(_ expiration: String) {
+        detectedExpirations.add(expiration)
+        if (detectedExpirations.count(for: expiration)) >= kSTPCardScanningMinimumValidScans {
+            finishIfReady()
+        }
+    }
+
+    // MARK: Completion
+    func finishIfReady() {
+        if !isScanning {
+            return
+        }
+        let detectedNumbers = self.detectedNumbers
+        let detectedExpirations = self.detectedExpirations
+
+        let topNumber = (detectedNumbers.allObjects as NSArray).sortedArray(comparator: {
+            obj1, obj2 in
+            let c1 = detectedNumbers.count(for: obj1)
+            let c2 = detectedNumbers.count(for: obj2)
+            if c1 < c2 {
+                return .orderedAscending
+            } else if c1 > c2 {
+                return .orderedDescending
+            } else {
+                return .orderedSame
+            }
+        }).last
+        let topExpiration = (detectedExpirations.allObjects as NSArray).sortedArray(comparator: {
+            obj1, obj2 in
+            let c1 = detectedExpirations.count(for: obj1)
+            let c2 = detectedExpirations.count(for: obj2)
+            if c1 < c2 {
+                return .orderedAscending
+            } else if c1 > c2 {
+                return .orderedDescending
+            } else {
+                return .orderedSame
+            }
+        }).last
+
+        var didSeeEnoughScans = false
+        if let topNumber = topNumber, let topExpiration = topExpiration {
+            didSeeEnoughScans = detectedNumbers.count(for: topNumber) >= kSTPCardScanningMinimumValidScans &&
+                detectedExpirations.count(for: topExpiration) >= kSTPCardScanningMinimumValidScans
+        }
+        if didTimeout || didSeeEnoughScans {
+            let params = STPPaymentMethodCardParams()
+            params.number = topNumber as? String
+            if let topExpiration = topExpiration {
+                params.expMonth = NSNumber(
+                    value: Int((topExpiration as! NSString).substring(to: 2)) ?? 0)
+                params.expYear = NSNumber(
+                    value: Int((topExpiration as! NSString).substring(from: 2)) ?? 0)
+            }
+            finish(with: params, error: nil)
+        }
+    }
+
+    func finish(with params: STPPaymentMethodCardParams?, error: Error?) {
+        var duration: TimeInterval?
+        if let startTime = startTime {
+            duration = Date().timeIntervalSince(startTime)
+        }
+        isScanning = false
+        captureDevice?.unlockForConfiguration()
+        captureSession?.stopRunning()
+
+        DispatchQueue.main.async(execute: {
+            if params == nil {
+                STPAnalyticsClient.sharedClient.logCardScanCancelled(withDuration: duration ?? 0.0)
+            } else {
+                STPAnalyticsClient.sharedClient.logCardScanSucceeded(withDuration: duration ?? 0.0)
+            }
+            self.delegate?.cardScanner(self, didFinishWith: params, error: error)
+            self.feedbackGenerator = nil
+            DispatchQueue.main.async {
+                self.cameraView?.captureSession = nil
+            }
+        })
+    }
+
+    // MARK: Orientation
+}
+
+// The number of successful scans required for both card number and expiration date before returning a result.
+private let kSTPCardScanningMinimumValidScans = 2
+// Once one successful scan is found, we'll stop scanning after this many seconds.
+private let kSTPCardScanningTimeout: TimeInterval = 0.6
+let OldSTPCardScannerErrorDomain = "STPCardScannerErrorDomain"
+
+/// :nodoc:
+@available(macCatalyst 14.0, *)
+extension OldSTPCardScanner: STPAnalyticsProtocol {
+    static var stp_analyticsIdentifier = "STPCardScanner"
+}
+
+#endif

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/OldCardSectionWithScannerView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/OldCardSectionWithScannerView.swift
@@ -19,8 +19,8 @@ import UIKit
  */
 /// For internal SDK use only
 @available(macCatalyst 14.0, *)
-@objc(STP_Internal_CardSectionWithScannerView)
-final class CardSectionWithScannerView: UIView {
+@objc(OldSTP_Internal_CardSectionWithScannerView)
+final class OldCardSectionWithScannerView: UIView {
     let cardSectionView: UIView
     let analyticsHelper: PaymentSheetAnalyticsHelper?
     lazy var cardScanButton: UIButton = {
@@ -28,17 +28,17 @@ final class CardSectionWithScannerView: UIView {
         button.addTarget(self, action: #selector(didTapCardScanButton), for: .touchUpInside)
         return button
     }()
-    lazy var cardScanningView: CardScanningView = {
-        let scanningView = CardScanningView()
+    lazy var cardScanningView: OldCardScanningView = {
+        let scanningView = OldCardScanningView()
         scanningView.isHidden = true
         scanningView.delegate = self
         return scanningView
     }()
-    weak var delegate: CardSectionWithScannerViewDelegate?
+    weak var delegate: OldCardSectionWithScannerViewDelegate?
     private let theme: ElementsAppearance
     private let linkAppearance: LinkAppearance?
 
-    init(cardSectionView: UIView, delegate: CardSectionWithScannerViewDelegate, theme: ElementsAppearance = .default, analyticsHelper: PaymentSheetAnalyticsHelper?, linkAppearance: LinkAppearance? = nil) {
+    init(cardSectionView: UIView, delegate: OldCardSectionWithScannerViewDelegate, theme: ElementsAppearance = .default, analyticsHelper: PaymentSheetAnalyticsHelper?, linkAppearance: LinkAppearance? = nil) {
         self.cardSectionView = cardSectionView
         self.delegate = delegate
         self.theme = theme
@@ -95,8 +95,8 @@ final class CardSectionWithScannerView: UIView {
 }
 
 @available(macCatalyst 14.0, *)
-extension CardSectionWithScannerView: STP_Internal_CardScanningViewDelegate {
-    func cardScanningView(_ cardScanningView: CardScanningView, didFinishWith cardParams: STPPaymentMethodCardParams?) {
+extension OldCardSectionWithScannerView: OldSTP_Internal_CardScanningViewDelegate {
+    func cardScanningView(_ cardScanningView: OldCardScanningView, didFinishWith cardParams: STPPaymentMethodCardParams?) {
         setCardScanVisible(false)
         if let cardParams = cardParams {
             self.delegate?.didScanCard(self, cardParams: cardParams)
@@ -105,8 +105,8 @@ extension CardSectionWithScannerView: STP_Internal_CardScanningViewDelegate {
 }
 
 // MARK: - CardFormElementViewDelegate
-protocol CardSectionWithScannerViewDelegate: AnyObject {
-    func didScanCard(_ cardSectionWithScannerView: CardSectionWithScannerView, cardParams: STPPaymentMethodCardParams)
+protocol OldCardSectionWithScannerViewDelegate: AnyObject {
+    func didScanCard(_ oldCardSectionWithScannerView: OldCardSectionWithScannerView, cardParams: STPPaymentMethodCardParams)
 }
 
 #endif

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/OldCardScanningView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/OldCardScanningView.swift
@@ -1,0 +1,296 @@
+//
+//  CardScanningView.swift
+//  StripePaymentSheet
+//
+//  Created by David Estes on 12/2/20.
+//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//
+
+#if !os(visionOS)
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
+@_spi(STP) import StripePaymentsUI
+@_spi(STP) import StripeUICore
+import UIKit
+
+private class OldCardScanningEasilyTappableButton: UIButton {
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        let newArea = bounds.insetBy(
+            dx: -(PaymentSheetUI.minimumTapSize.width - bounds.width) / 2,
+            dy: -(PaymentSheetUI.minimumTapSize.height - bounds.height) / 2)
+        return newArea.contains(point)
+    }
+}
+
+/// For internal SDK use only
+@available(macCatalyst 14.0, *)
+@objc protocol OldSTP_Internal_CardScanningViewDelegate: NSObjectProtocol {
+    func cardScanningView(
+        _ cardScanningView: OldCardScanningView, didFinishWith cardParams: STPPaymentMethodCardParams?)
+}
+
+/// For internal SDK use only
+@objc(OldSTP_Internal_CardScanningView)
+@available(macCatalyst 14.0, *)
+class OldCardScanningView: UIView, OldSTPCardScannerDelegate {
+    private(set) weak var cameraView: STPCameraView?
+
+    weak var delegate: OldSTP_Internal_CardScanningViewDelegate?
+
+    var deviceOrientation: UIDeviceOrientation = UIDevice.current.orientation {
+        didSet {
+            cardScanner?.deviceOrientation = deviceOrientation
+        }
+    }
+
+    private var isDisplayingError = false {
+        didSet {
+            errorLabel.isHidden = !isDisplayingError
+        }
+    }
+
+    func cardScanner(
+        _ scanner: OldSTPCardScanner,
+        didFinishWith cardParams: STPPaymentMethodCardParams?,
+        error: Error?
+    ) {
+        if error != nil {
+            self.isDisplayingError = true
+        } else {
+            self.delegate?.cardScanningView(self, didFinishWith: cardParams)
+        }
+    }
+
+    private lazy var cardScanner: OldSTPCardScanner? = nil
+
+    private static let cardSizeRatio: CGFloat = 2.125 / 3.370  // ID-1 card size (in inches)
+    private static let cardCornerRadius: CGFloat = 0.125 / 3.370  // radius / ID-1 card width
+    private static let cornerRadius: CGFloat = 4
+    private static let cardInset: CGFloat = 32
+    private static let textInset: CGFloat = 14
+
+    private lazy var cardOutlineView: UIView = {
+        let view = UIView()
+        view.layer.borderWidth = 3.0
+        view.layer.borderColor = UIColor.white.cgColor
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
+    }()
+
+    private lazy var blurEffect: UIBlurEffect = {
+        return UIBlurEffect(style: .systemUltraThinMaterialDark)
+    }()
+
+    private lazy var cardOuterBlurView: UIVisualEffectView = {
+        let view = UIVisualEffectView(effect: blurEffect)
+        view.layer.masksToBounds = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+
+        return view
+    }()
+
+    private lazy var instructionsLabel: UILabel = {
+        let label = UILabel()
+        label.text = ""
+        label.textAlignment = .center
+        label.font = .preferredFont(forTextStyle: .headline)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private lazy var errorLabel: UILabel = {
+        let label = UILabel()
+        label.text = String.Localized.allow_camera_access
+        label.textAlignment = .center
+        label.numberOfLines = 3
+        label.font = .preferredFont(forTextStyle: .subheadline)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.textColor = .white
+        label.isHidden = true
+        return label
+    }()
+
+    private lazy var closeButton: CircularButton = {
+        // TODO(porter): Customize card scanning view?
+        let button = CircularButton(style: .close)
+        button.accessibilityLabel = STPLocalizedString(
+            "Close card scanner", "Accessibility label for the button to close the card scanner.")
+        button.translatesAutoresizingMaskIntoConstraints = false
+        return button
+    }()
+
+    private lazy var containerView: UIView = {
+        let containerView = UIView()
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        return containerView
+    }()
+
+    private func setupBlurView() {
+        let vibrancyEffect = UIVibrancyEffect(blurEffect: blurEffect)
+        let vibrancyEffectView = UIVisualEffectView(effect: vibrancyEffect)
+        vibrancyEffectView.translatesAutoresizingMaskIntoConstraints = false
+
+        vibrancyEffectView.contentView.addSubview(instructionsLabel)
+        cardOuterBlurView.contentView.addSubview(vibrancyEffectView)
+
+        cardOuterBlurView.addConstraints([
+            vibrancyEffectView.bottomAnchor.constraint(
+                equalTo: cardOuterBlurView.bottomAnchor, constant: 0),
+            vibrancyEffectView.leftAnchor.constraint(
+                equalTo: cardOuterBlurView.leftAnchor, constant: 0),
+            vibrancyEffectView.rightAnchor.constraint(
+                equalTo: cardOuterBlurView.rightAnchor, constant: 0),
+            vibrancyEffectView.topAnchor.constraint(
+                equalTo: cardOuterBlurView.topAnchor, constant: 0),
+        ])
+
+        vibrancyEffectView.addConstraints([
+            instructionsLabel.leftAnchor.constraint(
+                equalTo: vibrancyEffectView.leftAnchor, constant: 0),
+            instructionsLabel.rightAnchor.constraint(
+                equalTo: vibrancyEffectView.rightAnchor, constant: 0),
+        ])
+    }
+
+    func start() {
+        cardScanner?.start()
+    }
+
+    func stop() {
+        if isDisplayingError {
+            self.delegate?.cardScanningView(self, didFinishWith: nil)
+        }
+        cardScanner?.stop()
+    }
+
+    @objc private func closeTapped() {
+        self.stop()
+    }
+
+    var snapshotView: UIView?
+
+    // The shape layers don't animate cleanly during setHidden,
+    // so let's use a snapshot view instead.
+    func prepDismissAnimation() {
+        if let snapshot = self.containerView.snapshotView(afterScreenUpdates: true) {
+            self.addSubview(snapshot)
+            self.snapshotView = snapshot
+        }
+    }
+
+    func completeDismissAnimation() {
+        snapshotView?.removeFromSuperview()
+        snapshotView = nil
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setupBlurView()
+
+        let cameraView = STPCameraView(frame: bounds)
+        cameraView.isAccessibilityElement = true
+        cameraView.accessibilityLabel = STPLocalizedString(
+            "Point the camera at your card.", "Accessibility instructions for card scanning.")
+        let cardScanner = OldSTPCardScanner(delegate: self)
+        cardScanner.cameraView = cameraView
+        self.cardScanner = cardScanner
+
+        closeButton.addTarget(self, action: #selector(closeTapped), for: .touchUpInside)
+
+        self.addSubview(containerView)
+        containerView.addSubview(cameraView)
+        containerView.addSubview(cardOutlineView)
+        containerView.addSubview(cardOuterBlurView)
+        containerView.addSubview(errorLabel)
+        containerView.addSubview(closeButton)
+
+        containerView.layer.cornerRadius = OldCardScanningView.cornerRadius
+        self.cameraView = cameraView
+        cameraView.layer.cornerRadius = OldCardScanningView.cornerRadius
+        self.cameraView?.translatesAutoresizingMaskIntoConstraints = false
+        // The first few frames of the camera view will be black, so our background should be black too.
+        self.cameraView?.backgroundColor = UIColor.black
+
+        // To get the right animation, we'll add a breakable bottom constraint
+        // and enable clipsToBounds. Then, when hidden, the view will shrink while
+        // the contents remain pinned to the top.
+        let bottomConstraint = containerView.bottomAnchor.constraint(equalTo: self.bottomAnchor)
+        bottomConstraint.priority = .defaultHigh
+        self.clipsToBounds = true
+
+        self.addConstraints(
+            [
+                containerView.topAnchor.constraint(equalTo: self.topAnchor),
+                containerView.leftAnchor.constraint(equalTo: self.leftAnchor),
+                containerView.rightAnchor.constraint(equalTo: self.rightAnchor),
+                bottomConstraint,
+
+                cameraView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 0),
+                cameraView.leftAnchor.constraint(equalTo: containerView.leftAnchor, constant: 0),
+                cameraView.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: 0),
+                cameraView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 0),
+
+                cardOuterBlurView.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 0),
+                cardOuterBlurView.leftAnchor.constraint(equalTo: containerView.leftAnchor, constant: 0),
+                cardOuterBlurView.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: 0),
+                cardOuterBlurView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: 0),
+
+                errorLabel.centerYAnchor.constraint(equalTo: containerView.centerYAnchor, constant: 0),
+                errorLabel.leftAnchor.constraint(equalTo: cardOutlineView.leftAnchor, constant: 8),
+                errorLabel.rightAnchor.constraint(
+                    equalTo: cardOutlineView.rightAnchor, constant: -8),
+
+                closeButton.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 8),
+                closeButton.rightAnchor.constraint(equalTo: containerView.rightAnchor, constant: -8),
+
+                cardOutlineView.heightAnchor.constraint(
+                    equalTo: cardOutlineView.widthAnchor, multiplier: OldCardScanningView.cardSizeRatio),
+
+                cardOutlineView.topAnchor.constraint(
+                    equalTo: containerView.topAnchor, constant: OldCardScanningView.cardInset),
+                cardOutlineView.leftAnchor.constraint(
+                    equalTo: containerView.leftAnchor, constant: OldCardScanningView.cardInset),
+                cardOutlineView.rightAnchor.constraint(
+                    equalTo: containerView.rightAnchor, constant: -OldCardScanningView.cardInset),
+                cardOutlineView.bottomAnchor.constraint(
+                    equalTo: containerView.bottomAnchor, constant: -OldCardScanningView.cardInset),
+            ])
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        let cornerRadius =
+            (self.bounds.size.width - (OldCardScanningView.cardInset * 2))
+            * OldCardScanningView.cardCornerRadius
+        cardOutlineView.layer.cornerRadius = cornerRadius
+
+        let outerPath = UIBezierPath(
+            roundedRect: CGRect(
+                x: 0, y: 0, width: self.bounds.size.width, height: self.bounds.size.height),
+            cornerRadius: OldCardScanningView.cornerRadius)
+        let innerPath = UIBezierPath(roundedRect: cardOutlineView.frame, cornerRadius: cornerRadius)
+
+        outerPath.append(innerPath)
+        outerPath.usesEvenOddFillRule = true
+
+        let maskLayer = CAShapeLayer()
+        maskLayer.path = outerPath.cgPath
+        maskLayer.fillRule = CAShapeLayerFillRule.evenOdd
+
+        cardOuterBlurView.layer.mask = maskLayer
+    }
+
+    required init?(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+
+    override func willMove(toWindow newWindow: UIWindow?) {
+        if newWindow == nil {
+            stop()
+        }
+        super.willMove(toWindow: newWindow)
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
Create branching card scanner implementations

## Motivation
Temporarily have parallel card scan implementations while we experiment with new one

## Testing
- Built and ran app without original versions of files to ensure copies are not pointing at them in any way
- Built and ran app with both versions to ensure that functionality remains same

## Changelog
N/A