### PR TITLE
Use new SFU behavior flag to drive updated mandate

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -394,6 +394,7 @@
 		CB6F8F892E0455D9003551D5 /* LinkController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6F8F882E0455D9003551D5 /* LinkController.swift */; };
 		CB71FA352E4D243C00875D13 /* Intent+SellerDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB71FA342E4D243C00875D13 /* Intent+SellerDetails.swift */; };
 		CB76C0792DE4B57D0009E086 /* LinkDefaultOptInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB76C0782DE4B57D0009E086 /* LinkDefaultOptInView.swift */; };
+		CBBE13E32E5639FA000CB977 /* MandateVariant.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBBE13E22E5639FA000CB977 /* MandateVariant.swift */; };
 		CBC98E222DD53F9D00458788 /* LinkFlowControllerHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBC98E212DD53F9D00458788 /* LinkFlowControllerHelpers.swift */; };
 		CBE09F4D2D8DA62A0083D0B8 /* LinkConfirmationExtras.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBE09F4C2D8DA62A0083D0B8 /* LinkConfirmationExtras.swift */; };
 		CBECCB382DB1BA4100EF0875 /* PaymentMethodWithLinkDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBECCB372DB1BA4100EF0875 /* PaymentMethodWithLinkDetails.swift */; };
@@ -929,6 +930,7 @@
 		CB6F8F882E0455D9003551D5 /* LinkController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkController.swift; sourceTree = "<group>"; };
 		CB71FA342E4D243C00875D13 /* Intent+SellerDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Intent+SellerDetails.swift"; sourceTree = "<group>"; };
 		CB76C0782DE4B57D0009E086 /* LinkDefaultOptInView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkDefaultOptInView.swift; sourceTree = "<group>"; };
+		CBBE13E22E5639FA000CB977 /* MandateVariant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MandateVariant.swift; sourceTree = "<group>"; };
 		CBC98E212DD53F9D00458788 /* LinkFlowControllerHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkFlowControllerHelpers.swift; sourceTree = "<group>"; };
 		CBCFE3D39D670C3C77C59722 /* cs-CZ */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "cs-CZ"; path = "cs-CZ.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		CBE09F4C2D8DA62A0083D0B8 /* LinkConfirmationExtras.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkConfirmationExtras.swift; sourceTree = "<group>"; };
@@ -1061,6 +1063,7 @@
 				F20379AE078D68A0AC83A6C5 /* PaymentSheetFormFactory+OXXO.swift */,
 				86D228B38C83AA4A2F614F92 /* PaymentSheetFormFactory+UPI.swift */,
 				5A21CC86104388EFE07CB37D /* PaymentSheetFormFactoryConfig.swift */,
+				CBBE13E22E5639FA000CB977 /* MandateVariant.swift */,
 			);
 			path = PaymentSheetFormFactory;
 			sourceTree = "<group>";
@@ -2654,6 +2657,7 @@
 				ED75C8F47475E4BE5D496C93 /* STPPaymentIntentShippingDetailsParams+PaymentSheet.swift in Sources */,
 				4313D6635F10EC460D2ED21E /* SavedPaymentMethodCollectionView.swift in Sources */,
 				CF2AD2C7F761C46AE559E563 /* SavedPaymentOptionsViewController.swift in Sources */,
