### PR TITLE
Disable auth error retries for sessions with auth intent ID

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -76,6 +76,7 @@ struct LinkPMDisplayDetails {
 
     let useMobileEndpoints: Bool
     let requestSurface: LinkRequestSurface
+    let createdFromAuthIntentID: Bool
 
     /// Publishable key of the Consumer Account.
     private(set) var publishableKey: String?
@@ -132,7 +133,8 @@ struct LinkPMDisplayDetails {
         apiClient: STPAPIClient = .shared,
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         useMobileEndpoints: Bool,
-        requestSurface: LinkRequestSurface = .default
+        requestSurface: LinkRequestSurface = .default,
+        createdFromAuthIntentID: Bool = false
     ) {
         self.email = email
         self.currentSession = session
@@ -142,6 +144,7 @@ struct LinkPMDisplayDetails {
         self.cookieStore = cookieStore
         self.useMobileEndpoints = useMobileEndpoints
         self.requestSurface = requestSurface
+        self.createdFromAuthIntentID = createdFromAuthIntentID
     }
 
     func signUp(
@@ -549,7 +552,7 @@ private extension PaymentSheetLinkAccount {
             case .success:
                 completion(result)
             case .failure(let error as NSError):
-                if error.isLinkAuthError && shouldRetry {
+                if error.isLinkAuthError && shouldRetry && self?.createdFromAuthIntentID != true {
                     self?.refreshSession { refreshSessionResult in
                         switch refreshSessionResult {
                         case .success(let refreshedSession):

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
@@ -205,7 +205,8 @@ final class LinkAccountService: LinkAccountServiceProtocol {
                         displayablePaymentDetails: session.displayablePaymentDetails,
                         apiClient: apiClient,
                         useMobileEndpoints: self.useMobileEndpoints,
-                        requestSurface: requestSurface
+                        requestSurface: requestSurface,
+                        createdFromAuthIntentID: true
                     )
                     let consentViewModel = LinkConsentViewModel(
                         email: session.consumerSession.emailAddress,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request disables automatic retries for auth-related errors in Link if the consumer session was created via a Link auth intent ID.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
