### PR TITLE
Adds switch for enabling iOS26 for CustomerSheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -11,6 +11,7 @@ import Contacts
 import Foundation
 import PassKit
 import StripePaymentSheet
+@_spi(STP) import StripeUICore
 import SwiftUI
 import UIKit
 
@@ -72,6 +73,7 @@ struct CustomerSheetTestPlayground: View {
                         SettingView(setting: $playgroundController.settings.defaultBillingAddress)
                         SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
                         SettingView(setting: $playgroundController.settings.cardBrandAcceptance)
+                        SettingView(setting: enableiOS26ChangesBinding)
                         SettingView(setting: $playgroundController.settings.autoreload)
                         TextField("headerTextForSelectionScreen", text: headerTextForSelectionScreenBinding)
                         SettingView(setting: $playgroundController.settings.allowsRemovalOfLastSavedPaymentMethod)
@@ -108,6 +110,16 @@ struct CustomerSheetTestPlayground: View {
                 .environmentObject(playgroundController)
         }
     }
+    var enableiOS26ChangesBinding: Binding<CustomerSheetTestPlaygroundSettings.EnableIOS26Changes> {
+        Binding<CustomerSheetTestPlaygroundSettings.EnableIOS26Changes> {
+            return playgroundController.settings.enableIOS26Changes
+        } set: { newValue in
+            LiquidGlassDetector.allowNewDesign = newValue == .on
+            playgroundController.appearance = PaymentSheet.Appearance()
+            playgroundController.settings.enableIOS26Changes = newValue
+        }
+    }
+
     var customerKeyTypeBinding: Binding<CustomerSheetTestPlaygroundSettings.CustomerKeyType> {
         Binding<CustomerSheetTestPlaygroundSettings.CustomerKeyType> {
             return playgroundController.settings.customerKeyType

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -155,6 +155,13 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
         case allowVisa
     }
 
+    enum EnableIOS26Changes: String, PickerEnum {
+        static var enumName: String { "Enable iOS26 changes" }
+
+        case on
+        case off
+    }
+
     enum OpensCardScannerAutomatically: String, PickerEnum {
         static let enumName: String = "opensCardScannerAutomatically"
         case on
@@ -168,6 +175,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     var applePay: ApplePay
     var headerTextForSelectionScreen: String?
     var defaultBillingAddress: DefaultBillingAddress
+    var enableIOS26Changes: EnableIOS26Changes
     var autoreload: Autoreload
 
     var attachDefaults: BillingDetailsAttachDefaults
@@ -193,6 +201,7 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
                                                    applePay: .on,
                                                    headerTextForSelectionScreen: nil,
                                                    defaultBillingAddress: .off,
+                                                   enableIOS26Changes: .off,
                                                    autoreload: .on,
                                                    attachDefaults: .off,
                                                    collectName: .automatic,


### PR DESCRIPTION
## Summary
Adds a switch to turn on feature flag for testing out CustomerSheet on iOS26

## Motivation
Enable iOS26 testing

## Testing
Manually tested

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
