### PR TITLE
Adds --major, --minor, and --patch flags to create_release script

### DIFF
--- a/ci_scripts/create_release.rb
+++ b/ci_scripts/create_release.rb
@@ -7,7 +7,7 @@ require_relative 'validate_version_number'
 @version = @specified_version
 
 # If no argument, exit
-abort("Specify a version number. (e.g. `#{__FILE__} --version 21.0.0`)") if @version.nil?
+abort("Specify a version number or increment flag. (e.g. `#{__FILE__} --version 21.0.0` or `#{__FILE__} --patch/minor/major`)") if @version.nil?
 
 # Make sure version is a valid version number
 unless @version.match(/^[0-9]+\.[0-9]+\.[0-9]+$/)


### PR DESCRIPTION
 Adds --major, --minor, and --patch flags to automatically increment the version from VERSION file, eliminating the need to manually specify the full version number each time.
```
  Usage examples:
  # Patch: 24.24.1 → 24.24.2
  ./ci_scripts/create_release.rb --patch

  # Minor: 24.24.1 → 24.25.0  
  ./ci_scripts/create_release.rb --minor

  # Major: 24.24.1 → 25.0.0
  ./ci_scripts/create_release.rb --major

  # Original way still works
  ./ci_scripts/create_release.rb --version 25.0.0
```

## Testing
Ran script w/ dry run

## Changelog
Not user facing