### PR TITLE
Crypto Onramp SDK: Updates call from `collectWalletAddress` to `registerWalletAddress` in Example App

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AttachWalletAddressView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AttachWalletAddressView.swift
@@ -105,7 +105,7 @@ struct AttachWalletAddressView: View {
 
         Task {
             do {
-                try await coordinator.collectWalletAddress(walletAddress: address, network: selectedNetwork)
+                try await coordinator.registerWalletAddress(walletAddress: address, network: selectedNetwork)
                 await MainActor.run {
                     isLoading.wrappedValue = false
                     isWalletAttached = true


### PR DESCRIPTION
## Summary
Resolving discrepancies between #5383 & #5377

## Motivation
Fix the build on `master`

## Testing
Built and ran the CryptoOnramp Example app on `master` successfully.

## Changelog
N/A
