### PR TITLE
Consume new flag to disable bank tab

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -386,7 +386,7 @@ extension PaymentSheet {
                 missingRequirements.formUnion(requirements)
             }
 
-            if let linkSettings = elementsSession.linkSettings, linkSettings.instantDebitsOnboardingDisabled {
+            if elementsSession.linkSettings?.instantDebitsOnboardingEnabled != true {
                 missingRequirements.insert(.instantDebitsDisabledForOnboarding)
             }
 
@@ -430,7 +430,7 @@ extension PaymentSheet {
                 missingRequirements.formUnion(requirements)
             }
 
-            if let linkSettings = elementsSession.linkSettings, linkSettings.instantDebitsOnboardingDisabled {
+            if elementsSession.linkSettings?.instantDebitsOnboardingEnabled != true {
                 missingRequirements.insert(.instantDebitsDisabledForOnboarding)
             }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -386,14 +386,8 @@ extension PaymentSheet {
                 missingRequirements.formUnion(requirements)
             }
 
-            // - US Bank Account is *not* an available payment method.
-            if elementsSession.orderedPaymentMethodTypes.contains(.USBankAccount) {
-                missingRequirements.insert(.unexpectedUsBankAccount)
-            }
-
-            // - Link Funding Sources contains Bank Account.
-            if elementsSession.linkFundingSources?.contains(.bankAccount) == false {
-                missingRequirements.insert(.linkFundingSourcesMissingBankAccount)
+            if let linkSettings = elementsSession.linkSettings, linkSettings.instantDebitsOnboardingDisabled {
+                missingRequirements.insert(.instantDebitsDisabledForOnboarding)
             }
 
             // - We collect an email, or a default non-empty email has been provided.
@@ -436,14 +430,8 @@ extension PaymentSheet {
                 missingRequirements.formUnion(requirements)
             }
 
-            // - Link Funding Sources contains Bank Account.
-            if elementsSession.linkFundingSources?.contains(.bankAccount) == false {
-                missingRequirements.insert(.linkFundingSourcesMissingBankAccount)
-            }
-
-            // - US Bank Account is *not* an available payment method.
-            if elementsSession.orderedPaymentMethodTypes.contains(.USBankAccount) {
-                missingRequirements.insert(.unexpectedUsBankAccount)
+            if let linkSettings = elementsSession.linkSettings, linkSettings.instantDebitsOnboardingDisabled {
+                missingRequirements.insert(.instantDebitsDisabledForOnboarding)
             }
 
             // - We collect an email, or a default non-empty email has been provided.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -214,7 +214,7 @@ extension PaymentSheet {
             case .invalidEmailCollectionConfiguration:
                 return "The provided configuration must either collect an email, or a default email must be provided. See https://docs.stripe.com/payments/payment-element/control-billing-details-collection"
             case .instantDebitsDisabledForOnboarding:
-                return "Instant Bank Payments are disabled for new users."
+                return "The Bank tab is configured to be hidden for your account."
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -186,14 +186,11 @@ extension PaymentSheet {
         /// Requires a valid us bank verification method
         case validUSBankVerificationMethod
 
-        /// The `us_bank_account` payment method is preventing this payment method from being shown.
-        case unexpectedUsBankAccount
-
         /// The email collection configuration is invalid for this payment method.
         case invalidEmailCollectionConfiguration
 
-        /// The Stripe account is not configured for bank payments.
-        case linkFundingSourcesMissingBankAccount
+        /// The Bank payment method is disabled.
+        case instantDebitsDisabledForOnboarding
 
         /// A helpful description for developers to better understand requirements so they can debug why payment methods are not present
         var debugDescription: String {
@@ -214,12 +211,10 @@ extension PaymentSheet {
                 return "financialConnectionsSDK: The FinancialConnections SDK must be linked. See https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet#ios-ach"
             case .validUSBankVerificationMethod:
                 return "Requires a valid US bank verification method."
-            case .unexpectedUsBankAccount:
-                return "The list of payment method types includes 'us_bank_account', which prevents the 'Bank' tab from being displayed."
             case .invalidEmailCollectionConfiguration:
                 return "The provided configuration must either collect an email, or a default email must be provided. See https://docs.stripe.com/payments/payment-element/control-billing-details-collection"
-            case .linkFundingSourcesMissingBankAccount:
-                return "Your account isn't set up to process Instant Bank Payments. Reach out to Stripe support."
+            case .instantDebitsDisabledForOnboarding:
+                return "Instant Bank Payments are disabled for new users."
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
@@ -165,7 +165,8 @@ final class PaymentMethodAvailabilityTest: XCTestCase {
 extension LinkSettings {
     static func _testValue(
         disableSignup: Bool = false,
-        flags: [String: Bool]? = nil
+        flags: [String: Bool]? = nil,
+        linkSupportedPaymentMethodsOnboardingEnabled: [String] = ["CARD"]
     ) -> LinkSettings {
         return .init(
             fundingSources: [.card, .bankAccount],
@@ -181,6 +182,7 @@ extension LinkSettings {
             linkDefaultOptIn: nil,
             linkEnableDisplayableDefaultValuesInECE: nil,
             linkShowPreferDebitCardHint: nil,
+            linkSupportedPaymentMethodsOnboardingEnabled: linkSupportedPaymentMethodsOnboardingEnabled,
             allResponseFields: [:]
         )
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
@@ -87,6 +87,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             linkDefaultOptIn: .full,
             linkEnableDisplayableDefaultValuesInECE: nil,
             linkShowPreferDebitCardHint: nil,
+            linkSupportedPaymentMethodsOnboardingEnabled: ["CARD"],
             allResponseFields: [:]
         )
         let experimentsData = ExperimentsData(
@@ -156,6 +157,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             linkDefaultOptIn: .optional,
             linkEnableDisplayableDefaultValuesInECE: nil,
             linkShowPreferDebitCardHint: nil,
+            linkSupportedPaymentMethodsOnboardingEnabled: ["CARD"],
             allResponseFields: [:]
         )
         let experimentsData = ExperimentsData(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
@@ -165,7 +165,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
 
     /// Returns true, iDEAL in `supportedPaymentMethods` and URL requirement is met but delayed payment method support requirement for setting up is not met
     func testSupportsAdding_inSupportedList_urlConfiguredRequiredDelayedRequiredButNotProvided() {
-        var configuration = makeConfiguration(hasReturnURL: true)
+        let configuration = makeConfiguration(hasReturnURL: true)
         XCTAssertEqual(
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: .iDEAL,
@@ -179,7 +179,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
 
     /// Returns true, iDEAL in `supportedPaymentMethods` and URL requirement and not setting up requirement are met
     func testSupportsAdding_inSupportedList_urlConfiguredRequiredDelayedNotRequired() {
-        var configuration = makeConfiguration(hasReturnURL: true)
+        let configuration = makeConfiguration(hasReturnURL: true)
         XCTAssertEqual(
             PaymentSheet.PaymentMethodType.supportsAdding(
                 paymentMethod: .iDEAL,
@@ -402,7 +402,8 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: ._testValue(
                 intent: intent,
                 linkMode: .linkCardBrand,
-                linkFundingSources: [.card, .bankAccount]
+                linkFundingSources: [.card, .bankAccount],
+                linkSupportedPaymentMethodsOnboardingEnabled: ["CARD", "INSTANT_DEBITS"]
             ),
             configuration: configuration
         )
@@ -436,7 +437,8 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         let elementsSession = STPElementsSession._testValue(
             intent: intent,
             linkMode: .linkPaymentMethod,
-            linkFundingSources: [.card, .bankAccount]
+            linkFundingSources: [.card, .bankAccount],
+            linkSupportedPaymentMethodsOnboardingEnabled: ["CARD", "INSTANT_DEBITS"]
         )
 
         let availability = PaymentSheet.PaymentMethodType.supportsInstantBankPayments(
@@ -447,13 +449,39 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         XCTAssertEqual(availability, .supported)
     }
 
+    func testSupportsInstantBankPayments_onboardingDisabled() {
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
+        let configuration = PaymentSheet.Configuration()
+        let elementsSession = STPElementsSession._testValue(
+            intent: intent,
+            linkMode: .linkCardBrand,
+            linkFundingSources: [.card, .bankAccount],
+            linkSupportedPaymentMethodsOnboardingEnabled: ["CARD"]
+        )
+
+        let availability = PaymentSheet.PaymentMethodType.supportsLinkCardIntegration(
+            configuration: configuration,
+            intent: intent,
+            elementsSession: elementsSession
+        )
+
+        guard case .missingRequirements(let requirements) = availability else {
+            XCTFail("Unexpected availability: \(availability)")
+            return
+        }
+
+        XCTAssertEqual(requirements.count, 1)
+        XCTAssertEqual(requirements.first, .instantDebitsDisabledForOnboarding)
+    }
+
     func testSupportsInstantBankPayments_missingLink() {
         let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
         let configuration = PaymentSheet.Configuration()
         let elementsSession = STPElementsSession._testValue(
             intent: intent,
             linkMode: .linkPaymentMethod,
-            linkFundingSources: [.card, .bankAccount]
+            linkFundingSources: [.card, .bankAccount],
+            linkSupportedPaymentMethodsOnboardingEnabled: ["CARD", "INSTANT_DEBITS"]
         )
 
         let availability = PaymentSheet.PaymentMethodType.supportsInstantBankPayments(
@@ -465,54 +493,6 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         XCTAssertEqual(availability, .notSupported)
     }
 
-    func testSupportsInstantBankPayments_unexpectedUsBankAccount() {
-        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card, .link, .USBankAccount])
-        let configuration = PaymentSheet.Configuration()
-        let elementsSession = STPElementsSession._testValue(
-            intent: intent,
-            linkMode: .linkPaymentMethod,
-            linkFundingSources: [.card, .bankAccount]
-        )
-
-        let availability = PaymentSheet.PaymentMethodType.supportsInstantBankPayments(
-            configuration: configuration,
-            intent: intent,
-            elementsSession: elementsSession
-        )
-
-        guard case .missingRequirements(let requirements) = availability else {
-            XCTFail("Unexpected availability: \(availability)")
-            return
-        }
-
-        XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .unexpectedUsBankAccount)
-    }
-
-    func testSupportsInstantBankPayments_linkFundingSourcesMissingBankAccount() {
-        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card, .link])
-        let configuration = PaymentSheet.Configuration()
-        let elementsSession = STPElementsSession._testValue(
-            intent: intent,
-            linkMode: .linkPaymentMethod,
-            linkFundingSources: [.card]
-        )
-
-        let availability = PaymentSheet.PaymentMethodType.supportsInstantBankPayments(
-            configuration: configuration,
-            intent: intent,
-            elementsSession: elementsSession
-        )
-
-        guard case .missingRequirements(let requirements) = availability else {
-            XCTFail("Unexpected availability: \(availability)")
-            return
-        }
-
-        XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .linkFundingSourcesMissingBankAccount)
-    }
-
     func testSupportsInstantBankPayments_invalidEmailCollectionConfiguration() {
         let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card, .link])
         var configuration = PaymentSheet.Configuration()
@@ -521,7 +501,8 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         let elementsSession = STPElementsSession._testValue(
             intent: intent,
             linkMode: .linkPaymentMethod,
-            linkFundingSources: [.card, .bankAccount]
+            linkFundingSources: [.card, .bankAccount],
+            linkSupportedPaymentMethodsOnboardingEnabled: ["CARD", "INSTANT_DEBITS"]
         )
 
         let availability = PaymentSheet.PaymentMethodType.supportsInstantBankPayments(
@@ -547,7 +528,8 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         let elementsSession = STPElementsSession._testValue(
             intent: intent,
             linkMode: .linkPaymentMethod,
-            linkFundingSources: [.card]
+            linkFundingSources: [.card],
+            linkSupportedPaymentMethodsOnboardingEnabled: ["CARD"]
         )
 
         let availability = PaymentSheet.PaymentMethodType.supportsInstantBankPayments(
@@ -562,11 +544,10 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         }
 
         let expectedMissingRequirements: Set<PaymentSheet.PaymentMethodTypeRequirement> = [
-            .unexpectedUsBankAccount,
-            .linkFundingSourcesMissingBankAccount,
+            .instantDebitsDisabledForOnboarding,
             .invalidEmailCollectionConfiguration,
         ]
-        XCTAssertEqual(requirements.count, 3)
+        XCTAssertEqual(requirements.count, 2)
         XCTAssertEqual(requirements, expectedMissingRequirements)
     }
 
@@ -625,7 +606,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         )
 
         let expectedDebugDescription = """
-        \t* Your account isn't set up to process Instant Bank Payments. Reach out to Stripe support.
+        \t* Instant Bank Payments are disabled for new users.
         """
         XCTAssertEqual(availability.debugDescription, expectedDebugDescription)
     }
@@ -659,7 +640,8 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         let elementsSession = STPElementsSession._testValue(
             intent: intent,
             linkMode: .linkCardBrand,
-            linkFundingSources: [.card, .bankAccount]
+            linkFundingSources: [.card, .bankAccount],
+            linkSupportedPaymentMethodsOnboardingEnabled: ["CARD", "INSTANT_DEBITS"]
         )
 
         let availability = PaymentSheet.PaymentMethodType.supportsLinkCardIntegration(
@@ -668,6 +650,31 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             elementsSession: elementsSession
         )
         XCTAssertEqual(availability, .supported)
+    }
+
+    func testSupportsLinkCardIntegration_onboardingDisabled() {
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
+        let configuration = PaymentSheet.Configuration()
+        let elementsSession = STPElementsSession._testValue(
+            intent: intent,
+            linkMode: .linkCardBrand,
+            linkFundingSources: [.card, .bankAccount],
+            linkSupportedPaymentMethodsOnboardingEnabled: ["CARD"]
+        )
+
+        let availability = PaymentSheet.PaymentMethodType.supportsLinkCardIntegration(
+            configuration: configuration,
+            intent: intent,
+            elementsSession: elementsSession
+        )
+
+        guard case .missingRequirements(let requirements) = availability else {
+            XCTFail("Unexpected availability: \(availability)")
+            return
+        }
+
+        XCTAssertEqual(requirements.count, 1)
+        XCTAssertEqual(requirements.first, .instantDebitsDisabledForOnboarding)
     }
 
     func testSupportsLinkCardIntegration_missingLink() {
@@ -688,54 +695,6 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         XCTAssertEqual(availability, .notSupported)
     }
 
-    func testSupportsLinkCardIntegration_unexpectedUsBankAccount() {
-        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card, .USBankAccount])
-        let configuration = PaymentSheet.Configuration()
-        let elementsSession = STPElementsSession._testValue(
-            intent: intent,
-            linkMode: .linkCardBrand,
-            linkFundingSources: [.card, .bankAccount]
-        )
-
-        let availability = PaymentSheet.PaymentMethodType.supportsLinkCardIntegration(
-            configuration: configuration,
-            intent: intent,
-            elementsSession: elementsSession
-        )
-
-        guard case .missingRequirements(let requirements) = availability else {
-            XCTFail("Unexpected availability: \(availability)")
-            return
-        }
-
-        XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .unexpectedUsBankAccount)
-    }
-
-    func testSupportsLinkCardIntegration_linkFundingSourcesMissingBankAccount() {
-        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
-        let configuration = PaymentSheet.Configuration()
-        let elementsSession = STPElementsSession._testValue(
-            intent: intent,
-            linkMode: .linkCardBrand,
-            linkFundingSources: [.card]
-        )
-
-        let availability = PaymentSheet.PaymentMethodType.supportsLinkCardIntegration(
-            configuration: configuration,
-            intent: intent,
-            elementsSession: elementsSession
-        )
-
-        guard case .missingRequirements(let requirements) = availability else {
-            XCTFail("Unexpected availability: \(availability)")
-            return
-        }
-
-        XCTAssertEqual(requirements.count, 1)
-        XCTAssertEqual(requirements.first, .linkFundingSourcesMissingBankAccount)
-    }
-
     func testSupportsLinkCardIntegration_invalidEmailCollectionConfiguration() {
         let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
         var configuration = PaymentSheet.Configuration()
@@ -744,7 +703,8 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         let elementsSession = STPElementsSession._testValue(
             intent: intent,
             linkMode: .linkCardBrand,
-            linkFundingSources: [.card, .bankAccount]
+            linkFundingSources: [.card, .bankAccount],
+            linkSupportedPaymentMethodsOnboardingEnabled: ["CARD", "INSTANT_DEBITS"]
         )
 
         let availability = PaymentSheet.PaymentMethodType.supportsLinkCardIntegration(
@@ -770,7 +730,8 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         let elementsSession = STPElementsSession._testValue(
             intent: intent,
             linkMode: .linkCardBrand,
-            linkFundingSources: [.card]
+            linkFundingSources: [.card],
+            linkSupportedPaymentMethodsOnboardingEnabled: ["CARD"]
         )
 
         let availability = PaymentSheet.PaymentMethodType.supportsLinkCardIntegration(
@@ -785,11 +746,10 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         }
 
         let expectedMissingRequirements: Set<PaymentSheet.PaymentMethodTypeRequirement> = [
-            .unexpectedUsBankAccount,
-            .linkFundingSourcesMissingBankAccount,
+            .instantDebitsDisabledForOnboarding,
             .invalidEmailCollectionConfiguration,
         ]
-        XCTAssertEqual(requirements.count, 3)
+        XCTAssertEqual(requirements.count, 2)
         XCTAssertEqual(requirements, expectedMissingRequirements)
     }
 
@@ -848,7 +808,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         )
 
         let expectedDebugDescription = """
-        \t* Your account isn't set up to process Instant Bank Payments. Reach out to Stripe support.
+        \t* Instant Bank Payments are disabled for new users.
         """
         XCTAssertEqual(availability.debugDescription, expectedDebugDescription)
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
@@ -606,7 +606,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         )
 
         let expectedDebugDescription = """
-        \t* Instant Bank Payments are disabled for new users.
+        \t* The Bank tab is configured to be hidden for your account.
         """
         XCTAssertEqual(availability.debugDescription, expectedDebugDescription)
     }
@@ -808,7 +808,7 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
         )
 
         let expectedDebugDescription = """
-        \t* Instant Bank Payments are disabled for new users.
+        \t* The Bank tab is configured to be hidden for your account.
         """
         XCTAssertEqual(availability.debugDescription, expectedDebugDescription)
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -113,7 +113,8 @@ extension STPElementsSession {
         paymentMethods: [[AnyHashable: Any]]? = nil,
         linkUseAttestation: Bool? = nil,
         linkSuppress2FA: Bool? = nil,
-        hasLinkConsumerIncentive: Bool = false
+        hasLinkConsumerIncentive: Bool = false,
+        linkSupportedPaymentMethodsOnboardingEnabled: [String] = ["CARD"]
     ) -> STPElementsSession {
         var json = STPTestUtils.jsonNamed("ElementsSession")!
         json[jsonDict: "payment_method_preference"]?["ordered_payment_method_types"] = paymentMethodTypes
@@ -182,6 +183,8 @@ extension STPElementsSession {
             json[jsonDict: "link_settings"]!["link_mobile_disable_signup"] = disableLinkSignup
         }
 
+        json[jsonDict: "link_settings"]!["link_supported_payment_methods_onboarding_enabled"] = linkSupportedPaymentMethodsOnboardingEnabled
+
         let elementsSession = STPElementsSession.decodedObject(fromAPIResponse: json)!
         return elementsSession
     }
