### PR TITLE
Crypto Onramp SDK: Enforces Verified Link Account Before Collecting Card/Bank Info

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator+Error.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator+Error.swift
@@ -26,7 +26,7 @@ public extension CryptoOnrampCoordinator {
         /// A crypto customer ID is missing but required.
         case missingCryptoCustomerID
 
-        /// The link account is not in a verified state.
+        /// The Link account is not in a verified state.
         case linkAccountNotVerified
 
         public var errorDescription: String? {
@@ -42,7 +42,7 @@ public extension CryptoOnrampCoordinator {
             case .missingCryptoCustomerID:
                 return "A crypto customer ID is missing but required. A crypto customer ID must either be provided to the Crypto Onramp Coordinator in the `create` API, or generated during the onramp flow by verifying a Link account using the `registerLinkUser`, `authenticateUser`, or `authorize` APIs."
             case .linkAccountNotVerified:
-                return "The customer’s link account is not in a verified state."
+                return "The customer’s Link account is not in a verified state."
             }
         }
     }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator+Error.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator+Error.swift
@@ -26,6 +26,9 @@ public extension CryptoOnrampCoordinator {
         /// A crypto customer ID is missing but required.
         case missingCryptoCustomerID
 
+        /// The link account is not in a verified state.
+        case linkAccountNotVerified
+
         public var errorDescription: String? {
             switch self {
             case .invalidPhoneFormat:
@@ -38,6 +41,8 @@ public extension CryptoOnrampCoordinator {
                 return "An unexpected error occurred internally. Selected payment source was not set to an expected value."
             case .missingCryptoCustomerID:
                 return "A crypto customer ID is missing but required. A crypto customer ID must either be provided to the Crypto Onramp Coordinator in the `create` API, or generated during the onramp flow by verifying a Link account using the `registerLinkUser`, `authenticateUser`, or `authorize` APIs."
+            case .linkAccountNotVerified:
+                return "The customer’s link account is not in a verified state."
             }
         }
     }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator+Error.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator+Error.swift
@@ -42,7 +42,7 @@ public extension CryptoOnrampCoordinator {
             case .missingCryptoCustomerID:
                 return "A crypto customer ID is missing but required. A crypto customer ID must either be provided to the Crypto Onramp Coordinator in the `create` API, or generated during the onramp flow by verifying a Link account using the `registerLinkUser`, `authenticateUser`, or `authorize` APIs."
             case .linkAccountNotVerified:
-                return "The customer’s Link account is not in a verified state."
+                return "No active Link consumer is available in a verified state."
             }
         }
     }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -423,7 +423,11 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
     ) async throws -> PaymentMethodDisplayData? {
         switch type {
         case .card, .bankAccount:
-            let email = try? await linkAccountInfo.email
+            let linkAccountInfo = try await linkAccountInfo
+            guard linkAccountInfo.sessionState == .verified else {
+                throw Error.linkAccountNotVerified
+            }
+
             guard let supportedPaymentMethodType = type.linkPaymentMethodType else {
                 return nil
             }
@@ -432,7 +436,7 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
             let collectName = type == .bankAccount
             guard let result = await linkController.collectPaymentMethod(
                 from: viewController,
-                with: email,
+                with: linkAccountInfo.email,
                 supportedPaymentMethodTypes: [supportedPaymentMethodType],
                 collectName: collectName
             ) else {


### PR DESCRIPTION
## Summary
Ensures that before collecting a card or bank account, we verify that we have a link account, and that the link account is in a verified state.

## Motivation
To ensure the SDK doesn’t allow collecting payment method without necessary details.

## Testing
Manually reset the crypto onramp session on a test branch before collecting payment method (`mliberatore/crypto-onramp-use-new-coordinator-when-collecting-payment`):

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-25 at 10 46 29" src="https://github.com/user-attachments/assets/83a4fd58-d9ef-4140-bb12-21e5c69dc408" />

Ensured that throwing the new error displayed the correct message:

<img width="300" alt="Simulator Screenshot - iPhone 16 Pro - 2025-09-25 at 10 57 34" src="https://github.com/user-attachments/assets/5c5fdf65-5af6-4c0e-a689-66463c7f0d8c" />


## Changelog
N/A
