### PR TITLE
Pass `allow_redisplay` along to FC SDK

### DIFF
--- a/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/ElementsSessionContext.swift
@@ -51,6 +51,7 @@ import Foundation
     @_spi(STP) public let linkMode: LinkMode?
     @_spi(STP) public let billingDetails: BillingDetails?
     @_spi(STP) public let eligibleForIncentive: Bool
+    @_spi(STP) public let allowRedisplay: String?
 
     @_spi(STP) public var billingAddress: BillingAddress? {
         BillingAddress(from: billingDetails)
@@ -70,7 +71,8 @@ import Foundation
         intentId: IntentID? = nil,
         linkMode: LinkMode? = nil,
         billingDetails: BillingDetails? = nil,
-        eligibleForIncentive: Bool = false
+        eligibleForIncentive: Bool = false,
+        allowRedisplay: String? = nil
     ) {
         self.amount = amount
         self.currency = currency
@@ -79,6 +81,7 @@ import Foundation
         self.linkMode = linkMode
         self.billingDetails = billingDetails
         self.eligibleForIncentive = eligibleForIncentive
+        self.allowRedisplay = allowRedisplay
     }
 }
 

--- a/StripeCore/StripeCore/Source/Connections Bindings/HostedAuthUrlBuilder.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/HostedAuthUrlBuilder.swift
@@ -85,6 +85,10 @@ import Foundation
 
         parameters.append("launched_by=ios_sdk")
 
+        if let allowRedisplay = elementsSessionContext?.allowRedisplay {
+            parameters.append("allow_redisplay=\(allowRedisplay)")
+        }
+
         // Join all values with an &, and URL encode.
         // We encode these parameters since they will be appended to the auth flow URL.
         let joinedParameters = parameters

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPI.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPI.swift
@@ -203,13 +203,15 @@ protocol FinancialConnectionsAPI {
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
         billingEmail: String?,
-        billingPhone: String?
+        billingPhone: String?,
+        allowRedisplay: String?
     ) -> Future<FinancialConnectionsSharePaymentDetails>
 
     func paymentMethods(
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
-        billingDetails: ElementsSessionContext.BillingDetails?
+        billingDetails: ElementsSessionContext.BillingDetails?,
+        allowRedisplay: String?
     ) -> Future<LinkBankPaymentMethod>
 
     func updateAvailableIncentives(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Wrappers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient+Wrappers.swift
@@ -449,7 +449,8 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
         billingEmail: String?,
-        billingPhone: String?
+        billingPhone: String?,
+        allowRedisplay: String?
     ) -> Future<FinancialConnectionsSharePaymentDetails> {
         wrapAsyncToFuture {
             try await self.sharePaymentDetails(
@@ -457,7 +458,8 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
                 paymentDetailsId: paymentDetailsId,
                 expectedPaymentMethodType: expectedPaymentMethodType,
                 billingEmail: billingEmail,
-                billingPhone: billingPhone
+                billingPhone: billingPhone,
+                allowRedisplay: allowRedisplay
             )
         }
     }
