### PR TITLE
Do not send client_attribution_metadata on Link confirm call when confirming with payment method

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -408,7 +408,6 @@ extension PaymentSheet {
                     paymentIntentParams.paymentMethodOptions = paymentOptions
                     paymentIntentParams.radarOptions = radarOptions
                     paymentIntentParams.mandateData = mandateData
-                    paymentIntentParams.clientAttributionMetadata = clientAttributionMetadata
                     paymentHandler.confirmPayment(
                         paymentIntentParams,
                         with: authenticationContext,
@@ -425,7 +424,6 @@ extension PaymentSheet {
                     setupIntentParams.returnURL = configuration.returnURL
                     setupIntentParams.mandateData = mandateData
                     setupIntentParams.radarOptions = radarOptions
-                    setupIntentParams.clientAttributionMetadata = clientAttributionMetadata
                     paymentHandler.confirmSetupIntent(
                         setupIntentParams,
                         with: authenticationContext,
@@ -438,7 +436,7 @@ extension PaymentSheet {
                     )
                 case .deferredIntent(let intentConfig):
                     handleDeferredIntentConfirmation(
-                        confirmType: .saved(paymentMethod, paymentOptions: nil, clientAttributionMetadata: clientAttributionMetadata),
+                        confirmType: .saved(paymentMethod, paymentOptions: nil, clientAttributionMetadata: nil),
                         configuration: configuration,
                         intentConfig: intentConfig,
                         authenticationContext: authenticationContext,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Link was sending client_attribution_metadata on two different calls in some cases. We only need to send it on the first call
Passthrough: share payment details and confirm
PMM: create pm and confirm
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Parity with web
## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Passthrough mode
share: https://admin.corp.stripe.com/request-log/req_OANffJcuvxceuY
confirm: https://admin.corp.stripe.com/request-log/req_sF0fJoORML36Rs

Payment method mode
create: https://admin.corp.stripe.com/request-log/req_cMaxewZeAU7sXY
confirm: https://admin.corp.stripe.com/request-log/req_JWjGITeN3guCbX
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A