### PR TITLE
Rename `analytics_session_id` to `mobile_session_id`

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CryptoOnrampAnalyticsClient.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CryptoOnrampAnalyticsClient.swift
@@ -31,7 +31,7 @@ final class CryptoOnrampAnalyticsClient {
         if AnalyticsHelper.shared.sessionID == nil {
             AnalyticsHelper.shared.generateSessionID()
         }
-        additionalParameters["analytics_session_id"] = AnalyticsHelper.shared.sessionID ?? "N/a"
+        additionalParameters["mobile_session_id"] = AnalyticsHelper.shared.sessionID ?? "N/a"
     }
 
     func log(_ event: CryptoOnrampAnalyticsEvent) {


### PR DESCRIPTION
## Summary

In the CryptoOnrampAnalyticsClient, this updates the session ID key name to `mobile_session_id` instead of `analytics_session_id`

## Motivation

https://stripe.slack.com/archives/C08G5K7ULLT/p1758045561763309

## Testing

N/a

## Changelog

N/a
