### PR TITLE
Crypto Onramp SDK: Tints Link OTP Progress Indicator

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationViewController.swift
@@ -63,6 +63,11 @@ final class LinkVerificationViewController: UIViewController {
     private lazy var activityIndicator: ActivityIndicator = {
         let activityIndicator = ActivityIndicator(size: .large)
         activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+
+        if let appearancePrimaryColor = appearance?.colors?.primary {
+            activityIndicator.tintColor = appearancePrimaryColor
+        }
+
         return activityIndicator
     }()
 


### PR DESCRIPTION
## Summary
Applies a tint color to the progress indicator that appears on the OTP / verification view.

## Motivation
:ghost:

## Testing

Ran the example app to see the lavender-colored activity indicator:


<img src="https://github.com/user-attachments/assets/5a653fab-95ca-41b0-9b57-0c914931085f" width="300" /> | <img src="https://github.com/user-attachments/assets/7510d859-8421-41ce-bbbd-b7258963400b" width="300" />

## Changelog
N/A
