### PR TITLE
Fix Spacing of Link Payment Picker on iPad

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/PaymentMethodPicker/LinkPaymentMethodPicker.swift
@@ -149,7 +149,6 @@ final class LinkPaymentMethodPicker: UIView {
         ])
 
         stackView.axis = .vertical
-        stackView.distribution = .equalSpacing
         stackView.clipsToBounds = true
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView


### PR DESCRIPTION
## Summary
This PR adjusts the spacing on iPad in the Link payment picker. 

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/64f3f617-f963-490b-a102-e3630ee9ec3c" width="300" /> | <img src="https://github.com/user-attachments/assets/dcf1a70f-45ba-433e-9566-0b462ceed769" width="300" /> |

This was caused by excess `_UIOLAGapGuide - UISV-distributing` views placed by the payment picker stack view on iPad. These views only cause a glitch on iPad and, when removed, don't modify layout on iPhone.

<img width="600" alt="view debugger" src="https://github.com/user-attachments/assets/391c454c-4d05-4481-a731-ea8112912dce" />

## Motivation
A visual UI glitch spotted during testing.

## Testing
Manual testing and snapshot review.
