### PR TITLE
Update appearance API, move ios26 changes to toplevel config, reset appearance when switching

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlayground.swift
@@ -77,7 +77,6 @@ struct CustomerSheetTestPlayground: View {
                         SettingView(setting: $playgroundController.settings.defaultBillingAddress)
                         SettingView(setting: $playgroundController.settings.preferredNetworksEnabled)
                         SettingView(setting: $playgroundController.settings.cardBrandAcceptance)
-                        SettingView(setting: enableiOS26ChangesBinding)
                         SettingView(setting: $playgroundController.settings.autoreload)
                         TextField("headerTextForSelectionScreen", text: headerTextForSelectionScreenBinding)
                         SettingView(setting: $playgroundController.settings.allowsRemovalOfLastSavedPaymentMethod)
@@ -112,15 +111,6 @@ struct CustomerSheetTestPlayground: View {
             Divider()
             CustomerSheetButtons()
                 .environmentObject(playgroundController)
-        }
-    }
-    var enableiOS26ChangesBinding: Binding<CustomerSheetTestPlaygroundSettings.EnableIOS26Changes> {
-        Binding<CustomerSheetTestPlaygroundSettings.EnableIOS26Changes> {
-            return playgroundController.settings.enableIOS26Changes
-        } set: { newValue in
-            LiquidGlassDetector.allowNewDesign = newValue == .on
-            playgroundController.appearance = PaymentSheet.Appearance()
-            playgroundController.settings.enableIOS26Changes = newValue
         }
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundSettings.swift
@@ -155,13 +155,6 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
         case allowVisa
     }
 
