### PR TITLE
Extend control over Link in `WalletButtonsView`

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -74,13 +74,10 @@ extension PaymentSheet {
     }
 
     static func isLinkSignupEnabled(elementsSession: STPElementsSession, configuration: PaymentElementConfiguration) -> Bool {
-        guard isLinkEnabled(elementsSession: elementsSession, configuration: configuration) else {
-            return false
-        }
+        let enableSignup = isLinkEnabled(elementsSession: elementsSession, configuration: configuration) && !elementsSession.disableLinkSignup
         // A non-nil account indicates that a consumer lookup has taken place, meaning that we have a customer email
         // via the billing details or customer session.
         let enableOptIn = elementsSession.linkSignupOptInFeatureEnabled && LinkAccountContext.shared.account != nil
-        let enableSignup = !elementsSession.disableLinkSignup
         return (enableSignup || enableOptIn) && elementsSession.supportsLinkCard
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -228,7 +228,7 @@ extension PaymentSheet {
         private var didDismissLinkVerificationDialog: Bool = false
 
         // If a WalletButtonsView is currently visible
-        var walletButtonsShownExternally: Bool = false {
+        var walletButtonsViewState: WalletButtonsViewState = .hidden {
             didSet {
                 // Update payment method options
                 self.updateForWalletButtonsView()
@@ -291,7 +291,12 @@ extension PaymentSheet {
             self.configuration = configuration
             self.analyticsHelper = analyticsHelper
             self.analyticsHelper.logInitialized()
-            self.viewController = Self.makeViewController(configuration: configuration, loadResult: loadResult, analyticsHelper: analyticsHelper, walletButtonsShownExternally: self.walletButtonsShownExternally)
+            self.viewController = Self.makeViewController(
+                configuration: configuration,
+                loadResult: loadResult,
+                analyticsHelper: analyticsHelper,
+                walletButtonsShownExternally: self.walletButtonsViewState.visibleButtons
+            )
             self.viewController.flowControllerDelegate = self
             self.passiveCaptchaChallenge = PassiveCaptchaChallenge(passiveCaptcha: loadResult.elementsSession.passiveCaptcha)
             self.viewController.passiveCaptchaChallenge = self.passiveCaptchaChallenge
@@ -628,7 +633,7 @@ extension PaymentSheet {
                         configuration: self.configuration,
                         loadResult: loadResult,
                         analyticsHelper: analyticsHelper,
-                        walletButtonsShownExternally: walletButtonsShownExternally,
+                        walletButtonsShownExternally: walletButtonsViewState.visibleButtons,
                         previousPaymentOption: self.internalPaymentOption
                     )
                     self.viewController.flowControllerDelegate = self
@@ -659,7 +664,7 @@ extension PaymentSheet {
                 configuration: self.configuration,
                 loadResult: updatedLoadResult,
                 analyticsHelper: analyticsHelper,
-                walletButtonsShownExternally: self.walletButtonsShownExternally,
+                walletButtonsShownExternally: self.walletButtonsViewState.visibleButtons,
                 previousLinkConfirmOption: self.viewController.linkConfirmOption,
                 previousPaymentOption: self.internalPaymentOption
             )
@@ -703,7 +708,7 @@ extension PaymentSheet {
             configuration: Configuration,
             loadResult: PaymentSheetLoader.LoadResult,
             analyticsHelper: PaymentSheetAnalyticsHelper,
-            walletButtonsShownExternally: Bool,
+            walletButtonsShownExternally: [String],
             previousLinkConfirmOption: LinkConfirmOption? = nil,
             previousPaymentOption: PaymentOption? = nil
         ) -> FlowControllerViewControllerProtocol {
@@ -728,6 +733,20 @@ extension PaymentSheet {
             }
             controller.linkConfirmOption = previousLinkConfirmOption
             return controller
+        }
+    }
+
+    enum WalletButtonsViewState {
+        case visible(allowedWallets: [String])
+        case hidden
+
+        var visibleButtons: [String] {
+            switch self {
+            case .visible(let allowedWallets):
+                return allowedWallets
+            case .hidden:
+                return []
+            }
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -291,12 +291,7 @@ extension PaymentSheet {
             self.configuration = configuration
             self.analyticsHelper = analyticsHelper
             self.analyticsHelper.logInitialized()
-            self.viewController = Self.makeViewController(
-                configuration: configuration,
-                loadResult: loadResult,
-                analyticsHelper: analyticsHelper,
-                walletButtonsShownExternally: self.walletButtonsViewState.visibleButtons
-            )
+            self.viewController = Self.makeViewController(configuration: configuration, loadResult: loadResult, analyticsHelper: analyticsHelper, walletButtonsViewState: self.walletButtonsViewState)
             self.viewController.flowControllerDelegate = self
             self.passiveCaptchaChallenge = PassiveCaptchaChallenge(passiveCaptcha: loadResult.elementsSession.passiveCaptcha)
             self.viewController.passiveCaptchaChallenge = self.passiveCaptchaChallenge
@@ -633,7 +628,7 @@ extension PaymentSheet {
                         configuration: self.configuration,
                         loadResult: loadResult,
                         analyticsHelper: analyticsHelper,
-                        walletButtonsShownExternally: walletButtonsViewState.visibleButtons,
+                        walletButtonsViewState: walletButtonsViewState,
                         previousPaymentOption: self.internalPaymentOption
                     )
                     self.viewController.flowControllerDelegate = self
@@ -664,7 +659,7 @@ extension PaymentSheet {
                 configuration: self.configuration,
                 loadResult: updatedLoadResult,
                 analyticsHelper: analyticsHelper,
-                walletButtonsShownExternally: self.walletButtonsViewState.visibleButtons,
+                walletButtonsViewState: self.walletButtonsViewState,
                 previousLinkConfirmOption: self.viewController.linkConfirmOption,
                 previousPaymentOption: self.internalPaymentOption
             )
@@ -708,7 +703,7 @@ extension PaymentSheet {
             configuration: Configuration,
             loadResult: PaymentSheetLoader.LoadResult,
             analyticsHelper: PaymentSheetAnalyticsHelper,
-            walletButtonsShownExternally: [String],
+            walletButtonsViewState: PaymentSheet.WalletButtonsViewState,
             previousLinkConfirmOption: LinkConfirmOption? = nil,
             previousPaymentOption: PaymentOption? = nil
         ) -> FlowControllerViewControllerProtocol {
@@ -727,7 +722,7 @@ extension PaymentSheet {
                     loadResult: loadResult,
                     isFlowController: true,
                     analyticsHelper: analyticsHelper,
-                    walletButtonsShownExternally: walletButtonsShownExternally,
+                    walletButtonsViewState: walletButtonsViewState,
                     previousPaymentOption: previousPaymentOption
                 )
             }
@@ -740,13 +735,30 @@ extension PaymentSheet {
         case visible(allowedWallets: [String])
         case hidden
 
-        var visibleButtons: [String] {
+        var isVisible: Bool {
+            switch self {
+            case .visible:
+                return true
+            case .hidden:
+                return false
+            }
+        }
+
+        private var visibleButtons: [String] {
             switch self {
             case .visible(let allowedWallets):
                 return allowedWallets
             case .hidden:
                 return []
             }
+        }
+
+        var showApplePay: Bool {
+            visibleButtons.contains("apple_pay")
+        }
+
+        var showLink: Bool {
+            visibleButtons.contains("link")
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -9,30 +9,35 @@ import WebKit
 
 @available(iOS 16.0, *)
 @_spi(STP) public struct WalletButtonsView: View {
-    enum ExpressType: Hashable {
-        case applePay
-        case link
-        case shopPay
+    @_spi(STP) public enum ExpressType: String, Hashable, CaseIterable {
+        case applePay = "apple_pay"
+        case link = "link"
+        case shopPay = "shop_pay"
     }
 
     let flowController: PaymentSheet.FlowController
     let confirmHandler: (PaymentSheetResult) -> Void
+    let walletsToShow: Set<ExpressType>
     @State var orderedWallets: [ExpressType]
 
     @_spi(STP) public init(flowController: PaymentSheet.FlowController,
+                           walletsToShow: Set<ExpressType> = Set(),
                            confirmHandler: @escaping (PaymentSheetResult) -> Void) {
         self.confirmHandler = confirmHandler
         self.flowController = flowController
+        self.walletsToShow = walletsToShow.isEmpty ? Set(ExpressType.allCases) : walletsToShow
 
-        let wallets = WalletButtonsView.determineAvailableWallets(for: flowController)
+        let wallets = WalletButtonsView.determineAvailableWallets(for: flowController, allowedWallets: walletsToShow)
         self._orderedWallets = State(initialValue: wallets)
     }
 
+    // TODO: Deprecate?
     init(flowController: PaymentSheet.FlowController,
          confirmHandler: @escaping (PaymentSheetResult) -> Void,
          orderedWallets: [ExpressType]) {
         self.flowController = flowController
         self.confirmHandler = confirmHandler
+        self.walletsToShow = Set(orderedWallets)
         self._orderedWallets = State(initialValue: orderedWallets)
     }
 
@@ -75,38 +80,50 @@ import WebKit
             .frame(maxWidth: .infinity)
             .animation(.easeInOut, value: orderedWallets)
             .onAppear {
-                flowController.walletButtonsShownExternally = true
+                let allowedWallets = walletsToShow.isEmpty ? Set(ExpressType.allCases) : walletsToShow
+                flowController.walletButtonsViewState = .visible(allowedWallets: allowedWallets.map(\.rawValue))
             }
             .onDisappear {
-                flowController.walletButtonsShownExternally = false
+                flowController.walletButtonsViewState = .hidden
             }
         }
     }
 
-    private static func determineAvailableWallets(for flowController: PaymentSheet.FlowController) -> [ExpressType] {
+    private static func determineAvailableWallets(
+        for flowController: PaymentSheet.FlowController,
+        allowedWallets: Set<ExpressType>
+    ) -> [ExpressType] {
         // Determine available wallets and their order from elementsSession
         var wallets: [ExpressType] = []
+
+        func appendIfAllowed(_ wallet: ExpressType) {
+            if allowedWallets.isEmpty || allowedWallets.contains(wallet) {
+                wallets.append(wallet)
+            }
+        }
 
         for type in flowController.elementsSession.orderedPaymentMethodTypesAndWallets {
             switch type {
             case "link":
                 if PaymentSheet.isLinkEnabled(elementsSession: flowController.elementsSession, configuration: flowController.configuration) {
-                    wallets.append(.link)
+                    appendIfAllowed(.link)
                 }
             case "apple_pay":
                 if PaymentSheet.isApplePayEnabled(elementsSession: flowController.elementsSession, configuration: flowController.configuration) {
-                    wallets.append(.applePay)
+                    appendIfAllowed(.applePay)
                 }
             case "shop_pay":
-                wallets.append(.shopPay)
+                if allowedWallets.isEmpty || allowedWallets.contains(.shopPay) {
+                    appendIfAllowed(.shopPay)
+                }
             default:
                 continue
             }
         }
 
-        if flowController.elementsSession.linkPassthroughModeEnabled {
+        if flowController.elementsSession.linkPassthroughModeEnabled && PaymentSheet.isLinkEnabled(elementsSession: flowController.elementsSession, configuration: flowController.configuration) {
             // Link in passthrough mode won't be in `orderedPaymentMethodTypesAndWallets`, so we append it.
-            wallets.append(.link)
+            appendIfAllowed(.link)
         }
 
         return wallets
@@ -142,7 +159,7 @@ import WebKit
                 canSkipWalletAfterVerification: flowController.elementsSession.canSkipLinkWallet,
                 completion: { confirmOptions, _ in
                     guard let confirmOptions else {
-                        self.orderedWallets = WalletButtonsView.determineAvailableWallets(for: flowController)
+//                        self.orderedWallets = WalletButtonsView.determineAvailableWallets(for: flowController)
                         return
                     }
                     flowController.viewController.linkConfirmOption = confirmOptions


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request extends control over Link in `WalletButtonsView`. 

It now respects `PaymentSheet.Configuration.LinkConfiguration` when Link is used in passthrough mode, and it allows limiting the list of allowed wallet types via `walletsToShow`.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
