### PR TITLE
Add latest scope for onramp

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
@@ -19,7 +19,7 @@ struct CryptoOnrampExampleView: View {
     @State private var coordinator: CryptoOnrampCoordinator?
     @State private var errorMessage: String?
     @State private var email: String = ""
-    @State private var selectedScopes: Set<OAuthScopes> = Set(OAuthScopes.inlineScope)
+    @State private var selectedScopes: Set<OAuthScopes> = Set(OAuthScopes.onrampScope)
     @State private var showRegistration: Bool = false
     @State private var showAuthenticatedView: Bool = false
     @State private var authenticationCustomerId: String?
@@ -54,8 +54,8 @@ struct CryptoOnrampExampleView: View {
 
                     OAuthScopeSelector(
                         selectedScopes: $selectedScopes,
-                        onInlineScopesSelected: {
-                            selectedScopes = Set(OAuthScopes.inlineScope)
+                        onOnrampScopesSelected: {
+                            selectedScopes = Set(OAuthScopes.onrampScope)
                         },
                         onAllScopesSelected: {
                             selectedScopes = Set(OAuthScopes.allScopes)
@@ -209,7 +209,7 @@ struct CryptoOnrampExampleView: View {
 
 struct OAuthScopeSelector: View {
     @Binding var selectedScopes: Set<OAuthScopes>
-    let onInlineScopesSelected: () -> Void
+    let onOnrampScopesSelected: () -> Void
     let onAllScopesSelected: () -> Void
 
     var body: some View {
@@ -222,8 +222,8 @@ struct OAuthScopeSelector: View {
                 Spacer()
 
                 HStack(spacing: 8) {
-                    Button("Inline") {
-                        onInlineScopesSelected()
+                    Button("Onramp") {
+                        onOnrampScopesSelected()
                     }
                     .buttonStyle(.bordered)
                     .controlSize(.small)

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Auth.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Auth.swift
@@ -10,7 +10,7 @@ import Foundation
 extension APIClient {
     func authenticateUser(
         with email: String,
-        oauthScopes: [OAuthScopes] = OAuthScopes.inlineScope
+        oauthScopes: [OAuthScopes] = OAuthScopes.onrampScope
     ) async throws -> AuthenticateUserResponse {
         let response: AuthenticateUserResponse = try await request(
             "auth_intent/create",

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/AuthenticatedUserRequest.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/AuthenticatedUserRequest.swift
@@ -16,7 +16,7 @@ struct AuthenticateUserRequest: Encodable {
         case oauthScopes = "oauth_scopes"
     }
 
-    init(email: String, oauthScopes: [OAuthScopes] = OAuthScopes.inlineScope) {
+    init(email: String, oauthScopes: [OAuthScopes] = OAuthScopes.onrampScope) {
         self.email = email
 
         // `manage_crypto_onramp` is required for our use cases, so we hardcode it into the request.

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/OAuthScope.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/OAuthScope.swift
@@ -8,9 +8,10 @@
 import Foundation
 
 enum OAuthScopes: String, CaseIterable {
-    static let inlineScope: [OAuthScopes] = [OAuthScopes.userinfoRead]
+    static let onrampScope: [OAuthScopes] = [OAuthScopes.cryptoRamp]
     static let allScopes: [OAuthScopes] = Self.allCases
 
+    case cryptoRamp = "crypto:ramp"
     case userinfoRead = "userinfo:read"
     case userinfoAddressesRead = "userinfo.addresses:read"
     case kycStatusRead = "kyc.status:read"

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/RegistrationView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/RegistrationView.swift
@@ -156,7 +156,7 @@ struct RegistrationView: View {
         RegistrationView(
             coordinator: coordinator,
             email: "test@example.com",
-            selectedScopes: OAuthScopes.inlineScope
+            selectedScopes: OAuthScopes.onrampScope
         )
     }
 }


### PR DESCRIPTION
## Summary

Adds `crypto:ramp` as the default OAuth scope, which is the newly added scope.

## Motivation

Unbloocks our example app

## Testing

Manually tested ✅ 

## Changelog

N/a