### PR TITLE
Update horizontal shovelers for iOS26, reverts capsule style to embedded

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -271,7 +271,7 @@
 		6B28A6B92BE9712500B47DBF /* CustomerSessionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B28A6B82BE9712500B47DBF /* CustomerSessionAdapter.swift */; };
 		6B31B9B82B9019730064E210 /* ElementsCustomer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B31B9B72B9019730064E210 /* ElementsCustomer.swift */; };
 		6B31B9BA2B90FCE60064E210 /* CustomerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B31B9B92B90FCE60064E210 /* CustomerSession.swift */; };
-		6B4299B82E5EB7740009E06B /* CapsuleRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4299B72E5EB75E0009E06B /* CapsuleRectangle.swift */; };
+		6B4299B82E5EB7740009E06B /* LiquidGlassRectangle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B4299B72E5EB75E0009E06B /* LiquidGlassRectangle.swift */; };
 		6B50BCEE2C29EE1F009702FB /* SavedPaymentOptionsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50BCED2C29EE1F009702FB /* SavedPaymentOptionsViewControllerTests.swift */; };
 		6B50BCF02C29F888009702FB /* CustomerSavedPaymentMethodsCollectionViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B50BCEF2C29F888009702FB /* CustomerSavedPaymentMethodsCollectionViewControllerTests.swift */; };
 		6B76DBD12C530B6C0037CD63 /* PaymentSheetGDPRConfirmFlowTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B76DBD02C530B6C0037CD63 /* PaymentSheetGDPRConfirmFlowTests.swift */; };
@@ -789,7 +789,7 @@
 		6B28A6B82BE9712500B47DBF /* CustomerSessionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSessionAdapter.swift; sourceTree = "<group>"; };
 		6B31B9B72B9019730064E210 /* ElementsCustomer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElementsCustomer.swift; sourceTree = "<group>"; };
 		6B31B9B92B90FCE60064E210 /* CustomerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSession.swift; sourceTree = "<group>"; };
-		6B4299B72E5EB75E0009E06B /* CapsuleRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CapsuleRectangle.swift; sourceTree = "<group>"; };
+		6B4299B72E5EB75E0009E06B /* LiquidGlassRectangle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiquidGlassRectangle.swift; sourceTree = "<group>"; };
 		6B50BCED2C29EE1F009702FB /* SavedPaymentOptionsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SavedPaymentOptionsViewControllerTests.swift; sourceTree = "<group>"; };
 		6B50BCEF2C29F888009702FB /* CustomerSavedPaymentMethodsCollectionViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSavedPaymentMethodsCollectionViewControllerTests.swift; sourceTree = "<group>"; };
 		6B680A2FF197F612D065F16C /* PaymentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheet.swift; sourceTree = "<group>"; };
@@ -1702,7 +1702,7 @@
 				24AB1D50F770A8A035EF31DF /* CardScanButton.swift */,
 				D34B92439E9DC6E36D498312 /* CardScanningView.swift */,
 				A68FBE0A16FE56AAAAF4ABBF /* CircularButton.swift */,
-				6B4299B72E5EB75E0009E06B /* CapsuleRectangle.swift */,
+				6B4299B72E5EB75E0009E06B /* LiquidGlassRectangle.swift */,
 				EFD640EBCE4B4224773DDF45 /* ConfirmButton.swift */,
 				6BA8D3392B0C1FBF008C51FF /* CVCPaymentMethodInformationView.swift */,
 				6BC19CCB2B16C4B2008E00C4 /* CVCRecollectionView.swift */,
@@ -2751,7 +2751,7 @@
 				F79DBDF42E5C0ED6B6DDC246 /* ConfirmButton.swift in Sources */,
 				5C0D1B932954D0EF3F3A679F /* ManualEntryButton.swift in Sources */,
 				49909A202D8AFAC80031EC33 /* FCLiteSession.swift in Sources */,
