### PR TITLE
Fix Financial Connections buttons on iOS 26

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/ExampleListViewController.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/ExampleListViewController.swift
@@ -37,7 +37,7 @@ class ExampleListViewController: UITableViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
+        title = "Financial Connections"
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: Constants.cellIdentifier)
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		C747113C75AC92643B283CBD /* close@3x.png in Resources */ = {isa = PBXBuildFile; fileRef = F1C7A2FE53419CB29CBB6C08 /* close@3x.png */; };
 		C7D2763ACCE2CC71E788E18F /* FinancialConnectionsLegalDetailsNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07526E95D85120F6492E78AE /* FinancialConnectionsLegalDetailsNotice.swift */; };
 		C906FC4DE38F16032B787607 /* ResetFlowDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D1C78684DD0B2D168C86229 /* ResetFlowDataSource.swift */; };
+		CB4BCC482E6F168B0066FE9E /* FinancialConnectionsLiquidGlassDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB4BCC472E6F168B0066FE9E /* FinancialConnectionsLiquidGlassDetector.swift */; };
 		CB734C25A19D38A87876FB2B /* FinancialConnectionsAnalyticsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73AB8A480620B5C3567F453C /* FinancialConnectionsAnalyticsTest.swift */; };
 		CBB6227D2D4846670003AF44 /* FinancialConnectionsRepairSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CBB6227C2D4846670003AF44 /* FinancialConnectionsRepairSession.swift */; };
 		CBF7BE2271D309F2B1E794CC /* FinancialConnectionsDataAccessNotice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32ED8A7E94822F14AD94A698 /* FinancialConnectionsDataAccessNotice.swift */; };
@@ -501,6 +502,7 @@
 		C93F7139E9BFB044902962D0 /* FinancialConnectionsImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsImage.swift; sourceTree = "<group>"; };
 		CA2DA47ECE153F888FA675CE /* StripeiOS Tests-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS Tests-Debug.xcconfig"; sourceTree = "<group>"; };
 		CB3C49A180D1697B03C79A59 /* UIViewController+KeyboardAvoiding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+KeyboardAvoiding.swift"; sourceTree = "<group>"; };
+		CB4BCC472E6F168B0066FE9E /* FinancialConnectionsLiquidGlassDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsLiquidGlassDetector.swift; sourceTree = "<group>"; };
 		CBB6227C2D4846670003AF44 /* FinancialConnectionsRepairSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinancialConnectionsRepairSession.swift; sourceTree = "<group>"; };
 		CDD861E4EB8BA294545B7651 /* NetworkingLinkVerificationViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkingLinkVerificationViewController.swift; sourceTree = "<group>"; };
 		CE10909F3FC7D60E13B65226 /* et-EE */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "et-EE"; path = "et-EE.lproj/Localizable.strings"; sourceTree = "<group>"; };
@@ -1093,6 +1095,7 @@
 				2C0F907D5B0AC58BE7A454BA /* StripeFinancialConnectionsBundleLocator.swift */,
 				BF7E41313B709F87B549D85F /* UIViewController+Extensions.swift */,
 				49B5BF752D43E1D500AB6C3F /* FinancialConnectionsAppearance.swift */,
+				CB4BCC472E6F168B0066FE9E /* FinancialConnectionsLiquidGlassDetector.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1491,6 +1494,7 @@
 				F0FB346A0F86C3561CD3C048 /* UITableView+Extensions.swift in Sources */,
 				A34AB3AC6D071605CABFFC9B /* UIViewController+KeyboardAvoiding.swift in Sources */,
 				B2970FE2753A4D79E428BA73 /* SuccessDataSource.swift in Sources */,
+				CB4BCC482E6F168B0066FE9E /* FinancialConnectionsLiquidGlassDetector.swift in Sources */,
 				C39214EA5995D85B847406BE /* SuccessFooterView.swift in Sources */,
 				6A1D42FF2B1686FC005A1EB0 /* InstitutionTableView.swift in Sources */,
 				B45B8DC3DAACDD5F04B1B1BE /* SuccessViewController.swift in Sources */,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FinancialConnectionsNavigationController.swift
