### PR TITLE
Add analytics events for WalletButtonView

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
@@ -39,8 +39,8 @@ public struct MobilePaymentElementAnalyticEvent {
         case selectedSavedPaymentMethod(SelectedSavedPaymentMethod)
         /// User removed a saved payment method
         case removedSavedPaymentMethod(RemovedSavedPaymentMethod)
-        /// User tapped a wallet button
-        case tappedWalletButton(TappedWalletButton)
+        /// User tapped an express checkout button
+        case tappedExpressButton(TappedExpressButton)
     }
 
     /// Details of the .selectedPaymentMethodType event
@@ -85,9 +85,9 @@ public struct MobilePaymentElementAnalyticEvent {
         public let paymentMethodType: String
     }
 
-    /// Details of the .tappedWalletButton event
-    public struct TappedWalletButton: Equatable {
-        /// The wallet type (apple_pay, link, shop_pay)
-        public let walletType: String
+    /// Details of the .tappedExpressButton event
+    public struct TappedExpressButton: Equatable {
+        /// The express checkout button type (apple_pay, link, shop_pay)
+        public let expressButtonType: String
     }
 }

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/Notification+Stripe.swift
@@ -39,6 +39,8 @@ public struct MobilePaymentElementAnalyticEvent {
         case selectedSavedPaymentMethod(SelectedSavedPaymentMethod)
         /// User removed a saved payment method
         case removedSavedPaymentMethod(RemovedSavedPaymentMethod)
+        /// User tapped a wallet button
+        case tappedWalletButton(TappedWalletButton)
     }
 
     /// Details of the .selectedPaymentMethodType event
@@ -81,5 +83,11 @@ public struct MobilePaymentElementAnalyticEvent {
     public struct RemovedSavedPaymentMethod: Equatable {
         /// The payment method type
         public let paymentMethodType: String
+    }
+
+    /// Details of the .tappedWalletButton event
+    public struct TappedWalletButton: Equatable {
+        /// The wallet type (apple_pay, link, shop_pay)
+        public let walletType: String
     }
 }

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -75,6 +75,14 @@ struct STPAnalyticsEventTranslator {
             }
             return .removedSavedPaymentMethod(.init(paymentMethodType: paymentMethodType))
 
+        // Wallet Button Taps
+        case .mcWalletButtonTapApplePay:
+            return .tappedWalletButton(.init(walletType: "apple_pay"))
+        case .mcWalletButtonTapLink:
+            return .tappedWalletButton(.init(walletType: "link"))
+        case .mcWalletButtonTapShopPay:
+            return .tappedWalletButton(.init(walletType: "shop_pay"))
+
         default:
             return nil
         }

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -75,13 +75,12 @@ struct STPAnalyticsEventTranslator {
             }
             return .removedSavedPaymentMethod(.init(paymentMethodType: paymentMethodType))
 
-        // Wallet Button Taps
-        case .mcWalletButtonTapApplePay:
-            return .tappedWalletButton(.init(walletType: "apple_pay"))
-        case .mcWalletButtonTapLink:
-            return .tappedWalletButton(.init(walletType: "link"))
-        case .mcWalletButtonTapShopPay:
-            return .tappedWalletButton(.init(walletType: "shop_pay"))
+        // Wallet Button Tap
+        case .mcWalletButtonTapped:
+            guard let walletType = walletType(payload) else {
+                return nil
+            }
+            return .tappedWalletButton(.init(walletType: walletType))
 
         default:
             return nil
