### PR TITLE
Fix Link inline signup issues

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -108,6 +108,8 @@ extension STPAPIClient {
             if let phoneNumber {
                 parameters["phone_number"] = phoneNumber
                 parameters["country_inferring_method"] = "PHONE_NUMBER"
+            } else {
+                parameters["country_inferring_method"] = "BILLING_ADDRESS"
             }
 
             if let legalName = legalName {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -126,4 +126,13 @@ extension PaymentSheet.LinkConfirmOption {
             return nil
         }
     }
+
+    var signupAction: LinkInlineSignupViewModel.Action? {
+        switch self {
+        case .signUp(let account, let phoneNumber, _, let legalName, _):
+            return .signupAndPay(account: account, phoneNumber: phoneNumber, legalName: legalName)
+        case .wallet, .withPaymentDetails, .withPaymentMethod:
+            return nil
+        }
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -24,6 +24,15 @@ extension PaymentSheetFormFactory {
         }
     }
 
+    var previouslyHadLinkSignupSelected: Bool {
+        switch previousLinkInlineSignupAction {
+        case .signupAndPay:
+            return true
+        default:
+            return false
+        }
+    }
+
     func makeCard(linkAppearance: LinkAppearance? = nil) -> PaymentMethodElement {
         let showLinkInlineSignup = showLinkInlineCardSignup
         let defaultCheckbox: Element? = {
@@ -128,6 +137,8 @@ extension PaymentSheetFormFactory {
         ]
 
         if case .paymentElement(let configuration, _) = configuration, let accountService, showLinkInlineSignup {
+            // Restore the signup state on recreation
+            let signupOptInInitialValue = signupOptInInitialValue || previouslyHadLinkSignupSelected
             let inlineSignupElement = LinkInlineSignupElement(
                 configuration: configuration,
                 linkAccount: linkAccount,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -47,6 +47,7 @@ class PaymentSheetFormFactory {
     let analyticsHelper: PaymentSheetAnalyticsHelper?
     let paymentMethodIncentive: PaymentMethodIncentive?
     let sellerName: String?
+    let previousLinkInlineSignupAction: LinkInlineSignupViewModel.Action?
 
     var shouldDisplaySaveCheckbox: Bool {
         // Don't show the save checkbox in Link
@@ -86,7 +87,8 @@ class PaymentSheetFormFactory {
         linkAccount: PaymentSheetLinkAccount? = nil,
         accountService: LinkAccountServiceProtocol,
         analyticsHelper: PaymentSheetAnalyticsHelper?,
-        linkAppearance: LinkAppearance? = nil
+        linkAppearance: LinkAppearance? = nil,
+        previousLinkInlineSignupAction: LinkInlineSignupViewModel.Action? = nil
     ) {
 
         /// Whether or not the card form should show the link inline signup checkbox
@@ -141,7 +143,8 @@ class PaymentSheetFormFactory {
                   analyticsHelper: analyticsHelper,
                   paymentMethodIncentive: elementsSession.incentive,
                   linkAppearance: linkAppearance,
-                  sellerName: intent.sellerDetails?.businessName
+                  sellerName: intent.sellerDetails?.businessName,
+                  previousLinkInlineSignupAction: previousLinkInlineSignupAction
         )
     }
 
@@ -168,7 +171,8 @@ class PaymentSheetFormFactory {
         analyticsHelper: PaymentSheetAnalyticsHelper?,
         paymentMethodIncentive: PaymentMethodIncentive?,
         linkAppearance: LinkAppearance? = nil,
-        sellerName: String? = nil
+        sellerName: String? = nil,
+        previousLinkInlineSignupAction: LinkInlineSignupViewModel.Action? = nil
     ) {
         self.configuration = configuration
         self.paymentMethod = paymentMethod
@@ -198,6 +202,7 @@ class PaymentSheetFormFactory {
         self.paymentMethodIncentive = paymentMethodIncentive
         self.linkAppearance = linkAppearance
         self.sellerName = sellerName
+        self.previousLinkInlineSignupAction = previousLinkInlineSignupAction
     }
 
     func make() -> PaymentMethodElement {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -101,7 +101,8 @@ class PaymentMethodFormViewController: UIViewController {
         analyticsHelper: PaymentSheetAnalyticsHelper,
         isLinkUI: Bool = false,
         delegate: PaymentMethodFormViewControllerDelegate,
-        linkAppearance: LinkAppearance? = nil
+        linkAppearance: LinkAppearance? = nil,
+        previousLinkInlineSignupAction: LinkInlineSignupViewModel.Action? = nil
     ) {
         self.paymentMethodType = type
         self.intent = intent
@@ -122,7 +123,8 @@ class PaymentMethodFormViewController: UIViewController {
                 linkAccount: LinkAccountContext.shared.account,
                 accountService: LinkAccountService(apiClient: configuration.apiClient, elementsSession: elementsSession),
                 analyticsHelper: analyticsHelper,
-                linkAppearance: linkAppearance
+                linkAppearance: linkAppearance,
+                previousLinkInlineSignupAction: previousLinkInlineSignupAction
             ).make()
             self.formCache[type] = form
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -855,6 +855,13 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
                 return nil
             }
         }()
+        let previousLinkInlineSignupAction: LinkInlineSignupViewModel.Action? = {
+            if case let .link(confirmOption) = previousPaymentOption {
+                return confirmOption.signupAction
+            } else {
+                return nil
+            }
+        }()
         let headerView: UIView = {
             let incentive = paymentMethodListViewController?.incentive?.takeIfAppliesTo(paymentMethodType)
             let currentForm = formCache[paymentMethodType]
@@ -908,7 +915,8 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
             headerView: headerView,
             analyticsHelper: analyticsHelper,
             isLinkUI: false,
-            delegate: self
+            delegate: self,
+            previousLinkInlineSignupAction: previousLinkInlineSignupAction
         )
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes two issues with the Link signup opt-in feature:
1. It preserves the checkbox state when re-opening the card form. This was broken because `updateForWalletButtons` recreated the card form with the initial checkbox state, not the most recent one.
2. It ensures that we always send a `country_inferring_method` in the signup call.

<details><summary>Recording</summary>
<p>

https://github.com/user-attachments/assets/9545ad7b-ed3a-4a9e-91af-a479f01e5f86

</p>
</details> 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
