### PR TITLE
Change removal message when payment_method_remove == .partial

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -267,6 +267,7 @@
 		6B50BCF02C29F888009702FB /* CustomerSavedPaymentMethodsCollectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50BCEF2C29F888009702FB /* CustomerSavedPaymentMethodsCollectionViewControllerTests.swift */; };
 		6B76DBD12C530B6C0037CD63 /* PaymentSheetGDPRConfirmFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B76DBD02C530B6C0037CD63 /* PaymentSheetGDPRConfirmFlowTests.swift */; };
 		6B7E675071649AE3047D388C /* PaymentSheetFormFactoryConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A21CC86104388EFE07CB37D /* PaymentSheetFormFactoryConfig.swift */; };
+		6B8110682E5661D700FEC2EC /* STPPaymentMethodRemove.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8110672E5661D400FEC2EC /* STPPaymentMethodRemove.swift */; };
 		6B9CFA972D7B64FE001A3C13 /* STPPaymentMethod+PaymentSheetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B9CFA962D7B64F5001A3C13 /* STPPaymentMethod+PaymentSheetTests.swift */; };
 		6BA8D3342B0C1F79008C51FF /* CVCRecollectionElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3332B0C1F79008C51FF /* CVCRecollectionElement.swift */; };
 		6BA8D3362B0C1F9B008C51FF /* CVCReconfirmationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA8D3352B0C1F9B008C51FF /* CVCReconfirmationViewController.swift */; };
