### PR TITLE
Adjust bottom constraint for keyboard in wallet view controller

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -168,6 +168,8 @@ extension PayWithLinkViewController {
             return stackView
         }()
 
+        private var containerViewBottomConstraint: NSLayoutConstraint!
+
         #if !os(visionOS)
         private let feedbackGenerator = UINotificationFeedbackGenerator()
         #endif
@@ -193,6 +195,16 @@ extension PayWithLinkViewController {
             viewModel.delegate = self
         }
 
+        override func viewWillAppear(_ animated: Bool) {
+            super.viewWillAppear(animated)
+            registerForKeyboardNotifications()
+        }
+
+        override func viewWillDisappear(_ animated: Bool) {
+            super.viewWillDisappear(animated)
+            NotificationCenter.default.removeObserver(self)
+        }
+
         func setupUI() {
             if viewModel.shouldShowApplePayButton {
                 containerView.addArrangedSubview(separator)
@@ -203,7 +215,20 @@ extension PayWithLinkViewController {
                 containerView.addArrangedSubview(cancelButton)
             }
 
-            contentView.addAndPinSubview(containerView, insets: .insets(bottom: LinkUI.bottomInset))
+            contentView.addSubview(containerView)
+            containerView.translatesAutoresizingMaskIntoConstraints = false
+
+            containerViewBottomConstraint = containerView.bottomAnchor.constraint(
+                equalTo: contentView.safeAreaLayoutGuide.bottomAnchor,
+                constant: -LinkUI.bottomInset
+            )
+
+            NSLayoutConstraint.activate([
+                containerView.topAnchor.constraint(equalTo: contentView.safeAreaLayoutGuide.topAnchor),
+                containerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+                containerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor),
+                containerViewBottomConstraint,
+            ])
 
             // If the initially selected payment method is not supported, we should automatically
             // expand the payment picker to hint the user to pick another payment method.
@@ -772,6 +797,45 @@ extension PayWithLinkViewController.WalletViewController: LinkMandateViewDelegat
         present(safariVC, animated: true)
     }
 
+}
+
+// MARK: - Keyboard handling
+
+private extension PayWithLinkViewController.WalletViewController {
+    func registerForKeyboardNotifications() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(adjustForKeyboard),
+            name: UIResponder.keyboardWillHideNotification,
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(adjustForKeyboard),
+            name: UIResponder.keyboardWillChangeFrameNotification,
+            object: nil
+        )
+    }
+
+    @objc func adjustForKeyboard(notification: Notification) {
+        guard let keyboardScreenEndFrame = (notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue else {
+            return
+        }
+
+        let keyboardViewEndFrame = view.convert(keyboardScreenEndFrame, from: view.window)
+        let keyboardInViewHeight = view.safeAreaLayoutGuide.layoutFrame.intersection(keyboardViewEndFrame).height
+
+        if notification.name == UIResponder.keyboardWillHideNotification {
+            containerViewBottomConstraint.constant = -LinkUI.bottomInset
+        } else {
+            containerViewBottomConstraint.constant = -keyboardInViewHeight - LinkUI.contentSpacing
+        }
+
+        view.setNeedsLayout()
+        UIView.animateAlongsideKeyboard(notification) {
+            self.view.layoutIfNeeded()
+        }
+    }
 }
 
 // MARK: - UpdatePaymentViewControllerDelegate


### PR DESCRIPTION
## Summary

Fixes an issue where the CVC recollection field was hidden under the keyboard in the Link wallet view controller. This now adjust the bottom constraint with the keyboard to ensure it is visible.

## Motivation

https://stripe.slack.com/archives/C08G5K7ULLT/p1758028460417169

## Testing

| Before | After |
|--------|--------|
| <img width="1170" height="2532" alt="img_0503" src="https://github.com/user-attachments/assets/95573d23-557a-471b-939e-7bed43113778" /> | <img width="1260" height="2736" alt="Simulator Screenshot - iPhone Air - 2025-09-16 at 10 34 49" src="https://github.com/user-attachments/assets/384e2ae1-613e-4814-a3e3-cd5aac0a4e5c" /> |

Here's the animation:

https://github.com/user-attachments/assets/3e6f0196-a91d-4f64-8d73-11412516616f

## Changelog

N/a