+				CBBE13E32E5639FA000CB977 /* MandateVariant.swift in Sources */,
 				418007102DE0EB85000FEB87 /* ShippingAddressesResponse.swift in Sources */,
 				F4EA474D60D0889E7D48E1CF /* BankAccountInfoView.swift in Sources */,
 				057A899F4123F3716F2AC0FA /* USBankAccountPaymentMethodElement.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -340,10 +340,8 @@ extension STPElementsSession {
         linkFlags["link_mobile_disable_default_opt_in"] != true
     }
 
-    var alwaysSaveForFutureUse: Bool {
-        // When this (now poorly named) feature flag is enabled for a merchant, we always show the reuse mandate,
-        // since the merchant will save the payment method for future use.
-        linkSignupOptInFeatureEnabled
+    var forceSaveFutureUseBehaviorAndNewMandateText: Bool {
+        flags["elements_mobile_force_setup_future_use_behavior_and_new_mandate_text"] == true
     }
 
     var linkSignupOptInFeatureEnabled: Bool {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -67,12 +67,11 @@ extension PayWithLinkViewController {
         var mandate: NSAttributedString? {
             switch selectedPaymentMethod?.details {
             case .card:
-                if context.elementsSession.alwaysSaveForFutureUse {
+                if context.elementsSession.forceSaveFutureUseBehaviorAndNewMandateText {
                     // Use the updated mandate text that can mention both payment method reuse and Link signup.
                     // Since the user is already signed up for Link, we don't need to save to Link.
                     return PaymentSheetFormFactory.makeMandateText(
-                        useCombinedReuseAndLinkSignupText: true,
-                        shouldSaveToLink: false,
+                        variant: .updated(shouldSignUpToLink: false),
                         merchantName: context.configuration.merchantDisplayName
                     )
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -163,7 +163,7 @@ extension PaymentSheet {
         let clientAttributionMetadata: STPClientAttributionMetadata = intent.clientAttributionMetadata(elementsSessionConfigId: elementsSession.sessionID)
 
         let isSettingUp: (STPPaymentMethodType) -> Bool = { paymentMethodType in
-            intent.isSetupFutureUsageSet(for: paymentMethodType) || elementsSession.alwaysSaveForFutureUse
+            intent.isSetupFutureUsageSet(for: paymentMethodType) || elementsSession.forceSaveFutureUseBehaviorAndNewMandateText
         }
 
         switch paymentOption {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/MandateVariant.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/MandateVariant.swift
@@ -1,0 +1,49 @@
+//
+//  MandateVariant.swift
+//  StripePaymentSheet
+//
+//  Created by Till Hellmund on 8/20/25.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePaymentsUI
+
+enum MandateVariant {
+    // The original mandate that describes reuse of the payment method by the merchant.
+    case original
+    // The updated mandate that describes reuse of the payment method by the merchant and optional Link signup.
+    case updated(shouldSignUpToLink: Bool)
+
+    func create(forMerchant merchant: String) -> NSAttributedString {
+        let formatText = switch self {
+        case .original:
+            String.Localized.by_providing_your_card_information_text
+        case .updated(let shouldSaveToLink):
+            if shouldSaveToLink {
+                String.Localized.by_continuing_you_agree_to_save_your_information_to_merchant_and_link
+            } else {
+                String.Localized.by_continuing_you_agree_to_save_your_information_to_merchant
+            }
+        }
+
+        let terms = String(format: formatText, merchant).removeTrailingDots()
+
+        if case .updated(true) = self {
+            let links = [
+                "link": URL(string: "https://link.com")!,
+                "terms": URL(string: "https://link.com/terms")!,
+                "privacy": URL(string: "https://link.com/privacy")!,
+            ]
+            return STPStringUtils.applyLinksToString(template: terms, links: links)
+        } else {
+            return NSAttributedString(string: terms)
+        }
+    }
+}
+
+private extension String {
+    func removeTrailingDots() -> String {
+        return hasSuffix("..") ? String(dropLast()) : self
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -142,15 +142,10 @@ extension PaymentSheetFormFactory {
         }
 
         let mandate: SimpleMandateElement? = {
-            if signupOptInFeatureEnabled {
-                // Respect this over all other configurations.
-                //
-                // It's possible that `signupOptInFeatureEnabled` is true, but the user has already used Link.
-                // This user would not see the signup opt-in toggle, but we still want to show the mandate.
-                // Therefore, always show the mandate if `signupOptInFeatureEnabled` is true, but only add
-                // the Link-specific terms if the signup opt-in toggle is actually visible via `shouldShowLinkSignupOptIn`.
-                let isSaveToLinkCheckboxChecked = shouldShowLinkSignupOptIn && signupOptInInitialValue
-                return makeMandate(shouldSaveToLink: !isLinkUI && isSaveToLinkCheckboxChecked)
+            if forceSaveFutureUseBehavior {
+                // Respect this over all other configurations, since we're forcing SFU behavior and thus need to show a mandate.
+                let isSaveToLinkCheckboxChecked = showLinkInlineSignup && signupOptInFeatureEnabled && signupOptInInitialValue
+                return makeMandate(shouldSaveToLink: isSaveToLinkCheckboxChecked)
             }
             switch configuration.termsDisplayFor(paymentMethodType: .stripe(.card)) {
             case .never:
@@ -176,46 +171,18 @@ extension PaymentSheetFormFactory {
     }
 
     private func makeMandate(shouldSaveToLink: Bool) -> SimpleMandateElement {
-        let mandateText = Self.makeMandateText(
-            useCombinedReuseAndLinkSignupText: signupOptInFeatureEnabled,
-            shouldSaveToLink: shouldSaveToLink,
-            merchantName: configuration.merchantDisplayName
-        )
+        let shouldSaveToLink = shouldSaveToLink && !isLinkUI
+        let variant: MandateVariant = forceSaveFutureUseBehavior
+            ? .updated(shouldSignUpToLink: shouldSaveToLink)
+            : .original
+        let mandateText = Self.makeMandateText(variant: variant, merchantName: configuration.merchantDisplayName)
         return makeMandate(mandateText: mandateText)
     }
 
     static func makeMandateText(
-        useCombinedReuseAndLinkSignupText: Bool,
-        shouldSaveToLink: Bool,
+        variant: MandateVariant,
         merchantName: String
     ) -> NSAttributedString {
-        let formatText = if useCombinedReuseAndLinkSignupText {
-            if shouldSaveToLink {
-                String.Localized.by_continuing_you_agree_to_save_your_information_to_merchant_and_link
-            } else {
-                String.Localized.by_continuing_you_agree_to_save_your_information_to_merchant
-            }
-        } else {
-            String.Localized.by_providing_your_card_information_text
-        }
-
-        let terms = String(format: formatText, merchantName).removeTrailingDots()
-
-        if useCombinedReuseAndLinkSignupText && shouldSaveToLink {
-            let links = [
-                "link": URL(string: "https://link.com")!,
-                "terms": URL(string: "https://link.com/terms")!,
-                "privacy": URL(string: "https://link.com/privacy")!,
-            ]
-            return STPStringUtils.applyLinksToString(template: terms, links: links)
-        } else {
-            return NSAttributedString(string: terms)
-        }
-    }
-}
-
-private extension String {
-    func removeTrailingDots() -> String {
-        return hasSuffix("..") ? String(dropLast()) : self
+        return variant.create(forMerchant: merchantName)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -144,15 +144,14 @@ extension PaymentSheetFormFactory {
         let mandate: SimpleMandateElement? = {
             if forceSaveFutureUseBehavior {
                 // Respect this over all other configurations, since we're forcing SFU behavior and thus need to show a mandate.
-                let isSaveToLinkCheckboxChecked = showLinkInlineSignup && signupOptInFeatureEnabled && signupOptInInitialValue
-                return makeMandate(shouldSaveToLink: isSaveToLinkCheckboxChecked)
+                return makeMandate()
             }
             switch configuration.termsDisplayFor(paymentMethodType: .stripe(.card)) {
             case .never:
                 return nil
             case .automatic:
                 if isSettingUp {
-                    return makeMandate(shouldSaveToLink: false)
+                    return makeMandate()
                 }
             }
             return nil
@@ -170,10 +169,11 @@ extension PaymentSheetFormFactory {
             customSpacing: customSpacing)
     }
 
-    private func makeMandate(shouldSaveToLink: Bool) -> SimpleMandateElement {
-        let shouldSaveToLink = shouldSaveToLink && !isLinkUI
+    private func makeMandate() -> SimpleMandateElement {
+        let shouldCheckSignupCheckbox = showLinkInlineCardSignup && signupOptInFeatureEnabled && signupOptInInitialValue
+        let shouldSignUpToLink = shouldCheckSignupCheckbox && !isLinkUI
         let variant: MandateVariant = forceSaveFutureUseBehavior
-            ? .updated(shouldSignUpToLink: shouldSaveToLink)
+            ? .updated(shouldSignUpToLink: shouldSignUpToLink)
             : .original
         let mandateText = Self.makeMandateText(variant: variant, merchantName: configuration.merchantDisplayName)
         return makeMandate(mandateText: mandateText)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -40,6 +40,7 @@ class PaymentSheetFormFactory {
     let savePaymentMethodConsentBehavior: SavePaymentMethodConsentBehavior
     let allowsSetAsDefaultPM: Bool
     let allowsLinkDefaultOptIn: Bool
+    let forceSaveFutureUseBehavior: Bool
     let signupOptInFeatureEnabled: Bool
     let signupOptInInitialValue: Bool
     let isFirstSavedPaymentMethod: Bool
@@ -52,11 +53,11 @@ class PaymentSheetFormFactory {
         guard !configuration.linkPaymentMethodsOnly else { return false }
         switch savePaymentMethodConsentBehavior {
         case .legacy:
-            return !shouldShowLinkSignupOptIn && !isSettingUp && configuration.hasCustomer && paymentMethod.supportsSaveForFutureUseCheckbox()
+            return !signupOptInFeatureEnabled && !isSettingUp && configuration.hasCustomer && paymentMethod.supportsSaveForFutureUseCheckbox()
         case .paymentSheetWithCustomerSessionPaymentMethodSaveDisabled:
             return false
         case .paymentSheetWithCustomerSessionPaymentMethodSaveEnabled:
-            return !shouldShowLinkSignupOptIn && configuration.hasCustomer && paymentMethod.supportsSaveForFutureUseCheckbox()
+            return !signupOptInFeatureEnabled && configuration.hasCustomer && paymentMethod.supportsSaveForFutureUseCheckbox()
         case .customerSheetWithCustomerSession:
             return false
         }
@@ -68,10 +69,6 @@ class PaymentSheetFormFactory {
 
     var theme: ElementsAppearance {
         return configuration.appearance.asElementsTheme
-    }
-
-    var shouldShowLinkSignupOptIn: Bool {
-        showLinkInlineCardSignup && signupOptInFeatureEnabled
     }
 
     private static let PayByBankDescriptionText = STPLocalizedString(
@@ -137,6 +134,7 @@ class PaymentSheetFormFactory {
                   savePaymentMethodConsentBehavior: elementsSession.savePaymentMethodConsentBehavior,
                   allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
                   allowsLinkDefaultOptIn: elementsSession.allowsLinkDefaultOptIn,
+                  forceSaveFutureUseBehavior: elementsSession.forceSaveFutureUseBehaviorAndNewMandateText,
                   signupOptInFeatureEnabled: elementsSession.linkSignupOptInFeatureEnabled,
                   signupOptInInitialValue: elementsSession.linkSignupOptInInitialValue,
                   isFirstSavedPaymentMethod: elementsSession.customer?.paymentMethods.isEmpty ?? true,
@@ -163,6 +161,7 @@ class PaymentSheetFormFactory {
         savePaymentMethodConsentBehavior: SavePaymentMethodConsentBehavior,
         allowsSetAsDefaultPM: Bool = false,
         allowsLinkDefaultOptIn: Bool = false,
+        forceSaveFutureUseBehavior: Bool = false,
         signupOptInFeatureEnabled: Bool = false,
         signupOptInInitialValue: Bool = false,
         isFirstSavedPaymentMethod: Bool = true,
@@ -191,6 +190,7 @@ class PaymentSheetFormFactory {
         self.savePaymentMethodConsentBehavior = savePaymentMethodConsentBehavior
         self.allowsSetAsDefaultPM = allowsSetAsDefaultPM
         self.allowsLinkDefaultOptIn = allowsLinkDefaultOptIn
+        self.forceSaveFutureUseBehavior = forceSaveFutureUseBehavior
         self.signupOptInFeatureEnabled = signupOptInFeatureEnabled
         self.signupOptInInitialValue = signupOptInInitialValue
         self.isFirstSavedPaymentMethod = isFirstSavedPaymentMethod

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -233,11 +233,11 @@ extension PaymentMethodFormViewController: ElementDelegate {
             }
         }
 
-        if let linkSignup = form.linkInlineSignupElement, let mandateElement = form.mandateElement {
-            // Update the mandate with or without Link
+        if let linkSignup = form.linkInlineSignupElement, linkSignup.viewModel.mode == .signupOptIn, let mandateElement = form.mandateElement {
+            // Update the mandate based on the checkbox state
+            let variant = MandateVariant.updated(shouldSignUpToLink: linkSignup.viewModel.saveCheckboxChecked)
             let text = PaymentSheetFormFactory.makeMandateText(
-                useCombinedReuseAndLinkSignupText: linkSignup.viewModel.mode == .signupOptIn,
-                shouldSaveToLink: linkSignup.viewModel.saveCheckboxChecked,
+                variant: variant,
                 merchantName: configuration.merchantDisplayName
             )
             mandateElement.mandateTextView.attributedText = text


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request starts using the new `elements_mobile_force_setup_future_use_behavior_and_new_mandate_text` flag on Elements session. This flag will now drive the forced SFU behavior and new mandate text, so that `link_settings.link_sign_up_opt_in_feature_enabled` can be used solely for determine the signup feature's state.

For greater clarity, I also added a new `MandateVariant` enum to distinguish between the original and updated mandate.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
