### PR TITLE
Crypto Onramp SDK: Example App Attach Wallet Address Sheet

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AttachWalletAddressView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AttachWalletAddressView.swift
@@ -36,7 +36,7 @@ struct AttachWalletAddressView: View {
             ScrollView {
                 VStack(spacing: 20) {
                     VStack(alignment: .leading, spacing: 8) {
-                        Text("Attach a wallet address to your Link account.")
+                        Text("Attach a wallet address to your account.")
                             .font(.subheadline)
                             .foregroundColor(.secondary)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -53,7 +53,7 @@ struct AttachWalletAddressView: View {
                     FormField("Network") {
                         Picker("Network", selection: $selectedNetwork) {
                             ForEach(CryptoNetwork.allCases, id: \.rawValue) { network in
-                                Text(network.rawValue.uppercased()).tag(network)
+                                Text(network.rawValue.localizedCapitalized).tag(network)
                             }
                         }
                         .pickerStyle(.menu)
@@ -63,21 +63,23 @@ struct AttachWalletAddressView: View {
                     if let errorMessage {
                         ErrorMessageView(message: errorMessage)
                     }
-
-                    Button("Submit") {
-                        submit()
-                    }
-                    .buttonStyle(PrimaryButtonStyle())
-                    .disabled(isSubmitDisabled)
-                    .opacity(isSubmitDisabled ? 0.5 : 1)
                 }
                 .padding()
             }
-.navigationTitle("Wallet Address")
+            .navigationTitle("Wallet Address")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("Close") { dismiss() }
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Submit") {
+                        submit()
+                    }
+                    .disabled(isSubmitDisabled)
+                    .opacity(isSubmitDisabled ? 0.5 : 1)
                 }
             }
         }
@@ -120,4 +122,3 @@ struct AttachWalletAddressView: View {
         AttachWalletAddressView(coordinator: coordinator)
     }
 }
