### PR TITLE
Don't log payment method type in Onramp's checkout API

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -505,12 +505,8 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
         authenticationContext: STPAuthenticationContext,
         onrampSessionClientSecretProvider: @escaping (_ onrampSessionId: String) async throws -> String
     ) async throws -> CheckoutResult {
-        guard let selectedPaymentSource else {
-            throw Error.invalidSelectedPaymentSource
-        }
         analyticsClient.log(.checkoutStarted(
-            onrampSessionId: onrampSessionId,
-            paymentMethodType: selectedPaymentSource.analyticsValue
+            onrampSessionId: onrampSessionId
         ))
         // First, attempt to check out and get the PaymentIntent
         let paymentIntent = try await performCheckoutAndRetrievePaymentIntent(
@@ -523,7 +519,6 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
             if case .completed = result {
                 analyticsClient.log(.checkoutCompleted(
                     onrampSessionId: onrampSessionId,
-                    paymentMethodType: selectedPaymentSource.analyticsValue,
                     requiredAction: false
                 ))
             }
@@ -550,7 +545,6 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
                     if case .completed = checkoutResult {
                         analyticsClient.log(.checkoutCompleted(
                             onrampSessionId: onrampSessionId,
-                            paymentMethodType: selectedPaymentSource.analyticsValue,
                             requiredAction: true
                         ))
                     }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CryptoOnrampAnalyticsEvent.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CryptoOnrampAnalyticsEvent.swift
@@ -39,8 +39,8 @@ enum CryptoOnrampAnalyticsEvent {
     case collectPaymentMethodStarted(paymentMethodType: String)
     case collectPaymentMethodCompleted(paymentMethodType: String)
     case cryptoPaymentTokenCreated(paymentMethodType: String)
-    case checkoutStarted(onrampSessionId: String, paymentMethodType: String)
-    case checkoutCompleted(onrampSessionId: String, paymentMethodType: String, requiredAction: Bool)
+    case checkoutStarted(onrampSessionId: String)
+    case checkoutCompleted(onrampSessionId: String, requiredAction: Bool)
     case userLoggedOut
     case errorOccurred(during: CryptoOnrampOperation, errorMessage: String)
 
@@ -112,15 +112,11 @@ enum CryptoOnrampAnalyticsEvent {
             return ["payment_method_type": paymentMethodType]
         case let .cryptoPaymentTokenCreated(paymentMethodType):
             return ["payment_method_type": paymentMethodType]
-        case let .checkoutStarted(onrampSessionId, paymentMethodType):
+        case let .checkoutStarted(onrampSessionId):
+            return ["onramp_session_id": onrampSessionId]
+        case let .checkoutCompleted(onrampSessionId, requiredAction):
             return [
                 "onramp_session_id": onrampSessionId,
-                "payment_method_type": paymentMethodType,
-            ]
-        case let .checkoutCompleted(onrampSessionId, paymentMethodType, requiredAction):
-            return [
-                "onramp_session_id": onrampSessionId,
-                "payment_method_type": paymentMethodType,
                 "required_action": requiredAction,
             ]
         case let .errorOccurred(operationName, errorMessage):


### PR DESCRIPTION
## Summary

We don't want to require a `selectedPaymentSource` at the time of checkout (which is set during the `collectPaymentMethod` API) to allow use of saved crypto payment tokens. That requirement was added for logging purposes, so we remove that here.

## Motivation

Allow checkouts with OTP

## Testing

Manually tested

## Changelog

N/a