### PR TITLE
Reduce polling timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## x.x.x x-x-x
+### PaymentSheet
+* [Fixed] Improved the cancellation UX when paying with Amazon Pay and Revolut Pay.
+
 ## 24.23.1 2025-09-08
 
 ### StripeCryptoOnramp

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -318,9 +318,9 @@ extension STPPaymentMethodType {
     var pollingRequirement: PollingRequirement? {
         switch self {
         // Note: Card only requires polling for 3DS2 web-based transactions
-        case .card, .amazonPay, .revolutPay:
+        case .card:
             return PollingRequirement(timeBetweenPollingAttempts: 3)
-        case .swish, .twint, .przelewy24:
+        case .swish, .twint, .przelewy24, .amazonPay, .revolutPay:
             // We are intentionally polling for Swish, Twint, and Przelewy24 even though they use the redirect trampoline.
             // The intent is still in `requires_action` status after redirecting following a successful payment (about 50% of the time for Swish).
             // This allows time for the intent to transition to its terminal state.


### PR DESCRIPTION
## Summary
- Reduces the polling timeout for Amazon Pay and Revolut Pay

## Motivation
- Improve UX

## Testing
- Data driven reduction in polling time.

## Changelog
See diff
