### PR TITLE
Fix iOS26 animation w/ apple pay button

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/WalletHeaderView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/WalletHeaderView.swift
@@ -169,7 +169,8 @@ extension PaymentSheetViewController {
             addAndPinSubview(stackView)
         }
         private func updateStackView() {
-            // Update Apple Pay Button's color
+            // There's no way to change the color (PKPaymentButtonStyle) of the button,
+            // so swap between light and dark versions of Apple Pay button if needed
             let isBlackApplePayButton = appearance.colors.background.contrastingColor == .black
             if isBlackApplePayButton {
                 if let whiteApplePayButtonIndex = stackView.arrangedSubviews.firstIndex(of: applePayButtonWhite) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/WalletHeaderView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/WalletHeaderView.swift
@@ -73,6 +73,18 @@ extension PaymentSheetViewController {
             return button
         }()
 
+        private var applePayButton: UIView {
+            return appearance.colors.background.contrastingColor == .black ? applePayButtonBlack : applePayButtonWhite
+        }
+
+        private lazy var applePayButtonBlack: UIView = {
+            return createApplePayButton(pkPaymentButtonStyle: .black)
+        }()
+
+        private lazy var applePayButtonWhite: UIView = {
+            return createApplePayButton(pkPaymentButtonStyle: .white)
+        }()
+
         private lazy var separatorLabel = SeparatorLabel()
 
         private var supportsApplePay: Bool {
@@ -134,12 +146,10 @@ extension PaymentSheetViewController {
         }
 
         private func buildAndPinStackView() {
-            stackView.removeFromSuperview()
-
             var buttons: [UIView] = []
 
             if supportsApplePay {
-                buttons.append(buildApplePayButton())
+                buttons.append(applePayButton)
             }
 
             if supportsPayWithLink {
@@ -156,10 +166,26 @@ extension PaymentSheetViewController {
 
             addAndPinSubview(stackView)
         }
+        private func updateStackView() {
+            // Update Apple Pay Button's color
+            let isBlackApplePayButton = appearance.colors.background.contrastingColor == .black
+            if isBlackApplePayButton {
+                if let whiteApplePayButtonIndex = stackView.arrangedSubviews.firstIndex(of: applePayButtonWhite) {
+                    applePayButtonWhite.removeFromSuperview()
+                    stackView.removeArrangedSubview(applePayButtonWhite)
+                    stackView.insertArrangedSubview(applePayButtonBlack, at: whiteApplePayButtonIndex)
+                }
+            } else {
+                if let blackApplePayButonIndex = stackView.arrangedSubviews.firstIndex(of: applePayButtonBlack) {
+                    applePayButtonBlack.removeFromSuperview()
+                    stackView.removeArrangedSubview(applePayButtonBlack)
+                    stackView.insertArrangedSubview(applePayButtonWhite, at: blackApplePayButonIndex)
+                }
+            }
+        }
 
-        private func buildApplePayButton() -> UIView {
-            let buttonStyle: PKPaymentButtonStyle = appearance.colors.background.contrastingColor == .black ? .black : .white
-            let button = PKPaymentButton(paymentButtonType: applePayButtonType, paymentButtonStyle: buttonStyle)
+        private func createApplePayButton(pkPaymentButtonStyle: PKPaymentButtonStyle) -> UIView {
+            let button = PKPaymentButton(paymentButtonType: applePayButtonType, paymentButtonStyle: pkPaymentButtonStyle)
             // The corner configuration API that powers ios26_applyCapsuleCornerConfiguration doesn't work on PKPaymentButton
             // Instead, we set the cornerRadius directly
             // TODO(gbirch): align Apple Pay button liquid glass styling with other elements
@@ -170,7 +196,6 @@ extension PaymentSheetViewController {
             NSLayoutConstraint.activate([
                 button.heightAnchor.constraint(equalToConstant: Constants.applePayButtonHeight)
             ])
-
             return button
         }
 
@@ -182,9 +207,8 @@ extension PaymentSheetViewController {
         }
 
         override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-            buildAndPinStackView()
+            updateStackView()
             updateSeparatorLabel()
-
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/WalletHeaderView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/New Payment Method Screen/WalletHeaderView.swift
@@ -84,6 +84,7 @@ extension PaymentSheetViewController {
         private lazy var applePayButtonWhite: UIView = {
             return createApplePayButton(pkPaymentButtonStyle: .white)
         }()
+        private var isApplePayLastButton: Bool = false
 
         private lazy var separatorLabel = SeparatorLabel()
 
@@ -162,6 +163,7 @@ extension PaymentSheetViewController {
 
             if let lastButton = buttons.last {
                 stackView.setCustomSpacing(Constants.labelSpacing, after: lastButton)
+                isApplePayLastButton = lastButton == applePayButton
             }
 
             addAndPinSubview(stackView)
@@ -174,12 +176,18 @@ extension PaymentSheetViewController {
                     applePayButtonWhite.removeFromSuperview()
                     stackView.removeArrangedSubview(applePayButtonWhite)
                     stackView.insertArrangedSubview(applePayButtonBlack, at: whiteApplePayButtonIndex)
+                    if isApplePayLastButton {
+                        stackView.setCustomSpacing(Constants.labelSpacing, after: applePayButtonBlack)
+                    }
                 }
             } else {
                 if let blackApplePayButonIndex = stackView.arrangedSubviews.firstIndex(of: applePayButtonBlack) {
                     applePayButtonBlack.removeFromSuperview()
                     stackView.removeArrangedSubview(applePayButtonBlack)
                     stackView.insertArrangedSubview(applePayButtonWhite, at: blackApplePayButonIndex)
+                    if isApplePayLastButton {
+                        stackView.setCustomSpacing(Constants.labelSpacing, after: applePayButtonWhite)
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
Animation bug with iOS26.

To repro:
* Returning customer
* Apple pay Enabld
* PaymentSheet.Complete w/ vertical mode
* Tap on "add card"

Observed behavior:
* Apple pay button grow/shrinks when switching out content between payment method view page and add card page

## Motivation
Animation bug with iOS26

## Testing
Manually on iOS26 and iOS18
* Switching between main page and add card page
* Switching between dark mode and light mode.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