@@ -193,7 +196,8 @@ extension STPElementsSession {
         linkFundingSources: Set<LinkSettings.FundingSource> = [],
         defaultPaymentMethod: String? = nil,
         paymentMethods: [[AnyHashable: Any]]? = nil,
-        allowsSetAsDefaultPM: Bool = false
+        allowsSetAsDefaultPM: Bool = false,
+        linkSupportedPaymentMethodsOnboardingEnabled: [String] = ["CARD"]
     ) -> STPElementsSession {
         let paymentMethodTypes: [String] = {
             switch intent {
@@ -227,7 +231,8 @@ extension STPElementsSession {
             linkMode: linkMode,
             linkFundingSources: linkFundingSources,
             defaultPaymentMethod: defaultPaymentMethod,
-            paymentMethods: paymentMethods
+            paymentMethods: paymentMethods,
+            linkSupportedPaymentMethodsOnboardingEnabled: linkSupportedPaymentMethodsOnboardingEnabled
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/elements_sessions_paymentMethod_200.json
+++ b/StripePaymentSheet/StripePaymentSheetTests/Resources/MockFiles/elements_sessions_paymentMethod_200.json
@@ -25,7 +25,11 @@
             "payment_method": "link_instant_debits",
         },
         "incentive_display_text": "$5",
-    }
+    },
+    "link_supported_payment_methods_onboarding_enabled": [
+        "CARD",
+        "INSTANT_DEBITS",
+    ]
   },
   "merchant_country": "US",
   "merchant_currency": "usd",

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
@@ -45,8 +45,8 @@ import Foundation
 
     @_spi(STP) public let allResponseFields: [AnyHashable: Any]
 
