### PR TITLE
Fix payment method filtering on Link wallet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -263,8 +263,8 @@ extension PayWithLinkViewController {
         }
 
         func reloadPaymentDetails(completion: (() -> Void)?) {
-            let supportedPaymentDetailsTypes = linkAccount
-                .supportedPaymentDetailsTypes(for: context.elementsSession)
+            let supportedPaymentDetailsTypes = context
+                .getSupportedPaymentDetailsTypes(linkAccount: linkAccount)
                 .toSortedArray()
 
             // Fire and forget; ignore any errors that might happen here.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -35,7 +35,7 @@ extension PayWithLinkViewController {
         }
 
         var supportedPaymentMethodTypes: Set<ConsumerPaymentDetails.DetailsType> {
-            return linkAccount.supportedPaymentDetailsTypes(for: context.elementsSession)
+            return context.getSupportedPaymentDetailsTypes(linkAccount: linkAccount)
         }
 
         var cvc: String? {


### PR DESCRIPTION
## Summary

Fixes payment method type filtering on the Link wallet. This was causing an issue where the list of payments methods would show unsupported types after refreshing the list.

## Motivation

https://docs.google.com/document/d/1Z5nGG-28X5ASe5MZxjk0Tnu9b180MYH9CStXxg_cmRo/edit?usp=sharing

## Testing

Before:

https://github.com/user-attachments/assets/6ad1db51-8981-4f28-b4a4-33b297cb14ec

After:

https://github.com/user-attachments/assets/c582da5f-38d3-418a-9651-e96fb026e105

## Changelog

N/a