### PR TITLE
Use sheet instead of dialog for Link RUX

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -320,7 +320,6 @@ import UIKit
 
         presentingViewController.presentNativeLink(
             selectedPaymentDetailsID: selectedPaymentDetails?.stripeID,
-            linkAccount: linkAccount,
             configuration: configuration,
             intent: intent,
             elementsSession: elementsSession,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -21,76 +21,11 @@ extension UIViewController {
 
     func presentNativeLink(
         selectedPaymentDetailsID: String?,
-        linkAccount: PaymentSheetLinkAccount? = LinkAccountContext.shared.account,
         configuration: PaymentElementConfiguration,
         intent: Intent,
         elementsSession: STPElementsSession,
         analyticsHelper: PaymentSheetAnalyticsHelper,
         supportedPaymentMethodTypes: [LinkPaymentMethodType] = LinkPaymentMethodType.allCases,
-        linkAppearance: LinkAppearance? = nil,
-        linkConfiguration: LinkConfiguration? = nil,
-        shouldShowSecondaryCta: Bool = true,
-        verificationDismissed: (() -> Void)? = nil,
-        hcaptchaToken: String? = nil,
-        callback: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
-    ) {
-        if let linkAccount, linkAccount.sessionState == .requiresVerification {
-            let verificationController = LinkVerificationController(
-                mode: .inlineLogin,
-                linkAccount: linkAccount,
-                configuration: configuration,
-                appearance: linkAppearance,
-                allowLogoutInDialog: true
-            )
-
-            verificationController.present(from: bottomSheetController ?? self) { [weak self] result in
-                if case .switchAccount = result {
-                    // The user logged out in the dialog. Clear the account, but still open the Link flow
-                    // to allow them to sign into another account.
-                    LinkAccountContext.shared.account = nil
-                }
-
-                guard let self, case .completed = result else {
-                    verificationDismissed?()
-                    return
-                }
-
-                self.presentNativeLink(
-                    selectedPaymentDetailsID: selectedPaymentDetailsID,
-                    intent: intent,
-                    elementsSession: elementsSession,
-                    configuration: configuration,
-                    analyticsHelper: analyticsHelper,
-                    supportedPaymentMethodTypes: supportedPaymentMethodTypes,
-                    linkAppearance: linkAppearance,
-                    linkConfiguration: linkConfiguration,
-                    callback: callback
-                )
-            }
-        } else {
-            presentNativeLink(
-                selectedPaymentDetailsID: selectedPaymentDetailsID,
-                intent: intent,
-                elementsSession: elementsSession,
-                configuration: configuration,
-                analyticsHelper: analyticsHelper,
-                supportedPaymentMethodTypes: supportedPaymentMethodTypes,
-                linkAppearance: linkAppearance,
-                linkConfiguration: linkConfiguration,
-                shouldShowSecondaryCta: shouldShowSecondaryCta,
-                hcaptchaToken: hcaptchaToken,
-                callback: callback
-            )
-        }
-    }
-
-    private func presentNativeLink(
-        selectedPaymentDetailsID: String?,
-        intent: Intent,
-        elementsSession: STPElementsSession,
-        configuration: PaymentElementConfiguration,
-        analyticsHelper: PaymentSheetAnalyticsHelper,
-        supportedPaymentMethodTypes: [LinkPaymentMethodType],
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
         shouldShowSecondaryCta: Bool = true,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -468,11 +468,6 @@ extension PaymentSheet {
             selectedPaymentDetailsID: String? = nil,
             returnToPaymentSheet: @escaping () -> Void
         ) {
-            let verificationDismissed: () -> Void = { [weak self] in
-                self?.didDismissLinkVerificationDialog = true
-                returnToPaymentSheet()
-            }
-
             let completionCallback: (PaymentSheet.LinkConfirmOption?, Bool) -> Void = { [weak self] confirmOption, shouldReturnToPaymentSheet in
                 guard let self else { return }
 
@@ -505,7 +500,6 @@ extension PaymentSheet {
                     intent: intent,
                     elementsSession: elementsSession,
                     analyticsHelper: analyticsHelper,
-                    verificationDismissed: verificationDismissed,
                     hcaptchaToken: hcaptchaToken,
                     callback: completionCallback
                 )


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request replaces the Link OTP dialog with the bottom sheet. This way, there's less switching between UI elements, which results in a smoother experience.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
