### PR TITLE
Fix link in `StripeConnect/README.md`

### DIFF
--- a/StripeConnect/README.md
+++ b/StripeConnect/README.md
@@ -9,7 +9,7 @@ Use Connect embedded components to add connected account dashboard functionality
 * [Requirements](#Requirements)
 * [Getting started](#Getting-started)
    * [Integration](#Integration)
-   * [Example](Example)
+   * [Example](#Example)
 * [Manual linking](#Manual-linking)
 
 <!--te-->


### PR DESCRIPTION
It's an internal link and it was missing the `#`

## Summary
<!-- Simple summary of what was changed. -->

Fixes a link in a readme file.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

A working link is better than a broken link.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

Manual.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
