### PR TITLE
[WalletButtonsView] Don't unset Apple Pay/Link on FlowController update

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetVerticalViewController.swift
@@ -446,7 +446,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     func makePaymentMethodListViewController(selection: RowButtonType?) -> VerticalPaymentMethodListViewController {
         var initialSelection = selection ?? calculateInitialSelection()
         // If Apple Pay or Link is selected, but wallet buttons should be shown externally, then don't select any default option.
-        if (configuration.willUseWalletButtonsView || walletButtonsShownExternally) &&
+        if (configuration.willUseWalletButtonsView || walletButtonsShownExternally) && previousPaymentOption == nil &&
             (
                 (initialSelection == .applePay && configuration.walletButtonsVisibility.paymentElement[.applePay] != .always) ||
                 initialSelection == .link && configuration.walletButtonsVisibility.paymentElement[.link] != .always) {


### PR DESCRIPTION
## Summary
I don't love the state management issues here, but this should fix the immediate problem. Just check if we have a previousPaymentOption (only true in an update call) and skip the "unset the default PM if it's Apple Pay or Link" behavior.

## Motivation
Link/Apple Pay get dropped after an `update` call.

## Testing
PaymentSheet Example

## Changelog
N/A