### PR TITLE
Tweak terms label in Link UI

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-NewPaymentViewController.swift
@@ -101,6 +101,9 @@ extension PayWithLinkViewController {
             configuration.linkPaymentMethodsOnly = true
             configuration.appearance = LinkUI.appearance
 
+            // AddPaymentMethodViewController uses textSecondary for the mandate, but Link uses linkTextTertiary
+            configuration.appearance.colors.textSecondary = .linkTextTertiary
+
             if let primaryColorOverride = context.linkAppearance?.colors?.primary {
                 configuration.appearance.colors.primary = primaryColorOverride
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
@@ -196,6 +196,7 @@ extension LinkUI {
         return (font.pointSize * lineHeight) - font.pointSize
     }
 
+    static let mandateLineSpacing: CGFloat = lineSpacing(fromRelativeHeight: 1.2, textStyle: .caption)
 }
 
 // MARK: - Appearance

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMandateView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMandateView.swift
@@ -24,10 +24,6 @@ protocol LinkMandateViewDelegate: AnyObject {
 /// For internal SDK use only
 @objc(STP_Internal_LinkMandateViewDelegate)
 final class LinkMandateView: UIView {
-    struct Constants {
-        static let lineHeight: CGFloat = 1.5
-    }
-
     weak var delegate: LinkMandateViewDelegate?
     private let linkTextColor: UIColor
 
@@ -58,14 +54,11 @@ final class LinkMandateView: UIView {
         let mutableString = NSMutableAttributedString(attributedString: formattedString)
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .center
-        paragraphStyle.lineSpacing = LinkUI.lineSpacing(
-            fromRelativeHeight: Constants.lineHeight,
-            textStyle: .caption
-        )
+        paragraphStyle.lineSpacing = LinkUI.mandateLineSpacing
 
         mutableString.addAttributes([.paragraphStyle: paragraphStyle], range: mutableString.extent)
 
-        return formattedString
+        return mutableString
     }
 }
 
@@ -94,7 +87,7 @@ private extension UITextView {
         isScrollEnabled = false
         isEditable = false
         backgroundColor = .clear
-        textColor = .linkTextSecondary
+        textColor = .linkTextTertiary
         textAlignment = .center
         textContainerInset = .zero
         textContainer.lineFragmentPadding = 0

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Mandates.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Mandates.swift
@@ -6,6 +6,7 @@
 //
 
 @_spi(STP) import StripeCore
+@_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripeUICore
 import UIKit
 
@@ -19,8 +20,22 @@ extension PaymentSheetFormFactory {
     func makeMandate(mandateText: NSAttributedString) -> SimpleMandateElement {
         // If there was previous customer input, check if it displayed the mandate for this payment method
         let customerAlreadySawMandate = previousCustomerInput?.didDisplayMandate ?? false
+
+        let updatedMandateText = {
+            guard isLinkUI else {
+                return mandateText
+            }
+
+            let mutableString = NSMutableAttributedString(attributedString: mandateText)
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.alignment = .center
+            paragraphStyle.lineSpacing = LinkUI.mandateLineSpacing
+            mutableString.addAttributes([.paragraphStyle: paragraphStyle], range: mutableString.extent)
+            return mutableString
+        }()
+
         return SimpleMandateElement(
-            mandateText: mandateText,
+            mandateText: updatedMandateText,
             customerAlreadySawMandate: customerAlreadySawMandate,
             textAlignment: isLinkUI ? .center : .natural,
             theme: theme


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request tweaks the look of the terms label in the Link UI. We now use a lighter text color and actually apply the line spacing.

| Before | After |
|--------|--------|
| <img width="1080" height="2340" alt="Simulator Screenshot - iPhone 12 mini - 2025-09-12 at 12 56 40" src="https://github.com/user-attachments/assets/e1e96da5-b303-4d31-8f62-56345c825d53" /> | <img width="1080" height="2340" alt="Simulator Screenshot - iPhone 12 mini - 2025-09-12 at 12 55 23" src="https://github.com/user-attachments/assets/6c708d90-5df1-4e2f-9ed6-aa16e18f67c7" /> |

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
