### PR TITLE
Add Link disabled reasons to analytics payload

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -138,7 +138,7 @@ final class PaymentSheetAnalyticsHelper {
         ]
         let linkEnabled: Bool = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
         if linkEnabled {
-            let linkMode: String = elementsSession.linkPassthroughModeEnabled ? "passthrough" : "payment_method_mode"
+            let linkMode = elementsSession.linkSettings?.linkMode?.rawValue
             params["link_mode"] = linkMode
         }
         params["link_display"] = configuration.link.display.rawValue
@@ -153,6 +153,9 @@ final class PaymentSheetAnalyticsHelper {
             guard let loadingStartDate else { return 0 }
             return Date().timeIntervalSince(loadingStartDate)
         }()
+
+        params["link_disabled_reasons"] = PaymentSheet.linkDisabledReasons(elementsSession: elementsSession, configuration: configuration).analyticsValue
+        params["link_signup_disabled_reasons"] = PaymentSheet.linkSignupDisabledReasons(elementsSession: elementsSession, configuration: configuration).analyticsValue
 
         log(
             event: .paymentSheetLoadSucceeded,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -136,10 +136,8 @@ final class PaymentSheetAnalyticsHelper {
             "ordered_lpms": orderedPaymentMethodTypes.map({ $0.identifier }).joined(separator: ","),
             "integration_shape": integrationShape.analyticsValue,
         ]
-        let linkEnabled: Bool = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
-        if linkEnabled {
-            let linkMode = elementsSession.linkSettings?.linkMode?.rawValue
-            params["link_mode"] = linkMode
+        if let linkMode = elementsSession.linkSettings?.linkMode {
+            params["link_mode"] = linkMode.rawValue
         }
         params["link_display"] = configuration.link.display.rawValue
         if elementsSession.customer?.customerSession != nil {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -125,3 +125,36 @@ extension PaymentSheet {
         @_spi(STP) public static var enableLinkInlineVerification: Bool = false
     }
 }
+
+// MARK: - Link disabled reasons
+
+extension PaymentSheet {
+
+    enum LinkDisabledReason: String {
+        case notSupportedInElementsSession = "not_supported_in_elements_session"
+        case linkConfiguration = "link_configuration"
+        case cardBrandFiltering = "card_brand_filtering"
+        case billingDetailsCollection = "billing_details_collection"
+    }
+
+    enum LinkSignupDisabledReason: String {
+        case linkNotEnabled = "link_not_enabled"
+        case linkCardNotSupported = "link_card_not_supported"
+        case disabledInElementsSession = "disabled_in_elements_session"
+        case signupOptInFeatureNoEmailProvided = "signup_opt_in_feature_no_email_provided"
+        case attestationIssues = "attestation_issues"
+        case linkUsedBefore = "link_used_before"
+    }
+}
+
+extension Array where Element == PaymentSheet.LinkDisabledReason {
+    var analyticsValue: String {
+        return self.map { $0.rawValue }.joined(separator: ",")
+    }
+}
+
+extension Array where Element == PaymentSheet.LinkSignupDisabledReason {
+    var analyticsValue: String {
+        return self.map { $0.rawValue }.joined(separator: ",")
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -131,18 +131,28 @@ extension PaymentSheet {
 extension PaymentSheet {
 
     enum LinkDisabledReason: String {
+        /// The Elements session response indicates that Link isn't supported.
         case notSupportedInElementsSession = "not_supported_in_elements_session"
+        /// Link is disabled via `PaymentSheet.LinkConfiguration`.
         case linkConfiguration = "link_configuration"
+        /// Card brand filtering is requested and native Link isn't available.
         case cardBrandFiltering = "card_brand_filtering"
+        /// Billing details collection is requested and native Link isn't available.
         case billingDetailsCollection = "billing_details_collection"
     }
 
     enum LinkSignupDisabledReason: String {
+        /// Link itself is not enabled.
         case linkNotEnabled = "link_not_enabled"
+        /// The card funding source is not supported.
         case linkCardNotSupported = "link_card_not_supported"
+        /// Link signup is disabled in Elements session. Consult backend logs for more info.
         case disabledInElementsSession = "disabled_in_elements_session"
+        /// Link signup opt-in feature is enabled, but the merchant didn't provide an email address via the customer or billing details.
         case signupOptInFeatureNoEmailProvided = "signup_opt_in_feature_no_email_provided"
+        /// Attestation is requested, but isn't supported on this device.
         case attestationIssues = "attestation_issues"
+        /// The customer has used Link before in this app.
         case linkUsedBefore = "link_used_before"
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -101,19 +101,8 @@ class PaymentSheetFormFactory {
                 return false
             }
 
-            // If attestation is enabled for this app but the specific device doesn't support attestation, don't show inline signup: It's unlikely to provide a good experience. We'll only allow the web popup flow.
-            let useAttestationEndpoints = elementsSession.linkSettings?.useAttestationEndpoints ?? false
-            if useAttestationEndpoints && !deviceCanUseNativeLink(elementsSession: elementsSession, configuration: configuration) {
-                return false
-            }
-
             let isAccountNotRegisteredOrMissing = linkAccount.flatMap({ !$0.isRegistered }) ?? true
-
-            // In live mode, we only show signup if the customer hasn't used Link in the merchant app before.
-            // In test mode, we continue to show it to make testing easier.
-            let canShowSignup = !UserDefaults.standard.customerHasUsedLink || configuration.apiClient.isTestmode
-
-            return isAccountNotRegisteredOrMissing && canShowSignup
+            return isAccountNotRegisteredOrMissing
         }()
         let paymentMethodType: STPPaymentMethodType = {
             if linkAccount != nil, configuration.linkPaymentMethodsOnly, !elementsSession.linkPassthroughModeEnabled {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
@@ -117,6 +117,10 @@ final class PaymentMethodAvailabilityTest: XCTestCase {
     }
 
     func testIsLinkSignupEnabled_enabled_for_linkSignupOptInFeatureEnabled_if_general_signup_disabled() {
+        // Set a test mode publishable key so that we don't check for attestation support
+        let originalPublishableKey = STPAPIClient.shared.publishableKey
+        STPAPIClient.shared.publishableKey = "pk_test_123"
+
         // Lookup happened during initialization and an email was provided
         LinkAccountContext.shared.account = ._testValue(email: "john@doe.com", isRegistered: false)
 
@@ -129,10 +133,13 @@ final class PaymentMethodAvailabilityTest: XCTestCase {
         let configuration = PaymentSheet.Configuration()
         let isLinkSignupEnabled = PaymentSheet.isLinkSignupEnabled(elementsSession: elementsSession, configuration: configuration)
 
+        STPAPIClient.shared.publishableKey = originalPublishableKey
         XCTAssertTrue(isLinkSignupEnabled, "Link inline signup should be enabled for linkSignupOptInFeatureEnabled even if general signup disabled")
     }
 
     func testIsLinkSignupEnabled_enabled_for_linkSignupOptInFeatureEnabled_if_email_provided() {
+        // Set a test mode publishable key so that we don't check for attestation support
+        let originalPublishableKey = STPAPIClient.shared.publishableKey
         STPAPIClient.shared.publishableKey = "pk_test_123"
 
         // Lookup happened during initialization and an email was provided
@@ -144,10 +151,13 @@ final class PaymentMethodAvailabilityTest: XCTestCase {
         let configuration = PaymentSheet.Configuration()
         let isLinkSignupEnabled = PaymentSheet.isLinkSignupEnabled(elementsSession: elementsSession, configuration: configuration)
 
+        STPAPIClient.shared.publishableKey = originalPublishableKey
         XCTAssertTrue(isLinkSignupEnabled, "Link inline signup should be enabled for linkSignupOptInFeatureEnabled if an email was provided")
     }
 
     func testIsLinkSignupEnabled_disabled_for_linkSignupOptInFeatureEnabled_if_no_email_provided() {
+        // Set a test mode publishable key so that we don't check for attestation support
+        let originalPublishableKey = STPAPIClient.shared.publishableKey
         STPAPIClient.shared.publishableKey = "pk_test_123"
 
         // Lookup happened during initialization and no email was provided
@@ -162,6 +172,7 @@ final class PaymentMethodAvailabilityTest: XCTestCase {
         let configuration = PaymentSheet.Configuration()
         let isLinkSignupEnabled = PaymentSheet.isLinkSignupEnabled(elementsSession: elementsSession, configuration: configuration)
 
+        STPAPIClient.shared.publishableKey = originalPublishableKey
         XCTAssertFalse(isLinkSignupEnabled, "Link inline signup should be disabled for linkSignupOptInFeatureEnabled if no email was provided")
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
@@ -133,6 +133,8 @@ final class PaymentMethodAvailabilityTest: XCTestCase {
     }
 
     func testIsLinkSignupEnabled_enabled_for_linkSignupOptInFeatureEnabled_if_email_provided() {
+        STPAPIClient.shared.publishableKey = "pk_test_123"
+
         // Lookup happened during initialization and an email was provided
         LinkAccountContext.shared.account = ._testValue(email: "john@doe.com", isRegistered: false)
 
@@ -146,6 +148,8 @@ final class PaymentMethodAvailabilityTest: XCTestCase {
     }
 
     func testIsLinkSignupEnabled_disabled_for_linkSignupOptInFeatureEnabled_if_no_email_provided() {
+        STPAPIClient.shared.publishableKey = "pk_test_123"
+
         // Lookup happened during initialization and no email was provided
         LinkAccountContext.shared.account = nil
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request adds two fields to our  MPE events: `link_disabled_reasons` will give us information on why Link is disabled, and `link_signup_disabled_reasons` on why inline signup is disabled. This helps us debug merchant integrations more easily.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