-    @_spi(STP) public var instantDebitsOnboardingDisabled: Bool {
-        !linkSupportedPaymentMethodsOnboardingEnabled.contains("INSTANT_DEBITS")
+    @_spi(STP) public var instantDebitsOnboardingEnabled: Bool {
+        linkSupportedPaymentMethodsOnboardingEnabled.contains("INSTANT_DEBITS")
     }
 
     @_spi(STP) public init(

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
@@ -41,8 +41,13 @@ import Foundation
     @_spi(STP) public let linkDefaultOptIn: LinkDefaultOptIn?
     @_spi(STP) public let linkEnableDisplayableDefaultValuesInECE: Bool?
     @_spi(STP) public let linkShowPreferDebitCardHint: Bool?
+    @_spi(STP) public let linkSupportedPaymentMethodsOnboardingEnabled: [String]
 
     @_spi(STP) public let allResponseFields: [AnyHashable: Any]
+
+    @_spi(STP) public var instantDebitsOnboardingDisabled: Bool {
+        !linkSupportedPaymentMethodsOnboardingEnabled.contains("INSTANT_DEBITS")
+    }
 
     @_spi(STP) public init(
         fundingSources: Set<FundingSource>,
@@ -58,6 +63,7 @@ import Foundation
         linkDefaultOptIn: LinkDefaultOptIn?,
         linkEnableDisplayableDefaultValuesInECE: Bool?,
         linkShowPreferDebitCardHint: Bool?,
+        linkSupportedPaymentMethodsOnboardingEnabled: [String],
         allResponseFields: [AnyHashable: Any]
     ) {
         self.fundingSources = fundingSources
@@ -73,6 +79,7 @@ import Foundation
         self.linkDefaultOptIn = linkDefaultOptIn
         self.linkEnableDisplayableDefaultValuesInECE = linkEnableDisplayableDefaultValuesInECE
         self.linkShowPreferDebitCardHint = linkShowPreferDebitCardHint
+        self.linkSupportedPaymentMethodsOnboardingEnabled = linkSupportedPaymentMethodsOnboardingEnabled
         self.allResponseFields = allResponseFields
     }
 
@@ -109,6 +116,8 @@ import Foundation
             nil
         }
 
+        let linkSupportedPaymentMethodsOnboardingEnabled = response["link_supported_payment_methods_onboarding_enabled"] as? [String] ?? []
+
         // Collect the flags for the URL generator
         let linkFlags = response.reduce(into: [String: Bool]()) { partialResult, element in
             if let key = element.key as? String, let value = element.value as? Bool {
@@ -130,6 +139,7 @@ import Foundation
             linkDefaultOptIn: linkDefaultOptIn,
             linkEnableDisplayableDefaultValuesInECE: linkEnableDisplayableDefaultValuesInECE,
             linkShowPreferDebitCardHint: linkShowPreferDebitCardHint,
+            linkSupportedPaymentMethodsOnboardingEnabled: linkSupportedPaymentMethodsOnboardingEnabled,
             allResponseFields: response
         ) as? Self
     }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request updates the SDK to disable the `Bank` tab if `link_supported_payment_methods_onboarding_enabled` does not include `"INSTANT_DEBITS"`.

This flag didn't exist when we rolled out Instant Debits initially, but should now be used instead of the client logic.

cc @ericazhou-stripe

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