@@ -465,13 +467,15 @@ extension FinancialConnectionsAsyncAPIClient: FinancialConnectionsAPI {
     func paymentMethods(
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
-        billingDetails: ElementsSessionContext.BillingDetails?
+        billingDetails: ElementsSessionContext.BillingDetails?,
+        allowRedisplay: String?
     ) -> Future<LinkBankPaymentMethod> {
         wrapAsyncToFuture {
             try await self.paymentMethods(
                 consumerSessionClientSecret: consumerSessionClientSecret,
                 paymentDetailsId: paymentDetailsId,
-                billingDetails: billingDetails
+                billingDetails: billingDetails,
+                allowRedisplay: allowRedisplay
             )
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -900,7 +900,8 @@ extension FinancialConnectionsAsyncAPIClient {
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
         billingEmail: String?,
-        billingPhone: String?
+        billingPhone: String?,
+        allowRedisplay: String?
     ) async throws -> FinancialConnectionsSharePaymentDetails {
         var parameters: [String: Any] = [
             "request_surface": requestSurface,
@@ -920,6 +921,10 @@ extension FinancialConnectionsAsyncAPIClient {
             parameters["billing_phone"] = billingPhone
         }
 
+        if let allowRedisplay {
+            parameters["allow_redisplay"] = allowRedisplay
+        }
+
         let parametersWithFraudDetection = await updateAndApplyFraudDetection(to: parameters)
         return try await post(endpoint: .sharePaymentDetails, parameters: parametersWithFraudDetection)
     }
@@ -927,7 +932,8 @@ extension FinancialConnectionsAsyncAPIClient {
     func paymentMethods(
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
-        billingDetails: ElementsSessionContext.BillingDetails?
+        billingDetails: ElementsSessionContext.BillingDetails?,
+        allowRedisplay: String?
     ) async throws -> LinkBankPaymentMethod {
         var parameters: [String: Any] = [
             "link": [
@@ -942,6 +948,10 @@ extension FinancialConnectionsAsyncAPIClient {
         if let billingDetails {
             let encodedBillingAddress = try Self.encodeAsParameters(billingDetails)
             parameters["billing_details"] = encodedBillingAddress
+        }
+
+        if let allowRedisplay {
+            parameters["allow_redisplay"] = allowRedisplay
         }
 
         let parametersWithFraudDetection = await updateAndApplyFraudDetection(to: parameters)

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -553,14 +553,16 @@ extension NativeFlowController {
                     paymentDetailsId: response.redactedPaymentDetails.id,
                     expectedPaymentMethodType: linkMode.expectedPaymentMethodType,
                     billingEmail: email,
-                    billingPhone: phone
+                    billingPhone: phone,
+                    allowRedisplay: elementsSessionContext?.allowRedisplay
                 )
                 .transformed { $0.paymentMethod }
             } else {
                 return self.dataManager.apiClient.paymentMethods(
                     consumerSessionClientSecret: consumerSession.clientSecret,
                     paymentDetailsId: response.redactedPaymentDetails.id,
-                    billingDetails: elementsSessionContext?.billingDetails
+                    billingDetails: elementsSessionContext?.billingDetails,
+                    allowRedisplay: elementsSessionContext?.allowRedisplay
                 )
             }
         }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/EmptyFinancialConnectionsAPIClient.swift
@@ -261,7 +261,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
         paymentDetailsId: String,
         expectedPaymentMethodType: String,
         billingEmail: String?,
-        billingPhone: String?
+        billingPhone: String?,
+        allowRedisplay: String?
     ) -> Future<FinancialConnectionsSharePaymentDetails> {
         Promise<StripeFinancialConnections.FinancialConnectionsSharePaymentDetails>()
     }
@@ -269,7 +270,8 @@ class EmptyFinancialConnectionsAPIClient: FinancialConnectionsAPI {
     func paymentMethods(
         consumerSessionClientSecret: String,
         paymentDetailsId: String,
-        billingDetails: ElementsSessionContext.BillingDetails?
+        billingDetails: ElementsSessionContext.BillingDetails?,
+        allowRedisplay: String?
     ) -> StripeCore.Future<StripeFinancialConnections.LinkBankPaymentMethod> {
         Promise<StripeFinancialConnections.LinkBankPaymentMethod>()
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -406,3 +406,25 @@ extension STPElementsSession {
         return true
     }
 }
+
+extension STPElementsSession {
+    func computeAllowRedisplay(isSettingUp: Bool) -> STPPaymentMethodAllowRedisplay? {
+        guard let customerSessionMobilePaymentElementFeatures else {
+            return nil
+        }
+
+        let allowRedisplayOverride = customerSessionMobilePaymentElementFeatures.paymentMethodSaveAllowRedisplayOverride
+
+        if isSettingUp {
+            return allowRedisplayOverride ?? .limited
+        } else {
+            return .unspecified
+        }
+    }
+
+    var useCardPaymentMethodTypeForIBP: Bool {
+        let canAcceptACH = orderedPaymentMethodTypes.contains(.USBankAccount)
+        let isLinkCardBrand = linkSettings?.linkMode?.isPantherPayment ?? false
+        return isLinkCardBrand && !canAcceptACH
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -336,22 +336,9 @@ extension PaymentMethodFormViewController {
         let linkMode = elementsSession.linkSettings?.linkMode
         let billingDetails = instantDebitsFormElement?.billingDetails
 
-        let paymentMethodType: STPPaymentMethodType = elementsSession.linkPassthroughModeEnabled ? .card : .link
+        let paymentMethodType: STPPaymentMethodType = elementsSession.useCardPaymentMethodTypeForIBP ? .card : .USBankAccount
         let isSettingUp = intent.isSetupFutureUsageSet(for: paymentMethodType) || elementsSession.forceSaveFutureUseBehaviorAndNewMandateText
-
-        let allowRedisplay: STPPaymentMethodAllowRedisplay? = {
-            guard let mobilePaymentElementFeatures = elementsSession.customerSessionMobilePaymentElementFeatures else {
-                return nil
-            }
-
-            let allowRedisplayOverride = mobilePaymentElementFeatures.paymentMethodSaveAllowRedisplayOverride
-
-            if isSettingUp {
-                return allowRedisplayOverride ?? .limited
-            } else {
-                return .unspecified
-            }
-        }()
+        let allowRedisplay = elementsSession.computeAllowRedisplay(isSettingUp: isSettingUp)
 
         return ElementsSessionContext(
             amount: intent.amount,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -336,6 +336,23 @@ extension PaymentMethodFormViewController {
         let linkMode = elementsSession.linkSettings?.linkMode
         let billingDetails = instantDebitsFormElement?.billingDetails
 
+        let paymentMethodType: STPPaymentMethodType = elementsSession.linkPassthroughModeEnabled ? .card : .link
+        let isSettingUp = intent.isSetupFutureUsageSet(for: paymentMethodType) || elementsSession.forceSaveFutureUseBehaviorAndNewMandateText
+
+        let allowRedisplay: STPPaymentMethodAllowRedisplay? = {
+            guard let mobilePaymentElementFeatures = elementsSession.customerSessionMobilePaymentElementFeatures else {
+                return nil
+            }
+
+            let allowRedisplayOverride = mobilePaymentElementFeatures.paymentMethodSaveAllowRedisplayOverride
+
+            if isSettingUp {
+                return allowRedisplayOverride ?? .limited
+            } else {
+                return .unspecified
+            }
+        }()
+
         return ElementsSessionContext(
             amount: intent.amount,
             currency: intent.currency,
@@ -343,7 +360,8 @@ extension PaymentMethodFormViewController {
             intentId: intentId,
             linkMode: linkMode,
             billingDetails: billingDetails,
-            eligibleForIncentive: instantDebitsFormElement?.displayableIncentive != nil
+            eligibleForIncentive: instantDebitsFormElement?.displayableIncentive != nil,
+            allowRedisplay: allowRedisplay?.stringValue
         )
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request makes us pass along the merchant-provided `allow_redisplay` value to the Financial Connections SDK. The Stripe.js implementation will be [updated](https://git.corp.stripe.com/stripe-internal/pay-server/pull/1180553) to then pass this value in the payment method creation call.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
