### PR TITLE
Fix changelog formatting, add enforcement of correct formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 24.24.0 2025-09-22
 
-## Connect
+### Connect
 * [Added] Payments and Payouts embedded components are available to use in public preview.
 
-## PaymentSheet
+### PaymentSheet
 * [Added] Added `Appearance.applyLiquidGlass()`, a convenience method that changes the values of various properties on the `Appearance` object used by PaymentSheet, PaymentSheet.FlowController, EmbeddedPaymentElement, CustomerSheet, and AddressViewController to match Liquid Glass when building with Xcode 26 or later and running on iOS 26. This includes `appearance.cornerRadius`, `appearance.borderWidth`, `appearance.navigationBarStyle`, `colors.background`, `navigationBarStyle`, and others. This feature is in public preview while we gather feedback and is subject to change. Please use https://github.com/stripe/stripe-ios/issues to file feedback!
 
 | <img src="https://github.com/user-attachments/assets/0d9d333e-41e0-43d0-816b-675916d19d0b" /> | <img src="https://github.com/user-attachments/assets/d043fe5d-65de-4901-be08-21945a2657c1" /> |
@@ -20,7 +20,7 @@
 
 ## 24.23.2 2025-09-16
 
-## PaymentSheet
+### PaymentSheet
 * [Fixed] Fixed an issue with the Liquid Glass keyboard toolbar where tapping on the sheet immediately above the keyboard didn't have an effect.
 
 ## 24.23.1 2025-09-08
@@ -1205,7 +1205,7 @@ When a customer is adding a new payment method, PaymentSheet uses information li
 * Adds support for CVC recollection in PaymentIntent confirm [#1473](https://github.com/stripe/stripe-ios/pull/1473)
 * Fixes a race condition when setting `defaultPaymentMethod` on `STPPaymentOptionsViewController` [#1476](https://github.com/stripe/stripe-ios/pull/1476)
 
-## 18.3.0 2019-12-3
+## 18.3.0 2019-12-03
 * STPAddCardViewControllerDelegate methods previously removed in v16.0.0 are now marked as deprecated, to help migrating users [#1439](https://github.com/stripe/stripe-ios/pull/1439)
 * Fixes an issue where canceling 3DS authentication could leave PaymentIntents in an inaccurate `requires_action` state [#1443](https://github.com/stripe/stripe-ios/pull/1443)
 * Fixes text color for large titles [#1446](https://github.com/stripe/stripe-ios/pull/1446)
@@ -1320,7 +1320,7 @@ When a customer is adding a new payment method, PaymentSheet uses information li
 * Updates sample apps to use `PaymentIntents` and `PaymentMethods` where available. [#1159](https://github.com/stripe/stripe-ios/pull/1159)
 * Changes `STPPaymentMethodCardParams` `expMonth` and `expYear` property types to `NSNumber *` to fix a bug using Apple Pay. [#1161](https://github.com/stripe/stripe-ios/pull/1161)
 
-## 15.0.0 2019-3-19
+## 15.0.0 2019-03-19
 * Renames all former references to 'PaymentMethod' to 'PaymentOption'. See [MIGRATING.md](/MIGRATING.md) for more details. [#1139](https://github.com/stripe/stripe-ios/pull/1139)
   * Renames `STPPaymentMethod` to `STPPaymentOption`
   * Renames `STPPaymentMethodType` to `STPPaymentOptionType`
@@ -1675,10 +1675,10 @@ When a customer is adding a new payment method, PaymentSheet uses information li
 ## 2.0.1 2014-09-18
 * Fix some small bugs related to ApplePay and iOS8
 
-## 2.0 2014-09-09
+## 2.0.0 2014-09-09
 * Add support for native payments via Pay
 
-## 1.2 2014-08-21
+## 1.2.0 2014-08-21
 * Removed PaymentKit as a dependency. If you'd like to use it, you may still do so by including it separately.
 * Removed STPView. PaymentKit provides a near-identical version of this functionality if you need to migrate.
 * Improve example project

--- a/ci_scripts/check_changelog.rb
+++ b/ci_scripts/check_changelog.rb
@@ -9,6 +9,7 @@ LATEST_RELEASE_HEADING_PATTERN = Regexp.new(
 )
 
 PLACEHOLDER_HEADING_PATTERN = /^## (X.Y.Z|X.X.X)/i.freeze
+VERSION_HEADING_PATTERN = /^## \d+\.\d+\.\d+ \d{4}-\d{2}-\d{2}$/
 
 first_line = File.open('CHANGELOG.md', &:readline)
 unless first_line.match(LATEST_RELEASE_HEADING_PATTERN) ||
@@ -24,4 +25,26 @@ unless first_line.match(LATEST_RELEASE_HEADING_PATTERN) ||
       ## X.Y.Z
     MESSAGE
   )
+end
+
+# Check that all ## headers follow version/date format or placeholder format
+File.readlines('CHANGELOG.md').each_with_index do |line, index|
+  line_number = index + 1
+  next unless line.start_with?('## ')
+  
+  unless line.match(VERSION_HEADING_PATTERN) || line.match(PLACEHOLDER_HEADING_PATTERN)
+    abort(
+      <<~MESSAGE
+        ERR: Line #{line_number} uses ## header but is not a version/date format:
+        
+        #{line.strip}
+        
+        ## headers should only be used for version entries like:
+        ## 1.2.3 2024-01-15
+        ## X.Y.Z (for unreleased)
+        
+        Use ### for module names instead.
+      MESSAGE
+    )
+  end
 end


### PR DESCRIPTION
## Summary
CHANGELOG should use a consistent date format and use different header types for modules and versions

## Motivation
Broken auto-generation of release notes

## Testing
Tested script in various scenarios

## Changelog
:) 
