### PR TITLE
Allow selecting OAuth scopes in Onramp example app

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Auth.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Auth.swift
@@ -8,8 +8,15 @@
 import Foundation
 
 extension APIClient {
-    func authenticateUser(with email: String) async throws -> AuthenticateUserResponse {
-        let response: AuthenticateUserResponse = try await request("auth_intent/create", method: .POST, body: AuthenticateUserRequest(email: email))
+    func authenticateUser(
+        with email: String,
+        oauthScopes: [OAuthScopes] = OAuthScopes.inlineScope
+    ) async throws -> AuthenticateUserResponse {
+        let response: AuthenticateUserResponse = try await request(
+            "auth_intent/create",
+            method: .POST,
+            body: AuthenticateUserRequest(email: email, oauthScopes: oauthScopes)
+        )
         setAuthToken(response.token)
         return response
     }

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/AuthenticatedUserRequest.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/AuthenticatedUserRequest.swift
@@ -9,4 +9,15 @@ import Foundation
 
 struct AuthenticateUserRequest: Encodable {
     let email: String
+    let oauthScopes: String
+
+    enum CodingKeys: String, CodingKey {
+        case email
+        case oauthScopes = "oauth_scopes"
+    }
+
+    init(email: String, oauthScopes: [OAuthScopes] = OAuthScopes.inlineScope) {
+        self.email = email
+        self.oauthScopes = oauthScopes.map(\.rawValue).joined(separator: ",")
+    }
 }

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/OAuthScope.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/OAuthScope.swift
@@ -1,0 +1,23 @@
+//
+//  OAuthScope.swift
+//  CryptoOnramp Example
+//
+//  Created by Mat Schmid on 8/23/25.
+//
+
+import Foundation
+
+enum OAuthScopes: String, CaseIterable {
+    static let inlineScope: [OAuthScopes] = [OAuthScopes.userinfoRead]
+    static let allScopes: [OAuthScopes] = Self.allCases
+
+    case userinfoRead = "userinfo:read"
+    case userinfoAddressesRead = "userinfo.addresses:read"
+    case kycStatusRead = "kyc.status:read"
+    case kycWrite = "kyc:write"
+    case kycRead = "kyc:read"
+    case kycShare = "kyc:share"
+    case authPersistLoginRead = "auth.persist_login:read"
+    case paymentMethodsRead = "payment_methods:read"
+    case paymentMethodsBankAccountsRead = "payment_methods.bank_accounts:read"
+}

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/RegistrationView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/RegistrationView.swift
@@ -23,6 +23,9 @@ struct RegistrationView: View {
     /// The email address associated with the new account being registered.
     let email: String
 
+    /// The OAuth scopes selected for authentication.
+    let selectedScopes: [OAuthScopes]
+
     @State private var fullName: String = ""
     @State private var phoneNumber: String = ""
     @State private var country: String = "US"
@@ -120,7 +123,10 @@ struct RegistrationView: View {
                 )
 
                 // Authenticate with the demo merchant backend as well.
-                _ = try await APIClient.shared.authenticateUser(with: email)
+                _ = try await APIClient.shared.authenticateUser(
+                    with: email,
+                    oauthScopes: selectedScopes
+                )
 
                 await MainActor.run {
                     isLoading.wrappedValue = false
@@ -149,7 +155,8 @@ struct RegistrationView: View {
     PreviewWrapperView { coordinator in
         RegistrationView(
             coordinator: coordinator,
-            email: "test@example.com"
+            email: "test@example.com",
+            selectedScopes: OAuthScopes.inlineScope
         )
     }
 }


### PR DESCRIPTION
## Summary

Adds a picker on the root Onramp example app view to select requested OAuth scopes. These are then passed into our example backend API to create a Link auth intent.

## Motivation

OAuth support

## Testing

https://github.com/user-attachments/assets/ffec17f2-77d0-4991-b057-5eb72a5a4627


## Changelog

N/a
