### PR TITLE
Fix Payment Sheet Example app memory leaks

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -562,20 +562,20 @@ class PlaygroundController: ObservableObject {
         self.appearance = appearance
         self.currentlyRenderedSettings = .defaultValues()
 
-        $settings.removeDuplicates().sink { newValue in
+        $settings.removeDuplicates().sink { [weak self] newValue in
             if newValue.autoreload == .on {
                 // This closure is called *before* `settings` is updated! Wait until the next run loop before calling `load`
                 DispatchQueue.main.async {
-                    self.load()
+                    self?.load()
                 }
             }
             if newValue.shakeAmbiguousViews == .on {
-                self.ambiguousViewTimer?.invalidate()
-                self.ambiguousViewTimer = .scheduledTimer(withTimeInterval: 5.0, repeats: true, block: { _ in
-                    self.checkForAmbiguousViews()
+                self?.ambiguousViewTimer?.invalidate()
+                self?.ambiguousViewTimer = .scheduledTimer(withTimeInterval: 5.0, repeats: true, block: { _ in
+                    self?.checkForAmbiguousViews()
                 })
             } else {
-                self.ambiguousViewTimer?.invalidate()
+                self?.ambiguousViewTimer?.invalidate()
             }
 
             // Hack to enable incentives in Instant Debits


### PR DESCRIPTION
## Summary
Use weak self to avoid retain cycles in Example App

## Motivation
We were leaking a full instance of the `PlaygroundController` and `CustomerSheetTestPlaygroundController` every time the corresponding playground was opened and closed

## Testing
N/A

## Changelog
N/A
