### PR TITLE
Add client context to CT creation params

### DIFF
--- a/Stripe/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe/Stripe.xcodeproj/project.pbxproj
@@ -125,6 +125,7 @@
 		609C2C8F10AFAA2711639CD0 /* NSArray+StripeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C17799DC7FA54E758EED31A6 /* NSArray+StripeTest.swift */; };
 		610DF5DC2B33597500DA6AAA /* HostedSurfaceTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610DF5DB2B33597500DA6AAA /* HostedSurfaceTest.swift */; };
 		61152B4F2B866827003B69A0 /* STPPaymentMethodAmazonPayParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61152B4E2B866827003B69A0 /* STPPaymentMethodAmazonPayParamsTests.swift */; };
+		611FFF962E86EE2D00383826 /* STPConfirmationTokenClientContextTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611FFF952E86EE2D00383826 /* STPConfirmationTokenClientContextTest.swift */; };
 		612677772E1C8266008A36D2 /* STPBankAccountCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 612677762E1C8266008A36D2 /* STPBankAccountCollectorTests.swift */; };
 		615242392E694314002459F6 /* STPAPIClientConfirmationTokensTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615242382E694314002459F6 /* STPAPIClientConfirmationTokensTest.swift */; };
 		616402452E786AFE003B551C /* STPConfirmationTokenTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616402442E786AFE003B551C /* STPConfirmationTokenTest.swift */; };
@@ -501,6 +502,7 @@
 		5FDD4956E0A04D33F0856F31 /* STPThreeDSLabelCustomizationTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPThreeDSLabelCustomizationTest.swift; sourceTree = "<group>"; };
 		610DF5DB2B33597500DA6AAA /* HostedSurfaceTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostedSurfaceTest.swift; sourceTree = "<group>"; };
 		61152B4E2B866827003B69A0 /* STPPaymentMethodAmazonPayParamsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAmazonPayParamsTests.swift; sourceTree = "<group>"; };
+		611FFF952E86EE2D00383826 /* STPConfirmationTokenClientContextTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPConfirmationTokenClientContextTest.swift; sourceTree = "<group>"; };
 		612677762E1C8266008A36D2 /* STPBankAccountCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPBankAccountCollectorTests.swift; sourceTree = "<group>"; };
 		615242382E694314002459F6 /* STPAPIClientConfirmationTokensTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPAPIClientConfirmationTokensTest.swift; sourceTree = "<group>"; };
 		616402442E786AFE003B551C /* STPConfirmationTokenTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPConfirmationTokenTest.swift; sourceTree = "<group>"; };
@@ -1069,6 +1071,7 @@
 				80BBCC4D386EE44E809A591C /* STPPaymentMethodOXXOTests.swift */,
 				4002981AC12687681616D21E /* STPPaymentMethodParamsTest.swift */,
 				61F2FA362E67FB29007AF688 /* STPConfirmationTokenParamsTest.swift */,
+				611FFF952E86EE2D00383826 /* STPConfirmationTokenClientContextTest.swift */,
 				615242382E694314002459F6 /* STPAPIClientConfirmationTokensTest.swift */,
 				DE2A766FB355DD9C461939C1 /* STPPaymentMethodPayPalParamsTests.swift */,
 				2A63AC868755CB4745E7458E /* STPPaymentMethodPayPalTests.swift */,
@@ -1466,6 +1469,7 @@
 				609C2C8F10AFAA2711639CD0 /* NSArray+StripeTest.swift in Sources */,
 				B98D71ED9ACC2E1B47372F53 /* NSDecimalNumber+StripeTest.swift in Sources */,
 				6E7AD3CCC966A7F34922B172 /* NSDictionary+StripeTest.swift in Sources */,
+				611FFF962E86EE2D00383826 /* STPConfirmationTokenClientContextTest.swift in Sources */,
 				325694E4284BEAE787A5ECB6 /* NSLocale+STPSwizzling.swift in Sources */,
 				C4C1295E7DA618DFB944A534 /* NSString+StripeTest.swift in Sources */,
 				68318DB86DFCD19505FC47BA /* NSURLComponents_StripeTest.swift in Sources */,

