### PR TITLE
Fix card scanner layout bug

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/CardScanningView.swift
@@ -168,7 +168,11 @@ class CardScanningView: UIView, STPCardScannerDelegate {
     // The shape layers don't animate cleanly during setHidden,
     // so let's use a snapshot view instead.
     func prepDismissAnimation() {
-        if let snapshot = snapshotView(afterScreenUpdates: true) {
+        // Taking a snapshot while the view is offscreen can result in layout issues,
+        //    and is unnecessary since we won't show an animation in this case
+        guard window != nil else { return }
+
+        if let snapshot = snapshotView(afterScreenUpdates: false) {
             self.addSubview(snapshot)
             self.snapshotView = snapshot
         }


### PR DESCRIPTION
## Summary
Fixed a layout bug that sometimes presents with the following changes:
- don't take a snapshot when the scanner is off screen
- use afterScreenUpdates=false
Without these changes, taking a snapshot causes breakages to the parent stackview's automatic layout constraints, resulting in a layout bug. Either of these changes alone fixes it, but I'm adding both for redundancy / extra safety

## Motivation
https://jira.corp.stripe.com/browse/MOBILESDK-3972

## Testing
Manual testing

## Changelog
N/A