### PR TITLE
Skip Link account lookup on FlowController update

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -602,7 +602,8 @@ extension PaymentSheet {
                 mode: .deferredIntent(intentConfiguration),
                 configuration: configuration,
                 analyticsHelper: analyticsHelper,
-                integrationShape: .flowController
+                integrationShape: .flowController,
+                isUpdate: true
             ) { [weak self] result in
                 assert(Thread.isMainThread, "PaymentSheet.FlowController.update load callback must be called from the main thread.")
                 guard let self = self else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -156,7 +156,6 @@ typealias ExpressType = PaymentSheet.WalletButtonsVisibility.ExpressType
                 canSkipWalletAfterVerification: flowController.elementsSession.canSkipLinkWallet,
                 completion: { confirmOptions, _ in
                     guard let confirmOptions else {
-//                        self.orderedWallets = WalletButtonsView.determineAvailableWallets(for: flowController)
                         return
                     }
                     flowController.viewController.linkConfirmOption = confirmOptions


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request makes an improvement to the Link experience when the merchant calls `FlowController.update()` in their checkout flow.

Instead of looking up the Link account again and thereby resetting its verification state, we now keep the existing Link account session alive. This avoids another OTP verification for the consumer.

<details><summary>Recording</summary>
<p>


https://github.com/user-attachments/assets/6aaced7d-a93c-4592-ba53-bba7d23b4267



</p>
</details> 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