--- a/Stripe/StripeiOSTests/STPAPIClientConfirmationTokensTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClientConfirmationTokensTest.swift
@@ -41,6 +41,13 @@ class STPAPIClientConfirmationTokensTest: STPNetworkStubbingTestCase {
         confirmationTokenParams.paymentMethodData = paymentMethodParams
         confirmationTokenParams.returnURL = "https://example.com/return"
 
+        // Add basic client context
+        let clientContext = STPConfirmationTokenClientContext()
+        clientContext.mode = "payment"
+        clientContext.currency = "usd"
+        clientContext.paymentMethodTypes = ["card"]
+        confirmationTokenParams.clientContext = clientContext
+
         // Test async method
         let confirmationToken = try await apiClient.createConfirmationToken(
             with: confirmationTokenParams
@@ -122,6 +129,16 @@ class STPAPIClientConfirmationTokensTest: STPNetworkStubbingTestCase {
         confirmationTokenParams.shipping = shippingDetails
         confirmationTokenParams.mandateData = mandateData
         confirmationTokenParams.setupFutureUsage = .offSession
+
+        // Add comprehensive client context
+        let clientContext = STPConfirmationTokenClientContext()
+        clientContext.mode = "payment"
+        clientContext.currency = "eur"
+        clientContext.setupFutureUsage = "off_session"
+        clientContext.captureMethod = "automatic"
+        clientContext.paymentMethodTypes = ["sepa_debit"]
+        clientContext.customer = "cus_test_customer"
+        confirmationTokenParams.clientContext = clientContext
 
         let confirmationToken = try await apiClient.createConfirmationToken(
             with: confirmationTokenParams
@@ -345,11 +362,29 @@ class STPAPIClientConfirmationTokensTest: STPNetworkStubbingTestCase {
         confirmationTokenParams.returnURL = "https://example.com/return"
         confirmationTokenParams.setupFutureUsage = .onSession
 
+        // Add client context for encoding verification
+        let clientContext = STPConfirmationTokenClientContext()
+        clientContext.mode = "payment"
+        clientContext.currency = "usd"
+        clientContext.setupFutureUsage = "on_session"
+        clientContext.captureMethod = "automatic"
+        clientContext.onBehalfOf = "acct_123"
+        confirmationTokenParams.clientContext = clientContext
+
         let encoded = STPFormEncoder.dictionary(forObject: confirmationTokenParams)
 
         // Verify key parameters are encoded correctly
         XCTAssertNotNil(encoded["payment_method_data"])
         XCTAssertEqual(encoded["return_url"] as? String, "https://example.com/return")
         XCTAssertEqual(encoded["setup_future_usage"] as? String, "on_session")
+
+        // Verify client context is encoded correctly
+        XCTAssertNotNil(encoded["client_context"])
+        let clientContextDict = encoded["client_context"] as? [String: Any]
+        XCTAssertEqual(clientContextDict?["mode"] as? String, "payment")
+        XCTAssertEqual(clientContextDict?["currency"] as? String, "usd")
+        XCTAssertEqual(clientContextDict?["setup_future_usage"] as? String, "on_session")
+        XCTAssertEqual(clientContextDict?["capture_method"] as? String, "automatic")
+        XCTAssertEqual(clientContextDict?["on_behalf_of"] as? String, "acct_123")
     }
 }

--- a/Stripe/StripeiOSTests/STPConfirmationTokenClientContextTest.swift
+++ b/Stripe/StripeiOSTests/STPConfirmationTokenClientContextTest.swift
@@ -1,0 +1,138 @@
+//
+//  STPConfirmationTokenClientContextTest.swift
+//  StripePaymentsTests
+//
+//  Created by Nick Porter on 9/26/25.
+//
+
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP)@_spi(ConfirmationTokensPublicPreview) import StripePayments
+import XCTest
+
+class STPConfirmationTokenClientContextTest: XCTestCase {
+
+
+    // MARK: - STPFormEncodable Tests
+
+    func testRootObjectName() {
+        XCTAssertEqual(STPConfirmationTokenClientContext.rootObjectName(), "client_context")
+    }
+
+    func testPropertyNamesToFormFieldNamesMapping() {
+        let clientContext = STPConfirmationTokenClientContext()
+        let mapping = STPConfirmationTokenClientContext.propertyNamesToFormFieldNamesMapping()
+
+        // Verify all property names don't contain colons
+        for propertyName in mapping.keys {
+            XCTAssertFalse(propertyName.contains(":"))
+            XCTAssert(clientContext.responds(to: NSSelectorFromString(propertyName)))
+        }
+
+        // Verify all form field names are non-empty
+        for formFieldName in mapping.values {
+            XCTAssert(formFieldName.count > 0)
+        }
+
+        // Verify all form field names are unique
+        XCTAssertEqual(mapping.values.count, Set(mapping.values).count)
+
+        // Verify expected mappings
+        XCTAssertEqual(mapping["mode"], "mode")
+        XCTAssertEqual(mapping["currency"], "currency")
+        XCTAssertEqual(mapping["setupFutureUsage"], "setup_future_usage")
+        XCTAssertEqual(mapping["captureMethod"], "capture_method")
+        XCTAssertEqual(mapping["paymentMethodTypes"], "payment_method_types")
+        XCTAssertEqual(mapping["onBehalfOf"], "on_behalf_of")
+        XCTAssertEqual(mapping["paymentMethodConfiguration"], "payment_method_configuration")
+        XCTAssertEqual(mapping["customer"], "customer")
+        XCTAssertEqual(mapping["paymentMethodOptions"], "payment_method_options")
+    }
+
+
+    // MARK: - Form Encoding Tests
+
+    func testFormEncodingWithAllProperties() {
+        let clientContext = STPConfirmationTokenClientContext()
+        clientContext.mode = "payment"
+        clientContext.currency = "usd"
+        clientContext.setupFutureUsage = "off_session"
+        clientContext.captureMethod = "automatic_async"
+        clientContext.paymentMethodTypes = ["card", "apple_pay"]
+        clientContext.onBehalfOf = "acct_123456"
+        clientContext.paymentMethodConfiguration = "pmc_123456"
+        clientContext.customer = "cus_123456"
+
+        let paymentMethodOptions = [
+            "card": ["setup_future_usage": "off_session"],
+            "us_bank_account": ["setup_future_usage": "on_session"]
+        ]
+        clientContext.paymentMethodOptions = paymentMethodOptions
+
+        let encoded = STPFormEncoder.dictionary(forObject: clientContext)
+
+        // Properties should be under "client_context" key due to rootObjectName()
+        let clientContextDict = encoded["client_context"] as? [String: Any]
+        XCTAssertNotNil(clientContextDict)
+        XCTAssertEqual(clientContextDict?["mode"] as? String, "payment")
+        XCTAssertEqual(clientContextDict?["currency"] as? String, "usd")
+        XCTAssertEqual(clientContextDict?["setup_future_usage"] as? String, "off_session")
+        XCTAssertEqual(clientContextDict?["capture_method"] as? String, "automatic_async")
+        XCTAssertEqual(clientContextDict?["payment_method_types"] as? [String], ["card", "apple_pay"])
+        XCTAssertEqual(clientContextDict?["on_behalf_of"] as? String, "acct_123456")
+        XCTAssertEqual(clientContextDict?["payment_method_configuration"] as? String, "pmc_123456")
+        XCTAssertEqual(clientContextDict?["customer"] as? String, "cus_123456")
+        XCTAssertNotNil(clientContextDict?["payment_method_options"])
+    }
+
+    func testFormEncodingWithMinimalProperties() {
+        let clientContext = STPConfirmationTokenClientContext()
+        clientContext.mode = "setup"
+        clientContext.currency = "eur"
+
+        let encoded = STPFormEncoder.dictionary(forObject: clientContext)
+
+        // Properties should be under "client_context" key due to rootObjectName()
+        let clientContextDict = encoded["client_context"] as? [String: Any]
+        XCTAssertNotNil(clientContextDict)
+        XCTAssertEqual(clientContextDict?["mode"] as? String, "setup")
+        XCTAssertEqual(clientContextDict?["currency"] as? String, "eur")
+        XCTAssertNil(clientContextDict?["setup_future_usage"])
+        XCTAssertNil(clientContextDict?["capture_method"])
+        XCTAssertNil(clientContextDict?["payment_method_types"])
+        XCTAssertNil(clientContextDict?["on_behalf_of"])
+        XCTAssertNil(clientContextDict?["payment_method_configuration"])
+        XCTAssertNil(clientContextDict?["customer"])
+        XCTAssertNil(clientContextDict?["payment_method_options"])
+    }
+
+    func testFormEncodingWithNilProperties() {
+        let clientContext = STPConfirmationTokenClientContext()
+
+        let encoded = STPFormEncoder.dictionary(forObject: clientContext)
+
+        // When all properties are nil, the client_context key should still be present but empty
+        let clientContextDict = encoded["client_context"] as? [String: Any]
+        XCTAssertNotNil(clientContextDict)
+        XCTAssertNil(clientContextDict?["mode"])
+        XCTAssertNil(clientContextDict?["currency"])
+        XCTAssertNil(clientContextDict?["setup_future_usage"])
+        XCTAssertNil(clientContextDict?["capture_method"])
+        XCTAssertNil(clientContextDict?["payment_method_types"])
+        XCTAssertNil(clientContextDict?["on_behalf_of"])
+        XCTAssertNil(clientContextDict?["payment_method_configuration"])
+        XCTAssertNil(clientContextDict?["customer"])
+        XCTAssertNil(clientContextDict?["payment_method_options"])
+    }
+
+    // MARK: - Additional API Parameters Tests
+
+    func testAdditionalAPIParameters() {
+        let clientContext = STPConfirmationTokenClientContext()
+
+        XCTAssertEqual(clientContext.additionalAPIParameters.count, 0)
+
+        clientContext.additionalAPIParameters = ["custom_key": "custom_value"]
+        XCTAssertEqual(clientContext.additionalAPIParameters["custom_key"] as? String, "custom_value")
+    }
+
+}

--- a/Stripe/StripeiOSTests/STPConfirmationTokenParamsTest.swift
+++ b/Stripe/StripeiOSTests/STPConfirmationTokenParamsTest.swift
@@ -26,6 +26,7 @@ class STPConfirmationTokenParamsTest: XCTestCase {
         XCTAssertNil(params.mandateData)
         XCTAssertNil(params.setAsDefaultPM)
         XCTAssertNil(params.clientAttributionMetadata)
+        XCTAssertNil(params.clientContext)
         XCTAssertNotNil(params.additionalAPIParameters)
         XCTAssertEqual(params.additionalAPIParameters.count, 0)
     }
@@ -76,6 +77,7 @@ class STPConfirmationTokenParamsTest: XCTestCase {
         XCTAssertTrue(description.contains("mandateData"))
         XCTAssertTrue(description.contains("setAsDefaultPM"))
         XCTAssertTrue(description.contains("clientAttributionMetadata"))
+        XCTAssertTrue(description.contains("clientContext"))
     }
 
     func testDescriptionWithPopulatedProperties() {
@@ -129,6 +131,7 @@ class STPConfirmationTokenParamsTest: XCTestCase {
         XCTAssertEqual(mapping["mandateData"], "mandate_data")
         XCTAssertEqual(mapping["setAsDefaultPM"], "set_as_default_payment_method")
         XCTAssertEqual(mapping["clientAttributionMetadata"], "client_attribution_metadata")
+        XCTAssertEqual(mapping["clientContext"], "client_context")
     }
 
     // MARK: - Individual Property Tests
@@ -237,6 +240,24 @@ class STPConfirmationTokenParamsTest: XCTestCase {
 
         params.clientAttributionMetadata = nil
         XCTAssertNil(params.clientAttributionMetadata)
+    }
+
+    func testClientContextProperty() {
+        let params = STPConfirmationTokenParams()
+
+        XCTAssertNil(params.clientContext)
+
+        let clientContext = STPConfirmationTokenClientContext()
+        clientContext.mode = "payment"
+        clientContext.currency = "usd"
+
+        params.clientContext = clientContext
+        XCTAssertEqual(params.clientContext, clientContext)
+        XCTAssertEqual(params.clientContext?.mode, "payment")
+        XCTAssertEqual(params.clientContext?.currency, "usd")
+
+        params.clientContext = nil
+        XCTAssertNil(params.clientContext)
     }
 
     // MARK: - Additional API Parameters Tests
@@ -394,6 +415,42 @@ class STPConfirmationTokenParamsTest: XCTestCase {
         XCTAssertNotNil(encoded["client_attribution_metadata"])
     }
 
+    func testFormEncodingWithClientContext() {
+        let params = STPConfirmationTokenParams()
+        let clientContext = STPConfirmationTokenClientContext()
+        clientContext.mode = "payment"
+        clientContext.currency = "usd"
+        clientContext.setupFutureUsage = "off_session"
+        clientContext.captureMethod = "automatic"
+        clientContext.paymentMethodTypes = ["card", "apple_pay"]
+        clientContext.onBehalfOf = "acct_123"
+        clientContext.paymentMethodConfiguration = "pmc_123"
+        clientContext.customer = "cus_123"
+
+        params.clientContext = clientContext
+
+        let encoded = STPFormEncoder.dictionary(forObject: params)
+        XCTAssertNotNil(encoded["client_context"])
+
+        let clientContextDict = encoded["client_context"] as? [String: Any]
+        XCTAssertNotNil(clientContextDict)
+        XCTAssertEqual(clientContextDict?["mode"] as? String, "payment")
+        XCTAssertEqual(clientContextDict?["currency"] as? String, "usd")
+        XCTAssertEqual(clientContextDict?["setup_future_usage"] as? String, "off_session")
+        XCTAssertEqual(clientContextDict?["capture_method"] as? String, "automatic")
+        XCTAssertEqual(clientContextDict?["payment_method_types"] as? [String], ["card", "apple_pay"])
+        XCTAssertEqual(clientContextDict?["on_behalf_of"] as? String, "acct_123")
+        XCTAssertEqual(clientContextDict?["payment_method_configuration"] as? String, "pmc_123")
+        XCTAssertEqual(clientContextDict?["customer"] as? String, "cus_123")
+    }
+
+    func testFormEncodingWithoutClientContext() {
+        let params = STPConfirmationTokenParams()
+
+        let encoded = STPFormEncoder.dictionary(forObject: params)
+        XCTAssertNil(encoded["client_context"])
+    }
+
     func testPropertyMutationAfterInit() {
         let params = STPConfirmationTokenParams()
 
@@ -447,6 +504,7 @@ class STPConfirmationTokenParamsTest: XCTestCase {
         XCTAssertNil(encoded["shipping"])
         XCTAssertNil(encoded["mandate_data"])
         XCTAssertNil(encoded["client_attribution_metadata"])
+        XCTAssertNil(encoded["client_context"])
 
         // setup_future_usage should not be present when .none
         XCTAssertNil(encoded["setup_future_usage"])

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -222,6 +222,8 @@
 		610EAAF02C0F5D9400124AB2 /* FormHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610EAAEF2C0F5D9400124AB2 /* FormHeaderView.swift */; };
 		6114AEC02D6519EC00C0EF40 /* RowButtonFlatWithCheckmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6114AEBF2D6519EC00C0EF40 /* RowButtonFlatWithCheckmark.swift */; };
 		6117D7122CB065E7005C4EC1 /* MandateTextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6117D7112CB065E7005C4EC1 /* MandateTextProvider.swift */; };
+		611FFF922E86EDF000383826 /* IntentConfiguration+ClientContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611FFF912E86EDF000383826 /* IntentConfiguration+ClientContext.swift */; };
+		611FFF982E86EE6900383826 /* IntentConfigurationClientContextTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611FFF972E86EE6900383826 /* IntentConfigurationClientContextTest.swift */; };
 		6123E94D2D4A84800088FBE8 /* EmbeddedPaymentElement+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6123E94C2D4A84800088FBE8 /* EmbeddedPaymentElement+SwiftUI.swift */; };
 		6123E94F2D4A86BA0088FBE8 /* EmbeddedPaymentElementViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6123E94E2D4A86BA0088FBE8 /* EmbeddedPaymentElementViewModelTests.swift */; };
 		61271F062E204B5A0016302B /* AddressViewController+SwiftUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61271F052E204B5A0016302B /* AddressViewController+SwiftUI.swift */; };
@@ -746,6 +748,8 @@
 		610EAAEF2C0F5D9400124AB2 /* FormHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FormHeaderView.swift; sourceTree = "<group>"; };
 		6114AEBF2D6519EC00C0EF40 /* RowButtonFlatWithCheckmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RowButtonFlatWithCheckmark.swift; sourceTree = "<group>"; };
 		6117D7112CB065E7005C4EC1 /* MandateTextProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MandateTextProvider.swift; sourceTree = "<group>"; };
+		611FFF912E86EDF000383826 /* IntentConfiguration+ClientContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "IntentConfiguration+ClientContext.swift"; sourceTree = "<group>"; };
+		611FFF972E86EE6900383826 /* IntentConfigurationClientContextTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentConfigurationClientContextTest.swift; sourceTree = "<group>"; };
 		6123E94C2D4A84800088FBE8 /* EmbeddedPaymentElement+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EmbeddedPaymentElement+SwiftUI.swift"; sourceTree = "<group>"; };
 		6123E94E2D4A86BA0088FBE8 /* EmbeddedPaymentElementViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmbeddedPaymentElementViewModelTests.swift; sourceTree = "<group>"; };
 		61271F052E204B5A0016302B /* AddressViewController+SwiftUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AddressViewController+SwiftUI.swift"; sourceTree = "<group>"; };
@@ -1301,6 +1305,7 @@
 				0DF4D51EEAB1092637BE144E /* PaymentSheetDeferredValidator.swift */,
 				E6DDBBAAC2892467CED23402 /* PaymentSheetError.swift */,
 				58A85D630BDEA7408391EB8B /* PaymentSheetFlowController.swift */,
+				611FFF912E86EDF000383826 /* IntentConfiguration+ClientContext.swift */,
 				0DFDF764857516CD54D9A62B /* PaymentSheetFormFactory */,
 				32332E0DB0AE12377EBDDEF1 /* PaymentSheetIntentConfiguration.swift */,
 				88DBDEE23A856CE8D3B49861 /* PaymentSheetLoader.swift */,
@@ -2048,6 +2053,7 @@
 				B6DBF0552E6A4FEE006EE338 /* FormElementSnapshotTest.swift */,
 				61D842902CB06047009D2D51 /* FormMandateProviderTests.swift */,
 				6B0E5AE62C08F4B5008AAFBE /* IntentConfirmParamsTest.swift */,
+				611FFF972E86EE6900383826 /* IntentConfigurationClientContextTest.swift */,
 				990304EF35A0EE37DCE20D5B /* IntentStatusPollerTest.swift */,
 				FCA28FF8CD5BA829A44CDCE7 /* Link */,
 				33B8F21A22FA091BC9D2924B /* LinkStubs.swift */,
@@ -2410,6 +2416,7 @@
 				3D3607748436E625FF6CF921 /* PaymentSheet+APITest.swift in Sources */,
 				68F13446778AF2CAA631ACDE /* PaymentSheet+DeferredAPITest.swift in Sources */,
 				830DB7F3A2D341445BDB600F /* PaymentSheetAddressTests.swift in Sources */,
