### PR TITLE
Don't search when the address search line is empty

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
@@ -123,7 +123,7 @@ class AutoCompleteViewController: UIViewController {
         self.addressSpecProvider = addressSpecProvider
         self.verticalOffset = verticalOffset
         super.init(nibName: nil, bundle: nil)
-        if let initialLine1Text = initialLine1Text {
+        if let initialLine1Text = initialLine1Text, !initialLine1Text.isEmpty {
             self.addressSearchCompleter.queryFragment = initialLine1Text
         }
     }
@@ -237,7 +237,9 @@ class AutoCompleteViewController: UIViewController {
 // MARK: ElementDelegate
 extension AutoCompleteViewController: ElementDelegate {
     func didUpdate(element: Element) {
-        addressSearchCompleter.queryFragment = autoCompleteLine.text
+        if !autoCompleteLine.text.isEmpty {
+            addressSearchCompleter.queryFragment = autoCompleteLine.text
+        }
     }
 
     func continueToNextField(element: Element) {


### PR DESCRIPTION
## Summary
In AddressViewController, if the string is empty, we tell MKLocalSearch to look for an empty string, which returns an error. Instead, don't update the query if the string is empty.

## Motivation
Fix "The operation couldn't be completed" errors when backspacing in AddressViewController.

## Testing
In PS Example

## Changelog
N/A