-    enum EnableIOS26Changes: String, PickerEnum {
-        static var enumName: String { "Enable iOS26 changes" }
-
-        case on
-        case off
-    }
-
     enum OpensCardScannerAutomatically: String, PickerEnum {
         static let enumName: String = "opensCardScannerAutomatically"
         case on
@@ -175,7 +168,6 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
     var applePay: ApplePay
     var headerTextForSelectionScreen: String?
     var defaultBillingAddress: DefaultBillingAddress
-    var enableIOS26Changes: EnableIOS26Changes
     var autoreload: Autoreload
 
     var attachDefaults: BillingDetailsAttachDefaults
@@ -201,7 +193,6 @@ public struct CustomerSheetTestPlaygroundSettings: Codable, Equatable {
                                                    applePay: .on,
                                                    headerTextForSelectionScreen: nil,
                                                    defaultBillingAddress: .off,
-                                                   enableIOS26Changes: .off,
                                                    autoreload: .on,
                                                    attachDefaults: .off,
                                                    collectName: .automatic,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
@@ -46,6 +46,7 @@ struct PaymentSheetExampleAppRootView: View {
     }
 
     private func oniOS26Enabled(_ isEnabled: Bool) {
+        PlaygroundController.clearAppearanceFromDefaults()
         PaymentSheet.Appearance.liquidGlassDesignEnabled = isEnabled
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct PaymentSheetExampleAppRootView: View {
-    @State private var isIOS26FeatureEnabled = false
+    @State private var isLiquidGlassAllowed = false
 
     private var destinationsBySection: [Section: [NavigationDestination]] {
         NavigationDestination.destinationsBySection
@@ -19,11 +19,11 @@ struct PaymentSheetExampleAppRootView: View {
             Form {
                 SwiftUI.Section("iOS 26 Features") {
                     HStack {
-                        Text("Enabled")
+                        Text("isAllowed")
                         Spacer()
-                        Toggle("", isOn: $isIOS26FeatureEnabled)
-                            .onChange(of: isIOS26FeatureEnabled) { isEnabled in
-                                oniOS26Enabled(isEnabled)
+                        Toggle("", isOn: $isLiquidGlassAllowed)
+                            .onChange(of: isLiquidGlassAllowed) { isAllowed in
+                                onIsLiquidGlassAllowedChange(isAllowed)
                             }
                     }
                 }
@@ -45,9 +45,9 @@ struct PaymentSheetExampleAppRootView: View {
         .navigationBarTitleDisplayMode(.inline)
     }
 
-    private func oniOS26Enabled(_ isEnabled: Bool) {
+    private func onIsLiquidGlassAllowedChange(_ isAllowed: Bool) {
         PlaygroundController.clearAppearanceFromDefaults()
-        PaymentSheet.Appearance.liquidGlassDesignEnabled = isEnabled
+        PaymentSheet.Appearance.isLiquidGlassAllowed = isAllowed
     }
 
     enum Section: String, CaseIterable {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
@@ -8,6 +8,8 @@ import SwiftUI
 
 @available(iOS 15.0, *)
 struct PaymentSheetExampleAppRootView: View {
+    @State private var isIOS26FeatureEnabled = false
+
     private var destinationsBySection: [Section: [NavigationDestination]] {
         NavigationDestination.destinationsBySection
     }
@@ -15,6 +17,16 @@ struct PaymentSheetExampleAppRootView: View {
     var body: some View {
         NavigationView {
             Form {
+                SwiftUI.Section("iOS 26 Features") {
+                    HStack {
+                        Text("Enabled")
+                        Spacer()
+                        Toggle("", isOn: $isIOS26FeatureEnabled)
+                            .onChange(of: isIOS26FeatureEnabled) { isEnabled in
+                                oniOS26Enabled(isEnabled)
+                            }
+                    }
+                }
                 ForEach(Section.allCases, id: \.self) { section in
                     SwiftUI.Section(section.rawValue) {
                         ForEach(destinationsBySection[section] ?? [], id: \.self) { destination in
@@ -31,6 +43,10 @@ struct PaymentSheetExampleAppRootView: View {
         }
         .navigationTitle("Examples")
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func oniOS26Enabled(_ isEnabled: Bool) {
+        PaymentSheet.Appearance.liquidGlassDesignEnabled = isEnabled
     }
 
     enum Section: String, CaseIterable {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
@@ -3,7 +3,7 @@
 //  PaymentSheet Example
 //
 
-import StripePaymentSheet
+@_spi(STP) import StripePaymentSheet
 import SwiftUI
 
 @available(iOS 15.0, *)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -41,7 +41,6 @@ struct PaymentSheetTestPlayground: View {
                 .autocorrectionDisabled()
                 .textInputAutocapitalization(.never)
         }
-        SettingView(setting: enableIos26Binding)
         Group {
             if playgroundController.settings.merchantCountryCode == .US {
                 SettingView(setting: linkEnabledModeBinding)
@@ -308,15 +307,6 @@ struct PaymentSheetTestPlayground: View {
                 playgroundController.settings.uiStyle = .paymentSheet
             }
             playgroundController.settings.integrationType = newIntegrationType
-        }
-    }
-    var enableIos26Binding: Binding<PaymentSheetTestPlaygroundSettings.EnableIOS26Changes> {
-        Binding<PaymentSheetTestPlaygroundSettings.EnableIOS26Changes> {
-            return playgroundController.settings.enableIOS26Changes
-        } set: { newValue in
-            LiquidGlassDetector.allowNewDesign = newValue == .on
-            playgroundController.appearance = PaymentSheet.Appearance()
-            playgroundController.settings.enableIOS26Changes = newValue
         }
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -299,12 +299,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case on
         case off
     }
-    enum EnableIOS26Changes: String, PickerEnum {
-        static var enumName: String { "Enable iOS26 changes" }
 
-        case on
-        case off
-    }
     enum PaymentMethodSave: String, PickerEnum {
         static var enumName: String { "PaymentMethodSave" }
 
@@ -671,7 +666,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var applePayEnabled: ApplePayEnabled
     var applePayButtonType: ApplePayButtonType
     var allowsDelayedPMs: AllowsDelayedPMs
-    var enableIOS26Changes: EnableIOS26Changes
     var paymentMethodSave: PaymentMethodSave
     var allowRedisplayOverride: AllowRedisplayOverride
     var paymentMethodRemove: PaymentMethodRemove
@@ -729,7 +723,6 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             applePayEnabled: .on,
             applePayButtonType: .buy,
             allowsDelayedPMs: .on,
-            enableIOS26Changes: .off,
             paymentMethodSave: .enabled,
             allowRedisplayOverride: .notSet,
             paymentMethodRemove: .enabled,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -1091,6 +1091,9 @@ extension PlaygroundController {
         }
         return nil
     }
+    static func clearAppearanceFromDefaults() {
+        UserDefaults.standard.removeObject(forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsAppearanceKey)
+    }
 
     func loadLastSavedCustomer() {
         if let customerIdData = UserDefaults.standard.value(forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsCustomerIDKey) as? Data {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -518,7 +518,7 @@ class PlaygroundController: ObservableObject {
     var customerSessionClientSecret: String?
     var paymentMethodTypes: [String]?
     var addressViewController: AddressViewController?
-    var appearance = PaymentSheet.Appearance.default
+    var appearance: PaymentSheet.Appearance
     var currentDataTask: URLSessionDataTask?
 
     var checkoutEndpoint: String {
@@ -1053,11 +1053,7 @@ extension PlaygroundController: STPAnalyticsClientDelegate {
 
 extension PlaygroundController {
     func serializeSettingsToNSUserDefaults() {
-        // Never save changes for iOS26 since we have to set allowNewDesign based on a flag that isn't ready during boot time.
-        var settingsWithoutiOS26 = settings
-        settingsWithoutiOS26.enableIOS26Changes = .off
-
-        let settingsData = try! JSONEncoder().encode(settingsWithoutiOS26)
+        let settingsData = try! JSONEncoder().encode(settings)
         UserDefaults.standard.set(settingsData, forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsKey)
 
         if let customerId {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITest.swift
@@ -1035,6 +1035,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
 
     func testSwiftUI() throws {
         app.launch()
+        app.swipeUp() // EmbeddedPaymentElement (SwiftUI)
         XCTAssertTrue(app.staticTexts["EmbeddedPaymentElement (SwiftUI)"].waitForExistenceAndTap())
 
         app.buttons["Card"].waitForExistenceAndTap(timeout: 10)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -225,7 +225,7 @@ extension PaymentMethodTypeCollectionView {
                 return ShadowedRoundedRectangle(appearance: appearance)
             }
             #else
-            return ShadowedRoundedRectangle(appearance: appearance)
+                return ShadowedRoundedRectangle(appearance: appearance)
             #endif
         }()
         lazy var paymentMethodLogoWidthConstraint: NSLayoutConstraint = {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -216,18 +216,33 @@ extension PaymentMethodTypeCollectionView {
         private lazy var promoBadge: PromoBadgeView = {
             PromoBadgeView(appearance: appearance, tinyMode: true)
         }()
-        private lazy var selectableRectangle: SelectableRectangle = {
+
+        // Store liquidGlassRectangle and shadowedRoundedRectangle separately because
+        // instances of PaymentTypeCell can stick around when turning on/off Appearance.liquidGlassDesignEnabled
+        // To repro issue: Launch PS with Appearance.liquidGlassDesignEnabled == true, then launch with
+        //                 Appearance.liquidGlassDesignEnabled == false
+        private lazy var _liquidGlassRectangle: SelectableRectangle = {
+            if #available(iOS 26.0, *) {
+                return LiquidGlassRectangle(appearance: appearance, isCapsule: false)
+            }
+            return _shadowedRoundedRectangle
+        }()
+        private lazy var _shadowedRoundedRectangle: SelectableRectangle = {
+            return ShadowedRoundedRectangle(appearance: appearance)
+        }()
+
+        private var selectableRectangle: SelectableRectangle {
             #if !os(visionOS)
             if #available(iOS 26.0, *),
                LiquidGlassDetector.isEnabled {
-                return LiquidGlassRectangle(appearance: appearance, isCapsule: false)
+                return _liquidGlassRectangle
             } else {
-                return ShadowedRoundedRectangle(appearance: appearance)
+                return _shadowedRoundedRectangle
             }
             #else
-                return ShadowedRoundedRectangle(appearance: appearance)
+            return _shadowedRoundedRectangle
             #endif
-        }()
+        }
         lazy var paymentMethodLogoWidthConstraint: NSLayoutConstraint = {
             paymentMethodLogo.widthAnchor.constraint(equalToConstant: 0)
         }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -218,9 +218,9 @@ extension PaymentMethodTypeCollectionView {
         }()
 
         // Store liquidGlassRectangle and shadowedRoundedRectangle separately because
-        // instances of PaymentTypeCell can stick around when turning on/off Appearance.liquidGlassDesignEnabled
-        // To repro issue: Launch PS with Appearance.liquidGlassDesignEnabled == true, then launch with
-        //                 Appearance.liquidGlassDesignEnabled == false
+        // instances of PaymentTypeCell can stick around when turning on/off Appearance.isLiquidGlassAllowed
+        // To repro issue: Launch PS with Appearance.isLiquidGlassAllowed == true, then launch with
+        //                 Appearance.isLiquidGlassAllowed == false
         private lazy var _liquidGlassRectangle: SelectableRectangle = {
             #if !os(visionOS)
             if #available(iOS 26.0, *) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -216,37 +216,18 @@ extension PaymentMethodTypeCollectionView {
         private lazy var promoBadge: PromoBadgeView = {
             PromoBadgeView(appearance: appearance, tinyMode: true)
         }()
-
-        // Store liquidGlassRectangle and shadowedRoundedRectangle separately because
-        // instances of PaymentTypeCell can stick around when turning on/off Appearance.isLiquidGlassAllowed
-        // To repro issue: Launch PS with Appearance.isLiquidGlassAllowed == true, then launch with
-        //                 Appearance.isLiquidGlassAllowed == false
-        private lazy var _liquidGlassRectangle: SelectableRectangle = {
-            #if !os(visionOS)
-            if #available(iOS 26.0, *) {
-                return LiquidGlassRectangle(appearance: appearance, isCapsule: false)
-            }
-            return _shadowedRoundedRectangle
-            #else
-            return _shadowedRoundedRectangle
-            #endif
-        }()
-        private lazy var _shadowedRoundedRectangle: SelectableRectangle = {
-            return ShadowedRoundedRectangle(appearance: appearance)
-        }()
-
-        private var selectableRectangle: SelectableRectangle {
+        private lazy var selectableRectangle: SelectableRectangle = {
             #if !os(visionOS)
             if #available(iOS 26.0, *),
                LiquidGlassDetector.isEnabled {
-                return _liquidGlassRectangle
+                return LiquidGlassRectangle(appearance: appearance, isCapsule: false)
             } else {
-                return _shadowedRoundedRectangle
+                return ShadowedRoundedRectangle(appearance: appearance)
             }
             #else
-            return _shadowedRoundedRectangle
+            return ShadowedRoundedRectangle(appearance: appearance)
             #endif
-        }
+        }()
         lazy var paymentMethodLogoWidthConstraint: NSLayoutConstraint = {
             paymentMethodLogo.widthAnchor.constraint(equalToConstant: 0)
         }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -222,10 +222,14 @@ extension PaymentMethodTypeCollectionView {
         // To repro issue: Launch PS with Appearance.liquidGlassDesignEnabled == true, then launch with
         //                 Appearance.liquidGlassDesignEnabled == false
         private lazy var _liquidGlassRectangle: SelectableRectangle = {
+            #if !os(visionOS)
             if #available(iOS 26.0, *) {
                 return LiquidGlassRectangle(appearance: appearance, isCapsule: false)
             }
             return _shadowedRoundedRectangle
+            #else
+            return _shadowedRoundedRectangle
+            #endif
         }()
         private lazy var _shadowedRoundedRectangle: SelectableRectangle = {
             return ShadowedRoundedRectangle(appearance: appearance)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
@@ -13,12 +13,9 @@ public extension PaymentSheet {
 
     /// Describes the appearance of PaymentSheet
     struct Appearance: Equatable {
-        /// Determines if the iOS 26 Liquid Glass design is allowed. This changes the navigation bar to be glassy and changes the default values of:
-        /// cornerRadius, borderWidth, shadow, sheetCornerRadius, verticalModeRowPadding, and colors.background
-        /// The default value is `true` on >= iOS 26 when compiling with >= Xcode 26
-        /// - Note: This must be set before initializing `PaymentSheet.Appearance`
-        /// - Note: This is ignored on < iOS 26, < Xcode 26, or if the Info.plist UIDesignRequiresCompatibility is true.
-        @_spi(STP) static public var isLiquidGlassAllowed: Bool {
+        /// Determines if the iOS 26 Liquid Glass design is allowed. Use this to opt-out of the iOS 26 Liquid Glass design by
+        /// setting this to false before initializing `PaymentSheet.Appearance`
+        @_spi(STP) public static var isLiquidGlassAllowed: Bool {
             get {
                 return LiquidGlassDetector.isNewDesignAllowed
             }
@@ -27,8 +24,13 @@ public extension PaymentSheet {
             }
         }
 
-        /// Describes if iOS 26 Liquid Glass has been enabled
-        @_spi(STP) public var isLiquidGlassEnabled: Bool {
+        /// Describes if iOS 26 Liquid Glass has been enabled. When enabled, it changes the navigation bar to be glassy and changes:
+        /// the default values of: cornerRadius, borderWidth, shadow, sheetCornerRadius, verticalModeRowPadding, textFieldInsets
+        /// and colors.background
+        /// The default value is `true` on >= iOS 26 when compiling with >= Xcode 26.
+        /// - Note: To opt-out set isLiquidGlassAllowed to `false` before initializing `PaymentSheet.Appearance`
+        /// - Note: This will be false on < iOS 26, < Xcode 26, or if the Info.plist UIDesignRequiresCompatibility is true.
+        @_spi(STP) public static var isLiquidGlassEnabled: Bool {
             return LiquidGlassDetector.isEnabled
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
@@ -13,20 +13,23 @@ public extension PaymentSheet {
 
     /// Describes the appearance of PaymentSheet
     struct Appearance: Equatable {
-        private static var _liquidGlassDesignEnabled: Bool = false
-
-        @_spi(STP) static public var liquidGlassDesignEnabled: Bool {
+        /// Determines if the iOS 26 Liquid Glass design is allowed. This changes the navigation bar to be glassy and changes the default values of:
+        /// cornerRadius, borderWidth, shadow, sheetCornerRadius, verticalModeRowPadding, and colors.background
+        /// The default value is `true` on >= iOS 26 when compiling with >= Xcode 26
+        /// - Note: This must be set before initializing `PaymentSheet.Appearance`
+        /// - Note: This is ignored on < iOS 26, < Xcode 26, or if the Info.plist UIDesignRequiresCompatibility is true.
+        @_spi(STP) static public var isLiquidGlassAllowed: Bool {
             get {
-                return _liquidGlassDesignEnabled
+                return LiquidGlassDetector.isNewDesignAllowed
             }
             set {
-                if !LiquidGlassDetector.canExecute {
-                    _liquidGlassDesignEnabled = false
-                } else {
-                    LiquidGlassDetector.allowNewDesign = newValue
-                    _liquidGlassDesignEnabled = newValue
-                }
+                LiquidGlassDetector.isNewDesignAllowed = newValue
             }
+        }
+
+        /// Describes if iOS 26 Liquid Glass has been enabled
+        @_spi(STP) public var isLiquidGlassEnabled: Bool {
+            return LiquidGlassDetector.isEnabled
         }
 
         /// The default appearance for PaymentSheet

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
@@ -15,7 +15,7 @@ public extension PaymentSheet {
     struct Appearance: Equatable {
         private static var _liquidGlassDesignEnabled: Bool = false
 
-        static public var liquidGlassDesignEnabled: Bool {
+        @_spi(STP) static public var liquidGlassDesignEnabled: Bool {
             get {
                 return _liquidGlassDesignEnabled
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
@@ -13,8 +13,26 @@ public extension PaymentSheet {
 
     /// Describes the appearance of PaymentSheet
     struct Appearance: Equatable {
+        private static var _liquidGlassDesignEnabled: Bool = true
+
+        static public var liquidGlassDesignEnabled: Bool {
+            get {
+                return _liquidGlassDesignEnabled
+            }
+            set {
+                if !LiquidGlassDetector.canExecute {
+                    _liquidGlassDesignEnabled = false
+                } else {
+                    LiquidGlassDetector.allowNewDesign = newValue
+                    _liquidGlassDesignEnabled = newValue
+                }
+            }
+        }
+
         /// The default appearance for PaymentSheet
-        public static let `default` = Appearance()
+        public static var `default`: Appearance {
+            return Appearance()
+        }
 
         /// Creates a `PaymentSheet.Appearance` with default values
         public init() {}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetAppearance.swift
@@ -13,7 +13,7 @@ public extension PaymentSheet {
 
     /// Describes the appearance of PaymentSheet
     struct Appearance: Equatable {
-        private static var _liquidGlassDesignEnabled: Bool = true
+        private static var _liquidGlassDesignEnabled: Bool = false
 
         static public var liquidGlassDesignEnabled: Bool {
             get {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
@@ -16,7 +16,11 @@ import XCTest
 final class PaymentSheetFlowControllerViewControllerSnapshotTests: STPSnapshotTestCase {
     override func setUp() {
         super.setUp()
-        PaymentSheet.Appearance.liquidGlassDesignEnabled = true
+        if #available(iOS 26.0, *) {
+            PaymentSheet.Appearance.liquidGlassDesignEnabled = true
+        } else {
+            PaymentSheet.Appearance.liquidGlassDesignEnabled = false
+        }
     }
     func makeTestLoadResult(savedPaymentMethods: [STPPaymentMethod]) -> PaymentSheetLoader.LoadResult {
         return .init(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
@@ -17,9 +17,9 @@ final class PaymentSheetFlowControllerViewControllerSnapshotTests: STPSnapshotTe
     override func setUp() {
         super.setUp()
         if #available(iOS 26.0, *) {
-            PaymentSheet.Appearance.liquidGlassDesignEnabled = true
+            PaymentSheet.Appearance.isLiquidGlassAllowed = true
         } else {
-            PaymentSheet.Appearance.liquidGlassDesignEnabled = false
+            PaymentSheet.Appearance.isLiquidGlassAllowed = false
         }
     }
     func makeTestLoadResult(savedPaymentMethods: [STPPaymentMethod]) -> PaymentSheetLoader.LoadResult {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
@@ -14,6 +14,10 @@ import XCTest
 
 // @iOS26
 final class PaymentSheetFlowControllerViewControllerSnapshotTests: STPSnapshotTestCase {
+    override func setUp() {
+        super.setUp()
+        PaymentSheet.Appearance.liquidGlassDesignEnabled = true
+    }
     func makeTestLoadResult(savedPaymentMethods: [STPPaymentMethod]) -> PaymentSheetLoader.LoadResult {
         return .init(
             intent: ._testValue(),

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetSnapshotTests.swift
@@ -35,9 +35,9 @@ class PaymentSheetSnapshotTests: STPSnapshotTestCase {
 //        recordMode = true
 
         if #available(iOS 26.0, *) {
-            PaymentSheet.Appearance.liquidGlassDesignEnabled = true
+            PaymentSheet.Appearance.isLiquidGlassAllowed = true
         } else {
-            PaymentSheet.Appearance.liquidGlassDesignEnabled = false
+            PaymentSheet.Appearance.isLiquidGlassAllowed = false
         }
 
         configuration = PaymentSheet.Configuration()

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetSnapshotTests.swift
@@ -13,7 +13,7 @@ import UIKit
 import XCTest
 
 @_spi(STP)@testable import StripeCore
-@_spi(AppearanceAPIAdditionsPreview) @testable import StripePaymentSheet
+@_spi(AppearanceAPIAdditionsPreview) @_spi(STP) @testable import StripePaymentSheet
 @_spi(STP)@testable import StripeUICore
 
 // @iOS26
@@ -33,6 +33,12 @@ class PaymentSheetSnapshotTests: STPSnapshotTestCase {
     override func setUp() {
         super.setUp()
 //        recordMode = true
+
+        if #available(iOS 26.0, *) {
+            PaymentSheet.Appearance.liquidGlassDesignEnabled = true
+        } else {
+            PaymentSheet.Appearance.liquidGlassDesignEnabled = false
+        }
 
         configuration = PaymentSheet.Configuration()
         configuration.merchantDisplayName = "Example, Inc."

--- a/StripeUICore/StripeUICore/Source/Helpers/LiquidGlassHelpers.swift
+++ b/StripeUICore/StripeUICore/Source/Helpers/LiquidGlassHelpers.swift
@@ -12,8 +12,7 @@ import UIKit
 // Our SDK runs inside a user's app, we can't explicitly opt into or out of the new "Liquid Glass" design.
 // Instead, we'll do our best to detect which design to use, and adjust the default UI spacing and icons accordingly.
 @_spi(STP) public class LiquidGlassDetector {
-    /// A feature flag during development of iOS 26 features, only `true` for testing.
-    @_spi(STP) public static var allowNewDesign: Bool = false
+    @_spi(STP) public static var isNewDesignAllowed: Bool = false // TODO: This will default to `true` when launched
 
     @_spi(STP) public static var canExecute: Bool {
         // If the app was built with Xcode 26 or later (which includes Swift compiler 6.2)...
@@ -32,7 +31,7 @@ import UIKit
     }
 
     @_spi(STP) public static var isEnabled: Bool {
-        return canExecute && allowNewDesign
+        return canExecute && isNewDesignAllowed
     }
 }
 

--- a/StripeUICore/StripeUICore/Source/Helpers/LiquidGlassHelpers.swift
+++ b/StripeUICore/StripeUICore/Source/Helpers/LiquidGlassHelpers.swift
@@ -13,22 +13,15 @@ import UIKit
 // Instead, we'll do our best to detect which design to use, and adjust the default UI spacing and icons accordingly.
 @_spi(STP) public class LiquidGlassDetector {
     /// A feature flag during development of iOS 26 features, only `true` for testing.
-    @_spi(STP) public static var allowNewDesign: Bool = {
-        if NSClassFromString("XCTestCase") != nil {
-            return true
-        }
-        return false
-    }()
-    @_spi(STP) public static var isEnabled: Bool {
+    @_spi(STP) public static var allowNewDesign: Bool = false
+
+    @_spi(STP) public static var canExecute: Bool {
         // If the app was built with Xcode 26 or later (which includes Swift compiler 6.2)...
         #if compiler(>=6.2)
         // And we're running on iOS 26 or later...
         if #available(iOS 26.0, *) {
             // And the app hasn't opted out of the new design...
-            if !(Bundle.main.infoDictionary?["UIDesignRequiresCompatibility"] as? Bool ?? false)
-                // ...and the feature flag is enabled...
-                && allowNewDesign
-            {
+            if !(Bundle.main.infoDictionary?["UIDesignRequiresCompatibility"] as? Bool ?? false) {
                 // Then assume we're using the new design!
                 return true
             }
@@ -36,6 +29,10 @@ import UIKit
         #endif
         // Otherwise, use the old design
         return false
+    }
+
+    @_spi(STP) public static var isEnabled: Bool {
+        return canExecute && allowNewDesign
     }
 }
 


### PR DESCRIPTION
## Summary
* Adds static opt-out flag behind (temporary) spi flag -- so we can merge this week.  Will remove last minute as documented in internal API review.
* Moves ios26 feature flag to appRootView since it is static and spans across PaymentSheet & CustomerSheet

## Motivation
iOS 26 design opt-out capability

## Testing
Relying on existing iOS26 tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