+				611FFF982E86EE6900383826 /* IntentConfigurationClientContextTest.swift in Sources */,
 				61FDF8EE2D81FA7F004B3B0D /* ExternalPaymentOptionTests.swift in Sources */,
 				731DA57DAF9979D11AA5A0F6 /* PaymentSheetDeferredValidatorTests.swift in Sources */,
 				96575C19CD0FE05ADA0B0094 /* PaymentSheetErrorTest.swift in Sources */,
@@ -2625,6 +2632,7 @@
 				495D53202DF7678A008B92F9 /* LinkButtonViewModel.swift in Sources */,
 				B615E8732CA4CC04007D684C /* EmbeddedPaymentElementConfiguration.swift in Sources */,
 				6123E94D2D4A84800088FBE8 /* EmbeddedPaymentElement+SwiftUI.swift in Sources */,
+				611FFF922E86EDF000383826 /* IntentConfiguration+ClientContext.swift in Sources */,
 				00A3805F91E6F903FA677393 /* SimpleMandateElement.swift in Sources */,
 				DFA10770E494AFB895BA4EE2 /* TextFieldElement+Card.swift in Sources */,
 				495D531E2DF7640D008B92F9 /* LinkButton.swift in Sources */,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfiguration+ClientContext.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfiguration+ClientContext.swift
@@ -1,0 +1,66 @@
+//
+//  IntentConfiguration+ClientContext.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 9/26/25.
+//
+
+import Foundation
+@_spi(STP) import StripePayments
+
+// MARK: - PaymentSheet IntentConfiguration to Client Context Mapping
+extension PaymentSheet.IntentConfiguration {
+
+    /// Creates a client context from this IntentConfiguration for use with confirmation tokens
+    /// - Parameter customerId: Optional customer ID
+    /// - Returns: A client context with populated fields from the intent configuration
+    func createClientContext(customerId: String?) -> STPConfirmationTokenClientContext {
+        let clientContext = STPConfirmationTokenClientContext()
+
+        // Map mode and mode-specific properties
+        switch mode {
+        case .payment(_, let currency, let setupFutureUsage, let captureMethod, let paymentMethodOptions):
+            clientContext.mode = "payment"
+            clientContext.currency = currency
+            clientContext.setupFutureUsage = setupFutureUsage?.rawValue
+            clientContext.captureMethod = captureMethod.rawValue
+            clientContext.paymentMethodOptions = paymentMethodOptions?.toDictionary()
+
+        case .setup(let currency, let setupFutureUsage):
+            clientContext.mode = "setup"
+            clientContext.currency = currency
+            clientContext.setupFutureUsage = setupFutureUsage.rawValue
+        }
+
+        // Map common properties
+        clientContext.paymentMethodTypes = paymentMethodTypes
+        clientContext.onBehalfOf = onBehalfOf
+        clientContext.paymentMethodConfiguration = paymentMethodConfigurationId
+        clientContext.customer = customerId
+
+        return clientContext
+    }
+}
+
+// MARK: - PaymentMethodOptions Conversion
+private extension PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions {
+
+    /// Converts PaymentSheet PaymentMethodOptions to a dictionary for API encoding
+    /// - Returns: Dictionary representation of payment method options
+    func toDictionary() -> [String: Any]? {
+        guard let setupFutureUsageValues = self.setupFutureUsageValues else {
+            return nil
+        }
+
+        var options: [String: Any] = [:]
+
+        // Convert setup future usage values for different payment method types
+        for (paymentMethodType, setupFutureUsage) in setupFutureUsageValues {
+            options[paymentMethodType.identifier] = [
+                "setup_future_usage": setupFutureUsage.rawValue
+            ]
+        }
+
+        return options.isEmpty ? nil : options
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -93,6 +93,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
             if let confirmationTokenConfirmHandler = intentConfig.confirmationTokenConfirmHandler {
                 // Confirmation token flow
                 handleConfirmationTokenFlow(
+                    intentConfig: intentConfig,
                     paymentMethod: stpPaymentMethod,
                     paymentInformation: paymentInformation,
                     context: context,
@@ -123,6 +124,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
     }
 
     private func handleConfirmationTokenFlow(
+        intentConfig: PaymentSheet.IntentConfiguration,
         paymentMethod: STPPaymentMethod,
         paymentInformation: PKPayment,
         context: STPApplePayContext,
@@ -134,6 +136,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         confirmationTokenParams.paymentMethod = paymentMethod.stripeId
         confirmationTokenParams.returnURL = context.returnUrl
         confirmationTokenParams.clientAttributionMetadata = context.clientAttributionMetadata
+        confirmationTokenParams.clientContext = intentConfig.createClientContext(customerId: paymentMethod.customerId)
 
         // Set shipping details if available
         if let shippingContact = paymentInformation.shippingContact,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfigurationClientContextTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/IntentConfigurationClientContextTest.swift
@@ -1,0 +1,151 @@
+//
+//  IntentConfigurationClientContextTest.swift
+//  StripePaymentSheetTests
+//
+//  Created by Nick Porter on 9/26/25.
+//
+
+@testable@_spi(STP)@_spi(PaymentMethodOptionsSetupFutureUsagePreview) import StripePaymentSheet
+@testable@_spi(STP) import StripePayments
+import XCTest
+
+class IntentConfigurationClientContextTest: XCTestCase {
+    
+    // MARK: - Payment Mode Tests
+    
+    func testCreateClientContextFromPaymentModeMinimal() {
+        let intentConfig = PaymentSheet.IntentConfiguration(
+            mode: .payment(amount: 1000, currency: "usd"),
+            confirmHandler: { _, _, _ in }
+        )
+        
+        let clientContext = intentConfig.createClientContext(customerId: nil)
+        
+        XCTAssertEqual(clientContext.mode, "payment")
+        XCTAssertEqual(clientContext.currency, "usd")
+        XCTAssertNil(clientContext.setupFutureUsage)
+        XCTAssertEqual(clientContext.captureMethod, "automatic") // default
+        XCTAssertNil(clientContext.paymentMethodOptions)
+        XCTAssertNil(clientContext.paymentMethodTypes)
+        XCTAssertNil(clientContext.onBehalfOf)
+        XCTAssertNil(clientContext.paymentMethodConfiguration)
+    }
+    
+    func testCreateClientContextFromPaymentModeComplete() {
+        let paymentMethodOptions = PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(
+            setupFutureUsageValues: [.card: .offSession]
+        )
+        
+        let intentConfig = PaymentSheet.IntentConfiguration(
+            mode: .payment(
+                amount: 2000,
+                currency: "eur",
+                setupFutureUsage: .onSession,
+                captureMethod: .manual,
+                paymentMethodOptions: paymentMethodOptions
+            ),
+            paymentMethodTypes: ["card", "apple_pay"],
+            onBehalfOf: "acct_123456",
+            paymentMethodConfigurationId: "pmc_123456",
+            confirmHandler: { _, _, _ in }
+        )
+        
+        let clientContext = intentConfig.createClientContext(customerId: nil)
+        
+        XCTAssertEqual(clientContext.mode, "payment")
+        XCTAssertEqual(clientContext.currency, "eur")
+        XCTAssertEqual(clientContext.setupFutureUsage, "on_session")
+        XCTAssertEqual(clientContext.captureMethod, "manual")
+        XCTAssertNotNil(clientContext.paymentMethodOptions)
+        XCTAssertEqual(clientContext.paymentMethodTypes, ["card", "apple_pay"])
+        XCTAssertEqual(clientContext.onBehalfOf, "acct_123456")
+        XCTAssertEqual(clientContext.paymentMethodConfiguration, "pmc_123456")
+    }
+    
+    func testCreateClientContextFromPaymentModeWithAutomaticAsync() {
+        let intentConfig = PaymentSheet.IntentConfiguration(
+            mode: .payment(
+                amount: 1500,
+                currency: "gbp",
+                setupFutureUsage: .offSession,
+                captureMethod: .automaticAsync
+            ),
+            confirmHandler: { _, _, _ in }
+        )
+        
+        let clientContext = intentConfig.createClientContext(customerId: nil)
+        
+        XCTAssertEqual(clientContext.mode, "payment")
+        XCTAssertEqual(clientContext.currency, "gbp")
+        XCTAssertEqual(clientContext.setupFutureUsage, "off_session")
+        XCTAssertEqual(clientContext.captureMethod, "automatic_async")
+    }
+    
+    // MARK: - Setup Mode Tests
+    
+    func testCreateClientContextFromSetupModeMinimal() {
+        let intentConfig = PaymentSheet.IntentConfiguration(
+            mode: .setup(),
+            confirmHandler: { _, _, _ in }
+        )
+        
+        let clientContext = intentConfig.createClientContext(customerId: nil)
+        
+        XCTAssertEqual(clientContext.mode, "setup")
+        XCTAssertNil(clientContext.currency) // default is nil for setup
+        XCTAssertEqual(clientContext.setupFutureUsage, "off_session") // default for setup
+        XCTAssertNil(clientContext.captureMethod) // not applicable for setup
+        XCTAssertNil(clientContext.paymentMethodOptions) // not applicable for setup
+        XCTAssertNil(clientContext.paymentMethodTypes)
+        XCTAssertNil(clientContext.onBehalfOf)
+        XCTAssertNil(clientContext.paymentMethodConfiguration)
+    }
+    
+    func testCreateClientContextFromSetupModeWithCurrency() {
+        let intentConfig = PaymentSheet.IntentConfiguration(
+            mode: .setup(currency: "cad", setupFutureUsage: .onSession),
+            paymentMethodTypes: ["card"],
+            onBehalfOf: "acct_789",
+            paymentMethodConfigurationId: "pmc_789",
+            confirmHandler: { _, _, _ in }
+        )
+        
+        let clientContext = intentConfig.createClientContext(customerId: nil)
+        
+        XCTAssertEqual(clientContext.mode, "setup")
+        XCTAssertEqual(clientContext.currency, "cad")
+        XCTAssertEqual(clientContext.setupFutureUsage, "on_session")
+        XCTAssertNil(clientContext.captureMethod) // not applicable for setup
+        XCTAssertNil(clientContext.paymentMethodOptions) // not applicable for setup
+        XCTAssertEqual(clientContext.paymentMethodTypes, ["card"])
+        XCTAssertEqual(clientContext.onBehalfOf, "acct_789")
+        XCTAssertEqual(clientContext.paymentMethodConfiguration, "pmc_789")
+    }
+    
+    
+    // MARK: - PaymentMethodOptions Conversion Tests
+    
+    func testPaymentMethodOptionsConversionWithSetupFutureUsage() {
+        let paymentMethodOptions = PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(
+            setupFutureUsageValues: [
+                .card: .offSession,
+                .USBankAccount: .onSession
+            ]
+        )
+        
+        let intentConfig = PaymentSheet.IntentConfiguration(
+            mode: .payment(
+                amount: 1000,
+                currency: "usd",
+                paymentMethodOptions: paymentMethodOptions
+            ),
+            confirmHandler: { _, _, _ in }
+        )
+        
+        let clientContext = intentConfig.createClientContext(customerId: nil)
+        
+        XCTAssertNotNil(clientContext.paymentMethodOptions)
+        // The actual conversion logic may be expanded in the future
+        // This test ensures the conversion method is called
+    }
+}

--- a/StripePayments/StripePayments.xcodeproj/project.pbxproj
+++ b/StripePayments/StripePayments.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		610DB7FAF395AEBE6CBEFAC8 /* STPPaymentMethodAffirmParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE3CBC01F0A15D28914DB070 /* STPPaymentMethodAffirmParams.swift */; };
 		61152B4B2B865F58003B69A0 /* STPPaymentMethodAmazonPayParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61152B4A2B865F58003B69A0 /* STPPaymentMethodAmazonPayParams.swift */; };
 		61152B4D2B865FBB003B69A0 /* STPPaymentMethodAmazonPay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61152B4C2B865FBB003B69A0 /* STPPaymentMethodAmazonPay.swift */; };
+		611FFF942E86EE1600383826 /* STPConfirmationTokenClientContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 611FFF932E86EE1600383826 /* STPConfirmationTokenClientContext.swift */; };
 		6151DDBA2B0D1EE800ED4F7E /* STPPaymentMethodUpdateParams.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6151DDB92B0D1EE800ED4F7E /* STPPaymentMethodUpdateParams.swift */; };
 		615242352E6942AE002459F6 /* STPConfirmationToken.swift in Sources */ = {isa = PBXBuildFile; fileRef = 615242342E6942AE002459F6 /* STPConfirmationToken.swift */; };
 		616402472E786B13003B551C /* STPPaymentMethodPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 616402462E786B13003B551C /* STPPaymentMethodPreview.swift */; };
