### PR TITLE
Remove lock icon in Link wallet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
@@ -34,7 +34,7 @@ class ConfirmButton: UIView {
         case applePay
     }
     enum CallToActionType {
-        case pay(amount: Int, currency: String)
+        case pay(amount: Int, currency: String, withLock: Bool = true)
         case add(paymentMethodType: PaymentSheet.PaymentMethodType)
         case `continue`
         case continueWithLock
@@ -61,15 +61,15 @@ class ConfirmButton: UIView {
         static func makeDefaultTypeForLink(intent: Intent) -> CallToActionType {
             switch intent {
             case .paymentIntent(let paymentIntent):
-                return .pay(amount: paymentIntent.amount, currency: paymentIntent.currency)
+                return .pay(amount: paymentIntent.amount, currency: paymentIntent.currency, withLock: false)
             case .setupIntent:
-                return .continueWithLock
+                return .continue
             case .deferredIntent(let intentConfig):
                 switch intentConfig.mode {
                 case .payment(let amount, let currency, _, _, _):
-                    return .pay(amount: amount, currency: currency)
+                    return .pay(amount: amount, currency: currency, withLock: false)
                 case .setup:
-                    return .continueWithLock
+                    return .continue
                 }
             }
         }
@@ -441,7 +441,7 @@ class ConfirmButton: UIView {
                         }
                     case .continue, .continueWithLock:
                         return String.Localized.continue
-                    case let .pay(amount, currency):
+                    case let .pay(amount, currency, _):
                         let localizedAmount = String.localizedAmountDisplayString(
                             for: amount, currency: currency)
                         let localized = STPLocalizedString(
@@ -480,7 +480,10 @@ class ConfirmButton: UIView {
             case .customWithLock, .continueWithLock:
                 lockIcon.isHidden = false
                 addIcon.isHidden = true
-            case .pay, .setup:
+            case .pay(_, _, let withLock):
+                lockIcon.isHidden = !withLock
+                addIcon.isHidden = true
+            case .setup:
                 lockIcon.isHidden = false
                 addIcon.isHidden = true
             }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request removes the lock icon from the primary button in Link.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Talking to designers.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
