### PR TITLE
Create ConfirmationTokens with STPConfirmationTokenParams

### DIFF
--- a/Stripe/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe/Stripe.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 		610DF5DC2B33597500DA6AAA /* HostedSurfaceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610DF5DB2B33597500DA6AAA /* HostedSurfaceTest.swift */; };
 		61152B4F2B866827003B69A0 /* STPPaymentMethodAmazonPayParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61152B4E2B866827003B69A0 /* STPPaymentMethodAmazonPayParamsTests.swift */; };
 		612677772E1C8266008A36D2 /* STPBankAccountCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612677762E1C8266008A36D2 /* STPBankAccountCollectorTests.swift */; };
+		615242392E694314002459F6 /* STPAPIClientConfirmationTokensTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615242382E694314002459F6 /* STPAPIClientConfirmationTokensTest.swift */; };
 		617C1C882BB4992400B10AC5 /* STPPaymentMethodAlmaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617C1C872BB4992400B10AC5 /* STPPaymentMethodAlmaTests.swift */; };
 		617C1C8A2BB4998C00B10AC5 /* STPPaymentMethodAlmaParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617C1C892BB4998C00B10AC5 /* STPPaymentMethodAlmaParamsTests.swift */; };
 		61951FB92B866BA1005F90BE /* STPPaymentMethodAmazonPayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61951FB82B866BA1005F90BE /* STPPaymentMethodAmazonPayTests.swift */; };
@@ -497,6 +498,7 @@
 		610DF5DB2B33597500DA6AAA /* HostedSurfaceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostedSurfaceTest.swift; sourceTree = "<group>"; };
 		61152B4E2B866827003B69A0 /* STPPaymentMethodAmazonPayParamsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAmazonPayParamsTests.swift; sourceTree = "<group>"; };
 		612677762E1C8266008A36D2 /* STPBankAccountCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPBankAccountCollectorTests.swift; sourceTree = "<group>"; };
+		615242382E694314002459F6 /* STPAPIClientConfirmationTokensTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPAPIClientConfirmationTokensTest.swift; sourceTree = "<group>"; };
 		617C1C872BB4992400B10AC5 /* STPPaymentMethodAlmaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAlmaTests.swift; sourceTree = "<group>"; };
 		617C1C892BB4998C00B10AC5 /* STPPaymentMethodAlmaParamsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAlmaParamsTests.swift; sourceTree = "<group>"; };
 		61951FB82B866BA1005F90BE /* STPPaymentMethodAmazonPayTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAmazonPayTests.swift; sourceTree = "<group>"; };
@@ -1058,6 +1060,7 @@
 				80BBCC4D386EE44E809A591C /* STPPaymentMethodOXXOTests.swift */,
 				4002981AC12687681616D21E /* STPPaymentMethodParamsTest.swift */,
 				61F2FA362E67FB29007AF688 /* STPConfirmationTokenParamsTest.swift */,
+				615242382E694314002459F6 /* STPAPIClientConfirmationTokensTest.swift */,
 				DE2A766FB355DD9C461939C1 /* STPPaymentMethodPayPalParamsTests.swift */,
 				2A63AC868755CB4745E7458E /* STPPaymentMethodPayPalTests.swift */,
 				A6269E77F81C32A5EC8BE412 /* STPPaymentMethodPrzelewy24ParamsTests.swift */,
@@ -1577,6 +1580,7 @@
 				8C977F8D224A7360AE8E15A7 /* STPPaymentMethodBoletoParamsTests.swift in Sources */,
 				5170651536332C4842E9D009 /* STPPaymentMethodBoletoTests.swift in Sources */,
 				FE7C38B95B3B7E028AB21238 /* STPPaymentMethodCardChecksTest.swift in Sources */,
+				615242392E694314002459F6 /* STPAPIClientConfirmationTokensTest.swift in Sources */,
 				8378F2A4B0796819BB1C6C54 /* STPPaymentMethodCardParamsTest.swift in Sources */,
 				43FFF2881D4EFA7B57A60E09 /* STPPaymentMethodCardTest.swift in Sources */,
 				F06EAD0F48302B061ED29E61 /* STPPaymentMethodCardWalletMasterpassTest.swift in Sources */,

--- a/Stripe/StripeiOSTests/STPAPIClientConfirmationTokensTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClientConfirmationTokensTest.swift
@@ -85,39 +85,6 @@ class STPAPIClientConfirmationTokensTest: STPNetworkStubbingTestCase {
         XCTAssertNotNil(confirmationToken.allResponseFields)
     }
 
