### PR TITLE
Fix switching between iOS26->iOS18

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/PaymentMethodTypeCollectionView.swift
@@ -222,10 +222,14 @@ extension PaymentMethodTypeCollectionView {
         // To repro issue: Launch PS with Appearance.liquidGlassDesignEnabled == true, then launch with
         //                 Appearance.liquidGlassDesignEnabled == false
         private lazy var _liquidGlassRectangle: SelectableRectangle = {
+            #if !os(visionOS)
             if #available(iOS 26.0, *) {
                 return LiquidGlassRectangle(appearance: appearance, isCapsule: false)
             }
             return _shadowedRoundedRectangle
+            #else
+            return _shadowedRoundedRectangle
+            #endif
         }()
         private lazy var _shadowedRoundedRectangle: SelectableRectangle = {
             return ShadowedRoundedRectangle(appearance: appearance)


### PR DESCRIPTION
## Summary
An assert fires if you:

* Execute payment sheet w/ horizontal mode & iOS26 mode on
* Dismiss payment sheet.
* Turn iOS26 off
* Relaunch payment sheet

## Motivation
assertion failure.

## Testing
Manually

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
