### PR TITLE
Fallback to web auth flow if we can't authenticate the Link user natively

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -148,6 +148,8 @@
 		47AD56A9889DF5EFBBA9CEFB /* PollingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ADE49E72DD5EDA448D12D88 /* PollingViewTests.swift */; };
 		47B19F96CCEA290541E3B988 /* CardSectionElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D03000A6807B09BFD8E6CB1 /* CardSectionElement.swift */; };
 		48DA2EFE0944E737B0F197B0 /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = B2AFFAD776D5F21DF837F1BD /* OHHTTPStubs */; };
+		4926A9B02E748F0D00E81597 /* SupportedVerificationTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4926A9AF2E748F0D00E81597 /* SupportedVerificationTypes.swift */; };
+		4926A9B22E74A27800E81597 /* LinkVerificationWebFallbackController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4926A9B12E74A27800E81597 /* LinkVerificationWebFallbackController.swift */; };
 		4926B9E22D9C66250049A43E /* ExperimentData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4926B9E12D9C66250049A43E /* ExperimentData.swift */; };
 		4930D8D52DB92CDC0091FBFE /* LinkPaymentMethodPicker-Email.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4930D8D42DB92CDC0091FBFE /* LinkPaymentMethodPicker-Email.swift */; };
 		4930D8D72DB93F060091FBFE /* LinkSeparatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4930D8D62DB93F060091FBFE /* LinkSeparatorView.swift */; };
@@ -662,6 +664,8 @@
 		446E3BBF316178C04343B193 /* STPApplePayContext+PaymentSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPApplePayContext+PaymentSheet.swift"; sourceTree = "<group>"; };
 		45B6DC9BD9183495E5649369 /* LinkAccountService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkAccountService.swift; sourceTree = "<group>"; };
 		47C5DB8C01BA7137369C8B4D /* TextFieldElement+Card.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TextFieldElement+Card.swift"; sourceTree = "<group>"; };
+		4926A9AF2E748F0D00E81597 /* SupportedVerificationTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportedVerificationTypes.swift; sourceTree = "<group>"; };
+		4926A9B12E74A27800E81597 /* LinkVerificationWebFallbackController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkVerificationWebFallbackController.swift; sourceTree = "<group>"; };
 		4926B9E12D9C66250049A43E /* ExperimentData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExperimentData.swift; sourceTree = "<group>"; };
 		492B254E43F3BB9F9CEAEA06 /* PaymentSheetLoaderStubbedTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentSheetLoaderStubbedTest.swift; sourceTree = "<group>"; };
 		4930D8D42DB92CDC0091FBFE /* LinkPaymentMethodPicker-Email.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "LinkPaymentMethodPicker-Email.swift"; sourceTree = "<group>"; };
@@ -1511,6 +1515,7 @@
 				3147CEBF2CC080570067B5E4 /* CookieStore */,
 				981F958E99945A0318D47BBF /* PaymentDetails.swift */,
 				F1E614E8481658A027599A92 /* STPAPIClient+Link.swift */,
+				4926A9AF2E748F0D00E81597 /* SupportedVerificationTypes.swift */,
 				B662953D2C63F6C2007B6B14 /* PaymentDetailsShareResponse.swift */,
 				441C3414745D483C9A47ED0B /* VerificationSession.swift */,
 				499E32A72E47982400575058 /* LinkRequestSurface.swift */,
@@ -1695,6 +1700,7 @@
 				3147CED52CC1BF860067B5E4 /* LinkVerificationView-LogoutView.swift */,
 				3147CED62CC1BF860067B5E4 /* LinkVerificationViewController.swift */,
 				3147CED72CC1BF860067B5E4 /* LinkVerificationViewController-PresentationController.swift */,
+				4926A9B12E74A27800E81597 /* LinkVerificationWebFallbackController.swift */,
 			);
 			path = Verification;
 			sourceTree = "<group>";
@@ -2708,6 +2714,7 @@
 				3147CED82CC1BF860067B5E4 /* LinkVerificationViewController.swift in Sources */,
 				3147CED92CC1BF860067B5E4 /* LinkVerificationController.swift in Sources */,
 				3147CEDA2CC1BF860067B5E4 /* LinkVerificationViewController-PresentationController.swift in Sources */,
+				4926A9B22E74A27800E81597 /* LinkVerificationWebFallbackController.swift in Sources */,
 				3147CEDB2CC1BF860067B5E4 /* LinkVerificationView.swift in Sources */,
 				A3B2F2B42CEE882D00C0E88C /* SavedPaymentMethodFormFactory.swift in Sources */,
 				3147CEDC2CC1BF860067B5E4 /* LinkVerificationView-Header.swift in Sources */,
