### PR TITLE
Fix Xcode 15 Link New Payment Snapshot Tests

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-NewPaymentViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-NewPaymentViewControllerSnapshotTests.swift
@@ -10,6 +10,7 @@ import StripeCoreTestUtils
 @testable@_spi(STP) import StripePaymentSheet
 @testable@_spi(STP) import StripeUICore
 
+// @iOS26
 class PayWithLinkViewController_NewPaymentViewControllerSnapshotTests: STPSnapshotTestCase {
 
     override func setUp() {


### PR DESCRIPTION
## Summary
The tests on Xcode 15 [failed](https://app.bitrise.io/app/b220f4ba85d134a7/pipelines/52a67dd3-86ca-4485-886a-cdcbe0c28ea7?tests_filter_status=all) when deploying v24.24.2. This PR fixes the build error with these tests by adding a missing `// @iOS26` tag to the tests.

## Motivation
Fix failing tests.

## Testing
- [ ] Run this locally on Xcode 15 (struggling to download this since Tahoe doesn't support)