@@ -518,6 +519,7 @@
 		609ECF94337298A5298081D0 /* STPPaymentMethodOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodOptions.swift; sourceTree = "<group>"; };
 		61152B4A2B865F58003B69A0 /* STPPaymentMethodAmazonPayParams.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAmazonPayParams.swift; sourceTree = "<group>"; };
 		61152B4C2B865FBB003B69A0 /* STPPaymentMethodAmazonPay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodAmazonPay.swift; sourceTree = "<group>"; };
+		611FFF932E86EE1600383826 /* STPConfirmationTokenClientContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPConfirmationTokenClientContext.swift; sourceTree = "<group>"; };
 		6151DDB92B0D1EE800ED4F7E /* STPPaymentMethodUpdateParams.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodUpdateParams.swift; sourceTree = "<group>"; };
 		615242342E6942AE002459F6 /* STPConfirmationToken.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPConfirmationToken.swift; sourceTree = "<group>"; };
 		616402462E786B13003B551C /* STPPaymentMethodPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = STPPaymentMethodPreview.swift; sourceTree = "<group>"; };
@@ -1035,6 +1037,7 @@
 				615242342E6942AE002459F6 /* STPConfirmationToken.swift */,
 				616402462E786B13003B551C /* STPPaymentMethodPreview.swift */,
 				61F2FA312E67F69E007AF688 /* STPConfirmationTokenParams.swift */,
+				611FFF932E86EE1600383826 /* STPConfirmationTokenClientContext.swift */,
 			);
 			path = ConfirmationTokens;
 			sourceTree = "<group>";
@@ -1898,6 +1901,7 @@
 				3AA85604F2D3F04F584C616E /* Enums+CustomStringConvertible.swift in Sources */,
 				049CB212CD3D7E69F789BE59 /* STPBINController.swift in Sources */,
 				9F670429C96CADA2BC705EDC /* STPBankAccountCollector.swift in Sources */,
+				611FFF942E86EE1600383826 /* STPConfirmationTokenClientContext.swift in Sources */,
 				457AB5EDA3C13FF9FE9FBD9A /* STPBlocks.swift in Sources */,
 				B7C7040F66A5BBA92AA3E311 /* STPCardValidator.swift in Sources */,
 				CBFB5A1330C916D5DC95F6FF /* STPLocalizedString.swift in Sources */,