@@ -2774,6 +2781,7 @@
 				18A5870973D314A946B92748 /* SheetNavigationButton.swift in Sources */,
 				70FEF1703F45F8A90F687E51 /* SimpleMandateTextView.swift in Sources */,
 				310B6D982DFBB323009CA85D /* ECEViewController.swift in Sources */,
+				4926A9B02E748F0D00E81597 /* SupportedVerificationTypes.swift in Sources */,
 				429A68EA92C4101C9BC88269 /* TestModeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -218,7 +218,6 @@ struct LinkPMDisplayDetails {
 
         session.startVerification(
             with: apiClient,
-            cookieStore: cookieStore,
             consumerAccountPublishableKey: publishableKey,
             requestSurface: requestSurface
         ) { [weak self] result in
@@ -255,7 +254,6 @@ struct LinkPMDisplayDetails {
         session.confirmSMSVerification(
             with: oneTimePasscode,
             with: apiClient,
-            cookieStore: cookieStore,
             consumerAccountPublishableKey: publishableKey,
             requestSurface: requestSurface,
             consentGranted: consentGranted
@@ -500,6 +498,29 @@ struct LinkPMDisplayDetails {
                 requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
+        }
+    }
+
+    func refresh(
+        completion: @escaping (Result<ConsumerSession, Error>) -> Void
+    ) {
+        guard let session = currentSession else {
+            stpAssertionFailure()
+            completion(.failure(
+                PaymentSheetError.unknown(debugDescription: "Refreshing session without valid current session")
+            ))
+            return
+        }
+
+        session.refreshSession(
+            with: apiClient,
+            consumerAccountPublishableKey: publishableKey,
+            requestSurface: requestSurface
+        ) { [weak self] result in
+            if case .success(let refreshedSession) = result {
+                self?.currentSession = refreshedSession
+            }
+            completion(result)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -122,6 +122,11 @@ struct LinkPMDisplayDetails {
         currentSession?.isVerifiedForSignup ?? false
     }
 
+    // Webview fallback URLs have a lifespan of one attempt.
+    // If a user opens one and dismisses it, it can't be used again,
+    // So we'll fetch a new one in that case.
+    var visitedFallbackURLs: [URL] = []
+
     private(set) var currentSession: ConsumerSession?
     let displayablePaymentDetails: ConsumerSession.DisplayablePaymentDetails?
 
@@ -514,7 +519,6 @@ struct LinkPMDisplayDetails {
 
         session.refreshSession(
             with: apiClient,
-            consumerAccountPublishableKey: publishableKey,
             requestSurface: requestSurface
         ) { [weak self] result in
             if case .success(let refreshedSession) = result {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -21,6 +21,7 @@ final class ConsumerSession: Decodable {
     let phoneNumberCountry: String?
     let verificationSessions: [VerificationSession]
     let supportedPaymentDetailsTypes: Set<ConsumerPaymentDetails.DetailsType>
+    let mobileFallbackWebviewParams: MobileFallbackWebviewParams?
 
     init(
         clientSecret: String,
@@ -29,7 +30,8 @@ final class ConsumerSession: Decodable {
         unredactedPhoneNumber: String?,
         phoneNumberCountry: String?,
         verificationSessions: [VerificationSession],
-        supportedPaymentDetailsTypes: Set<ConsumerPaymentDetails.DetailsType>
+        supportedPaymentDetailsTypes: Set<ConsumerPaymentDetails.DetailsType>,
+        mobileFallbackWebviewParams: MobileFallbackWebviewParams?
     ) {
         self.clientSecret = clientSecret
         self.emailAddress = emailAddress
@@ -38,6 +40,7 @@ final class ConsumerSession: Decodable {
         self.phoneNumberCountry = phoneNumberCountry
         self.verificationSessions = verificationSessions
         self.supportedPaymentDetailsTypes = supportedPaymentDetailsTypes
+        self.mobileFallbackWebviewParams = mobileFallbackWebviewParams
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -48,6 +51,7 @@ final class ConsumerSession: Decodable {
         case phoneNumberCountry
         case verificationSessions
         case supportedPaymentDetailsTypes = "supportPaymentDetailsTypes"
+        case mobileFallbackWebviewParams = "mobile_fallback_webview_params"
     }
 
     init(from decoder: Decoder) throws {
@@ -59,8 +63,39 @@ final class ConsumerSession: Decodable {
         self.phoneNumberCountry = try container.decodeIfPresent(String.self, forKey: .phoneNumberCountry)
         self.verificationSessions = try container.decodeIfPresent([ConsumerSession.VerificationSession].self, forKey: .verificationSessions) ?? []
         self.supportedPaymentDetailsTypes = try container.decodeIfPresent(Set<ConsumerPaymentDetails.DetailsType>.self, forKey: .supportedPaymentDetailsTypes) ?? []
+        self.mobileFallbackWebviewParams = try container.decodeIfPresent(MobileFallbackWebviewParams.self, forKey: .mobileFallbackWebviewParams)
     }
 
+}
+
+extension ConsumerSession {
+    struct MobileFallbackWebviewParams: Decodable {
+        let webviewOpenUrl: URL?
+        let webviewRequirementType: WebviewRequirementType
+
+        enum WebviewRequirementType: String, SafeEnumDecodable {
+            case required = "required"
+            case notRequired = "notrequired"
+            case unparsable
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let requirementType = try container.decode(WebviewRequirementType.self, forKey: .webviewRequirementType)
+            self.webviewRequirementType = requirementType
+
+            if let urlString = try container.decodeIfPresent(String.self, forKey: .webviewOpenUrl) {
+                self.webviewOpenUrl = URL(string: urlString)
+            } else {
+                self.webviewOpenUrl = nil
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case webviewOpenUrl = "webview_open_url"
+            case webviewRequirementType = "webview_requirement_type"
+        }
+    }
 }
 
 extension ConsumerSession: Equatable {
@@ -224,7 +259,6 @@ extension ConsumerSession {
         type: VerificationSession.SessionType = .sms,
         locale: Locale = .autoupdatingCurrent,
         with apiClient: STPAPIClient = STPAPIClient.shared,
-        cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
@@ -233,7 +267,6 @@ extension ConsumerSession {
             for: clientSecret,
             type: type,
             locale: locale,
-            cookieStore: cookieStore,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             completion: completion)
@@ -242,7 +275,6 @@ extension ConsumerSession {
     func confirmSMSVerification(
         with code: String,
         with apiClient: STPAPIClient = STPAPIClient.shared,
-        cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         consentGranted: Bool? = nil,
@@ -251,7 +283,6 @@ extension ConsumerSession {
         apiClient.confirmSMSVerification(
             for: clientSecret,
             with: code,
-            cookieStore: cookieStore,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             consentGranted: consentGranted,
@@ -361,17 +392,29 @@ extension ConsumerSession {
 
     func logout(
         with apiClient: STPAPIClient = STPAPIClient.shared,
-        cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
         apiClient.logout(
             consumerSessionClientSecret: clientSecret,
-            cookieStore: cookieStore,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             completion: completion)
+    }
+
+    func refreshSession(
+        with apiClient: STPAPIClient = STPAPIClient.shared,
+        consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
+        completion: @escaping (Result<ConsumerSession, Error>) -> Void
+    ) {
+        apiClient.refreshSession(
+            consumerSessionClientSecret: clientSecret,
+            consumerAccountPublishableKey: consumerAccountPublishableKey,
+            requestSurface: requestSurface,
+            completion: completion
+        )
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -405,13 +405,11 @@ extension ConsumerSession {
 
     func refreshSession(
         with apiClient: STPAPIClient = STPAPIClient.shared,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
         apiClient.refreshSession(
             consumerSessionClientSecret: clientSecret,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             completion: completion
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -600,7 +600,6 @@ extension STPAPIClient {
 
     func refreshSession(
         consumerSessionClientSecret: String,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
@@ -611,12 +610,13 @@ extension STPAPIClient {
                 "consumer_session_client_secret": consumerSessionClientSecret,
             ],
             "request_surface": requestSurface.rawValue,
+            "supported_verification_types": SupportedVerificationType.allCases.map(\.rawValue),
         ]
 
         makeConsumerSessionRequest(
             endpoint: endpoint,
             parameters: parameters,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
+            consumerAccountPublishableKey: nil,
             completion: completion
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -91,6 +91,10 @@ extension STPAPIClient {
 
         var mutableParameters = parameters
 
+        if useMobileEndpoints {
+            mutableParameters["supported_verification_types"] = SupportedVerificationType.allCases.map(\.rawValue)
+        }
+
         let requestAssertionHandle: StripeAttest.AssertionHandle? = await {
             if useMobileEndpoints {
                 do {
@@ -296,7 +300,6 @@ extension STPAPIClient {
     private func makeConsumerSessionRequest(
         endpoint: String,
         parameters: [String: Any],
-        cookieStore: LinkCookieStore,
         consumerAccountPublishableKey: String?,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
@@ -574,7 +577,6 @@ extension STPAPIClient {
 
     func logout(
         consumerSessionClientSecret: String,
-        cookieStore: LinkCookieStore,
         consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
@@ -591,7 +593,29 @@ extension STPAPIClient {
         makeConsumerSessionRequest(
             endpoint: endpoint,
             parameters: parameters,
-            cookieStore: cookieStore,
+            consumerAccountPublishableKey: consumerAccountPublishableKey,
+            completion: completion
+        )
+    }
+
+    func refreshSession(
+        consumerSessionClientSecret: String,
+        consumerAccountPublishableKey: String?,
+        requestSurface: LinkRequestSurface = .default,
+        completion: @escaping (Result<ConsumerSession, Error>) -> Void
+    ) {
+        let endpoint: String = "consumers/sessions/refresh"
+
+        let parameters: [String: Any] = [
+            "credentials": [
+                "consumer_session_client_secret": consumerSessionClientSecret,
+            ],
+            "request_surface": requestSurface.rawValue,
+        ]
+
+        makeConsumerSessionRequest(
+            endpoint: endpoint,
+            parameters: parameters,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion
         )
@@ -601,7 +625,6 @@ extension STPAPIClient {
         for consumerSessionClientSecret: String,
         type: ConsumerSession.VerificationSession.SessionType,
         locale: Locale,
-        cookieStore: LinkCookieStore,
         consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
@@ -628,7 +651,6 @@ extension STPAPIClient {
         makeConsumerSessionRequest(
             endpoint: endpoint,
             parameters: parameters,
-            cookieStore: cookieStore,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion
         )
@@ -637,7 +659,6 @@ extension STPAPIClient {
     func confirmSMSVerification(
         for consumerSessionClientSecret: String,
         with code: String,
-        cookieStore: LinkCookieStore,
         consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         consentGranted: Bool? = nil,
@@ -659,7 +680,6 @@ extension STPAPIClient {
         makeConsumerSessionRequest(
             endpoint: endpoint,
             parameters: parameters,
-            cookieStore: cookieStore,
             consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/SupportedVerificationTypes.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/SupportedVerificationTypes.swift
@@ -1,0 +1,14 @@
+//
+//  SupportedVerificationTypes.swift
+//  StripePaymentSheet
+//
+//  Created by Mat Schmid on 9/12/25.
+//
+
+import Foundation
+
+// Add new cases here whenever they are supported.
+// String values should map to those in zoolander/../common.proto/VerificationType
+enum SupportedVerificationType: String, CaseIterable {
+    case sms = "SMS"
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-VerifyAccountViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-VerifyAccountViewController.swift
@@ -15,6 +15,7 @@ extension PayWithLinkViewController {
     final class VerifyAccountViewController: BaseViewController {
 
         private let linkAccount: PaymentSheetLinkAccount
+        private var isUsingWebviewFallback: Bool = false
 
         private lazy var verificationVC: LinkVerificationViewController = {
             let vc = LinkVerificationViewController(mode: .embedded, linkAccount: linkAccount)
@@ -26,10 +27,6 @@ extension PayWithLinkViewController {
         init(linkAccount: PaymentSheetLinkAccount, context: Context) {
             self.linkAccount = linkAccount
             super.init(context: context)
-
-            addChild(verificationVC)
-
-            contentView.addSubview(verificationVC.view)
         }
 
         override var requiresFullScreen: Bool { true }
@@ -41,8 +38,27 @@ extension PayWithLinkViewController {
         override func viewDidLoad() {
             super.viewDidLoad()
 
-            verificationVC.view.translatesAutoresizingMaskIntoConstraints = false
+            // Determine the verification flow (potentially with refresh)
+            determineMobileFallbackURL { [weak self] url in
+                guard let self = self else { return }
 
+                DispatchQueue.main.async {
+                    if let url = url {
+                        self.isUsingWebviewFallback = true
+                        self.presentMobileFallbackWebview(url: url)
+                    } else {
+                        self.isUsingWebviewFallback = false
+                        self.setupEmbeddedVerification()
+                    }
+                }
+            }
+        }
+
+        private func setupEmbeddedVerification() {
+            addChild(verificationVC)
+            contentView.addSubview(verificationVC.view)
+
+            verificationVC.view.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
                 contentView.topAnchor.constraint(equalTo: verificationVC.view.topAnchor),
                 contentView.leadingAnchor.constraint(equalTo: verificationVC.view.leadingAnchor),
@@ -50,6 +66,98 @@ extension PayWithLinkViewController {
                 contentView.bottomAnchor.constraint(greaterThanOrEqualTo: verificationVC.view.bottomAnchor),
                 contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 300),
             ])
+        }
+
+        private func determineMobileFallbackURL(completion: @escaping (URL?) -> Void) {
+            guard let mobileFallbackParams = linkAccount.currentSession?.mobileFallbackWebviewParams,
+                  let webviewUrl = mobileFallbackParams.webviewOpenUrl,
+                  mobileFallbackParams.webviewRequirementType == .required else {
+                completion(nil)
+                return
+            }
+
+            // Check if this URL was already visited
+            if linkAccount.visitedFallbackURLs.contains(webviewUrl) {
+                // Refresh to get a new URL
+                linkAccount.refresh { [weak self] _ in
+                    guard let self else {
+                        completion(nil)
+                        return
+                    }
+
+                    // After refresh, get the new URL
+                    let newURL = Self.mobileFallbackURL(from: self.linkAccount)
+                    completion(newURL)
+                }
+            } else {
+                // URL is fresh, use it directly
+                completion(webviewUrl)
+            }
+        }
+
+        private static func mobileFallbackURL(from linkAccount: PaymentSheetLinkAccount) -> URL? {
+            guard let mobileFallbackParams = linkAccount.currentSession?.mobileFallbackWebviewParams,
+                  let webviewUrl = mobileFallbackParams.webviewOpenUrl,
+                  mobileFallbackParams.webviewRequirementType == .required else {
+                return nil
+            }
+            return webviewUrl
+        }
+
+        private func presentMobileFallbackWebview(url: URL) {
+            // Mark this URL as visited
+            linkAccount.visitedFallbackURLs.append(url)
+
+            let webviewController = LinkVerificationWebFallbackController(
+                authenticationUrl: url,
+                presentingWindow: view.window
+            )
+
+            webviewController.present { [weak self] result in
+                guard let self else { return }
+
+                // If verification completed successfully, refresh the session
+                if case .completed = result {
+                    self.linkAccount.refresh { [weak self] _ in
+                        self?.handleVerificationResult(result)
+                    }
+                } else {
+                    self.handleVerificationResult(result)
+                }
+            }
+        }
+
+        private func handleVerificationResult(_ result: LinkVerificationViewController.VerificationResult) {
+            switch result {
+            case .completed:
+                coordinator?.accountUpdated(linkAccount)
+            case .canceled:
+                if isUsingWebviewFallback {
+                    // Webview was canceled - return to payment sheet (same as cancel button in WalletViewController)
+                    coordinator?.cancel(shouldReturnToPaymentSheet: true)
+                } else {
+                    // Embedded verification was canceled - logout
+                    coordinator?.logout(cancel: false)
+                }
+            case .switchAccount:
+                coordinator?.logout(cancel: false)
+            case .failed(let error):
+                let alertController = UIAlertController(
+                    title: String.Localized.error,
+                    message: error.nonGenericDescription,
+                    preferredStyle: .alert
+                )
+
+                alertController.addAction(UIAlertAction(
+                    title: String.Localized.ok,
+                    style: .default,
+                    handler: { [weak self] _ in
+                        self?.coordinator?.logout(cancel: false)
+                    }
+                ))
+
+                navigationController?.present(alertController, animated: true)
+            }
         }
 
         override func didTapOrSwipeToDismiss() {
@@ -65,28 +173,7 @@ extension PayWithLinkViewController.VerifyAccountViewController: LinkVerificatio
         _ controller: LinkVerificationViewController,
         didFinishWithResult result: LinkVerificationViewController.VerificationResult
     ) {
-        switch result {
-        case .completed:
-            coordinator?.accountUpdated(linkAccount)
-        case .canceled, .switchAccount:
-            coordinator?.logout(cancel: false)
-        case .failed(let error):
-            let alertController = UIAlertController(
-                title: String.Localized.error,
-                message: error.nonGenericDescription,
-                preferredStyle: .alert
-            )
-
-            alertController.addAction(UIAlertAction(
-                title: String.Localized.ok,
-                style: .default,
-                handler: { [weak self] _ in
-                    self?.coordinator?.logout(cancel: false)
-                }
-            ))
-
-            navigationController?.present(alertController, animated: true)
-        }
+        handleVerificationResult(result)
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-VerifyAccountViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-VerifyAccountViewController.swift
@@ -133,7 +133,7 @@ extension PayWithLinkViewController {
                 coordinator?.accountUpdated(linkAccount)
             case .canceled:
                 if isUsingWebviewFallback {
-                    // Webview was canceled - return to payment sheet (same as cancel button in WalletViewController)
+                    // Webview was canceled - return to payment sheet
                     coordinator?.cancel(shouldReturnToPaymentSheet: true)
                 } else {
                     // Embedded verification was canceled - logout

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
@@ -66,8 +66,11 @@ final class LinkVerificationController {
     }
 
     private func presentMobileFallbackWebview(from presentingController: UIViewController, webviewUrl: URL) {
-        let webviewController = LinkVerificationWebFallbackController(authenticationUrl: webviewUrl)
-        webviewController.present(from: presentingController) { [weak self] result in
+        let webviewController = LinkVerificationWebFallbackController(
+            authenticationUrl: webviewUrl,
+            presentingWindow: presentingController.view.window
+        )
+        webviewController.present { [weak self] result in
             guard let self = self else { return }
 
             // If verification completed successfully, refresh the session

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
@@ -75,16 +75,11 @@ final class LinkVerificationController {
 
             // If verification completed successfully, refresh the session
             if case .completed = result {
-                self.linkAccount.refresh { refreshResult in
-                    // Log refresh result but continue with original completion
-                    if case .failure(let error) = refreshResult {
-                        print("Warning: Failed to refresh session after web verification: \(error)")
-                    }
-                    self.completion?(result)
-                    self.selfRetainer = nil
+                self.linkAccount.refresh { [weak self] refreshResult in
+                    self?.completion?(result)
+                    self?.selfRetainer = nil
                 }
             } else {
-                // For non-successful results, proceed directly
                 self.completion?(result)
                 self.selfRetainer = nil
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationWebFallbackController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationWebFallbackController.swift
@@ -1,0 +1,92 @@
+//
+//  LinkVerificationWebFallbackController.swift
+//  StripePaymentSheet
+//
+//  Created by Mat Schmid on 9/12/25.
+//
+
+import AuthenticationServices
+import UIKit
+
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+
+final class LinkVerificationWebFallbackController: NSObject {
+    private static let callbackURLSchme = "link-popup"
+
+    typealias CompletionBlock = (LinkVerificationViewController.VerificationResult) -> Void
+
+    private let authenticationUrl: URL
+    private var authenticationSession: ASWebAuthenticationSession?
+    private var completion: CompletionBlock?
+    private var selfRetainer: LinkVerificationWebFallbackController?
+
+    init(authenticationUrl: URL) {
+        self.authenticationUrl = authenticationUrl
+        super.init()
+    }
+
+    func present(
+        from presentingController: UIViewController,
+        completion: @escaping CompletionBlock
+    ) {
+        self.completion = completion
+        self.selfRetainer = self
+
+        authenticationSession = ASWebAuthenticationSession(
+            url: authenticationUrl,
+            callbackURLScheme: Self.callbackURLSchme
+        ) { [weak self] callbackURL, error in
+            self?.handleAuthenticationResult(callbackURL: callbackURL, error: error)
+        }
+
+        authenticationSession?.presentationContextProvider = self
+        authenticationSession?.prefersEphemeralWebBrowserSession = true
+        authenticationSession?.start()
+    }
+
+    private func handleAuthenticationResult(callbackURL: URL?, error: Error?) {
+        defer {
+            authenticationSession = nil
+            selfRetainer = nil
+        }
+
+        if let error {
+            if let authError = error as? ASWebAuthenticationSessionError {
+                switch authError.code {
+                case .canceledLogin:
+                    completion?(.canceled)
+                default:
+                    completion?(.failed(error))
+                }
+            } else {
+                completion?(.failed(error))
+            }
+            return
+        }
+
+        guard let callbackURL else {
+            completion?(.failed(ASWebAuthenticationSessionError(.presentationContextNotProvided)))
+            return
+        }
+
+        // Check if this is the completion URL
+        if callbackURL.scheme == Self.callbackURLSchme && callbackURL.host == "complete" {
+            completion?(.completed)
+        } else {
+            completion?(.failed(ASWebAuthenticationSessionError(.presentationContextNotProvided)))
+        }
+    }
+}
+
+// MARK: - ASWebAuthenticationPresentationContextProviding
+
+extension LinkVerificationWebFallbackController: ASWebAuthenticationPresentationContextProviding {
+
+    func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        return UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap { $0.windows }
+            .first { $0.isKeyWindow } ?? UIWindow()
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationWebFallbackController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationWebFallbackController.swift
@@ -8,28 +8,24 @@
 import AuthenticationServices
 import UIKit
 
-@_spi(STP) import StripeCore
-@_spi(STP) import StripeUICore
-
 final class LinkVerificationWebFallbackController: NSObject {
     private static let callbackURLSchme = "link-popup"
 
     typealias CompletionBlock = (LinkVerificationViewController.VerificationResult) -> Void
 
     private let authenticationUrl: URL
+    private let window: UIWindow?
     private var authenticationSession: ASWebAuthenticationSession?
     private var completion: CompletionBlock?
     private var selfRetainer: LinkVerificationWebFallbackController?
 
-    init(authenticationUrl: URL) {
+    init(authenticationUrl: URL, presentingWindow: UIWindow?) {
         self.authenticationUrl = authenticationUrl
+        self.window = presentingWindow
         super.init()
     }
 
-    func present(
-        from presentingController: UIViewController,
-        completion: @escaping CompletionBlock
-    ) {
+    func present(completion: @escaping CompletionBlock) {
         self.completion = completion
         self.selfRetainer = self
 
@@ -84,9 +80,6 @@ final class LinkVerificationWebFallbackController: NSObject {
 extension LinkVerificationWebFallbackController: ASWebAuthenticationPresentationContextProviding {
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-        return UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap { $0.windows }
-            .first { $0.isKeyWindow } ?? UIWindow()
+        return window ?? ASPresentationAnchor()
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -177,15 +177,16 @@ final class PayWithNativeLinkController {
             )
 
             self.completion =  { completionResult in
-                payWithLinkVC.dismiss(animated: true)
-                completion(completionResult)
+                payWithLinkVC.dismiss(animated: true) {
+                    completion(completionResult)
 
-                guard completionResult.shouldShowPaymentSheetAgain else {
-                    return
-                }
-                // Handle representing the previous bottom sheet
-                if let targetBottomSheet, let targetPresentationController, hidingUnderlyingBottomSheet {
-                    targetPresentationController.presentAsBottomSheet(targetBottomSheet, appearance: self.configuration.appearance)
+                    guard completionResult.shouldShowPaymentSheetAgain else {
+                        return
+                    }
+                    // Handle representing the previous bottom sheet
+                    if let targetBottomSheet, let targetPresentationController, hidingUnderlyingBottomSheet {
+                        targetPresentationController.presentAsBottomSheet(targetBottomSheet, appearance: self.configuration.appearance)
+                    }
                 }
             }
         }
@@ -209,8 +210,9 @@ extension PayWithNativeLinkController: PayWithLinkViewControllerDelegate {
         _ payWithLinkViewController: PayWithLinkViewController,
         confirmOption: PaymentSheet.LinkConfirmOption
     ) {
-        payWithLinkViewController.dismiss(animated: true)
-        completion?(.paymentMethodSelection(confirmOption: confirmOption))
+        payWithLinkViewController.dismiss(animated: true) {
+            self.completion?(.paymentMethodSelection(confirmOption: confirmOption))
+        }
     }
 
     func payWithLinkViewControllerDidConfirm(
@@ -239,25 +241,26 @@ extension PayWithNativeLinkController: PayWithLinkViewControllerDelegate {
     }
 
     func payWithLinkViewControllerDidCancel(_ payWithLinkViewController: PayWithLinkViewController, shouldReturnToPaymentSheet: Bool) {
-        payWithLinkViewController.dismiss(animated: true)
+        payWithLinkViewController.dismiss(animated: true) {
+            let completionResult: CompletionResult = {
+                switch self.mode {
+                case .paymentMethodSelection:
+                    return .paymentMethodSelection(confirmOption: nil, shouldReturnToPaymentSheet: shouldReturnToPaymentSheet)
+                case .full:
+                    return .full(result: .canceled, deferredIntentConfirmationType: nil, didFinish: false)
+                }
+            }()
 
-        let completionResult: CompletionResult = {
-            switch mode {
-            case .paymentMethodSelection:
-                return .paymentMethodSelection(confirmOption: nil, shouldReturnToPaymentSheet: shouldReturnToPaymentSheet)
-            case .full:
-                return .full(result: .canceled, deferredIntentConfirmationType: nil, didFinish: false)
-            }
-        }()
-
-        completion?(completionResult)
-        selfRetainer = nil
+            self.completion?(completionResult)
+            self.selfRetainer = nil
+        }
     }
 
     func payWithLinkViewControllerDidFinish(_ payWithLinkViewController: PayWithLinkViewController, result: PaymentSheetResult, deferredIntentConfirmationType: STPAnalyticsClient.DeferredIntentConfirmationType?) {
-        payWithLinkViewController.dismiss(animated: true)
-        completion?(.full(result: result, deferredIntentConfirmationType: deferredIntentConfirmationType, didFinish: true))
-        selfRetainer = nil
+        payWithLinkViewController.dismiss(animated: true) {
+            self.completion?(.full(result: result, deferredIntentConfirmationType: deferredIntentConfirmationType, didFinish: true))
+            self.selfRetainer = nil
+        }
     }
 
     func payWithLinkViewControllerShouldCancel3DS2ChallengeFlow(_ payWithLinkViewController: PayWithLinkViewController) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/LinkInlineVerificationView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/LinkInlineVerificationView.swift
@@ -149,7 +149,8 @@ enum Stubs {
         unredactedPhoneNumber: "+17070707070",
         phoneNumberCountry: "US",
         verificationSessions: [],
-        supportedPaymentDetailsTypes: [.card]
+        supportedPaymentDetailsTypes: [.card],
+        mobileFallbackWebviewParams: nil
     )
 
     static func displayablePaymentDetails(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
@@ -1430,7 +1430,8 @@ extension PaymentSheetLinkAccount {
                 verificationSessions: [
                     .init(type: .sms, state: .verified)
                 ],
-                supportedPaymentDetailsTypes: [.card]
+                supportedPaymentDetailsTypes: [.card],
+                mobileFallbackWebviewParams: nil
             )
         }
         return .init(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkButtonSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkButtonSnapshotTests.swift
@@ -117,7 +117,8 @@ enum Stubs {
         unredactedPhoneNumber: "+17070707070",
         phoneNumberCountry: "US",
         verificationSessions: [],
-        supportedPaymentDetailsTypes: [.card, .bankAccount]
+        supportedPaymentDetailsTypes: [.card, .bankAccount],
+        mobileFallbackWebviewParams: nil
     )
 
     static func displayablePaymentDetails(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/LinkStubs.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/LinkStubs.swift
@@ -96,7 +96,8 @@ extension LinkStubs {
             unredactedPhoneNumber: "(555) 555-5555",
             phoneNumberCountry: "US",
             verificationSessions: [],
-            supportedPaymentDetailsTypes: supportedPaymentDetailsTypes
+            supportedPaymentDetailsTypes: supportedPaymentDetailsTypes,
+            mobileFallbackWebviewParams: nil
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
@@ -83,7 +83,8 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
                         unredactedPhoneNumber: "(555) 555-5555",
                         phoneNumberCountry: "US",
                         verificationSessions: [.init(type: .sms, state: .verified)],
-                        supportedPaymentDetailsTypes: [.card]
+                        supportedPaymentDetailsTypes: [.card],
+                        mobileFallbackWebviewParams: nil
                     ),
                     publishableKey: "pk_xxx_for_link_account_xxx",
                     displayablePaymentDetails: nil,
@@ -189,7 +190,8 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
                             unredactedPhoneNumber: "(555) 555-5555",
                             phoneNumberCountry: "US",
                             verificationSessions: [.init(type: .sms, state: .verified)],
-                            supportedPaymentDetailsTypes: [.card]
+                            supportedPaymentDetailsTypes: [.card],
+                            mobileFallbackWebviewParams: nil
                         ),
                         publishableKey: MockParams.publicKey,
                         displayablePaymentDetails: nil,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
@@ -160,7 +160,8 @@ class PaymentSheetLinkAccountDelegateStub: PaymentSheetLinkAccountDelegate {
             unredactedPhoneNumber: "(555) 555-5555",
             phoneNumberCountry: "US",
             verificationSessions: [],
-            supportedPaymentDetailsTypes: [.card, .bankAccount]
+            supportedPaymentDetailsTypes: [.card, .bankAccount],
+            mobileFallbackWebviewParams: nil
         )
         completion(.success(stubSession))
         expectation.fulfill()


### PR DESCRIPTION
## Summary

Adds a fallback web-based Link authentication flow, used when we can't authenticate the Link user natively.

The general flow is:

1. Pass the known supported verification factors to the `/lookup` call
2. In the response, we will get back `mobile_fallback_webview_params`, which will tell us if we can or can't verify the user natively, based on the required verification factors for the current Link user
3. Using the URL provided in `mobile_fallback_webview_params.webview_open_url`, we launch a secure webview. This will authenticate the Link user
4. We observe for redirects to `link-popup://complete`, and dismiss the webview when detected
5. Call a new `/refresh` endpoint to get the latest consumer session back on the client.

## Motivation

https://docs.google.com/document/d/1Yxlz__5R4malxex123db3jyh8KnGaedBxLBUEEu2a0s/edit?usp=sharing

## Testing

> [!NOTE]  
>To test out the fallback flow yourself, set a random value (such as `["abc"]`) as the `supported_verification_types` in the mobile `/lookup` call [here](https://github.com/stripe/stripe-ios/pull/5534/files#diff-37b1d3022a0265c5ae1a48d7f4f2027426df1271f4c2b03bacb2ce6bc5b7e3b4R95)

https://github.com/user-attachments/assets/cc395110-9514-4f6a-a041-753766f6979c

## Changelog

N/a
