### PR TITLE
Crypto Onramp SDK: Fixes `ConfirmButton+Link` Background Color on Success

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
@@ -23,8 +23,9 @@ extension ConfirmButton {
         var appearance = LinkUI.appearance
 
         if let linkAppearance {
-            if let colors = linkAppearance.colors {
-                appearance.primaryButton.backgroundColor = colors.primary
+            if let primaryColor = linkAppearance.colors?.primary {
+                appearance.primaryButton.backgroundColor = primaryColor
+                appearance.primaryButton.successBackgroundColor = primaryColor
             }
 
             if let buttonConfiguration = linkAppearance.primaryButton {


### PR DESCRIPTION
## Summary
A follow-up to #5605, which highlights an issue where the `LinkAppearance` color isn’t applied to the success state of the Confirm button. This PR fixes that issue.

## Motivation
Consistent button color throughout the UI flow.

## Testing

| Before (via @mats-stripe)  | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/a32aecb5-d536-47c2-ab66-03a2630b300d" width="300" /> | <img src="https://github.com/user-attachments/assets/25c5dc0e-01b5-4ed9-be08-db238f69d0e3" width="300" /> |

## Changelog
N/A
