### PR TITLE
Update Link signup button to Continue

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewModel.swift
@@ -107,10 +107,7 @@ final class LinkSignUpViewModel: NSObject {
 
     var signUpButtonTitle: String {
         shouldShowPhoneNumberField
-            ? STPLocalizedString(
-                "Agree and continue",
-                "Title for a button that when tapped creates a Link account for the user."
-            )
+            ? String.Localized.continue
             : STPLocalizedString(
                 "Log in or sign up",
                 "Title for a button that indicates a user can log in or sign up."


### PR DESCRIPTION
## Summary

Updates the Link signup button to say `Continue` rather than `Agree and continue`.

## Motivation

https://jira.corp.stripe.com/browse/RUN_LINK_PREFERENCE-2235

## Testing

<img width=40% src="https://github.com/user-attachments/assets/8ecd08f4-b727-4308-980b-bd91d6027edb" />

## Changelog

N/a