### PR TITLE
Handle additional error code in Link API requests

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Error+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Error+Link.swift
@@ -8,11 +8,16 @@
 import Foundation
 @_spi(STP) import StripeCore
 
+private let authErrorCodes: Set<String?> = [
+    "consumer_session_credentials_invalid",
+    "consumer_session_expired",
+]
+
 extension Error {
     var isLinkAuthError: Bool {
         if let stripeError = self as? StripeError,
            case let .apiError(stripeAPIError) = stripeError,
-           stripeAPIError.code == "consumer_session_credentials_invalid" {
+           authErrorCodes.contains(stripeAPIError.code) {
             return true
         }
         return false


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request extends `refreshLinkSession` to also attempt to re-authenticate the consumer for the `consumer_session_expired` error code.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

https://git.corp.stripe.com/stripe-internal/pay-server/pull/1348407

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
