### PR TITLE
Add declineCode parameter to STPError.localizedUserMessage API

### DIFF
--- a/StripeCore/StripeCore/Source/Helpers/STPError.swift
+++ b/StripeCore/StripeCore/Source/Helpers/STPError.swift
@@ -76,9 +76,11 @@ import Foundation
     /// Returns a localized user-facing message for a given error code.
     /// This method can be used to display an appropriate error message to the user.
     /// - Parameter errorCode: The error code string from Stripe API (e.g., "incorrect_number", "card_declined")
+    /// - Parameter declineCode: The decline code string from Stripe API (e.g., "insufficient_funds", "card_velocity_exceeded")
     /// - Returns: A localized error message, or nil if the error code is not recognized
-    @objc public static func localizedUserMessage(forErrorCode errorCode: String) -> String? {
-        return NSError.Utils.localizedMessage(fromAPIErrorCode: errorCode)
+    @objc public static func localizedUserMessage(forErrorCode errorCode: String,
+                                                  declineCode: String? = nil) -> String? {
+        return NSError.Utils.localizedMessage(fromAPIErrorCode: errorCode, declineCode: declineCode)
     }
 }
 
@@ -119,8 +121,8 @@ extension NSError {
             declineCode: String? = nil
         ) -> String? {
             return
-                (apiErrorCodeToMessage[errorCode]
-                ?? declineCode.flatMap { apiErrorCodeToMessage[$0] })
+                (declineCode.flatMap { apiErrorCodeToMessage[$0] }
+                ?? apiErrorCodeToMessage[errorCode])
         }
 
         @_spi(STP) public static func cardErrorCode(

--- a/StripeCore/StripeCoreTests/Helpers/STPErrorTests.swift
+++ b/StripeCore/StripeCoreTests/Helpers/STPErrorTests.swift
@@ -52,9 +52,15 @@ class STPErrorTests: XCTestCase {
     }
 
     func testLocalizedUserMessageWithDeclineCode() {
-        // Test decline codes (which should map correctly through the same API)
+        // Test that specific decline codes take priority when available
         XCTAssertEqual(
-            STPError.localizedUserMessage(forErrorCode: "card_declined"),
+            STPError.localizedUserMessage(forErrorCode: "card_declined", declineCode: "invalid_cvc"),
+            NSError.stp_cardInvalidCVCUserMessage()
+        )
+
+        // Test that unknown decline codes fall back to error code
+        XCTAssertEqual(
+            STPError.localizedUserMessage(forErrorCode: "card_declined", declineCode: "insufficient_funds"),
             NSError.stp_cardErrorDeclinedUserMessage()
         )
 


### PR DESCRIPTION
## Summary
Re-adds the `declineCode` parameter to the `STPError.localizedUserMessage` API as discussed in the mobile API review. This addresses the need to provide more specific error messages when decline codes are available while maintaining backward compatibility.

- Add optional `declineCode` parameter with default `nil` to maintain backward compatibility
- Prioritize `declineCode` over `errorCode` when both are present for more specific error messages  
- Fall back to generic `card_declined` message when `declineCode` is unknown
- Add comprehensive tests for the fallback behavior

## Test plan
- [x] Existing tests pass to ensure backward compatibility
- [x] New tests verify `declineCode` priority (e.g., `invalid_cvc` returns specific CVC message)
- [x] New tests verify fallback behavior (e.g., `insufficient_funds` returns generic declined message)
- [x] Linting and formatting checks pass