### PR TITLE
Use merchant publishable key for Link requests

### DIFF
--- a/Stripe/StripeiOSTests/ConsumerSessionTests.swift
+++ b/Stripe/StripeiOSTests/ConsumerSessionTests.swift
@@ -189,17 +189,16 @@ class ConsumerSessionTests: STPNetworkStubbingTestCase {
         let useDetailsAfterLogoutExpectation = self.expectation(description: "try using payment details after logout")
         consumerSession.createPaymentDetails(
             paymentMethodParams: paymentMethodParams,
-            with: apiClient,
-            consumerAccountPublishableKey: sessionWithKey?.publishableKey
+            with: apiClient
         ) { result in
             switch result {
             case .success:
                 // If this succeeds, log out...
-                consumerSession.logout(with: self.apiClient, consumerAccountPublishableKey: sessionWithKey?.publishableKey) { logoutResult in
+                consumerSession.logout(with: self.apiClient) { logoutResult in
                     switch logoutResult {
                     case .success:
                         // Try to use the session again, it shouldn't work
-                        consumerSession.createPaymentDetails(paymentMethodParams: paymentMethodParams, with: self.apiClient, consumerAccountPublishableKey: sessionWithKey?.publishableKey) { loggedOutAuthenticatedActionResult in
+                        consumerSession.createPaymentDetails(paymentMethodParams: paymentMethodParams, with: self.apiClient) { loggedOutAuthenticatedActionResult in
                             switch loggedOutAuthenticatedActionResult {
                             case .success:
                                 XCTFail("Logout failed to invalidate token")
@@ -291,8 +290,7 @@ class ConsumerSessionTests: STPNetworkStubbingTestCase {
         let createExpectation = self.expectation(description: "create payment details")
         consumerSession.createPaymentDetails(
             paymentMethodParams: paymentMethodParams,
-            with: apiClient,
-            consumerAccountPublishableKey: sessionWithKey?.publishableKey
+            with: apiClient
         ) { result in
             switch result {
             case .success:

--- a/Stripe/StripeiOSTests/STPAPIClientStubbedTest.swift
+++ b/Stripe/StripeiOSTests/STPAPIClientStubbedTest.swift
@@ -389,7 +389,7 @@ class STPAPIClientStubbedTest: APIStubbedTestCase {
         let clientAttributionMetadata: STPClientAttributionMetadata = STPClientAttributionMetadata(elementsSessionConfigId: "elements_session_config_id", paymentIntentCreationFlow: .deferred, paymentMethodSelectionFlow: .automatic)
         stubClientAttributionMetadata(base: "payment_method_options", clientAttributionMetadata: clientAttributionMetadata)
         let e = expectation(description: "")
-        sut.sharePaymentDetails(for: "consumer_session_client_secret", id: "id", consumerAccountPublishableKey: nil, allowRedisplay: nil, cvc: nil, expectedPaymentMethodType: nil, billingPhoneNumber: nil, clientAttributionMetadata: clientAttributionMetadata) { _ in
+        sut.sharePaymentDetails(for: "consumer_session_client_secret", id: "id", allowRedisplay: nil, cvc: nil, expectedPaymentMethodType: nil, billingPhoneNumber: nil, clientAttributionMetadata: clientAttributionMetadata) { _ in
             e.fulfill()
         }
         waitForExpectations(timeout: 10)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -223,7 +223,6 @@ struct LinkPMDisplayDetails {
 
         session.startVerification(
             with: apiClient,
-            consumerAccountPublishableKey: publishableKey,
             requestSurface: requestSurface
         ) { [weak self] result in
             switch result {
@@ -259,7 +258,6 @@ struct LinkPMDisplayDetails {
         session.confirmSMSVerification(
             with: oneTimePasscode,
             with: apiClient,
-            consumerAccountPublishableKey: publishableKey,
             requestSurface: requestSurface,
             consentGranted: consentGranted
         ) { [weak self] result in
@@ -290,7 +288,6 @@ struct LinkPMDisplayDetails {
             }
 
             session.createLinkAccountSession(
-                consumerAccountPublishableKey: self.publishableKey,
                 requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
@@ -314,7 +311,6 @@ struct LinkPMDisplayDetails {
             session.createPaymentDetails(
                 paymentMethodParams: paymentMethodParams,
                 with: self.apiClient,
-                consumerAccountPublishableKey: self.publishableKey,
                 isDefault: isDefault,
                 requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
@@ -336,7 +332,6 @@ struct LinkPMDisplayDetails {
 
             session.createPaymentDetails(
                 linkedAccountId: linkedAccountId,
-                consumerAccountPublishableKey: self.publishableKey,
                 isDefault: isDefault,
                 requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
@@ -381,7 +376,6 @@ struct LinkPMDisplayDetails {
             session.listPaymentDetails(
                 with: self.apiClient,
                 supportedPaymentDetailsTypes: supportedTypes,
-                consumerAccountPublishableKey: self.publishableKey,
                 requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
@@ -417,7 +411,7 @@ struct LinkPMDisplayDetails {
                 return
             }
 
-            session.listShippingAddress(with: self.apiClient, consumerAccountPublishableKey: self.publishableKey, requestSurface: self.requestSurface, completion: completionRetryingOnAuthErrors)
+            session.listShippingAddress(with: self.apiClient, requestSurface: self.requestSurface, completion: completionRetryingOnAuthErrors)
         }
     }
 
@@ -437,7 +431,6 @@ struct LinkPMDisplayDetails {
             session.deletePaymentDetails(
                 with: self.apiClient,
                 id: id,
-                consumerAccountPublishableKey: self.publishableKey,
                 requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
@@ -449,7 +442,7 @@ struct LinkPMDisplayDetails {
         updateParams: UpdatePaymentDetailsParams,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
-        retryingOnAuthError(completion: completion) { [apiClient, publishableKey] completionRetryingOnAuthErrors in
+        retryingOnAuthError(completion: completion) { [apiClient] completionRetryingOnAuthErrors in
             guard let session = self.currentSession else {
                 stpAssertionFailure()
                 return completion(
@@ -465,7 +458,6 @@ struct LinkPMDisplayDetails {
                 with: apiClient,
                 id: id,
                 updateParams: updateParams,
-                consumerAccountPublishableKey: publishableKey,
                 requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
             )
@@ -481,7 +473,7 @@ struct LinkPMDisplayDetails {
         clientAttributionMetadata: STPClientAttributionMetadata,
         completion: @escaping (Result<PaymentDetailsShareResponse, Error>
     ) -> Void) {
-        retryingOnAuthError(completion: completion) { [apiClient, publishableKey] completionRetryingOnAuthErrors in
+        retryingOnAuthError(completion: completion) { [apiClient] completionRetryingOnAuthErrors in
             guard let session = self.currentSession else {
                 stpAssertionFailure()
                 return completion(
@@ -498,7 +490,6 @@ struct LinkPMDisplayDetails {
                 allowRedisplay: allowRedisplay,
                 expectedPaymentMethodType: expectedPaymentMethodType,
                 billingPhoneNumber: billingPhoneNumber,
-                consumerAccountPublishableKey: publishableKey,
                 clientAttributionMetadata: clientAttributionMetadata,
                 requestSurface: self.requestSurface,
                 completion: completionRetryingOnAuthErrors
@@ -532,7 +523,7 @@ struct LinkPMDisplayDetails {
         guard let session = currentSession else {
             return
         }
-        session.logout(with: apiClient, consumerAccountPublishableKey: publishableKey, requestSurface: requestSurface) { _ in
+        session.logout(with: apiClient, requestSurface: requestSurface) { _ in
             // We don't need to do anything if this fails, the key will expire automatically.
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -205,7 +205,6 @@ extension ConsumerSession {
     func createPaymentDetails(
         paymentMethodParams: STPPaymentMethodParams,
         with apiClient: STPAPIClient = STPAPIClient.shared,
-        consumerAccountPublishableKey: String?,
         isDefault: Bool = false,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
@@ -233,7 +232,6 @@ extension ConsumerSession {
             billingEmailAddress: billingEmailAddress,
             billingDetails: paymentMethodParams.nonnil_billingDetails,
             isDefault: isDefault,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             completion: completion)
     }
@@ -241,7 +239,6 @@ extension ConsumerSession {
     func createPaymentDetails(
         linkedAccountId: String,
         with apiClient: STPAPIClient = STPAPIClient.shared,
-        consumerAccountPublishableKey: String?,
         isDefault: Bool,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
@@ -249,7 +246,6 @@ extension ConsumerSession {
         apiClient.createPaymentDetails(
             for: clientSecret,
             linkedAccountId: linkedAccountId,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             isDefault: isDefault,
             requestSurface: requestSurface,
             completion: completion)
@@ -259,7 +255,6 @@ extension ConsumerSession {
         type: VerificationSession.SessionType = .sms,
         locale: Locale = .autoupdatingCurrent,
         with apiClient: STPAPIClient = STPAPIClient.shared,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
@@ -267,7 +262,6 @@ extension ConsumerSession {
             for: clientSecret,
             type: type,
             locale: locale,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             completion: completion)
     }
@@ -275,7 +269,6 @@ extension ConsumerSession {
     func confirmSMSVerification(
         with code: String,
         with apiClient: STPAPIClient = STPAPIClient.shared,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         consentGranted: Bool? = nil,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
@@ -283,7 +276,6 @@ extension ConsumerSession {
         apiClient.confirmSMSVerification(
             for: clientSecret,
             with: code,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             consentGranted: consentGranted,
             completion: completion)
@@ -291,7 +283,6 @@ extension ConsumerSession {
 
     func createLinkAccountSession(
         with apiClient: STPAPIClient = STPAPIClient.shared,
-        consumerAccountPublishableKey: String?,
         linkMode: LinkMode? = nil,
         intentToken: String? = nil,
         requestSurface: LinkRequestSurface = .default,
@@ -299,7 +290,6 @@ extension ConsumerSession {
     ) {
         apiClient.createLinkAccountSession(
             for: clientSecret,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             linkMode: linkMode,
             intentToken: intentToken,
             requestSurface: requestSurface,
@@ -309,27 +299,23 @@ extension ConsumerSession {
     func listPaymentDetails(
         with apiClient: STPAPIClient = STPAPIClient.shared,
         supportedPaymentDetailsTypes: [ConsumerPaymentDetails.DetailsType],
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<[ConsumerPaymentDetails], Error>) -> Void
     ) {
         apiClient.listPaymentDetails(
             for: clientSecret,
             supportedPaymentDetailsTypes: supportedPaymentDetailsTypes,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             completion: completion)
     }
 
     func listShippingAddress(
         with apiClient: STPAPIClient = STPAPIClient.shared,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ShippingAddressesResponse, Error>) -> Void
     ) {
         apiClient.listShippingAddress(
             for: clientSecret,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             completion: completion)
     }
@@ -337,14 +323,12 @@ extension ConsumerSession {
     func deletePaymentDetails(
         with apiClient: STPAPIClient = STPAPIClient.shared,
         id: String,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         apiClient.deletePaymentDetails(
             for: clientSecret,
             id: id,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             completion: completion)
     }
@@ -353,14 +337,12 @@ extension ConsumerSession {
         with apiClient: STPAPIClient = STPAPIClient.shared,
         id: String,
         updateParams: UpdatePaymentDetailsParams,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         apiClient.updatePaymentDetails(
             for: clientSecret, id: id,
             updateParams: updateParams,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             completion: completion)
     }
@@ -372,7 +354,6 @@ extension ConsumerSession {
         allowRedisplay: STPPaymentMethodAllowRedisplay?,
         expectedPaymentMethodType: String?,
         billingPhoneNumber: String?,
-        consumerAccountPublishableKey: String?,
         clientAttributionMetadata: STPClientAttributionMetadata,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<PaymentDetailsShareResponse, Error>) -> Void
@@ -380,7 +361,6 @@ extension ConsumerSession {
         apiClient.sharePaymentDetails(
             for: clientSecret,
             id: id,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             allowRedisplay: allowRedisplay,
             cvc: cvc,
             expectedPaymentMethodType: expectedPaymentMethodType,
@@ -392,13 +372,11 @@ extension ConsumerSession {
 
     func logout(
         with apiClient: STPAPIClient = STPAPIClient.shared,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
         apiClient.logout(
             consumerSessionClientSecret: clientSecret,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             completion: completion)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -202,13 +202,11 @@ extension STPAPIClient {
     private func makePaymentDetailsRequest(
         endpoint: String,
         parameters: [String: Any],
-        consumerAccountPublishableKey: String?,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
         post(
             resource: endpoint,
-            parameters: parameters,
-            consumerPublishableKey: consumerAccountPublishableKey
+            parameters: parameters
         ) { (result: Result<DetailsResponse, Error>) in
             completion(result.map { $0.redactedPaymentDetails })
         }
@@ -220,7 +218,6 @@ extension STPAPIClient {
         billingEmailAddress: String,
         billingDetails: STPPaymentMethodBillingDetails,
         isDefault: Bool,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
@@ -230,7 +227,6 @@ extension STPAPIClient {
             billingEmailAddress: billingEmailAddress,
             billingDetails: billingDetails,
             isDefault: isDefault,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             requestSurface: requestSurface,
             completion: completion
         )
@@ -242,7 +238,6 @@ extension STPAPIClient {
         billingEmailAddress: String,
         billingDetails: STPPaymentMethodBillingDetails,
         isDefault: Bool,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
@@ -264,7 +259,6 @@ extension STPAPIClient {
         makePaymentDetailsRequest(
             endpoint: endpoint,
             parameters: parameters,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion
         )
     }
@@ -272,7 +266,6 @@ extension STPAPIClient {
     func createPaymentDetails(
         for consumerSessionClientSecret: String,
         linkedAccountId: String,
-        consumerAccountPublishableKey: String?,
         isDefault: Bool,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
@@ -292,7 +285,6 @@ extension STPAPIClient {
         makePaymentDetailsRequest(
             endpoint: endpoint,
             parameters: parameters,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion
         )
     }
@@ -300,13 +292,11 @@ extension STPAPIClient {
     private func makeConsumerSessionRequest(
         endpoint: String,
         parameters: [String: Any],
-        consumerAccountPublishableKey: String?,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
         post(
             resource: endpoint,
-            parameters: parameters,
-            consumerPublishableKey: consumerAccountPublishableKey
+            parameters: parameters
         ) { (result: Result<SessionResponse, Error>) in
             completion(result.map { $0.consumerSession })
         }
@@ -341,7 +331,6 @@ extension STPAPIClient {
 
     func createLinkAccountSession(
         for consumerSessionClientSecret: String,
-        consumerAccountPublishableKey: String?,
         linkMode: LinkMode? = nil,
         intentToken: String? = nil,
         requestSurface: LinkRequestSurface = .default,
@@ -361,7 +350,7 @@ extension STPAPIClient {
         APIRequest<LinkAccountSession>.post(
             with: self,
             endpoint: endpoint,
-            additionalHeaders: authorizationHeader(using: consumerAccountPublishableKey),
+            additionalHeaders: authorizationHeader(),
             parameters: parameters,
             completion: completion
         )
@@ -370,7 +359,6 @@ extension STPAPIClient {
     func sharePaymentDetails(
         for consumerSessionClientSecret: String,
         id: String,
-        consumerAccountPublishableKey: String?,
         overridePublishableKey: String? = nil,
         allowRedisplay: STPPaymentMethodAllowRedisplay?,
         cvc: String?,
@@ -428,7 +416,6 @@ extension STPAPIClient {
     func listPaymentDetails(
         for consumerSessionClientSecret: String,
         supportedPaymentDetailsTypes: [ConsumerPaymentDetails.DetailsType],
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<[ConsumerPaymentDetails], Error>) -> Void
     ) {
@@ -442,8 +429,7 @@ extension STPAPIClient {
 
         post(
             resource: endpoint,
-            parameters: parameters,
-            consumerPublishableKey: consumerAccountPublishableKey
+            parameters: parameters
         ) { (result: Result<DetailsListResponse, Error>) in
             completion(result.map { $0.redactedPaymentDetails })
         }
@@ -451,7 +437,6 @@ extension STPAPIClient {
 
     func listShippingAddress(
         for consumerSessionClientSecret: String,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ShippingAddressesResponse, Error>) -> Void
     ) {
@@ -462,8 +447,7 @@ extension STPAPIClient {
         ]
         post(
             resource: endPoint,
-            parameters: parameters,
-            consumerPublishableKey: consumerAccountPublishableKey
+            parameters: parameters
         ) { (result: Result<ShippingAddressesResponse, Error>) in
             completion(result)
         }
@@ -472,7 +456,6 @@ extension STPAPIClient {
     func deletePaymentDetails(
         for consumerSessionClientSecret: String,
         id: String,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
@@ -486,7 +469,7 @@ extension STPAPIClient {
         APIRequest<STPEmptyStripeResponse>.delete(
             with: self,
             endpoint: endpoint,
-            additionalHeaders: authorizationHeader(using: consumerAccountPublishableKey),
+            additionalHeaders: authorizationHeader(),
             parameters: parameters
         ) { result in
             completion(result.map { _ in () } )
@@ -497,7 +480,6 @@ extension STPAPIClient {
         for consumerSessionClientSecret: String,
         id: String,
         updateParams: UpdatePaymentDetailsParams,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerPaymentDetails, Error>) -> Void
     ) {
@@ -544,14 +526,12 @@ extension STPAPIClient {
         makePaymentDetailsRequest(
             endpoint: endpoint,
             parameters: parameters,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion
         )
     }
 
     func updatePhoneNumber(
         consumerSessionClientSecret: String,
-        consumerAccountPublishableKey: String?,
         phoneNumber: String,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
@@ -568,8 +548,7 @@ extension STPAPIClient {
 
         post(
             resource: endpoint,
-            parameters: parameters,
-            consumerPublishableKey: consumerAccountPublishableKey
+            parameters: parameters
         ) { (result: Result<UpdatePhoneNumberResponse, Error>) in
             completion(result.map { $0.consumerSession })
         }
@@ -577,7 +556,6 @@ extension STPAPIClient {
 
     func logout(
         consumerSessionClientSecret: String,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
@@ -593,7 +571,6 @@ extension STPAPIClient {
         makeConsumerSessionRequest(
             endpoint: endpoint,
             parameters: parameters,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion
         )
     }
@@ -616,7 +593,6 @@ extension STPAPIClient {
         makeConsumerSessionRequest(
             endpoint: endpoint,
             parameters: parameters,
-            consumerAccountPublishableKey: nil,
             completion: completion
         )
     }
@@ -625,7 +601,6 @@ extension STPAPIClient {
         for consumerSessionClientSecret: String,
         type: ConsumerSession.VerificationSession.SessionType,
         locale: Locale,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
@@ -651,7 +626,6 @@ extension STPAPIClient {
         makeConsumerSessionRequest(
             endpoint: endpoint,
             parameters: parameters,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion
         )
     }
@@ -659,7 +633,6 @@ extension STPAPIClient {
     func confirmSMSVerification(
         for consumerSessionClientSecret: String,
         with code: String,
-        consumerAccountPublishableKey: String?,
         requestSurface: LinkRequestSurface = .default,
         consentGranted: Bool? = nil,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
@@ -680,7 +653,6 @@ extension STPAPIClient {
         makeConsumerSessionRequest(
             endpoint: endpoint,
             parameters: parameters,
-            consumerAccountPublishableKey: consumerAccountPublishableKey,
             completion: completion
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -602,7 +602,6 @@ extension PayWithLinkViewController: PayWithLinkCoordinating {
             switch sessionResult {
             case .success(let session):
                 session.createLinkAccountSession(
-                    consumerAccountPublishableKey: linkAccount.publishableKey,
                     linkMode: self?.context.elementsSession.linkSettings?.linkMode,
                     intentToken: self?.context.intent.stripeId
                 ) { [session, weak self] linkAccountSessionResult in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -502,7 +502,6 @@ import UIKit
 
         apiClient.updatePhoneNumber(
             consumerSessionClientSecret: consumerSessionClientSecret,
-            consumerAccountPublishableKey: linkAccount.publishableKey,
             phoneNumber: phoneNumber,
             requestSurface: requestSurface
         ) { [weak self] result in
@@ -523,14 +522,13 @@ import UIKit
             completion(.success(()))
         }
 
-        guard let session = linkAccount?.currentSession, let publishableKey = linkAccount?.publishableKey else {
+        guard let session = linkAccount?.currentSession else {
             // If no Link account is available, treat this as a success.
             clearLinkAccountContextAndComplete()
             return
         }
 
         session.logout(
-            consumerAccountPublishableKey: publishableKey,
             requestSurface: requestSurface,
             completion: { result in
                 switch result {
@@ -605,7 +603,6 @@ import UIKit
         apiClient.sharePaymentDetails(
             for: consumerSessionClientSecret,
             id: paymentDetails.stripeID,
-            consumerAccountPublishableKey: nil,
             overridePublishableKey: overridePublishableKey,
             allowRedisplay: nil,
             cvc: paymentDetails.cvc,


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request switches to using the merchant publishable key (together with the consumer session client secret) for consumer API requests. This aligns iOS with other platforms.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
