### PR TITLE
Add `logOut` API to LinkController / CryptoOnrampCoordinator

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/AuthenticatedView.swift
@@ -249,6 +249,28 @@ struct AuthenticatedView: View {
                 .background(Color.secondary.opacity(0.1))
                 .cornerRadius(8)
 
+                VStack(alignment: .leading, spacing: 12) {
+                    HStack {
+                        Text("Account")
+                            .font(.headline)
+                            .foregroundColor(.secondary)
+
+                        Spacer()
+
+                        Button("Log out") {
+                            logOut()
+                        }
+                        .font(.body)
+                        .foregroundColor(.red)
+                        .disabled(shouldDisableButtons)
+                        .opacity(shouldDisableButtons ? 0.5 : 1)
+                    }
+                }
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(Color.secondary.opacity(0.1))
+                .cornerRadius(8)
+
                 HiddenNavigationLink(
                     destination: KYCInfoView(coordinator: coordinator),
                     isActive: $showKYCView
@@ -482,6 +504,31 @@ struct AuthenticatedView: View {
                 await MainActor.run {
                     errorMessage = "Checkout failed: \(error.localizedDescription)"
                     isLoading.wrappedValue = false
+                }
+            }
+        }
+    }
+
+    private func logOut() {
+        guard let viewController = UIApplication.shared.findTopNavigationController() else {
+            errorMessage = "Unable to find view controller to navigate from."
+            return
+        }
+
+        isLoading.wrappedValue = true
+        errorMessage = nil
+
+        Task {
+            do {
+                try await coordinator.logOut()
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    viewController.popToRootViewController(animated: true)
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    errorMessage = "Log out failed: \(error.localizedDescription)"
                 }
             }
         }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -126,6 +126,10 @@ protocol CryptoOnrampCoordinatorProtocol {
         authenticationContext: STPAuthenticationContext,
         onrampSessionClientSecretProvider: @escaping (_ onrampSessionId: String) async throws -> String
     ) async throws -> CheckoutResult
+
+    /// Logs out the current Link user, if any.
+    /// Throws if an API error occurs.
+    func logOut() async throws
 }
 
 /// Coordinates headless Link user authentication and identity verification, leaving most of the UI to the client.
@@ -439,6 +443,10 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
         case .canceled:
             return .canceled
         }
+    }
+
+    public func logOut() async throws {
+        try await linkController.logOut()
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -496,6 +496,36 @@ import UIKit
         }
     }
 
+    /// Logs out the current Link user, if any.
+    /// Throws if an API error occurs.
+    @_spi(STP) public func logOut(completion: @escaping (Result<Void, Error>) -> Void) {
+        func clearLinkAccountContextAndComplete() {
+            LinkAccountContext.shared.account = nil
+            completion(.success(()))
+        }
+
+        guard let session = linkAccount?.currentSession, let publishableKey = linkAccount?.publishableKey else {
+            // If no Link account is available, treat this as a success.
+            clearLinkAccountContextAndComplete()
+            return
+        }
+
+        session.logout(
+            consumerAccountPublishableKey: publishableKey,
+            requestSurface: requestSurface,
+            completion: { [] result in
+                switch result {
+                case .success:
+                    clearLinkAccountContextAndComplete()
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            }
+        )
+    }
+
+    // MARK: - Private methods
+
     private func updateLinkAccount(with consumerSession: ConsumerSession) {
         guard let linkAccount else {
             return
@@ -544,8 +574,6 @@ import UIKit
             }
         }
     }
-
-    // MARK: - Private methods
 
     private func createPaymentMethodInPassthroughMode(
         paymentDetails: ConsumerPaymentDetails,
@@ -894,6 +922,21 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
     func updatePhoneNumber(to phoneNumber: String) async throws {
         return try await withCheckedThrowingContinuation { continuation in
             updatePhoneNumber(to: phoneNumber) { result in
+                switch result {
+                case .success:
+                    continuation.resume(returning: ())
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Logs out the current Link user, if any.
+    /// Throws if an API error occurs.
+    func logOut() async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            logOut { result in
                 switch result {
                 case .success:
                     continuation.resume(returning: ())


### PR DESCRIPTION
## Summary

Adds a `logOut` API to the `LinkController` and `CryptoOnrampCoordinator`.

## Motivation

Android equivalent https://github.com/stripe/stripe-android/pull/11487

## Testing


https://github.com/user-attachments/assets/8666d346-df1c-4c4d-92f3-da438076faeb


## Changelog

N/a