--- a/StripePayments/StripePayments/Source/API Bindings/Models/ConfirmationTokens/STPConfirmationTokenClientContext.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/ConfirmationTokens/STPConfirmationTokenClientContext.swift
@@ -1,0 +1,93 @@
+//
+//  STPConfirmationTokenClientContext.swift
+//  StripePayments
+//
+//  Created by Nick Porter on 9/26/25.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+/// Client context for a ConfirmationToken, containing information about the payment flow context.
+/// Only includes properties that can be populated from PaymentSheet.IntentConfiguration.
+/// - seealso: https://stripe.com/docs/api/confirmation_tokens
+@_spi(STP) public class STPConfirmationTokenClientContext: NSObject, STPFormEncodable {
+    private var _additionalAPIParameters: [AnyHashable: Any] = [:]
+
+    /// The mode of this intent, either "payment" or "setup"
+    @objc public var mode: String?
+
+    /// Three-letter ISO currency code
+    @objc public var currency: String?
+
+    /// Indicates how the payment method is intended to be used in the future
+    @objc public var setupFutureUsage: String?
+
+    /// Controls when the funds will be captured (payment mode only)
+    @objc public var captureMethod: String?
+
+    /// The payment method types for the intent
+    @objc public var paymentMethodTypes: [String]?
+
+    /// The account (if any) for which the funds of the intent are intended
+    @objc public var onBehalfOf: String?
+
+    /// Configuration ID for the selected payment method configuration
+    @objc public var paymentMethodConfiguration: String?
+
+    /// Customer ID
+    @objc public var customer: String?
+
+    /// Payment method specific options as a dictionary
+    @objc public var paymentMethodOptions: [String: Any]?
+
+    /// :nodoc:
+    @objc public override var description: String {
+        let props = [
+            // Object
+            String(format: "%@: %p", NSStringFromClass(STPConfirmationTokenClientContext.self), self),
+            // Client context details
+            "mode = \(mode ?? "")",
+            "currency = \(currency ?? "")",
+            "setupFutureUsage = \(setupFutureUsage ?? "")",
+            "captureMethod = \(captureMethod ?? "")",
+            "paymentMethodTypes = \(String(describing: paymentMethodTypes))",
+            "onBehalfOf = \(onBehalfOf ?? "")",
+            "paymentMethodConfiguration = \(paymentMethodConfiguration ?? "")",
+            "customer = \(customer ?? "")",
+            "paymentMethodOptions = \(String(describing: paymentMethodOptions))",
+        ]
+        return "<\(props.joined(separator: "; "))>"
+    }
+
+    // MARK: - STPFormEncodable
+
+    @objc
+    public static func rootObjectName() -> String? {
+        return "client_context"
+    }
+
+    @objc
+    public static func propertyNamesToFormFieldNamesMapping() -> [String: String] {
+        return [
+            NSStringFromSelector(#selector(getter: mode)): "mode",
+            NSStringFromSelector(#selector(getter: currency)): "currency",
+            NSStringFromSelector(#selector(getter: setupFutureUsage)): "setup_future_usage",
+            NSStringFromSelector(#selector(getter: captureMethod)): "capture_method",
+            NSStringFromSelector(#selector(getter: paymentMethodTypes)): "payment_method_types",
+            NSStringFromSelector(#selector(getter: onBehalfOf)): "on_behalf_of",
+            NSStringFromSelector(#selector(getter: paymentMethodConfiguration)): "payment_method_configuration",
+            NSStringFromSelector(#selector(getter: customer)): "customer",
+            NSStringFromSelector(#selector(getter: paymentMethodOptions)): "payment_method_options",
+        ]
+    }
+
+    @objc public var additionalAPIParameters: [AnyHashable: Any] {
+        get {
+            return _additionalAPIParameters
+        }
+        set {
+            _additionalAPIParameters = newValue
+        }
+    }
+}

--- a/StripePayments/StripePayments/Source/API Bindings/Models/ConfirmationTokens/STPConfirmationTokenParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/ConfirmationTokens/STPConfirmationTokenParams.swift
@@ -41,6 +41,9 @@ import Foundation
     /// Contains metadata with identifiers for the session and information about the integration
     @objc @_spi(STP) public var clientAttributionMetadata: STPClientAttributionMetadata?
 
+    /// Client context for the ConfirmationToken, containing information about the payment flow context
+    @objc @_spi(STP) public var clientContext: STPConfirmationTokenClientContext?
+
     /// :nodoc:
     @objc public override var description: String {
         let props = [
@@ -56,6 +59,7 @@ import Foundation
             "mandateData = \(String(describing: mandateData))",
             "setAsDefaultPM = \(String(describing: setAsDefaultPM))",
             "clientAttributionMetadata = \(String(describing: clientAttributionMetadata))",
+            "clientContext = \(String(describing: clientContext))",
         ]
         return "<\(props.joined(separator: "; "))>"
     }
@@ -78,6 +82,7 @@ import Foundation
             NSStringFromSelector(#selector(getter: mandateData)): "mandate_data",
             NSStringFromSelector(#selector(getter: setAsDefaultPM)): "set_as_default_payment_method",
             NSStringFromSelector(#selector(getter: clientAttributionMetadata)): "client_attribution_metadata",
+            NSStringFromSelector(#selector(getter: clientContext)): "client_context",
         ]
     }
 

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0000_post_create_ephemeral_key.tail
@@ -4,15 +4,15 @@ https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_ephemeral_ke
 text/html
 Content-Type: text/html;charset=utf-8
 Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-Set-Cookie: rack.session=Hq%2F06ARjs0w3qX3hTfWmOGEeeOvSJWlrzKn94Jk7zSu%2BAjf9hC0TEgzL%2F8GY5NEL6%2BxMs8mD1jJXUCmrjlRHKR%2Bmi5HFQUf7RuXA9Gs8DvhGplpkJqBU9ZZN%2FjXlxHbXENqq4iNA9PjSqj2tSKcjUPn2U9qL2ofSQfagvnTteRx8pPHAMbJ%2BFSmSI4NSVo4Cgv3P8HvFvuer4UO8jrmnRRlwkOORbimTv6gCBRWQem8%3D; path=/
+Set-Cookie: rack.session=P7Ozpsmh7iVn9oEcnBLH5G5rESu6JhSzNQHXk1NPjArwe8REI2yHe7VDaxTYIaQ9onw8i59nRaOkIIVq0rOobKHBZ4dylfpMQdYVWP4A5jsuEWU912RrsDi8uj4f5dBJYPTnc3sQFC7QMOGunBKi%2FRdKxauFMq8ClHKFk9rVrA0mdfPBRPhJRSvcJkAwnmGsHryapfWFSH8aknORmBA4l1MrhSpOd9rCUFIib26O8N8%3D; path=/
 Server: Google Frontend
-x-cloud-trace-context: 2d948eedc089aba1b0ee546768601f32;o=1
+x-cloud-trace-context: 7c8bb589f3aa5f33fc370d93b0aa758e;o=1
 Via: 1.1 google
 x-xss-protection: 1; mode=block
-Date: Thu, 04 Sep 2025 15:17:15 GMT
+Date: Fri, 26 Sep 2025 16:31:36 GMT
 x-robots-tag: noindex, nofollow
 Content-Length: 149
 x-content-type-options: nosniff
 x-frame-options: SAMEORIGIN
 
-{"ephemeral_key_secret":"ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLGVjUExhNGZwR3ppUGJEOW1OQUIxWm93ck9tSEczNGs_00G7WJP6JI","customer":"cus_SzeCHemxoXJzje"}
+{"ephemeral_key_secret":"ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLFhiNlNqOWhobkJJeVhnNW5aeUNjRzdDSlBkd0FwT0c_00k0gbdyla","customer":"cus_T7uNgM4NvVaILE"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0001_post_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0001_post_v1_payment_methods.tail
@@ -3,7 +3,7 @@ https:\/\/api\.stripe\.com\/v1\/payment_methods$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=AQqRMFirvLP7NAbp5k0pcjF7M1U26ZzkqN4aanhT-qtqtjEQTKJyZxpEAHasM5EkU4BImi4Jiawx2Yu-
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=nCHQV3Dw1QMlpE7JCwjR0qKZbJdHJO9y1ohWEsJgWyrna6k2IXRm-dS3P9U5bV9JssO4MXNEroyPIxdr
 Server: nginx
 Cache-Control: no-cache, no-store
 x-wc: ABGHIJ
@@ -12,13 +12,13 @@ Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
 x-stripe-routing-context-priority-tier: api-testmode
-request-id: req_zBo9BfWhMwjGEt
+request-id: req_TaWkWVN5Fg1Qgh
 Content-Length: 991
 Vary: Origin
-Date: Thu, 04 Sep 2025 15:17:15 GMT
-original-request: req_zBo9BfWhMwjGEt
+Date: Fri, 26 Sep 2025 16:31:37 GMT
+original-request: req_TaWkWVN5Fg1Qgh
 stripe-version: 2020-08-27
-idempotency-key: 1048389c-d46b-4f2a-a41f-1f549ebfa614
+idempotency-key: e9ae8706-891e-4093-8f57-8c8c8090f94f
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
@@ -27,7 +27,7 @@ X-Stripe-Mock-Request: allow_redisplay=unspecified&card\[cvc]=123&card\[exp_mont
 
 {
   "object" : "payment_method",
-  "id" : "pm_1S3euVFY0qyl6XeWdNqxWFuk",
+  "id" : "pm_1SBeYWFY0qyl6XeWAR3hWT9b",
   "billing_details" : {
     "email" : null,
     "phone" : null,
@@ -69,7 +69,7 @@ X-Stripe-Mock-Request: allow_redisplay=unspecified&card\[cvc]=123&card\[exp_mont
     "country" : "US"
   },
   "livemode" : false,
-  "created" : 1756999035,
+  "created" : 1758904297,
   "allow_redisplay" : "unspecified",
   "type" : "card",
   "customer" : null

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0002_post_v1_payment_methods_pm_1SBeYWFY0qyl6XeWAR3hWT9b_attach.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0002_post_v1_payment_methods_pm_1SBeYWFY0qyl6XeWAR3hWT9b_attach.tail
@@ -1,9 +1,9 @@
 POST
-https:\/\/api\.stripe\.com\/v1\/elements\/payment_methods\/pm_1S3euVFY0qyl6XeWdNqxWFuk\/detach$
+https:\/\/api\.stripe\.com\/v1\/payment_methods\/pm_1SBeYWFY0qyl6XeWAR3hWT9b\/attach$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=M3wkePSpCSn9ZJOJgZsdhffmFSDs38pq0m747b63lmLoU7hXSohdpHA2xmwmbAusWQ-B0JCBo_CJMzYI
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=BeIBUWhErEO8L7TNgHxsqztRNqa8j6UVhBxh-HrVksYtyyJLnr7dgRuGuhMlix4KhExYcIc_hkrunawF
 Server: nginx
 Cache-Control: no-cache, no-store
 x-wc: ABGHIJ
@@ -12,22 +12,22 @@ Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
 x-stripe-routing-context-priority-tier: api-testmode
-request-id: req_NUFlwiT1CfbkYh
-Content-Length: 1030
+request-id: req_Sv1ScPFrPuLzSz
+Content-Length: 1046
 Vary: Origin
-Date: Thu, 04 Sep 2025 15:17:18 GMT
-original-request: req_NUFlwiT1CfbkYh
+Date: Fri, 26 Sep 2025 16:31:38 GMT
+original-request: req_Sv1ScPFrPuLzSz
 stripe-version: 2020-08-27
-idempotency-key: 0cf44b08-cab1-4e4b-aa88-a8f9d50a5736
+idempotency-key: 3576980e-8c54-4d6b-8b42-6fc50cfda642
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
 Content-Type: application/json
-X-Stripe-Mock-Request: customer_session_client_secret=cuss_secret_SzeCnfmGV3FvAmrGAMF2m0wj9nXHRHeCHOkEmhnwYqDUlGl
+X-Stripe-Mock-Request: customer=cus_T7uNgM4NvVaILE
 
 {
   "object" : "payment_method",
-  "id" : "pm_1S3euVFY0qyl6XeWdNqxWFuk",
+  "id" : "pm_1SBeYWFY0qyl6XeWAR3hWT9b",
   "billing_details" : {
     "email" : null,
     "phone" : null,
@@ -70,8 +70,8 @@ X-Stripe-Mock-Request: customer_session_client_secret=cuss_secret_SzeCnfmGV3FvAm
     "country" : "US"
   },
   "livemode" : false,
-  "created" : 1756999035,
+  "created" : 1758904297,
   "allow_redisplay" : "unspecified",
   "type" : "card",
-  "customer" : null
+  "customer" : "cus_T7uNgM4NvVaILE"
 }

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0003_post_create_customer_session_cs.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0003_post_create_customer_session_cs.tail
@@ -4,15 +4,15 @@ https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_customer_ses
 text/html
 Content-Type: text/html;charset=utf-8
 Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
-Set-Cookie: rack.session=5Xm6hbKDooIyC6Gd9XLVt3mXcqCK77WkGptNIxRpHBtIocIcm4DwqJPvwKVzdZgCHuAudUD7q5htpEsSUTHnMFjJHcTv9M%2F9mtd20ik%2BCSDGgys1caz0wbXcUMuROkKLKdgCYMzA%2Fk%2ByoZiqCv3Mz3j95wyzcFKip5pO6KBnd3sEhHZrc6CGlBtqRbDqERdoX3s9HVWYY2QWCf6qS0J4aO5PwVokBLhDs7qx2tCqAeM%3D; path=/
+Set-Cookie: rack.session=oj%2BHphw771rxRYehtZq%2B9SIB%2BBE5xrGIcqoKoJKfYVJOX54%2BlUNHSF2Tv5LRn11mPxYz9igJmjfBX%2BPq4fENPmEo9rQKUYpLoDoRTqhUQ3vR7gl3FHgvW5HXARgUUdzurWHJVgc5w%2BpH4U%2F56%2FEnW7gqv1Hw02OVemtw4xeH%2BGF4WHU%2FGjzznhWduzwwiLBXgwSobRGZizlVC8Dn1ZaS%2BDqCFsFzSujGFmwKNln5F4k%3D; path=/
 Server: Google Frontend
-x-cloud-trace-context: 56c30aaa437705aab23fcf1954bd217c
+x-cloud-trace-context: bedbbe094c5d7a818ee1bc1135dcb3a0
 Via: 1.1 google
 x-xss-protection: 1; mode=block
-Date: Thu, 04 Sep 2025 15:17:16 GMT
+Date: Fri, 26 Sep 2025 16:31:38 GMT
 x-robots-tag: noindex, nofollow
 Content-Length: 128
 x-content-type-options: nosniff
 x-frame-options: SAMEORIGIN
 
-{"customer_session_client_secret":"cuss_secret_SzeCnfmGV3FvAmrGAMF2m0wj9nXHRHeCHOkEmhnwYqDUlGl","customer":"cus_SzeCHemxoXJzje"}
+{"customer_session_client_secret":"cuss_secret_T7uNZD9x9SsRwdw3AQW595yfT9apIvLO7a35zgSzY8dIECj","customer":"cus_T7uNgM4NvVaILE"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0004_get_v1_elements_sessions.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0004_get_v1_elements_sessions.tail
@@ -1,25 +1,25 @@
 GET
-https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?customer_session_client_secret=cuss_secret_SzeCnfmGV3FvAmrGAMF2m0wj9nXHRHeCHOkEmhnwYqDUlGl&deferred_intent%5Bcurrency%5D=usd&deferred_intent%5Bmode%5D=setup&deferred_intent%5Bsetup_future_usage%5D=off_session&key=pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6&locale=en-US&mobile_app_id=com\.apple\.dt\.xctest\.tool&type=deferred_intent$
+https:\/\/api\.stripe\.com\/v1\/elements\/sessions\?customer_session_client_secret=cuss_secret_T7uNZD9x9SsRwdw3AQW595yfT9apIvLO7a35zgSzY8dIECj&deferred_intent%5Bcurrency%5D=usd&deferred_intent%5Bmode%5D=setup&deferred_intent%5Bsetup_future_usage%5D=off_session&key=pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6&locale=en-US&mobile_app_id=com\.apple\.dt\.xctest\.tool&type=deferred_intent$
 200
 application/json
 Content-Type: application/json
 Access-Control-Allow-Origin: *
 x-stripe-priority-routing-enabled: true
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=GQZta_9ktJUzAKvj4c7RjbtjwoJd_Xdcpgn_E05KwmtEkIouDOp7cyJ0Aj8rn8yIo61wb16qfvrk4y_N
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=6jROz_u8Q62Vpbt7KFT7ORKPddGyJmI8eeU4Me7N99BmaqFm2cWB1uWRycxSVDIoHkNv4pLIvhAiZBgs
 x-wc: ABGHIJ
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
 Server: nginx
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 Cache-Control: no-cache, no-store
-Date: Thu, 04 Sep 2025 15:17:17 GMT
+Date: Fri, 26 Sep 2025 16:31:38 GMT
 stripe-version: 2020-08-27
 access-control-allow-credentials: true
-Content-Length: 17757
+Content-Length: 18222
 x-stripe-routing-context-priority-tier: api-testmode
 Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
 Vary: Origin
-request-id: req_UYxo3DvyAKdxlC
+request-id: req_dEvMHEG85eFvwr
 
 {
   "payment_method_preference" : {
@@ -29,8 +29,8 @@ request-id: req_UYxo3DvyAKdxlC
     "ordered_payment_method_types" : [
       "card",
       "cashapp",
-      "us_bank_account",
-      "amazon_pay"
+      "amazon_pay",
+      "us_bank_account"
     ]
   },
   "capability_enabled_card_networks" : [
@@ -46,6 +46,7 @@ request-id: req_UYxo3DvyAKdxlC
     "elements_enable_installments_on_deferred_intents" : true,
     "paypal_billing_address_support_in_ece" : false,
     "distinctly_link_pe_backup_payment_method" : false,
+    "elements_easel_enable_elements_inspector" : false,
     "paypal_express_checkout_recurring_support_elements_for_new_ece_shape" : true,
     "elements_enable_new_google_places_api" : true,
     "elements_enable_ach_consumer_sign_up_incentive" : true,
@@ -53,20 +54,24 @@ request-id: req_UYxo3DvyAKdxlC
     "elements_enable_cb_apple_pay_for_connect_platforms" : true,
     "elements_enable_read_allow_redisplay" : false,
     "id_bank_transfers_v1_integration" : false,
-    "networked_business_profile_demo" : false,
+    "link_decommission_autofill_modal" : false,
     "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
-    "paypal_phone_number_support_in_ece" : false,
+    "networked_business_profile_demo" : false,
     "elements_easel_enable_lpm_autofills" : true,
     "elements_disable_express_checkout_button_shop_pay" : false,
+    "paypal_phone_number_support_in_ece" : false,
     "elements_easel_disable_payment_fill" : false,
     "elements_spm_set_as_default" : true,
     "link_payment_element_minor_signup_ui_updates" : false,
     "elements_disable_paypal_express" : false,
+    "link_enable_auth_partner_sizing_logging" : true,
     "abstracted_adaptive_pricing_should_show_markup_disclosure_percentage" : false,
     "linkglobalholdbackmanager_test_rollout" : true,
     "elements_enable_save_for_future_payments_pre_check" : false,
     "elements_enable_nz_bank_account_spm" : false,
     "elements_enable_write_allow_redisplay" : false,
+    "elements_does_not_collect_postal_code_for_non_us_card_transactions_killswitch" : false,
+    "link_payment_element_steerage_enabled" : false,
     "elements_hide_card_brand_icons" : false,
     "enable_cashapp_afterpay_logo_checkout" : true,
     "payto_enable_modal_in_payment_element" : false,
@@ -74,6 +79,8 @@ request-id: req_UYxo3DvyAKdxlC
     "link_disable_login_if_signed_up_outside_of_elements" : false,
     "elements_enable_link_card_brand_in_saved_payment_methods" : true,
     "financial_connections_enable_deferred_intent_flow" : true,
+    "elements_enable_easel_for_pi" : false,
+    "elements_enable_pay_by_bank_multi_country_bank_selector" : true,
     "elements_disable_payment_element_custom_payment_methods_byof" : false,
     "elements_easel_disable_position_customization" : false,
     "elements_disable_link_global_holdback_lookup" : false,
@@ -81,6 +88,8 @@ request-id: req_UYxo3DvyAKdxlC
     "paypal_express_checkout_recurring_support" : false,
     "elements_easel_disable_magic_fill" : false,
     "elements_disable_payment_element_card_country_zip_validations" : false,
+    "elements_enable_interac_apple_pay" : false,
+    "link_auth_partner_consume_link_auth_intent" : false,
     "disable_cbc_in_link_popup" : false,
     "link_enable_card_brand_choice" : true,
     "link_express_checkout_element_one_click_killswitch" : true,
@@ -88,11 +97,12 @@ request-id: req_UYxo3DvyAKdxlC
     "elements_enable_blik" : true,
     "apple_pay_pe_killswitch" : false,
     "elements_enable_invalid_country_for_pm_error" : true,
-    "link_payment_element_default_value_auto_open_modal" : false,
+    "link_payment_element_default_value_auto_open_modal" : true,
     "link_express_checkout_element_inline_otp_killswitch" : true,
     "elements_enable_19_digit_pans" : false,
     "elements_disable_express_checkout_button_amazon_pay" : false,
     "link_in_accordion_layout_available_in_stripejs" : false,
+    "distinctly_link_pe_purchase_protection" : false,
     "link_user_action_attempt_login_using_stored_credentials" : true,
     "elements_easel_disable_tax_id_fill" : false,
     "apple_pay_ece_killswitch" : false,
@@ -105,19 +115,18 @@ request-id: req_UYxo3DvyAKdxlC
     "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
     "elements_enable_ephemeral_key_for_confirmation_token_creation" : true,
     "show_swish_factoring_notice" : true,
-    "show_swish_redirect_and_qr_code_auth_flows" : true,
     "elements_lpm_holdback_use_backend_treatments" : true,
     "elements_easel_disable_optimizations_check" : false,
     "elements_enable_express_checkout_button_demo_pay" : false,
     "elements_prefer_fc_lite" : false,
     "elements_enable_jp_card_installments" : true,
     "elements_easel_disable_feedback" : false,
+    "elements_enable_easel_for_pi_killswitch" : false,
     "elements_spm_messages" : false,
     "elements_enable_bacs_debit_spm" : false,
     "distinctly_link_cbc_killswitch" : false,
     "elements_disable_link_email_otp" : false,
     "elements_disable_progressive_cursor" : false,
-    "easel_testmode_customer_location" : true,
     "elements_enable_payment_element_custom_payment_methods_byof" : false,
     "elements_show_expanded_spm" : false,
     "enable_custom_checkout_currency_selector_element" : false,
@@ -151,10 +160,10 @@ request-id: req_UYxo3DvyAKdxlC
     "link_enable_universal_ncdv_l3" : true
   },
   "merchant_logo_url" : null,
-  "session_id" : "elements_session_1fFJ7kZqs9o",
+  "session_id" : "elements_session_1X76A5wS8rw",
   "card_installments_enabled" : false,
   "account_id" : "acct_1G6m1pFY0qyl6XeW",
-  "config_id" : "f29e606d-3d75-44d0-9b8a-b42c05ce9c19",
+  "config_id" : "6ee6f311-8c85-4f2e-bd05-f7cf47005832",
   "merchant_currency" : "usd",
   "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
   "card_brand_choice" : {
@@ -173,14 +182,18 @@ request-id: req_UYxo3DvyAKdxlC
   "custom_payment_method_data" : null,
   "meta_pay_signed_container_context" : null,
   "apple_pay_preference" : "enabled",
-  "lpm_promotions" : null,
+  "payment_method_configuration_id" : "pmc_1JwXxwFY0qyl6XeWe0tY6hZ0",
   "merchant_country" : "US",
   "google_pay_preference" : "enabled",
-  "payment_method_configuration_id" : "pmc_1JwXxwFY0qyl6XeWe0tY6hZ0",
+  "paypal_express_config" : {
+    "client_id" : null,
+    "client_token" : null,
+    "paypal_merchant_id" : null
+  },
   "experiments_data" : {
-    "arb_id" : "b1ca1ee4-8513-4301-925d-702bc09093f4",
+    "arb_id" : "4ae49a17-4096-4219-84cf-c2edeee20c0e",
     "experiment_metadata" : {
-      "seed" : "b65dc74f22e672956a4edc5cdc855c4afd01e978463b001b031642b9a0e807f4",
+      "seed" : "0ab49de9eeaf3b936d1330e75fd0e78d679aa458b54827d8871e55f1044affaf",
       "semi_dominant_payment_methods" : [
 
       ],
@@ -193,15 +206,14 @@ request-id: req_UYxo3DvyAKdxlC
       ]
     },
     "experiment_assignments" : {
-      "link_popup_webview_option_ios" : "control",
-      "elements_merchant_ui_api_srv" : "control",
+      "ocs_buyer_xp_elements_ece_pe_does_not_wait" : "control",
       "paypal_payment_handler" : "control",
       "ocs_buyer_xp_redirect_simplification_v2" : "control",
       "ocs_buyer_xp_elements_ece_timeout_time" : "control",
       "link_ab_test_aa" : "control",
       "ocs_buyer_xp_elements_redirect_form_simplification" : "control",
       "ocs_buyer_xp_elements_remove_postal_code_card_non_us" : "control",
-      "ocs_buyer_xp_elements_ece_pe_does_not_wait" : "control"
+      "connections_elements_us_bank_account_picker_icons" : "control"
     }
   },
   "legacy_customer" : null,
@@ -325,11 +337,6 @@ request-id: req_UYxo3DvyAKdxlC
       }
     }
   ],
-  "paypal_express_config" : {
-    "client_id" : null,
-    "client_token" : null,
-    "paypal_merchant_id" : null
-  },
   "prefill_selectors" : {
     "default_values" : {
       "email" : [
@@ -340,8 +347,8 @@ request-id: req_UYxo3DvyAKdxlC
   },
   "unactivated_payment_method_types" : [
     "cashapp",
-    "us_bank_account",
-    "amazon_pay"
+    "amazon_pay",
+    "us_bank_account"
   ],
   "unverified_payment_methods_on_domain" : [
     "apple_pay"
@@ -357,7 +364,7 @@ request-id: req_UYxo3DvyAKdxlC
     "payment_methods" : [
       {
         "object" : "payment_method",
-        "id" : "pm_1S3euVFY0qyl6XeWdNqxWFuk",
+        "id" : "pm_1SBeYWFY0qyl6XeWAR3hWT9b",
         "billing_details" : {
           "email" : null,
           "phone" : null,
@@ -399,17 +406,17 @@ request-id: req_UYxo3DvyAKdxlC
           "country" : "US"
         },
         "livemode" : false,
-        "created" : 1756999035,
+        "created" : 1758904297,
         "allow_redisplay" : "unspecified",
         "type" : "card",
-        "customer" : "cus_SzeCHemxoXJzje"
+        "customer" : "cus_T7uNgM4NvVaILE"
       }
     ],
     "payment_methods_with_link_details" : [
       {
         "payment_method" : {
           "object" : "payment_method",
-          "id" : "pm_1S3euVFY0qyl6XeWdNqxWFuk",
+          "id" : "pm_1SBeYWFY0qyl6XeWAR3hWT9b",
           "billing_details" : {
             "email" : null,
             "phone" : null,
@@ -451,10 +458,10 @@ request-id: req_UYxo3DvyAKdxlC
             "country" : "US"
           },
           "livemode" : false,
-          "created" : 1756999035,
+          "created" : 1758904297,
           "allow_redisplay" : "unspecified",
           "type" : "card",
-          "customer" : "cus_SzeCHemxoXJzje"
+          "customer" : "cus_T7uNgM4NvVaILE"
         },
         "is_link_origin" : false,
         "link_payment_details" : null
@@ -463,8 +470,8 @@ request-id: req_UYxo3DvyAKdxlC
     "default_payment_method" : null,
     "customer_session" : {
       "object" : "customer_session",
-      "api_key_expiry" : 1757000837,
-      "id" : "cuss_1S3euWFY0qyl6XeWdudjr35t",
+      "api_key_expiry" : 1758907898,
+      "id" : "cuss_1SBeYYFY0qyl6XeWJgDGzkGx",
       "livemode" : false,
       "components" : {
         "customer_sheet" : {
@@ -498,8 +505,8 @@ request-id: req_UYxo3DvyAKdxlC
           "enabled" : false
         }
       },
-      "customer" : "cus_SzeCHemxoXJzje",
-      "api_key" : "ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLHhiWHpWVzlET1VlRUxlWVcxOEEyVmR4VHZaNnhFTmk_00MZEY7g5p"
+      "customer" : "cus_T7uNgM4NvVaILE",
+      "api_key" : "ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLFJBZFdDSWpmRFF4alZlb2Vha3d3Vjl4TW5VSHRsRDA_00WwinZZWJ"
     }
   },
   "klarna_express_config" : {
@@ -519,8 +526,8 @@ request-id: req_UYxo3DvyAKdxlC
     "apple_pay",
     "google_pay",
     "cashapp",
-    "us_bank_account",
-    "amazon_pay"
+    "amazon_pay",
+    "us_bank_account"
   ],
   "customer_error" : null
 }

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0005_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0005_post_v1_confirmation_tokens.tail
@@ -3,7 +3,7 @@ https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=BgkaGBkq9wGH_VR09HVcVxV5n_SANuUYMK2xZ9L3S4cqUVSYgKd5MWLpmsZe-wUKOCHXbDgNzhPjDhfh
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=ES_A69Gy805HAys6sL7dTf0qpk2qcP_nNhkBnZ_WtVAEG-EXlvGCdjzuMli3J9By67-8M5nVXF_zjX-3
 Server: nginx
 Cache-Control: no-cache, no-store
 x-wc: ABGHIJ
@@ -12,26 +12,26 @@ Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
 x-stripe-routing-context-priority-tier: api-testmode
-request-id: req_zL26fMQTXb5f26
+request-id: req_x2GwHUkOCnnzU7
 Content-Length: 1443
 Vary: Origin
-Date: Thu, 04 Sep 2025 15:17:17 GMT
-original-request: req_zL26fMQTXb5f26
+Date: Fri, 26 Sep 2025 16:31:39 GMT
+original-request: req_x2GwHUkOCnnzU7
 stripe-version: 2020-08-27
-idempotency-key: 780cf52b-6fc5-4c7a-8e7f-13ef7929ea87
+idempotency-key: 7f211d3f-5ff5-471d-983d-e787cf305e79
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
 Content-Type: application/json
-X-Stripe-Mock-Request: payment_method=pm_1S3euVFY0qyl6XeWdNqxWFuk&return_url=https%3A\/\/example\.com\/return&setup_future_usage=off_session
+X-Stripe-Mock-Request: payment_method=pm_1SBeYWFY0qyl6XeWAR3hWT9b&return_url=https%3A\/\/example\.com\/return&setup_future_usage=off_session
 
 {
-  "id" : "ctoken_1S3euXFY0qyl6XeWs8gXLJrE",
+  "id" : "ctoken_1SBeYZFY0qyl6XeWQVrmPHGi",
   "setup_intent" : null,
   "livemode" : false,
   "shipping" : null,
   "mandate_data" : null,
-  "expires_at" : 1757042237,
+  "expires_at" : 1758947499,
   "return_url" : "https:\/\/example.com\/return",
   "setup_future_usage" : "off_session",
   "object" : "confirmation_token",
@@ -51,7 +51,7 @@ X-Stripe-Mock-Request: payment_method=pm_1S3euVFY0qyl6XeWdNqxWFuk&return_url=htt
         "postal_code" : null
       }
     },
-    "customer" : "cus_SzeCHemxoXJzje",
+    "customer" : "cus_T7uNgM4NvVaILE",
     "card" : {
       "regulated_status" : "unregulated",
       "fingerprint" : "96sroMqLCHmUdUpL",
@@ -81,7 +81,7 @@ X-Stripe-Mock-Request: payment_method=pm_1S3euVFY0qyl6XeWdNqxWFuk&return_url=htt
     },
     "type" : "card"
   },
-  "created" : 1756999037,
+  "created" : 1758904299,
   "payment_intent" : null,
   "use_stripe_sdk" : true,
   "payment_method_options" : null

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0006_post_v1_elements_payment_methods_pm_1SBeYWFY0qyl6XeWAR3hWT9b_detach.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithAttachedPaymentMethod/0006_post_v1_elements_payment_methods_pm_1SBeYWFY0qyl6XeWAR3hWT9b_detach.tail
@@ -1,9 +1,9 @@
 POST
-https:\/\/api\.stripe\.com\/v1\/payment_methods\/pm_1S3euVFY0qyl6XeWdNqxWFuk\/attach$
+https:\/\/api\.stripe\.com\/v1\/elements\/payment_methods\/pm_1SBeYWFY0qyl6XeWAR3hWT9b\/detach$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=dTYTfMEC3tXgP6Z9bOIrXKPnZNDx9NoVi_Ca-LZxl9__TTm0H4S1oDjjjj_Cwr0wCg9wwsiwavxUgVlg
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=RouoU7ygenX2gzu_4mwpsfJ2l00ofswBG5WaMHrf8t8JRoPBJ2campi1sH4escQ-LVUIWr8-2u8m6pk1
 Server: nginx
 Cache-Control: no-cache, no-store
 x-wc: ABGHIJ
@@ -12,22 +12,22 @@ Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
 x-stripe-routing-context-priority-tier: api-testmode
-request-id: req_YpmlUYsPEJrlli
-Content-Length: 1046
+request-id: req_26O6DJVXCN4dfY
+Content-Length: 1030
 Vary: Origin
-Date: Thu, 04 Sep 2025 15:17:16 GMT
-original-request: req_YpmlUYsPEJrlli
+Date: Fri, 26 Sep 2025 16:31:39 GMT
+original-request: req_26O6DJVXCN4dfY
 stripe-version: 2020-08-27
-idempotency-key: 98c317e3-aff4-46ce-8e52-a2b085fb7931
+idempotency-key: 1385a2c9-bdfc-4f2c-85ac-a7cd5a07b35d
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
 Content-Type: application/json
-X-Stripe-Mock-Request: customer=cus_SzeCHemxoXJzje
+X-Stripe-Mock-Request: customer_session_client_secret=cuss_secret_T7uNZD9x9SsRwdw3AQW595yfT9apIvLO7a35zgSzY8dIECj
 
 {
   "object" : "payment_method",
-  "id" : "pm_1S3euVFY0qyl6XeWdNqxWFuk",
+  "id" : "pm_1SBeYWFY0qyl6XeWAR3hWT9b",
   "billing_details" : {
     "email" : null,
     "phone" : null,
@@ -70,8 +70,8 @@ X-Stripe-Mock-Request: customer=cus_SzeCHemxoXJzje
     "country" : "US"
   },
   "livemode" : false,
-  "created" : 1756999035,
+  "created" : 1758904297,
   "allow_redisplay" : "unspecified",
   "type" : "card",
-  "customer" : "cus_SzeCHemxoXJzje"
+  "customer" : null
 }

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithExistingPaymentMethod/0000_post_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithExistingPaymentMethod/0000_post_v1_payment_methods.tail
@@ -3,7 +3,7 @@ https:\/\/api\.stripe\.com\/v1\/payment_methods$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=R0_0tqCg-WrH3pQKcC5UMol8CAvAASajedZ3KoPKN9hx1tZq4dca5J_yWxcEPVbiAKdNVhZB37Nl7vna
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=couyBoHTKcnzFvGwJjir8DohHFKfpEnah3wlOUdkyzkeE-SM-u-jTWFJUHb5bsYj5Xve4rQeTjHxneve
 Server: nginx
 Cache-Control: no-cache, no-store
 x-wc: ABGHIJ
@@ -12,13 +12,13 @@ Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
 x-stripe-routing-context-priority-tier: api-testmode
-request-id: req_T9EhNozfwGJ2X2
+request-id: req_kYPTHtQRhMNIQN
 Content-Length: 991
 Vary: Origin
-Date: Thu, 04 Sep 2025 15:17:18 GMT
-original-request: req_T9EhNozfwGJ2X2
+Date: Fri, 26 Sep 2025 16:31:39 GMT
+original-request: req_kYPTHtQRhMNIQN
 stripe-version: 2020-08-27
-idempotency-key: 03325602-29c4-447c-9a89-707c340ee257
+idempotency-key: 65308f39-6ed6-4a7e-90c5-c64f1408e358
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
@@ -27,7 +27,7 @@ X-Stripe-Mock-Request: allow_redisplay=unspecified&card\[cvc]=123&card\[exp_mont
 
 {
   "object" : "payment_method",
-  "id" : "pm_1S3euYFY0qyl6XeW82VPaAwV",
+  "id" : "pm_1SBeYZFY0qyl6XeWI7t2Puw5",
   "billing_details" : {
     "email" : null,
     "phone" : null,
@@ -69,7 +69,7 @@ X-Stripe-Mock-Request: allow_redisplay=unspecified&card\[cvc]=123&card\[exp_mont
     "country" : "US"
   },
   "livemode" : false,
-  "created" : 1756999038,
+  "created" : 1758904299,
   "allow_redisplay" : "unspecified",
   "type" : "card",
   "customer" : null

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithExistingPaymentMethod/0001_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithExistingPaymentMethod/0001_post_v1_confirmation_tokens.tail
@@ -3,7 +3,7 @@ https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=eHOa8xH8IB8auXby-3yMjrvbPA0zYr0__MqA4IuYHOsAorqcXu8pzZP53U68iAZ9NIxT2SY--3-PuTU1
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=tSlXPYfY7zM9E18eM6JvPKKzvZV28bkKaVifD24j5wMC5v2wTKOAa5sM6HZWYHR1R-plZpVuqrY-0P23
 Server: nginx
 Cache-Control: no-cache, no-store
 x-wc: ABGHIJ
@@ -12,25 +12,25 @@ Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
 x-stripe-routing-context-priority-tier: api-testmode
-request-id: req_bQbJercLyQBQbN
+request-id: req_2maH2NwjbNgUjx
 Content-Length: 1353
 Vary: Origin
-Date: Thu, 04 Sep 2025 15:17:18 GMT
-original-request: req_bQbJercLyQBQbN
+Date: Fri, 26 Sep 2025 16:31:40 GMT
+original-request: req_2maH2NwjbNgUjx
 stripe-version: 2020-08-27
-idempotency-key: dacb2113-df8a-4c6e-bb02-e333591af146
+idempotency-key: 4eabee8b-6b11-4177-9520-cad6b920e6fc
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
 Content-Type: application/json
-X-Stripe-Mock-Request: payment_method=pm_1S3euYFY0qyl6XeW82VPaAwV&return_url=https%3A\/\/example\.com\/return
+X-Stripe-Mock-Request: payment_method=pm_1SBeYZFY0qyl6XeWI7t2Puw5&return_url=https%3A\/\/example\.com\/return
 
 {
-  "id" : "ctoken_1S3euYFY0qyl6XeWzUs1m9QS",
+  "id" : "ctoken_1SBeYaFY0qyl6XeWCEhd6oDC",
   "setup_intent" : null,
   "livemode" : false,
   "shipping" : null,
-  "expires_at" : 1757042238,
+  "expires_at" : 1758947500,
   "return_url" : "https:\/\/example.com\/return",
   "setup_future_usage" : null,
   "object" : "confirmation_token",
@@ -79,7 +79,7 @@ X-Stripe-Mock-Request: payment_method=pm_1S3euYFY0qyl6XeW82VPaAwV&return_url=htt
     },
     "type" : "card"
   },
-  "created" : 1756999038,
+  "created" : 1758904300,
   "payment_intent" : null,
   "use_stripe_sdk" : true,
   "payment_method_options" : null

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithInvalidCard/0000_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithInvalidCard/0000_post_v1_confirmation_tokens.tail
@@ -3,7 +3,7 @@ https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=JxKphkQcyNKTYhPC5SkciU_hcIAc3hv4raw_70rtClpBzh6veq65RKqkvcXWZj-gm3MZhyZESTGCRQEU
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=hBZnBZUAOb-j1Zz7UhJ4teqiqhMM7OyKqIe2YlGY7DaHKHly9bVtFxrkR96XTRoJl_Z1d90QMUiFupeg
 Server: nginx
 Cache-Control: no-cache, no-store
 x-wc: ABGHIJ
@@ -12,13 +12,13 @@ Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
 x-stripe-routing-context-priority-tier: api-testmode
-request-id: req_60BVVAmYolu0Tg
+request-id: req_qY5NWTH9xIwbv7
 Content-Length: 1353
 Vary: Origin
-Date: Thu, 04 Sep 2025 15:17:19 GMT
-original-request: req_60BVVAmYolu0Tg
+Date: Fri, 26 Sep 2025 16:31:40 GMT
+original-request: req_qY5NWTH9xIwbv7
 stripe-version: 2020-08-27
-idempotency-key: 38fc86c5-003b-4e7a-8901-4c45edceb0e9
+idempotency-key: a45d282f-1928-4957-b21c-261a0ca5d0d6
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
@@ -26,11 +26,11 @@ Content-Type: application/json
 X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[card]\[cvc]=123&payment_method_data\[card]\[exp_month]=12&payment_method_data\[card]\[exp_year]=2030&payment_method_data\[card]\[number]=4000000000000002&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sid]=.*&payment_method_data\[type]=card&return_url=https%3A\/\/example\.com\/return
 
 {
-  "id" : "ctoken_1S3euZFY0qyl6XeWfD0JD2nv",
+  "id" : "ctoken_1SBeYaFY0qyl6XeWR0QTh8NV",
   "setup_intent" : null,
   "livemode" : false,
   "shipping" : null,
-  "expires_at" : 1757042239,
+  "expires_at" : 1758947500,
   "return_url" : "https:\/\/example.com\/return",
   "setup_future_usage" : null,
   "object" : "confirmation_token",
@@ -79,7 +79,7 @@ X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment
     },
     "type" : "card"
   },
-  "created" : 1756999039,
+  "created" : 1758904300,
   "payment_intent" : null,
   "use_stripe_sdk" : true,
   "payment_method_options" : null

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithPaymentMethodData/0000_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithPaymentMethodData/0000_post_v1_confirmation_tokens.tail
@@ -3,7 +3,7 @@ https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=R0_0tqCg-WrH3pQKcC5UMol8CAvAASajedZ3KoPKN9hx1tZq4dca5J_yWxcEPVbiAKdNVhZB37Nl7vna
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=8OwJeIUr4j-yTvOkQYDb3vmyqiIDoPaNzAnsOtlDq-pXSz-M_RVD-6EeWOnaEV8ktpBLRFwGf99Z-HVc
 Server: nginx
 Cache-Control: no-cache, no-store
 x-wc: ABGHIJ
@@ -12,25 +12,25 @@ Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
 x-stripe-routing-context-priority-tier: api-testmode
-request-id: req_N4SRzJJQnxyCSY
+request-id: req_B4rZBk8pUfS3fw
 Content-Length: 1353
 Vary: Origin
-Date: Thu, 04 Sep 2025 15:17:19 GMT
-original-request: req_N4SRzJJQnxyCSY
+Date: Fri, 26 Sep 2025 16:31:41 GMT
+original-request: req_B4rZBk8pUfS3fw
 stripe-version: 2020-08-27
-idempotency-key: b0765b21-87f2-4045-905d-7928633b17ae
+idempotency-key: 5d98b523-2c7c-414d-a214-ae322a65a483
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
 Content-Type: application/json
-X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[card]\[cvc]=123&payment_method_data\[card]\[exp_month]=12&payment_method_data\[card]\[exp_year]=2030&payment_method_data\[card]\[number]=4242424242424242&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sid]=.*&payment_method_data\[type]=card&return_url=https%3A\/\/example\.com\/return
+X-Stripe-Mock-Request: client_context\[currency]=usd&client_context\[mode]=payment&client_context\[payment_method_types]\[0]=card&payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[card]\[cvc]=123&payment_method_data\[card]\[exp_month]=12&payment_method_data\[card]\[exp_year]=2030&payment_method_data\[card]\[number]=4242424242424242&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sid]=.*&payment_method_data\[type]=card&return_url=https%3A\/\/example\.com\/return
 
 {
-  "id" : "ctoken_1S3euZFY0qyl6XeWXydkUJEa",
+  "id" : "ctoken_1SBeYbFY0qyl6XeWINfapEmY",
   "setup_intent" : null,
   "livemode" : false,
   "shipping" : null,
-  "expires_at" : 1757042239,
+  "expires_at" : 1758947501,
   "return_url" : "https:\/\/example.com\/return",
   "setup_future_usage" : null,
   "object" : "confirmation_token",
@@ -79,7 +79,7 @@ X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment
     },
     "type" : "card"
   },
-  "created" : 1756999039,
+  "created" : 1758904301,
   "payment_intent" : null,
   "use_stripe_sdk" : true,
   "payment_method_options" : null

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithPaymentMethodOptions/0000_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithPaymentMethodOptions/0000_post_v1_confirmation_tokens.tail
@@ -3,7 +3,7 @@ https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=o68ZM_AlzDO9kYwycHA4QackK-ieFixWX49872tgpO3hRH7Q_DcJ2e4Z6F5P2OL27VOPt-ZfPmK09Xes
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=8OwJeIUr4j-yTvOkQYDb3vmyqiIDoPaNzAnsOtlDq-pXSz-M_RVD-6EeWOnaEV8ktpBLRFwGf99Z-HVc
 Server: nginx
 Cache-Control: no-cache, no-store
 x-wc: ABGHIJ
@@ -12,13 +12,13 @@ Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
 x-stripe-routing-context-priority-tier: api-testmode
-request-id: req_ibyzcunvK1Wevv
+request-id: req_NxNdUmwU0QRs2B
 Content-Length: 1353
 Vary: Origin
-Date: Thu, 18 Sep 2025 15:59:25 GMT
-original-request: req_ibyzcunvK1Wevv
+Date: Fri, 26 Sep 2025 16:31:41 GMT
+original-request: req_NxNdUmwU0QRs2B
 stripe-version: 2020-08-27
-idempotency-key: 2683025c-2677-420f-bec1-cc38fe82dafd
+idempotency-key: 7d343944-8895-4297-9077-8435b8d3c967
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
@@ -26,11 +26,11 @@ Content-Type: application/json
 X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[card]\[cvc]=123&payment_method_data\[card]\[exp_month]=12&payment_method_data\[card]\[exp_year]=2030&payment_method_data\[card]\[number]=4242424242424242&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sid]=.*&payment_method_data\[type]=card&return_url=https%3A\/\/example\.com\/return
 
 {
-  "id" : "ctoken_1S8kEzFY0qyl6XeWE0VjGW2n",
+  "id" : "ctoken_1SBeYbFY0qyl6XeWeJ2y9mwi",
   "setup_intent" : null,
   "livemode" : false,
   "shipping" : null,
-  "expires_at" : 1758254365,
+  "expires_at" : 1758947501,
   "return_url" : "https:\/\/example.com\/return",
   "setup_future_usage" : null,
   "object" : "confirmation_token",
@@ -79,7 +79,7 @@ X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment
     },
     "type" : "card"
   },
-  "created" : 1758211165,
+  "created" : 1758904301,
   "payment_intent" : null,
   "use_stripe_sdk" : true,
   "payment_method_options" : null

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithSetAsDefaultPaymentMethod/0000_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithSetAsDefaultPaymentMethod/0000_post_v1_confirmation_tokens.tail
@@ -3,7 +3,7 @@ https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=eHOa8xH8IB8auXby-3yMjrvbPA0zYr0__MqA4IuYHOsAorqcXu8pzZP53U68iAZ9NIxT2SY--3-PuTU1
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=qV7t2xVgFNl-OFarpUD4Kb0ztJn7Adxxbs1SCrlFTPiuP0JCBb_8zcvAgpl4wlD3XOD9ITYd6y6dzMTZ
 Server: nginx
 Cache-Control: no-cache, no-store
 x-wc: ABGHIJ
@@ -12,13 +12,13 @@ Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
 x-stripe-routing-context-priority-tier: api-testmode
-request-id: req_Xv5BMoyLYTqK7M
+request-id: req_N8vI9tzhBxQ6yH
 Content-Length: 1362
 Vary: Origin
-Date: Thu, 04 Sep 2025 15:17:20 GMT
-original-request: req_Xv5BMoyLYTqK7M
+Date: Fri, 26 Sep 2025 16:31:42 GMT
+original-request: req_N8vI9tzhBxQ6yH
 stripe-version: 2020-08-27
-idempotency-key: fef5d81a-20e9-46ca-97fb-e734b4e5f775
+idempotency-key: 1b17babd-5802-4488-a754-e22a24d6941c
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
@@ -26,11 +26,11 @@ Content-Type: application/json
 X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[card]\[cvc]=123&payment_method_data\[card]\[exp_month]=12&payment_method_data\[card]\[exp_year]=2030&payment_method_data\[card]\[number]=4242424242424242&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sid]=.*&payment_method_data\[type]=card&return_url=https%3A\/\/example\.com\/return&set_as_default_payment_method=true&setup_future_usage=off_session
 
 {
-  "id" : "ctoken_1S3euaFY0qyl6XeWpSWhx3p9",
+  "id" : "ctoken_1SBeYcFY0qyl6XeWJsKnQxl7",
   "setup_intent" : null,
   "livemode" : false,
   "shipping" : null,
-  "expires_at" : 1757042240,
+  "expires_at" : 1758947502,
   "return_url" : "https:\/\/example.com\/return",
   "setup_future_usage" : "off_session",
   "object" : "confirmation_token",
@@ -79,7 +79,7 @@ X-Stripe-Mock-Request: payment_method_data\[allow_redisplay]=unspecified&payment
     },
     "type" : "card"
   },
-  "created" : 1756999040,
+  "created" : 1758904302,
   "payment_intent" : null,
   "use_stripe_sdk" : true,
   "payment_method_options" : null

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithShippingAndMandateData/0000_post_v1_confirmation_tokens.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientConfirmationTokensTest/testCreateConfirmationTokenWithShippingAndMandateData/0000_post_v1_confirmation_tokens.tail
@@ -3,7 +3,7 @@ https:\/\/api\.stripe\.com\/v1\/confirmation_tokens$
 200
 application/json
 access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
-content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=eHOa8xH8IB8auXby-3yMjrvbPA0zYr0__MqA4IuYHOsAorqcXu8pzZP53U68iAZ9NIxT2SY--3-PuTU1
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=8OwJeIUr4j-yTvOkQYDb3vmyqiIDoPaNzAnsOtlDq-pXSz-M_RVD-6EeWOnaEV8ktpBLRFwGf99Z-HVc
 Server: nginx
 Cache-Control: no-cache, no-store
 x-wc: ABGHIJ
@@ -12,21 +12,21 @@ Access-Control-Allow-Origin: *
 stripe-should-retry: false
 x-stripe-priority-routing-enabled: true
 x-stripe-routing-context-priority-tier: api-testmode
-request-id: req_NxRTUYvKO61ZhN
+request-id: req_MWZc2JGARou1xs
 Content-Length: 1284
 Vary: Origin
-Date: Thu, 04 Sep 2025 15:17:20 GMT
-original-request: req_NxRTUYvKO61ZhN
+Date: Fri, 26 Sep 2025 16:31:42 GMT
+original-request: req_MWZc2JGARou1xs
 stripe-version: 2020-08-27
-idempotency-key: 08321877-e798-4b80-89de-b1850abbdb37
+idempotency-key: 2ba5dad8-1d89-469a-ad59-a8aa514e9fa5
 access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
 access-control-max-age: 300
 access-control-allow-credentials: true
 Content-Type: application/json
-X-Stripe-Mock-Request: mandate_data\[customer_acceptance]\[online]\[infer_from_client]=true&mandate_data\[customer_acceptance]\[type]=online&payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[billing_details]\[email]=jenny%40example\.com&payment_method_data\[billing_details]\[name]=Jenny%20Rosen&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sepa_debit]\[iban]=DE89370400440532013000&payment_method_data\[sid]=.*&payment_method_data\[type]=sepa_debit&return_url=https%3A\/\/example\.com\/return&setup_future_usage=off_session&shipping\[address]\[city]=San%20Francisco&shipping\[address]\[country]=US&shipping\[address]\[line1]=123%20Main%20St&shipping\[address]\[postal_code]=94111&shipping\[address]\[state]=CA&shipping\[name]=Test%20Customer
+X-Stripe-Mock-Request: client_context\[capture_method]=automatic&client_context\[currency]=eur&client_context\[customer]=cus_test_customer&client_context\[mode]=payment&client_context\[payment_method_types]\[0]=sepa_debit&client_context\[setup_future_usage]=off_session&mandate_data\[customer_acceptance]\[online]\[infer_from_client]=true&mandate_data\[customer_acceptance]\[type]=online&payment_method_data\[allow_redisplay]=unspecified&payment_method_data\[billing_details]\[email]=jenny%40example\.com&payment_method_data\[billing_details]\[name]=Jenny%20Rosen&payment_method_data\[guid]=.*&payment_method_data\[muid]=.*&payment_method_data\[payment_user_agent]=.*&payment_method_data\[sepa_debit]\[iban]=DE89370400440532013000&payment_method_data\[sid]=.*&payment_method_data\[type]=sepa_debit&return_url=https%3A\/\/example\.com\/return&setup_future_usage=off_session&shipping\[address]\[city]=San%20Francisco&shipping\[address]\[country]=US&shipping\[address]\[line1]=123%20Main%20St&shipping\[address]\[postal_code]=94111&shipping\[address]\[state]=CA&shipping\[name]=Test%20Customer
 
 {
-  "id" : "ctoken_1S3euaFY0qyl6XeWMSnBJPJP",
+  "id" : "ctoken_1SBeYcFY0qyl6XeWn8GtyPjk",
   "setup_intent" : null,
   "livemode" : false,
   "shipping" : {
@@ -41,7 +41,7 @@ X-Stripe-Mock-Request: mandate_data\[customer_acceptance]\[online]\[infer_from_c
     "name" : "Test Customer",
     "phone" : null
   },
-  "expires_at" : 1757042240,
+  "expires_at" : 1758947502,
   "return_url" : "https:\/\/example.com\/return",
   "setup_future_usage" : "off_session",
   "object" : "confirmation_token",
@@ -75,7 +75,7 @@ X-Stripe-Mock-Request: mandate_data\[customer_acceptance]\[online]\[infer_from_c
     },
     "type" : "sepa_debit"
   },
-  "created" : 1756999040,
+  "created" : 1758904302,
   "payment_intent" : null,
   "use_stripe_sdk" : true,
   "payment_method_options" : null


### PR DESCRIPTION
## Summary
- To match web, we need to send client context when we create ConfirmationTokens
- Web request: req_GPJ3wgcDpyrj2c

## Motivation
- ConfirmationTokens

## Testing
- New tests
- Updated tests

## Changelog
N/A