### PR TITLE
Retry for network errors on first call

### DIFF
--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1525,12 +1525,11 @@ public class STPPaymentHandler: NSObject {
                         timeout: pollingBudget?.networkTimeout
                     ) { [self] paymentIntent, error in
                         guard let paymentIntent, error == nil else {
-                            // If we got an error retrieving the intent, retry if budget allows.
-                            // Note: This will only retry if we have a pollingBudget, which means it's a polling call.
-                            // We won't retry if it's the first call (no pollingBudget). Ideally we should retry
-                            // on the first call too, but this is a limitation to address in a future rewrite.
-                            if let pollingBudget, pollingBudget.canPoll {
-                                pollingBudget.pollAfter {
+                            // Retry if polling budget allows. For the first call (no polling budget), create a minimal
+                            // budget to allow one retry. This handles transient network errors.
+                            let effectivePollingBudget = pollingBudget ?? PollingBudget(startDate: Date(), duration: 1)
+                            if effectivePollingBudget.canPoll {
+                                effectivePollingBudget.pollAfter {
                                     self._retrieveAndCheckIntentForCurrentAction(
                                         pollingBudget: pollingBudget
                                     )
@@ -1619,12 +1618,11 @@ public class STPPaymentHandler: NSObject {
                 timeout: pollingBudget?.networkTimeout
             ) { setupIntent, error in
                 guard let setupIntent, error == nil else {
-                    // If we got an error retrieving the intent, retry if budget allows.
-                    // Note: This will only retry if we have a pollingBudget, which means it's a polling call.
-                    // We won't retry if it's the first call (no pollingBudget). Ideally we should retry
-                    // on the first call too, but this is a limitation to address in a future rewrite.
-                    if let pollingBudget, pollingBudget.canPoll {
-                        pollingBudget.pollAfter {
+                    // Retry if polling budget allows. For the first call (no polling budget), create a minimal
+                    // budget to allow one retry. This handles transient network errors.
+                    let effectivePollingBudget = pollingBudget ?? PollingBudget(startDate: Date(), duration: 1)
+                    if effectivePollingBudget.canPoll {
+                        effectivePollingBudget.pollAfter {
                             self._retrieveAndCheckIntentForCurrentAction(
                                 pollingBudget: pollingBudget
                             )


### PR DESCRIPTION
## Summary
- Completes a TODO that we should retry on the first fetch of an intent if we get back a network error to be more resilient. 

## Motivation
- Improved error handling, more graceful

## Testing
- Manual in live mode 

## Changelog
N/A
