### PR TITLE
Add lookup by Link Auth Intent API

### DIFF
--- a/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
+++ b/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
@@ -155,6 +155,25 @@ extension LinkInlineSignupElementSnapshotTests {
             )
         }
 
+        func lookupLinkAuthIntent(
+            linkAuthIntentID: String,
+            requestSurface: StripePaymentSheet.LinkRequestSurface = .default,
+            completion: @escaping (Result<PaymentSheetLinkAccount?, Error>) -> Void
+        ) {
+            completion(
+                .success(
+                    PaymentSheetLinkAccount(
+                        email: "user@example.com",
+                        session: nil,
+                        publishableKey: nil,
+                        displayablePaymentDetails: nil,
+                        useMobileEndpoints: false,
+                        requestSurface: requestSurface
+                    )
+                )
+            )
+        }
+
         func hasEmailLoggedOut(email: String) -> Bool {
             // TODO(porter): Determine if we want to implement this in tests
             return false

--- a/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
+++ b/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
@@ -283,6 +283,29 @@ extension LinkInlineSignupViewModelTests {
             }
         }
 
+        func lookupLinkAuthIntent(
+            linkAuthIntentID: String,
+            requestSurface: StripePaymentSheet.LinkRequestSurface = .default,
+            completion: @escaping (Result<PaymentSheetLinkAccount?, Error>) -> Void
+        ) {
+            if shouldFailLookup {
+                completion(.failure(NSError.stp_genericConnectionError()))
+            } else {
+                completion(
+                    .success(
+                        PaymentSheetLinkAccount(
+                            email: "user@example.com",
+                            session: nil,
+                            publishableKey: nil,
+                            displayablePaymentDetails: nil,
+                            useMobileEndpoints: false,
+                            requestSurface: requestSurface
+                        )
+                    )
+                )
+            }
+        }
+
         func hasEmailLoggedOut(email: String) -> Bool {
             // TODO(porter): Determine if we want to implement this in tests
             return false

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -121,6 +121,27 @@ extension ConsumerSession {
         )
     }
 
+    class func lookupLinkAuthIntent(
+        linkAuthIntentID: String,
+        sessionID: String,
+        customerID: String?,
+        with apiClient: STPAPIClient = STPAPIClient.shared,
+        cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
+        useMobileEndpoints: Bool,
+        requestSurface: LinkRequestSurface = .default,
+        completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
+    ) {
+        apiClient.lookupLinkAuthIntent(
+            linkAuthIntentID: linkAuthIntentID,
+            sessionID: sessionID,
+            customerID: customerID,
+            cookieStore: cookieStore,
+            useMobileEndpoints: useMobileEndpoints,
+            requestSurface: requestSurface,
+            completion: completion
+        )
+    }
+
     class func signUp(
         email: String,
         phoneNumber: String?,


### PR DESCRIPTION
## Summary

Adds a new endpoint in `STPAPIClient+Link` to call `/lookup` (or the mobile lookup endpoint) by a Link auth intent ID. This will provide details on the auth intent, such as the consent status and some server-driven content, which will be implemented in a subsequent PR.

## Motivation

https://docs.google.com/document/d/1Mov3xDsMnajKl1RqCNx9-3pJ_KKOHdwcE0EZN-H_kz4/edit?usp=sharing

## Testing

<img width="971" height="469" alt="Screenshot 2025-08-19 at 11 07 55 AM" src="https://github.com/user-attachments/assets/7054f1a7-a3fc-43b0-9039-935ca06d6046" />


## Changelog

N/a
