### PR TITLE
Properly parse prefixes on phone numbers in AE

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -362,10 +362,18 @@ extension AddressViewController {
         // Populate name and phone if available
         addressSection.name?.setText(addressDetails.name ?? "")
         if let phone = addressDetails.phone {
-            addressSection.phone?.setPhoneNumber(phone)
-        }
-        if let phoneCountry = addressDetails.address.country {
-            addressSection.phone?.setSelectedCountryCode(phoneCountry, shouldUpdateDefaultNumber: false)
+            // Check if phone number is in E.164 format and parse it properly
+            if let parsedPhone = PhoneNumber.fromE164(phone) {
+                // Use parsed country code and local number for E.164 format
+                addressSection.phone?.setSelectedCountryCode(parsedPhone.countryCode, shouldUpdateDefaultNumber: false)
+                addressSection.phone?.setPhoneNumber(parsedPhone.number)
+            } else {
+                // Fall back to original logic for non-E.164 numbers
+                addressSection.phone?.setPhoneNumber(phone)
+                if let phoneCountry = addressDetails.address.country {
+                    addressSection.phone?.setSelectedCountryCode(phoneCountry, shouldUpdateDefaultNumber: false)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Try to parse phone numbers to get their country prefix before pre-filling.

## Motivation
- 🐛 

## Testing
- Manual

## Changelog
N/A under STP/spi
