### PR TITLE
Confirm Apple Pay with ConfirmationTokens

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -1218,6 +1218,36 @@ class PaymentSheetDeferredServerSideUITests: PaymentSheetUITestCase {
         payWithApplePay()
     }
 
+    func testDeferredPaymentIntent_ApplePay_ConfirmationToken_ClientSideConfirmation() {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.layout = .horizontal
+        settings.integrationType = .deferred_csc_ct
+        settings.apmsEnabled = .off
+        loadPlayground(app, settings)
+
+        app.buttons["Present PaymentSheet"].tap()
+        let applePayButton = app.buttons["apple_pay_button"]
+        XCTAssertTrue(applePayButton.waitForExistence(timeout: 4.0))
+        applePayButton.tap()
+
+        payWithApplePay()
+    }
+
+    func testDeferredPaymentIntent_ApplePay_ConfirmationToken_ServerSideConfirmation() {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.layout = .horizontal
+        settings.integrationType = .deferred_ssc_ct
+        settings.apmsEnabled = .off
+        loadPlayground(app, settings)
+
+        app.buttons["Present PaymentSheet"].tap()
+        let applePayButton = app.buttons["apple_pay_button"]
+        XCTAssertTrue(applePayButton.waitForExistence(timeout: 4.0))
+        applePayButton.tap()
+
+        payWithApplePay()
+    }
+
     func testPaymentSheetFlowControllerSaveAndRemoveCard_DeferredIntent_ServerSideConfirmation() throws {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.layout = .horizontal

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -96,7 +96,6 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
                     paymentMethod: stpPaymentMethod,
                     paymentInformation: paymentInformation,
                     context: context,
-                    intentConfig: intentConfig,
                     confirmationTokenConfirmHandler: confirmationTokenConfirmHandler,
                     completion: completion
                 )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -10,7 +10,7 @@ import Foundation
 import PassKit
 @_spi(STP) import StripeApplePay
 @_spi(STP) import StripeCore
-@_spi(STP) import StripePayments
+@_spi(STP)@_spi(ConfirmationTokensPublicPreview) import StripePayments
 
 typealias PaymentSheetResultCompletionBlock = ((PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void)
 
@@ -89,19 +89,99 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
                 return
             }
 
-            // Regular deferred intent flow
-            let shouldSavePaymentMethod = false // Apple Pay doesn't present the customer the choice to choose to save their payment method
-            intentConfig.confirmHandler?(stpPaymentMethod, shouldSavePaymentMethod) { result in
-                switch result {
-                case .success(let clientSecret):
-                    guard clientSecret != PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT else {
-                        completion(STPApplePayContext.COMPLETE_WITHOUT_CONFIRMING_INTENT, nil)
-                        return
+            // Route to confirmation token flow or regular flow based on available handlers
+            if let confirmationTokenConfirmHandler = intentConfig.confirmationTokenConfirmHandler {
+                // Confirmation token flow
+                handleConfirmationTokenFlow(
+                    paymentMethod: stpPaymentMethod,
+                    paymentInformation: paymentInformation,
+                    context: context,
+                    intentConfig: intentConfig,
+                    confirmationTokenConfirmHandler: confirmationTokenConfirmHandler,
+                    completion: completion
+                )
+            } else if let confirmHandler = intentConfig.confirmHandler {
+                // Regular deferred intent flow
+                let shouldSavePaymentMethod = false // Apple Pay doesn't present the customer the choice to choose to save their payment method
+                confirmHandler(stpPaymentMethod, shouldSavePaymentMethod) { result in
+                    switch result {
+                    case .success(let clientSecret):
+                        guard clientSecret != PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT else {
+                            completion(STPApplePayContext.COMPLETE_WITHOUT_CONFIRMING_INTENT, nil)
+                            return
+                        }
+                        completion(clientSecret, nil)
+                    case .failure(let error):
+                        completion(nil, error)
                     }
-                    completion(clientSecret, nil)
-                case .failure(let error):
-                    completion(nil, error)
                 }
+            } else {
+                // Neither handler is available
+                let error = PaymentSheetError.unknown(debugDescription: "No confirm handler available in IntentConfiguration")
+                completion(nil, error)
+            }
+        }
+    }
+
+    private func handleConfirmationTokenFlow(
+        paymentMethod: STPPaymentMethod,
+        paymentInformation: PKPayment,
+        context: STPApplePayContext,
+        intentConfig: PaymentSheet.IntentConfiguration,
+        confirmationTokenConfirmHandler: @escaping PaymentSheet.IntentConfiguration.ConfirmationTokenConfirmHandler,
+        completion: @escaping STPIntentClientSecretCompletionBlock
+    ) {
+        // Create confirmation token params
+        let confirmationTokenParams = STPConfirmationTokenParams()
+        confirmationTokenParams.paymentMethod = paymentMethod.stripeId
+        confirmationTokenParams.returnURL = context.returnUrl
+        confirmationTokenParams.clientAttributionMetadata = context.clientAttributionMetadata
+
+        // Set shipping details if available
+        if let shippingContact = paymentInformation.shippingContact,
+           let nameComponents = shippingContact.name {
+            let name = PersonNameComponentsFormatter.localizedString(from: nameComponents, style: .default)
+            let shippingAddress = STPAddress(pkContact: shippingContact)
+
+            // Only set shipping details if we have a valid address line1
+            if let line1 = shippingAddress.line1 {
+                // Create address params manually
+                let addressParams = STPPaymentIntentShippingDetailsAddressParams(line1: line1)
+                addressParams.line2 = shippingAddress.line2
+                addressParams.city = shippingAddress.city
+                addressParams.state = shippingAddress.state
+                addressParams.postalCode = shippingAddress.postalCode
+                addressParams.country = shippingAddress.country
+
+                let shippingDetailsParams = STPPaymentIntentShippingDetailsParams(address: addressParams, name: name)
+                shippingDetailsParams.phone = shippingAddress.phone
+                confirmationTokenParams.shipping = shippingDetailsParams
+            }
+        }
+
+        Task {
+            do {
+                // Create the confirmation token
+                let confirmationToken = try await context.apiClient.createConfirmationToken(with: confirmationTokenParams, ephemeralKeySecret: nil)
+
+                // Call the confirmation token handler
+                await MainActor.run {
+                    confirmationTokenConfirmHandler(confirmationToken) { result in
+                        switch result {
+                        case .success(let clientSecret):
+                            // Handle manual confirmation
+                            guard clientSecret != PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT else {
+                                completion(STPApplePayContext.COMPLETE_WITHOUT_CONFIRMING_INTENT, nil)
+                                return
+                            }
+                            completion(clientSecret, nil)
+                        case .failure(let error):
+                            completion(nil, error)
+                        }
+                    }
+                }
+            } catch {
+                completion(nil, error)
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -127,7 +127,6 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         paymentMethod: STPPaymentMethod,
         paymentInformation: PKPayment,
         context: STPApplePayContext,
-        intentConfig: PaymentSheet.IntentConfiguration,
         confirmationTokenConfirmHandler: @escaping PaymentSheet.IntentConfiguration.ConfirmationTokenConfirmHandler,
         completion: @escaping STPIntentClientSecretCompletionBlock
     ) {


### PR DESCRIPTION
## Summary
- Adds support for confirming Apple Pay intents with ConfirmationTokens

## Motivation
- Confirmation tokens

## Testing
- Manual
- New unit tests
- E2E tests

## Changelog
N/A