### PR TITLE
Switch Onramp SDK to using @_spi(STP) annotation

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AttachWalletAddressView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AttachWalletAddressView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 import StripeCryptoOnramp
 
 @_spi(STP)

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -8,7 +8,7 @@
 import PassKit
 import SwiftUI
 
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 import StripeCryptoOnramp
 
 @_spi(STP)

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
@@ -8,7 +8,7 @@
 import StripeCore
 import SwiftUI
 
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 import StripeCryptoOnramp
 
 @_spi(STP)

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/KYCInfoView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/KYCInfoView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 import StripeCryptoOnramp
 
 @_spi(STP)

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/RegistrationView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/RegistrationView.swift
@@ -8,7 +8,7 @@
 import StripeCore
 import SwiftUI
 
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 import StripeCryptoOnramp
 
 @_spi(STP)

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/PaymentMethodCardView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/PaymentMethodCardView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 import StripeCryptoOnramp
 
 /// A view that displays the information from `PaymentMethodSelectionResult.PaymentMethodDisplayData`

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/PreviewWrapperView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/PreviewWrapperView.swift
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 import StripeCryptoOnramp
 
 @_spi(STP)

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/Address.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/Address.swift
@@ -10,7 +10,7 @@ import Foundation
 @_spi(STP) import StripePaymentSheet
 
 /// Represents an address used with `KYCInfo`.
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 public struct Address: Equatable {
 
     /// City, district, suburb, town, or village.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/AuthenticationResult.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/AuthenticationResult.swift
@@ -6,7 +6,7 @@
 //
 
 /// The result after a user has been presented with Link authentication UI.
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 public enum AuthenticationResult {
 
     /// Authentication was completed successfully. The customer ID is attached.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CheckoutResult.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CheckoutResult.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// The result of a call to `CryptoOnrampCoordinator.performCheckout()`.
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 public enum CheckoutResult {
 
     /// The checkout was completed successfully.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoNetwork.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoNetwork.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Supported crypto networks for wallet address registration.
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 public enum CryptoNetwork: String, Codable, CaseIterable {
     case bitcoin = "bitcoin"
     case ethereum = "ethereum"

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -114,7 +114,7 @@ protocol CryptoOnrampCoordinatorProtocol {
 }
 
 /// Coordinates headless Link user authentication and identity verification, leaving most of the UI to the client.
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorProtocol {
 
     /// A subset of errors that may be thrown by `CryptoOnrampCoordinator` APIs.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/IdType.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/IdType.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Represents possible types of customer identification.
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 public enum IdType: String, Codable, CaseIterable {
     case socialSecurityNumber = "social_security_number"
 }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/IdentityVerificationResult.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/IdentityVerificationResult.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Encapsulates the possible return values for `CryptoOnrampCoordinator.promptForIdentityVerification()`.
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 public enum IdentityVerificationResult {
 
     /// The user has completed uploading their documents.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/KycInfo.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/KycInfo.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// Represents KYC information required for crypto operations.
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 public struct KycInfo: Equatable {
 
     /// Represents a fixed date using simple components (day, month, year).

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/PaymentMethodDisplayData.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/PaymentMethodDisplayData.swift
@@ -9,7 +9,7 @@ import Foundation
 import UIKit
 
 /// Represents the payment method currently selected by the user.
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 public struct PaymentMethodDisplayData {
 
     /// The payment method icon to render in your screen.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/PaymentMethodType.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/PaymentMethodType.swift
@@ -9,7 +9,7 @@ import PassKit
 @_spi(STP) import StripePaymentSheet
 
 /// Represents possible payment types that can be collected for checkout.
-@_spi(CryptoOnrampSDKPreview)
+@_spi(STP)
 public enum PaymentMethodType {
 
     /// Card-based payment, such as a credit or debit card.

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
@@ -7,7 +7,7 @@
 
 import StripeCore
 import StripeCoreTestUtils
-@testable @_spi(CryptoOnrampSDKPreview) import StripeCryptoOnramp
+@testable @_spi(STP) import StripeCryptoOnramp
 @_spi(STP) import StripePaymentSheet
 
 import OHHTTPStubs


### PR DESCRIPTION
## Summary

Since this SDK will only be exposed to `stripe-react-native`, it can use our internally-public annotation.

## Motivation

Only expose these types internally

## Testing

N/a

## Changelog

N/a