### PR TITLE
Allow hiding processing label in confirm button

### DIFF
--- a/Stripe/StripeiOSTests/ConfirmButtonSnapshotTests.swift
+++ b/Stripe/StripeiOSTests/ConfirmButtonSnapshotTests.swift
@@ -200,6 +200,7 @@ class ConfirmButtonSnapshotTests: STPSnapshotTestCase {
 
         let confirmButton = ConfirmButton.makeLinkButton(
             callToAction: .continue,
+            showProcessingLabel: true,
             didTap: {}
         )
         verify(confirmButton)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -30,6 +30,7 @@ extension PayWithLinkViewController {
 
         private lazy var confirmButton: ConfirmButton = .makeLinkButton(
             callToAction: context.callToAction,
+            showProcessingLabel: context.showProcessingLabel,
             // Use a compact button if we are also displaying the Apple Pay button.
             compact: shouldShowApplePayButton,
             linkAppearance: context.linkAppearance,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-UpdatePaymentViewController.swift
@@ -49,6 +49,7 @@ extension PayWithLinkViewController {
 
         private lazy var updateButton: ConfirmButton = .makeLinkButton(
             callToAction: isBillingDetailsUpdateFlow ? context.callToAction : .custom(title: String.Localized.update_card),
+            showProcessingLabel: context.showProcessingLabel,
             linkAppearance: context.linkAppearance,
             didTapWhenDisabled: didTapWhenDisabled
         ) { [weak self] in

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -53,6 +53,7 @@ extension PayWithLinkViewController {
 
         private lazy var confirmButton = ConfirmButton.makeLinkButton(
             callToAction: viewModel.confirmButtonCallToAction,
+            showProcessingLabel: context.showProcessingLabel,
             compact: viewModel.shouldUseCompactConfirmButton,
             linkAppearance: viewModel.linkAppearance
         ) { [weak self] in

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -105,6 +105,13 @@ final class PayWithLinkViewController: BottomSheetViewController {
             }
         }
 
+        var showProcessingLabel: Bool {
+            // If launched from FlowController for payment method selection (and not confirmation), we don't
+            // want to show the "Processing…" label, as that label implies that the transaction is being
+            // completed, which is not the case.
+            !launchedFromFlowController
+        }
+
         /// Returns the supported payment details types for the current Link account, filtered by the supportedPaymentMethodTypes.
         /// Returns [.card] as fallback if no types are supported after filtering.
         func getSupportedPaymentDetailsTypes(linkAccount: PaymentSheetLinkAccount) -> Set<ConsumerPaymentDetails.DetailsType> {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
@@ -12,6 +12,7 @@ extension ConfirmButton {
 
     static func makeLinkButton(
         callToAction: CallToActionType,
+        showProcessingLabel: Bool,
         compact: Bool = false,
         linkAppearance: LinkAppearance? = nil,
         didTapWhenDisabled: @escaping () -> Void = {},
@@ -41,6 +42,7 @@ extension ConfirmButton {
 
         let button = ConfirmButton(
             callToAction: callToAction,
+            showProcessingLabel: showProcessingLabel,
             appearance: appearance,
             didTap: didTap,
             didTapWhenDisabled: didTapWhenDisabled

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
@@ -96,7 +96,7 @@ class ConfirmButton: UIView {
 
     // MARK: Private Properties
     private lazy var buyButton: BuyButton = {
-        let buyButton = BuyButton(appearance: appearance)
+        let buyButton = BuyButton(showProcessingLabel: showProcessingLabel, appearance: appearance)
         buyButton.addTarget(self, action: #selector(handleTap), for: .touchUpInside)
         return buyButton
     }()
@@ -110,6 +110,7 @@ class ConfirmButton: UIView {
     private let didTap: () -> Void
     private let didTapWhenDisabled: () -> Void
     private let appearance: PaymentSheet.Appearance
+    private let showProcessingLabel: Bool
 
     // MARK: Init
 
@@ -118,6 +119,7 @@ class ConfirmButton: UIView {
         style: Style = .stripe,
         callToAction: CallToActionType,
         applePayButtonType: PKPaymentButtonType = .plain,
+        showProcessingLabel: Bool = true,
         appearance: PaymentSheet.Appearance = PaymentSheet.Appearance.default,
         didTap: @escaping () -> Void,
         didTapWhenDisabled: @escaping () -> Void = {}
@@ -126,6 +128,7 @@ class ConfirmButton: UIView {
         self.style = style
         self.callToAction = callToAction
         self.applePayButtonType = applePayButtonType
+        self.showProcessingLabel = showProcessingLabel
         self.appearance = appearance
         self.didTap = didTap
         self.didTapWhenDisabled = didTapWhenDisabled
@@ -270,6 +273,7 @@ class ConfirmButton: UIView {
 
         private var status: Status = .enabled
         private let appearance: PaymentSheet.Appearance
+        private let showProcessingLabel: Bool
 
         override var intrinsicContentSize: CGSize {
             return CGSize(
@@ -348,7 +352,11 @@ class ConfirmButton: UIView {
 
         var overriddenForegroundColor: UIColor?
 
-        init(appearance: PaymentSheet.Appearance = .default) {
+        init(
+            showProcessingLabel: Bool = true,
+            appearance: PaymentSheet.Appearance = .default
+        ) {
+            self.showProcessingLabel = showProcessingLabel
             self.appearance = appearance
             super.init(frame: .zero)
             preservesSuperviewLayoutMargins = true
@@ -450,10 +458,10 @@ class ConfirmButton: UIView {
                         return title
                     }
                 case .processing:
-                    return STPLocalizedString(
+                    return showProcessingLabel ? STPLocalizedString(
                         "Processing...",
                         "Label of a button that, when tapped, initiates payment, becomes disabled, and displays this text"
-                    )
+                    ) : nil
                 case .succeeded:
                     return nil
                 }
@@ -540,8 +548,8 @@ class ConfirmButton: UIView {
                     self.lockIcon.alpha = 0
                     self.addIcon.alpha = 0
                     self.spinner.alpha = 1
-                    self.spinnerCenteredToLockConstraint.isActive = true
-                    self.spinnerCenteredConstraint.isActive = false
+                    self.spinnerCenteredToLockConstraint.isActive = self.showProcessingLabel
+                    self.spinnerCenteredConstraint.isActive = !self.showProcessingLabel
                     self.spinner.beginProgress()
                 case .succeeded:
                     // Assumes this is only true once in ConfirmButton's lifetime


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request hides the `Processing…` label on Link's primary button if Link was launched from FlowController for payment method selection instead of confirmation.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Hiding the label when opening Link for payment method selection, which doesn't include confirmation.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
