### PR TITLE
Allow re-showing Link inline signup in test mode

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -108,7 +108,12 @@ class PaymentSheetFormFactory {
             }
 
             let isAccountNotRegisteredOrMissing = linkAccount.flatMap({ !$0.isRegistered }) ?? true
-            return isAccountNotRegisteredOrMissing && !UserDefaults.standard.customerHasUsedLink
+
+            // In live mode, we only show signup if the customer hasn't used Link in the merchant app before.
+            // In test mode, we continue to show it to make testing easier.
+            let canShowSignup = !UserDefaults.standard.customerHasUsedLink || configuration.apiClient.isTestmode
+
+            return isAccountNotRegisteredOrMissing && canShowSignup
         }()
         let paymentMethodType: STPPaymentMethodType = {
             if linkAccount != nil, configuration.linkPaymentMethodsOnly, !elementsSession.linkPassthroughModeEnabled {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request updates the logic for showing the Link inline signup. While we continue to hide the signup after a user has successfully used Link, we now continue to show it if the user is in test mode. This is intended to cause less confusion with merchants during integration and make testing easier.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
