### PR TITLE
Fix download localizations script by using --async flag

### DIFF
--- a/ci_scripts/download_localized_strings_from_lokalise.sh
+++ b/ci_scripts/download_localized_strings_from_lokalise.sh
@@ -2,10 +2,18 @@
 
 set -e
 
+REQUIRED_VERSION="3.1.4"
+
 if [[ -z $(which lokalise2) ]]; then
-    echo "Installing lokalise2 via homebrew..."
+    echo "Installing lokalise2 v${REQUIRED_VERSION} via homebrew..."
     brew tap lokalise/cli-2
     brew install lokalise2
+else
+    CURRENT_VERSION=$(lokalise2 --version 2>&1 | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+    if [[ "$(printf '%s\n' "$REQUIRED_VERSION" "$CURRENT_VERSION" | sort -V | head -n1)" != "$REQUIRED_VERSION" ]]; then
+        echo "lokalise2 v${CURRENT_VERSION} is installed, but v${REQUIRED_VERSION} or newer is required. Upgrading..."
+        brew upgrade lokalise2
+    fi
 fi
 
 if [[ -z $(which recode) ]]; then
@@ -26,6 +34,7 @@ FINAL_STATUS_ID=587
 lokalise2 --token "$API_TOKEN" \
           --project-id $PROJECT_ID \
           file download \
+          --async \
           --format strings \
           --filter-langs "$LANGUAGES" \
           --filter-filenames "$LOKALISE_FILENAMES" \


### PR DESCRIPTION
## Summary
```
2025/09/29 11:48:36 Warning: Project too big for sync export. Please use our async export endpoint instead. (/files/async-download)
```

Now we use the async flag.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4724

## Testing
Ran the script locally, saw it successfully download.

## Changelog
Not user facing
