### PR TITLE
Assert merchants don't use a restricted key (rk_*)

### DIFF
--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -153,10 +153,13 @@ import UIKit
             )
             return
         }
-        let secretKey = publishableKey.hasPrefix("sk_")
         assert(
-            !secretKey,
+            !publishableKey.hasPrefix("sk_"),
             "You are using a secret key. Use a publishable key instead. For more info, see https://stripe.com/docs/keys"
+        )
+        assert(
+            !publishableKey.hasPrefix("rk_"),
+            "You are using a restricted key. Use a publishable key instead. For more info, see https://stripe.com/docs/keys"
         )
         #if !DEBUG
             if publishableKey.lowercased().hasPrefix("pk_test") && !didShowTestmodeKeyWarning {


### PR DESCRIPTION
.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4722

## Changelog
Don't think this is worth calling out.