### PR TITLE
Fix push_spm_mirror erroring by creating shorter path tmp directory f…

### DIFF
--- a/ci_scripts/push_spm_mirror.rb
+++ b/ci_scripts/push_spm_mirror.rb
@@ -16,7 +16,7 @@ abort('Version number must be in the format `x.x.x`, e.g. `ci_scripts/push_spm_m
 puts "Creating SPM mirror tag for version: #{@version}".red
 
 # Create a new temporary directory
-Dir.mktmpdir do |tmp_dir|
+Dir.mktmpdir(nil, "/tmp") do |tmp_dir|
   # create a temporary clone of stripe-ios-spm
   full_repo_dir = tmp_dir + '/stripe-ios'
   spm_repo_dir = tmp_dir + '/stripe-ios-spm'


### PR DESCRIPTION
…or rsync?

## Summary
**Problem**
* rsync kept failing after partially transferring files. 
* It also started with this error: `rsync(58062): error: mkstempsock: Invalid argument`

**Solution**
LLM suggested this fix to use use /tmp rather than the default /var/folders/blahblah

Before:
```
> rsync -av  . /var/folders/lx/bttxs0ws1x73fbv0hvj94nv00000gn/T/d20250826-58057-onzxph/stripe-ios
```

After:
```
> rsync -av  . /tmp/d20250826-59105-a38gph/stripe-ios
```

## Testing
Before:
```
Continuing from step 8: push_spm_mirror
# push_spm_mirror (step 8/9)
Pushing the release to our SPM mirror.
> ci_scripts/push_spm_mirror.rb --version 24.21.1
Creating SPM mirror tag for version: 24.21.1
> rsync -av  . /var/folders/lx/bttxs0ws1x73fbv0hvj94nv00000gn/T/d20250826-58057-onzxph/stripe-ios
Transfer starting: 9653 files
rsync(58062): error: mkstempsock: Invalid argument
...
sent 2198072129 bytes  received 177372 bytes  191017587 bytes/sec
total size is 2196172379  speedup is 1.00
rsync(58061): warning: child 58062 exited with status 23
```

After
```
Continuing from step 8: push_spm_mirror
# push_spm_mirror (step 8/9)
Pushing the release to our SPM mirror.
> ci_scripts/push_spm_mirror.rb --version 24.21.1
Creating SPM mirror tag for version: 24.21.1
> rsync -av  . /tmp/d20250826-59105-a38gph/stripe-ios
Transfer starting: 9653 files
...
```

## Changelog
Not user facing