-

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AttachWalletAddressView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AttachWalletAddressView.swift
@@ -19,6 +19,9 @@ struct AttachWalletAddressView: View {
     /// The coordinator used to submit the wallet address.
     let coordinator: CryptoOnrampCoordinator
 
+    /// Binding to inform presenting view that a wallet was successfully attached.
+    @Binding var isWalletAttached: Bool
+
     @State private var walletAddress: String = "0x4242424242424242424242424242424242424242"
     @State private var selectedNetwork: CryptoNetwork = .ethereum
     @State private var errorMessage: String?
@@ -105,6 +108,7 @@ struct AttachWalletAddressView: View {
                 try await coordinator.collectWalletAddress(walletAddress: address, network: selectedNetwork)
                 await MainActor.run {
                     isLoading.wrappedValue = false
+                    isWalletAttached = true
                     dismiss()
                 }
             } catch {
@@ -119,6 +123,6 @@ struct AttachWalletAddressView: View {
 
 #Preview {
     PreviewWrapperView { coordinator in
-        AttachWalletAddressView(coordinator: coordinator)
+        AttachWalletAddressView(coordinator: coordinator, isWalletAttached: .constant(false))
     }
 }

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AttachWalletAddressView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AttachWalletAddressView.swift
@@ -1,0 +1,123 @@
+//
+//  AttachWalletAddressView.swift
+//  CryptoOnramp Example
+//
+//  Created by Michael Liberatore on 8/20/25.
+//
+
+import SwiftUI
+
+@_spi(CryptoOnrampSDKPreview)
+import StripeCryptoOnramp
+
+@_spi(STP)
+import StripePaymentSheet
+
+/// A view shown in a sheet to attach a crypto wallet address to the current user’s account.
+struct AttachWalletAddressView: View {
+
+    /// The coordinator used to submit the wallet address.
+    let coordinator: CryptoOnrampCoordinator
+
+    @State private var walletAddress: String = "0x4242424242424242424242424242424242424242"
+    @State private var selectedNetwork: CryptoNetwork = .ethereum
+    @State private var errorMessage: String?
+
+    @Environment(\.isLoading) private var isLoading
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var walletFieldFocused: Bool
+
+    private var isSubmitDisabled: Bool {
+        isLoading.wrappedValue || walletAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 20) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Attach a wallet address to your Link account.")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    FormField("Wallet Address") {
+                        TextField("Enter wallet address", text: $walletAddress)
+                            .textFieldStyle(RoundedBorderTextFieldStyle())
+                            .autocapitalization(.none)
+                            .disableAutocorrection(true)
+                            .focused($walletFieldFocused)
+                    }
+
+                    FormField("Network") {
+                        Picker("Network", selection: $selectedNetwork) {
+                            ForEach(CryptoNetwork.allCases, id: \.rawValue) { network in
+                                Text(network.rawValue.uppercased()).tag(network)
+                            }
+                        }
+                        .pickerStyle(.menu)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    }
+
+                    if let errorMessage {
+                        ErrorMessageView(message: errorMessage)
+                    }
+
+                    Button("Submit") {
+                        submit()
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                    .disabled(isSubmitDisabled)
+                    .opacity(isSubmitDisabled ? 0.5 : 1)
+                }
+                .padding()
+            }
+.navigationTitle("Wallet Address")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+        }
+        .onAppear {
+            // Focus and select the text so the user can quickly delete the default address if needed.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                walletFieldFocused = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    UIApplication.shared.sendAction(#selector(UIResponder.selectAll(_:)), to: nil, from: nil, for: nil)
+                }
+            }
+        }
+    }
+
+    private func submit() {
+        isLoading.wrappedValue = true
+        errorMessage = nil
+
+        let address = walletAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        Task {
+            do {
+                try await coordinator.collectWalletAddress(walletAddress: address, network: selectedNetwork)
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    dismiss()
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    errorMessage = "Attach wallet failed: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PreviewWrapperView { coordinator in
+        AttachWalletAddressView(coordinator: coordinator)
+    }
+}
+

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -26,6 +26,7 @@ struct AuthenticatedView: View {
     @State private var errorMessage: String?
     @State private var isIdentityVerificationComplete = false
     @State private var showKYCView = false
+    @State private var showAttachWalletSheet = false
     @State private var selectedPaymentMethod: PaymentMethodPreview?
     @State private var cryptoPaymentToken: String?
 
@@ -66,6 +67,13 @@ struct AuthenticatedView: View {
 
                     Button("Submit KYC Information") {
                         showKYCView = true
+                    }
+                    .buttonStyle(PrimaryButtonStyle())
+                    .disabled(shouldDisableButtons)
+                    .opacity(shouldDisableButtons ? 0.5 : 1)
+
+                    Button("Attach Wallet Address") {
+                        showAttachWalletSheet = true
                     }
                     .buttonStyle(PrimaryButtonStyle())
                     .disabled(shouldDisableButtons)
@@ -163,6 +171,9 @@ struct AuthenticatedView: View {
         }
         .navigationTitle("Authenticated")
         .navigationBarTitleDisplayMode(.inline)
+        .sheet(isPresented: $showAttachWalletSheet) {
+            AttachWalletAddressView(coordinator: coordinator)
+        }
     }
 
     private func verifyIdentity() {

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -27,6 +27,7 @@ struct AuthenticatedView: View {
     @State private var isIdentityVerificationComplete = false
     @State private var showKYCView = false
     @State private var showAttachWalletSheet = false
+    @State private var isWalletAttached = false
     @State private var selectedPaymentMethod: PaymentMethodPreview?
     @State private var cryptoPaymentToken: String?
 
@@ -72,12 +73,23 @@ struct AuthenticatedView: View {
                     .disabled(shouldDisableButtons)
                     .opacity(shouldDisableButtons ? 0.5 : 1)
 
-                    Button("Attach Wallet Address") {
-                        showAttachWalletSheet = true
+                    if isWalletAttached {
+                        Text("Wallet Successfully Attached")
+                            .foregroundColor(.green)
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background {
+                                RoundedRectangle(cornerRadius: 8)
+                                    .foregroundColor(.green.opacity(0.1))
+                            }
+                    } else {
+                        Button("Attach Wallet Address") {
+                            showAttachWalletSheet = true
+                        }
+                        .buttonStyle(PrimaryButtonStyle())
+                        .disabled(shouldDisableButtons)
+                        .opacity(shouldDisableButtons ? 0.5 : 1)
                     }
-                    .buttonStyle(PrimaryButtonStyle())
-                    .disabled(shouldDisableButtons)
-                    .opacity(shouldDisableButtons ? 0.5 : 1)
 
                     HStack(spacing: 4) {
                         Text("Customer ID:")
@@ -172,7 +184,7 @@ struct AuthenticatedView: View {
         .navigationTitle("Authenticated")
         .navigationBarTitleDisplayMode(.inline)
         .sheet(isPresented: $showAttachWalletSheet) {
-            AttachWalletAddressView(coordinator: coordinator)
+            AttachWalletAddressView(coordinator: coordinator, isWalletAttached: $isWalletAttached)
         }
     }
 

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
@@ -85,6 +85,7 @@ struct CryptoOnrampExampleView: View {
             .navigationTitle("CryptoOnramp Example")
             .navigationBarTitleDisplayMode(.inline)
         }
+        .navigationViewStyle(.stack)
         .onAppear {
             guard coordinator == nil else {
                 return

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoNetwork.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoNetwork.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// Supported crypto networks for wallet address registration.
 @_spi(CryptoOnrampSDKPreview)
-public enum CryptoNetwork: String, Codable {
+public enum CryptoNetwork: String, Codable, CaseIterable {
     case bitcoin = "bitcoin"
     case ethereum = "ethereum"
     case solana = "solana"


### PR DESCRIPTION
## Summary
Adds an interface to attach a wallet address that calls the coordinator’s `collectWalletAddress` method. Note that the wallet information is not stored or persisted locally, or fetched the next time this UI appears. Defaults to a test eth wallet address that we’re currently using.

## Motivation
Working towards an end-to-end checkout example.

## Testing

https://github.com/user-attachments/assets/3758bf15-8152-4e93-8169-ff57a9610735

## Changelog

N/A