### PR TITLE
[Identity] Implementing `is_stripe` and `skip_success_page` functionality

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/API Bindings/IdentityAPIClient.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/IdentityAPIClient.swift
@@ -47,7 +47,7 @@ final class IdentityAPIClientImpl: IdentityAPIClient {
     /// SDK is capable of using.
     ///
     /// - Note: Update this value when a new API version is ready for use in production.
-    static let productionApiVersion: Int = 6
+    static let productionApiVersion: Int = 7
 
     var betas: Set<String> {
         return ["identity_client_api=v\(apiVersion)"]

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPage.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPage.swift
@@ -46,9 +46,9 @@ extension StripeAPI {
         /// session ID to identify experiement exposure
         let userSessionId: String
         let experiments: [VerificationPageStaticContentExperiment]
-        /// Whether this verification is for Stripe (internal flows)
+        /// Whether this verification was triggered by Stripe
         let isStripe: Bool
-        /// If true, the client should skip rendering a success page at the end of the flow
+        /// If true, the SDK will skip rendering a success page at the end of the flow
         let skipSuccessPage: Bool
 
     }

--- a/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPage.swift
+++ b/StripeIdentity/StripeIdentity/Source/API Bindings/Models/VerificationPage/VerificationPage.swift
@@ -46,6 +46,10 @@ extension StripeAPI {
         /// session ID to identify experiement exposure
         let userSessionId: String
         let experiments: [VerificationPageStaticContentExperiment]
+        /// Whether this verification is for Stripe (internal flows)
+        let isStripe: Bool
+        /// If true, the client should skip rendering a success page at the end of the flow
+        let skipSuccessPage: Bool
 
     }
 
@@ -53,6 +57,6 @@ extension StripeAPI {
 
 extension StripeAPI.VerificationPage {
     func copyWithNewMissings(newMissings: Set<StripeAPI.VerificationPageFieldType>) -> StripeAPI.VerificationPage {
-        return StripeAPI.VerificationPage(biometricConsent: self.biometricConsent, documentCapture: self.documentCapture, documentSelect: self.documentSelect, individual: self.individual, countryNotListed: self.countryNotListed, individualWelcome: self.individualWelcome, phoneOtp: self.phoneOtp, fallbackUrl: self.fallbackUrl, id: self.id, livemode: self.livemode, requirements: StripeAPI.VerificationPageRequirements(missing: newMissings), selfie: self.selfie, status: self.status, submitted: self.submitted, success: self.success, unsupportedClient: self.unsupportedClient, bottomsheet: self.bottomsheet, userSessionId: self.userSessionId, experiments: self.experiments)
+        return StripeAPI.VerificationPage(biometricConsent: self.biometricConsent, documentCapture: self.documentCapture, documentSelect: self.documentSelect, individual: self.individual, countryNotListed: self.countryNotListed, individualWelcome: self.individualWelcome, phoneOtp: self.phoneOtp, fallbackUrl: self.fallbackUrl, id: self.id, livemode: self.livemode, requirements: StripeAPI.VerificationPageRequirements(missing: newMissings), selfie: self.selfie, status: self.status, submitted: self.submitted, success: self.success, unsupportedClient: self.unsupportedClient, bottomsheet: self.bottomsheet, userSessionId: self.userSessionId, experiments: self.experiments, isStripe: self.isStripe, skipSuccessPage: self.skipSuccessPage)
     }
 }

--- a/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
+++ b/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
@@ -32,21 +32,15 @@ final public class IdentityVerificationSheet {
         /// dynamic UIImage to support different images in light vs dark mode.
         public var brandLogo: UIImage
 
-        /// Whether or not to show the stripe logo on the biometric consent screen in the document flow
-        public var showsStripeLogo: Bool
-
         /// Initializes a Configuration.
         /// - Parameters:
         ///   - brandLogo: An image of your customer-facing business logo.
         ///     The recommended image size is 32 x 32 points. The image will be
         ///     displayed in both light and dark modes, if the app supports it.
-        ///   - showsStripeLogo: Whether or not to show the stripe logo on the biometric consent screen in the document flow
         public init(
-            brandLogo: UIImage,
-            showsStripeLogo: Bool = true
+            brandLogo: UIImage
         ) {
             self.brandLogo = brandLogo
-            self.showsStripeLogo = showsStripeLogo
         }
     }
 
@@ -98,8 +92,7 @@ final public class IdentityVerificationSheet {
                     ephemeralKeySecret: ephemeralKeySecret
                 ),
                 flowController: VerificationSheetFlowController(
-                    brandLogo: configuration.brandLogo,
-                    showsStripeLogo: configuration.showsStripeLogo
+                    brandLogo: configuration.brandLogo
                 ),
                 mlModelLoader: IdentityMLModelLoader(),
                 analyticsClient: IdentityAnalyticsClient(

--- a/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
+++ b/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
@@ -31,6 +31,8 @@ final public class IdentityVerificationSheet {
         /// displayed in both light and dark modes, if the app supports it. Use a
         /// dynamic UIImage to support different images in light vs dark mode.
         public var brandLogo: UIImage
+        
+        public var showsStripeLogo: Bool
 
         /// Initializes a Configuration.
         /// - Parameters:
@@ -38,9 +40,11 @@ final public class IdentityVerificationSheet {
         ///     The recommended image size is 32 x 32 points. The image will be
         ///     displayed in both light and dark modes, if the app supports it.
         public init(
-            brandLogo: UIImage
+            brandLogo: UIImage,
+            showsStripeLogo: Bool = true
         ) {
             self.brandLogo = brandLogo
+            self.showsStripeLogo = showsStripeLogo
         }
     }
 
@@ -92,7 +96,8 @@ final public class IdentityVerificationSheet {
                     ephemeralKeySecret: ephemeralKeySecret
                 ),
                 flowController: VerificationSheetFlowController(
-                    brandLogo: configuration.brandLogo
+                    brandLogo: configuration.brandLogo,
+                    showsStripeLogo: configuration.showsStripeLogo
                 ),
                 mlModelLoader: IdentityMLModelLoader(),
                 analyticsClient: IdentityAnalyticsClient(

--- a/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
+++ b/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
@@ -31,7 +31,7 @@ final public class IdentityVerificationSheet {
         /// displayed in both light and dark modes, if the app supports it. Use a
         /// dynamic UIImage to support different images in light vs dark mode.
         public var brandLogo: UIImage
-        
+
         /// Whether or not to show the stripe logo on the biometric consent screen in the document flow
         public var showsStripeLogo: Bool
 

--- a/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
+++ b/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
@@ -32,6 +32,7 @@ final public class IdentityVerificationSheet {
         /// dynamic UIImage to support different images in light vs dark mode.
         public var brandLogo: UIImage
         
+        /// Whether or not to show the stripe logo on the biometric consent screen in the document flow
         public var showsStripeLogo: Bool
 
         /// Initializes a Configuration.
@@ -39,6 +40,7 @@ final public class IdentityVerificationSheet {
         ///   - brandLogo: An image of your customer-facing business logo.
         ///     The recommended image size is 32 x 32 points. The image will be
         ///     displayed in both light and dark modes, if the app supports it.
+        ///   - showsStripeLogo: Whether or not to show the stripe logo on the biometric consent screen in the document flow
         public init(
             brandLogo: UIImage,
             showsStripeLogo: Bool = true

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -525,7 +525,6 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
         do {
             return try IndividualWelcomeViewController(
                 brandLogo: brandLogo,
-                showsStripeLogo: !staticContent.isStripe,
                 welcomeContent: staticContent.individualWelcome,
                 sheetController: sheetController
             )

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -83,7 +83,6 @@ protocol VerificationSheetFlowControllerProtocol: AnyObject {
 final class VerificationSheetFlowController: NSObject {
 
     let brandLogo: UIImage
-    let showsStripeLogo: Bool
 
     weak var delegate: VerificationSheetFlowControllerDelegate?
 
@@ -94,11 +93,9 @@ final class VerificationSheetFlowController: NSObject {
     private(set) var documentUploader: DocumentUploaderProtocol?
 
     init(
-        brandLogo: UIImage,
-        showsStripeLogo: Bool
+        brandLogo: UIImage
     ) {
         self.brandLogo = brandLogo
-        self.showsStripeLogo = showsStripeLogo
     }
 
     private(set) lazy var navigationController: UINavigationController = {
@@ -528,6 +525,7 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
         do {
             return try IndividualWelcomeViewController(
                 brandLogo: brandLogo,
+                showsStripeLogo: !staticContent.isStripe,
                 welcomeContent: staticContent.individualWelcome,
                 sheetController: sheetController
             )
@@ -593,7 +591,7 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
         do {
             return try BiometricConsentViewController(
                 brandLogo: brandLogo,
-                showsStripeLogo: showsStripeLogo,
+                showsStripeLogo: !staticContent.isStripe,
                 consentContent: staticContent.biometricConsent,
                 sheetController: sheetController
             )

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -434,6 +434,10 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
 
         // Show success screen if submitted and closed
         if updateDataResponse?.submittedAndClosed() == true {
+            if staticContent.skipSuccessPage {
+                navigationController.dismiss(animated: true)
+                return
+            }
             return completion(
                 SuccessViewController(
                     successContent: staticContent.success,
@@ -498,6 +502,10 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
                 )
             )
         case .confirmationDestination:
+            if staticContent.skipSuccessPage {
+                navigationController.dismiss(animated: true)
+                return
+            }
             return completion(
                 SuccessViewController(
                     successContent: staticContent.success,

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -83,6 +83,7 @@ protocol VerificationSheetFlowControllerProtocol: AnyObject {
 final class VerificationSheetFlowController: NSObject {
 
     let brandLogo: UIImage
+    let showsStripeLogo: Bool
 
     weak var delegate: VerificationSheetFlowControllerDelegate?
 
@@ -93,9 +94,11 @@ final class VerificationSheetFlowController: NSObject {
     private(set) var documentUploader: DocumentUploaderProtocol?
 
     init(
-        brandLogo: UIImage
+        brandLogo: UIImage,
+        showsStripeLogo: Bool
     ) {
         self.brandLogo = brandLogo
+        self.showsStripeLogo = showsStripeLogo
     }
 
     private(set) lazy var navigationController: UINavigationController = {
@@ -590,6 +593,7 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
         do {
             return try BiometricConsentViewController(
                 brandLogo: brandLogo,
+                showsStripeLogo: showsStripeLogo,
                 consentContent: staticContent.biometricConsent,
                 sheetController: sheetController
             )

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/BiometricConsentViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/BiometricConsentViewController.swift
@@ -24,6 +24,7 @@ final class BiometricConsentViewController: IdentityFlowViewController {
     private let privacyPolicyView = HTMLTextView()
 
     let brandLogo: UIImage
+    let showsStripeLogo: Bool
     let consentContent: StripeAPI.VerificationPageStaticContentConsentPage
 
     struct Style {
@@ -108,7 +109,7 @@ final class BiometricConsentViewController: IdentityFlowViewController {
                         // Otherwise this is the first screen, show icons
                         return .banner(
                             iconViewModel: .init(
-                                iconType: .brand,
+                                iconType: showsStripeLogo ? .brand : .plain,
                                 iconImage: brandLogo,
                                 iconImageContentMode: .scaleToFill,
                                 useLargeIcon: true
@@ -130,10 +131,12 @@ final class BiometricConsentViewController: IdentityFlowViewController {
 
     init(
         brandLogo: UIImage,
+        showsStripeLogo: Bool,
         consentContent: StripeAPI.VerificationPageStaticContentConsentPage,
         sheetController: VerificationSheetControllerProtocol
     ) throws {
         self.brandLogo = brandLogo
+        self.showsStripeLogo = showsStripeLogo
         self.consentContent = consentContent
         super.init(sheetController: sheetController, analyticsScreenName: .biometricConsent)
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IndividualWelcomeViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IndividualWelcomeViewController.swift
@@ -13,6 +13,7 @@ final class IndividualWelcomeViewController: IdentityFlowViewController {
     let flowViewModel: IdentityFlowView.ViewModel
     init(
         brandLogo: UIImage,
+        showsStripeLogo: Bool,
         welcomeContent: StripeAPI.VerificationPageStaticContentIndividualWelcomePage,
         sheetController: VerificationSheetControllerProtocol
     ) throws {
@@ -26,7 +27,7 @@ final class IndividualWelcomeViewController: IdentityFlowViewController {
                 backgroundColor: .systemBackground,
                 headerType: .banner(
                     iconViewModel: .init(
-                        iconType: .brand,
+                        iconType: showsStripeLogo ? .brand : .plain,
                         iconImage: brandLogo,
                         iconImageContentMode: .scaleToFill,
                         useLargeIcon: true

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IndividualWelcomeViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IndividualWelcomeViewController.swift
@@ -13,7 +13,6 @@ final class IndividualWelcomeViewController: IdentityFlowViewController {
     let flowViewModel: IdentityFlowView.ViewModel
     init(
         brandLogo: UIImage,
-        showsStripeLogo: Bool,
         welcomeContent: StripeAPI.VerificationPageStaticContentIndividualWelcomePage,
         sheetController: VerificationSheetControllerProtocol
     ) throws {
@@ -27,7 +26,7 @@ final class IndividualWelcomeViewController: IdentityFlowViewController {
                 backgroundColor: .systemBackground,
                 headerType: .banner(
                     iconViewModel: .init(
-                        iconType: showsStripeLogo ? .brand : .plain,
+                        iconType: .brand,
                         iconImage: brandLogo,
                         iconImageContentMode: .scaleToFill,
                         useLargeIcon: true

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200.json
@@ -186,6 +186,8 @@
       "title": "Andrew's Audio works with Stripe to verify your identity"
     },
     "id": "VS_123",
+    "is_stripe": false,
+    "skip_success_page": false,
     "livemode": true,
     "object": "identity.verification_page",
     "requirements": {

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200_no_consent_header.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200_no_consent_header.json
@@ -186,6 +186,8 @@
       "title": "Andrew's Audio works with Stripe to verify your identity"
     },
     "id": "VS_123",
+    "is_stripe": false,
+    "skip_success_page": false,
     "livemode": true,
     "object": "identity.verification_page",
     "requirements": {

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200_no_exp.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200_no_exp.json
@@ -186,6 +186,8 @@
       "title": "Andrew's Audio works with Stripe to verify your identity"
     },
     "id": "VS_123",
+    "is_stripe": false,
+    "skip_success_page": false,
     "livemode": true,
     "object": "identity.verification_page",
     "requirements": {

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200_submitted.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200_submitted.json
@@ -186,6 +186,8 @@
       "title": "Andrew's Audio works with Stripe to verify your identity"
     },
     "id": "VS_123",
+    "is_stripe": false,
+    "skip_success_page": false,
     "livemode": true,
     "object": "identity.verification_page",
     "requirements": {

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200_testMode.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_200_testMode.json
@@ -186,6 +186,8 @@
       "title": "Andrew's Audio works with Stripe to verify your identity"
     },
     "id": "VS_123",
+    "is_stripe": false,
+    "skip_success_page": false,
     "livemode": false,
     "object": "identity.verification_page",
     "requirements": {

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_no_selfie.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_no_selfie.json
@@ -186,6 +186,8 @@
       "title": "Andrew's Audio works with Stripe to verify your identity"
     },
     "id": "VS_123",
+    "is_stripe": false,
+    "skip_success_page": false,
     "livemode": true,
     "object": "identity.verification_page",
     "requirements": {

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_require_live_capture.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_require_live_capture.json
@@ -186,6 +186,8 @@
       "title": "Andrew's Audio works with Stripe to verify your identity"
     },
     "id": "VS_123",
+    "is_stripe": false,
+    "skip_success_page": false,
     "livemode": true,
     "object": "identity.verification_page",
     "requirements": {

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_address.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_address.json
@@ -1,5 +1,7 @@
 {
   "id": "vs_1MOrKBEGkPhabJTjBA2ohFAW",
+  "is_stripe": false,
+  "skip_success_page": false,
   "object": "identity.verification_page",
   "biometric_consent": {
     "accept_button_text": "Agree and continue",

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_address.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_address.json
@@ -1,5 +1,7 @@
 {
   "id": "vs_1MRjwTEGkPhabJTjIEKiUmmS",
+    "is_stripe": false,
+    "skip_success_page": false,
   "object": "identity.verification_page",
   "biometric_consent": {
     "accept_button_text": "Agree and continue",

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_idNumber.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_idNumber.json
@@ -1,5 +1,7 @@
 {
   "id": "vs_1MOrPwEGkPhabJTjzCzKF4DM",
+    "is_stripe": false,
+    "skip_success_page": false,
   "object": "identity.verification_page",
   "biometric_consent": {
     "accept_button_text": "Agree and continue",

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_idNumber_and_address.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_doc_require_idNumber_and_address.json
@@ -1,5 +1,7 @@
 {
   "id": "vs_1MTb71EGkPhabJTjK2kJQ5xI",
+    "is_stripe": false,
+    "skip_success_page": false,
   "object": "identity.verification_page",
   "biometric_consent": {
     "accept_button_text": "Agree and continue",

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_idNumber.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_idNumber.json
@@ -1,5 +1,7 @@
 {
   "id": "vs_1MOrMgEGkPhabJTjkbUNVfh6",
+    "is_stripe": false,
+    "skip_success_page": false,
   "object": "identity.verification_page",
   "biometric_consent": {
     "accept_button_text": "Agree and continue",

--- a/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_phone.json
+++ b/StripeIdentity/StripeIdentityTests/Mock Files/VerificationPage/VerificationPage_type_phone.json
@@ -1,5 +1,7 @@
 {
   "id": "vs_1MOrKBEGkPhabJTjBA2ohFAW",
+    "is_stripe": false,
+    "skip_success_page": false,
   "object": "identity.verification_page",
   "biometric_consent": {
     "accept_button_text": "Agree and continue",

--- a/StripeIdentity/StripeIdentityTests/Snapshot/BiometricConsentViewControllerSnapshotTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Snapshot/BiometricConsentViewControllerSnapshotTest.swift
@@ -19,6 +19,7 @@ final class BiometricConsentViewControllerSnapshotTest: STPSnapshotTestCase {
     func testViewIsConfiguredFromAPI() throws {
         let vc = try BiometricConsentViewController(
             brandLogo: SnapshotTestMockData.uiImage(image: .headerIcon),
+            showsStripeLogo: true,
             consentContent: BiometricConsentViewControllerSnapshotTest.mockVerificationPage
                 .biometricConsent,
             sheetController: VerificationSheetControllerMock()
@@ -30,6 +31,7 @@ final class BiometricConsentViewControllerSnapshotTest: STPSnapshotTestCase {
     func testViewIsConfiguredFromAPINoConsentHeader() throws {
         let vc = try BiometricConsentViewController(
             brandLogo: SnapshotTestMockData.uiImage(image: .headerIcon),
+            showsStripeLogo: true,
             consentContent: BiometricConsentViewControllerSnapshotTest.mockVerificationPageNoConsentHeader
                 .biometricConsent,
             sheetController: VerificationSheetControllerMock()

--- a/StripeIdentity/StripeIdentityTests/Snapshot/BiometricConsentViewControllerSnapshotTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Snapshot/BiometricConsentViewControllerSnapshotTest.swift
@@ -19,7 +19,7 @@ final class BiometricConsentViewControllerSnapshotTest: STPSnapshotTestCase {
     func testViewIsConfiguredFromAPI() throws {
         let vc = try BiometricConsentViewController(
             brandLogo: SnapshotTestMockData.uiImage(image: .headerIcon),
-            showsStripeLogo: true,
+            showsStripeLogo: !BiometricConsentViewControllerSnapshotTest.mockVerificationPage.isStripe,
             consentContent: BiometricConsentViewControllerSnapshotTest.mockVerificationPage
                 .biometricConsent,
             sheetController: VerificationSheetControllerMock()
@@ -31,7 +31,7 @@ final class BiometricConsentViewControllerSnapshotTest: STPSnapshotTestCase {
     func testViewIsConfiguredFromAPINoConsentHeader() throws {
         let vc = try BiometricConsentViewController(
             brandLogo: SnapshotTestMockData.uiImage(image: .headerIcon),
-            showsStripeLogo: true,
+            showsStripeLogo: !BiometricConsentViewControllerSnapshotTest.mockVerificationPageNoConsentHeader.isStripe,
             consentContent: BiometricConsentViewControllerSnapshotTest.mockVerificationPageNoConsentHeader
                 .biometricConsent,
             sheetController: VerificationSheetControllerMock()

--- a/StripeIdentity/StripeIdentityTests/Unit/API Bindings/IdentityAPIClientTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/API Bindings/IdentityAPIClientTest.swift
@@ -264,7 +264,7 @@ private func verifyHeaders(
     )
     XCTAssertEqual(
         urlRequest.allHTTPHeaderFields?["Stripe-Version"],
-        "2020-08-27; identity_client_api=v6",
+        "2020-08-27; identity_client_api=v7",
         file: file,
         line: line
     )

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
@@ -22,7 +22,7 @@ final class VerificationSheetFlowControllerTest: XCTestCase {
         [.biometricConsent], [.idDocumentFront, .idDocumentBack],
     ]
 
-    let flowController = VerificationSheetFlowController(brandLogo: UIImage())
+    let flowController = VerificationSheetFlowController(brandLogo: UIImage(), showsStripeLogo: true)
     var mockMLModelLoader: IdentityMLModelLoaderMock!
     var mockSheetController: VerificationSheetControllerMock!
 

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
@@ -22,7 +22,7 @@ final class VerificationSheetFlowControllerTest: XCTestCase {
         [.biometricConsent], [.idDocumentFront, .idDocumentBack],
     ]
 
-    let flowController = VerificationSheetFlowController(brandLogo: UIImage(), showsStripeLogo: true)
+let flowController = VerificationSheetFlowController(brandLogo: UIImage())
     var mockMLModelLoader: IdentityMLModelLoaderMock!
     var mockSheetController: VerificationSheetControllerMock!
 

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/BiometricConsentViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/BiometricConsentViewControllerTest.swift
@@ -23,7 +23,7 @@ final class BiometricConsentViewControllerTest: XCTestCase {
 
         vc = try! BiometricConsentViewController(
             brandLogo: UIImage(),
-            showsStripeLogo: true,
+            showsStripeLogo: !BiometricConsentViewControllerTest.mockVerificationPage.isStripe,
             consentContent: BiometricConsentViewControllerTest.mockVerificationPage
                 .biometricConsent,
             sheetController: mockSheetController

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/BiometricConsentViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/BiometricConsentViewControllerTest.swift
@@ -23,6 +23,7 @@ final class BiometricConsentViewControllerTest: XCTestCase {
 
         vc = try! BiometricConsentViewController(
             brandLogo: UIImage(),
+            showsStripeLogo: true,
             consentContent: BiometricConsentViewControllerTest.mockVerificationPage
                 .biometricConsent,
             sheetController: mockSheetController


### PR DESCRIPTION
## Summary

This implements the functionality of the two new fields on the verification page. This also bumps the API version to 7.

These are the two functionality changes:

1. From the verification page mode, if the model has `is_stripe` set to true - the biometric consent screen will _not_ show the stripe logo, only the brand logo.

2. On that same model, if the `skip_success_page` is set to true - the final screen (success) of the identity flow is skipped and the flow just submits.

## Testing

I tested both these scenarios by replacing the boolean checks with the opposite values that I received from the API, and both scenarios behaved as intended.

---

The is_stripe change, where only the brand logo appears:

<img width="645" height="1398" alt="IMG_1959" src="https://github.com/user-attachments/assets/1d1e0b8c-f6a3-42a3-b650-c5320c3c3e63" />
