### PR TITLE
Rename crypto onramp localized string file

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -53,11 +53,11 @@
 		49A11F432E5A295B002ECED5 /* AuthorizeResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A11F422E5A295B002ECED5 /* AuthorizeResult.swift */; };
 		49B34BBB2E5D0ACC0067E44F /* Image.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B34BBA2E5D0ACC0067E44F /* Image.swift */; };
 		49B7F6882E57988D0053C83B /* OnrampSessionResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B7F6872E57988D0053C83B /* OnrampSessionResponse.swift */; };
+		49D189A82E79EDEE007433ED /* STPLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D189A72E79EDEE007433ED /* STPLocalizedString.swift */; };
 		49D233A82E439EB900F51263 /* CryptoNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A72E439EB900F51263 /* CryptoNetwork.swift */; };
 		49D233AA2E439FAA00F51263 /* RegisterWalletRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */; };
 		49D233AC2E439FB200F51263 /* RegisterWalletResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */; };
 		49D73DF32E4E499F00E35F1F /* StripeCryptoOnrampBundleLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D73DF22E4E499F00E35F1F /* StripeCryptoOnrampBundleLocator.swift */; };
-		49D73DF52E4E49C300E35F1F /* STPLocalizedString+StripeCryptoOnramp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D73DF42E4E49C300E35F1F /* STPLocalizedString+StripeCryptoOnramp.swift */; };
 		49D73DF92E4E49EC00E35F1F /* String+Localized.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D73DF82E4E49EC00E35F1F /* String+Localized.swift */; };
 		49E3D7312E708490006CE394 /* OHHTTPStubs in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6DF3512E298A6B008B1800 /* OHHTTPStubs */; };
 		49E3D7322E708490006CE394 /* OHHTTPStubsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6DF3522E298A6B008B1800 /* OHHTTPStubsSwift */; };
@@ -135,11 +135,11 @@
 		49A11F422E5A295B002ECED5 /* AuthorizeResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthorizeResult.swift; sourceTree = "<group>"; };
 		49B34BBA2E5D0ACC0067E44F /* Image.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Image.swift; sourceTree = "<group>"; };
 		49B7F6872E57988D0053C83B /* OnrampSessionResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnrampSessionResponse.swift; sourceTree = "<group>"; };
+		49D189A72E79EDEE007433ED /* STPLocalizedString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPLocalizedString.swift; sourceTree = "<group>"; };
 		49D233A72E439EB900F51263 /* CryptoNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoNetwork.swift; sourceTree = "<group>"; };
 		49D233A92E439FAA00F51263 /* RegisterWalletRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterWalletRequest.swift; sourceTree = "<group>"; };
 		49D233AB2E439FB200F51263 /* RegisterWalletResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegisterWalletResponse.swift; sourceTree = "<group>"; };
 		49D73DF22E4E499F00E35F1F /* StripeCryptoOnrampBundleLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StripeCryptoOnrampBundleLocator.swift; sourceTree = "<group>"; };
-		49D73DF42E4E49C300E35F1F /* STPLocalizedString+StripeCryptoOnramp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "STPLocalizedString+StripeCryptoOnramp.swift"; sourceTree = "<group>"; };
 		49D73DF82E4E49EC00E35F1F /* String+Localized.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Localized.swift"; sourceTree = "<group>"; };
 		49E3D7622E71EF5F006CE394 /* CryptoOnrampAnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoOnrampAnalyticsClient.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -207,7 +207,7 @@
 				0B089E6E2E53935B007D160E /* CheckoutError.swift */,
 				0B6DF3472E296E2F008B1800 /* API Bindings */,
 				49D73DF22E4E499F00E35F1F /* StripeCryptoOnrampBundleLocator.swift */,
-				49D73DF42E4E49C300E35F1F /* STPLocalizedString+StripeCryptoOnramp.swift */,
+				49D189A72E79EDEE007433ED /* STPLocalizedString.swift */,
 				49D73DF82E4E49EC00E35F1F /* String+Localized.swift */,
 				49B34BBA2E5D0ACC0067E44F /* Image.swift */,
 				49E3D7622E71EF5F006CE394 /* CryptoOnrampAnalyticsClient.swift */,
@@ -507,12 +507,12 @@
 				49B34BBB2E5D0ACC0067E44F /* Image.swift in Sources */,
 				49D233AC2E439FB200F51263 /* RegisterWalletResponse.swift in Sources */,
 				0B6DF34B2E297E0A008B1800 /* CustomerRequest.swift in Sources */,
+				49D189A82E79EDEE007433ED /* STPLocalizedString.swift in Sources */,
 				0B089E692E5378F7007D160E /* PaymentMethodType.swift in Sources */,
 				4926A97F2E73450500E81597 /* CryptoOnrampAnalyticsEvent.swift in Sources */,
 				0B089E6B2E5386C9007D160E /* SelectedPaymentSource.swift in Sources */,
 				490D4AC72E5541A600FAF4FF /* CreatePaymentTokenRequest.swift in Sources */,
 				49E3D7632E71EF5F006CE394 /* CryptoOnrampAnalyticsClient.swift in Sources */,
-				49D73DF52E4E49C300E35F1F /* STPLocalizedString+StripeCryptoOnramp.swift in Sources */,
 				0B6DF34D2E297E27008B1800 /* CustomerResponse.swift in Sources */,
 				0BF41E8B2E3AB84800CA4171 /* IdType.swift in Sources */,
 				0BA7050C2E413DA40044B483 /* Credentials.swift in Sources */,

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/STPLocalizedString.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/STPLocalizedString.swift
@@ -1,8 +1,8 @@
 //
-//  STPLocalizedString+StripeCryptoOnramp.swift
+//  STPLocalizedString.swift
 //  StripeCryptoOnramp
 //
-//  Created by Mat Schmid on 8/14/25.
+//  Created by Mat Schmid on 9/16/25.
 //
 
 import Foundation


### PR DESCRIPTION
## Summary

Fixes an error spotted in https://app.bitrise.io/build/f8e2199a-2bb3-41d9-875a-cda01210945f?tests_filter_status=failed: 

```
genstrings: error: bad entry in file StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/STPLocalizedString+StripeCryptoOnramp.swift (line = 11): Argument is not a literal string.
```

All other modules use the exact filename `STPLocalizedString.swift`, which the genstrings script explicitly excludes with `! -name STPLocalizedString.swift`.

## Motivation

☝️ 

## Testing

Check CI and make sure this step works on this branch!

## Changelog

N/a