### PR TITLE
Adjust iOS26 navbar sizing and spacing

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -25,7 +25,9 @@ class PaymentMethodTypeCollectionView: UICollectionView {
 
     // MARK: - Constants
     internal static let paymentMethodLogoSize: CGSize = CGSize(width: UIView.noIntrinsicMetric, height: 12)
-    internal static let cellHeight: CGFloat = LiquidGlassDetector.isEnabled ? 64 : 52
+    internal static var cellHeight: CGFloat {
+        return LiquidGlassDetector.isEnabled ? 64 : 52
+    }
     internal static let minInteritemSpacing: CGFloat = 12
 
     let reuseIdentifier: String = "PaymentMethodTypeCollectionView.PaymentTypeCell"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
@@ -22,7 +22,9 @@ enum PaymentSheetUI {
 #if os(visionOS)
     static let navBarPadding: CGFloat = 30
 #else
-    static let navBarPadding = LiquidGlassDetector.isEnabled ? 16 : defaultPadding
+    static var navBarPadding: CGFloat {
+        return LiquidGlassDetector.isEnabled ? 16 : defaultPadding
+    }
 #endif
 
     static let defaultSheetMargins: NSDirectionalEdgeInsets = .insets(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
@@ -22,7 +22,7 @@ enum PaymentSheetUI {
 #if os(visionOS)
     static let navBarPadding: CGFloat = 30
 #else
-    static let navBarPadding = defaultPadding
+    static let navBarPadding = LiquidGlassDetector.isEnabled ? 16 : defaultPadding
 #endif
 
     static let defaultSheetMargins: NSDirectionalEdgeInsets = .insets(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
@@ -19,7 +19,9 @@ protocol SheetNavigationBarDelegate: AnyObject {
 /// For internal SDK use only
 @objc(STP_Internal_SheetNavigationBar)
 class SheetNavigationBar: UIView {
-    static let height: CGFloat = LiquidGlassDetector.isEnabled ? 76 : 52
+    static var height: CGFloat {
+        return LiquidGlassDetector.isEnabled ? 76 : 52
+    }
     weak var delegate: SheetNavigationBarDelegate?
     fileprivate lazy var leftItemsStackView: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [dummyView, closeButtonLeft, backButton, testModeView])

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/SheetNavigationBar.swift
@@ -19,7 +19,7 @@ protocol SheetNavigationBarDelegate: AnyObject {
 /// For internal SDK use only
 @objc(STP_Internal_SheetNavigationBar)
 class SheetNavigationBar: UIView {
-    static let height: CGFloat = LiquidGlassDetector.isEnabled ? 64 : 52
+    static let height: CGFloat = LiquidGlassDetector.isEnabled ? 76 : 52
     weak var delegate: SheetNavigationBarDelegate?
     fileprivate lazy var leftItemsStackView: UIStackView = {
         let stack = UIStackView(arrangedSubviews: [dummyView, closeButtonLeft, backButton, testModeView])
@@ -225,13 +225,17 @@ class SheetNavigationBar: UIView {
 
     func createBackButton() -> UIButton {
         let button = SheetNavigationButton(type: .custom)
-        button.setImage(Image.icon_chevron_left_standalone.makeImage(template: true), for: .normal)
+        let image = Image.icon_chevron_left_standalone.makeImage(template: true)
+        button.setImage(image, for: .normal)
         button.tintColor = appearance.colors.icon
         button.accessibilityLabel = String.Localized.back
         button.accessibilityIdentifier = "UIButton.Back"
         #if compiler(>=6.2)
         if #available(iOS 26.0, *),
            LiquidGlassDetector.isEnabled {
+            // Setting to 20x20 w/ glass results in a button that is sized to 44x44 with .glass()
+            let resizedImage = image.resized(to: CGSize(width: 20, height: 20))
+            button.setImage(resizedImage, for: .normal)
             button.configuration = .glass()
         }
         #endif
@@ -240,13 +244,17 @@ class SheetNavigationBar: UIView {
 
     func createCloseButton() -> UIButton {
         let button = SheetNavigationButton(type: .custom)
-        button.setImage(Image.icon_x_standalone.makeImage(template: true), for: .normal)
+        let image = Image.icon_x_standalone.makeImage(template: true)
+        button.setImage(image, for: .normal)
         button.tintColor = appearance.colors.icon
         button.accessibilityLabel = String.Localized.close
         button.accessibilityIdentifier = "UIButton.Close"
         #if compiler(>=6.2)
         if #available(iOS 26.0, *),
            LiquidGlassDetector.isEnabled{
+            // Setting to 20x20 w/ glass results in a button that is sized to 44x44 with .glass()
+            let resizedImage = image.resized(to: CGSize(width: 20, height: 20))
+            button.setImage(resizedImage, for: .normal)
             button.configuration = .glass()
         }
         #endif


### PR DESCRIPTION
## Summary
Updates navbar items to 44x44 px with 16 x 16 from the top and left/right.

## Motivation
Design tweaks

## Testing
Manually

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