@@ -91,6 +90,13 @@ struct STPAnalyticsEventTranslator {
     func paymentMethodType(_ originalPayload: [String: Any]) -> String? {
         if let paymentMethodType = originalPayload["selected_lpm"] as? String {
             return paymentMethodType
+        }
+        return nil
+    }
+    
+    func walletType(_ originalPayload: [String: Any]) -> String? {
+        if let walletType = originalPayload["selected_lpm"] as? String {
+            return walletType
         }
         return nil
     }

--- a/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
+++ b/StripeCore/StripeCore/Source/Analytics/Eventing/STPAnalyticsEventTranslator.swift
@@ -75,12 +75,12 @@ struct STPAnalyticsEventTranslator {
             }
             return .removedSavedPaymentMethod(.init(paymentMethodType: paymentMethodType))
 
-        // Wallet Button Tap
+        // Express Button Tap
         case .mcWalletButtonTapped:
-            guard let walletType = walletType(payload) else {
+            guard let expressButtonType = walletType(payload) else {
                 return nil
             }
-            return .tappedWalletButton(.init(walletType: walletType))
+            return .tappedExpressButton(.init(expressButtonType: expressButtonType))
 
         default:
             return nil
@@ -93,7 +93,7 @@ struct STPAnalyticsEventTranslator {
         }
         return nil
     }
-    
+
     func walletType(_ originalPayload: [String: Any]) -> String? {
         if let walletType = originalPayload["selected_lpm"] as? String {
             return walletType

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -132,6 +132,11 @@ import Foundation
     case mcOptionSelectCompleteLink = "mc_complete_paymentoption_link_select"
     case mcOptionSelectEmbeddedSavedPM = "mc_embedded_paymentoption_savedpm_select"
 
+    // MARK: - PaymentSheet Wallet Button Taps
+    case mcWalletButtonTapApplePay = "mc_wallet_button_tap_applepay"
+    case mcWalletButtonTapLink = "mc_wallet_button_tap_link"
+    case mcWalletButtonTapShopPay = "mc_wallet_button_tap_shoppay"
+
     // MARK: - PaymentSheet Saved Payment Method Removed
     case mcOptionRemoveCustomSavedPM = "mc_custom_paymentoption_removed"
     case mcOptionRemoveCompleteSavedPM = "mc_complete_paymentoption_removed"

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -132,10 +132,8 @@ import Foundation
     case mcOptionSelectCompleteLink = "mc_complete_paymentoption_link_select"
     case mcOptionSelectEmbeddedSavedPM = "mc_embedded_paymentoption_savedpm_select"
 
-    // MARK: - PaymentSheet Wallet Button Taps
-    case mcWalletButtonTapApplePay = "mc_wallet_button_tap_applepay"
-    case mcWalletButtonTapLink = "mc_wallet_button_tap_link"
-    case mcWalletButtonTapShopPay = "mc_wallet_button_tap_shoppay"
+    // MARK: - PaymentSheet Wallet Button Tap
+    case mcWalletButtonTapped = "mc_wallet_button_tapped"
 
     // MARK: - PaymentSheet Saved Payment Method Removed
     case mcOptionRemoveCustomSavedPM = "mc_custom_paymentoption_removed"

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
@@ -47,6 +47,14 @@ class STPAnalyticsTranslatedEventTest: XCTestCase {
         _testTranslationMapping(event: .mcOptionRemoveEmbeddedSavedPM, payload: payloadWithLPM,
                                 translatedEventName: .removedSavedPaymentMethod(.init(paymentMethodType: "card")))
     }
+    func testWalletButtonTaps() {
+        _testTranslationMapping(event: .mcWalletButtonTapApplePay, payload: payloadWithoutLPM,
+                                translatedEventName: .tappedWalletButton(.init(walletType: "apple_pay")))
+        _testTranslationMapping(event: .mcWalletButtonTapLink, payload: payloadWithoutLPM,
+                                translatedEventName: .tappedWalletButton(.init(walletType: "link")))
+        _testTranslationMapping(event: .mcWalletButtonTapShopPay, payload: payloadWithoutLPM,
+                                translatedEventName: .tappedWalletButton(.init(walletType: "shop_pay")))
+    }
     func testAnalyticNotTranslated() {
         let translator = STPAnalyticsEventTranslator()
 

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
@@ -47,17 +47,17 @@ class STPAnalyticsTranslatedEventTest: XCTestCase {
         _testTranslationMapping(event: .mcOptionRemoveEmbeddedSavedPM, payload: payloadWithLPM,
                                 translatedEventName: .removedSavedPaymentMethod(.init(paymentMethodType: "card")))
     }
-    func testWalletButtonTaps() {
+    func testExpressButtonTaps() {
         let applePayPayload: [String: Any] = ["selected_lpm": "apple_pay"]
         let linkPayload: [String: Any] = ["selected_lpm": "link"]
         let shopPayPayload: [String: Any] = ["selected_lpm": "shop_pay"]
-        
+
         _testTranslationMapping(event: .mcWalletButtonTapped, payload: applePayPayload,
-                                translatedEventName: .tappedWalletButton(.init(walletType: "apple_pay")))
+                                translatedEventName: .tappedExpressButton(.init(expressButtonType: "apple_pay")))
         _testTranslationMapping(event: .mcWalletButtonTapped, payload: linkPayload,
-                                translatedEventName: .tappedWalletButton(.init(walletType: "link")))
+                                translatedEventName: .tappedExpressButton(.init(expressButtonType: "link")))
         _testTranslationMapping(event: .mcWalletButtonTapped, payload: shopPayPayload,
-                                translatedEventName: .tappedWalletButton(.init(walletType: "shop_pay")))
+                                translatedEventName: .tappedExpressButton(.init(expressButtonType: "shop_pay")))
     }
     func testAnalyticNotTranslated() {
         let translator = STPAnalyticsEventTranslator()

--- a/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
+++ b/StripeCore/StripeCoreTests/Analytics/STPAnalyticsEventTranslatorTest.swift
@@ -48,11 +48,15 @@ class STPAnalyticsTranslatedEventTest: XCTestCase {
                                 translatedEventName: .removedSavedPaymentMethod(.init(paymentMethodType: "card")))
     }
     func testWalletButtonTaps() {
-        _testTranslationMapping(event: .mcWalletButtonTapApplePay, payload: payloadWithoutLPM,
+        let applePayPayload: [String: Any] = ["selected_lpm": "apple_pay"]
+        let linkPayload: [String: Any] = ["selected_lpm": "link"]
+        let shopPayPayload: [String: Any] = ["selected_lpm": "shop_pay"]
+        
+        _testTranslationMapping(event: .mcWalletButtonTapped, payload: applePayPayload,
                                 translatedEventName: .tappedWalletButton(.init(walletType: "apple_pay")))
-        _testTranslationMapping(event: .mcWalletButtonTapLink, payload: payloadWithoutLPM,
+        _testTranslationMapping(event: .mcWalletButtonTapped, payload: linkPayload,
                                 translatedEventName: .tappedWalletButton(.init(walletType: "link")))
-        _testTranslationMapping(event: .mcWalletButtonTapShopPay, payload: payloadWithoutLPM,
+        _testTranslationMapping(event: .mcWalletButtonTapped, payload: shopPayPayload,
                                 translatedEventName: .tappedWalletButton(.init(walletType: "shop_pay")))
     }
     func testAnalyticNotTranslated() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -230,17 +230,17 @@ final class PaymentSheetAnalyticsHelper {
     }
 
     func logWalletButtonTapped(walletType: PaymentSheet.WalletButtonsVisibility.ExpressType) {
-        let event: STPAnalyticEvent = {
+        let selectedLPM: String = {
             switch walletType {
             case .applePay:
-                return .mcWalletButtonTapApplePay
+                return "apple_pay"
             case .link:
-                return .mcWalletButtonTapLink
+                return "link"
             case .shopPay:
-                return .mcWalletButtonTapShopPay
+                return "shop_pay"
             }
         }()
-        log(event: event)
+        log(event: .mcWalletButtonTapped, selectedLPM: selectedLPM)
     }
 
     func logSavedPaymentMethodRemoved(paymentMethod: STPPaymentMethod) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -228,6 +228,21 @@ final class PaymentSheetAnalyticsHelper {
     func logNewPaymentMethodSelected(paymentMethodTypeIdentifier: String) {
         log(event: .paymentSheetCarouselPaymentMethodTapped, selectedLPM: paymentMethodTypeIdentifier)
     }
+
+    func logWalletButtonTapped(walletType: PaymentSheet.WalletButtonsVisibility.ExpressType) {
+        let event: STPAnalyticEvent = {
+            switch walletType {
+            case .applePay:
+                return .mcWalletButtonTapApplePay
+            case .link:
+                return .mcWalletButtonTapLink
+            case .shopPay:
+                return .mcWalletButtonTapShopPay
+            }
+        }()
+        log(event: event)
+    }
+
     func logSavedPaymentMethodRemoved(paymentMethod: STPPaymentMethod) {
         let event: STPAnalyticEvent = {
             switch integrationShape {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -126,7 +126,7 @@ typealias ExpressType = PaymentSheet.WalletButtonsVisibility.ExpressType
     func checkoutTapped(_ expressType: ExpressType) {
         // Log wallet button tap analytics
         flowController.analyticsHelper.logWalletButtonTapped(walletType: expressType)
-        
+
         switch expressType {
         case .applePay:
             // Launch directly into Apple Pay and confirm the payment

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -124,6 +124,9 @@ typealias ExpressType = PaymentSheet.WalletButtonsVisibility.ExpressType
     }
 
     func checkoutTapped(_ expressType: ExpressType) {
+        // Log wallet button tap analytics
+        flowController.analyticsHelper.logWalletButtonTapped(walletType: expressType)
+        
         switch expressType {
         case .applePay:
             // Launch directly into Apple Pay and confirm the payment


### PR DESCRIPTION
## Summary
Add an analytic event for WalletButtonsView, along with a publicly observable event for `tappedExpressButton`.

## Motivation
Allows analytics for WalletButtonsView.

## Testing
Added unit tests.

## Changelog
N/A, private feature