### PR TITLE
Crypto Onramp SDK: Prevents Back Navigation When Necessary in Example App

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampExampleView.swift
@@ -106,59 +106,61 @@ struct CryptoOnrampExampleView: View {
             .navigationBarTitleDisplayMode(.inline)
             .navigationDestination(for: CryptoOnrampFlowCoordinator.Route.self) { route in
                 if let coordinator {
-                    switch route {
-                    case let .registration(email, scopes):
-                        RegistrationView(
-                            coordinator: coordinator,
-                            email: email,
-                            selectedScopes: scopes,
-                            livemode: livemode
-                        ) { customerId in
-                            flowCoordinator.advanceAfterRegistration(customerId: customerId)
-                        }
-                    case .kycInfo:
-                        KYCInfoView(coordinator: coordinator) {
-                            flowCoordinator.advanceAfterKyc()
-                        }
-                        .authenticatedUserToolbar(coordinator: coordinator, flowCoordinator: flowCoordinator)
-                    case .identity:
-                        IdentityVerificationView(coordinator: coordinator) {
-                            flowCoordinator.advanceAfterIdentity()
-                        }
-                        .authenticatedUserToolbar(coordinator: coordinator, flowCoordinator: flowCoordinator)
-                    case let .wallets(customerId):
-                        WalletSelectionView(
-                            coordinator: coordinator,
-                            customerId: customerId
-                        ) { wallet in
-                            flowCoordinator.advanceAfterWalletSelection(wallet)
-                        }
-                        .authenticatedUserToolbar(coordinator: coordinator, flowCoordinator: flowCoordinator)
-                    case let .payment(customerId, wallet):
-                        PaymentView(
-                            coordinator: coordinator,
-                            customerId: customerId,
-                            wallet: wallet
-                        ) { response, selectedPaymentMethodDescription in
-                            flowCoordinator.advanceAfterPayment(
-                                createOnrampSessionResponse: response,
+                    ZStack {
+                        switch route {
+                        case let .registration(email, scopes):
+                            RegistrationView(
+                                coordinator: coordinator,
+                                email: email,
+                                selectedScopes: scopes,
+                                livemode: livemode
+                            ) { customerId in
+                                flowCoordinator.advanceAfterRegistration(customerId: customerId)
+                            }
+                        case .kycInfo:
+                            KYCInfoView(coordinator: coordinator) {
+                                flowCoordinator.advanceAfterKyc()
+                            }
+                        case .identity:
+                            IdentityVerificationView(coordinator: coordinator) {
+                                flowCoordinator.advanceAfterIdentity()
+                            }
+                        case let .wallets(customerId):
+                            WalletSelectionView(
+                                coordinator: coordinator,
+                                customerId: customerId
+                            ) { wallet in
+                                flowCoordinator.advanceAfterWalletSelection(wallet)
+                            }
+                        case let .payment(customerId, wallet):
+                            PaymentView(
+                                coordinator: coordinator,
+                                customerId: customerId,
+                                wallet: wallet
+                            ) { response, selectedPaymentMethodDescription in
+                                flowCoordinator.advanceAfterPayment(
+                                    createOnrampSessionResponse: response,
+                                    selectedPaymentMethodDescription: selectedPaymentMethodDescription
+                                )
+                            }
+                        case let .paymentSummary(createOnrampSessionResponse, selectedPaymentMethodDescription):
+                            PaymentSummaryView(
+                                coordinator: coordinator,
+                                onrampSessionResponse: createOnrampSessionResponse,
                                 selectedPaymentMethodDescription: selectedPaymentMethodDescription
-                            )
+                            ) { message in
+                                flowCoordinator.advanceAfterPaymentSummary(successfulCheckoutMessage: message)
+                            }
+                        case let .checkoutSuccess(message):
+                            CheckoutSuccessView(message: message)
                         }
-                        .authenticatedUserToolbar(coordinator: coordinator, flowCoordinator: flowCoordinator)
-                    case let .paymentSummary(createOnrampSessionResponse, selectedPaymentMethodDescription):
-                        PaymentSummaryView(
-                            coordinator: coordinator,
-                            onrampSessionResponse: createOnrampSessionResponse,
-                            selectedPaymentMethodDescription: selectedPaymentMethodDescription
-                        ) { message in
-                            flowCoordinator.advanceAfterPaymentSummary(successfulCheckoutMessage: message)
-                        }
-                        .authenticatedUserToolbar(coordinator: coordinator, flowCoordinator: flowCoordinator)
-                    case let .checkoutSuccess(message):
-                        CheckoutSuccessView(message: message)
-                            .authenticatedUserToolbar(coordinator: coordinator, flowCoordinator: flowCoordinator)
                     }
+                    .navigationBarBackButtonHidden(!route.allowsBackNavigation)
+                    .authenticatedUserToolbar(
+                        isShown: route.showsAuthenticatedUserToolbarItem,
+                        coordinator: coordinator,
+                        flowCoordinator: flowCoordinator
+                    )
                 }
             }
         }

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampFlowCoordinator.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/CryptoOnrampFlowCoordinator.swift
@@ -169,3 +169,26 @@ private extension CustomerInformationResponse {
         verifications.contains { $0.name == "id_document_verified" && $0.status == "verified" }
     }
 }
+
+extension CryptoOnrampFlowCoordinator.Route {
+
+    /// Whether the user should be able to advance backwards from this step.
+    var allowsBackNavigation: Bool {
+        switch self {
+        case .registration, .payment, .paymentSummary:
+            true
+        case .wallets, .kycInfo, .identity, .checkoutSuccess:
+            false
+        }
+    }
+
+    /// Whether to display the toolbar item for authenticated user actions, such as logging out.
+    var showsAuthenticatedUserToolbarItem: Bool {
+        switch self {
+        case .wallets, .kycInfo, .identity, .payment, .paymentSummary, .checkoutSuccess:
+            true
+        case .registration:
+            false
+        }
+    }
+}

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/AuthenticatedUserToolbarItemModifier.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/UI Helpers/AuthenticatedUserToolbarItemModifier.swift
@@ -14,15 +14,17 @@ extension View {
 
     /// Convenience modifier to show a trailing toolbar item for accessing user-related actions, such as "log out".
     /// - Parameters:
+    ///   - isShown: Whether the toolbar item is shown.
     ///   - coordinator: The coordinator used to perform user-related actions.
     ///   - flowCoordinator: The flow coordinator used to manipulate the navigation stack.
     /// - Returns: The modified view.
-    func authenticatedUserToolbar(coordinator: CryptoOnrampCoordinator, flowCoordinator: CryptoOnrampFlowCoordinator?) -> some View {
-        self.modifier(AuthenticatedUserToolbarItemModifier(coordinator: coordinator, flowCoordinator: flowCoordinator))
+    func authenticatedUserToolbar(isShown: Bool, coordinator: CryptoOnrampCoordinator, flowCoordinator: CryptoOnrampFlowCoordinator?) -> some View {
+        self.modifier(AuthenticatedUserToolbarItemModifier(isShown: isShown, coordinator: coordinator, flowCoordinator: flowCoordinator))
     }
 }
 
 private struct AuthenticatedUserToolbarItemModifier: ViewModifier {
+    let isShown: Bool
     let coordinator: CryptoOnrampCoordinator
     let flowCoordinator: CryptoOnrampFlowCoordinator?
 
@@ -31,20 +33,22 @@ private struct AuthenticatedUserToolbarItemModifier: ViewModifier {
     func body(content: Content) -> some View {
         content
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                Menu {
-                    Button(role: .destructive) {
-                        logOut()
+            if isShown {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Menu {
+                        Button(role: .destructive) {
+                            logOut()
+                        } label: {
+                            Label("Log out", systemImage: "rectangle.portrait.and.arrow.right")
+                                .tint(.red)
+                        }
                     } label: {
-                        Label("Log out", systemImage: "rectangle.portrait.and.arrow.right")
-                            .tint(.red)
+                        Image(systemName: "person.fill")
                     }
-                } label: {
-                    Image(systemName: "person.fill")
+                    .disabled(isLoading.wrappedValue)
+                    .opacity(isLoading.wrappedValue ? 0.5 : 1)
+                    .tint(.accentColor)
                 }
-                .disabled(isLoading.wrappedValue)
-                .opacity(isLoading.wrappedValue ? 0.5 : 1)
-                .tint(.accentColor)
             }
         }
      }


### PR DESCRIPTION
## Summary

Originally, I wanted to drop path items from the back stack if certain steps couldn’t be completed (e.g. advancing back after completing registration, the pre-filled email address would no longer work to register, so drop that step) but this was causing navigation animation issues that required hacks to work around.

Instead, from certain steps, I disallow back navigation, except where the previous step (e.g. selecting a crypto wallet, selecting a payment method) could be repeated successfully and used in subsequent steps. Additionally, since the logout toolbar item could be applied using a similar pattern, I cleaned up the code around this to avoid duplication of that modifier.

## Motivation
To not allow the user to repeat a successful step that we know would cause an error.

## Testing
Ran through the flow with a new account to ensure the back button (and ability to swipe back) was only present when expected. I could only get as far as payment selection, as[ I’m receiving 500s from the demo backend](https://lickability.slack.com/archives/C094P3BRBL1/p1759340960103889) when creating an onramp session.

| Registration | KYC | Identity | Wallet | Payment |
| --- | --- | --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/938337e5-cb9c-4ca7-8238-b7e7c1494d1a" width="300" /> | <img src="https://github.com/user-attachments/assets/d836fedf-575c-4871-9da8-782033dfed91" width="300" /> | <img src="https://github.com/user-attachments/assets/5151babe-c801-47df-ba06-8b35b06da8ac" width="300" /> | <img src="https://github.com/user-attachments/assets/ca3819a2-5971-42c9-a1c5-a5da2e350196" width="300" /> | <img src="https://github.com/user-attachments/assets/ee21d88a-ee3f-4337-a9c4-507494f2d5f5" width="300" /> |

## Changelog
N/A