### PR TITLE
Make create release script ensure there are no unstaged changes before proceeding

### DIFF
--- a/ci_scripts/create_release.rb
+++ b/ci_scripts/create_release.rb
@@ -16,6 +16,10 @@ end
 
 puts "Proposing version: #{@version}".red
 
+# Ensure there are no unstaged changes before starting
+unstaged_changes = `git diff --name-only`.strip
+abort('You have unstaged changes. Please commit or stash them before creating a release.') unless unstaged_changes.empty?
+
 # Create a new branch for the release, e.g. bg/release-9.0.0
 @branchname = "releases/#{@version}"
 


### PR DESCRIPTION
## Summary
see title

## Motivation
The script unconditionally adds all changes and pushes - if you have unstaged changes when you run the script, they'll accidentally be included in the release branch.

## Testing
Untested

## Changelog
Not user facing
