### PR TITLE
Crypto Onramp SDK: Fixes UI Inconsistencies in RegistrationView (Example App)

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/RegistrationView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/RegistrationView.swift
@@ -50,10 +50,10 @@ struct RegistrationView: View {
     }
 
     private var isUpdatePhoneNumberButtonDisabled: Bool {
-        !isRegistrationComplete
+        isLoading.wrappedValue || !isRegistrationComplete
     }
 
-    private var shouldDisableButtons: Bool {
+    private var isAuthenticateButtonDisabled: Bool {
         isLoading.wrappedValue
     }
 
@@ -101,15 +101,17 @@ struct RegistrationView: View {
 
                 if isRegistrationComplete {
                     Button("Authenticate") {
+                        resetFocusState()
                         Task {
                             try await verify()
                         }
                     }
                     .buttonStyle(PrimaryButtonStyle())
-                    .disabled(shouldDisableButtons)
-                    .opacity(shouldDisableButtons ? 0.5 : 1)
+                    .disabled(isAuthenticateButtonDisabled)
+                    .opacity(isAuthenticateButtonDisabled ? 0.5 : 1)
                 } else {
                     Button("Register") {
+                        resetFocusState()
                         registerUser()
                     }
                     .buttonStyle(PrimaryButtonStyle())
@@ -118,6 +120,7 @@ struct RegistrationView: View {
                 }
 
                 Button("Update Phone Number") {
+                    resetFocusState()
                     updatePhoneNumberInput = phoneNumber
                     showUpdatePhoneNumberSheet = true
                 }
@@ -264,6 +267,12 @@ struct RegistrationView: View {
                 }
             }
         }
+    }
+
+    private func resetFocusState() {
+        isFullNameFieldFocused = false
+        isPhoneNumberFieldFocused = false
+        isCountryFieldFocused = false
     }
 }
 


### PR DESCRIPTION
## Summary
Fixes two issues in `RegistrationView`:
- Focus was not dismissed prior to showing the OTP view, which resulted in a buggy animation when the OTP view dismissed.
- Not all buttons were visually disabled while authenticating.

## Motivation
:ghost:

## Testing

**Before:**

https://github.com/user-attachments/assets/208cf759-755c-4bcf-90fe-0fbe71dc71da


**After**

https://github.com/user-attachments/assets/340ab0b9-212d-44ff-aeb3-6b2de86df9e7

## Changelog
N/A