### PR TITLE
Add in helper to convert address to shipping params

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/AddressDetails+STPAddress.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/AddressDetails+STPAddress.swift
@@ -18,4 +18,22 @@ extension AddressViewController.AddressDetails {
         stpAddress.country = address.country
         return stpAddress
     }
+
+    var paymentIntentShippingDetailsParams: STPPaymentIntentShippingDetailsParams? {
+        guard let name = name else {
+            return nil
+        }
+
+        let addressParams = STPPaymentIntentShippingDetailsAddressParams(line1: address.line1)
+        addressParams.line2 = address.line2
+        addressParams.city = address.city
+        addressParams.state = address.state
+        addressParams.postalCode = address.postalCode
+        addressParams.country = address.country
+
+        let shippingDetailsParams = STPPaymentIntentShippingDetailsParams(address: addressParams, name: name)
+        shippingDetailsParams.phone = phone
+
+        return shippingDetailsParams
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAddressTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAddressTests.swift
@@ -8,6 +8,7 @@
 
 import XCTest
 
+@testable@_spi(STP) import StripePayments
 @testable@_spi(STP) import StripePaymentSheet
 
 class PaymentSheetAddressTests: XCTestCase {
@@ -306,6 +307,220 @@ class PaymentSheetAddressTests: XCTestCase {
         )
 
         XCTAssertEqual(address.editDistance(from: otherAddress), 10)
+    }
+
+    // MARK: - paymentIntentShippingDetailsParams Tests
+
+    func testPaymentIntentShippingDetailsParamsReturnsNilWhenNameIsNil() {
+        let address = AddressViewController.AddressDetails.Address(
+            city: "San Francisco",
+            country: "US",
+            line1: "510 Townsend St.",
+            line2: nil,
+            postalCode: "94102",
+            state: "CA"
+        )
+
+        let addressDetails = AddressViewController.AddressDetails(
+            address: address,
+            name: nil,
+            phone: "+15551234567"
+        )
+
+        XCTAssertNil(addressDetails.paymentIntentShippingDetailsParams)
+    }
+
+    func testPaymentIntentShippingDetailsParamsWithCompleteValidData() {
+        let address = AddressViewController.AddressDetails.Address(
+            city: "San Francisco",
+            country: "US",
+            line1: "510 Townsend St.",
+            line2: "Apt 123",
+            postalCode: "94102",
+            state: "CA"
+        )
+
+        let addressDetails = AddressViewController.AddressDetails(
+            address: address,
+            name: "John Doe",
+            phone: "+15551234567"
+        )
+
+        let shippingParams = addressDetails.paymentIntentShippingDetailsParams
+
+        XCTAssertNotNil(shippingParams)
+        XCTAssertEqual(shippingParams?.name, "John Doe")
+        XCTAssertEqual(shippingParams?.phone, "+15551234567")
+
+        let addressParams = shippingParams?.address
+        XCTAssertNotNil(addressParams)
+        XCTAssertEqual(addressParams?.line1, "510 Townsend St.")
+        XCTAssertEqual(addressParams?.line2, "Apt 123")
+        XCTAssertEqual(addressParams?.city, "San Francisco")
+        XCTAssertEqual(addressParams?.state, "CA")
+        XCTAssertEqual(addressParams?.postalCode, "94102")
+        XCTAssertEqual(addressParams?.country, "US")
+    }
+
+    func testPaymentIntentShippingDetailsParamsWithMinimalValidData() {
+        let address = AddressViewController.AddressDetails.Address(
+            country: "US",
+            line1: "510 Townsend St."
+        )
+
+        let addressDetails = AddressViewController.AddressDetails(
+            address: address,
+            name: "Jane Smith"
+        )
+
+        let shippingParams = addressDetails.paymentIntentShippingDetailsParams
+
+        XCTAssertNotNil(shippingParams)
+        XCTAssertEqual(shippingParams?.name, "Jane Smith")
+        XCTAssertNil(shippingParams?.phone)
+
+        let addressParams = shippingParams?.address
+        XCTAssertNotNil(addressParams)
+        XCTAssertEqual(addressParams?.line1, "510 Townsend St.")
+        XCTAssertNil(addressParams?.line2)
+        XCTAssertNil(addressParams?.city)
+        XCTAssertNil(addressParams?.state)
+        XCTAssertNil(addressParams?.postalCode)
+        XCTAssertEqual(addressParams?.country, "US")
+    }
+
+    func testPaymentIntentShippingDetailsParamsWithMissingOptionalAddressFields() {
+        let address = AddressViewController.AddressDetails.Address(
+            city: nil,
+            country: "US",
+            line1: "123 Main St.",
+            line2: nil,
+            postalCode: nil,
+            state: nil
+        )
+
+        let addressDetails = AddressViewController.AddressDetails(
+            address: address,
+            name: "Test User"
+        )
+
+        let shippingParams = addressDetails.paymentIntentShippingDetailsParams
+
+        XCTAssertNotNil(shippingParams)
+        XCTAssertEqual(shippingParams?.name, "Test User")
+
+        let addressParams = shippingParams?.address
+        XCTAssertNotNil(addressParams)
+        XCTAssertEqual(addressParams?.line1, "123 Main St.")
+        XCTAssertNil(addressParams?.line2)
+        XCTAssertNil(addressParams?.city)
+        XCTAssertNil(addressParams?.state)
+        XCTAssertNil(addressParams?.postalCode)
+        XCTAssertEqual(addressParams?.country, "US")
+    }
+
+    func testPaymentIntentShippingDetailsParamsWithDifferentCountryCodes() {
+        let testCases = [
+            ("GB", "United Kingdom"),
+            ("CA", "Canada"),
+            ("AU", "Australia"),
+            ("DE", "Germany"),
+        ]
+
+        for (countryCode, _) in testCases {
+            let address = AddressViewController.AddressDetails.Address(
+                city: "Test City",
+                country: countryCode,
+                line1: "Test Address",
+                line2: nil,
+                postalCode: "12345",
+                state: nil
+            )
+
+            let addressDetails = AddressViewController.AddressDetails(
+                address: address,
+                name: "Test User"
+            )
+
+            let shippingParams = addressDetails.paymentIntentShippingDetailsParams
+
+            XCTAssertNotNil(shippingParams, "Should create params for country: \(countryCode)")
+            XCTAssertEqual(shippingParams?.address.country, countryCode, "Country should match for: \(countryCode)")
+        }
+    }
+
+    func testPaymentIntentShippingDetailsParamsPhoneNumberHandling() {
+        let address = AddressViewController.AddressDetails.Address(
+            country: "US",
+            line1: "123 Test St."
+        )
+
+        // Test with nil phone
+        let addressDetailsWithNilPhone = AddressViewController.AddressDetails(
+            address: address,
+            name: "User One",
+            phone: nil
+        )
+
+        let shippingParamsNilPhone = addressDetailsWithNilPhone.paymentIntentShippingDetailsParams
+        XCTAssertNotNil(shippingParamsNilPhone)
+        XCTAssertNil(shippingParamsNilPhone?.phone)
+
+        // Test with valid phone
+        let addressDetailsWithPhone = AddressViewController.AddressDetails(
+            address: address,
+            name: "User Two",
+            phone: "+15551234567"
+        )
+
+        let shippingParamsWithPhone = addressDetailsWithPhone.paymentIntentShippingDetailsParams
+        XCTAssertNotNil(shippingParamsWithPhone)
+        XCTAssertEqual(shippingParamsWithPhone?.phone, "+15551234567")
+
+        // Test with empty phone string
+        let addressDetailsWithEmptyPhone = AddressViewController.AddressDetails(
+            address: address,
+            name: "User Three",
+            phone: ""
+        )
+
+        let shippingParamsEmptyPhone = addressDetailsWithEmptyPhone.paymentIntentShippingDetailsParams
+        XCTAssertNotNil(shippingParamsEmptyPhone)
+        XCTAssertEqual(shippingParamsEmptyPhone?.phone, "")
+    }
+
+    func testPaymentIntentShippingDetailsParamsPropertyMappingConsistency() {
+        let address = AddressViewController.AddressDetails.Address(
+            city: "Mapping City",
+            country: "FR",
+            line1: "456 Mapping Ave",
+            line2: "Suite 789",
+            postalCode: "75001",
+            state: "Île-de-France"
+        )
+
+        let addressDetails = AddressViewController.AddressDetails(
+            address: address,
+            name: "Mapping User",
+            phone: "+33123456789"
+        )
+
+        let shippingParams = addressDetails.paymentIntentShippingDetailsParams
+
+        XCTAssertNotNil(shippingParams)
+
+        // Verify top-level properties
+        XCTAssertEqual(shippingParams?.name, addressDetails.name)
+        XCTAssertEqual(shippingParams?.phone, addressDetails.phone)
+
+        // Verify nested address properties
+        let addressParams = shippingParams?.address
+        XCTAssertEqual(addressParams?.line1, addressDetails.address.line1)
+        XCTAssertEqual(addressParams?.line2, addressDetails.address.line2)
+        XCTAssertEqual(addressParams?.city, addressDetails.address.city)
+        XCTAssertEqual(addressParams?.state, addressDetails.address.state)
+        XCTAssertEqual(addressParams?.postalCode, addressDetails.address.postalCode)
+        XCTAssertEqual(addressParams?.country, addressDetails.address.country)
     }
 
 }


### PR DESCRIPTION
## Summary
- Add a helper to convert a address to a shipping address params when creating a confirmation token.
- Shipping address will come from [here](https://github.com/stripe/stripe-ios/blob/master/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift#L159) and will be populated [here](https://github.com/stripe/stripe-ios/blob/master/StripePayments/StripePayments/Source/API%20Bindings/Models/ConfirmationTokens/STPConfirmationTokenParams.swift#L32), we need a conversion helper.

## Motivation
- Enable easy confirmation tokens implementation

## Testing
- New unit tests

## Changelog
N/A
