### PR TITLE
Don't show Link in WalletButtonsView when disabled client-side

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -104,7 +104,7 @@ import WebKit
             }
         }
 
-        if flowController.elementsSession.linkPassthroughModeEnabled {
+        if flowController.elementsSession.linkPassthroughModeEnabled && PaymentSheet.isLinkEnabled(elementsSession: flowController.elementsSession, configuration: flowController.configuration) {
             // Link in passthrough mode won't be in `orderedPaymentMethodTypesAndWallets`, so we append it.
             wallets.append(.link)
         }


### PR DESCRIPTION
## Summary
Don't show Link if it's disabled by the client-side Link config.

## Testing
In PS Example

## Changelog
N/A