### PR TITLE
Add click handler to WalletButtonsView

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleWalletButtonsView.swift
@@ -286,15 +286,16 @@ struct WalletButtonsFlowControllerView: View {
             WalletButtonsView(
                 flowController: flowController,
                 confirmHandler: { _ in },
-                clickHandler: enableClickHandler ? { expressType in
-                    let shouldReject = switch expressType {
-                    case .applePay: rejectApplePay
-                    case .link: rejectLink
-                    case .shopPay: rejectShopPay
+                clickHandler: enableClickHandler ? { walletType in
+                    let shouldReject = switch walletType {
+                    case "apple_pay": rejectApplePay
+                    case "link": rejectLink
+                    case "shop_pay": rejectShopPay
+                    default: false
                     }
 
                     if shouldReject {
-                        errorMessage = "Click rejected for \(expressType.rawValue)"
+                        errorMessage = "Click rejected for \(walletType)"
                         showingError = true
                         return false
                     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/WalletButtonsViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/WalletButtonsViewTests.swift
@@ -272,7 +272,7 @@ class WalletButtonsViewTests: XCTestCase {
         XCTAssertEqual(view.orderedWallets, [.applePay, .shopPay])
     }
 
-    func testClickHandlerInvokedWithCorrectExpressType() async {
+    func testClickHandlerInvokedWithCorrectExpressType() {
         // Create mock elements session with Link and Apple Pay
         let elementsSession = STPElementsSession(
             allResponseFields: [:],
@@ -304,9 +304,9 @@ class WalletButtonsViewTests: XCTestCase {
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
         let flowController = PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
 
-        var capturedExpressType: ExpressType?
-        let clickHandler: WalletButtonsView.WalletButtonClickHandler = { expressType in
-            capturedExpressType = expressType
+        var capturedWalletType: String?
+        let clickHandler: WalletButtonsView.WalletButtonClickHandler = { walletType in
+            capturedWalletType = walletType
             return true
         }
 
@@ -314,13 +314,13 @@ class WalletButtonsViewTests: XCTestCase {
         let view = WalletButtonsView(flowController: flowController, confirmHandler: { _ in }, clickHandler: clickHandler)
 
         // Simulate button tap
-        await view.checkoutTapped(.applePay)
+        view.checkoutTapped(.applePay)
 
-        // Verify handler was called with correct express type
-        XCTAssertEqual(capturedExpressType, .applePay)
+        // Verify handler was called with correct wallet type string
+        XCTAssertEqual(capturedWalletType, "apple_pay")
     }
 
-    func testClickHandlerReturningTrueAllowsCheckout() async {
+    func testClickHandlerReturningTrueAllowsCheckout() {
         // Create mock elements session with Link and Apple Pay
         let elementsSession = STPElementsSession(
             allResponseFields: [:],
@@ -366,14 +366,14 @@ class WalletButtonsViewTests: XCTestCase {
         }, clickHandler: clickHandler)
 
         // Simulate button tap
-        await view.checkoutTapped(.applePay)
+        view.checkoutTapped(.applePay)
 
         // Verify handler was called
         XCTAssertTrue(handlerWasCalled)
         // Note: We can't reliably test if confirm was called since Apple Pay requires actual device capabilities
     }
 
-    func testClickHandlerReturningFalseCancelsCheckout() async {
+    func testClickHandlerReturningFalseCancelsCheckout() {
         // Create mock elements session with Link and Apple Pay
         let elementsSession = STPElementsSession(
             allResponseFields: [:],
@@ -419,7 +419,7 @@ class WalletButtonsViewTests: XCTestCase {
         }, clickHandler: clickHandler)
 
         // Simulate button tap
-        await view.checkoutTapped(.applePay)
+        view.checkoutTapped(.applePay)
 
         // Verify handler was called
         XCTAssertTrue(handlerWasCalled)
@@ -427,7 +427,7 @@ class WalletButtonsViewTests: XCTestCase {
         XCTAssertFalse(confirmHandlerWasCalled)
     }
 
-    func testNoClickHandlerAllowsNormalCheckout() async {
+    func testNoClickHandlerAllowsNormalCheckout() {
         // Create mock elements session with Link and Apple Pay
         let elementsSession = STPElementsSession(
             allResponseFields: [:],
@@ -463,7 +463,7 @@ class WalletButtonsViewTests: XCTestCase {
         let view = WalletButtonsView(flowController: flowController, confirmHandler: { _ in })
 
         // Simulate button tap - should proceed normally without error
-        await view.checkoutTapped(.applePay)
+        view.checkoutTapped(.applePay)
 
         // Test passes if no error is thrown
     }


### PR DESCRIPTION
## Summary
Add support for intercepting wallet button clicks via a synchronous handler. This allows developers to validate or perform checks before allowing checkout to proceed.

The API is similar to the web's `ExpressCheckoutElement.on('click')` but uses a simpler synchronous Swift pattern with string wallet type identifiers.

## Changes
- Added `WalletButtonClickHandler` typealias: `(String) -> Bool`
- Added optional `clickHandler` parameter to `WalletButtonsView` initializers
- Modified `checkoutTapped` to invoke handler (passing wallet type as string) before proceeding with checkout
- Updated button action closures to call the synchronous `checkoutTapped` function
- Added comprehensive unit tests for click handler behavior
- Added testing UI in `ExampleWalletButtonsView` with options to reject clicks per wallet type

## API Usage
```swift
let view = WalletButtonsView(
    flowController: flowController,
    confirmHandler: { result in /* ... */ },
    clickHandler: { walletType in
        // walletType is "apple_pay", "link", or "shop_pay"
        let isValid = validateCheckout() // synchronous
        return isValid // true to proceed, false to cancel
    }
)
```

## Test Plan
- Added unit tests covering all scenarios:
  - Handler called with correct wallet type string
  - Checkout proceeds when handler returns true
  - Checkout cancelled when handler returns false
  - Normal checkout flow when no handler is set
- Added manual testing UI in example app with toggles to test rejection behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)