### PR TITLE
Fix Link inline signup view on iOS 26

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/AppearancePlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/AppearancePlaygroundView.swift
@@ -497,6 +497,7 @@ struct AppearancePlaygroundView: View {
                             Text("Apply Liquid Glass🥃")
                         }
                         Button {
+                            resetLinkUI()
                             appearance = PaymentSheet.Appearance()
                             appearance.applyLiquidGlass()
                             doneAction(appearance)
@@ -506,6 +507,7 @@ struct AppearancePlaygroundView: View {
                     }
                 }
                 Button {
+                    resetLinkUI()
                     appearance = PaymentSheet.Appearance()
                     doneAction(appearance)
                 } label: {

--- a/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
+++ b/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
@@ -17,14 +17,6 @@ import UIKit
 // @iOS26
 class LinkInlineSignupElementSnapshotTests: STPSnapshotTestCase {
 
-    override static func setUp() {
-        if #available(iOS 26, *) {
-            var configuration = PaymentSheet.Configuration()
-            configuration.appearance.applyLiquidGlass()
-            LinkUI.applyLiquidGlassIfPossible(configuration: configuration)
-        }
-    }
-
     // MARK: Normal mode
 
     func testDefaultState() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
@@ -39,7 +39,7 @@ extension LinkInlineSignupView {
 
         private lazy var checkboxButton: CheckboxButton = {
             var appearanceCopy = appearance
-            if LinkUI.useLiquidGlass {
+            if appearance.cornerRadius == nil && LiquidGlassDetector.isEnabledInMerchantApp {
                 // Make the checkbox in Link use the same background color as its container, which is componentBackground
                 appearanceCopy.colors.background = appearance.colors.componentBackground
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
@@ -26,10 +26,14 @@ final class LinkInlineSignupView: UIView {
         return viewModel.configuration.appearance.asElementsTheme
     }
 
+    private var isUsingLiquidGlass: Bool {
+        theme.cornerRadius == nil && LiquidGlassDetector.isEnabledInMerchantApp
+    }
+
     private var combinedEmailNameSectionTheme: ElementsAppearance {
         var themeCopy = theme
         themeCopy.borderWidth = viewModel.combinedEmailNameSectionBorderWidth
-        if LinkUI.useLiquidGlass && viewModel.mode == .checkbox {
+        if isUsingLiquidGlass && viewModel.mode == .checkbox {
             // Use a smaller corner radius than the container
             themeCopy.cornerRadius = LinkUI.nestedInlineSignupSectionCornerRadius
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/LinkUI.swift
@@ -136,6 +136,14 @@ extension LinkUI {
 
 }
 
+@_spi(STP) public func resetLinkUI() {
+    // We should refactor LinkUI to not be a singleton anymore, now that it's dependent
+    // on the dynamic configuration. That being said, we still want to be able to accurately
+    // reset it in the playground. That's what this method is for.
+    let configuration = PaymentSheet.Configuration()
+    LinkUI.applyLiquidGlassIfPossible(configuration: configuration)
+}
+
 // MARK: - Typography
 
 extension LinkUI {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
@@ -147,6 +147,10 @@ final class LinkInlineSignupViewModel {
         }
     }
 
+    var useLiquidGlass: Bool {
+        configuration.appearance.cornerRadius == nil && LiquidGlassDetector.isEnabledInMerchantApp
+    }
+
     var requiresNameCollection: Bool {
         return country != "US"
     }
@@ -301,7 +305,7 @@ final class LinkInlineSignupViewModel {
     var bordered: Bool {
         switch mode {
         case .checkbox:
-            return !LinkUI.useLiquidGlass
+            return !useLiquidGlass
         case .checkboxWithDefaultOptIn, .textFieldsOnlyEmailFirst, .textFieldsOnlyPhoneFirst, .signupOptIn:
             return false
         }
@@ -310,7 +314,7 @@ final class LinkInlineSignupViewModel {
     var containerBackground: UIColor {
         switch mode {
         case .checkbox:
-            if LinkUI.useLiquidGlass {
+            if useLiquidGlass {
                 return configuration.appearance.colors.componentBackground
             } else {
                 return configuration.appearance.colors.background
@@ -323,7 +327,7 @@ final class LinkInlineSignupViewModel {
     var containerCornerRadius: CGFloat? {
         switch mode {
         case .checkbox:
-            return LinkUI.useLiquidGlass ? nil : configuration.appearance.cornerRadius
+            return configuration.appearance.cornerRadius
         case .checkboxWithDefaultOptIn, .textFieldsOnlyEmailFirst, .textFieldsOnlyPhoneFirst, .signupOptIn:
             // The content is right at the border of the view. Remove the corner radius so that we don't cut off anything.
             return 0


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue with the Link inline signup view looking incorrect on iOS 26.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

🥛

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

Made snapshot test setup more similar to production setup.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
