### PR TITLE
Add liquid glass opt out status to analytics

### DIFF
--- a/StripeCore/StripeCore/Source/Categories/NSBundle+Stripe_AppName.swift
+++ b/StripeCore/StripeCore/Source/Categories/NSBundle+Stripe_AppName.swift
@@ -29,9 +29,4 @@ extension Bundle {
         return self.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? self.main
             .object(forInfoDictionaryKey: "CFBundleName") as? String
     }
-
-    // returns whether the UIDesignRequiresCompatibility Info.plist property, which is used to indicate that the app is opting out of Liquid Glass, is set to true
-    @_spi(STP) public class var liquidGlassOptedOut: Bool {
-        return self.main.object(forInfoDictionaryKey: "UIDesignRequiresCompatibility") as? Bool == true
-    }
 }

--- a/StripeCore/StripeCore/Source/Categories/NSBundle+Stripe_AppName.swift
+++ b/StripeCore/StripeCore/Source/Categories/NSBundle+Stripe_AppName.swift
@@ -29,4 +29,9 @@ extension Bundle {
         return self.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? self.main
             .object(forInfoDictionaryKey: "CFBundleName") as? String
     }
+
+    // returns whether the UIDesignRequiresCompatibility Info.plist property, which is used to indicate that the app is opting out of Liquid Glass, is set to true
+    @_spi(STP) public class var liquidGlassOptedOut: Bool {
+        return self.main.object(forInfoDictionaryKey: "UIDesignRequiresCompatibility") as? Bool == true
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -71,6 +71,7 @@ extension PaymentSheet.Appearance {
         payload["primary_button"] = primaryButton != PaymentSheet.Appearance.default.primaryButton
         payload["navigation_bar_style"] = navigationBarStyle.analyticsValue
         payload["apply_liquid_glass"] = didCallApplyLiquidGlass
+        payload["app_opted_out_liquid_glass"] = Bundle.liquidGlassOptedOut
 
         // Convenience payload item to make querying high level appearance usage easier
         payload["usage"] = payload.values.contains(where: { value in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -72,7 +72,8 @@ extension PaymentSheet.Appearance {
         payload["primary_button"] = primaryButton != PaymentSheet.Appearance.default.primaryButton
         payload["navigation_bar_style"] = navigationBarStyle.analyticsValue
         payload["apply_liquid_glass"] = didCallApplyLiquidGlass
-        payload["app_opted_out_liquid_glass"] = LiquidGlassDetector.hasOptedOut
+        payload["ui_design_requires_compatibility"] = LiquidGlassDetector.hasOptedOut
+        payload["has_liquid_glass_compiler_requirements"] = LiquidGlassDetector.meetsCompilerRequirements
 
         // Convenience payload item to make querying high level appearance usage easier
         payload["usage"] = payload.values.contains(where: { value in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -10,6 +10,7 @@ import Foundation
 @_spi(STP) import StripeApplePay
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
 
 extension STPAnalyticsClient {
     /// ⚠️ Deprecated - use `PaymentSheetAnalyticsHelper` if you are actually a PaymentSheet analytic so that you can send all the params common to PaymentSheet analytics. 
@@ -71,7 +72,7 @@ extension PaymentSheet.Appearance {
         payload["primary_button"] = primaryButton != PaymentSheet.Appearance.default.primaryButton
         payload["navigation_bar_style"] = navigationBarStyle.analyticsValue
         payload["apply_liquid_glass"] = didCallApplyLiquidGlass
-        payload["app_opted_out_liquid_glass"] = Bundle.liquidGlassOptedOut
+        payload["app_opted_out_liquid_glass"] = LiquidGlassDetector.hasOptedOut
 
         // Convenience payload item to make querying high level appearance usage easier
         payload["usage"] = payload.values.contains(where: { value in


### PR DESCRIPTION
## Summary
Add a payment sheet appearance analytics value tracking whether or not the host app has opted out of Liquid Glass

## Motivation
Get better data on whether or not users are opting out of Liquid Glass

## Testing
Tested that the correct values were sent by a sample app in the following scenarios:
- UIDesignRequiresCompatibility not present; iOS 26 device
- UIDesignRequiresCompatibility = false; iOS 26 device
- UIDesignRequiresCompatibility = true; iOS 26 devices
- UIDesignRequiresCompatibility = false; iOS 18 device
- UIDesignRequiresCompatibility = true; iOS 18 device

## Changelog
N/A
