### PR TITLE
Don't show Link webview fallback immediately when opening the payment sheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -47,7 +47,8 @@ extension STPElementsSession {
         linkAccount.sessionState == .requiresVerification &&
         !linkAccount.hasStartedSMSVerification &&
         linkAccount.useMobileEndpoints &&
-        self.linkSettings?.suppress2FAModal != true
+        self.linkSettings?.suppress2FAModal != true &&
+        linkAccount.currentSession?.mobileFallbackWebviewParams?.webviewRequirementType != .required
     }
 
     var linkFlags: [String: Bool] {


### PR DESCRIPTION
## Summary

Showing the Link webview fallback immediately when opening the payment sheet is a bit jarring. We won't launch right into it anymore.

## Motivation

Felt right

## Testing

Before:

https://github.com/user-attachments/assets/b1056aa7-f0d5-41d3-a765-cd907bbcd32b

After:

https://github.com/user-attachments/assets/e74519e3-c05f-4aa2-9f27-b8d289b646b9


## Changelog

N/a