@@ -774,6 +775,7 @@
 		6B50BCEF2C29F888009702FB /* CustomerSavedPaymentMethodsCollectionViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSavedPaymentMethodsCollectionViewControllerTests.swift; sourceTree = "<group>"; };
 		6B680A2FF197F612D065F16C /* PaymentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheet.swift; sourceTree = "<group>"; };
 		6B76DBD02C530B6C0037CD63 /* PaymentSheetGDPRConfirmFlowTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetGDPRConfirmFlowTests.swift; sourceTree = "<group>"; };
+		6B8110672E5661D400FEC2EC /* STPPaymentMethodRemove.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodRemove.swift; sourceTree = "<group>"; };
 		6B9A346A7A4290BAA7BCA1A2 /* PaymentMethodTypeCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodTypeCollectionView.swift; sourceTree = "<group>"; };
 		6B9CFA962D7B64F5001A3C13 /* STPPaymentMethod+PaymentSheetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPPaymentMethod+PaymentSheetTests.swift"; sourceTree = "<group>"; };
 		6BA8D3332B0C1F79008C51FF /* CVCRecollectionElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CVCRecollectionElement.swift; sourceTree = "<group>"; };
@@ -1068,6 +1070,7 @@
 		1B84E8DA16EA02948055C084 /* v1-elements-sessions */ = {
 			isa = PBXGroup;
 			children = (
+				6B8110672E5661D400FEC2EC /* STPPaymentMethodRemove.swift */,
 				2BFA5FA03C7093654EC6926F /* ExternalPaymentMethod.swift */,
 				61D946052D7901B400BFCD0C /* CustomPaymentMethod.swift */,
 				CC3498CF4AEAA8F169616CDF /* STPCardBrandChoice.swift */,
@@ -2419,6 +2422,7 @@
 				B66D70FA2C54086600DECB3D /* HostedSurface.swift in Sources */,
 				4E5A3324BBD882A780925E2B /* STPAnalyticsClient+Address.swift in Sources */,
 				0FB52E5B87B1854B28362BF3 /* STPAnalyticsClient+CustomerSheet.swift in Sources */,
+				6B8110682E5661D700FEC2EC /* STPPaymentMethodRemove.swift in Sources */,
 				6A529F76ECB33C9154314C1F /* STPAnalyticsClient+LUXE.swift in Sources */,
 				61D842892CADE4B9009D2D51 /* PaymentElementConfiguration.swift in Sources */,
 				06976DDC67A61176FC54AA76 /* Data+SHA256.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/bg-BG.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/bg-BG.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Това е настройката по подразбиране.";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Този метод на плащане ще бъде премахнат, но ще остане наличен за абонаменти %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Твърде много опити. Моля, опитайте отново след няколко минути.";
 
 "Unavailable for this purchase" = "Недостъпно за тази покупка";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ca-ES.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ca-ES.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Aquesta és l'opció per defecte";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Aquesta forma de pagament se suprimirà, però continuarà disponible per a les subscripcions del %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Massa intents. Torneu-ho a provar d'aquí uns minuts.";
 
 "Unavailable for this purchase" = "No disponible per a aquesta compra";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/cs-CZ.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/cs-CZ.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Toto je výchozí nastavení";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Tato platební metoda bude odebrána, ale zůstane dostupná pro předplatné %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Příliš mnoho pokusů. Zkuste to prosím za pár minut znovu.";
 
 "Unavailable for this purchase" = "Není k dispozici pro tento nákup";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/da.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/da.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Dette er din standard";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Denne betalingsmetode vil blive fjernet, men vil fortsat være tilgængelig for %@-abonnementer.";
+
 "Too many attempts. Please try again in a few minutes." = "For mange forsøg. Prøv igen om et par minutter.";
 
 "Unavailable for this purchase" = "Ikke tilgængelig for dette køb";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/de.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/de.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Dies ist Ihre Standard-Methode";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Diese Zahlungsmethode wird entfernt, bleibt jedoch für %@ Abos verfügbar.";
+
 "Too many attempts. Please try again in a few minutes." = "Zu viele Versuche. Versuchen Sie es in ein paar Minuten noch einmal.";
 
 "Unavailable for this purchase" = "Nicht verfügbar für diesen Kauf";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/el-GR.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/el-GR.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Αυτή είναι η προεπιλογή σας";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Αυτή η μέθοδος πληρωμής θα καταργηθεί, αλλά θα παραμείνει διαθέσιμη για %@ συνδρομές.";
+
 "Too many attempts. Please try again in a few minutes." = "Πραγματοποιήθηκαν πολλές προσπάθειες. Δοκιμάστε ξανά σε λίγα λεπτά.";
 
 "Unavailable for this purchase" = "Δεν είναι διαθέσιμο για αυτήν την αγορά";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en-GB.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en-GB.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "This is your default";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "This payment method will be removed but will remain available for %@ subscriptions.";
+
 "Too many attempts. Please try again in a few minutes." = "Too many attempts. Please try again in a few minutes.";
 
 "Unavailable for this purchase" = "Unavailable for this purchase";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -442,6 +442,9 @@ is not supported by the merchant */
 /* Text of a label indicating that a payment method is the default. */
 "This is your default" = "This is your default";
 
+/* Content for alert popup prompting if they want to remove a payment method when using payment_method_remove == .partial. %@ is replaced by the merchant name */
+"This payment method will be removed but will remain available for %@ subscriptions." = "This payment method will be removed but will remain available for %@ subscriptions.";
+
 /* Error message shown when the user enters an incorrect verification code too many times. */
 "Too many attempts. Please try again in a few minutes." = "Too many attempts. Please try again in a few minutes.";
 

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/es-419.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/es-419.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Tu método predeterminado";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Este método de pago se eliminará, pero seguirá disponible para las suscripciones de %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Se hicieron demasiados intentos. Vuelve a intentarlo en unos minutos.";
 
 "Unavailable for this purchase" = "No disponible para esta compra";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/es.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/es.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Este es tu valor predeterminado";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Este método de pago se eliminará, pero seguirá disponible para %@ suscripciones.";
+
 "Too many attempts. Please try again in a few minutes." = "Demasiados intentos. Vuelve a intentarlo dentro de unos minutos.";
 
 "Unavailable for this purchase" = "No disponible para esta compra";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/et-EE.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/et-EE.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "See on teie vaikimisi makseviis";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "See makseviis eemaldatakse, kuid jääb %@ kordustellimuste jaoks saadavale.";
+
 "Too many attempts. Please try again in a few minutes." = "Liiga palju katseid. Proovige paari minuti pärast uuesti.";
 
 "Unavailable for this purchase" = "Pole selle ostu puhul saadaval";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fi.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fi.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Tämä on oletusarvoinen";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Tämä maksutapa poistetaan, mutta se on edelleen käytettävissä %@ tilauksissa.";
+
 "Too many attempts. Please try again in a few minutes." = "Liian monta yritystä. Kokeile uudelleen muutaman minuutin kuluttua.";
 
 "Unavailable for this purchase" = "Ei käytettävissä tälle ostolle";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fil.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fil.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Ito ang iyong default";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Tatanggalin ang paraan ng pagbabayad na ito pero mananatiling available para sa %@ (na) subskripsiyon.";
+
 "Too many attempts. Please try again in a few minutes." = "Masyado nang marami ang pagtatangka. Pakisubukan muli sa loob ng ilang minuto.";
 
 "Unavailable for this purchase" = "Hindi magamit sa pagbiling ito";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fr-CA.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fr-CA.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Votre moyen de paiement par défaut";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Ce mode de paiement sera supprimé mais restera disponible pour les abonnements %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Vous avez effectué un nombre trop élevé de tentatives. Veuillez réessayer dans quelques minutes.";
 
 "Unavailable for this purchase" = "Indisponible pour cet achat";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fr.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Votre moyen de paiement par défaut";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Ce moyen de paiement sera supprimé mais restera disponible pour les Abonnements %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Vous avez effectué un nombre trop élevé de tentatives. Veuillez réessayer dans quelques minutes.";
 
 "Unavailable for this purchase" = "Indisponible pour cet achat";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/hr.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/hr.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Ovo je vaša zadana vrijednost";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Ovaj način plaćanja bit će uklonjen, ali će ostati dostupan za pretplate %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Previše pokušaja. Pokušajte ponovno za nekoliko minuta.";
 
 "Unavailable for this purchase" = "Nije dostupno za ovu kupnju";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/hu.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/hu.lproj/Localizable.strings
@@ -284,6 +284,8 @@
 
 "This is your default" = "Ez az alapértelmezett";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Ez a fizetési mód eltávolításra kerül, de továbbra is elérhető marad %@ előfizetések esetén.";
+
 "Too many attempts. Please try again in a few minutes." = "Túl sok kísérlet. Próbálja meg újra néhány perc múlva.";
 
 "Unavailable for this purchase" = "Nem érhető el ennél a vásárlásnál";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/id.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/id.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Ini default Anda";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Metode pembayaran ini akan dihapus tetapi akan tetap tersedia untuk langganan %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Terlalu banyak percobaan. Cobalah lagi sebentar lagi.";
 
 "Unavailable for this purchase" = "Tidak tersedia untuk pembelian ini";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/it.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/it.lproj/Localizable.strings
@@ -60,6 +60,8 @@
 
 "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>." = "Se continui, accetti di autorizzare i pagamenti conformemente ai <terms>questi termini</terms>.";
 
+"By continuing, you agree to save your information for future purchases with %@ and <link>Link</link> according to Link <terms>terms</terms> and <privacy>privacy</privacy>." = "Continuando, accetti di salvare le tue informazioni per acquisti futuri con %@ e <link>Link</link> secondo i <terms>Termini</terms> e la <privacy>privacy</privacy> di Link.";
+
 "By continuing, you agree to save your information for future purchases with %@." = "Continuando, accetti di salvare le tue informazioni per acquisti futuri con %@.";
 
 "By continuing, you authorize %@ to automatically debit your Satispay Balance on a recurring basis in accordance with your purchase or subscription plan." = "Continuando, autorizzi %@ a effettuare addebiti sul tuo saldo Satispay su base ricorrente in base al tuo piano di acquisto o abbonamento.";
@@ -283,6 +285,8 @@
 "This card has expired. Update your card info or choose a different payment method." = "La carta è scaduta. Aggiorna i dati della carta o scegli un altro metodo di pagamento.";
 
 "This is your default" = "È la tua impostazione predefinita";
+
+"This payment method will be removed but will remain available for %@ subscriptions." = "Questo metodo di pagamento sarà rimosso, ma rimarrà disponibile per gli abbonamenti %@.";
 
 "Too many attempts. Please try again in a few minutes." = "Troppi tentativi. Riprova tra qualche minuto.";
 

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ja.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "これはデフォルトです";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "この決済手段は削除されますが、%@ のサブスクリプションでは引き続き使用できます。";
+
 "Too many attempts. Please try again in a few minutes." = "試行回数が多すぎます。数分後に再度お試しください。";
 
 "Unavailable for this purchase" = "この購入には利用できません";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ko.lproj/Localizable.strings
@@ -284,6 +284,8 @@
 
 "This is your default" = "기본값입니다";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "이 결제 방식은 제거되지만 %@ 구독에는 계속 사용할 수 있습니다.";
+
 "Too many attempts. Please try again in a few minutes." = "너무 많이 시도했습니다. 몇 분 후에 다시 시도해 주십시오.";
 
 "Unavailable for this purchase" = "해당 구매에는 사용 불가능";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/lt-LT.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/lt-LT.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Tai jūsų numatytasis mokėjimo būdas";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Šis mokėjimo būdas bus pašalintas, tačiau ir toliau bus galima naudotis %@ prenumeratomis.";
+
 "Too many attempts. Please try again in a few minutes." = "Per daug bandymų. Bandykite dar kartą po kelių minučių.";
 
 "Unavailable for this purchase" = "Šiam pirkiniui nepasiekiama";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/lv-LV.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/lv-LV.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Tas ir jūsu noklusējums";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Šis maksājuma veids tiks noņemts, bet joprojām būs pieejams %@ abonementiem.";
+
 "Too many attempts. Please try again in a few minutes." = "Pārāk daudz mēģinājumu. Mēģiniet vēlreiz pēc dažām minūtēm.";
 
 "Unavailable for this purchase" = "Nav pieejams šim pirkumam";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ms-MY.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ms-MY.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Ini tetapan asal anda";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Kaedah pembayaran ini akan dialih keluar tetapi akan kekal tersedia untuk langganan %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Terlalu banyak percubaan. Sila cuba lagi dalam beberapa minit.";
 
 "Unavailable for this purchase" = "Tidak tersedia untuk pembelian ini";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/mt.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/mt.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Dan il-metodu tal-pagament standard tiegħek";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Dan il-metodu ta' pagament se jitneħħa iżda se jibqa' disponibbli għal abbonamenti ta' %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Ippruvajt wisq drabi. Jekk jogħġbok erġa' pprova wara ftit minuti.";
 
 "Unavailable for this purchase" = "Mhux disponibbli għal dix-xirja";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/nb.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/nb.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Dette er standarden din";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Denne betalingsmåten vil bli fjernet, men vil fortsatt være tilgjengelig for %@ abonnementer.";
+
 "Too many attempts. Please try again in a few minutes." = "For mange forsøk. Prøv på nytt om noen få minutter.";
 
 "Unavailable for this purchase" = "Utilgjengelig for dette kjøpet";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/nl.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/nl.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Dit is je standaard";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Deze betaalmethode wordt verwijderd, maar blijft beschikbaar voor %@ abonnementen.";
+
 "Too many attempts. Please try again in a few minutes." = "Te veel pogingen. Probeer het over een paar minuten opnieuw.";
 
 "Unavailable for this purchase" = "Niet beschikbaar voor deze aankoop";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pl-PL.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pl-PL.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "To Twoje ustawienie domyślne";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Ta metoda płatności zostanie usunięta, ale pozostanie dostępna dla %@ subskrypcji.";
+
 "Too many attempts. Please try again in a few minutes." = "Zbyt wiele prób. Spróbuj ponownie za kilka minut.";
 
 "Unavailable for this purchase" = "Niedostępne dla tego zakupu";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -60,6 +60,8 @@
 
 "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>." = "Ao continuar, você aceita autorizar pagamentos de acordo com <terms>estes termos</terms>.";
 
+"By continuing, you agree to save your information for future purchases with %@ and <link>Link</link> according to Link <terms>terms</terms> and <privacy>privacy</privacy>." = "Ao continuar, você concorda em salvar seus dados para compras futuras com %@ e <link>Link</link> de acordo com os <terms>termos</terms> e a <privacy>privacidade</privacy> do Link.";
+
 "By continuing, you agree to save your information for future purchases with %@." = "Ao continuar, você concorda em salvar seus dados para compras futuras com %@.";
 
 "By continuing, you authorize %@ to automatically debit your Satispay Balance on a recurring basis in accordance with your purchase or subscription plan." = "Ao continuar, você autoriza a %@ a debitar automaticamente do seu saldo Satispay, de forma recorrente, de acordo com sua compra ou plano de assinatura.";
@@ -283,6 +285,8 @@
 "This card has expired. Update your card info or choose a different payment method." = "Este cartão expirou. Atualize as informações do seu cartão ou escolha outra forma de pagamento.";
 
 "This is your default" = "Este é o seu padrão";
+
+"This payment method will be removed but will remain available for %@ subscriptions." = "Esta forma de pagamento será removida, mas permanecerá disponível para %@ assinaturas.";
 
 "Too many attempts. Please try again in a few minutes." = "Excesso de tentativas. Tente novamente em alguns minutos.";
 

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pt-PT.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pt-PT.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Este é o seu método predefinido";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Este método de pagamento será removido, mas continuará disponível para subscrições %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Demasiadas tentativas. Tente novamente dentro de alguns minutos.";
 
 "Unavailable for this purchase" = "Indisponível para esta compra";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ro-RO.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ro-RO.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Aceasta este setarea dvs. implicită";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Această metodă de plată va fi eliminată, dar va rămâne disponibilă pentru abonamentele %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Prea multe încercări. Vă rugăm să încercați din nou în câteva minute.";
 
 "Unavailable for this purchase" = "Nu este disponibilă pentru această achiziție";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ru.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Это ваше значение по умолчанию";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Этот способ оплаты будет удален, но останется доступным для подписок (%@).";
+
 "Too many attempts. Please try again in a few minutes." = "Превышено разрешенное число попыток. Попробуйте еще раз через несколько минут.";
 
 "Unavailable for this purchase" = "Не предусмотрено для этой покупки";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sk-SK.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sk-SK.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Toto je váš predvolený spôsob platby";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Tento spôsob platby sa odstráni, ale ostane k dispozícii pre predplatné %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Príliš veľa pokusov. Skúste to znova o niekoľko minút.";
 
 "Unavailable for this purchase" = "Nie je k dispozícii pre tento nákup";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sl-SI.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sl-SI.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "To je vaš privzeti način plačila";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Ta način plačila bo odstranjen, vendar bo še naprej na voljo za naročnine %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Preveč poskusov. Poskusite znova čez nekaj minut.";
 
 "Unavailable for this purchase" = "Ni na voljo za ta nakup";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sv.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sv.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Detta är din standardbetalningsmetod";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Den här betalningsmetoden kommer att tas bort, men förblir tillgänglig för %@ abonnemang..";
+
 "Too many attempts. Please try again in a few minutes." = "För många försök. Försök igen om några minuter.";
 
 "Unavailable for this purchase" = "Otillgängligt för detta köp";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/th.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/th.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "นี่คือค่าเริ่มต้นของคุณ";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "วิธีการชำระเงินนี้จะถูกนำออกไปแต่จะยังคงใช้ได้สำหรับการชำระเงินตามรอบบิล %@";
+
 "Too many attempts. Please try again in a few minutes." = "ลองหลายครั้งเกินไป โปรดลองใหม่ในอีกสักครู่";
 
 "Unavailable for this purchase" = "ใช้กับการซื้อรายการนี้ไม่ได้";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/tr.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/tr.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Bu varsayılan ödeme yönteminizdir";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Bu ödeme yöntemi kaldırılacak ancak %@ abonelikleri için kullanılabilir kalacaktır.";
+
 "Too many attempts. Please try again in a few minutes." = "Çok fazla deneme yapıldı. Lütfen birkaç dakika içinde tekrar deneyin.";
 
 "Unavailable for this purchase" = "Bu satın alım için kullanılamaz";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/vi.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/vi.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "Đây là thông tin mặc định của bạn";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "Phương thức thanh toán này sẽ bị xóa nhưng sẽ vẫn khả dụng cho các gói đăng ký %@.";
+
 "Too many attempts. Please try again in a few minutes." = "Đã thử quá nhiều lần. Vui lòng thử lại sau vài phút.";
 
 "Unavailable for this purchase" = "Không khả dụng cho giao dịch mua hàng này";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/zh-HK.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/zh-HK.lproj/Localizable.strings
@@ -284,6 +284,8 @@
 
 "This is your default" = "這是您的預設支付方式";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "此支付方式將被移除，但仍適用於 %@ 項訂閱。";
+
 "Too many attempts. Please try again in a few minutes." = "嘗試次數過多。請幾分鐘後重試。";
 
 "Unavailable for this purchase" = "無法完成這筆訂單";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -286,6 +286,8 @@
 
 "This is your default" = "这是您的默认地址";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "此支付方式将被移除，但仍可用于 %@ 订阅。";
+
 "Too many attempts. Please try again in a few minutes." = "尝试次数过多。请几分钟后重试。";
 
 "Unavailable for this purchase" = "无法完成这笔订单";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -270,6 +270,8 @@
 
 "This is your default" = "這是您的預設支付方式";
 
+"This payment method will be removed but will remain available for %@ subscriptions." = "此支付方式將被移除，但仍適用於 %@ 項訂閱。";
+
 "Too many attempts. Please try again in a few minutes." = "嘗試次數過多。請幾分鐘後重試。";
 
 "Unavailable for this purchase" = "無法完成這筆訂單";

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/CustomerSession.swift
@@ -36,7 +36,7 @@ struct CustomerSession: Equatable, Hashable {
            mobilePaymentElementEnabled {
             guard let mobilePaymentElementFeaturesDict = mobilePaymentElementDict["features"] as? [AnyHashable: Any],
                   let paymentMethodSave = mobilePaymentElementFeaturesDict["payment_method_save"] as? String,
-                  let paymentMethodRemove = mobilePaymentElementFeaturesDict["payment_method_remove"] as? String else {
+                  let paymentMethodRemoveString = mobilePaymentElementFeaturesDict["payment_method_remove"] as? String else {
                 return nil
             }
             let paymentMethodRemoveLast = mobilePaymentElementFeaturesDict["payment_method_remove_last"] as? String ?? "enabled"
@@ -46,10 +46,11 @@ struct CustomerSession: Equatable, Hashable {
             if let allowRedisplayOverride = mobilePaymentElementFeaturesDict["payment_method_save_allow_redisplay_override"] as? String {
                 allowRedisplayOverrideValue = STPPaymentMethod.allowRedisplay(from: allowRedisplayOverride)
             }
+            let paymentMethodRemove = STPPaymentMethodRemove.paymentMethodRemove(from: paymentMethodRemoveString)
 
             mobilePaymentElementComponent = MobilePaymentElementComponent(enabled: true,
                                                                           features: MobilePaymentElementComponentFeature(paymentMethodSave: paymentMethodSave == "enabled",
-                                                                                                                         paymentMethodRemove: paymentMethodRemove == "enabled" || paymentMethodRemove == "partial",
+                                                                                                                         paymentMethodRemove: paymentMethodRemove,
                                                                                                                          paymentMethodRemoveLast: paymentMethodRemoveLast == "enabled",
                                                                                                                          paymentMethodSaveAllowRedisplayOverride: allowRedisplayOverrideValue,
                                                                                                                          paymentMethodSetAsDefault: paymentMethodSetAsDefault == "enabled"))
@@ -62,13 +63,15 @@ struct CustomerSession: Equatable, Hashable {
             let customerSheetEnabled = customerSheetDict["enabled"] as? Bool,
            customerSheetEnabled {
             guard let customerSheetFeaturesDict = customerSheetDict["features"] as? [AnyHashable: Any],
-                  let paymentMethodRemove = customerSheetFeaturesDict["payment_method_remove"] as? String else {
+                  let paymentMethodRemoveString = customerSheetFeaturesDict["payment_method_remove"] as? String else {
                 return nil
             }
             let paymentMethodRemoveLast = customerSheetFeaturesDict["payment_method_remove_last"] as? String ?? "enabled"
             let paymentMethodSyncDefault = customerSheetFeaturesDict["payment_method_sync_default"] as? String ?? "disabled"
+            let paymentMethodRemove = STPPaymentMethodRemove.paymentMethodRemove(from: paymentMethodRemoveString)
+
             customerSheetComponent = CustomerSheetComponent(enabled: true,
-                                                            features: CustomerSheetComponentFeature(paymentMethodRemove: paymentMethodRemove == "enabled" || paymentMethodRemove == "partial",
+                                                            features: CustomerSheetComponentFeature(paymentMethodRemove: paymentMethodRemove,
                                                                                                     paymentMethodRemoveLast: paymentMethodRemoveLast == "enabled",
                                                                                                     paymentMethodSyncDefault: paymentMethodSyncDefault == "enabled"))
         } else {
@@ -94,7 +97,7 @@ struct MobilePaymentElementComponent: Equatable, Hashable {
 /// https://docs.corp.stripe.com/api/customer_sessions/object#customer_session_object-components-mobile_payment_element-features
 struct MobilePaymentElementComponentFeature: Equatable, Hashable {
     let paymentMethodSave: Bool
-    let paymentMethodRemove: Bool
+    let paymentMethodRemove: STPPaymentMethodRemove
     let paymentMethodRemoveLast: Bool
     let paymentMethodSaveAllowRedisplayOverride: STPPaymentMethodAllowRedisplay?
     let paymentMethodSetAsDefault: Bool
@@ -106,7 +109,7 @@ struct CustomerSheetComponent: Equatable, Hashable {
 }
 
 struct CustomerSheetComponentFeature: Equatable, Hashable {
-    let paymentMethodRemove: Bool
+    let paymentMethodRemove: STPPaymentMethodRemove
     let paymentMethodRemoveLast: Bool
     let paymentMethodSyncDefault: Bool
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -278,12 +278,23 @@ extension STPElementsSession {
         if let customerSession = customer?.customerSession {
             if customerSession.mobilePaymentElementComponent.enabled,
                let features = customerSession.mobilePaymentElementComponent.features {
-                allowsRemovalOfPaymentMethods = features.paymentMethodRemove
+                allowsRemovalOfPaymentMethods = features.paymentMethodRemove == .enabled || features.paymentMethodRemove == .partial
             }
         } else {
             allowsRemovalOfPaymentMethods = true
         }
         return allowsRemovalOfPaymentMethods
+    }
+
+    func paymentMethodRemoveIsPartialForPaymentSheet() -> Bool {
+        let isParital = false
+        if let customerSession = customer?.customerSession {
+            if customerSession.mobilePaymentElementComponent.enabled,
+               let features = customerSession.mobilePaymentElementComponent.features {
+                return features.paymentMethodRemove == .partial
+            }
+        }
+        return isParital
     }
 
     func paymentMethodRemoveLast(configuration: PaymentElementConfiguration) -> Bool{
@@ -313,12 +324,22 @@ extension STPElementsSession {
         if let customerSession = customer?.customerSession {
             if customerSession.customerSheetComponent.enabled,
                let features = customerSession.customerSheetComponent.features {
-                allowsRemovalOfPaymentMethods = features.paymentMethodRemove
+                allowsRemovalOfPaymentMethods = features.paymentMethodRemove == .enabled || features.paymentMethodRemove == .partial
             }
         } else {
             allowsRemovalOfPaymentMethods = true
         }
         return allowsRemovalOfPaymentMethods
+    }
+    func paymentMethodRemoveIsPartialForCustomerSheet() -> Bool {
+        let isParital = false
+        if let customerSession = customer?.customerSession {
+            if customerSession.mobilePaymentElementComponent.enabled,
+               let features = customerSession.customerSheetComponent.features {
+                return features.paymentMethodRemove == .partial
+            }
+        }
+        return isParital
     }
     var paymentMethodRemoveLastForCustomerSheet: Bool {
         return customer?.customerSession.customerSheetComponent.features?.paymentMethodRemoveLast ?? true

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -334,7 +334,7 @@ extension STPElementsSession {
     func paymentMethodRemoveIsPartialForCustomerSheet() -> Bool {
         let isParital = false
         if let customerSession = customer?.customerSession {
-            if customerSession.mobilePaymentElementComponent.enabled,
+            if customerSession.customerSheetComponent.enabled,
                let features = customerSession.customerSheetComponent.features {
                 return features.paymentMethodRemove == .partial
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPPaymentMethodRemove.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPPaymentMethodRemove.swift
@@ -1,0 +1,21 @@
+//
+//  STPPaymentMethodRemove.swift
+//  StripePaymentSheet
+//
+
+enum STPPaymentMethodRemove {
+    case enabled
+    case disabled
+    case partial
+
+    static func paymentMethodRemove(from value: String) -> STPPaymentMethodRemove {
+        if value == "enabled" {
+            return .enabled
+        } else if value == "disabled" {
+            return .disabled
+        } else if value == "partial" {
+            return .partial
+        }
+        return .disabled
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -82,6 +82,7 @@ class CustomerSavedPaymentMethodsCollectionViewController: UIViewController {
         let showApplePay: Bool
         let allowsRemovalOfLastSavedPaymentMethod: Bool
         let paymentMethodRemove: Bool
+        let paymentMethodRemoveIsPartial: Bool
         let paymentMethodUpdate: Bool
         let paymentMethodSyncDefault: Bool
         let isTestMode: Bool
@@ -452,7 +453,11 @@ extension CustomerSavedPaymentMethodsCollectionViewController: PaymentOptionCell
                                                                            canRemove: configuration.paymentMethodRemove && (savedPaymentMethods.count > 1 || configuration.allowsRemovalOfLastSavedPaymentMethod),
                                                                            canUpdate: configuration.paymentMethodUpdate,
                                                                            isCBCEligible: paymentMethod.isCoBrandedCard && cbcEligible)
-        let editVc = UpdatePaymentMethodViewController(removeSavedPaymentMethodMessage: savedPaymentMethodsConfiguration.removeSavedPaymentMethodMessage,
+        let removeSavedPaymentMethodMessage = UpdatePaymentMethodViewController.resolveRemoveMessage(
+            removeSavedPaymentMethodMessage: savedPaymentMethodsConfiguration.removeSavedPaymentMethodMessage,
+            paymentMethodRemoveIsPartial: configuration.paymentMethodRemoveIsPartial,
+            merchantName: savedPaymentMethodsConfiguration.merchantDisplayName)
+        let editVc = UpdatePaymentMethodViewController(removeSavedPaymentMethodMessage: removeSavedPaymentMethodMessage,
                                                        isTestMode: configuration.isTestMode,
                                                        configuration: updateConfig)
         editVc.delegate = self

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -34,6 +34,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
     let configuration: CustomerSheet.Configuration
     let customerSheetDataSource: CustomerSheetDataSource
     let paymentMethodRemove: Bool
+    let paymentMethodRemoveIsPartial: Bool
     let paymentMethodUpdate: Bool
     let paymentMethodSyncDefault: Bool
     let allowsRemovalOfLastSavedPaymentMethod: Bool
@@ -111,6 +112,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                 showApplePay: showApplePay,
                 allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
                 paymentMethodRemove: paymentMethodRemove,
+                paymentMethodRemoveIsPartial: paymentMethodRemoveIsPartial,
                 paymentMethodUpdate: paymentMethodUpdate,
                 paymentMethodSyncDefault: paymentMethodSyncDefault,
                 isTestMode: configuration.apiClient.isTestmode
@@ -155,6 +157,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         customerSheetDataSource: CustomerSheetDataSource,
         isApplePayEnabled: Bool,
         paymentMethodRemove: Bool,
+        paymentMethodRemoveIsPartial: Bool,
         paymentMethodUpdate: Bool,
         paymentMethodSyncDefault: Bool,
         allowsRemovalOfLastSavedPaymentMethod: Bool,
@@ -169,6 +172,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
         self.customerSheetDataSource = customerSheetDataSource
         self.isApplePayEnabled = isApplePayEnabled
         self.paymentMethodRemove = paymentMethodRemove
+        self.paymentMethodRemoveIsPartial = paymentMethodRemoveIsPartial
         self.paymentMethodUpdate = paymentMethodUpdate
         self.paymentMethodSyncDefault = paymentMethodSyncDefault
         self.allowsRemovalOfLastSavedPaymentMethod = allowsRemovalOfLastSavedPaymentMethod
@@ -675,6 +679,7 @@ class CustomerSavedPaymentMethodsViewController: UIViewController {
                 showApplePay: showApplePay,
                 allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
                 paymentMethodRemove: paymentMethodRemove,
+                paymentMethodRemoveIsPartial: paymentMethodRemoveIsPartial,
                 paymentMethodUpdate: paymentMethodUpdate,
                 paymentMethodSyncDefault: paymentMethodSyncDefault,
                 isTestMode: configuration.apiClient.isTestmode

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -168,6 +168,7 @@ public class CustomerSheet {
             case .success((let savedPaymentMethods, let selectedPaymentMethodOption, let elementsSession)):
                 let merchantSupportedPaymentMethodTypes = customerSheetDataSource.merchantSupportedPaymentMethodTypes(elementsSession: elementsSession)
                 let paymentMethodRemove = customerSheetDataSource.paymentMethodRemove(elementsSession: elementsSession)
+                let paymentMethodRemoveIsPartial = customerSheetDataSource.paymentMethodRemoveIsPartial(elementsSession: elementsSession)
                 let paymentMethodUpdate = customerSheetDataSource.paymentMethodUpdate(elementsSession: elementsSession)
                 let paymentMethodSyncDefault = customerSheetDataSource.paymentMethodSyncDefault(elementsSession: elementsSession)
                 let allowsRemovalOfLastSavedPaymentMethod = CustomerSheet.allowsRemovalOfLastPaymentMethod(elementsSession: elementsSession, configuration: self.configuration)
@@ -177,6 +178,7 @@ public class CustomerSheet {
                              merchantSupportedPaymentMethodTypes: merchantSupportedPaymentMethodTypes,
                              customerSheetDataSource: customerSheetDataSource,
                              paymentMethodRemove: paymentMethodRemove,
+                             paymentMethodRemoveIsPartial: paymentMethodRemoveIsPartial,
                              paymentMethodUpdate: paymentMethodUpdate,
                              paymentMethodSyncDefault: paymentMethodSyncDefault,
                              allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
@@ -211,6 +213,7 @@ public class CustomerSheet {
                  merchantSupportedPaymentMethodTypes: [STPPaymentMethodType],
                  customerSheetDataSource: CustomerSheetDataSource,
                  paymentMethodRemove: Bool,
+                 paymentMethodRemoveIsPartial: Bool,
                  paymentMethodUpdate: Bool,
                  paymentMethodSyncDefault: Bool,
                  allowsRemovalOfLastSavedPaymentMethod: Bool,
@@ -229,6 +232,7 @@ public class CustomerSheet {
                                                                                 customerSheetDataSource: customerSheetDataSource,
                                                                                 isApplePayEnabled: isApplePayEnabled,
                                                                                 paymentMethodRemove: paymentMethodRemove,
+                                                                                paymentMethodRemoveIsPartial: paymentMethodRemoveIsPartial,
                                                                                 paymentMethodUpdate: paymentMethodUpdate,
                                                                                 paymentMethodSyncDefault: paymentMethodSyncDefault,
                                                                                 allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetDataSource.swift
@@ -208,6 +208,16 @@ extension CustomerSheetDataSource {
             return elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
         }
     }
+
+    func paymentMethodRemoveIsPartial(elementsSession: STPElementsSession) -> Bool {
+        switch dataSource {
+        case .customerAdapter:
+            return false
+        case .customerSession:
+            return elementsSession.paymentMethodRemoveIsPartialForCustomerSheet()
+        }
+    }
+
     func paymentMethodUpdate(elementsSession: STPElementsSession) -> Bool {
         switch dataSource {
         case .customerAdapter:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -183,7 +183,11 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
                                                                                isCBCEligible: paymentMethod.isCoBrandedCard && elementsSession.isCardBrandChoiceEligible,
                                                                                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
                                                                                isDefault: paymentMethod == defaultPaymentMethod)
-            let updateViewController = UpdatePaymentMethodViewController(removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
+            let removeSavedPaymentMethodMessage = UpdatePaymentMethodViewController.resolveRemoveMessage(
+                removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
+                paymentMethodRemoveIsPartial: elementsSession.paymentMethodRemoveIsPartialForPaymentSheet(),
+                merchantName: configuration.merchantDisplayName)
+            let updateViewController = UpdatePaymentMethodViewController(removeSavedPaymentMethodMessage: removeSavedPaymentMethodMessage,
                                                                          isTestMode: configuration.apiClient.isTestmode,
                                                                          configuration: updateConfig)
             updateViewController.delegate = self

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -603,7 +603,11 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
                                                                            isCBCEligible: paymentMethod.isCoBrandedCard && cbcEligible,
                                                                            allowsSetAsDefaultPM: configuration.allowsSetAsDefaultPM,
                                                                            isDefault: isDefaultPaymentMethod(savedPaymentMethodId: paymentMethod.stripeId))
-        let editVc = UpdatePaymentMethodViewController(removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
+        let removeSavedPaymentMethodMessage = UpdatePaymentMethodViewController.resolveRemoveMessage(
+            removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
+            paymentMethodRemoveIsPartial: elementsSession.paymentMethodRemoveIsPartialForPaymentSheet(),
+            merchantName: configuration.merchantDisplayName)
+        let editVc = UpdatePaymentMethodViewController(removeSavedPaymentMethodMessage: removeSavedPaymentMethodMessage,
                                                        isTestMode: configuration.isTestMode,
                                                        configuration: updateConfig)
         editVc.delegate = self

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -357,7 +357,11 @@ extension VerticalSavedPaymentMethodsViewController: SavedPaymentMethodRowButton
                                                                            isCBCEligible: paymentMethod.isCoBrandedCard && isCBCEligible,
                                                                            allowsSetAsDefaultPM: paymentMethodSetAsDefault,
                                                                            isDefault: isDefaultPaymentMethod(paymentMethodId: paymentMethod.stripeId))
-        let updateViewController = UpdatePaymentMethodViewController(removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
+        let removeSavedPaymentMethodMessage = UpdatePaymentMethodViewController.resolveRemoveMessage(
+            removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
+            paymentMethodRemoveIsPartial: elementsSession.paymentMethodRemoveIsPartialForPaymentSheet(),
+            merchantName: configuration.merchantDisplayName)
+        let updateViewController = UpdatePaymentMethodViewController(removeSavedPaymentMethodMessage: removeSavedPaymentMethodMessage,
                                                                      isTestMode: configuration.apiClient.isTestmode,
                                                                      configuration: updateConfig)
         updateViewController.delegate = self

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -726,7 +726,11 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                                                                                isCBCEligible: paymentMethod.isCoBrandedCard && elementsSession.isCardBrandChoiceEligible,
                                                                                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
                                                                                isDefault: paymentMethod == defaultPaymentMethod)
-            let updateViewController = UpdatePaymentMethodViewController(removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
+            let removeSavedPaymentMethodMessage = UpdatePaymentMethodViewController.resolveRemoveMessage(
+                removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
+                paymentMethodRemoveIsPartial: elementsSession.paymentMethodRemoveIsPartialForPaymentSheet(),
+                merchantName: configuration.merchantDisplayName)
+            let updateViewController = UpdatePaymentMethodViewController(removeSavedPaymentMethodMessage: removeSavedPaymentMethodMessage,
                                                                          isTestMode: configuration.apiClient.isTestmode,
                                                                          configuration: updateConfig)
             updateViewController.delegate = self

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController.swift
@@ -415,3 +415,23 @@ extension STPPaymentMethodCard {
         return nil
     }
 }
+
+extension UpdatePaymentMethodViewController {
+    static func resolveRemoveMessage(removeSavedPaymentMethodMessage: String?,
+                                     paymentMethodRemoveIsPartial: Bool,
+                                     merchantName: String) -> String? {
+        if let removeSavedPaymentMethodMessage {
+            return removeSavedPaymentMethodMessage
+        }
+        if paymentMethodRemoveIsPartial {
+            return String(
+                format: STPLocalizedString(
+                    "This payment method will be removed but will remain available for %@ subscriptions.",
+                    "Content for alert popup prompting if they want to remove a payment method when using payment_method_remove == .partial. %@ is replaced by the merchant name"
+                ),
+                merchantName
+            )
+        }
+        return nil
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewControllerTests.swift
@@ -208,6 +208,7 @@ class CustomerSavedPaymentMethodsCollectionViewControllerTests: XCTestCase {
                                                                                  showApplePay: false,
                                                                                  allowsRemovalOfLastSavedPaymentMethod: allowsRemovalOfLastSavedPaymentMethod,
                                                                                  paymentMethodRemove: paymentMethodRemove,
+                                                                                 paymentMethodRemoveIsPartial: false,
                                                                                  paymentMethodUpdate: paymentMethodUpdate,
                                                                                  paymentMethodSyncDefault: paymentMethodSyncDefault,
                                                                                  isTestMode: true)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfirmParamsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfirmParamsTest.swift
@@ -41,7 +41,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .selected
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: .disabled, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
                                               isSettingUp: true)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -50,7 +50,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .deselected
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: .disabled, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
                                               isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -62,7 +62,7 @@ class IntentConfirmParamsTest: XCTestCase {
 
         // The backend will prevent allowRedisplayValue from being set, when paymentMethodSave is set to enabled
         // but our code should be defensive enough to ensure allowRedisplayOverride does not override the value
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .always, paymentMethodSetAsDefault: false),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: .disabled, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .always, paymentMethodSetAsDefault: false),
                                               isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -72,7 +72,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .hidden
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: .disabled, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
                                               isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -82,7 +82,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .hidden
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .always, paymentMethodSetAsDefault: false),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: .disabled, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .always, paymentMethodSetAsDefault: false),
                                               isSettingUp: true)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -91,7 +91,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .hidden
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .limited, paymentMethodSetAsDefault: false),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: .disabled, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .limited, paymentMethodSetAsDefault: false),
                                               isSettingUp: true)
 
         XCTAssertEqual(.limited, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -100,7 +100,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .hidden
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .unspecified, paymentMethodSetAsDefault: false),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: .disabled, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .unspecified, paymentMethodSetAsDefault: false),
                                               isSettingUp: true)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -110,7 +110,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .deselected
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: .disabled, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
                                               isSettingUp: false)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -119,7 +119,7 @@ class IntentConfirmParamsTest: XCTestCase {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
         intentConfirmParams.saveForFutureUseCheckboxState = .selected
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: true, paymentMethodRemove: .disabled, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
                                               isSettingUp: false)
 
         XCTAssertEqual(.always, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -127,7 +127,7 @@ class IntentConfirmParamsTest: XCTestCase {
     func testSetAllowRedisplay_PI_saveDisabled_hidden() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: .disabled, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: nil, paymentMethodSetAsDefault: false),
                                               isSettingUp: false)
 
         XCTAssertEqual(.unspecified, intentConfirmParams.paymentMethodParams.allowRedisplay)
@@ -136,7 +136,7 @@ class IntentConfirmParamsTest: XCTestCase {
     func testSetAllowRedisplay_PI_saveDisabled_hidden_doesNotOverride() {
         let intentConfirmParams = IntentConfirmParams(type: .stripe(.card))
 
-        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: false, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .limited, paymentMethodSetAsDefault: false),
+        intentConfirmParams.setAllowRedisplay(mobilePaymentElementFeatures: .init(paymentMethodSave: false, paymentMethodRemove: .disabled, paymentMethodRemoveLast: true, paymentMethodSaveAllowRedisplayOverride: .limited, paymentMethodSetAsDefault: false),
                                               isSettingUp: false)
 
         // Ensure that allowRedisplayOverride doesn't override: (hidden checkbox and not attached to customer)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -296,6 +296,7 @@ class STPElementsSessionTest: XCTestCase {
 
         XCTAssertFalse(allowsRemoval)
         XCTAssertEqual(.paymentSheetWithCustomerSessionPaymentMethodSaveEnabled, savePaymentMethodConsentBehavior)
+        XCTAssertFalse(elementsSession.paymentMethodRemoveIsPartialForPaymentSheet())
     }
     func testSPMConsentAndRemoval_pmsD_pmrD() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
@@ -336,6 +337,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
 
         XCTAssertTrue(allowsRemoval)
+        XCTAssertTrue(elementsSession.paymentMethodRemoveIsPartialForPaymentSheet())
         XCTAssertEqual(.paymentSheetWithCustomerSessionPaymentMethodSaveEnabled, savePaymentMethodConsentBehavior)
     }
 
@@ -357,6 +359,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
 
         XCTAssertTrue(allowsRemoval)
+        XCTAssertTrue(elementsSession.paymentMethodRemoveIsPartialForPaymentSheet())
         XCTAssertEqual(.paymentSheetWithCustomerSessionPaymentMethodSaveDisabled, savePaymentMethodConsentBehavior)
     }
     func testPaymentMethodRemoveLast_enabled() {
@@ -377,6 +380,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
 
         XCTAssertTrue(allowsRemoval)
+        XCTAssertFalse(elementsSession.paymentMethodRemoveIsPartialForPaymentSheet())
         XCTAssertTrue(elementsSession.customer!.customerSession.mobilePaymentElementComponent.features!.paymentMethodRemoveLast)
 
         // Test that local config can override behavior
@@ -407,6 +411,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
 
         XCTAssertTrue(allowsRemoval)
+        XCTAssertFalse(elementsSession.paymentMethodRemoveIsPartialForPaymentSheet())
         XCTAssertFalse(elementsSession.customer!.customerSession.mobilePaymentElementComponent.features!.paymentMethodRemoveLast)
 
         // Test that local config can override behavior
@@ -517,6 +522,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
 
         XCTAssertFalse(allowsRemoval)
+        XCTAssertFalse(elementsSession.paymentMethodRemoveIsPartialForCustomerSheet())
         XCTAssertTrue(elementsSession.paymentMethodRemoveLastForCustomerSheet)
     }
 
@@ -536,6 +542,7 @@ class STPElementsSessionTest: XCTestCase {
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
 
         XCTAssertTrue(allowsRemoval)
+        XCTAssertTrue(elementsSession.paymentMethodRemoveIsPartialForCustomerSheet())
         XCTAssertTrue(elementsSession.paymentMethodRemoveLastForCustomerSheet)
     }
     func testAllowsRemovalOfPaymentMethodsForCustomerSheet_removeLast_enabled() {
@@ -554,6 +561,7 @@ class STPElementsSessionTest: XCTestCase {
 
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
         XCTAssertTrue(allowsRemoval)
+        XCTAssertFalse(elementsSession.paymentMethodRemoveIsPartialForCustomerSheet())
         XCTAssertTrue(elementsSession.paymentMethodRemoveLastForCustomerSheet)
     }
     func testAllowsRemovalOfPaymentMethodsForCustomerSheet_removeLast_disabled() {
@@ -572,6 +580,7 @@ class STPElementsSessionTest: XCTestCase {
 
         let allowsRemoval = elementsSession.allowsRemovalOfPaymentMethodsForCustomerSheet()
         XCTAssertTrue(allowsRemoval)
+        XCTAssertFalse(elementsSession.paymentMethodRemoveIsPartialForCustomerSheet())
         XCTAssertFalse(elementsSession.paymentMethodRemoveLastForCustomerSheet)
     }
     func testSetAsDefaultForCustomerSheet_enabled() {
@@ -590,6 +599,7 @@ class STPElementsSessionTest: XCTestCase {
 
         let allowsSetAsDefault = elementsSession.paymentMethodSyncDefaultForCustomerSheet
         XCTAssertTrue(allowsSetAsDefault)
+        XCTAssertFalse(elementsSession.paymentMethodRemoveIsPartialForCustomerSheet())
     }
     func testSetAsDefaultForCustomerSheet_disabled() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],
@@ -605,6 +615,7 @@ class STPElementsSessionTest: XCTestCase {
 
         let allowsSetAsDefault = elementsSession.paymentMethodSyncDefaultForCustomerSheet
         XCTAssertFalse(allowsSetAsDefault)
+        XCTAssertFalse(elementsSession.paymentMethodRemoveIsPartialForCustomerSheet())
     }
     func testCanDeserializeMPEWithoutCS() {
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"],

--- a/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/nl.lproj/Localizable.strings
+++ b/StripePaymentsUI/StripePaymentsUI/Resources/Localizations/nl.lproj/Localizable.strings
@@ -22,6 +22,8 @@
 
 "Billing address" = "Factuuradres";
 
+"Billing details" = "Facturatiegegevens";
+
 "CVC" = "Cvc";
 
 "Card information" = "Kaartgegevens";

--- a/StripeUICore/StripeUICore/Resources/Localizations/bg-BG.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/bg-BG.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Вашият пощенски код е непълен.";
 
-"Your postal code is invalid." = "Вашият пощенски код е невалиден.";
-
 "ZIP" = "п.к.";

--- a/StripeUICore/StripeUICore/Resources/Localizations/ca-ES.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/ca-ES.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "El teu codi postal no està complet.";
 
-"Your postal code is invalid." = "El codi postal no és vàlid.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/cs-CZ.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/cs-CZ.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Vaše poštovní směrovací číslo je neúplné.";
 
-"Your postal code is invalid." = "Vaše poštovní směrovací číslo je neplatné.";
-
 "ZIP" = "PSČ";

--- a/StripeUICore/StripeUICore/Resources/Localizations/da.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/da.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Dit postnummer er ikke fuldendt.";
 
-"Your postal code is invalid." = "Dit postnummer er ugyldigt.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/de.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/de.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Postleitzahl ist unvollständig.";
 
-"Your postal code is invalid." = "Ihre Postleitzahl ist ungültig.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/el-GR.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/el-GR.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Ο ταχυδρομικός κώδικάς σας είναι ελλιπής.";
 
-"Your postal code is invalid." = "Ο ταχυδρομικός κώδικας είναι μη έγκυρος.";
-
 "ZIP" = "Τ.Κ.";

--- a/StripeUICore/StripeUICore/Resources/Localizations/en-GB.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/en-GB.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Your postcode is incomplete.";
 
-"Your postal code is invalid." = "Your postcode is invalid.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/es-419.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/es-419.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "El código postal está incompleto.";
 
-"Your postal code is invalid." = "El código postal no es válido.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/es.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/es.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "El código postal está incompleto.";
 
-"Your postal code is invalid." = "Tu código postal no es válido.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/et-EE.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/et-EE.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Sihtnumber on puudulik.";
 
-"Your postal code is invalid." = "Teie sihtnumber on kehtetu.";
-
 "ZIP" = "Sihtnr";

--- a/StripeUICore/StripeUICore/Resources/Localizations/fi.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/fi.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Postinumero on puutteellinen.";
 
-"Your postal code is invalid." = "Postinumerosi on virheellinen.";
-
 "ZIP" = "Postinumero";

--- a/StripeUICore/StripeUICore/Resources/Localizations/fil.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/fil.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Ang iyong postal code ay di kumpleto.";
 
-"Your postal code is invalid." = "Hindi valid ang postal code mo.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/fr-CA.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/fr-CA.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Votre code postal est incomplet.";
 
-"Your postal code is invalid." = "Votre code postal n'est pas valide.";
-
 "ZIP" = "Code postal";

--- a/StripeUICore/StripeUICore/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/fr.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Votre code postal est incomplet.";
 
-"Your postal code is invalid." = "Votre code postal est invalide.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/hr.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/hr.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Vaš poštanski broj nije kompletan.";
 
-"Your postal code is invalid." = "Vaš poštanski broj nevaljan je.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/hu.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/hu.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Az irányítószám hiányos.";
 
-"Your postal code is invalid." = "Az irányítószáma érvénytelen.";
-
 "ZIP" = "Irányítószám";

--- a/StripeUICore/StripeUICore/Resources/Localizations/id.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/id.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Kode pos Anda tidak lengkap.";
 
-"Your postal code is invalid." = "Kode pos Anda tidak valid.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/it.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/it.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Il codice postale è incompleto.";
 
-"Your postal code is invalid." = "Il tuo codice postale non è valido.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/ja.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "郵便番号の入力に不備があります。";
 
-"Your postal code is invalid." = "郵便番号が無効です。";
-
 "ZIP" = "郵便番号";

--- a/StripeUICore/StripeUICore/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/ko.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "우편번호가 불완전합니다.";
 
-"Your postal code is invalid." = "우편번호가 유효하지 않습니다.";
-
 "ZIP" = "우편번호";

--- a/StripeUICore/StripeUICore/Resources/Localizations/lv-LV.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/lv-LV.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Pasta indekss nav pilnīgs.";
 
-"Your postal code is invalid." = "Jūsu pasta indekss ir nederīgs.";
-
 "ZIP" = "Pasta ind.";

--- a/StripeUICore/StripeUICore/Resources/Localizations/ms-MY.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/ms-MY.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Poskod anda tidak lengkap.";
 
-"Your postal code is invalid." = "Poskod anda tidak sah.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/mt.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/mt.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Il-kodiċi postali tiegħek mhux komplut.";
 
-"Your postal code is invalid." = "Il-kodiċi postali tiegħek huwa invalidu.";
-
 "ZIP" = "Kodiċi Postali";

--- a/StripeUICore/StripeUICore/Resources/Localizations/nb.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/nb.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Postnummeret er ufullstendig.";
 
-"Your postal code is invalid." = "Postnummeret ditt er ugyldig.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/nl.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/nl.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Je postcode is onvolledig.";
 
-"Your postal code is invalid." = "Uw postcode is ongeldig.";
-
 "ZIP" = "Postcode";

--- a/StripeUICore/StripeUICore/Resources/Localizations/pl-PL.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/pl-PL.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Kod pocztowy jest niekompletny.";
 
-"Your postal code is invalid." = "Nieprawidłowy kod pocztowy.";
-
 "ZIP" = "Kod p";

--- a/StripeUICore/StripeUICore/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Código postal incompleto.";
 
-"Your postal code is invalid." = "Código postal inválido.";
-
 "ZIP" = "CEP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/pt-PT.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/pt-PT.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "O seu código postal está incompleto.";
 
-"Your postal code is invalid." = "O seu código postal é inválido.";
-
 "ZIP" = "C.P.";

--- a/StripeUICore/StripeUICore/Resources/Localizations/ro-RO.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/ro-RO.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Codul dvs. poștal nu este complet.";
 
-"Your postal code is invalid." = "Codul dvs. poștal nu este valid.";
-
 "ZIP" = "Cod poștal";

--- a/StripeUICore/StripeUICore/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/ru.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Введенный почтовый индекс неполон.";
 
-"Your postal code is invalid." = "Недействительный почтовый индекс.";
-
 "ZIP" = "Почтовый индекс";

--- a/StripeUICore/StripeUICore/Resources/Localizations/sk-SK.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/sk-SK.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Vaše poštové smerovacie číslo je neúplné.";
 
-"Your postal code is invalid." = "Vaše poštové smerovacie číslo je neplatné.";
-
 "ZIP" = "PSČ";

--- a/StripeUICore/StripeUICore/Resources/Localizations/sl-SI.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/sl-SI.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Vaša poštna številka ni popolna.";
 
-"Your postal code is invalid." = "Vaša poštna številka je neveljavna.";
-
 "ZIP" = "Poštna številka";

--- a/StripeUICore/StripeUICore/Resources/Localizations/sv.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/sv.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Ditt postnummer är ofullständigt.";
 
-"Your postal code is invalid." = "Postnumret är ogiltigt.";
-
 "ZIP" = "Postkod";

--- a/StripeUICore/StripeUICore/Resources/Localizations/th.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/th.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "รหัสไปรษณีย์ไม่ครบถ้วน";
 
-"Your postal code is invalid." = "รหัสไปรษณีย์ของคุณไม่ถูกต้อง";
-
 "ZIP" = "รหัสไปรษณีย์";

--- a/StripeUICore/StripeUICore/Resources/Localizations/tr.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/tr.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Posta kodunuz eksik.";
 
-"Your postal code is invalid." = "Posta kodunuz geçersiz.";
-
 "ZIP" = "Posta Kodu";

--- a/StripeUICore/StripeUICore/Resources/Localizations/vi.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/vi.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "Mã bưu điện chưa đầy đủ.";
 
-"Your postal code is invalid." = "Mã bưu chính của bạn không hợp lệ.";
-
 "ZIP" = "ZIP";

--- a/StripeUICore/StripeUICore/Resources/Localizations/zh-HK.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/zh-HK.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "您的郵區編號不完整。";
 
-"Your postal code is invalid." = "您的郵政編碼無效。";
-
 "ZIP" = "郵區編號";

--- a/StripeUICore/StripeUICore/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -144,6 +144,4 @@
 
 "Your postal code is incomplete." = "您的邮编不完整。";
 
-"Your postal code is invalid." = "您的邮编无效。";
-
 "ZIP" = "邮编";

--- a/StripeUICore/StripeUICore/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/StripeUICore/StripeUICore/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -142,6 +142,4 @@
 
 "Your postal code is incomplete." = "您的郵遞區號不完整。";
 
-"Your postal code is invalid." = "您的郵遞區號無效。";
-
 "ZIP" = "郵遞區號";


### PR DESCRIPTION
## Summary
Changes the removal message when instantiating CustomerSessions w/ payment_method_remove == `.partial`

## Motivation
Different experience needed

## Testing
Will add tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
