### PR TITLE
[Onramp] Clean up `performCheckout` API

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		0BF41E8B2E3AB84800CA4171 /* IdType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF41E8A2E3AB84800CA4171 /* IdType.swift */; };
 		490D4AAE2E552D6F00FAF4FF /* PlatformSettingsResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4907AF502E54B80000F0C49D /* PlatformSettingsResponse.swift */; };
 		490D4AC72E5541A600FAF4FF /* CreatePaymentTokenRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 490D4AC62E5541A600FAF4FF /* CreatePaymentTokenRequest.swift */; };
+		49B7F6882E57988D0053C83B /* OnrampSessionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B7F6872E57988D0053C83B /* OnrampSessionResponse.swift */; };
 		49D233A82E439EB900F51263 /* CryptoNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A72E439EB900F51263 /* CryptoNetwork.swift */; };
 		49D233AA2E439FAA00F51263 /* RegisterWalletRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */; };
 		49D233AC2E439FB200F51263 /* RegisterWalletResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */; };
@@ -124,6 +125,7 @@
 		0BF41E8A2E3AB84800CA4171 /* IdType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdType.swift; sourceTree = "<group>"; };
 		4907AF502E54B80000F0C49D /* PlatformSettingsResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformSettingsResponse.swift; sourceTree = "<group>"; };
 		490D4AC62E5541A600FAF4FF /* CreatePaymentTokenRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreatePaymentTokenRequest.swift; sourceTree = "<group>"; };
+		49B7F6872E57988D0053C83B /* OnrampSessionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampSessionResponse.swift; sourceTree = "<group>"; };
 		49D233A72E439EB900F51263 /* CryptoNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoNetwork.swift; sourceTree = "<group>"; };
 		49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterWalletRequest.swift; sourceTree = "<group>"; };
 		49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterWalletResponse.swift; sourceTree = "<group>"; };
@@ -215,6 +217,7 @@
 				49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */,
 				49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */,
 				4907AF502E54B80000F0C49D /* PlatformSettingsResponse.swift */,
+				49B7F6872E57988D0053C83B /* OnrampSessionResponse.swift */,
 			);
 			path = "API Bindings";
 			sourceTree = "<group>";
@@ -437,6 +440,7 @@
 			files = (
 				0BB716442E4A5BCC002F17B8 /* Address.swift in Sources */,
 				0B649EE22E4293AB00AFAFB1 /* IdentityVerificationResult.swift in Sources */,
+				49B7F6882E57988D0053C83B /* OnrampSessionResponse.swift in Sources */,
 				0B089E832E53B25A007D160E /* CreatePaymentTokenResponse.swift in Sources */,
 				0BED9B622E255BC2009FFF76 /* CryptoOnrampCoordinator.swift in Sources */,
 				49D233AA2E439FAA00F51263 /* RegisterWalletRequest.swift in Sources */,

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/OnrampSessionResponse.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/OnrampSessionResponse.swift
@@ -1,0 +1,29 @@
+//
+//  OnrampSessionResponse.swift
+//  StripeCryptoOnramp
+//
+//  Created by Mat Schmid on 8/21/25.
+//
+
+import Foundation
+
+/// Codable model representing a response from the `/v1/crypto/internal/onramp_session` endpoint.
+struct OnrampSessionResponse: Codable {
+
+    /// The onramp session's unique identifier.
+    /// `cos_XXXXXXXXX`
+    let id: String
+
+    /// The onramp session client secret.
+    /// `cos_XXXXXXXXX_secret_XXXXXXXXX`
+    let clientSecret: String
+
+    /// The PaymentIntent client secret associated with this onramp session.
+    let paymentIntentClientSecret: String
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case clientSecret = "client_secret"
+        case paymentIntentClientSecret = "payment_intent_client_secret"
+    }
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -111,18 +111,18 @@ extension STPAPIClient {
         return try await post(resource: endpoint, object: requestObject)
     }
 
-    /// Retrieves the PaymentIntent from an onramp session.
+    /// Retrieves an onramp session.
     /// - Parameters:
     ///   - sessionId: The onramp session identifier.
     ///   - sessionClientSecret: The onramp session client secret.
-    /// - Returns: The PaymentIntent associated with the onramp session.
-    func retrievePaymentIntentFromOnrampSession(
+    /// - Returns: The onramp session details.
+    func getOnrampSession(
         sessionId: String,
         sessionClientSecret: String
-    ) async throws -> STPPaymentIntent {
+    ) async throws -> OnrampSessionResponse {
         let endpoint = "crypto/internal/onramp_session"
         let parameters = ["crypto_onramp_session": sessionId, "client_secret": sessionClientSecret]
-        return try await APIRequest<STPPaymentIntent>.getWith(self, endpoint: endpoint, parameters: parameters)
+        return try await get(resource: endpoint, parameters: parameters)
     }
 
     /// Creates a crypto payment token from a given payment method and consumer.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CheckoutError.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CheckoutError.swift
@@ -19,9 +19,6 @@ enum CheckoutError: Error {
     /// The user canceled the payment.
     case userCanceled
 
-    /// The maximum number of attempts to complete the payment has been exceeded.
-    case maximumAttemptsExceeded
-
     /// An unexpected error occurred.
     case unexpectedError
 }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CheckoutError.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CheckoutError.swift
@@ -19,6 +19,9 @@ enum CheckoutError: Error {
     /// The user canceled the payment.
     case userCanceled
 
+    /// The maximum number of attempts to complete the payment has been exceeded.
+    case maximumAttemptsExceeded
+
     /// An unexpected error occurred.
     case unexpectedError
 }


### PR DESCRIPTION
## Summary

Updates our `performCheckout` API to a cleaner state:

```swift
/// Performs the checkout flow for a crypto onramp session, handling any required authentication steps.
/// - Parameters:
///   - onrampSessionId: The onramp session identifier.
///   - authenticationContext: The authentication context used to handle any required next actions (e.g., 3DS authentication).
///   - onrampSessionClientSecretProvider: An async closure that calls your backend to perform a checkout.
///     Your backend should call Stripe's `/v1/crypto/onramp_sessions/:id/checkout` endpoint with the provided onramp session ID.
///     The closure should return the onramp session client secret on success, or throw an Error on failure.
///     This closure may be called twice: once initially, and once more after handling any required authentication.
/// - Returns: A `CheckoutResult` indicating whether the checkout succeeded or failed.
func performCheckout(
    onrampSessionId: String,
    authenticationContext: STPAuthenticationContext,
    onrampSessionClientSecretProvider: @escaping (_ onrampSessionId: String) async throws -> String
) async -> CheckoutResult
```

## Motivation

https://docs.google.com/document/d/1eDA1zA0ve68TKoSm7nLtpZGFvB6RoQqGiqsj_oMJu_g/edit?usp=sharing

## Testing

N/a

## Changelog

N/a