### PR TITLE
Remove unused platform from CI

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,7 +41,6 @@ stages:
     - framework-tests-ios-26: {}
     - test-builds-xcode-16: {}
     - test-builds-xcode-26: {}
-    - test-builds-vision: {}
     - install-tests: {}
     - lint-tests: {}
     - size-report: {}
@@ -60,7 +59,6 @@ stages:
     - test-builds-xcode-16-release: {}
     - test-builds-xcode-26: {}
     - test-builds-xcode-26-release: {}
-    - test-builds-vision: {}
     - deploy-docs: {}
     - install-tests: {}
     - lint-tests: {}
@@ -436,19 +434,6 @@ workflows:
     meta:
       bitrise.io:
         stack: osx-xcode-26.0.x-edge
-  test-builds-vision:
-    steps:
-    - xcode-build-for-test@2:
-        inputs:
-        - scheme: StripePaymentSheet
-        - destination: generic/platform=visionOS Simulator
-    - deploy-to-bitrise-io@2: {}
-    before_run:
-    - prep_all
-    meta:
-      bitrise.io:
-        stack: osx-xcode-16.0.x
-        machine_type_id: g2.mac.large
   install-tests:
     steps:
     - fastlane@3:


### PR DESCRIPTION
## Summary
Remove unused OS platform from CI. This was already broken on Xcode 26, and we're not seeing any current usage. We won't intentionally remove support, but we'll wait until someone asks for it before we re-enable this build.

## Testing
CI

## Changelog
N/A, does not change existing 