### PR TITLE
Fix LiquidGlassDetector.isEnabled not checking iOS 26

### DIFF
--- a/StripeUICore/StripeUICore/Source/Helpers/LiquidGlassHelpers.swift
+++ b/StripeUICore/StripeUICore/Source/Helpers/LiquidGlassHelpers.swift
@@ -18,6 +18,9 @@ import UIKit
     }()
 
     @_spi(STP) public static var isEnabled: Bool {
+        guard #available(iOS 26.0, *) else {
+            return false
+        }
         return isEnabledInMerchantApp && allowNewDesign
     }
 


### PR DESCRIPTION
.