### PR TITLE
Improve state mismatch issues in StripeAttest

### DIFF
--- a/Stripe/StripeiOSTests/ConsumerSessionTests.swift
+++ b/Stripe/StripeiOSTests/ConsumerSessionTests.swift
@@ -36,6 +36,7 @@ class ConsumerSessionTests: STPNetworkStubbingTestCase {
             customerID: nil,
             with: apiClient,
             useMobileEndpoints: false,
+            canSyncAttestationState: false,
             doNotLogConsumerFunnelEvent: false
         ) {
             result in
@@ -70,6 +71,7 @@ class ConsumerSessionTests: STPNetworkStubbingTestCase {
             customerID: nil,
             with: apiClient,
             useMobileEndpoints: false,
+            canSyncAttestationState: false,
             doNotLogConsumerFunnelEvent: false
         ) { result in
             switch result {
@@ -103,6 +105,7 @@ class ConsumerSessionTests: STPNetworkStubbingTestCase {
             customerID: nil,
             with: apiClient,
             useMobileEndpoints: false,
+            canSyncAttestationState: false,
             doNotLogConsumerFunnelEvent: false
         ) { result in
             switch result {
@@ -140,6 +143,7 @@ class ConsumerSessionTests: STPNetworkStubbingTestCase {
             countryCode: "US",
             consentAction: PaymentSheetLinkAccount.ConsentAction.checkbox_v0.rawValue,
             useMobileEndpoints: false,
+            canSyncAttestationState: false,
             with: apiClient
         ) { result in
             switch result {
@@ -244,6 +248,7 @@ class ConsumerSessionTests: STPNetworkStubbingTestCase {
             countryCode: "US",
             consentAction: PaymentSheetLinkAccount.ConsentAction.checkbox_v0.rawValue,
             useMobileEndpoints: false,
+            canSyncAttestationState: false,
             with: apiClient
         ) { result in
             switch result {

--- a/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
+++ b/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
@@ -158,6 +158,7 @@ extension LinkInlineSignupElementSnapshotTests {
                         publishableKey: nil,
                         displayablePaymentDetails: nil,
                         useMobileEndpoints: false,
+                        canSyncAttestationState: false,
                         requestSurface: requestSurface
                     )
                 )
@@ -175,6 +176,7 @@ extension LinkInlineSignupElementSnapshotTests {
                 publishableKey: nil,
                 displayablePaymentDetails: nil,
                 useMobileEndpoints: false,
+                canSyncAttestationState: false,
                 requestSurface: requestSurface
             )
             let response = StripePaymentSheet.LookupLinkAuthIntentResponse(
@@ -215,7 +217,8 @@ extension LinkInlineSignupElementSnapshotTests {
                 session: nil,
                 publishableKey: nil,
                 displayablePaymentDetails: nil,
-                useMobileEndpoints: false
+                useMobileEndpoints: false,
+                canSyncAttestationState: false
             )
         }
 

--- a/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
+++ b/Stripe/StripeiOSTests/LinkSignupViewModelTests.swift
@@ -276,6 +276,7 @@ extension LinkInlineSignupViewModelTests {
                             publishableKey: nil,
                             displayablePaymentDetails: nil,
                             useMobileEndpoints: false,
+                            canSyncAttestationState: false,
                             requestSurface: requestSurface
                         )
                     )
@@ -297,6 +298,7 @@ extension LinkInlineSignupViewModelTests {
                     publishableKey: nil,
                     displayablePaymentDetails: nil,
                     useMobileEndpoints: false,
+                    canSyncAttestationState: false,
                     requestSurface: requestSurface
                 )
                 let response = StripePaymentSheet.LookupLinkAuthIntentResponse(
@@ -328,7 +330,8 @@ extension LinkInlineSignupViewModelTests {
             session: nil,
             publishableKey: nil,
             displayablePaymentDetails: nil,
-            useMobileEndpoints: false
+            useMobileEndpoints: false,
+            canSyncAttestationState: false
         )
         : nil
 

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -296,6 +296,9 @@ import Foundation
     case assertionSucceeded = "stripeios.attest.assertion.succeeded"
     case resetKeyForAssertionError = "stripeios.attest.reset_key_for_assertion_error"
     case resetKeyForAttestationError = "stripeios.attest.reset_key_for_attestation_error"
+    case stateAlignmentMismatch = "stripeios.attest.state_alignment_mismatch"
+    case stateAlignmentFailed = "stripeios.attest.state_alignment_failed"
+    case maxConsecutiveStateErrorsReached = "stripeios.attest.max_consecutive_state_errors_reached"
 
     // MARK: - Custom Payment Methods
     case paymentSheetInvalidCPM = "mc_invalid_cpm"

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -296,9 +296,6 @@ import Foundation
     case assertionSucceeded = "stripeios.attest.assertion.succeeded"
     case resetKeyForAssertionError = "stripeios.attest.reset_key_for_assertion_error"
     case resetKeyForAttestationError = "stripeios.attest.reset_key_for_attestation_error"
-    case stateAlignmentMismatch = "stripeios.attest.state_alignment_mismatch"
-    case stateAlignmentFailed = "stripeios.attest.state_alignment_failed"
-    case maxConsecutiveStateErrorsReached = "stripeios.attest.max_consecutive_state_errors_reached"
 
     // MARK: - Custom Payment Methods
     case paymentSheetInvalidCPM = "mc_invalid_cpm"

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -296,6 +296,8 @@ import Foundation
     case assertionSucceeded = "stripeios.attest.assertion.succeeded"
     case resetKeyForAssertionError = "stripeios.attest.reset_key_for_assertion_error"
     case resetKeyForAttestationError = "stripeios.attest.reset_key_for_attestation_error"
+    case stateMismatchNotAttestedLocally = "stripeios.attest.state_mismatch.not_attested_locally"
+    case stateMismatchNotAttestedRemotely = "stripeios.attest.state_mismatch.not_attested_remotely"
 
     // MARK: - Custom Payment Methods
     case paymentSheetInvalidCPM = "mc_invalid_cpm"

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -262,6 +262,10 @@ import UIKit
         if canSyncState && !challenge.initial_attestation_required && !successfullyAttested {
             // Server has attestation but client doesn't know - update client
             successfullyAttested = true
+            let event = GenericAnalytic(event: .stateMismatchNotAttestedLocally, params: [:])
+            if let apiClient {
+                STPAnalyticsClient.sharedClient.log(analytic: event, apiClient: apiClient)
+            }
         } else if challenge.initial_attestation_required && successfullyAttested {
             // Server needs attestation but client thinks it's done - reset client and retry
             if isRetry || !canSyncState {
@@ -271,7 +275,10 @@ import UIKit
             } else {
                 // Reset and retry
                 resetKey()
-                try await self.attest()
+                let event = GenericAnalytic(event: .stateMismatchNotAttestedRemotely, params: [:])
+                if let apiClient {
+                    STPAnalyticsClient.sharedClient.log(analytic: event, apiClient: apiClient)
+                }
                 return try await _assert(canSyncState: canSyncState, isRetry: true)
             }
         }

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -19,7 +19,7 @@ import UIKit
     /// Sign an assertion.
     /// Will create and attest a new device key if needed.
     /// Returns an AssertionHandle, which must be called after the network request completes (with success or failure) in order to unblock future assertions.
-    @_spi(STP) public func assert(canRetry: Bool) async throws -> AssertionHandle {
+    @_spi(STP) public func assert(canSyncState: Bool) async throws -> AssertionHandle {
         // Make sure we only process one assertion at a time, until the latest
         if assertionInProgress {
             try await withCheckedThrowingContinuation { continuation in
@@ -29,7 +29,7 @@ import UIKit
         assertionInProgress = true
 
         do {
-            let assertion = try await _assert(canRetry: canRetry)
+            let assertion = try await _assert(canSyncState: canSyncState)
             let successAnalytic = GenericAnalytic(event: .assertionSucceeded, params: [:])
             if let apiClient {
                 STPAnalyticsClient.sharedClient.log(analytic: successAnalytic, apiClient: apiClient)
@@ -248,7 +248,7 @@ import UIKit
     private var assertionInProgress: Bool = false
     private var assertionWaiters: [CheckedContinuation<Void, Error>] = []
 
-    func _assert(canRetry: Bool, isRetry: Bool = false) async throws -> Assertion {
+    func _assert(canSyncState: Bool, isRetry: Bool = false) async throws -> Assertion {
         let keyId = try await self.getOrCreateKeyID()
 
         if !successfullyAttested {
@@ -258,21 +258,21 @@ import UIKit
 
         let challenge = try await getChallenge()
 
-        // Simple state alignment: sync client state with server reality
-        if !challenge.initial_attestation_required && !successfullyAttested {
+        // State alignment: sync client state with server
+        if canSyncState && !challenge.initial_attestation_required && !successfullyAttested {
             // Server has attestation but client doesn't know - update client
             successfullyAttested = true
         } else if challenge.initial_attestation_required && successfullyAttested {
             // Server needs attestation but client thinks it's done - reset client and retry
-            if isRetry || !canRetry {
-                // We already tried once, or retries are disabled - something is wrong
+            if isRetry || !canSyncState {
+                // We already tried once - something is wrong
                 resetKey()
                 throw AttestationError.shouldAttestButKeyIsAlreadyAttested
             } else {
                 // Reset and retry
                 resetKey()
                 try await self.attest()
-                return try await _assert(canRetry: canRetry, isRetry: true)
+                return try await _assert(canSyncState: canSyncState, isRetry: true)
             }
         }
 

--- a/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
+++ b/StripeCore/StripeCore/Source/Attestation/StripeAttest.swift
@@ -74,24 +74,6 @@ import UIKit
         if let apiClient {
             STPAnalyticsClient.sharedClient.log(analytic: resetKeyAnalytic, apiClient: apiClient)
         }
-
-        // Check if this is a Link assertion error, which might indicate state issues
-        if StripeAttest.isLinkAssertionError(error: error) {
-            consecutiveStateErrors += 1
-
-            // If we've hit too many consecutive errors, clear all state
-            if consecutiveStateErrors >= Self.maxConsecutiveStateErrors {
-                clearAllAttestationState()
-                let maxErrorsAnalytic = GenericAnalytic(
-                    event: .maxConsecutiveStateErrorsReached,
-                    params: ["error_type": "link_assertion_error"]
-                )
-                if let apiClient {
-                    STPAnalyticsClient.sharedClient.log(analytic: maxErrorsAnalytic, apiClient: apiClient)
-                }
-            }
-        }
-
         resetKey()
     }
 
@@ -227,11 +209,6 @@ import UIKit
     /// The API client to use for network requests
     weak var apiClient: STPAPIClient?
 
-    /// Track consecutive state synchronization errors
-    private var consecutiveStateErrors: Int = 0
-    /// Maximum consecutive state errors before forcing full reset
-    private static let maxConsecutiveStateErrors = 3
-
     /// The maximum number of key generation attempts allowed per day.
     /// This is a safeguard against generating keys too often, as each key generation
     /// permanently increases a counter for the device/app pair.
@@ -274,35 +251,20 @@ import UIKit
     func _assert() async throws -> Assertion {
         let keyId = try await self.getOrCreateKeyID()
 
-        // Verify client/server state alignment before proceeding and get challenge
-        let challenge = try await verifyStateAlignment()
-
         if !successfullyAttested {
             // We haven't attested yet, so do that first.
             try await self.attest()
         }
 
-        // If the backend claims that attestation is required, but we already have an attested key,
-        // something has gone wrong.
-        if challenge.initial_attestation_required {
-            // Track consecutive state errors
-            consecutiveStateErrors += 1
+        let challenge = try await getChallenge()
 
-            // Reset the key, we'll try again next time:
+        // Simple state alignment: sync client state with server reality
+        if !challenge.initial_attestation_required && !successfullyAttested {
+            // Server has attestation but client doesn't know - update client
+            successfullyAttested = true
+        } else if challenge.initial_attestation_required && successfullyAttested {
+            // Server needs attestation but client thinks it's done - reset client and restart
             resetKey()
-
-            // If we've hit too many consecutive state errors, clear all state
-            if consecutiveStateErrors >= Self.maxConsecutiveStateErrors {
-                clearAllAttestationState()
-                let maxErrorsAnalytic = GenericAnalytic(
-                    event: .maxConsecutiveStateErrorsReached,
-                    params: ["error_type": "shouldAttestButKeyIsAlreadyAttested"]
-                )
-                if let apiClient {
-                    STPAnalyticsClient.sharedClient.log(analytic: maxErrorsAnalytic, apiClient: apiClient)
-                }
-            }
-
             throw AttestationError.shouldAttestButKeyIsAlreadyAttested
         }
 
@@ -310,10 +272,6 @@ import UIKit
         let appId = try getAppID()
 
         let assertion = try await generateAssertion(keyId: keyId, challenge: challenge.challenge)
-
-        // Reset consecutive error count on successful assertion
-        consecutiveStateErrors = 0
-
         return Assertion(assertionData: assertion, deviceID: deviceId, appID: appId, keyID: keyId)
     }
 
@@ -345,25 +303,9 @@ import UIKit
         let challenge = try await getChallenge()
         // If the backend claims that attestation isn't required, we should not attempt it.
         guard challenge.initial_attestation_required else {
-            // Track consecutive state errors
-            consecutiveStateErrors += 1
-
             // And reset the key, as something has gone wrong.
             // The server thinks we've attested, but we think we haven't.
             resetKey()
-
-            // If we've hit too many consecutive state errors, clear all state
-            if consecutiveStateErrors >= Self.maxConsecutiveStateErrors {
-                clearAllAttestationState()
-                let maxErrorsAnalytic = GenericAnalytic(
-                    event: .maxConsecutiveStateErrorsReached,
-                    params: ["error_type": "shouldNotAttest"]
-                )
-                if let apiClient {
-                    STPAnalyticsClient.sharedClient.log(analytic: maxErrorsAnalytic, apiClient: apiClient)
-                }
-            }
-
             throw AttestationError.shouldNotAttest
         }
         guard let challengeData = challenge.challenge.data(using: .utf8) else {
@@ -386,8 +328,6 @@ import UIKit
             try await appAttestBackend.attest(appId: appId, deviceId: deviceId, keyId: keyId, attestation: attestation)
             // Store the successful attestation
             successfullyAttested = true
-            // Reset consecutive error count on successful attestation
-            consecutiveStateErrors = 0
         } catch {
             // If error is DCErrorInvalidKey (3) and the domain is DCErrorDomain,
             // we need to generate a new key as the key has already been attested or is otherwise corrupt.
@@ -425,17 +365,6 @@ import UIKit
         successfullyAttested = false
     }
 
-    /// Clear all attestation state including error tracking.
-    /// This is a more aggressive reset used when consecutive state errors suggest
-    /// persistent synchronization issues.
-    private func clearAllAttestationState() {
-        storedKeyID = nil
-        successfullyAttested = false
-        consecutiveStateErrors = 0
-        dailyAttemptCount = 0
-        firstAttemptToday = nil
-    }
-
     private func createKey() async throws -> String {
         let keyId = try await appAttestService.generateKey()
         // Save the Key ID, and that the key is not attested.
@@ -462,56 +391,6 @@ import UIKit
     func getChallenge() async throws -> StripeChallengeResponse {
         let keyID = try await self.getOrCreateKeyID()
         return try await appAttestBackend.getChallenge(appId: getAppID(), deviceId: getDeviceID(), keyId: keyID)
-    }
-
-    /// Verify that client and server state are aligned.
-    /// If misaligned, reset local state to match server expectations.
-    /// Returns the challenge response for reuse.
-    private func verifyStateAlignment() async throws -> StripeChallengeResponse {
-        do {
-            let challenge = try await getChallenge()
-            let serverExpectsAttestation = challenge.initial_attestation_required
-            let clientThinksAttested = successfullyAttested
-
-            // Check for state mismatch
-            if serverExpectsAttestation && clientThinksAttested {
-                // Server thinks we need to attest, but client thinks we're already attested
-                let mismatchAnalytic = GenericAnalytic(
-                    event: .stateAlignmentMismatch,
-                    params: ["type": "server_needs_attestation_client_thinks_attested"]
-                )
-                if let apiClient {
-                    STPAnalyticsClient.sharedClient.log(analytic: mismatchAnalytic, apiClient: apiClient)
-                }
-                resetKey()
-            } else if !serverExpectsAttestation && !clientThinksAttested {
-                // Server thinks we're attested, but client thinks we need to attest
-                let mismatchAnalytic = GenericAnalytic(
-                    event: .stateAlignmentMismatch,
-                    params: ["type": "server_thinks_attested_client_thinks_not"]
-                )
-                if let apiClient {
-                    STPAnalyticsClient.sharedClient.log(analytic: mismatchAnalytic, apiClient: apiClient)
-                }
-                successfullyAttested = true
-            }
-
-            // Reset consecutive error count on successful alignment check
-            consecutiveStateErrors = 0
-            return challenge
-        } catch {
-            // Don't let state verification failures block the main flow
-            // Just log the error for debugging
-            let verificationErrorAnalytic = ErrorAnalytic(
-                event: .stateAlignmentFailed,
-                error: error
-            )
-            if let apiClient {
-                STPAnalyticsClient.sharedClient.log(analytic: verificationErrorAnalytic, apiClient: apiClient)
-            }
-            // Re-throw so caller can handle it
-            throw error
-        }
     }
 
     /// Generate the assertion data from a key and challenge.

--- a/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
+++ b/StripeCore/StripeCoreTests/Attestation/StripeAttestTest.swift
@@ -32,12 +32,12 @@ class StripeAttestTest: XCTestCase {
 
     func testAppAttestService() async {
         try! await stripeAttest.attest()
-        let assertionHandle = try! await stripeAttest.assert()
+        let assertionHandle = try! await stripeAttest.assert(canSyncState: false)
         try! await self.mockAttestBackend.assertionTest(assertion: assertionHandle.assertion)
     }
 
     func testCanAssertWithoutAttestation() async {
-        let assertionHandle = try! await stripeAttest.assert()
+        let assertionHandle = try! await stripeAttest.assert(canSyncState: false)
         try! await self.mockAttestBackend.assertionTest(assertion: assertionHandle.assertion)
     }
 
@@ -51,7 +51,7 @@ class StripeAttestTest: XCTestCase {
             // But fail the assertion, causing the key to be reset
             await mockAttestService.setShouldFailAssertionWithError(invalidKeyError)
             do {
-                _ = try await stripeAttest.assert()
+                _ = try await stripeAttest.assert(canSyncState: false)
                 XCTFail("Should not succeed on attempt \(i)")
             } catch {
                 if i < 3 {
@@ -81,7 +81,7 @@ class StripeAttestTest: XCTestCase {
         // But fail the assertion, which will cause us to try to re-attest the key
         await mockAttestService.setShouldFailAssertionWithError(invalidKeyError)
         do {
-            _ = try await stripeAttest.assert()
+            _ = try await stripeAttest.assert(canSyncState: false)
             XCTFail("Should not succeed")
         } catch {
             // Should get a shouldNotAttest error from the server, as we're re-attesting an already-attested key
@@ -104,7 +104,7 @@ class StripeAttestTest: XCTestCase {
             let invalidKeyError = NSError(domain: DCErrorDomain, code: DCError.invalidKey.rawValue, userInfo: nil)
             await mockAttestService.setShouldFailAssertionWithError(invalidKeyError)
 
-            _ = try await stripeAttest.assert()
+            _ = try await stripeAttest.assert(canSyncState: false)
             XCTFail("Should not succeed")
         } catch {
             XCTAssertEqual(error as! StripeAttest.AttestationError, StripeAttest.AttestationError.shouldNotAttest)
@@ -132,7 +132,7 @@ class StripeAttestTest: XCTestCase {
         // assertions still won't work, so we'll send the testmode data instead.
         let invalidKeyError = NSError(domain: DCErrorDomain, code: DCError.invalidKey.rawValue, userInfo: nil)
         await mockAttestService.setShouldFailAssertionWithError(invalidKeyError)
-        let assertionHandle = try! await stripeAttest.assert()
+        let assertionHandle = try! await stripeAttest.assert(canSyncState: false)
         XCTAssertEqual(assertionHandle.assertion.keyID, "TestKeyID")
     }
 
@@ -141,7 +141,7 @@ class StripeAttestTest: XCTestCase {
         try! await withThrowingTaskGroup(of: Void.self) { group in
             for _ in 0..<iterations {
                 group.addTask {
-                    let assertionHandle = try! await self.stripeAttest.assert()
+                    let assertionHandle = try! await self.stripeAttest.assert(canSyncState: false)
                     // Check the assertion against the mock backend (which will enforce that the counter value has incremented since the last assertion)
                     try! await self.mockAttestBackend.assertionTest(assertion: assertionHandle.assertion)
                     // Then complete the assertion
@@ -164,7 +164,7 @@ class StripeAttestTest: XCTestCase {
                 for _ in 0..<iterations {
                     group.addTask {
                         do {
-                            _ = try await self.stripeAttest.assert()
+                            _ = try await self.stripeAttest.assert(canSyncState: false)
                             XCTFail("Should not succeed")
                         } catch {
                             XCTAssertEqual(error as NSError, unknownError)
@@ -176,5 +176,96 @@ class StripeAttestTest: XCTestCase {
             }
         }
         await fulfillment(of: [expectation], timeout: 1)
+    }
+
+    func testStateAlignmentServerHasAttestationClientDoesnt() async {
+        // Case 1: Server has attestation but client doesn't know
+        // Setup: Client thinks it's not attested, but server says no attestation required
+        await stripeAttest.resetKey()
+        
+        // First get a key ID by attempting an assertion (this will create the key)
+        var keyId: String = ""
+        do {
+            let handle = try await stripeAttest.assert(canSyncState: false)
+            keyId = handle.assertion.keyID
+            handle.complete()
+        } catch {
+            // Expected to fail since we haven't configured the backend yet
+        }
+        
+        // Reset client state so it thinks it's not attested
+        await stripeAttest.resetKey()
+        
+        // But mark the key as attested on the server side
+        // This simulates the case where server has attestation but client doesn't know
+        if !keyId.isEmpty {
+            mockAttestBackend.keyHasBeenAttested[keyId] = true
+        }
+        
+        // Client should sync state and succeed without throwing
+        let assertionHandle = try! await stripeAttest.assert(canSyncState: true)
+        
+        // Verify the assertion was created successfully
+        XCTAssertFalse(assertionHandle.assertion.assertionData.isEmpty)
+        XCTAssertFalse(assertionHandle.assertion.keyID.isEmpty)
+        
+        assertionHandle.complete()
+    }
+    
+    func testStateAlignmentServerNeedsAttestationClientThinksItsDone() async {
+        // Case 2: Server needs attestation but client thinks it's done
+        // Setup: Client thinks it's attested, but server says attestation is required
+        
+        // First, attest successfully to set client state
+        try! await stripeAttest.attest()
+        
+        // Get the key ID from a successful assertion
+        let firstHandle = try! await stripeAttest.assert(canSyncState: false)
+        let keyId = firstHandle.assertion.keyID
+        firstHandle.complete()
+        
+        // Now simulate server losing the attestation (key mismatch scenario)
+        // Remove the key from the mock backend's attested keys
+        mockAttestBackend.keyHasBeenAttested[keyId] = false
+        
+        // Client should detect mismatch, reset, re-attest, and succeed
+        let assertionHandle = try! await stripeAttest.assert(canSyncState: true)
+        
+        // Verify the assertion was created successfully after retry
+        XCTAssertFalse(assertionHandle.assertion.assertionData.isEmpty)
+        XCTAssertFalse(assertionHandle.assertion.keyID.isEmpty)
+        
+        // The key ID might have changed after reset, so we don't assert equality
+        // But we can verify that the backend now has the new key as attested
+        XCTAssertTrue(mockAttestBackend.keyHasBeenAttested[assertionHandle.assertion.keyID] ?? false)
+        
+        assertionHandle.complete()
+    }
+    
+    func testStateAlignmentWithoutCanSyncStateThrowsError() async {
+        // Case 2 without state sync should throw an error
+        // Setup: Client thinks it's attested, but server says attestation is required
+        
+        // First, attest successfully to set client state
+        try! await stripeAttest.attest()
+        
+        // Get the key ID from a successful assertion
+        let firstHandle = try! await stripeAttest.assert(canSyncState: false)
+        let keyId = firstHandle.assertion.keyID
+        firstHandle.complete()
+        
+        // Now simulate server losing the attestation (same as previous test)
+        mockAttestBackend.keyHasBeenAttested[keyId] = false
+        
+        // With canSyncState = false, should throw shouldAttestButKeyIsAlreadyAttested
+        do {
+            _ = try await stripeAttest.assert(canSyncState: false)
+            XCTFail("Should have thrown shouldAttestButKeyIsAlreadyAttested error")
+        } catch {
+            XCTAssertEqual(
+                error as! StripeAttest.AttestationError,
+                StripeAttest.AttestationError.shouldAttestButKeyIsAlreadyAttested
+            )
+        }
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -97,7 +97,7 @@ final class FinancialConnectionsAsyncAPIClient {
     ) async -> [String: Any] {
         do {
             let attest = backingAPIClient.stripeAttest
-            let handle = try await attest.assert(canRetry: false)
+            let handle = try await attest.assert(canSyncState: false)
             logger.log(.attestationRequestTokenSucceeded(api), pane: pane)
             let newParameters = baseParameters.merging(handle.assertion.requestFields) { (_, new) in new }
             return newParameters

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -97,7 +97,7 @@ final class FinancialConnectionsAsyncAPIClient {
     ) async -> [String: Any] {
         do {
             let attest = backingAPIClient.stripeAttest
-            let handle = try await attest.assert()
+            let handle = try await attest.assert(canRetry: false)
             logger.log(.attestationRequestTokenSucceeded(api), pane: pane)
             let newParameters = baseParameters.merging(handle.assertion.requestFields) { (_, new) in new }
             return newParameters

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -75,6 +75,7 @@ struct LinkPMDisplayDetails {
     let cookieStore: LinkCookieStore
 
     let useMobileEndpoints: Bool
+    let canSyncAttestationState: Bool
     let requestSurface: LinkRequestSurface
     let createdFromAuthIntentID: Bool
 
@@ -138,6 +139,7 @@ struct LinkPMDisplayDetails {
         apiClient: STPAPIClient = .shared,
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         useMobileEndpoints: Bool,
+        canSyncAttestationState: Bool,
         requestSurface: LinkRequestSurface = .default,
         createdFromAuthIntentID: Bool = false
     ) {
@@ -148,6 +150,7 @@ struct LinkPMDisplayDetails {
         self.apiClient = apiClient
         self.cookieStore = cookieStore
         self.useMobileEndpoints = useMobileEndpoints
+        self.canSyncAttestationState = canSyncAttestationState
         self.requestSurface = requestSurface
         self.createdFromAuthIntentID = createdFromAuthIntentID
     }
@@ -194,6 +197,7 @@ struct LinkPMDisplayDetails {
             countryCode: countryCode,
             consentAction: consentAction.rawValue,
             useMobileEndpoints: useMobileEndpoints,
+            canSyncAttestationState: canSyncAttestationState,
             with: apiClient,
             requestSurface: requestSurface
         ) { [weak self] result in

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -139,6 +139,7 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         useMobileEndpoints: Bool,
+        canRetryAssertion: Bool,
         doNotLogConsumerFunnelEvent: Bool,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
@@ -150,6 +151,7 @@ extension ConsumerSession {
             customerID: customerID,
             cookieStore: cookieStore,
             useMobileEndpoints: useMobileEndpoints,
+            canRetryAssertion: canRetryAssertion,
             doNotLogConsumerFunnelEvent: doNotLogConsumerFunnelEvent,
             requestSurface: requestSurface,
             completion: completion
@@ -163,6 +165,7 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         useMobileEndpoints: Bool,
+        canRetryAssertion: Bool,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
     ) {
@@ -172,6 +175,7 @@ extension ConsumerSession {
             customerID: customerID,
             cookieStore: cookieStore,
             useMobileEndpoints: useMobileEndpoints,
+            canRetryAssertion: canRetryAssertion,
             requestSurface: requestSurface,
             completion: completion
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -139,7 +139,7 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         useMobileEndpoints: Bool,
-        canRetryAssertion: Bool,
+        canSyncAttestationState: Bool,
         doNotLogConsumerFunnelEvent: Bool,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
@@ -151,7 +151,7 @@ extension ConsumerSession {
             customerID: customerID,
             cookieStore: cookieStore,
             useMobileEndpoints: useMobileEndpoints,
-            canRetryAssertion: canRetryAssertion,
+            canSyncAttestationState: canSyncAttestationState,
             doNotLogConsumerFunnelEvent: doNotLogConsumerFunnelEvent,
             requestSurface: requestSurface,
             completion: completion
@@ -165,7 +165,7 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         cookieStore: LinkCookieStore = LinkSecureCookieStore.shared,
         useMobileEndpoints: Bool,
-        canRetryAssertion: Bool,
+        canSyncAttestationState: Bool,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
     ) {
@@ -175,7 +175,7 @@ extension ConsumerSession {
             customerID: customerID,
             cookieStore: cookieStore,
             useMobileEndpoints: useMobileEndpoints,
-            canRetryAssertion: canRetryAssertion,
+            canSyncAttestationState: canSyncAttestationState,
             requestSurface: requestSurface,
             completion: completion
         )
@@ -189,6 +189,7 @@ extension ConsumerSession {
         countryCode: String?,
         consentAction: String?,
         useMobileEndpoints: Bool,
+        canSyncAttestationState: Bool,
         with apiClient: STPAPIClient = STPAPIClient.shared,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<SessionWithPublishableKey, Error>) -> Void
@@ -201,6 +202,7 @@ extension ConsumerSession {
             countryCode: countryCode,
             consentAction: consentAction,
             useMobileEndpoints: useMobileEndpoints,
+            canSyncAttestationState: canSyncAttestationState,
             requestSurface: requestSurface,
             completion: completion
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -22,7 +22,7 @@ extension STPAPIClient {
         customerID: String?,
         cookieStore: LinkCookieStore,
         useMobileEndpoints: Bool,
-        canRetryAssertion: Bool,
+        canSyncAttestationState: Bool,
         doNotLogConsumerFunnelEvent: Bool,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
@@ -52,7 +52,7 @@ extension STPAPIClient {
             await performConsumerLookup(
                 parameters: parameters,
                 useMobileEndpoints: useMobileEndpoints,
-                canRetryAssertion: canRetryAssertion,
+                canSyncAttestationState: canSyncAttestationState,
                 completion: completion
             )
         }
@@ -64,7 +64,7 @@ extension STPAPIClient {
         customerID: String?,
         cookieStore: LinkCookieStore,
         useMobileEndpoints: Bool,
-        canRetryAssertion: Bool,
+        canSyncAttestationState: Bool,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
     ) {
@@ -79,7 +79,7 @@ extension STPAPIClient {
             await performConsumerLookup(
                 parameters: parameters,
                 useMobileEndpoints: useMobileEndpoints,
-                canRetryAssertion: canRetryAssertion,
+                canSyncAttestationState: canSyncAttestationState,
                 completion: completion
             )
         }
@@ -88,7 +88,7 @@ extension STPAPIClient {
     private func performConsumerLookup(
         parameters: [String: Any],
         useMobileEndpoints: Bool,
-        canRetryAssertion: Bool,
+        canSyncAttestationState: Bool,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
     ) async {
         let legacyEndpoint = "consumers/sessions/lookup"
@@ -103,7 +103,7 @@ extension STPAPIClient {
         let requestAssertionHandle: StripeAttest.AssertionHandle? = await {
             if useMobileEndpoints {
                 do {
-                    let assertionHandle = try await stripeAttest.assert(canRetry: canRetryAssertion)
+                    let assertionHandle = try await stripeAttest.assert(canSyncState: canSyncAttestationState)
                     mutableParameters = mutableParameters.merging(assertionHandle.assertion.requestFields) { (_, new) in new }
                     return assertionHandle
                 } catch {
@@ -140,6 +140,7 @@ extension STPAPIClient {
         countryCode: String?,
         consentAction: String?,
         useMobileEndpoints: Bool,
+        canSyncAttestationState: Bool,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.SessionWithPublishableKey, Error>) -> Void
     ) {
@@ -175,7 +176,7 @@ extension STPAPIClient {
             let requestAssertionHandle: StripeAttest.AssertionHandle? = await {
                 if useMobileEndpoints {
                     do {
-                        let assertionHandle = try await stripeAttest.assert()
+                        let assertionHandle = try await stripeAttest.assert(canSyncState: canSyncAttestationState)
                         parameters = parameters.merging(assertionHandle.assertion.requestFields) { (_, new) in new }
                         return assertionHandle
                     } catch {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -22,6 +22,7 @@ extension STPAPIClient {
         customerID: String?,
         cookieStore: LinkCookieStore,
         useMobileEndpoints: Bool,
+        canRetryAssertion: Bool,
         doNotLogConsumerFunnelEvent: Bool,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
@@ -51,6 +52,7 @@ extension STPAPIClient {
             await performConsumerLookup(
                 parameters: parameters,
                 useMobileEndpoints: useMobileEndpoints,
+                canRetryAssertion: canRetryAssertion,
                 completion: completion
             )
         }
@@ -62,6 +64,7 @@ extension STPAPIClient {
         customerID: String?,
         cookieStore: LinkCookieStore,
         useMobileEndpoints: Bool,
+        canRetryAssertion: Bool,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
     ) {
@@ -76,6 +79,7 @@ extension STPAPIClient {
             await performConsumerLookup(
                 parameters: parameters,
                 useMobileEndpoints: useMobileEndpoints,
+                canRetryAssertion: canRetryAssertion,
                 completion: completion
             )
         }
@@ -84,6 +88,7 @@ extension STPAPIClient {
     private func performConsumerLookup(
         parameters: [String: Any],
         useMobileEndpoints: Bool,
+        canRetryAssertion: Bool,
         completion: @escaping (Result<ConsumerSession.LookupResponse, Error>) -> Void
     ) async {
         let legacyEndpoint = "consumers/sessions/lookup"
@@ -98,7 +103,7 @@ extension STPAPIClient {
         let requestAssertionHandle: StripeAttest.AssertionHandle? = await {
             if useMobileEndpoints {
                 do {
-                    let assertionHandle = try await stripeAttest.assert()
+                    let assertionHandle = try await stripeAttest.assert(canRetry: canRetryAssertion)
                     mutableParameters = mutableParameters.merging(assertionHandle.assertion.requestFields) { (_, new) in new }
                     return assertionHandle
                 } catch {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
@@ -56,6 +56,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
     let sessionID: String
     let customerID: String?
     let useMobileEndpoints: Bool
+    let canRetryAssertion: Bool
     let merchantLogoUrl: URL?
 
     /// The default cookie store used by new instances of the service.
@@ -72,6 +73,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
             apiClient: apiClient,
             cookieStore: cookieStore,
             useMobileEndpoints: elementsSession.linkSettings?.useAttestationEndpoints ?? false,
+            canRetryAssertion: elementsSession.linkSettings?.linkMobileCanRetryAssertion ?? false,
             sessionID: elementsSession.sessionID,
             customerID: elementsSession.customer?.customerSession.customer,
             shouldPassCustomerIdToLookup: shouldPassCustomerIdToLookup,
@@ -83,6 +85,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
         apiClient: STPAPIClient = .shared,
         cookieStore: LinkCookieStore = defaultCookieStore,
         useMobileEndpoints: Bool,
+        canRetryAssertion: Bool,
         sessionID: String,
         customerID: String?,
         shouldPassCustomerIdToLookup: Bool,
@@ -91,6 +94,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
         self.apiClient = apiClient
         self.cookieStore = cookieStore
         self.useMobileEndpoints = useMobileEndpoints
+        self.canRetryAssertion = canRetryAssertion
         self.sessionID = sessionID
         self.customerID = shouldPassCustomerIdToLookup ? customerID : nil
         self.merchantLogoUrl = merchantLogoUrl
@@ -115,6 +119,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
             customerID: customerID,
             with: apiClient,
             useMobileEndpoints: useMobileEndpoints,
+            canRetryAssertion: canRetryAssertion,
             doNotLogConsumerFunnelEvent: doNotLogConsumerFunnelEvent,
             requestSurface: requestSurface
         ) { [apiClient] result in
@@ -190,6 +195,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
             with: apiClient,
             cookieStore: cookieStore,
             useMobileEndpoints: useMobileEndpoints,
+            canRetryAssertion: canRetryAssertion,
             requestSurface: requestSurface
         ) { [weak self, apiClient] result in
             guard let self else { return }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Services/LinkAccountService.swift
@@ -56,7 +56,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
     let sessionID: String
     let customerID: String?
     let useMobileEndpoints: Bool
-    let canRetryAssertion: Bool
+    let canSyncAttestationState: Bool
     let merchantLogoUrl: URL?
 
     /// The default cookie store used by new instances of the service.
@@ -73,7 +73,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
             apiClient: apiClient,
             cookieStore: cookieStore,
             useMobileEndpoints: elementsSession.linkSettings?.useAttestationEndpoints ?? false,
-            canRetryAssertion: elementsSession.linkSettings?.linkMobileCanRetryAssertion ?? false,
+            canSyncAttestationState: elementsSession.linkSettings?.attestationStateSyncEnabled ?? false,
             sessionID: elementsSession.sessionID,
             customerID: elementsSession.customer?.customerSession.customer,
             shouldPassCustomerIdToLookup: shouldPassCustomerIdToLookup,
@@ -85,7 +85,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
         apiClient: STPAPIClient = .shared,
         cookieStore: LinkCookieStore = defaultCookieStore,
         useMobileEndpoints: Bool,
-        canRetryAssertion: Bool,
+        canSyncAttestationState: Bool,
         sessionID: String,
         customerID: String?,
         shouldPassCustomerIdToLookup: Bool,
@@ -94,7 +94,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
         self.apiClient = apiClient
         self.cookieStore = cookieStore
         self.useMobileEndpoints = useMobileEndpoints
-        self.canRetryAssertion = canRetryAssertion
+        self.canSyncAttestationState = canSyncAttestationState
         self.sessionID = sessionID
         self.customerID = shouldPassCustomerIdToLookup ? customerID : nil
         self.merchantLogoUrl = merchantLogoUrl
@@ -119,7 +119,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
             customerID: customerID,
             with: apiClient,
             useMobileEndpoints: useMobileEndpoints,
-            canRetryAssertion: canRetryAssertion,
+            canSyncAttestationState: canSyncAttestationState,
             doNotLogConsumerFunnelEvent: doNotLogConsumerFunnelEvent,
             requestSurface: requestSurface
         ) { [apiClient] result in
@@ -136,6 +136,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
                             displayablePaymentDetails: session.displayablePaymentDetails,
                             apiClient: apiClient,
                             useMobileEndpoints: self.useMobileEndpoints,
+                            canSyncAttestationState: self.canSyncAttestationState,
                             requestSurface: requestSurface
                         )
                     ))
@@ -149,6 +150,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
                                 displayablePaymentDetails: nil,
                                 apiClient: self.apiClient,
                                 useMobileEndpoints: self.useMobileEndpoints,
+                                canSyncAttestationState: self.canSyncAttestationState,
                                 requestSurface: requestSurface
                             )
                         ))
@@ -195,7 +197,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
             with: apiClient,
             cookieStore: cookieStore,
             useMobileEndpoints: useMobileEndpoints,
-            canRetryAssertion: canRetryAssertion,
+            canSyncAttestationState: canSyncAttestationState,
             requestSurface: requestSurface
         ) { [weak self, apiClient] result in
             guard let self else { return }
@@ -211,6 +213,7 @@ final class LinkAccountService: LinkAccountServiceProtocol {
                         displayablePaymentDetails: session.displayablePaymentDetails,
                         apiClient: apiClient,
                         useMobileEndpoints: self.useMobileEndpoints,
+                        canSyncAttestationState: self.canSyncAttestationState,
                         requestSurface: requestSurface,
                         createdFromAuthIntentID: true
                     )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -558,6 +558,7 @@ import UIKit
             apiClient: linkAccount.apiClient,
             cookieStore: linkAccount.cookieStore,
             useMobileEndpoints: linkAccount.useMobileEndpoints,
+            canSyncAttestationState: linkAccount.canSyncAttestationState,
             requestSurface: linkAccount.requestSurface
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/LinkInlineVerificationView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/LinkInlineVerificationView.swift
@@ -173,7 +173,8 @@ enum Stubs {
             session: isRegistered ? Self.consumerSession : nil,
             publishableKey: "pk_test_123",
             displayablePaymentDetails: paymentMethodType.map { Self.displayablePaymentDetails(paymentMethodType: $0) },
-            useMobileEndpoints: true
+            useMobileEndpoints: true,
+            canSyncAttestationState: false
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
@@ -1439,7 +1439,8 @@ extension PaymentSheetLinkAccount {
             session: session,
             publishableKey: "pk_123",
             displayablePaymentDetails: displayablePaymentDetails,
-            useMobileEndpoints: true
+            useMobileEndpoints: true,
+            canSyncAttestationState: false
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkButtonSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkButtonSnapshotTests.swift
@@ -141,7 +141,8 @@ enum Stubs {
             session: isRegistered ? Self.consumerSession : nil,
             publishableKey: "pk_test_123",
             displayablePaymentDetails: paymentMethodType.map { Self.displayablePaymentDetails(paymentMethodType: $0) },
-            useMobileEndpoints: true
+            useMobileEndpoints: true,
+            canSyncAttestationState: false
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkSignUpViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkSignUpViewControllerSnapshotTests.swift
@@ -63,7 +63,8 @@ extension LinkSignUpViewControllerSnapshotTests {
                 session: session,
                 publishableKey: nil,
                 displayablePaymentDetails: nil,
-                useMobileEndpoints: false
+                useMobileEndpoints: false,
+                canSyncAttestationState: false
             ),
             defaultBillingDetails: nil
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
@@ -269,7 +269,8 @@ extension PayWithLinkViewController_WalletViewModelTests {
                 session: LinkStubs.consumerSession(supportedPaymentDetailsTypes: supportedPaymentDetailsTypes),
                 publishableKey: nil,
                 displayablePaymentDetails: nil,
-                useMobileEndpoints: false
+                useMobileEndpoints: false,
+                canSyncAttestationState: false
             ),
             context: .init(
                 intent: intent,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/WalletViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/WalletViewControllerSnapshotTests.swift
@@ -103,7 +103,8 @@ extension WalletViewControllerSnapshotTests {
             session: session,
             publishableKey: "pk_123",
             displayablePaymentDetails: nil,
-            useMobileEndpoints: true
+            useMobileEndpoints: true,
+            canSyncAttestationState: false
         )
 
         return PayWithLinkViewController.WalletViewController(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
@@ -88,7 +88,8 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
                     ),
                     publishableKey: "pk_xxx_for_link_account_xxx",
                     displayablePaymentDetails: nil,
-                    useMobileEndpoints: false
+                    useMobileEndpoints: false,
+                    canSyncAttestationState: false
                 ),
                 paymentDetails: .init(
                     stripeID: "pd1",
@@ -195,7 +196,9 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
                         ),
                         publishableKey: MockParams.publicKey,
                         displayablePaymentDetails: nil,
-                        useMobileEndpoints: false),
+                        useMobileEndpoints: false,
+                        canSyncAttestationState: false
+                    ),
                     paymentDetails: .init(
                         stripeID: "pd1",
                         details: .card(card: .init(
@@ -263,7 +266,8 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
                     session: nil,
                     publishableKey: "pk_123",
                     displayablePaymentDetails: nil,
-                    useMobileEndpoints: false
+                    useMobileEndpoints: false,
+                    canSyncAttestationState: false
                 ),
                 phoneNumber: PhoneNumber(number: "5555555555", countryCode: "US")!,
                 consentAction: .implied_v0_0,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
@@ -182,7 +182,7 @@ extension LinkSettings {
             linkDefaultOptIn: nil,
             linkEnableDisplayableDefaultValuesInECE: nil,
             linkShowPreferDebitCardHint: nil,
-            linkMobileCanRetryAssertion: nil,
+            attestationStateSyncEnabled: nil,
             linkSupportedPaymentMethodsOnboardingEnabled: linkSupportedPaymentMethodsOnboardingEnabled,
             allResponseFields: [:]
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+PaymentMethodAvailabilityTest.swift
@@ -182,6 +182,7 @@ extension LinkSettings {
             linkDefaultOptIn: nil,
             linkEnableDisplayableDefaultValuesInECE: nil,
             linkShowPreferDebitCardHint: nil,
+            linkMobileCanRetryAssertion: nil,
             linkSupportedPaymentMethodsOnboardingEnabled: linkSupportedPaymentMethodsOnboardingEnabled,
             allResponseFields: [:]
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
@@ -87,6 +87,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             linkDefaultOptIn: .full,
             linkEnableDisplayableDefaultValuesInECE: nil,
             linkShowPreferDebitCardHint: nil,
+            linkMobileCanRetryAssertion: nil,
             linkSupportedPaymentMethodsOnboardingEnabled: ["CARD"],
             allResponseFields: [:]
         )
@@ -157,6 +158,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             linkDefaultOptIn: .optional,
             linkEnableDisplayableDefaultValuesInECE: nil,
             linkShowPreferDebitCardHint: nil,
+            linkMobileCanRetryAssertion: nil,
             linkSupportedPaymentMethodsOnboardingEnabled: ["CARD"],
             allResponseFields: [:]
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
@@ -87,7 +87,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             linkDefaultOptIn: .full,
             linkEnableDisplayableDefaultValuesInECE: nil,
             linkShowPreferDebitCardHint: nil,
-            linkMobileCanRetryAssertion: nil,
+            attestationStateSyncEnabled: nil,
             linkSupportedPaymentMethodsOnboardingEnabled: ["CARD"],
             allResponseFields: [:]
         )
@@ -111,7 +111,8 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             session: nil,
             publishableKey: nil,
             displayablePaymentDetails: nil,
-            useMobileEndpoints: true
+            useMobileEndpoints: true,
+            canSyncAttestationState: false
         )
 
         let experiment = LinkGlobalHoldback(
@@ -158,7 +159,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             linkDefaultOptIn: .optional,
             linkEnableDisplayableDefaultValuesInECE: nil,
             linkShowPreferDebitCardHint: nil,
-            linkMobileCanRetryAssertion: nil,
+            attestationStateSyncEnabled: nil,
             linkSupportedPaymentMethodsOnboardingEnabled: ["CARD"],
             allResponseFields: [:]
         )
@@ -181,7 +182,8 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             session: LinkStubs.consumerSession(),
             publishableKey: nil,
             displayablePaymentDetails: nil,
-            useMobileEndpoints: true
+            useMobileEndpoints: true,
+            canSyncAttestationState: false
         )
 
         let experiment = LinkABTest(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -56,7 +56,8 @@ class PaymentSheetFlowControllerTests: XCTestCase {
             publishableKey: nil,
             displayablePaymentDetails: nil,
             apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey),
-            useMobileEndpoints: false
+            useMobileEndpoints: false,
+            canSyncAttestationState: false
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -1841,7 +1841,8 @@ class PaymentSheetFormFactoryTest: XCTestCase {
                     session: nil,
                     publishableKey: nil,
                     displayablePaymentDetails: nil,
-                    useMobileEndpoints: false
+                    useMobileEndpoints: false,
+                    canSyncAttestationState: false
                 ),
                 accountService: LinkAccountService._testValue(),
                 analyticsHelper: ._testValue(analyticsClient: analyticsClient)
@@ -1887,7 +1888,8 @@ class PaymentSheetFormFactoryTest: XCTestCase {
                     session: nil,
                     publishableKey: nil,
                     displayablePaymentDetails: nil,
-                    useMobileEndpoints: false
+                    useMobileEndpoints: false,
+                    canSyncAttestationState: false
                 ),
                 accountService: LinkAccountService._testValue(),
                 analyticsHelper: ._testValue(analyticsClient: analyticsClient)
@@ -1931,7 +1933,8 @@ class PaymentSheetFormFactoryTest: XCTestCase {
                     session: nil,
                     publishableKey: nil,
                     displayablePaymentDetails: nil,
-                    useMobileEndpoints: false
+                    useMobileEndpoints: false,
+                    canSyncAttestationState: false
                 ),
                 accountService: LinkAccountService._testValue(),
                 analyticsHelper: ._testValue(analyticsClient: analyticsClient)
@@ -1975,7 +1978,8 @@ class PaymentSheetFormFactoryTest: XCTestCase {
                     session: nil,
                     publishableKey: nil,
                     displayablePaymentDetails: nil,
-                    useMobileEndpoints: false
+                    useMobileEndpoints: false,
+                    canSyncAttestationState: false
                 ),
                 accountService: LinkAccountService._testValue(),
                 analyticsHelper: ._testValue(analyticsClient: analyticsClient)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
@@ -196,7 +196,8 @@ extension PaymentSheetLinkAccountTests {
             publishableKey: nil,
             displayablePaymentDetails: nil,
             apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey),
-            useMobileEndpoints: false
+            useMobileEndpoints: false,
+            canSyncAttestationState: false
         )
     }
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
@@ -41,6 +41,7 @@ import Foundation
     @_spi(STP) public let linkDefaultOptIn: LinkDefaultOptIn?
     @_spi(STP) public let linkEnableDisplayableDefaultValuesInECE: Bool?
     @_spi(STP) public let linkShowPreferDebitCardHint: Bool?
+    @_spi(STP) public let linkMobileCanRetryAssertion: Bool?
     @_spi(STP) public let linkSupportedPaymentMethodsOnboardingEnabled: [String]
 
     @_spi(STP) public let allResponseFields: [AnyHashable: Any]
@@ -63,6 +64,7 @@ import Foundation
         linkDefaultOptIn: LinkDefaultOptIn?,
         linkEnableDisplayableDefaultValuesInECE: Bool?,
         linkShowPreferDebitCardHint: Bool?,
+        linkMobileCanRetryAssertion: Bool?,
         linkSupportedPaymentMethodsOnboardingEnabled: [String],
         allResponseFields: [AnyHashable: Any]
     ) {
@@ -79,6 +81,7 @@ import Foundation
         self.linkDefaultOptIn = linkDefaultOptIn
         self.linkEnableDisplayableDefaultValuesInECE = linkEnableDisplayableDefaultValuesInECE
         self.linkShowPreferDebitCardHint = linkShowPreferDebitCardHint
+        self.linkMobileCanRetryAssertion = linkMobileCanRetryAssertion
         self.linkSupportedPaymentMethodsOnboardingEnabled = linkSupportedPaymentMethodsOnboardingEnabled
         self.allResponseFields = allResponseFields
     }
@@ -106,6 +109,7 @@ import Foundation
         let linkDefaultOptIn = (response["link_default_opt_in"] as? String).flatMap { LinkDefaultOptIn(rawValue: $0) }
         let linkEnableDisplayableDefaultValuesInECE = response["link_enable_displayable_default_values_in_ece"] as? Bool ?? false
         let linkShowPreferDebitCardHint = response["link_show_prefer_debit_card_hint"] as? Bool ?? false
+        let linkMobileCanRetryAssertion = response["link_mobile_can_retry_assertion"] as? Bool
 
         let linkIncentivesEnabled = UserDefaults.standard.bool(forKey: "FINANCIAL_CONNECTIONS_INSTANT_DEBITS_INCENTIVES")
         let linkConsumerIncentive: LinkConsumerIncentive? = if linkIncentivesEnabled {
@@ -139,6 +143,7 @@ import Foundation
             linkDefaultOptIn: linkDefaultOptIn,
             linkEnableDisplayableDefaultValuesInECE: linkEnableDisplayableDefaultValuesInECE,
             linkShowPreferDebitCardHint: linkShowPreferDebitCardHint,
+            linkMobileCanRetryAssertion: linkMobileCanRetryAssertion,
             linkSupportedPaymentMethodsOnboardingEnabled: linkSupportedPaymentMethodsOnboardingEnabled,
             allResponseFields: response
         ) as? Self

--- a/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/Shared/LinkSettings.swift
@@ -41,7 +41,7 @@ import Foundation
     @_spi(STP) public let linkDefaultOptIn: LinkDefaultOptIn?
     @_spi(STP) public let linkEnableDisplayableDefaultValuesInECE: Bool?
     @_spi(STP) public let linkShowPreferDebitCardHint: Bool?
-    @_spi(STP) public let linkMobileCanRetryAssertion: Bool?
+    @_spi(STP) public let attestationStateSyncEnabled: Bool?
     @_spi(STP) public let linkSupportedPaymentMethodsOnboardingEnabled: [String]
 
     @_spi(STP) public let allResponseFields: [AnyHashable: Any]
@@ -64,7 +64,7 @@ import Foundation
         linkDefaultOptIn: LinkDefaultOptIn?,
         linkEnableDisplayableDefaultValuesInECE: Bool?,
         linkShowPreferDebitCardHint: Bool?,
-        linkMobileCanRetryAssertion: Bool?,
+        attestationStateSyncEnabled: Bool?,
         linkSupportedPaymentMethodsOnboardingEnabled: [String],
         allResponseFields: [AnyHashable: Any]
     ) {
@@ -81,7 +81,7 @@ import Foundation
         self.linkDefaultOptIn = linkDefaultOptIn
         self.linkEnableDisplayableDefaultValuesInECE = linkEnableDisplayableDefaultValuesInECE
         self.linkShowPreferDebitCardHint = linkShowPreferDebitCardHint
-        self.linkMobileCanRetryAssertion = linkMobileCanRetryAssertion
+        self.attestationStateSyncEnabled = attestationStateSyncEnabled
         self.linkSupportedPaymentMethodsOnboardingEnabled = linkSupportedPaymentMethodsOnboardingEnabled
         self.allResponseFields = allResponseFields
     }
@@ -109,7 +109,7 @@ import Foundation
         let linkDefaultOptIn = (response["link_default_opt_in"] as? String).flatMap { LinkDefaultOptIn(rawValue: $0) }
         let linkEnableDisplayableDefaultValuesInECE = response["link_enable_displayable_default_values_in_ece"] as? Bool ?? false
         let linkShowPreferDebitCardHint = response["link_show_prefer_debit_card_hint"] as? Bool ?? false
-        let linkMobileCanRetryAssertion = response["link_mobile_can_retry_assertion"] as? Bool
+        let attestationStateSyncEnabled = response["link_mobile_attestation_state_sync_enabled"] as? Bool
 
         let linkIncentivesEnabled = UserDefaults.standard.bool(forKey: "FINANCIAL_CONNECTIONS_INSTANT_DEBITS_INCENTIVES")
         let linkConsumerIncentive: LinkConsumerIncentive? = if linkIncentivesEnabled {
@@ -143,7 +143,7 @@ import Foundation
             linkDefaultOptIn: linkDefaultOptIn,
             linkEnableDisplayableDefaultValuesInECE: linkEnableDisplayableDefaultValuesInECE,
             linkShowPreferDebitCardHint: linkShowPreferDebitCardHint,
-            linkMobileCanRetryAssertion: linkMobileCanRetryAssertion,
+            attestationStateSyncEnabled: attestationStateSyncEnabled,
             linkSupportedPaymentMethodsOnboardingEnabled: linkSupportedPaymentMethodsOnboardingEnabled,
             allResponseFields: response
         ) as? Self


### PR DESCRIPTION
## Summary

This makes a few tweaks to the `StripeAttest` client to better handle client and server state mismatches. There are two scenarios this addresses:

1. Client thinks it's not attested, but server has attestation
    - Action: Client updates its local state to match server
2. Client thinks it's attested, but server needs attestation
    - Action: Client resets and re-attests

[I'm adding a feature flag](https://git.corp.stripe.com/stripe-internal/pay-server/pull/1208789) `link_mobile_attestation_state_sync_enabled` to control this new behavior, as we don't know yet if it is a risky change.

I'm also adding new analytic events for those two scenarios,

## Motivation

More details here https://docs.google.com/document/d/1NMQoDpCOv4dvYjMmwfrsezGhc---wKy2eFkeH_DBjAQ/edit?usp=sharing

## Testing

Unit tests added

## Changelog

N/a