### PR TITLE
Allow changing payment methods in the Onramp example app

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -95,29 +95,40 @@ struct AuthenticatedView: View {
                         .foregroundColor(.secondary)
 
                     if let selectedPaymentMethod {
-                        HStack {
-                            Spacer()
-                            PaymentMethodCardView(preview: selectedPaymentMethod)
-                            Spacer()
-                        }
+                        VStack(spacing: 12) {
+                            HStack {
+                                Spacer()
+                                PaymentMethodCardView(preview: selectedPaymentMethod)
+                                Spacer()
+                            }
 
-                        Button("Create crypto payment token") {
-                            createCryptoPaymentToken()
-                        }
-                        .buttonStyle(PrimaryButtonStyle())
+                            Button("Create crypto payment token") {
+                                createCryptoPaymentToken()
+                            }
+                            .buttonStyle(PrimaryButtonStyle())
 
-                        if let cryptoPaymentToken {
-                            HStack(spacing: 4) {
-                                Text("Crypto payment token:")
-                                    .font(.footnote)
-                                    .bold()
+                            if let cryptoPaymentToken {
+                                HStack(spacing: 4) {
+                                    Text("Crypto payment token:")
+                                        .font(.footnote)
+                                        .bold()
+                                        .foregroundColor(.secondary)
+                                    Text(cryptoPaymentToken)
+                                        .font(.footnote.monospaced())
+                                        .foregroundColor(.secondary)
+                                }
+                            } else {
+                                Divider()
+
+                                Text("Change Payment Method")
+                                    .font(.subheadline)
                                     .foregroundColor(.secondary)
-                                Text(cryptoPaymentToken)
-                                    .font(.footnote.monospaced())
-                                    .foregroundColor(.secondary)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
                             }
                         }
-                    } else {
+                    }
+
+                    if cryptoPaymentToken == nil {
                         VStack(spacing: 8) {
                             // Note: Apple Pay does not require iOS 16, but the native SwiftUI
                             // `PayWithApplePayButton` does, which we're using in this example.


### PR DESCRIPTION
## Summary

Allows changing payment methods after one has been selected in the Onramp example app. Once a payment token is created, you can no longer change payment methods.

## Motivation

💅 

## Testing


https://github.com/user-attachments/assets/7a578359-fd3c-4404-82d3-ca3819a7f63a



## Changelog

N/a
