### PR TITLE
Hide 'Use billing as shipping' checkbox when address is missing a line1

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -179,8 +179,11 @@ public class AddressViewController: UIViewController {
 
         guard isCompatible else { return nil }
 
-        // Default to checked if shipping address (defaultValues) is empty and billing address has at least line1
-        let isSelectedByDefault = configuration.defaultValues.address.isEmpty && billingAddress.address.line1?.nonEmpty != nil
+        // Only show checkbox if billing address has at least line1
+        guard billingAddress.address.line1?.nonEmpty != nil else { return nil }
+
+        // Default to checked if shipping address (defaultValues) is empty
+        let isSelectedByDefault = configuration.defaultValues.address.isEmpty
 
         return CheckboxElement(
             theme: configuration.appearance.asElementsTheme,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -179,8 +179,8 @@ public class AddressViewController: UIViewController {
 
         guard isCompatible else { return nil }
 
-        // Default to checked if shipping address (defaultValues) is empty or not provided
-        let isSelectedByDefault = configuration.defaultValues.address.isEmpty
+        // Default to checked if shipping address (defaultValues) is empty and billing address has at least line1
+        let isSelectedByDefault = configuration.defaultValues.address.isEmpty && billingAddress.address.line1?.nonEmpty != nil
 
         return CheckboxElement(
             theme: configuration.appearance.asElementsTheme,


### PR DESCRIPTION
## Summary
- Only show the "Use billing as shipping" checkbox when the address has a line1
- Previously it was checked whenever shipping address was empty, even if billing address was incomplete
- This confused users into thinking their billing address was fully populated

## Test plan
In PaymentSheet Example