-    func testCreateConfirmationTokenWithAdditionalPaymentUserAgentValues() async throws {
-        // Create payment method params
-        let cardParams = STPPaymentMethodCardParams()
-        cardParams.number = "4242424242424242"
-        cardParams.expMonth = 12
-        cardParams.expYear = 2030
-        cardParams.cvc = "123"
-
-        let paymentMethodParams = STPPaymentMethodParams(
-            card: cardParams,
-            billingDetails: nil,
-            metadata: nil
-        )
-
-        // Create confirmation token params
-        let confirmationTokenParams = STPConfirmationTokenParams()
-        confirmationTokenParams.paymentMethodData = paymentMethodParams
-        confirmationTokenParams.returnURL = "https://example.com/return"
-
-        // Test with additional user agent values
-        let additionalValues = ["PaymentSheet/1.0", "CustomSDK/2.1"]
-        let confirmationToken = try await apiClient.createConfirmationToken(
-            with: confirmationTokenParams,
-            additionalPaymentUserAgentValues: additionalValues
-        )
-
-        // Verify the response
-        XCTAssertNotNil(confirmationToken)
-        XCTAssertFalse(confirmationToken.stripeId.isEmpty)
-        XCTAssertEqual(confirmationToken.object, "confirmation_token")
-        XCTAssertNotNil(confirmationToken.allResponseFields)
-    }
-
     func testCreateConfirmationTokenWithShippingAndMandateData() async throws {
         // Create payment method params for SEPA Debit (requires mandate)
         let sepaParams = STPPaymentMethodSEPADebitParams()

--- a/Stripe/StripeiOSTests/STPAPIClientConfirmationTokensTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClientConfirmationTokensTest.swift
@@ -85,8 +85,8 @@ class STPAPIClientConfirmationTokensTest: XCTestCase {
     }
 
     func testCreateConfirmationTokenWithCustomer() async throws {
-        // Create a customer and ephemeral key
-        let customerAndEphemeralKey = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(
+        // Create a customer and customer session
+        let customerAndCustomerSession = try await STPTestingAPIClient.shared().fetchCustomerAndCustomerSessionClientSecret(
             customerID: nil,
             merchantCountry: "us"
         )
@@ -110,10 +110,10 @@ class STPAPIClientConfirmationTokensTest: XCTestCase {
         confirmationTokenParams.returnURL = "https://example.com/return"
         confirmationTokenParams.setupFutureUsage = .offSession
 
-        // Test with ephemeral key
+        // Test with customer session
         let confirmationToken = try await apiClient.createConfirmationToken(
             with: confirmationTokenParams,
-            ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret
+            ephemeralKeySecret: customerAndCustomerSession.customerSessionClientSecret
         )
 
         // Verify the response
@@ -206,8 +206,8 @@ class STPAPIClientConfirmationTokensTest: XCTestCase {
     }
 
     func testCreateConfirmationTokenWithAttachedPaymentMethod() async throws {
-        // Create a new EK for the Customer
-        let customerAndEphemeralKey = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(
+        // Create a new customer session for the Customer
+        let customerAndCustomerSession = try await STPTestingAPIClient.shared().fetchCustomerAndCustomerSessionClientSecret(
             customerID: nil,
             merchantCountry: "us"
         )
@@ -230,8 +230,8 @@ class STPAPIClientConfirmationTokensTest: XCTestCase {
         // Attach the payment method to the customer
         try await apiClient.attachPaymentMethod(
             paymentMethod.stripeId,
-            customerID: customerAndEphemeralKey.customer,
-            ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret
+            customerID: customerAndCustomerSession.customer,
+            ephemeralKeySecret: customerAndCustomerSession.customerSessionClientSecret
         )
         
         // Create confirmation token with attached payment method
@@ -242,7 +242,7 @@ class STPAPIClientConfirmationTokensTest: XCTestCase {
         
         let confirmationToken = try await apiClient.createConfirmationToken(
             with: confirmationTokenParams,
-            ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret
+            ephemeralKeySecret: customerAndCustomerSession.customerSessionClientSecret
         )
         
         // Verify the response
@@ -254,13 +254,13 @@ class STPAPIClientConfirmationTokensTest: XCTestCase {
         // Clean up: detach the payment method from the customer
         try await apiClient.detachPaymentMethod(
             paymentMethod.stripeId,
-            fromCustomerUsing: customerAndEphemeralKey.ephemeralKeySecret
+            fromCustomerUsing: customerAndCustomerSession.customerSessionClientSecret
         )
     }
 
     func testCreateConfirmationTokenWithSetAsDefaultPaymentMethod() async throws {
-        // Create a new customer and ephemeral key
-        let customerAndEphemeralKey = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(
+        // Create a new customer and customer session
+        let customerAndCustomerSession = try await STPTestingAPIClient.shared().fetchCustomerAndCustomerSessionClientSecret(
             customerID: nil,
             merchantCountry: "us"
         )
@@ -285,10 +285,10 @@ class STPAPIClientConfirmationTokensTest: XCTestCase {
         confirmationTokenParams.setupFutureUsage = .offSession
         confirmationTokenParams.setAsDefaultPM = NSNumber(value: true)
         
-        // Create confirmation token with ephemeral key
+        // Create confirmation token with customer session
         let confirmationToken = try await apiClient.createConfirmationToken(
             with: confirmationTokenParams,
-            ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret
+            ephemeralKeySecret: customerAndCustomerSession.customerSessionClientSecret
         )
         
         // Verify the response

--- a/Stripe/StripeiOSTests/STPAPIClientConfirmationTokensTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClientConfirmationTokensTest.swift
@@ -1,0 +1,349 @@
+//
+//  STPAPIClientConfirmationTokensTest.swift
+//  StripePaymentsTests
+//
+//  Created by Nick Porter on 9/4/25.
+//
+
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP)@_spi(ConfirmationTokensPublicPreview) import StripePayments
+@testable import StripePaymentsTestUtils
+import XCTest
+
+class STPAPIClientConfirmationTokensTest: XCTestCase {
+
+    var apiClient: STPAPIClient!
+    
+    override func setUp() {
+        super.setUp()
+        apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+    }
+
+    // MARK: - Async createConfirmationToken Tests
+
+    func testCreateConfirmationTokenWithPaymentMethodData() async throws {
+        // Create payment method params
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.expMonth = 12
+        cardParams.expYear = 2030
+        cardParams.cvc = "123"
+
+        let paymentMethodParams = STPPaymentMethodParams(
+            card: cardParams,
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        // Create confirmation token params
+        let confirmationTokenParams = STPConfirmationTokenParams()
+        confirmationTokenParams.paymentMethodData = paymentMethodParams
+        confirmationTokenParams.returnURL = "https://example.com/return"
+
+        // Test async method
+        let confirmationToken = try await apiClient.createConfirmationToken(
+            with: confirmationTokenParams
+        )
+
+        // Verify the response
+        XCTAssertNotNil(confirmationToken)
+        XCTAssertFalse(confirmationToken.stripeId.isEmpty)
+        XCTAssertEqual(confirmationToken.object, "confirmation_token")
+        XCTAssertNotNil(confirmationToken.allResponseFields)
+    }
+
+    func testCreateConfirmationTokenWithExistingPaymentMethod() async throws {
+        // First create a payment method
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.expMonth = 12
+        cardParams.expYear = 2030
+        cardParams.cvc = "123"
+
+        let paymentMethodParams = STPPaymentMethodParams(
+            card: cardParams,
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        let paymentMethod = try await apiClient.createPaymentMethod(with: paymentMethodParams)
+
+        // Now create confirmation token with existing payment method
+        let confirmationTokenParams = STPConfirmationTokenParams()
+        confirmationTokenParams.paymentMethod = paymentMethod.stripeId
+        confirmationTokenParams.returnURL = "https://example.com/return"
+
+        let confirmationToken = try await apiClient.createConfirmationToken(
+            with: confirmationTokenParams
+        )
+
+        // Verify the response
+        XCTAssertNotNil(confirmationToken)
+        XCTAssertFalse(confirmationToken.stripeId.isEmpty)
+        XCTAssertEqual(confirmationToken.object, "confirmation_token")
+        XCTAssertNotNil(confirmationToken.allResponseFields)
+    }
+
+    func testCreateConfirmationTokenWithCustomer() async throws {
+        // Create a customer and ephemeral key
+        let customerAndEphemeralKey = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(
+            customerID: nil,
+            merchantCountry: "us"
+        )
+
+        // Create payment method params
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.expMonth = 12
+        cardParams.expYear = 2030
+        cardParams.cvc = "123"
+
+        let paymentMethodParams = STPPaymentMethodParams(
+            card: cardParams,
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        // Create confirmation token params
+        let confirmationTokenParams = STPConfirmationTokenParams()
+        confirmationTokenParams.paymentMethodData = paymentMethodParams
+        confirmationTokenParams.returnURL = "https://example.com/return"
+        confirmationTokenParams.setupFutureUsage = .offSession
+
+        // Test with ephemeral key
+        let confirmationToken = try await apiClient.createConfirmationToken(
+            with: confirmationTokenParams,
+            ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret
+        )
+
+        // Verify the response
+        XCTAssertNotNil(confirmationToken)
+        XCTAssertFalse(confirmationToken.stripeId.isEmpty)
+        XCTAssertEqual(confirmationToken.object, "confirmation_token")
+        XCTAssertNotNil(confirmationToken.allResponseFields)
+    }
+
+    func testCreateConfirmationTokenWithAdditionalPaymentUserAgentValues() async throws {
+        // Create payment method params
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.expMonth = 12
+        cardParams.expYear = 2030
+        cardParams.cvc = "123"
+
+        let paymentMethodParams = STPPaymentMethodParams(
+            card: cardParams,
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        // Create confirmation token params
+        let confirmationTokenParams = STPConfirmationTokenParams()
+        confirmationTokenParams.paymentMethodData = paymentMethodParams
+        confirmationTokenParams.returnURL = "https://example.com/return"
+
+        // Test with additional user agent values
+        let additionalValues = ["PaymentSheet/1.0", "CustomSDK/2.1"]
+        let confirmationToken = try await apiClient.createConfirmationToken(
+            with: confirmationTokenParams,
+            additionalPaymentUserAgentValues: additionalValues
+        )
+
+        // Verify the response
+        XCTAssertNotNil(confirmationToken)
+        XCTAssertFalse(confirmationToken.stripeId.isEmpty)
+        XCTAssertEqual(confirmationToken.object, "confirmation_token")
+        XCTAssertNotNil(confirmationToken.allResponseFields)
+    }
+
+    func testCreateConfirmationTokenWithShippingAndMandateData() async throws {
+        // Create payment method params for SEPA Debit (requires mandate)
+        let sepaParams = STPPaymentMethodSEPADebitParams()
+        sepaParams.iban = "DE89370400440532013000"
+
+        let billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.name = "Jenny Rosen"
+        billingDetails.email = "jenny@example.com"
+
+        let paymentMethodParams = STPPaymentMethodParams(
+            sepaDebit: sepaParams,
+            billingDetails: billingDetails,
+            metadata: nil
+        )
+
+        // Create shipping details
+        let addressParams = STPPaymentIntentShippingDetailsAddressParams(line1: "123 Main St")
+        addressParams.city = "San Francisco"
+        addressParams.state = "CA"
+        addressParams.postalCode = "94111"
+        addressParams.country = "US"
+
+        let shippingDetails = STPPaymentIntentShippingDetailsParams(
+            address: addressParams,
+            name: "Test Customer"
+        )
+
+        // Create mandate data
+        let mandateData = STPMandateDataParams.makeWithInferredValues()
+
+        // Create confirmation token params
+        let confirmationTokenParams = STPConfirmationTokenParams()
+        confirmationTokenParams.paymentMethodData = paymentMethodParams
+        confirmationTokenParams.returnURL = "https://example.com/return"
+        confirmationTokenParams.shipping = shippingDetails
+        confirmationTokenParams.mandateData = mandateData
+        confirmationTokenParams.setupFutureUsage = .offSession
+
+        let confirmationToken = try await apiClient.createConfirmationToken(
+            with: confirmationTokenParams
+        )
+
+        // Verify the response
+        XCTAssertNotNil(confirmationToken)
+        XCTAssertFalse(confirmationToken.stripeId.isEmpty)
+        XCTAssertEqual(confirmationToken.object, "confirmation_token")
+        XCTAssertNotNil(confirmationToken.allResponseFields)
+    }
+
+    func testCreateConfirmationTokenWithAttachedPaymentMethod() async throws {
+        // Create a new EK for the Customer
+        let customerAndEphemeralKey = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(
+            customerID: nil,
+            merchantCountry: "us"
+        )
+        
+        // Create a new payment method
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.expMonth = 12
+        cardParams.expYear = 2030
+        cardParams.cvc = "123"
+        
+        let paymentMethodParams = STPPaymentMethodParams(
+            card: cardParams,
+            billingDetails: nil,
+            metadata: nil
+        )
+        
+        let paymentMethod = try await apiClient.createPaymentMethod(with: paymentMethodParams)
+        
+        // Attach the payment method to the customer
+        try await apiClient.attachPaymentMethod(
+            paymentMethod.stripeId,
+            customerID: customerAndEphemeralKey.customer,
+            ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret
+        )
+        
+        // Create confirmation token with attached payment method
+        let confirmationTokenParams = STPConfirmationTokenParams()
+        confirmationTokenParams.paymentMethod = paymentMethod.stripeId
+        confirmationTokenParams.returnURL = "https://example.com/return"
+        confirmationTokenParams.setupFutureUsage = .offSession
+        
+        let confirmationToken = try await apiClient.createConfirmationToken(
+            with: confirmationTokenParams,
+            ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret
+        )
+        
+        // Verify the response
+        XCTAssertNotNil(confirmationToken)
+        XCTAssertFalse(confirmationToken.stripeId.isEmpty)
+        XCTAssertEqual(confirmationToken.object, "confirmation_token")
+        XCTAssertNotNil(confirmationToken.allResponseFields)
+        
+        // Clean up: detach the payment method from the customer
+        try await apiClient.detachPaymentMethod(
+            paymentMethod.stripeId,
+            fromCustomerUsing: customerAndEphemeralKey.ephemeralKeySecret
+        )
+    }
+
+    // MARK: - Error Handling Tests
+
+    func testCreateConfirmationTokenWithInvalidCard() async {
+        // Create payment method params with invalid card
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4000000000000002" // Declined card
+        cardParams.expMonth = 12
+        cardParams.expYear = 2030
+        cardParams.cvc = "123"
+
+        let paymentMethodParams = STPPaymentMethodParams(
+            card: cardParams,
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        let confirmationTokenParams = STPConfirmationTokenParams()
+        confirmationTokenParams.paymentMethodData = paymentMethodParams
+        confirmationTokenParams.returnURL = "https://example.com/return"
+
+        do {
+            _ = try await apiClient.createConfirmationToken(with: confirmationTokenParams)
+            // Note: Creating a confirmation token with a declined card should still succeed,
+            // as the card is not charged at this point. The error would occur during confirmation.
+            // So we don't expect an error here.
+        } catch {
+            // If there is an error, it should be a proper Stripe error
+            XCTAssertNotNil(error)
+        }
+    }
+
+    func testCreateConfirmationTokenNetworkError() async {
+        // Create an API client with an invalid URL to simulate network error
+        let invalidApiClient = STPAPIClient(publishableKey: "pk_test_invalid")
+        invalidApiClient.apiURL = URL(string: "https://invalid.stripe.com")!
+
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.expMonth = 12
+        cardParams.expYear = 2030
+        cardParams.cvc = "123"
+
+        let paymentMethodParams = STPPaymentMethodParams(
+            card: cardParams,
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        let confirmationTokenParams = STPConfirmationTokenParams()
+        confirmationTokenParams.paymentMethodData = paymentMethodParams
+        confirmationTokenParams.returnURL = "https://example.com/return"
+
+        do {
+            _ = try await invalidApiClient.createConfirmationToken(with: confirmationTokenParams)
+            XCTFail("Expected network error")
+        } catch {
+            XCTAssertNotNil(error)
+        }
+    }
+
+    // MARK: - Parameter Encoding Tests
+
+    func testConfirmationTokenParamsEncoding() {
+        // Test that our params are properly encoded
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.expMonth = 12
+        cardParams.expYear = 2030
+        cardParams.cvc = "123"
+
+        let paymentMethodParams = STPPaymentMethodParams(
+            card: cardParams,
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        let confirmationTokenParams = STPConfirmationTokenParams()
+        confirmationTokenParams.paymentMethodData = paymentMethodParams
+        confirmationTokenParams.returnURL = "https://example.com/return"
+        confirmationTokenParams.setupFutureUsage = .onSession
+
+        let encoded = STPFormEncoder.dictionary(forObject: confirmationTokenParams)
+
+        // Verify key parameters are encoded correctly
+        XCTAssertNotNil(encoded["payment_method_data"])
+        XCTAssertEqual(encoded["return_url"] as? String, "https://example.com/return")
+        XCTAssertEqual(encoded["setup_future_usage"] as? String, "on_session")
+    }
+}

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -19,6 +19,7 @@ import Foundation
 
     case paymentMethodCreation = "stripeios.payment_method_creation"
     case paymentMethodUpdate = "stripeios.payment_method_update"
+    case confirmationTokenCreation = "stripeios.confirmation_token_creation"
     case paymentMethodIntentCreation = "stripeios.payment_intent_confirmation"
     case setupIntentConfirmationAttempt = "stripeios.setup_intent_confirmation"
 

--- a/StripePayments/StripePayments.xcodeproj/project.pbxproj
+++ b/StripePayments/StripePayments.xcodeproj/project.pbxproj
@@ -123,6 +123,7 @@
 		61152B4B2B865F58003B69A0 /* STPPaymentMethodAmazonPayParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61152B4A2B865F58003B69A0 /* STPPaymentMethodAmazonPayParams.swift */; };
 		61152B4D2B865FBB003B69A0 /* STPPaymentMethodAmazonPay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61152B4C2B865FBB003B69A0 /* STPPaymentMethodAmazonPay.swift */; };
 		6151DDBA2B0D1EE800ED4F7E /* STPPaymentMethodUpdateParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6151DDB92B0D1EE800ED4F7E /* STPPaymentMethodUpdateParams.swift */; };
+		615242352E6942AE002459F6 /* STPConfirmationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615242342E6942AE002459F6 /* STPConfirmationToken.swift */; };
 		617C1C842BB4962500B10AC5 /* STPPaymentMethodAlmaParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617C1C832BB4962500B10AC5 /* STPPaymentMethodAlmaParams.swift */; };
 		617C1C862BB496FC00B10AC5 /* STPPaymentMethodAlma.swift in Sources */ = {isa = PBXBuildFile; fileRef = 617C1C852BB496FC00B10AC5 /* STPPaymentMethodAlma.swift */; };
 		61E1CA1B2BD6B1AE00A421AE /* STPPaymentMethodMultibanco.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61E1CA1A2BD6B1AE00A421AE /* STPPaymentMethodMultibanco.swift */; };
@@ -516,6 +517,7 @@
 		61152B4A2B865F58003B69A0 /* STPPaymentMethodAmazonPayParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAmazonPayParams.swift; sourceTree = "<group>"; };
 		61152B4C2B865FBB003B69A0 /* STPPaymentMethodAmazonPay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAmazonPay.swift; sourceTree = "<group>"; };
 		6151DDB92B0D1EE800ED4F7E /* STPPaymentMethodUpdateParams.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodUpdateParams.swift; sourceTree = "<group>"; };
+		615242342E6942AE002459F6 /* STPConfirmationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPConfirmationToken.swift; sourceTree = "<group>"; };
 		617C1C832BB4962500B10AC5 /* STPPaymentMethodAlmaParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAlmaParams.swift; sourceTree = "<group>"; };
 		617C1C852BB496FC00B10AC5 /* STPPaymentMethodAlma.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAlma.swift; sourceTree = "<group>"; };
 		61E1CA1A2BD6B1AE00A421AE /* STPPaymentMethodMultibanco.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodMultibanco.swift; sourceTree = "<group>"; };
@@ -1026,6 +1028,7 @@
 		61F2FA332E67F69E007AF688 /* ConfirmationTokens */ = {
 			isa = PBXGroup;
 			children = (
+				615242342E6942AE002459F6 /* STPConfirmationToken.swift */,
 				61F2FA312E67F69E007AF688 /* STPConfirmationTokenParams.swift */,
 			);
 			path = ConfirmationTokens;
@@ -1924,6 +1927,7 @@
 				31B7F54E2BD1D4E500BF1015 /* HCaptchaHtml.swift in Sources */,
 				CB28DBAD2DBD452A008DD7DF /* STPConfirmLinkOptions.swift in Sources */,
 				71A589E7CCAEA272B9CC37AB /* STPThreeDSLabelCustomization.swift in Sources */,
+				615242352E6942AE002459F6 /* STPConfirmationToken.swift in Sources */,
 				AC555A609E63E94BCAA468C5 /* STPThreeDSNavigationBarCustomization.swift in Sources */,
 				31B7F5582BD1D4E500BF1015 /* HCaptchaEvent.swift in Sources */,
 				D38818756D495C674E53AE6D /* STPThreeDSSelectionCustomization.swift in Sources */,

--- a/StripePayments/StripePayments/Source/API Bindings/Models/ConfirmationTokens/STPConfirmationToken.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/ConfirmationTokens/STPConfirmationToken.swift
@@ -1,0 +1,70 @@
+//
+//  STPConfirmationToken.swift
+//  StripePayments
+//
+//  Created by Nick Porter on 9/4/25.
+//
+
+import Foundation
+
+/// A ConfirmationToken object represents a client-side confirmation token that can be used to confirm a PaymentIntent or SetupIntent.
+/// - seealso: https://stripe.com/docs/api/confirmation_tokens
+@_spi(ConfirmationTokensPublicPreview) public class STPConfirmationToken: NSObject, STPAPIResponseDecodable {
+    /// You cannot directly instantiate an `STPConfirmationToken`. You should only use one that is returned from the Stripe API.
+    required internal override init() {
+        super.init()
+    }
+
+    /// The unique identifier for the ConfirmationToken.
+    @objc public private(set) var stripeId: String = ""
+    /// String representing the object's type. Objects of the same type share the same value.
+    @objc public private(set) var object: String = ""
+    /// Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+    @objc public private(set) var livemode: Bool = false
+    /// Time at which the object was created. Measured in seconds since the Unix epoch.
+    @objc public private(set) var created: Date = Date()
+
+    /// :nodoc:
+    @objc public private(set) var allResponseFields: [AnyHashable: Any] = [:]
+
+    // MARK: - STPAPIResponseDecodable
+
+    @objc
+    public static func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
+        guard let response = response else {
+            return nil
+        }
+
+        let confirmationToken = self.init()
+        confirmationToken.allResponseFields = response
+
+        // Parse basic fields
+        confirmationToken.stripeId = response["id"] as? String ?? ""
+        confirmationToken.object = response["object"] as? String ?? ""
+        confirmationToken.livemode = response["livemode"] as? Bool ?? false
+
+        // Parse created timestamp
+        if let createdTimestamp = response["created"] as? TimeInterval {
+            confirmationToken.created = Date(timeIntervalSince1970: createdTimestamp)
+        }
+
+        return confirmationToken
+    }
+
+    // MARK: - NSObject
+
+    /// :nodoc:
+    @objc public override var description: String {
+        let props = [
+            // Object
+            String(format: "%@: %p", NSStringFromClass(STPConfirmationToken.self), self),
+            // ConfirmationToken details
+            "id = \(stripeId)",
+            "object = \(object)",
+            "livemode = \(livemode ? "YES" : "NO")",
+            "created = \(created)",
+        ]
+
+        return "<\(props.joined(separator: "; "))>"
+    }
+}

--- a/StripePayments/StripePayments/Source/API Bindings/Models/ConfirmationTokens/STPConfirmationTokenParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/ConfirmationTokens/STPConfirmationTokenParams.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// An object representing parameters used to create a ConfirmationToken object.
 /// - seealso: https://stripe.com/docs/api/confirmation_tokens
-@_spi(STP) public class STPConfirmationTokenParams: NSObject, STPFormEncodable {
+@_spi(ConfirmationTokensPublicPreview) public class STPConfirmationTokenParams: NSObject, STPFormEncodable {
     private var _additionalAPIParameters: [AnyHashable: Any] = [:]
 
     /// ID of an existing PaymentMethod to use for this ConfirmationToken.

--- a/StripePayments/StripePayments/Source/API Bindings/Models/ConfirmationTokens/STPConfirmationTokenParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/ConfirmationTokens/STPConfirmationTokenParams.swift
@@ -9,7 +9,7 @@ import Foundation
 
 /// An object representing parameters used to create a ConfirmationToken object.
 /// - seealso: https://stripe.com/docs/api/confirmation_tokens
-@_spi(ConfirmationTokensPublicPreview) public class STPConfirmationTokenParams: NSObject, STPFormEncodable {
+@_spi(STP) public class STPConfirmationTokenParams: NSObject, STPFormEncodable {
     private var _additionalAPIParameters: [AnyHashable: Any] = [:]
 
     /// ID of an existing PaymentMethod to use for this ConfirmationToken.

--- a/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/STPAPIClient+Payments.swift
@@ -1501,18 +1501,15 @@ extension STPAPIClient {
     /// - seealso: https://stripe.com/docs/api/confirmation_tokens/create
     /// - Parameters:
     ///   - confirmationTokenParams:  The `STPConfirmationTokenParams` to pass to `/v1/confirmation_tokens`.  Cannot be nil.
-    ///   - additionalPaymentUserAgentValues: Additional payment user agent values to send with the request.
     ///   - ephemeralKeySecret: The ephemeral key secret to use for authentication if working with customer-scoped objects.
     /// - Returns: The created ConfirmationToken object.
     @_spi(ConfirmationTokensPublicPreview) public func createConfirmationToken(
         with confirmationTokenParams: STPConfirmationTokenParams,
-        additionalPaymentUserAgentValues: [String] = [],
         ephemeralKeySecret: String? = nil
     ) async throws -> STPConfirmationToken {
         return try await withCheckedThrowingContinuation { continuation in
             createConfirmationToken(
                 with: confirmationTokenParams,
-                additionalPaymentUserAgentValues: additionalPaymentUserAgentValues,
                 ephemeralKeySecret: ephemeralKeySecret
             ) { confirmationToken, error in
                 guard let confirmationToken = confirmationToken else {
@@ -1526,7 +1523,6 @@ extension STPAPIClient {
 
     func createConfirmationToken(
         with confirmationTokenParams: STPConfirmationTokenParams,
-        additionalPaymentUserAgentValues: [String] = [],
         ephemeralKeySecret: String? = nil,
         completion: @escaping STPConfirmationTokenCompletionBlock
     ) {

--- a/StripePayments/StripePayments/Source/Helpers/STPBlocks.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBlocks.swift
@@ -118,5 +118,11 @@ public typealias STPPaymentStatusBlock = (STPPaymentStatus, Error?) -> Void
 ///    - error: The error that occured, if any.
 public typealias STPRadarSessionCompletionBlock = (STPRadarSession?, Error?) -> Void
 
+/// A callback to be run with a ConfirmationToken response from the Stripe API.
+/// - Parameters:
+///   - confirmationToken: The Stripe ConfirmationToken from the response. Will be nil if an error occurs. - seealso: STPConfirmationToken
+///   - error: The error returned from the response, or nil if none occurs. - seealso: StripeError.h for possible values.
+@_spi(ConfirmationTokensPublicPreview) public typealias STPConfirmationTokenCompletionBlock = (STPConfirmationToken?, Error?) -> Void
+
 /// An empty block, called with no arguments, returning nothing.
 public typealias STPVoidBlock = () -> Void

--- a/StripePayments/StripePayments/Source/Helpers/STPBlocks.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBlocks.swift
@@ -122,7 +122,7 @@ public typealias STPRadarSessionCompletionBlock = (STPRadarSession?, Error?) -> 
 /// - Parameters:
 ///   - confirmationToken: The Stripe ConfirmationToken from the response. Will be nil if an error occurs. - seealso: STPConfirmationToken
 ///   - error: The error returned from the response, or nil if none occurs. - seealso: StripeError.h for possible values.
-@_spi(ConfirmationTokensPublicPreview) public typealias STPConfirmationTokenCompletionBlock = (STPConfirmationToken?, Error?) -> Void
+@_spi(STP) public typealias STPConfirmationTokenCompletionBlock = (STPConfirmationToken?, Error?) -> Void
 
 /// An empty block, called with no arguments, returning nothing.
 public typealias STPVoidBlock = () -> Void

--- a/StripePayments/StripePayments/Source/Internal/Analytics/STPAnalyticsClient+Payments.swift
+++ b/StripePayments/StripePayments/Source/Internal/Analytics/STPAnalyticsClient+Payments.swift
@@ -69,6 +69,18 @@ extension STPAnalyticsClient {
             )
         )
     }
+
+    func logConfirmationTokenCreationAttempt(
+        with configuration: NSObject?
+    ) {
+        log(
+            analytic: GenericPaymentAnalytic(
+                event: .confirmationTokenCreation,
+                paymentConfiguration: configuration,
+                additionalParams: [:]
+            )
+        )
+    }
 }
 
 // MARK: - Confirmation

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAdditionalPaymentUserAgentValues/0000_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAdditionalPaymentUserAgentValues/0000_post_v1_confirmation_tokens.tail
@@ -1,0 +1,86 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=MiTLMRl2sVhC-5t5IIoKOqDO-kXOyNjXRUlawiV8CDiJLbqXp8T1X1ogyotqKq_-L3VNah7JeoGKfJvi
+Server: nginx
+Cache-Control: no-cache, no-store
+x-wc: ABGHIJ
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+x-stripe-routing-context-priority-tier: api-testmode
+request-id: req_wJu3EnaE1nJYau
+Content-Length: 1353
+Vary: Origin
+Date: Thu, 04 Sep 2025 15:17:14 GMT
+original-request: req_wJu3EnaE1nJYau
+stripe-version: 2020-08-27
+idempotency-key: 6edb615c-e71f-4c18-b8fe-780c68526143
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[card]\[cvc]=123&payment_method_data\[card]\[exp_month]=12&payment_method_data\[card]\[exp_year]=2030&payment_method_data\[card]\[number]=4242424242424242&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sid]=.*&payment_method_data\[type]=card&return_url=https%3A\/\/example\.com\/return
+
+{
+  "id" : "ctoken_1S3euUFY0qyl6XeWMbk3RC54",
+  "setup_intent" : null,
+  "livemode" : false,
+  "shipping" : null,
+  "expires_at" : 1757042234,
+  "return_url" : "https:\/\/example.com\/return",
+  "setup_future_usage" : null,
+  "object" : "confirmation_token",
+  "payment_method_preview" : {
+    "allow_redisplay" : "unspecified",
+    "billing_details" : {
+      "email" : null,
+      "phone" : null,
+      "tax_id" : null,
+      "name" : null,
+      "address" : {
+        "state" : null,
+        "country" : null,
+        "line2" : null,
+        "city" : null,
+        "line1" : null,
+        "postal_code" : null
+      }
+    },
+    "customer" : null,
+    "card" : {
+      "regulated_status" : "unregulated",
+      "last4" : "4242",
+      "funding" : "credit",
+      "generated_from" : null,
+      "networks" : {
+        "available" : [
+          "visa"
+        ],
+        "preferred" : null
+      },
+      "brand" : "visa",
+      "checks" : {
+        "address_postal_code_check" : null,
+        "cvc_check" : null,
+        "address_line1_check" : null
+      },
+      "three_d_secure_usage" : {
+        "supported" : true
+      },
+      "wallet" : null,
+      "display_brand" : "visa",
+      "exp_month" : 12,
+      "exp_year" : 2030,
+      "country" : "US"
+    },
+    "type" : "card"
+  },
+  "created" : 1756999034,
+  "payment_intent" : null,
+  "use_stripe_sdk" : true,
+  "payment_method_options" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0000_post_create_ephemeral_key.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_ephemeral_key$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=Hq%2F06ARjs0w3qX3hTfWmOGEeeOvSJWlrzKn94Jk7zSu%2BAjf9hC0TEgzL%2F8GY5NEL6%2BxMs8mD1jJXUCmrjlRHKR%2Bmi5HFQUf7RuXA9Gs8DvhGplpkJqBU9ZZN%2FjXlxHbXENqq4iNA9PjSqj2tSKcjUPn2U9qL2ofSQfagvnTteRx8pPHAMbJ%2BFSmSI4NSVo4Cgv3P8HvFvuer4UO8jrmnRRlwkOORbimTv6gCBRWQem8%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 2d948eedc089aba1b0ee546768601f32;o=1
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Thu, 04 Sep 2025 15:17:15 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 149
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"ephemeral_key_secret":"ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLGVjUExhNGZwR3ppUGJEOW1OQUIxWm93ck9tSEczNGs_00G7WJP6JI","customer":"cus_SzeCHemxoXJzje"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0001_post_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0001_post_v1_payment_methods.tail
@@ -1,0 +1,76 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_methods$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AQqRMFirvLP7NAbp5k0pcjF7M1U26ZzkqN4aanhT-qtqtjEQTKJyZxpEAHasM5EkU4BImi4Jiawx2Yu-
+Server: nginx
+Cache-Control: no-cache, no-store
+x-wc: ABGHIJ
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+x-stripe-routing-context-priority-tier: api-testmode
+request-id: req_zBo9BfWhMwjGEt
+Content-Length: 991
+Vary: Origin
+Date: Thu, 04 Sep 2025 15:17:15 GMT
+original-request: req_zBo9BfWhMwjGEt
+stripe-version: 2020-08-27
+idempotency-key: 1048389c-d46b-4f2a-a41f-1f549ebfa614
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: allow_redisplay=unspecified&card\[cvc]=123&card\[exp_month]=12&card\[exp_year]=2030&card\[number]=4242424242424242&guid=.*&muid=.*&payment_user_agent=.*&sid=.*&type=card
+
+{
+  "object" : "payment_method",
+  "id" : "pm_1S3euVFY0qyl6XeWdNqxWFuk",
+  "billing_details" : {
+    "email" : null,
+    "phone" : null,
+    "tax_id" : null,
+    "name" : null,
+    "address" : {
+      "state" : null,
+      "country" : null,
+      "line2" : null,
+      "city" : null,
+      "line1" : null,
+      "postal_code" : null
+    }
+  },
+  "card" : {
+    "regulated_status" : "unregulated",
+    "last4" : "4242",
+    "funding" : "credit",
+    "generated_from" : null,
+    "networks" : {
+      "available" : [
+        "visa"
+      ],
+      "preferred" : null
+    },
+    "brand" : "visa",
+    "checks" : {
+      "address_postal_code_check" : null,
+      "cvc_check" : null,
+      "address_line1_check" : null
+    },
+    "three_d_secure_usage" : {
+      "supported" : true
+    },
+    "wallet" : null,
+    "display_brand" : "visa",
+    "exp_month" : 12,
+    "exp_year" : 2030,
+    "country" : "US"
+  },
+  "livemode" : false,
+  "created" : 1756999035,
+  "allow_redisplay" : "unspecified",
+  "type" : "card",
+  "customer" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0002_post_v1_payment_methods_pm_1S3euVFY0qyl6XeWdNqxWFuk_attach.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0002_post_v1_payment_methods_pm_1S3euVFY0qyl6XeWdNqxWFuk_attach.tail
@@ -1,0 +1,77 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_methods\/pm_1S3euVFY0qyl6XeWdNqxWFuk\/attach$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=dTYTfMEC3tXgP6Z9bOIrXKPnZNDx9NoVi_Ca-LZxl9__TTm0H4S1oDjjjj_Cwr0wCg9wwsiwavxUgVlg
+Server: nginx
+Cache-Control: no-cache, no-store
+x-wc: ABGHIJ
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+x-stripe-routing-context-priority-tier: api-testmode
+request-id: req_YpmlUYsPEJrlli
+Content-Length: 1046
+Vary: Origin
+Date: Thu, 04 Sep 2025 15:17:16 GMT
+original-request: req_YpmlUYsPEJrlli
+stripe-version: 2020-08-27
+idempotency-key: 98c317e3-aff4-46ce-8e52-a2b085fb7931
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: customer=cus_SzeCHemxoXJzje
+
+{
+  "object" : "payment_method",
+  "id" : "pm_1S3euVFY0qyl6XeWdNqxWFuk",
+  "billing_details" : {
+    "email" : null,
+    "phone" : null,
+    "tax_id" : null,
+    "name" : null,
+    "address" : {
+      "state" : null,
+      "country" : null,
+      "line2" : null,
+      "city" : null,
+      "line1" : null,
+      "postal_code" : null
+    }
+  },
+  "card" : {
+    "regulated_status" : "unregulated",
+    "fingerprint" : "96sroMqLCHmUdUpL",
+    "last4" : "4242",
+    "funding" : "credit",
+    "generated_from" : null,
+    "networks" : {
+      "available" : [
+        "visa"
+      ],
+      "preferred" : null
+    },
+    "brand" : "visa",
+    "checks" : {
+      "address_postal_code_check" : null,
+      "cvc_check" : null,
+      "address_line1_check" : null
+    },
+    "three_d_secure_usage" : {
+      "supported" : true
+    },
+    "wallet" : null,
+    "display_brand" : "visa",
+    "exp_month" : 12,
+    "exp_year" : 2030,
+    "country" : "US"
+  },
+  "livemode" : false,
+  "created" : 1756999035,
+  "allow_redisplay" : "unspecified",
+  "type" : "card",
+  "customer" : "cus_SzeCHemxoXJzje"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0003_post_create_customer_session_cs.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0003_post_create_customer_session_cs.tail
@@ -1,0 +1,18 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_customer_session_cs$
+200
+text/html
+Content-Type: text/html;charset=utf-8
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+Set-Cookie: rack.session=5Xm6hbKDooIyC6Gd9XLVt3mXcqCK77WkGptNIxRpHBtIocIcm4DwqJPvwKVzdZgCHuAudUD7q5htpEsSUTHnMFjJHcTv9M%2F9mtd20ik%2BCSDGgys1caz0wbXcUMuROkKLKdgCYMzA%2Fk%2ByoZiqCv3Mz3j95wyzcFKip5pO6KBnd3sEhHZrc6CGlBtqRbDqERdoX3s9HVWYY2QWCf6qS0J4aO5PwVokBLhDs7qx2tCqAeM%3D; path=/
+Server: Google Frontend
+x-cloud-trace-context: 56c30aaa437705aab23fcf1954bd217c
+Via: 1.1 google
+x-xss-protection: 1; mode=block
+Date: Thu, 04 Sep 2025 15:17:16 GMT
+x-robots-tag: noindex, nofollow
+Content-Length: 128
+x-content-type-options: nosniff
+x-frame-options: SAMEORIGIN
+
+{"customer_session_client_secret":"cuss_secret_SzeCnfmGV3FvAmrGAMF2m0wj9nXHRHeCHOkEmhnwYqDUlGl","customer":"cus_SzeCHemxoXJzje"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0004_get_v1_elements_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0004_get_v1_elements_sessions.tail
@@ -1,0 +1,526 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?customer_session_client_secret=cuss_secret_SzeCnfmGV3FvAmrGAMF2m0wj9nXHRHeCHOkEmhnwYqDUlGl&deferred_intent%5Bcurrency%5D=usd&deferred_intent%5Bmode%5D=setup&deferred_intent%5Bsetup_future_usage%5D=off_session&key=pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6&locale=en-US&mobile_app_id=com\.apple\.dt\.xctest\.tool&type=deferred_intent$
+200
+application/json
+Content-Type: application/json
+Access-Control-Allow-Origin: *
+x-stripe-priority-routing-enabled: true
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=GQZta_9ktJUzAKvj4c7RjbtjwoJd_Xdcpgn_E05KwmtEkIouDOp7cyJ0Aj8rn8yIo61wb16qfvrk4y_N
+x-wc: ABGHIJ
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+Server: nginx
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+Cache-Control: no-cache, no-store
+Date: Thu, 04 Sep 2025 15:17:17 GMT
+stripe-version: 2020-08-27
+access-control-allow-credentials: true
+Content-Length: 17757
+x-stripe-routing-context-priority-tier: api-testmode
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Vary: Origin
+request-id: req_UYxo3DvyAKdxlC
+
+{
+  "payment_method_preference" : {
+    "country_code" : "US",
+    "object" : "payment_method_preference",
+    "type" : "deferred_intent",
+    "ordered_payment_method_types" : [
+      "card",
+      "cashapp",
+      "us_bank_account",
+      "amazon_pay"
+    ]
+  },
+  "capability_enabled_card_networks" : [
+    "cartes_bancaires",
+    "jcb",
+    "diners",
+    "discover"
+  ],
+  "flags" : {
+    "legacy_confirmation_tokens" : false,
+    "elements_enable_jp_installments_updated_ui" : true,
+    "elements_spm_max_visible_payment_methods" : false,
+    "elements_enable_installments_on_deferred_intents" : true,
+    "paypal_billing_address_support_in_ece" : false,
+    "distinctly_link_pe_backup_payment_method" : false,
+    "paypal_express_checkout_recurring_support_elements_for_new_ece_shape" : true,
+    "elements_enable_new_google_places_api" : true,
+    "elements_enable_ach_consumer_sign_up_incentive" : true,
+    "elements_enable_br_card_installments" : false,
+    "elements_enable_cb_apple_pay_for_connect_platforms" : true,
+    "elements_enable_read_allow_redisplay" : false,
+    "id_bank_transfers_v1_integration" : false,
+    "networked_business_profile_demo" : false,
+    "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
+    "paypal_phone_number_support_in_ece" : false,
+    "elements_easel_enable_lpm_autofills" : true,
+    "elements_disable_express_checkout_button_shop_pay" : false,
+    "elements_easel_disable_payment_fill" : false,
+    "elements_spm_set_as_default" : true,
+    "link_payment_element_minor_signup_ui_updates" : false,
+    "elements_disable_paypal_express" : false,
+    "abstracted_adaptive_pricing_should_show_markup_disclosure_percentage" : false,
+    "linkglobalholdbackmanager_test_rollout" : true,
+    "elements_enable_save_for_future_payments_pre_check" : false,
+    "elements_enable_nz_bank_account_spm" : false,
+    "elements_enable_write_allow_redisplay" : false,
+    "elements_hide_card_brand_icons" : false,
+    "enable_cashapp_afterpay_logo_checkout" : true,
+    "payto_enable_modal_in_payment_element" : false,
+    "elements_easel_disable_address_fill" : false,
+    "link_disable_login_if_signed_up_outside_of_elements" : false,
+    "elements_enable_link_card_brand_in_saved_payment_methods" : true,
+    "financial_connections_enable_deferred_intent_flow" : true,
+    "elements_disable_payment_element_custom_payment_methods_byof" : false,
+    "elements_easel_disable_position_customization" : false,
+    "elements_disable_link_global_holdback_lookup" : false,
+    "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text" : false,
+    "paypal_express_checkout_recurring_support" : false,
+    "elements_easel_disable_magic_fill" : false,
+    "elements_disable_payment_element_card_country_zip_validations" : false,
+    "disable_cbc_in_link_popup" : false,
+    "link_enable_card_brand_choice" : true,
+    "link_express_checkout_element_one_click_killswitch" : true,
+    "elements_stop_move_focus_to_first_errored_field" : true,
+    "elements_enable_blik" : true,
+    "apple_pay_pe_killswitch" : false,
+    "elements_enable_invalid_country_for_pm_error" : true,
+    "link_payment_element_default_value_auto_open_modal" : false,
+    "link_express_checkout_element_inline_otp_killswitch" : true,
+    "elements_enable_19_digit_pans" : false,
+    "elements_disable_express_checkout_button_amazon_pay" : false,
+    "link_in_accordion_layout_available_in_stripejs" : false,
+    "link_user_action_attempt_login_using_stored_credentials" : true,
+    "elements_easel_disable_tax_id_fill" : false,
+    "apple_pay_ece_killswitch" : false,
+    "elements_easel_disable_health_check" : false,
+    "elements_enable_au_becs_debit_spm" : false,
+    "elements_enable_south_korea_market_underlying_pms" : false,
+    "enable_payment_method_api_shop_pay" : true,
+    "link_disable_auth_partner_ua_check" : false,
+    "elements_easel_disable_session_summary" : false,
+    "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
+    "elements_enable_ephemeral_key_for_confirmation_token_creation" : true,
+    "show_swish_factoring_notice" : true,
+    "show_swish_redirect_and_qr_code_auth_flows" : true,
+    "elements_lpm_holdback_use_backend_treatments" : true,
+    "elements_easel_disable_optimizations_check" : false,
+    "elements_enable_express_checkout_button_demo_pay" : false,
+    "elements_prefer_fc_lite" : false,
+    "elements_enable_jp_card_installments" : true,
+    "elements_easel_disable_feedback" : false,
+    "elements_spm_messages" : false,
+    "elements_enable_bacs_debit_spm" : false,
+    "distinctly_link_cbc_killswitch" : false,
+    "elements_disable_link_email_otp" : false,
+    "elements_disable_progressive_cursor" : false,
+    "easel_testmode_customer_location" : true,
+    "elements_enable_payment_element_custom_payment_methods_byof" : false,
+    "elements_show_expanded_spm" : false,
+    "enable_custom_checkout_currency_selector_element" : false,
+    "link_dedupe_shipping_address_creation" : false,
+    "payment_element_link_modal_preload_killswitch" : false,
+    "elements_enable_instant_debits_postal_code_collection" : false,
+    "elements_enable_remove_last_validation" : true,
+    "apple_pay_prb_killswitch" : false,
+    "ece_apple_pay_payment_request_passthrough" : false,
+    "elements_disable_express_checkout_button_klarna" : false,
+    "disable_payment_element_if_required_billing_config" : false,
+    "elements_enable_billing_details_in_pe_change_event" : true,
+    "elements_enable_link_spm" : true,
+    "link_enable_address_country_restrictions" : false,
+    "elements_enable_fraud_signal_data_transfer_to_hcaptcha" : false,
+    "elements_disable_fc_lite" : false,
+    "link_enable_auth_partner_communication" : true,
+    "link_enable_ncdv_recall_id_selectors_l3" : true,
+    "elements_easel_disable" : false,
+    "link_express_checkout_element_two_step_killswitch" : true,
+    "elements_enable_passive_captcha" : false,
+    "link_payment_element_keep_optional_doi_open_rollout" : true,
+    "link_purchase_protections_rollout" : true,
+    "elements_enable_link_spm_branding" : true,
+    "elements_enable_mx_card_installments" : true,
+    "link_enable_ncdv_usage_id_selectors_l3" : true,
+    "elements_easel_disable_customer_location_mocking" : false,
+    "enable_merchant_instructed_orchestration_on_checkout" : false,
+    "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+    "link_enable_white_ece_button_theme" : false,
+    "link_enable_universal_ncdv_l3" : true
+  },
+  "merchant_logo_url" : null,
+  "session_id" : "elements_session_1fFJ7kZqs9o",
+  "card_installments_enabled" : false,
+  "account_id" : "acct_1G6m1pFY0qyl6XeW",
+  "config_id" : "f29e606d-3d75-44d0-9b8a-b42c05ce9c19",
+  "merchant_currency" : "usd",
+  "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping_address_settings" : {
+    "autocomplete_allowed" : false
+  },
+  "external_payment_method_data" : null,
+  "custom_payment_method_data" : null,
+  "meta_pay_signed_container_context" : null,
+  "apple_pay_preference" : "enabled",
+  "lpm_promotions" : null,
+  "merchant_country" : "US",
+  "google_pay_preference" : "enabled",
+  "payment_method_configuration_id" : "pmc_1JwXxwFY0qyl6XeWe0tY6hZ0",
+  "experiments_data" : {
+    "arb_id" : "b1ca1ee4-8513-4301-925d-702bc09093f4",
+    "experiment_metadata" : {
+      "seed" : "b65dc74f22e672956a4edc5cdc855c4afd01e978463b001b031642b9a0e807f4",
+      "semi_dominant_payment_methods" : [
+
+      ],
+      "lpm_holdback_t1_payment_methods" : [
+
+      ],
+      "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false,
+      "lpm_holdback_t2_payment_methods" : [
+
+      ]
+    },
+    "experiment_assignments" : {
+      "link_popup_webview_option_ios" : "control",
+      "elements_merchant_ui_api_srv" : "control",
+      "paypal_payment_handler" : "control",
+      "ocs_buyer_xp_redirect_simplification_v2" : "control",
+      "ocs_buyer_xp_elements_ece_timeout_time" : "control",
+      "link_ab_test_aa" : "control",
+      "ocs_buyer_xp_elements_redirect_form_simplification" : "control",
+      "ocs_buyer_xp_elements_remove_postal_code_card_non_us" : "control",
+      "ocs_buyer_xp_elements_ece_pe_does_not_wait" : "control"
+    }
+  },
+  "legacy_customer" : null,
+  "link_settings" : {
+    "link_passthrough_mode_enabled" : false,
+    "link_payment_element_smart_defaults_enabled" : false,
+    "link_no_code_default_values_recall" : true,
+    "link_funding_sources" : [
+
+    ],
+    "link_crypto_onramp_force_cvc_reverification" : false,
+    "link_enable_signup_in_express_checkout_element" : false,
+    "link_wanderlust_in_elements_enabled" : false,
+    "link_consumer_incentive" : null,
+    "link_crypto_onramp_bank_upsell" : false,
+    "link_enable_email_otp_for_link_popup" : false,
+    "link_crypto_onramp_elements_logout_disabled" : false,
+    "link_no_code_default_values_identification" : true,
+    "link_pay_button_element_enabled" : true,
+    "link_payment_element_enable_webauthn_login" : false,
+    "link_bank_onboarding_enabled" : false,
+    "link_enable_instant_debits_in_testmode" : false,
+    "link_payment_element_disabled_by_targeting" : false,
+    "link_payment_element_disable_signup_experiment" : false,
+    "link_sign_up_opt_in_feature_enabled" : false,
+    "link_only_for_payment_method_types_enabled" : false,
+    "link_disabled_reasons" : {
+      "payment_element_payment_method_mode" : [
+        "link_not_specified_in_payment_method_types"
+      ],
+      "payment_element_passthrough_mode" : [
+        "automatic_payment_methods_enabled",
+        "link_not_enabled_on_payment_config",
+        "not_gated_into_enable_m2_passthrough_mode"
+      ]
+    },
+    "link_sign_up_opt_in_initial_value" : false,
+    "link_mobile_use_attestation_endpoints" : false,
+    "link_elements_pageload_sign_up_disabled" : false,
+    "link_disable_pe_signup_prompt" : false,
+    "link_elements_is_crypto_onramp" : false,
+    "link_no_code_default_values_usage" : true,
+    "link_enable_webauthn_for_link_popup" : false,
+    "link_email_verification_login_enabled" : false,
+    "link_popup_webview_option" : "shared",
+    "link_targeting_results" : {
+      "payment_element_passthrough_mode" : null
+    },
+    "link_trusted_merchant_check_enabled" : false,
+    "link_global_holdback_on" : false,
+    "link_show_prefer_debit_card_hint" : false,
+    "link_local_storage_login_enabled" : false,
+    "link_payment_session_context" : null,
+    "link_session_storage_login_enabled" : false,
+    "link_disable_in_safari_private_browsing" : false,
+    "link_mobile_disable_rux_in_flow_controller" : false,
+    "link_authenticated_change_event_enabled" : false,
+    "link_pm_killswitch_on_in_elements" : false,
+    "link_supported_payment_methods_onboarding_enabled" : [
+
+    ],
+    "link_hcaptcha_site_key" : "20000000-ffff-ffff-ffff-000000000002",
+    "link_payment_element_disable_signup" : false,
+    "link_enable_displayable_default_values_in_ece" : false,
+    "link_disable_email_otp" : false,
+    "link_hcaptcha_rqdata" : null,
+    "link_default_opt_in" : "NONE",
+    "link_mobile_skip_wallet_in_flow_controller" : false,
+    "link_mobile_disable_default_opt_in" : false,
+    "link_mode" : null,
+    "link_supported_payment_methods" : [
+
+    ],
+    "link_mobile_disable_signup" : false,
+    "link_popup_smart_defaults_enabled" : false
+  },
+  "passive_captcha" : null,
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "fields" : [
+
+      ],
+      "selector_icon" : {
+        "light_theme_png" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-amazonpay_light@3x-46eb8b8a4a252b78d7b4c3b96d4ed7ae.png",
+        "light_theme_svg" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-amazonpay_light-22cdec0f5f5609554a34fa62fa583f23.svg"
+      },
+      "type" : "amazon_pay",
+      "next_action_spec" : {
+        "confirm_response_status_specs" : {
+          "requires_action" : {
+            "type" : "redirect_to_url"
+          }
+        },
+        "post_confirm_handling_pi_status_specs" : {
+          "requires_action" : {
+            "type" : "canceled"
+          },
+          "succeeded" : {
+            "type" : "finished"
+          }
+        }
+      }
+    },
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    },
+    {
+      "async" : false,
+      "fields" : [
+
+      ],
+      "type" : "cashapp",
+      "selector_icon" : {
+        "light_theme_png" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-cashapp@3x-a89c5d8d0651cae2a511bb49a6be1cfc.png",
+        "light_theme_svg" : "https:\/\/js.stripe.com\/v3\/fingerprinted\/img\/payment-methods\/icon-pm-cashapp-981164a833e417d28a8ac2684fda2324.svg"
+      }
+    }
+  ],
+  "paypal_express_config" : {
+    "client_id" : null,
+    "client_token" : null,
+    "paypal_merchant_id" : null
+  },
+  "prefill_selectors" : {
+    "default_values" : {
+      "email" : [
+
+      ],
+      "merchant_provides_default_values_on_update" : true
+    }
+  },
+  "unactivated_payment_method_types" : [
+    "cashapp",
+    "us_bank_account",
+    "amazon_pay"
+  ],
+  "unverified_payment_methods_on_domain" : [
+    "apple_pay"
+  ],
+  "order" : null,
+  "link_purchase_protections_data" : {
+    "type" : null,
+    "is_eligible" : false
+  },
+  "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "customer" : {
+    "email" : null,
+    "payment_methods" : [
+      {
+        "object" : "payment_method",
+        "id" : "pm_1S3euVFY0qyl6XeWdNqxWFuk",
+        "billing_details" : {
+          "email" : null,
+          "phone" : null,
+          "tax_id" : null,
+          "name" : null,
+          "address" : {
+            "state" : null,
+            "country" : null,
+            "line2" : null,
+            "city" : null,
+            "line1" : null,
+            "postal_code" : null
+          }
+        },
+        "card" : {
+          "regulated_status" : "unregulated",
+          "last4" : "4242",
+          "funding" : "credit",
+          "generated_from" : null,
+          "networks" : {
+            "available" : [
+              "visa"
+            ],
+            "preferred" : null
+          },
+          "brand" : "visa",
+          "checks" : {
+            "address_postal_code_check" : null,
+            "cvc_check" : null,
+            "address_line1_check" : null
+          },
+          "three_d_secure_usage" : {
+            "supported" : true
+          },
+          "wallet" : null,
+          "display_brand" : "visa",
+          "exp_month" : 12,
+          "exp_year" : 2030,
+          "country" : "US"
+        },
+        "livemode" : false,
+        "created" : 1756999035,
+        "allow_redisplay" : "unspecified",
+        "type" : "card",
+        "customer" : "cus_SzeCHemxoXJzje"
+      }
+    ],
+    "payment_methods_with_link_details" : [
+      {
+        "payment_method" : {
+          "object" : "payment_method",
+          "id" : "pm_1S3euVFY0qyl6XeWdNqxWFuk",
+          "billing_details" : {
+            "email" : null,
+            "phone" : null,
+            "tax_id" : null,
+            "name" : null,
+            "address" : {
+              "state" : null,
+              "country" : null,
+              "line2" : null,
+              "city" : null,
+              "line1" : null,
+              "postal_code" : null
+            }
+          },
+          "card" : {
+            "regulated_status" : "unregulated",
+            "last4" : "4242",
+            "funding" : "credit",
+            "generated_from" : null,
+            "networks" : {
+              "available" : [
+                "visa"
+              ],
+              "preferred" : null
+            },
+            "brand" : "visa",
+            "checks" : {
+              "address_postal_code_check" : null,
+              "cvc_check" : null,
+              "address_line1_check" : null
+            },
+            "three_d_secure_usage" : {
+              "supported" : true
+            },
+            "wallet" : null,
+            "display_brand" : "visa",
+            "exp_month" : 12,
+            "exp_year" : 2030,
+            "country" : "US"
+          },
+          "livemode" : false,
+          "created" : 1756999035,
+          "allow_redisplay" : "unspecified",
+          "type" : "card",
+          "customer" : "cus_SzeCHemxoXJzje"
+        },
+        "is_link_origin" : false,
+        "link_payment_details" : null
+      }
+    ],
+    "default_payment_method" : null,
+    "customer_session" : {
+      "object" : "customer_session",
+      "api_key_expiry" : 1757000837,
+      "id" : "cuss_1S3euWFY0qyl6XeWdudjr35t",
+      "livemode" : false,
+      "components" : {
+        "customer_sheet" : {
+          "enabled" : false,
+          "features" : null
+        },
+        "pricing_table" : {
+          "enabled" : false
+        },
+        "mobile_payment_element" : {
+          "enabled" : true,
+          "features" : {
+            "payment_method_save_allow_redisplay_override" : null,
+            "payment_method_redisplay" : "enabled",
+            "payment_method_save" : "enabled",
+            "payment_method_set_as_default" : "disabled",
+            "payment_method_allow_redisplay_filters" : [
+              "unspecified",
+              "limited",
+              "always"
+            ],
+            "payment_method_remove" : "enabled",
+            "payment_method_remove_last" : "enabled"
+          }
+        },
+        "payment_element" : {
+          "enabled" : false,
+          "features" : null
+        },
+        "buy_button" : {
+          "enabled" : false
+        }
+      },
+      "customer" : "cus_SzeCHemxoXJzje",
+      "api_key" : "ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLHhiWHpWVzlET1VlRUxlWVcxOEEyVmR4VHZaNnhFTmk_00MZEY7g5p"
+    }
+  },
+  "klarna_express_config" : {
+    "klarna_mid" : null
+  },
+  "lpm_killswitches" : {
+    "express_checkout" : [
+
+    ],
+    "payment_element" : [
+
+    ]
+  },
+  "business_name" : "CI Stuff",
+  "ordered_payment_method_types_and_wallets" : [
+    "card",
+    "apple_pay",
+    "google_pay",
+    "cashapp",
+    "us_bank_account",
+    "amazon_pay"
+  ],
+  "customer_error" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0005_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0005_post_v1_confirmation_tokens.tail
@@ -1,0 +1,88 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=BgkaGBkq9wGH_VR09HVcVxV5n_SANuUYMK2xZ9L3S4cqUVSYgKd5MWLpmsZe-wUKOCHXbDgNzhPjDhfh
+Server: nginx
+Cache-Control: no-cache, no-store
+x-wc: ABGHIJ
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+x-stripe-routing-context-priority-tier: api-testmode
+request-id: req_zL26fMQTXb5f26
+Content-Length: 1443
+Vary: Origin
+Date: Thu, 04 Sep 2025 15:17:17 GMT
+original-request: req_zL26fMQTXb5f26
+stripe-version: 2020-08-27
+idempotency-key: 780cf52b-6fc5-4c7a-8e7f-13ef7929ea87
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: payment_method=pm_1S3euVFY0qyl6XeWdNqxWFuk&return_url=https%3A\/\/example\.com\/return&setup_future_usage=off_session
+
+{
+  "id" : "ctoken_1S3euXFY0qyl6XeWs8gXLJrE",
+  "setup_intent" : null,
+  "livemode" : false,
+  "shipping" : null,
+  "mandate_data" : null,
+  "expires_at" : 1757042237,
+  "return_url" : "https:\/\/example.com\/return",
+  "setup_future_usage" : "off_session",
+  "object" : "confirmation_token",
+  "payment_method_preview" : {
+    "allow_redisplay" : "unspecified",
+    "billing_details" : {
+      "email" : null,
+      "phone" : null,
+      "tax_id" : null,
+      "name" : null,
+      "address" : {
+        "state" : null,
+        "country" : null,
+        "line2" : null,
+        "city" : null,
+        "line1" : null,
+        "postal_code" : null
+      }
+    },
+    "customer" : "cus_SzeCHemxoXJzje",
+    "card" : {
+      "regulated_status" : "unregulated",
+      "fingerprint" : "96sroMqLCHmUdUpL",
+      "last4" : "4242",
+      "funding" : "credit",
+      "generated_from" : null,
+      "networks" : {
+        "available" : [
+          "visa"
+        ],
+        "preferred" : null
+      },
+      "brand" : "visa",
+      "checks" : {
+        "address_postal_code_check" : null,
+        "cvc_check" : null,
+        "address_line1_check" : null
+      },
+      "three_d_secure_usage" : {
+        "supported" : true
+      },
+      "wallet" : null,
+      "display_brand" : "visa",
+      "exp_month" : 12,
+      "exp_year" : 2030,
+      "country" : "US"
+    },
+    "type" : "card"
+  },
+  "created" : 1756999037,
+  "payment_intent" : null,
+  "use_stripe_sdk" : true,
+  "payment_method_options" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0006_post_v1_elements_payment_methods_pm_1S3euVFY0qyl6XeWdNqxWFuk_detach.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0006_post_v1_elements_payment_methods_pm_1S3euVFY0qyl6XeWdNqxWFuk_detach.tail
@@ -1,0 +1,77 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/elements\/payment_methods\/pm_1S3euVFY0qyl6XeWdNqxWFuk\/detach$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=M3wkePSpCSn9ZJOJgZsdhffmFSDs38pq0m747b63lmLoU7hXSohdpHA2xmwmbAusWQ-B0JCBo_CJMzYI
+Server: nginx
+Cache-Control: no-cache, no-store
+x-wc: ABGHIJ
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+x-stripe-routing-context-priority-tier: api-testmode
+request-id: req_NUFlwiT1CfbkYh
+Content-Length: 1030
+Vary: Origin
+Date: Thu, 04 Sep 2025 15:17:18 GMT
+original-request: req_NUFlwiT1CfbkYh
+stripe-version: 2020-08-27
+idempotency-key: 0cf44b08-cab1-4e4b-aa88-a8f9d50a5736
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: customer_session_client_secret=cuss_secret_SzeCnfmGV3FvAmrGAMF2m0wj9nXHRHeCHOkEmhnwYqDUlGl
+
+{
+  "object" : "payment_method",
+  "id" : "pm_1S3euVFY0qyl6XeWdNqxWFuk",
+  "billing_details" : {
+    "email" : null,
+    "phone" : null,
+    "tax_id" : null,
+    "name" : null,
+    "address" : {
+      "state" : null,
+      "country" : null,
+      "line2" : null,
+      "city" : null,
+      "line1" : null,
+      "postal_code" : null
+    }
+  },
+  "card" : {
+    "regulated_status" : "unregulated",
+    "fingerprint" : "96sroMqLCHmUdUpL",
+    "last4" : "4242",
+    "funding" : "credit",
+    "generated_from" : null,
+    "networks" : {
+      "available" : [
+        "visa"
+      ],
+      "preferred" : null
+    },
+    "brand" : "visa",
+    "checks" : {
+      "address_postal_code_check" : null,
+      "cvc_check" : null,
+      "address_line1_check" : null
+    },
+    "three_d_secure_usage" : {
+      "supported" : true
+    },
+    "wallet" : null,
+    "display_brand" : "visa",
+    "exp_month" : 12,
+    "exp_year" : 2030,
+    "country" : "US"
+  },
+  "livemode" : false,
+  "created" : 1756999035,
+  "allow_redisplay" : "unspecified",
+  "type" : "card",
+  "customer" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithExistingPaymentMethod/0000_post_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithExistingPaymentMethod/0000_post_v1_payment_methods.tail
@@ -1,0 +1,76 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_methods$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=R0_0tqCg-WrH3pQKcC5UMol8CAvAASajedZ3KoPKN9hx1tZq4dca5J_yWxcEPVbiAKdNVhZB37Nl7vna
+Server: nginx
+Cache-Control: no-cache, no-store
+x-wc: ABGHIJ
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+x-stripe-routing-context-priority-tier: api-testmode
+request-id: req_T9EhNozfwGJ2X2
+Content-Length: 991
+Vary: Origin
+Date: Thu, 04 Sep 2025 15:17:18 GMT
+original-request: req_T9EhNozfwGJ2X2
+stripe-version: 2020-08-27
+idempotency-key: 03325602-29c4-447c-9a89-707c340ee257
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: allow_redisplay=unspecified&card\[cvc]=123&card\[exp_month]=12&card\[exp_year]=2030&card\[number]=4242424242424242&guid=.*&muid=.*&payment_user_agent=.*&sid=.*&type=card
+
+{
+  "object" : "payment_method",
+  "id" : "pm_1S3euYFY0qyl6XeW82VPaAwV",
+  "billing_details" : {
+    "email" : null,
+    "phone" : null,
+    "tax_id" : null,
+    "name" : null,
+    "address" : {
+      "state" : null,
+      "country" : null,
+      "line2" : null,
+      "city" : null,
+      "line1" : null,
+      "postal_code" : null
+    }
+  },
+  "card" : {
+    "regulated_status" : "unregulated",
+    "last4" : "4242",
+    "funding" : "credit",
+    "generated_from" : null,
+    "networks" : {
+      "available" : [
+        "visa"
+      ],
+      "preferred" : null
+    },
+    "brand" : "visa",
+    "checks" : {
+      "address_postal_code_check" : null,
+      "cvc_check" : null,
+      "address_line1_check" : null
+    },
+    "three_d_secure_usage" : {
+      "supported" : true
+    },
+    "wallet" : null,
+    "display_brand" : "visa",
+    "exp_month" : 12,
+    "exp_year" : 2030,
+    "country" : "US"
+  },
+  "livemode" : false,
+  "created" : 1756999038,
+  "allow_redisplay" : "unspecified",
+  "type" : "card",
+  "customer" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithExistingPaymentMethod/0001_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithExistingPaymentMethod/0001_post_v1_confirmation_tokens.tail
@@ -1,0 +1,86 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=eHOa8xH8IB8auXby-3yMjrvbPA0zYr0__MqA4IuYHOsAorqcXu8pzZP53U68iAZ9NIxT2SY--3-PuTU1
+Server: nginx
+Cache-Control: no-cache, no-store
+x-wc: ABGHIJ
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+x-stripe-routing-context-priority-tier: api-testmode
+request-id: req_bQbJercLyQBQbN
+Content-Length: 1353
+Vary: Origin
+Date: Thu, 04 Sep 2025 15:17:18 GMT
+original-request: req_bQbJercLyQBQbN
+stripe-version: 2020-08-27
+idempotency-key: dacb2113-df8a-4c6e-bb02-e333591af146
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: payment_method=pm_1S3euYFY0qyl6XeW82VPaAwV&return_url=https%3A\/\/example\.com\/return
+
+{
+  "id" : "ctoken_1S3euYFY0qyl6XeWzUs1m9QS",
+  "setup_intent" : null,
+  "livemode" : false,
+  "shipping" : null,
+  "expires_at" : 1757042238,
+  "return_url" : "https:\/\/example.com\/return",
+  "setup_future_usage" : null,
+  "object" : "confirmation_token",
+  "payment_method_preview" : {
+    "allow_redisplay" : "unspecified",
+    "billing_details" : {
+      "email" : null,
+      "phone" : null,
+      "tax_id" : null,
+      "name" : null,
+      "address" : {
+        "state" : null,
+        "country" : null,
+        "line2" : null,
+        "city" : null,
+        "line1" : null,
+        "postal_code" : null
+      }
+    },
+    "customer" : null,
+    "card" : {
+      "regulated_status" : "unregulated",
+      "last4" : "4242",
+      "funding" : "credit",
+      "generated_from" : null,
+      "networks" : {
+        "available" : [
+          "visa"
+        ],
+        "preferred" : null
+      },
+      "brand" : "visa",
+      "checks" : {
+        "address_postal_code_check" : null,
+        "cvc_check" : null,
+        "address_line1_check" : null
+      },
+      "three_d_secure_usage" : {
+        "supported" : true
+      },
+      "wallet" : null,
+      "display_brand" : "visa",
+      "exp_month" : 12,
+      "exp_year" : 2030,
+      "country" : "US"
+    },
+    "type" : "card"
+  },
+  "created" : 1756999038,
+  "payment_intent" : null,
+  "use_stripe_sdk" : true,
+  "payment_method_options" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithInvalidCard/0000_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithInvalidCard/0000_post_v1_confirmation_tokens.tail
@@ -1,0 +1,86 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=JxKphkQcyNKTYhPC5SkciU_hcIAc3hv4raw_70rtClpBzh6veq65RKqkvcXWZj-gm3MZhyZESTGCRQEU
+Server: nginx
+Cache-Control: no-cache, no-store
+x-wc: ABGHIJ
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+x-stripe-routing-context-priority-tier: api-testmode
+request-id: req_60BVVAmYolu0Tg
+Content-Length: 1353
+Vary: Origin
+Date: Thu, 04 Sep 2025 15:17:19 GMT
+original-request: req_60BVVAmYolu0Tg
+stripe-version: 2020-08-27
+idempotency-key: 38fc86c5-003b-4e7a-8901-4c45edceb0e9
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[card]\[cvc]=123&payment_method_data\[card]\[exp_month]=12&payment_method_data\[card]\[exp_year]=2030&payment_method_data\[card]\[number]=4000000000000002&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sid]=.*&payment_method_data\[type]=card&return_url=https%3A\/\/example\.com\/return
+
+{
+  "id" : "ctoken_1S3euZFY0qyl6XeWfD0JD2nv",
+  "setup_intent" : null,
+  "livemode" : false,
+  "shipping" : null,
+  "expires_at" : 1757042239,
+  "return_url" : "https:\/\/example.com\/return",
+  "setup_future_usage" : null,
+  "object" : "confirmation_token",
+  "payment_method_preview" : {
+    "allow_redisplay" : "unspecified",
+    "billing_details" : {
+      "email" : null,
+      "phone" : null,
+      "tax_id" : null,
+      "name" : null,
+      "address" : {
+        "state" : null,
+        "country" : null,
+        "line2" : null,
+        "city" : null,
+        "line1" : null,
+        "postal_code" : null
+      }
+    },
+    "customer" : null,
+    "card" : {
+      "regulated_status" : "unregulated",
+      "last4" : "0002",
+      "funding" : "credit",
+      "generated_from" : null,
+      "networks" : {
+        "available" : [
+          "visa"
+        ],
+        "preferred" : null
+      },
+      "brand" : "visa",
+      "checks" : {
+        "address_postal_code_check" : null,
+        "cvc_check" : null,
+        "address_line1_check" : null
+      },
+      "three_d_secure_usage" : {
+        "supported" : true
+      },
+      "wallet" : null,
+      "display_brand" : "visa",
+      "exp_month" : 12,
+      "exp_year" : 2030,
+      "country" : "US"
+    },
+    "type" : "card"
+  },
+  "created" : 1756999039,
+  "payment_intent" : null,
+  "use_stripe_sdk" : true,
+  "payment_method_options" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithPaymentMethodData/0000_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithPaymentMethodData/0000_post_v1_confirmation_tokens.tail
@@ -1,0 +1,86 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=R0_0tqCg-WrH3pQKcC5UMol8CAvAASajedZ3KoPKN9hx1tZq4dca5J_yWxcEPVbiAKdNVhZB37Nl7vna
+Server: nginx
+Cache-Control: no-cache, no-store
+x-wc: ABGHIJ
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+x-stripe-routing-context-priority-tier: api-testmode
+request-id: req_N4SRzJJQnxyCSY
+Content-Length: 1353
+Vary: Origin
+Date: Thu, 04 Sep 2025 15:17:19 GMT
+original-request: req_N4SRzJJQnxyCSY
+stripe-version: 2020-08-27
+idempotency-key: b0765b21-87f2-4045-905d-7928633b17ae
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[card]\[cvc]=123&payment_method_data\[card]\[exp_month]=12&payment_method_data\[card]\[exp_year]=2030&payment_method_data\[card]\[number]=4242424242424242&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sid]=.*&payment_method_data\[type]=card&return_url=https%3A\/\/example\.com\/return
+
+{
+  "id" : "ctoken_1S3euZFY0qyl6XeWXydkUJEa",
+  "setup_intent" : null,
+  "livemode" : false,
+  "shipping" : null,
+  "expires_at" : 1757042239,
+  "return_url" : "https:\/\/example.com\/return",
+  "setup_future_usage" : null,
+  "object" : "confirmation_token",
+  "payment_method_preview" : {
+    "allow_redisplay" : "unspecified",
+    "billing_details" : {
+      "email" : null,
+      "phone" : null,
+      "tax_id" : null,
+      "name" : null,
+      "address" : {
+        "state" : null,
+        "country" : null,
+        "line2" : null,
+        "city" : null,
+        "line1" : null,
+        "postal_code" : null
+      }
+    },
+    "customer" : null,
+    "card" : {
+      "regulated_status" : "unregulated",
+      "last4" : "4242",
+      "funding" : "credit",
+      "generated_from" : null,
+      "networks" : {
+        "available" : [
+          "visa"
+        ],
+        "preferred" : null
+      },
+      "brand" : "visa",
+      "checks" : {
+        "address_postal_code_check" : null,
+        "cvc_check" : null,
+        "address_line1_check" : null
+      },
+      "three_d_secure_usage" : {
+        "supported" : true
+      },
+      "wallet" : null,
+      "display_brand" : "visa",
+      "exp_month" : 12,
+      "exp_year" : 2030,
+      "country" : "US"
+    },
+    "type" : "card"
+  },
+  "created" : 1756999039,
+  "payment_intent" : null,
+  "use_stripe_sdk" : true,
+  "payment_method_options" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithSetAsDefaultPaymentMethod/0000_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithSetAsDefaultPaymentMethod/0000_post_v1_confirmation_tokens.tail
@@ -1,0 +1,86 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=eHOa8xH8IB8auXby-3yMjrvbPA0zYr0__MqA4IuYHOsAorqcXu8pzZP53U68iAZ9NIxT2SY--3-PuTU1
+Server: nginx
+Cache-Control: no-cache, no-store
+x-wc: ABGHIJ
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+x-stripe-routing-context-priority-tier: api-testmode
+request-id: req_Xv5BMoyLYTqK7M
+Content-Length: 1362
+Vary: Origin
+Date: Thu, 04 Sep 2025 15:17:20 GMT
+original-request: req_Xv5BMoyLYTqK7M
+stripe-version: 2020-08-27
+idempotency-key: fef5d81a-20e9-46ca-97fb-e734b4e5f775
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[card]\[cvc]=123&payment_method_data\[card]\[exp_month]=12&payment_method_data\[card]\[exp_year]=2030&payment_method_data\[card]\[number]=4242424242424242&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sid]=.*&payment_method_data\[type]=card&return_url=https%3A\/\/example\.com\/return&set_as_default_payment_method=true&setup_future_usage=off_session
+
+{
+  "id" : "ctoken_1S3euaFY0qyl6XeWpSWhx3p9",
+  "setup_intent" : null,
+  "livemode" : false,
+  "shipping" : null,
+  "expires_at" : 1757042240,
+  "return_url" : "https:\/\/example.com\/return",
+  "setup_future_usage" : "off_session",
+  "object" : "confirmation_token",
+  "payment_method_preview" : {
+    "allow_redisplay" : "unspecified",
+    "billing_details" : {
+      "email" : null,
+      "phone" : null,
+      "tax_id" : null,
+      "name" : null,
+      "address" : {
+        "state" : null,
+        "country" : null,
+        "line2" : null,
+        "city" : null,
+        "line1" : null,
+        "postal_code" : null
+      }
+    },
+    "customer" : null,
+    "card" : {
+      "regulated_status" : "unregulated",
+      "last4" : "4242",
+      "funding" : "credit",
+      "generated_from" : null,
+      "networks" : {
+        "available" : [
+          "visa"
+        ],
+        "preferred" : null
+      },
+      "brand" : "visa",
+      "checks" : {
+        "address_postal_code_check" : null,
+        "cvc_check" : null,
+        "address_line1_check" : null
+      },
+      "three_d_secure_usage" : {
+        "supported" : true
+      },
+      "wallet" : null,
+      "display_brand" : "visa",
+      "exp_month" : 12,
+      "exp_year" : 2030,
+      "country" : "US"
+    },
+    "type" : "card"
+  },
+  "created" : 1756999040,
+  "payment_intent" : null,
+  "use_stripe_sdk" : true,
+  "payment_method_options" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithShippingAndMandateData/0000_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithShippingAndMandateData/0000_post_v1_confirmation_tokens.tail
@@ -1,0 +1,82 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=eHOa8xH8IB8auXby-3yMjrvbPA0zYr0__MqA4IuYHOsAorqcXu8pzZP53U68iAZ9NIxT2SY--3-PuTU1
+Server: nginx
+Cache-Control: no-cache, no-store
+x-wc: ABGHIJ
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+x-stripe-routing-context-priority-tier: api-testmode
+request-id: req_NxRTUYvKO61ZhN
+Content-Length: 1284
+Vary: Origin
+Date: Thu, 04 Sep 2025 15:17:20 GMT
+original-request: req_NxRTUYvKO61ZhN
+stripe-version: 2020-08-27
+idempotency-key: 08321877-e798-4b80-89de-b1850abbdb37
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: mandate_data\[customer_acceptance]\[online]\[infer_from_client]=true&mandate_data\[customer_acceptance]\[type]=online&payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[billing_details]\[email]=jenny%40example\.com&payment_method_data\[billing_details]\[name]=Jenny%20Rosen&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sepa_debit]\[iban]=DE89370400440532013000&payment_method_data\[sid]=.*&payment_method_data\[type]=sepa_debit&return_url=https%3A\/\/example\.com\/return&setup_future_usage=off_session&shipping\[address]\[city]=San%20Francisco&shipping\[address]\[country]=US&shipping\[address]\[line1]=123%20Main%20St&shipping\[address]\[postal_code]=94111&shipping\[address]\[state]=CA&shipping\[name]=Test%20Customer
+
+{
+  "id" : "ctoken_1S3euaFY0qyl6XeWMSnBJPJP",
+  "setup_intent" : null,
+  "livemode" : false,
+  "shipping" : {
+    "address" : {
+      "state" : "CA",
+      "country" : "US",
+      "line2" : null,
+      "city" : "San Francisco",
+      "line1" : "123 Main St",
+      "postal_code" : "94111"
+    },
+    "name" : "Test Customer",
+    "phone" : null
+  },
+  "expires_at" : 1757042240,
+  "return_url" : "https:\/\/example.com\/return",
+  "setup_future_usage" : "off_session",
+  "object" : "confirmation_token",
+  "payment_method_preview" : {
+    "allow_redisplay" : "unspecified",
+    "billing_details" : {
+      "email" : "jenny@example.com",
+      "phone" : null,
+      "tax_id" : null,
+      "name" : "Jenny Rosen",
+      "address" : {
+        "state" : null,
+        "country" : null,
+        "line2" : null,
+        "city" : null,
+        "line1" : null,
+        "postal_code" : null
+      }
+    },
+    "customer" : null,
+    "sepa_debit" : {
+      "fingerprint" : "vifs0Ho7vwRn1Miu",
+      "country" : "DE",
+      "last4" : "3000",
+      "bank_code" : "37040044",
+      "generated_from" : {
+        "setup_attempt" : null,
+        "charge" : null
+      },
+      "branch_code" : ""
+    },
+    "type" : "sepa_debit"
+  },
+  "created" : 1756999040,
+  "payment_intent" : null,
+  "use_stripe_sdk" : true,
+  "payment_method_options" : null
+}


### PR DESCRIPTION
## Summary
- We use the STPConfirmationTokenParams to hit the create confirmation token endpoint to actually create a confirmation token
- We decode the ConfirmationToken and verify it was created successfully
- In a following PR we will decode the entire ConfirmationToken and verify it's contents, but for now we just stub out some basic properties until API review is complete.

## Motivation
- https://www.google.com/url?sa=t&rct=j&esrc=s&source=appssearch&uact=8&cd=0&cad=rja&q&sig2=ez0WcCo2ZR2WgsVrrFL-Hw&ved=0ahUKEwjQxs_gv7CPAxUthYoHHV9_J9Q4ABABKAAwAA&url=https://drive.google.com/a/stripe.com/open?id%3D1v8r8ARfsTcc61wUjgvPGNJhsDncTqxupTI5sHAkv9xQ&usg=AOvVaw0Xl_m2-p5dhDtAQBfwCS5F

## Testing
- New unit tests

## Changelog
N/A