### PR TITLE
Remove nav workaround for iOS26

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -404,26 +404,6 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
         }
         navigationBarContainerView.addInteraction(navigationBarBlur)
     }
-    func disableNavigationBarBlurInteraction() {
-        guard let navigationBarBlur else {
-            return
-        }
-        navigationBarContainerView.removeInteraction(navigationBarBlur)
-    }
-
-    // Workaround: Remove blur in `preAnimateHeightChange`, prior to swapping out content. Otherwise, the blur effect
-    // animates away over new content that is most likely different. In `postLayoutAnimations`, decide
-    // whether or not new content is scrollable.  If so, add the blur back, otherwise, keep it removed.
-    func preAnimateHeightChange() {
-        self.disableNavigationBarBlurInteraction()
-    }
-    func postLayoutAnimations(containerView: UIView, toView: UIView) {
-        if self.scrollView.contentSize.height > self.scrollView.frame.size.height {
-            self.enableNavigationBarBlurInteraction()
-        } else {
-            self.disableNavigationBarBlurInteraction()
-        }
-    }
     #endif
     private func registerForKeyboardNotifications() {
         NotificationCenter.default.addObserver(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PaymentSheetUIKitAdditions.swift
@@ -103,9 +103,6 @@ extension UIViewController {
             fromVC.willMove(toParent: nil)
             fromVC.removeFromParent()
 
-            #if compiler(>=6.2)
-            self.bottomSheetController?.preAnimateHeightChange()
-            #endif
             animateHeightChange(
                 {
                     containerView.updateHeight()
@@ -117,9 +114,6 @@ extension UIViewController {
                     if let contentOffsetPercentage {
                         self.bottomSheetController?.contentOffsetPercentage = contentOffsetPercentage
                     }
-                    #if compiler(>=6.2)
-                    self.bottomSheetController?.postLayoutAnimations(containerView: containerView, toView: toVC.view)
-                    #endif
                 },
                 completion: { _ in
                     toVC.endAppearanceTransition()


### PR DESCRIPTION
## Summary
Reverts navbar workaround for iOS26

## Motivation
Improved perf in iOS26.1, so reverting this for now.

## Testing


## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
