### PR TITLE
Crypto Onramp SDK: Fixes ProgressView Legibility in Dark Mode (Example App)

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnramp_ExampleApp.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnramp_ExampleApp.swift
@@ -25,7 +25,10 @@ struct CryptoOnramp_ExampleApp: App {
                         .ignoresSafeArea()
                     ProgressView("Loading…")
                         .padding()
-                        .background(Color(white: 0.9).cornerRadius(8))
+                        .background {
+                            Color(.tertiarySystemBackground)
+                                .cornerRadius(8)
+                        }
                 }
             }
         }


### PR DESCRIPTION
## Summary
The background color of the progress view in the example app made the text illegible. See: https://github.com/stripe/stripe-ios/pull/5392#discussion_r2298718606

This PR fixes it by using an environment-aware color for the progress view’s background.

## Motivation
:ghost:

## Testing

| Light Mode | Dark Mode |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/11295959-935f-447b-b488-3ef7789911b2" width="300" /> | <img src="https://github.com/user-attachments/assets/51088144-9397-4027-bb2b-29cb58a05742" width="300" /> |

## Changelog
N/A
