### PR TITLE
[iOS 26] Fix keyboard input accessory view not overlapping content no…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -428,10 +428,12 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
                 if notification.name == UIResponder.keyboardWillHideNotification {
                     bottomAnchor.constant = 0
                 } else {
+                    #if !os(visionOS)
                     if #available(iOS 26.0, *), let inputAccessoryView = self.view.firstResponder()?.inputAccessoryView {
                         // On iOS 26, the input accessory view is transparent, so we don't want shift the content above it.
                        keyboardInViewHeight -= inputAccessoryView.frame.height
                     }
+                    #endif
                     bottomAnchor.constant = -keyboardInViewHeight
                 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -417,7 +417,7 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
                 else {
                     return
                 }
-
+                
                 let keyboardViewEndFrame = self.view.convert(keyboardScreenEndFrame, from: self.view.window)
                 var keyboardInViewHeight = self.view.bounds.intersection(keyboardViewEndFrame).height
                 // Account for edge case where keyboard is taller than our view
@@ -428,6 +428,10 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
                 if notification.name == UIResponder.keyboardWillHideNotification {
                     bottomAnchor.constant = 0
                 } else {
+                    if #available(iOS 26.0, *), let inputAccessoryView = self.view.firstResponder()?.inputAccessoryView {
+                        // On iOS 26, the input accessory view is transparent, so we don't want shift the content above it.
+                       keyboardInViewHeight -= inputAccessoryView.frame.height
+                    }
                     bottomAnchor.constant = -keyboardInViewHeight
                 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -417,7 +417,7 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
                 else {
                     return
                 }
-                
+
                 let keyboardViewEndFrame = self.view.convert(keyboardScreenEndFrame, from: self.view.window)
                 var keyboardInViewHeight = self.view.bounds.intersection(keyboardViewEndFrame).height
                 // Account for edge case where keyboard is taller than our view


### PR DESCRIPTION
…w that it's transparent.

## Motivation
ios26 bug

## Testing
<img width="500" alt="image" src="https://github.com/user-attachments/assets/c60a5780-9dc6-4213-9a58-8b0347572fad" />


