### PR TITLE
Refactor validator to be less tied to a payment method

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+DeferredAPI.swift
@@ -188,7 +188,7 @@ extension PaymentSheet {
                     let setupIntent = try await configuration.apiClient.retrieveSetupIntent(clientSecret: clientSecret, expand: ["payment_method"])
                     if [STPSetupIntentStatus.requiresPaymentMethod, STPSetupIntentStatus.requiresConfirmation].contains(setupIntent.status) {
                         // 4a. Client-side confirmation
-                        try PaymentSheetDeferredValidator.validate(setupIntent: setupIntent, intentConfiguration: intentConfig)
+                        try PaymentSheetDeferredValidator.validate(intentConfiguration: intentConfig)
                         try PaymentSheetDeferredValidator.validatePaymentMethod(intentPaymentMethod: setupIntent.paymentMethod, paymentMethod: paymentMethod)
                         let setupIntentParams = makeSetupIntentParams(
                             confirmPaymentMethodType: confirmType,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
@@ -29,8 +29,7 @@ enum PaymentSheetDeferredValidator {
         }
     }
 
-    static func validate(setupIntent: STPSetupIntent,
-                         intentConfiguration: PaymentSheet.IntentConfiguration) throws {
+    static func validate(intentConfiguration: PaymentSheet.IntentConfiguration) throws {
         guard case .setup = intentConfiguration.mode else {
             throw PaymentSheetError.deferredIntentValidationFailed(message: "You returned a SetupIntent client secret but used a PaymentSheet.IntentConfiguration in payment mode.")
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetDeferredValidator.swift
@@ -12,16 +12,14 @@ enum PaymentSheetDeferredValidator {
     /// Note: We don't validate amount (for any payment method) because there are use cases where the amount can change slightly between PM collection and confirmation.
     static func validate(paymentIntent: STPPaymentIntent,
                          intentConfiguration: PaymentSheet.IntentConfiguration,
-                         paymentMethod: STPPaymentMethod,
                          isFlowController: Bool) throws {
-        guard case let .payment(_, currency, setupFutureUsage, _, paymentMethodOptions) = intentConfiguration.mode else {
+        guard case let .payment(_, currency, _, _, _) = intentConfiguration.mode else {
             throw PaymentSheetError.deferredIntentValidationFailed(message: "You returned a PaymentIntent client secret but used a PaymentSheet.IntentConfiguration in setup mode.")
         }
         guard paymentIntent.currency.uppercased() == currency.uppercased() else {
             throw PaymentSheetError.deferredIntentValidationFailed(message: "Your PaymentIntent currency (\(paymentIntent.currency.uppercased())) does not match the PaymentSheet.IntentConfiguration currency (\(currency.uppercased())).")
         }
-        try validateSFUAndPMOSFU(setupFutureUsage: setupFutureUsage, paymentMethodOptions: paymentMethodOptions, paymentMethodType: paymentMethod.type, paymentIntent: paymentIntent)
-        try validatePaymentMethod(intentPaymentMethod: paymentIntent.paymentMethod, paymentMethod: paymentMethod)
+
         /*
          Manual confirmation is only available using FlowController because merchants own the final step of confirmation.
          Showing a successful payment in the complete flow may be misleading when merchants still need to do a final confirmation which could fail e.g., bad network
@@ -32,12 +30,10 @@ enum PaymentSheetDeferredValidator {
     }
 
     static func validate(setupIntent: STPSetupIntent,
-                         intentConfiguration: PaymentSheet.IntentConfiguration,
-                         paymentMethod: STPPaymentMethod) throws {
+                         intentConfiguration: PaymentSheet.IntentConfiguration) throws {
         guard case .setup = intentConfiguration.mode else {
             throw PaymentSheetError.deferredIntentValidationFailed(message: "You returned a SetupIntent client secret but used a PaymentSheet.IntentConfiguration in payment mode.")
         }
-        try validatePaymentMethod(intentPaymentMethod: setupIntent.paymentMethod, paymentMethod: paymentMethod)
     }
 
     static func validatePaymentMethod(intentPaymentMethod: STPPaymentMethod?, paymentMethod: STPPaymentMethod) throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
@@ -19,13 +19,12 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         let intentConfig_si = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD"), confirmHandler: confirmHandler)
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig_si,
-                                                                        paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false)) { error in
             XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. You returned a PaymentIntent client secret but used a PaymentSheet.IntentConfiguration in setup mode.")
         }
         let si = STPFixtures.makeSetupIntent()
         let intentConfig_pi = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1080, currency: "USD"), confirmHandler: confirmHandler)
-        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(setupIntent: si, intentConfiguration: intentConfig_pi, paymentMethod: STPPaymentMethod._testCard())) { error in
+        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(setupIntent: si, intentConfiguration: intentConfig_pi)) { error in
             XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. You returned a SetupIntent client secret but used a PaymentSheet.IntentConfiguration in payment mode.")
         }
     }
@@ -35,7 +34,6 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD"), confirmHandler: confirmHandler)
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
-                                                                        paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false)) { error in
             XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. Your PaymentIntent currency (GBP) does not match the PaymentSheet.IntentConfiguration currency (USD).")
         }
@@ -44,10 +42,21 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
     func testPaymentIntentMismatchedSetupFutureUsage() throws {
         let pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", setupFutureUsage: .offSession)
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD"), confirmHandler: confirmHandler)
-        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
-                                                                        intentConfiguration: intentConfig,
-                                                                        paymentMethod: STPPaymentMethod._testCard(),
-                                                                        isFlowController: false)) { error in
+        // Test the main validation first
+        try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
+                                                  intentConfiguration: intentConfig,
+                                                  isFlowController: false)
+        // Test the SFU validation separately - this should fail
+        guard case let .payment(_, _, setupFutureUsage, _, paymentMethodOptions) = intentConfig.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage,
+            paymentMethodOptions: paymentMethodOptions,
+            paymentMethodType: .card,
+            paymentIntent: pi
+        )) { error in
             XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. Your PaymentIntent setupFutureUsage (offSession) does not match the IntentConfiguration setupFutureUsage (nil).")
         }
     }
@@ -59,8 +68,18 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         try PaymentSheetDeferredValidator.validate(
             paymentIntent: pi,
             intentConfiguration: intentConfig,
-            paymentMethod: STPPaymentMethod._testCard(),
             isFlowController: false
+        )
+        // Test SFU validation separately - this should succeed (off_session vs on_session mismatch is allowed)
+        guard case let .payment(_, _, setupFutureUsage, _, paymentMethodOptions) = intentConfig.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage,
+            paymentMethodOptions: paymentMethodOptions,
+            paymentMethodType: .card,
+            paymentIntent: pi
         )
 
         // PMO SFU
@@ -78,18 +97,39 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         try PaymentSheetDeferredValidator.validate(
             paymentIntent: pi_with_pmo_sfu_on_session,
             intentConfiguration: intentConfig_with_pmo_sfu_off_session,
-            paymentMethod: STPPaymentMethod._testCard(),
             isFlowController: false
+        )
+        // Test PMO SFU validation separately - this should succeed (off_session vs on_session mismatch is allowed)
+        guard case let .payment(_, _, setupFutureUsage2, _, paymentMethodOptions2) = intentConfig_with_pmo_sfu_off_session.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage2,
+            paymentMethodOptions: paymentMethodOptions2,
+            paymentMethodType: .card,
+            paymentIntent: pi_with_pmo_sfu_on_session
         )
     }
 
     func testPaymentIntentConfigurationNoneTopLevelSetupFutureUsage() throws {
         let pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD")
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", setupFutureUsage: PaymentSheet.IntentConfiguration.SetupFutureUsage.none), confirmHandler: confirmHandler)
-        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
-                                                                        intentConfiguration: intentConfig,
-                                                                        paymentMethod: STPPaymentMethod._testCard(),
-                                                                        isFlowController: false)) { error in
+        // Test the main validation first
+        try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
+                                                  intentConfiguration: intentConfig,
+                                                  isFlowController: false)
+        // Test the SFU validation separately - this should fail for .none
+        guard case let .payment(_, _, setupFutureUsage, _, paymentMethodOptions) = intentConfig.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage,
+            paymentMethodOptions: paymentMethodOptions,
+            paymentMethodType: .card,
+            paymentIntent: pi
+        )) { error in
             XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. Your IntentConfiguration setupFutureUsage (none) is invalid. You can only set it to `.onSession`, `.offSession`, or leave it `nil`.")
         }
     }
@@ -114,24 +154,54 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         try PaymentSheetDeferredValidator.validate(
             paymentIntent: pi_without_pmo_sfu_or_sfu,
             intentConfiguration: intentConfig_with_pmo_set,
-            paymentMethod: STPPaymentMethod._testCard(),
             isFlowController: false
+        )
+        // Test SFU validation separately - should pass
+        guard case let .payment(_, _, setupFutureUsage1, _, paymentMethodOptions1) = intentConfig_with_pmo_set.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage1,
+            paymentMethodOptions: paymentMethodOptions1,
+            paymentMethodType: .card,
+            paymentIntent: pi_without_pmo_sfu_or_sfu
         )
 
         let intentConfig_with_sfu_and_pmo_sfu_set = makeIntentConfiguration(topLevelSFU: .offSession, pmoSFU: .offSession)
         try PaymentSheetDeferredValidator.validate(
             paymentIntent: pi_without_pmo_sfu_or_sfu,
             intentConfiguration: intentConfig_with_sfu_and_pmo_sfu_set,
-            paymentMethod: STPPaymentMethod._testCard(),
             isFlowController: false
+        )
+        // Test SFU validation separately - should pass
+        guard case let .payment(_, _, setupFutureUsage2, _, paymentMethodOptions2) = intentConfig_with_sfu_and_pmo_sfu_set.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage2,
+            paymentMethodOptions: paymentMethodOptions2,
+            paymentMethodType: .card,
+            paymentIntent: pi_without_pmo_sfu_or_sfu
         )
 
         let intentConfig_with_none_set = makeIntentConfiguration(topLevelSFU: nil, pmoSFU: nil)
         try PaymentSheetDeferredValidator.validate(
             paymentIntent: pi_without_pmo_sfu_or_sfu,
             intentConfiguration: intentConfig_with_none_set,
-            paymentMethod: STPPaymentMethod._testCard(),
             isFlowController: false
+        )
+        // Test SFU validation separately - should pass
+        guard case let .payment(_, _, setupFutureUsage3, _, paymentMethodOptions3) = intentConfig_with_none_set.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage3,
+            paymentMethodOptions: paymentMethodOptions3,
+            paymentMethodType: .card,
+            paymentIntent: pi_without_pmo_sfu_or_sfu
         )
     }
 
@@ -153,8 +223,18 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         XCTAssertNoThrow(try PaymentSheetDeferredValidator.validate(
             paymentIntent: pi_matching,
             intentConfiguration: intentConfig_matching,
-            paymentMethod: STPPaymentMethod._testCard(),
             isFlowController: false
+        ))
+        // Test SFU validation separately - should succeed
+        guard case let .payment(_, _, setupFutureUsage1, _, paymentMethodOptions1) = intentConfig_matching.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        XCTAssertNoThrow(try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage1,
+            paymentMethodOptions: paymentMethodOptions1,
+            paymentMethodType: .card,
+            paymentIntent: pi_matching
         ))
 
         // PI and IntentConfig with differing SFU values...
@@ -165,12 +245,22 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
             setupFutureUsage: .offSession
         )
         let intentConfig_sfu_nil = makeIntentConfiguration(topLevelSFU: nil, pmoSFU: nil)
-        // ...should fail validation
-        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(
+        // Test the main validation first
+        try PaymentSheetDeferredValidator.validate(
             paymentIntent: pi_sfu_off_session,
             intentConfiguration: intentConfig_sfu_nil,
-            paymentMethod: STPPaymentMethod._testCard(),
             isFlowController: false
+        )
+        // Test SFU validation separately - should fail
+        guard case let .payment(_, _, setupFutureUsage2, _, paymentMethodOptions2) = intentConfig_sfu_nil.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage2,
+            paymentMethodOptions: paymentMethodOptions2,
+            paymentMethodType: .card,
+            paymentIntent: pi_sfu_off_session
         )) { error in
             XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. Your PaymentIntent setupFutureUsage (offSession) does not match the IntentConfiguration setupFutureUsage (nil).")
         }
@@ -188,12 +278,22 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
             )
         )
         let intentConfig_with_pmo_sfu_nil = makeIntentConfiguration(topLevelSFU: .offSession, pmoSFU: nil)
-        // ...should fail validation
-        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(
+        // Test the main validation first
+        try PaymentSheetDeferredValidator.validate(
             paymentIntent: pi_with_pmo_sfu_none,
             intentConfiguration: intentConfig_with_pmo_sfu_nil,
-            paymentMethod: STPPaymentMethod._testCard(),
             isFlowController: false
+        )
+        // Test SFU validation separately - should fail
+        guard case let .payment(_, _, setupFutureUsage3, _, paymentMethodOptions3) = intentConfig_with_pmo_sfu_nil.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage3,
+            paymentMethodOptions: paymentMethodOptions3,
+            paymentMethodType: .card,
+            paymentIntent: pi_with_pmo_sfu_none
         )) { error in
             XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. Your PaymentIntent payment_method_options[card][setup_future_usage] value (none) does not match the IntentConfiguration value (nil)")
         }
@@ -205,37 +305,90 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         var intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.USBankAccount: .offSession, .card: .offSession])), confirmHandler: confirmHandler)
         XCTAssertNoThrow(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
-                                                                        paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
+        // Test SFU validation separately
+        guard case let .payment(_, _, setupFutureUsage1, _, paymentMethodOptions1) = intentConfig.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        XCTAssertNoThrow(try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage1,
+            paymentMethodOptions: paymentMethodOptions1,
+            paymentMethodType: .card,
+            paymentIntent: pi
+        ))
+
         // both nil
         pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD")
         intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD"), confirmHandler: confirmHandler)
         XCTAssertNoThrow(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
-                                                                        paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
+        // Test SFU validation separately
+        guard case let .payment(_, _, setupFutureUsage2, _, paymentMethodOptions2) = intentConfig.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        XCTAssertNoThrow(try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage2,
+            paymentMethodOptions: paymentMethodOptions2,
+            paymentMethodType: .card,
+            paymentIntent: pi
+        ))
+
         // pi pmo non-nil but not sfu-related
         pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodTypes: [.card], paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: .init(requireCvcRecollection: true, cvcToken: "1234", allResponseFields: ["require_cvc_recollection": true, "cvc_token": "1234"]), allResponseFields: ["card": ["require_cvc_recollection": true]]))
         intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD"), confirmHandler: confirmHandler)
         XCTAssertNoThrow(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
-                                                                        paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
+        // Test SFU validation separately
+        guard case let .payment(_, _, setupFutureUsage3, _, paymentMethodOptions3) = intentConfig.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        XCTAssertNoThrow(try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage3,
+            paymentMethodOptions: paymentMethodOptions3,
+            paymentMethodType: .card,
+            paymentIntent: pi
+        ))
+
         // pi sepa_debit got filtered out, but sepa_debit pmo sfu set on the IntentConfiguration
         pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodTypes: [.card, .USBankAccount], paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"], "us_bank_account": ["setup_future_usage": "off_session"]]))
         intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.USBankAccount: .offSession, .card: .offSession, .SEPADebit: .offSession])), confirmHandler: confirmHandler)
         XCTAssertNoThrow(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
-                                                                        paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
+        // Test SFU validation separately
+        guard case let .payment(_, _, setupFutureUsage4, _, paymentMethodOptions4) = intentConfig.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        XCTAssertNoThrow(try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage4,
+            paymentMethodOptions: paymentMethodOptions4,
+            paymentMethodType: .card,
+            paymentIntent: pi
+        ))
 
         // intent pmo and intent config pmo have things that don't match, but for the payment method types on the intent, they do
         pi = STPFixtures.makePaymentIntent(amount: 100, currency: "USD", paymentMethodTypes: [.card, .USBankAccount], paymentMethodOptions: STPPaymentMethodOptions(usBankAccount: nil, card: nil, allResponseFields: ["card": ["setup_future_usage": "off_session"], "us_bank_account": ["setup_future_usage": "off_session", "cashapp": "on_session"]]))
         intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 100, currency: "USD", paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: [.USBankAccount: .offSession, .card: .offSession, .SEPADebit: .offSession])), confirmHandler: confirmHandler)
         XCTAssertNoThrow(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
-                                                                        paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false))
+        // Test SFU validation separately
+        guard case let .payment(_, _, setupFutureUsage5, _, paymentMethodOptions5) = intentConfig.mode else {
+            XCTFail("Expected payment mode")
+            return
+        }
+        XCTAssertNoThrow(try PaymentSheetDeferredValidator.validateSFUAndPMOSFU(
+            setupFutureUsage: setupFutureUsage5,
+            paymentMethodOptions: paymentMethodOptions5,
+            paymentMethodType: .card,
+            paymentIntent: pi
+        ))
     }
 
     func testPaymentIntentNotFlowControllerManualConfirmationMethod() throws {
@@ -243,7 +396,6 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD"), confirmHandler: confirmHandler)
         XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(paymentIntent: pi,
                                                                         intentConfiguration: intentConfig,
-                                                                        paymentMethod: STPPaymentMethod._testCard(),
                                                                         isFlowController: false)) { error in
             XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. Your PaymentIntent confirmationMethod (manual) can only be used with PaymentSheet.FlowController.")
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetDeferredValidatorTests.swift
@@ -24,7 +24,7 @@ final class PaymentSheetDeferredValidatorTests: XCTestCase {
         }
         let si = STPFixtures.makeSetupIntent()
         let intentConfig_pi = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1080, currency: "USD"), confirmHandler: confirmHandler)
-        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(setupIntent: si, intentConfiguration: intentConfig_pi)) { error in
+        XCTAssertThrowsError(try PaymentSheetDeferredValidator.validate(intentConfiguration: intentConfig_pi)) { error in
             XCTAssertEqual("\(error)", "An error occurred in PaymentSheet. You returned a SetupIntent client secret but used a PaymentSheet.IntentConfiguration in payment mode.")
         }
     }


### PR DESCRIPTION
## Summary
Refactored PaymentSheet deferred validation logic by breaking down monolithic validation methods into smaller, focused functions for better maintainability and testing:

- Extracted validation logic: Split PaymentSheetDeferredValidator.validate() methods to separate payment method validation and setup future usage validation from core validation
- Added dedicated methods: Created validatePaymentMethod() and validateSFUAndPMOSFU() for specific validation concerns
- Updated test coverage: Modified tests to validate each component separately, ensuring proper error handling and validation behavior
- This will enable better reuse of the validation logic by ConfirmationTokens as it does not always have a payment method

## Motivation
- Confirmation Tokens

## Testing
- Updated tests

## Changelog
N/A
