### PR TITLE
Add assertions for konbini/blik with confirmation tokens

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -160,6 +160,14 @@ final class PaymentSheetLoader {
                 )
                 let paymentMethodTypes = PaymentSheet.PaymentMethodType.filteredPaymentMethodTypes(from: intent, elementsSession: elementsSession, configuration: configuration, logAvailability: true)
 
+                // Assert if using konbini or blik with confirmation tokens
+                if case .deferredIntent(let intentConfiguration) = mode,
+                   intentConfiguration.confirmationTokenConfirmHandler != nil {
+                    if paymentMethodTypes.contains(.stripe(.konbini)) || paymentMethodTypes.contains(.stripe(.blik)) {
+                        stpAssertionFailure("Konbini and BLIK payment methods are not supported with ConfirmationTokens. Use init(mode:paymentMethodTypes:onBehalfOf:paymentMethodConfigurationId:confirmHandler:requireCVCRecollection:) instead.")
+                    }
+                }
+
                 // Ensure that there's at least 1 payment method type available for the intent and configuration.
                 guard !paymentMethodTypes.isEmpty else {
                     throw PaymentSheetError.noPaymentMethodTypesAvailable(intentPaymentMethods: elementsSession.orderedPaymentMethodTypes)


### PR DESCRIPTION
## Summary
- Assert in PaymentSheetLoader when konbini or blik payment methods are used with confirmation tokens
- https://docs.google.com/document/d/1v8r8ARfsTcc61wUjgvPGNJhsDncTqxupTI5sHAkv9xQ/edit?tab=t.0#bookmark=id.85omqywecb1d


## Motivation
- Confirmation Tokens

## Testing
- Manual

## Changelog
N/A