@@ -130,7 +130,7 @@ extension FinancialConnectionsNavigationController {
         let backButtonImage = Image
             .back_arrow
             .makeImage(template: false)
-            .withAlignmentRectInsets(UIEdgeInsets(top: 0, left: -13, bottom: -2, right: 0))
+            .applyFinancialConnectionsBackButtonEdgeInsets()
         let appearance = UINavigationBarAppearance()
         appearance.setBackIndicatorImage(backButtonImage, transitionMaskImage: backButtonImage)
         appearance.backgroundColor = FinancialConnectionsAppearance.Colors.background

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/HostViewController.swift
@@ -39,7 +39,7 @@ final class HostViewController: UIViewController {
             action: #selector(didTapClose)
         )
         item.tintColor = FinancialConnectionsAppearance.Colors.icon
-        item.imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
+        item.applyFinancialConnectionsCloseButtonEdgeInsets()
         return item
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsLiquidGlassDetector.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsLiquidGlassDetector.swift
@@ -1,0 +1,27 @@
+//
+//  FinancialConnectionsLiquidGlassDetector.swift
+//  StripeFinancialConnections
+//
+//  Created by Till Hellmund on 9/8/25.
+//
+
+import Foundation
+
+class FinancialConnectionsLiquidGlassDetector {
+
+    static var isEnabled: Bool {
+        // If the app was built with Xcode 26 or later (which includes Swift compiler 6.2)...
+        #if compiler(>=6.2)
+        // And we're running on iOS 26 or later...
+        if #available(iOS 26.0, *) {
+            // And the app hasn't opted out of the new design...
+            if !(Bundle.main.infoDictionary?["UIDesignRequiresCompatibility"] as? Bool ?? false) {
+                // Then assume we're using the new design!
+                return true
+            }
+        }
+        #endif
+        // Otherwise, use the old design
+        return false
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/Image.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/Image.swift
@@ -35,17 +35,17 @@ enum Image: String, ImageMaker {
 
 extension UIImage {
     func applyFinancialConnectionsBackButtonEdgeInsets() -> UIImage {
-        if #unavailable(iOS 26.0) {
-            return withAlignmentRectInsets(UIEdgeInsets(top: 0, left: -13, bottom: -2, right: 0))
-        } else {
+        if FinancialConnectionsLiquidGlassDetector.isEnabled {
             return self
+        } else {
+            return withAlignmentRectInsets(UIEdgeInsets(top: 0, left: -13, bottom: -2, right: 0))
         }
     }
 }
 
 extension UIBarButtonItem {
     func applyFinancialConnectionsCloseButtonEdgeInsets() {
-        if #unavailable(iOS 26.0) {
+        if !FinancialConnectionsLiquidGlassDetector.isEnabled {
             imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/Image.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/Image.swift
@@ -5,8 +5,8 @@
 //  Created by Vardges Avetisyan on 11/22/21.
 //
 
-import Foundation
 @_spi(STP) import StripeUICore
+import UIKit
 
 /// The canonical set of all image files in the `StripeFinancialConnections` module.
 /// This helps us avoid duplicates and automatically test that all images load properly
@@ -31,4 +31,22 @@ enum Image: String, ImageMaker {
     case testmode
     case warning_triangle
     case bullet
+}
+
+extension UIImage {
+    func applyFinancialConnectionsBackButtonEdgeInsets() -> UIImage {
+        if #unavailable(iOS 26.0) {
+            return withAlignmentRectInsets(UIEdgeInsets(top: 0, left: -13, bottom: -2, right: 0))
+        } else {
+            return self
+        }
+    }
+}
+
+extension UIBarButtonItem {
+    func applyFinancialConnectionsCloseButtonEdgeInsets() {
+        if #unavailable(iOS 26.0) {
+            imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
+        }
+    }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -42,7 +42,7 @@ class NativeFlowController {
             action: #selector(didSelectNavigationBarCloseButton)
         )
         item.tintColor = FinancialConnectionsAppearance.Colors.icon
-        item.imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
+        item.applyFinancialConnectionsCloseButtonEdgeInsets()
         return item
     }()
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -82,7 +82,7 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
             action: #selector(didTapClose)
         )
         item.tintColor = FinancialConnectionsAppearance.Colors.icon
-        item.imageInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 5)
+        item.applyFinancialConnectionsCloseButtonEdgeInsets()
         return item
     }()
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes minor issues on iOS 26 with the navigation bar buttons in the Financial Connections flow. No other iOS 26 design changes are planned for this flow.

| Before | After |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-05 at 11 14 38" src="https://github.com/user-attachments/assets/a50272db-f5bf-4874-8031-aa1cd0d8d582" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-05 at 11 13 07" src="https://github.com/user-attachments/assets/98fdb65f-ccdc-4446-9fcc-665a06b09ce5" /> |

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
