### PR TITLE
Fix issue with invalid Link selection for RUX flows

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -482,6 +482,12 @@ extension PaymentSheet {
                 }
 
                 if shouldReturnToPaymentSheet {
+                    self.viewController.linkConfirmOption = nil
+                    if case .link(let option) = self.internalPaymentOption, case .wallet = option {
+                        // The Link row was selected before we launched the Link flow, but the user decided to drop out
+                        // of the Link flow. We clear the selection to avoid having Link stay selected.
+                        self.viewController.clearSelection()
+                    }
                     self.updatePaymentOption()
                     returnToPaymentSheet()
                     return
@@ -837,6 +843,7 @@ internal protocol FlowControllerViewControllerProtocol: BottomSheetContentViewCo
     var selectedPaymentMethodType: PaymentSheet.PaymentMethodType? { get }
     var flowControllerDelegate: FlowControllerViewControllerDelegate? { get set }
     var passiveCaptchaChallenge: PassiveCaptchaChallenge? { get set }
+    func clearSelection()
 }
 
 extension PaymentOption {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -451,7 +451,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         }
     }
 
-    private func unselectPaymentMethod() {
+    func unselectPaymentMethod() {
         guard let selectedIndexPath = selectedIndexPath else {
             return
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -529,7 +529,11 @@ extension RowButton {
     static func makeForLink(appearance: PaymentSheet.Appearance, isEmbedded: Bool = false, didTap: @escaping DidTapClosure) -> RowButton {
         let imageView = UIImageView(image: Image.link_icon.makeImage())
         imageView.contentMode = .scaleAspectFit
-        let button = RowButton.create(appearance: appearance, type: .link, imageView: imageView, text: STPPaymentMethodType.link.displayName, subtext: .Localized.link_subtitle_text, isEmbedded: isEmbedded, didTap: didTap)
+        var subtext = String.Localized.link_subtitle_text
+        if let linkAccount = LinkAccountContext.shared.account, linkAccount.isRegistered {
+            subtext = linkAccount.email
+        }
+        let button = RowButton.create(appearance: appearance, type: .link, imageView: imageView, text: STPPaymentMethodType.link.displayName, subtext: subtext, isEmbedded: isEmbedded, didTap: didTap)
         button.accessibilityHelperView.accessibilityLabel = String.Localized.pay_with_link
         return button
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
@@ -43,6 +43,12 @@ class VerticalPaymentMethodListViewController: UIViewController {
         fatalError("init(coder:) has not been implemented")
     }
 
+    func clearSelection() {
+        currentSelection = nil
+        initialSelection = nil
+        refreshContent()
+    }
+
     init(
         initialSelection: RowButtonType?,
         savedPaymentMethods: [STPPaymentMethod],

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -460,6 +460,11 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         }
     }
 
+    func clearSelection() {
+        savedPaymentOptionsViewController.unselectPaymentMethod()
+        updateButton()
+    }
+
     @objc
     private func didTapContinueButton() {
         // The user is continuing with an LPM, so we un-select Link

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -568,6 +568,11 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                 callback: { [weak self] confirmOption, _ in
                     guard let self else { return }
                     self.linkConfirmOption = confirmOption
+                    if confirmOption == nil {
+                        // The Link row was selected before we launched the Link flow, but the user decided to
+                        // drop out of the Link flow. We clear the selection to avoid having Link stay selected.
+                        self.clearSelection()
+                    }
                     self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
                 }
             )
@@ -687,6 +692,11 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                 }
             }
         }
+    }
+
+    func clearSelection() {
+        paymentMethodListViewController?.clearSelection()
+        updatePrimaryButton()
     }
 
     @objc func didTapPrimaryButton() {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request resolves an issue where dropping out of the Link bottom sheet and back into MPE would leave `link(confirmOption: .wallet)` as the currently selected payment option, which isn't a great experience. Instead, we now clear the current selection.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