-				6B4299B82E5EB7740009E06B /* CapsuleRectangle.swift in Sources */,
+				6B4299B82E5EB7740009E06B /* LiquidGlassRectangle.swift in Sources */,
 				A3B2F2B82CF1343F00C0E88C /* SavedPaymentMethodFormFactory+USBankAccount.swift in Sources */,
 				3DE056395324C5B3A5AAABDA /* PayWithLinkButton.swift in Sources */,
 				7F9545AB83E3836A85AE714F /* PaymentSheetUIKitAdditions.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -25,7 +25,7 @@ class PaymentMethodTypeCollectionView: UICollectionView {
 
     // MARK: - Constants
     internal static let paymentMethodLogoSize: CGSize = CGSize(width: UIView.noIntrinsicMetric, height: 12)
-    internal static let cellHeight: CGFloat = 52
+    internal static let cellHeight: CGFloat = LiquidGlassDetector.isEnabled ? 64 : 52
     internal static let minInteritemSpacing: CGFloat = 12
 
     let reuseIdentifier: String = "PaymentMethodTypeCollectionView.PaymentTypeCell"
@@ -214,8 +214,17 @@ extension PaymentMethodTypeCollectionView {
         private lazy var promoBadge: PromoBadgeView = {
             PromoBadgeView(appearance: appearance, tinyMode: true)
         }()
-        private lazy var shadowRoundedRectangle: ShadowedRoundedRectangle = {
-            return ShadowedRoundedRectangle(appearance: appearance)
+        private lazy var selectableRectangle: SelectableRectangle = {
+            #if !os(visionOS)
+            if #available(iOS 26.0, *),
+               LiquidGlassDetector.isEnabled {
+                return LiquidGlassRectangle(appearance: appearance, isCapsule: false)
+            } else {
+                return ShadowedRoundedRectangle(appearance: appearance)
+            }
+            #else
+                return ShadowedRoundedRectangle(appearance: appearance)
+            #endif
         }()
         lazy var paymentMethodLogoWidthConstraint: NSLayoutConstraint = {
             paymentMethodLogo.widthAnchor.constraint(equalToConstant: 0)
@@ -243,31 +252,31 @@ extension PaymentMethodTypeCollectionView {
             super.init(frame: frame)
 
             [paymentMethodLogo, label, promoBadge].forEach {
-                shadowRoundedRectangle.addSubview($0)
+                selectableRectangle.addSubview($0)
                 $0.translatesAutoresizingMaskIntoConstraints = false
             }
 
             isAccessibilityElement = true
-            contentView.addAndPinSubview(shadowRoundedRectangle)
-            shadowRoundedRectangle.frame = bounds
+            contentView.addAndPinSubview(selectableRectangle)
+            selectableRectangle.frame = bounds
 
             NSLayoutConstraint.activate([
                 paymentMethodLogo.topAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.topAnchor, constant: 12),
+                    equalTo: selectableRectangle.topAnchor, constant: LiquidGlassDetector.isEnabled ? 16 : 12),
                 paymentMethodLogo.leadingAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.leadingAnchor, constant: 12),
+                    equalTo: selectableRectangle.leadingAnchor, constant: LiquidGlassDetector.isEnabled ? 16 : 12),
                 paymentMethodLogo.heightAnchor.constraint(
                     equalToConstant: PaymentMethodTypeCollectionView.paymentMethodLogoSize.height),
                 paymentMethodLogoWidthConstraint,
 
                 label.topAnchor.constraint(equalTo: paymentMethodLogo.bottomAnchor, constant: 4),
                 label.bottomAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.bottomAnchor, constant: -8),
+                    equalTo: selectableRectangle.bottomAnchor, constant: -8),
                 label.leadingAnchor.constraint(equalTo: paymentMethodLogo.leadingAnchor),
-                label.trailingAnchor.constraint(equalTo: shadowRoundedRectangle.trailingAnchor, constant: -12), // should be -const of paymentMethodLogo leftAnchor
+                label.trailingAnchor.constraint(equalTo: selectableRectangle.trailingAnchor, constant: -12), // should be -const of paymentMethodLogo leftAnchor
 
                 promoBadge.centerYAnchor.constraint(equalTo: paymentMethodLogo.centerYAnchor),
-                promoBadge.trailingAnchor.constraint(equalTo: shadowRoundedRectangle.trailingAnchor, constant: -12),
+                promoBadge.trailingAnchor.constraint(equalTo: selectableRectangle.trailingAnchor, constant: -12),
             ])
 
             contentView.layer.cornerRadius = appearance.cornerRadius
@@ -321,7 +330,7 @@ extension PaymentMethodTypeCollectionView {
         var paymentMethodTypeOfCurrentImage: PaymentSheet.PaymentMethodType = .stripe(.unknown)
         private func update() {
             contentView.layer.cornerRadius = appearance.cornerRadius
-            shadowRoundedRectangle.appearance = appearance
+            selectableRectangle.appearance = appearance
             label.text = paymentMethodType.displayName
 
             label.font = appearance.scaledFont(for: appearance.font.base.medium, style: .footnote, maximumPointSize: 20)
@@ -349,7 +358,7 @@ extension PaymentMethodTypeCollectionView {
                 promoBadge.setText(promoBadgeText)
             }
 
-            shadowRoundedRectangle.isSelected = isSelected
+            selectableRectangle.isSelected = isSelected
             // Set text color
             label.textColor = appearance.colors.componentText
             accessibilityLabel = label.text

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
@@ -30,7 +30,7 @@ public extension PaymentSheet {
 
         /// The corner radius used for buttons, inputs, tabs in PaymentSheet
         /// - Note: The behavior of this property is consistent with the behavior of corner radius on `CALayer`
-        public var cornerRadius: CGFloat = LiquidGlassDetector.isEnabled ? 16.0 : 6.0
+        public var cornerRadius: CGFloat = 6.0
 
         /// The border used for inputs and tabs in PaymentSheet
         /// - Note: The thickness of divider lines between input fields also uses `borderWidth` for consistency, with a minimum thickness of 0.5.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -91,8 +91,17 @@ extension SavedPaymentMethodCollectionView {
                                                   fillColor: UIColor.dynamic(
             light: .systemGray5, dark: .tertiaryLabel))
         lazy var selectedIcon: CircleIconView = CircleIconView(icon: .icon_checkmark, fillColor: appearance.colors.primary)
-        lazy var shadowRoundedRectangle: ShadowedRoundedRectangle = {
+        lazy var selectableRectangle: SelectableRectangle = {
+        #if !os(visionOS)
+        if #available(iOS 26.0, *),
+           LiquidGlassDetector.isEnabled {
+            return LiquidGlassRectangle(appearance: appearance, isCapsule: false)
+        } else {
             return ShadowedRoundedRectangle(appearance: appearance)
+        }
+        #else
+            return ShadowedRoundedRectangle(appearance: appearance)
+        #endif
         }()
         lazy var accessoryButton: CircularButton = {
             let button = CircularButton(style: .edit, iconStyle: appearance.iconStyle)
@@ -135,7 +144,7 @@ extension SavedPaymentMethodCollectionView {
         var appearance = PaymentSheet.Appearance.default {
             didSet {
                 update()
-                shadowRoundedRectangle.appearance = appearance
+                selectableRectangle.appearance = appearance
             }
         }
 
@@ -161,7 +170,7 @@ extension SavedPaymentMethodCollectionView {
             super.init(frame: frame)
 
             [paymentMethodLogo, plus, selectedIcon].forEach {
-                shadowRoundedRectangle.addSubview($0)
+                selectableRectangle.addSubview($0)
                 $0.translatesAutoresizingMaskIntoConstraints = false
             }
 
@@ -170,54 +179,54 @@ extension SavedPaymentMethodCollectionView {
             isAccessibilityElement = false
             // We choose the rectangle to represent the cell
             label.isAccessibilityElement = false
-            accessibilityElements = [shadowRoundedRectangle, accessoryButton]
-            shadowRoundedRectangle.isAccessibilityElement = true
-            shadowRoundedRectangle.accessibilityTraits = [.button]
+            accessibilityElements = [selectableRectangle, accessoryButton]
+            selectableRectangle.isAccessibilityElement = true
+            selectableRectangle.accessibilityTraits = [.button]
 
             paymentMethodLogo.contentMode = .scaleAspectFit
             accessoryButton.addTarget(self, action: #selector(didSelectAccessory), for: .touchUpInside)
             let views = [
-                label, shadowRoundedRectangle, paymentMethodLogo, plus, selectedIcon, accessoryButton, defaultBadge
+                label, selectableRectangle, paymentMethodLogo, plus, selectedIcon, accessoryButton, defaultBadge
             ]
             views.forEach {
                 $0.translatesAutoresizingMaskIntoConstraints = false
                 contentView.addSubview($0)
             }
             NSLayoutConstraint.activate([
-                shadowRoundedRectangle.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 6),
-                shadowRoundedRectangle.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
-                shadowRoundedRectangle.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -6),
-                shadowRoundedRectangle.widthAnchor.constraint(
+                selectableRectangle.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 6),
+                selectableRectangle.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                selectableRectangle.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -6),
+                selectableRectangle.widthAnchor.constraint(
                     equalToConstant: roundedRectangleSize.width),
-                shadowRoundedRectangle.heightAnchor.constraint(
+                selectableRectangle.heightAnchor.constraint(
                     equalToConstant: roundedRectangleSize.height),
 
                 label.topAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.bottomAnchor, constant: 4),
+                    equalTo: selectableRectangle.bottomAnchor, constant: 4),
                 labelBottomConstraint,
                 label.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 2),
                 label.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
 
                 paymentMethodLogo.centerXAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.centerXAnchor),
+                    equalTo: selectableRectangle.centerXAnchor),
                 paymentMethodLogo.centerYAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.centerYAnchor),
+                    equalTo: selectableRectangle.centerYAnchor),
                 paymentMethodLogo.widthAnchor.constraint(
                     equalToConstant: paymentMethodLogoSize.width),
                 paymentMethodLogo.heightAnchor.constraint(
                     equalToConstant: paymentMethodLogoSize.height),
 
-                plus.centerXAnchor.constraint(equalTo: shadowRoundedRectangle.centerXAnchor),
-                plus.centerYAnchor.constraint(equalTo: shadowRoundedRectangle.centerYAnchor),
+                plus.centerXAnchor.constraint(equalTo: selectableRectangle.centerXAnchor),
+                plus.centerYAnchor.constraint(equalTo: selectableRectangle.centerYAnchor),
                 plus.widthAnchor.constraint(equalToConstant: 32),
                 plus.heightAnchor.constraint(equalToConstant: 32),
 
                 selectedIcon.widthAnchor.constraint(equalToConstant: 26),
                 selectedIcon.heightAnchor.constraint(equalToConstant: 26),
                 selectedIcon.trailingAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.trailingAnchor, constant: 6),
+                    equalTo: selectableRectangle.trailingAnchor, constant: 6),
                 selectedIcon.bottomAnchor.constraint(
-                    equalTo: shadowRoundedRectangle.bottomAnchor, constant: 6),
+                    equalTo: selectableRectangle.bottomAnchor, constant: 6),
 
                 accessoryButton.trailingAnchor.constraint(
                     equalTo: contentView.trailingAnchor, constant: 0),
@@ -264,7 +273,7 @@ extension SavedPaymentMethodCollectionView {
         func setViewModel(_ viewModel: SavedPaymentOptionsViewController.Selection, cbcEligible: Bool, allowsPaymentMethodRemoval: Bool, allowsPaymentMethodUpdate: Bool, allowsSetAsDefaultPM: Bool = false, needsVerticalPaddingForBadge: Bool = false, showDefaultPMBadge: Bool = false) {
             paymentMethodLogo.isHidden = false
             plus.isHidden = true
-            shadowRoundedRectangle.isHidden = false
+            selectableRectangle.isHidden = false
             self.viewModel = viewModel
             self.cbcEligible = cbcEligible
             self.allowsPaymentMethodRemoval = allowsPaymentMethodRemoval
@@ -350,21 +359,21 @@ extension SavedPaymentMethodCollectionView {
                             label.text = paymentMethod.paymentSheetLabel
                         }
                         accessibilityIdentifier = label.text
-                        shadowRoundedRectangle.accessibilityIdentifier = label.text
-                        shadowRoundedRectangle.accessibilityLabel = paymentMethod.paymentSheetAccessibilityLabel
+                        selectableRectangle.accessibilityIdentifier = label.text
+                        selectableRectangle.accessibilityLabel = paymentMethod.paymentSheetAccessibilityLabel
                         paymentMethodLogo.image = paymentMethod.makeSavedPaymentMethodCellImage(overrideUserInterfaceStyle: overrideUserInterfaceStyle, iconStyle: appearance.iconStyle)
                     case .applePay:
                         // TODO (cleanup) - get this from PaymentOptionDisplayData?
                         label.text = String.Localized.apple_pay
                         accessibilityIdentifier = label.text
-                        shadowRoundedRectangle.accessibilityIdentifier = label.text
-                        shadowRoundedRectangle.accessibilityLabel = label.text
+                        selectableRectangle.accessibilityIdentifier = label.text
+                        selectableRectangle.accessibilityLabel = label.text
                         paymentMethodLogo.image = PaymentOption.applePay.makeSavedPaymentMethodCellImage(overrideUserInterfaceStyle: overrideUserInterfaceStyle, iconStyle: appearance.iconStyle)
                     case .link:
                         label.text = STPPaymentMethodType.link.displayName
                         accessibilityIdentifier = label.text
-                        shadowRoundedRectangle.accessibilityIdentifier = label.text
-                        shadowRoundedRectangle.accessibilityLabel = label.text
+                        selectableRectangle.accessibilityIdentifier = label.text
+                        selectableRectangle.accessibilityLabel = label.text
                         paymentMethodLogo.image = PaymentOption.link(option: .wallet).makeSavedPaymentMethodCellImage(overrideUserInterfaceStyle: overrideUserInterfaceStyle, iconStyle: appearance.iconStyle)
                         paymentMethodLogo.tintColor = UIColor.linkIconBrand.resolvedContrastingColor(
                             forBackgroundColor: appearance.colors.componentBackground
@@ -374,16 +383,16 @@ extension SavedPaymentMethodCollectionView {
                             "+ Add",
                             "Text for a button that, when tapped, displays another screen where the customer can add payment method details"
                         )
-                        shadowRoundedRectangle.accessibilityLabel = String.Localized.add_new_payment_method
-                        shadowRoundedRectangle.accessibilityIdentifier = "+ Add"
+                        selectableRectangle.accessibilityLabel = String.Localized.add_new_payment_method
+                        selectableRectangle.accessibilityIdentifier = "+ Add"
                         paymentMethodLogo.isHidden = true
                         plus.isHidden = false
                         plus.setNeedsDisplay()
                     }
                 }
                 let applyDefaultStyle: () -> Void = { [self] in
-                    shadowRoundedRectangle.isEnabled = true
-                    shadowRoundedRectangle.isSelected = false
+                    selectableRectangle.isEnabled = true
+                    selectableRectangle.isSelected = false
                     label.textColor = appearance.colors.text
                     paymentMethodLogo.alpha = 1
                     plus.alpha = 1
@@ -401,7 +410,7 @@ extension SavedPaymentMethodCollectionView {
                         accessoryButton.isHidden = true
 
                         // apply disabled style
-                        shadowRoundedRectangle.isEnabled = false
+                        selectableRectangle.isEnabled = false
                         paymentMethodLogo.alpha = 0.6
                         plus.alpha = 0.6
                         label.textColor = appearance.colors.text.disabledColor
@@ -409,7 +418,7 @@ extension SavedPaymentMethodCollectionView {
 
                 } else if isSelected {
                     accessoryButton.isHidden = true
-                    shadowRoundedRectangle.isEnabled = true
+                    selectableRectangle.isEnabled = true
                     label.textColor = appearance.colors.text
                     paymentMethodLogo.alpha = 1
                     plus.alpha = 1
@@ -417,7 +426,7 @@ extension SavedPaymentMethodCollectionView {
                     selectedIcon.backgroundColor = appearance.colors.primary
 
                     // Draw a border with primary color
-                    shadowRoundedRectangle.isSelected = true
+                    selectableRectangle.isSelected = true
                 } else {
                     accessoryButton.isHidden = true
                     applyDefaultStyle()
@@ -425,7 +434,7 @@ extension SavedPaymentMethodCollectionView {
                 accessoryButton.isAccessibilityElement = !accessoryButton.isHidden
                 label.font = appearance.scaledFont(for: appearance.font.base.medium, style: .footnote, maximumPointSize: 20)
 
-                shadowRoundedRectangle.accessibilityTraits = {
+                selectableRectangle.accessibilityTraits = {
                     if isRemovingPaymentMethods {
                         return [.notEnabled]
                     } else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFloating.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFloating.swift
@@ -17,8 +17,8 @@ final class RowButtonFloating: RowButton {
     private lazy var selectableRectangle: SelectableRectangle = {
         #if !os(visionOS)
         if #available(iOS 26.0, *),
-           LiquidGlassDetector.isEnabled {
-            return CapsuleRectangle(appearance: appearance)
+           LiquidGlassDetector.isEnabled && !isEmbedded {
+            return LiquidGlassRectangle(appearance: appearance, isCapsule: true)
         } else {
             return ShadowedRoundedRectangle(appearance: appearance)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/LiquidGlassRectangle.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/LiquidGlassRectangle.swift
@@ -2,19 +2,20 @@
 //  CapsuleRectangleView.swift
 //  StripePaymentSheet
 //
-//  Created by John Woo on 8/26/25.
-//
 
 @_spi(STP) import StripeUICore
 import UIKit
 
 protocol SelectableRectangle: UIView {
+    var appearance: PaymentSheet.Appearance { get set }
     var isSelected: Bool { get set }
+    var isEnabled: Bool { get set }
 }
 
 @available(iOS 26.0, *)
-class CapsuleRectangle: UIView, SelectableRectangle {
+class LiquidGlassRectangle: UIView, SelectableRectangle {
     private let roundedRectangle: UIView
+    private let isCapsule: Bool
     var appearance: PaymentSheet.Appearance {
         didSet {
             update()
@@ -41,9 +42,12 @@ class CapsuleRectangle: UIView, SelectableRectangle {
         } else {
             roundedRectangle.backgroundColor = appearance.colors.componentBackground.disabledColor
         }
-        #if compiler(>=6.2)
-        roundedRectangle.cornerConfiguration = .capsule()
-        #endif
+
+        if isCapsule {
+            roundedRectangle.ios26_applyCapsuleCornerConfiguration()
+        } else {
+            roundedRectangle.ios26_applyDefaultCornerConfiguration()
+        }
 
         // Border
         if isSelected {
@@ -61,8 +65,9 @@ class CapsuleRectangle: UIView, SelectableRectangle {
         }
     }
 
-    required init(appearance: PaymentSheet.Appearance) {
+    required init(appearance: PaymentSheet.Appearance, isCapsule: Bool) {
         self.appearance = appearance
+        self.isCapsule = isCapsule
         roundedRectangle = UIView()
         roundedRectangle.layer.masksToBounds = true
         super.init(frame: .zero)


### PR DESCRIPTION
## Summary
* Adds iOS26 radius changes to horizontal shovlers.
* Reverts capsule style to embedde

## Motivation
iOS26

## Testing
Manual testing
|Before| After |
|-------|------|
|<img width="422" height="428" alt="image" src="https://github.com/user-attachments/assets/527ec462-ce57-4381-8de5-f6cdf8c9fdab" />|<img width="414" height="423" alt="image" src="https://github.com/user-attachments/assets/6619a27b-dc29-4e90-9b51-1093574c7160" />|
|<img width="411" height="807" alt="image" src="https://github.com/user-attachments/assets/46485c0a-50ec-41f0-9710-001176cef843" />|<img width="412" height="804" alt="image" src="https://github.com/user-attachments/assets/87f5fbe8-cf92-4fc5-9e7d-263081e89ec0" />|
| |(note ignore issue with link in-line signup for now)|


## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
