### PR TITLE
Add confirmation token to intent confirm params

### DIFF
--- a/Stripe/StripeiOSTests/STPPaymentIntentParamsTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentIntentParamsTest.swift
@@ -37,6 +37,7 @@ class STPPaymentIntentParamsTest: XCTestCase {
             XCTAssertNil(params.mandateData)
             XCTAssertNil(params.paymentMethodOptions)
             XCTAssertNil(params.shipping)
+            XCTAssertNil(params.confirmationToken)
         }
     }
 
@@ -161,6 +162,7 @@ class STPPaymentIntentParamsTest: XCTestCase {
             address: STPPaymentIntentShippingDetailsAddressParams(line1: ""),
             name: ""
         )
+        params.confirmationToken = "ctoken_test_123"
 
         let paramsCopy = params.copy() as! STPPaymentIntentParams
         XCTAssertEqual(params.clientSecret, paramsCopy.clientSecret)
@@ -181,7 +183,28 @@ class STPPaymentIntentParamsTest: XCTestCase {
             params.additionalAPIParameters as NSDictionary,
             paramsCopy.additionalAPIParameters as NSDictionary
         )
+        XCTAssertEqual(params.confirmationToken, paramsCopy.confirmationToken)
 
+    }
+
+    func testConfirmationTokenProperty() {
+        let params = STPPaymentIntentParams()
+
+        XCTAssertNil(params.confirmationToken)
+
+        params.confirmationToken = "ctoken_test_123"
+        XCTAssertEqual(params.confirmationToken, "ctoken_test_123")
+
+        params.confirmationToken = ""
+        XCTAssertEqual(params.confirmationToken, "")
+
+        params.confirmationToken = nil
+        XCTAssertNil(params.confirmationToken)
+    }
+
+    func testFormFieldMappingIncludesConfirmationToken() {
+        let mapping = STPPaymentIntentParams.propertyNamesToFormFieldNamesMapping()
+        XCTAssertEqual(mapping[NSStringFromSelector(#selector(getter: STPPaymentIntentParams.confirmationToken))], "confirmation_token")
     }
 
     func testClientSecretValidation() {

--- a/Stripe/StripeiOSTests/STPSetupIntentConfirmParamsTest.swift
+++ b/Stripe/StripeiOSTests/STPSetupIntentConfirmParamsTest.swift
@@ -27,6 +27,7 @@ class STPSetupIntentConfirmParamsTest: XCTestCase {
             XCTAssertNil(params.setAsDefaultPM)
             XCTAssertNil(params.useStripeSDK)
             XCTAssertNil(params.mandateData)
+            XCTAssertNil(params.confirmationToken)
         }
     }
 
@@ -106,6 +107,7 @@ class STPSetupIntentConfirmParamsTest: XCTestCase {
         params.additionalAPIParameters = [
             "other_param": "other_value"
         ]
+        params.confirmationToken = "ctoken_test_123"
 
         let paramsCopy = params.copy() as! STPSetupIntentConfirmParams
         XCTAssertEqual(params.clientSecret, paramsCopy.clientSecret)
@@ -122,7 +124,28 @@ class STPSetupIntentConfirmParamsTest: XCTestCase {
             params.additionalAPIParameters as NSDictionary,
             paramsCopy.additionalAPIParameters as NSDictionary
         )
+        XCTAssertEqual(params.confirmationToken, paramsCopy.confirmationToken)
 
+    }
+
+    func testConfirmationTokenProperty() {
+        let params = STPSetupIntentConfirmParams()
+
+        XCTAssertNil(params.confirmationToken)
+
+        params.confirmationToken = "ctoken_test_123"
+        XCTAssertEqual(params.confirmationToken, "ctoken_test_123")
+
+        params.confirmationToken = ""
+        XCTAssertEqual(params.confirmationToken, "")
+
+        params.confirmationToken = nil
+        XCTAssertNil(params.confirmationToken)
+    }
+
+    func testFormFieldMappingIncludesConfirmationToken() {
+        let mapping = STPSetupIntentConfirmParams.propertyNamesToFormFieldNamesMapping()
+        XCTAssertEqual(mapping[NSStringFromSelector(#selector(getter: STPSetupIntentConfirmParams.confirmationToken))], "confirmation_token")
     }
 
     func testClientSecretValidation() {

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPPaymentIntentParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentIntents/STPPaymentIntentParams.swift
@@ -161,6 +161,9 @@ public class STPPaymentIntentParams: NSObject {
     /// Contains metadata with identifiers for the session and information about the integration
     @objc @_spi(STP) public var clientAttributionMetadata: STPClientAttributionMetadata?
 
+    /// ID of an existing ConfirmationToken to use for this PaymentIntent confirmation.
+    @objc @_spi(STP) public var confirmationToken: String?
+
     /// The URL to redirect your customer back to after they authenticate or cancel
     /// their payment on the payment method’s app or site.
     /// This property has been renamed to `returnURL` and deprecated.
@@ -221,6 +224,8 @@ public class STPPaymentIntentParams: NSObject {
             "radarOptions = @\(String(describing: radarOptions))",
             // ClientAttributionMetadata
             "clientAttributionMetadata = @\(String(describing: clientAttributionMetadata))",
+            // ConfirmationToken
+            "confirmationToken = \(String(describing: confirmationToken))",
             // Additional params set by app
             "additionalAPIParameters = \(additionalAPIParameters)",
         ]
@@ -275,6 +280,7 @@ extension STPPaymentIntentParams: STPFormEncodable {
             NSStringFromSelector(#selector(getter: shipping)): "shipping",
             NSStringFromSelector(#selector(getter: radarOptions)): "radar_options",
             NSStringFromSelector(#selector(getter: clientAttributionMetadata)): "client_attribution_metadata",
+            NSStringFromSelector(#selector(getter: confirmationToken)): "confirmation_token",
         ]
     }
 }
@@ -304,6 +310,7 @@ extension STPPaymentIntentParams: NSCopying {
         copy.shipping = shipping
         copy.radarOptions = radarOptions
         copy.clientAttributionMetadata = clientAttributionMetadata
+        copy.confirmationToken = confirmationToken
         copy.additionalAPIParameters = additionalAPIParameters
 
         return copy

--- a/StripePayments/StripePayments/Source/API Bindings/Models/SetupIntents/STPSetupIntentConfirmParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/SetupIntents/STPSetupIntentConfirmParams.swift
@@ -98,6 +98,9 @@ public class STPSetupIntentConfirmParams: NSObject, NSCopying, STPFormEncodable 
     /// Contains metadata with identifiers for the session and information about the integration
     @objc @_spi(STP) public var clientAttributionMetadata: STPClientAttributionMetadata?
 
+    /// ID of an existing ConfirmationToken to use for this SetupIntent confirmation.
+    @objc @_spi(STP) public var confirmationToken: String?
+
     override convenience init() {
         // Not a valid clientSecret, but at least it'll be non-null
         self.init(clientSecret: "")
@@ -122,6 +125,8 @@ public class STPSetupIntentConfirmParams: NSObject, NSCopying, STPFormEncodable 
             "radarOptions = \(String(describing: radarOptions))",
             // ClientAttributionMetadata
             "clientAttributionMetadata = @\(String(describing: clientAttributionMetadata))",
+            // ConfirmationToken
+            "confirmationToken = \(String(describing: confirmationToken))",
             // Additional params set by app
             "additionalAPIParameters = \(additionalAPIParameters )",
         ]
@@ -145,6 +150,7 @@ public class STPSetupIntentConfirmParams: NSObject, NSCopying, STPFormEncodable 
         copy.mandateData = mandateData
         copy.radarOptions = radarOptions
         copy.clientAttributionMetadata = clientAttributionMetadata
+        copy.confirmationToken = confirmationToken
         copy.additionalAPIParameters = additionalAPIParameters
 
         return copy
@@ -166,6 +172,7 @@ public class STPSetupIntentConfirmParams: NSObject, NSCopying, STPFormEncodable 
             NSStringFromSelector(#selector(getter: mandateData)): "mandate_data",
             NSStringFromSelector(#selector(getter: radarOptions)): "radar_options",
             NSStringFromSelector(#selector(getter: clientAttributionMetadata)): "client_attribution_metadata",
+            NSStringFromSelector(#selector(getter: confirmationToken)): "confirmation_token",
         ]
     }
 


### PR DESCRIPTION
## Summary
- Adds `confirmation_token` to the confirm params so we can use them to confirm intents client-side later.
- https://docs.stripe.com/api/setup_intents/confirm?api-version=2025-06-30.preview&rds=1#confirm_setup_intent-confirmation_token
- https://docs.stripe.com/api/payment_intents/confirm?api-version=2025-06-30.preview&rds=1#confirm_payment_intent-confirmation_token

## Motivation
- Confirmation Tokens

## Testing
- New tests

## Changelog
N/A
