### PR TITLE
Fix updating Link-originated saved payment methods

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -426,7 +426,7 @@ extension VerticalSavedPaymentMethodsViewController: UpdatePaymentMethodViewCont
         do {
             // Update the payment method
             let updatedPaymentMethod = try await savedPaymentMethodManager.update(paymentMethod: paymentMethod, with: updateParams)
-
+            updatedPaymentMethod.updateLocalFields(from: paymentMethod)
             replace(paymentMethod: paymentMethod, with: updatedPaymentMethod)
             return .success(())
         } catch {
@@ -493,6 +493,12 @@ private extension STPPaymentMethod {
             return type != .card
         }
         return linkPaymentDetails.isNotCard
+    }
+
+    func updateLocalFields(from original: STPPaymentMethod) {
+        // We don't receive the following fields as part of the update response, so we need to copy them over
+        linkPaymentDetails = original.linkPaymentDetails
+        isLinkPassthroughMode = original.isLinkPassthroughMode
     }
 }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where updating a Link-originated saved payment method (added via passthrough mode) made it lose its Link branding.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
