### PR TITLE
CryptoOnramp SDK: Exposes SDK Error Types

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -13,7 +13,8 @@
 extension STPAPIClient {
 
     /// Errors that can occur that are specific to usage of crypto endpoints.
-    enum CryptoOnrampAPIError: LocalizedError {
+    @_spi(STP)
+    public enum CryptoOnrampAPIError: LocalizedError {
 
         /// No consumer session client secret was found to be associated with the active link account session.
         case missingConsumerSessionClientSecret
@@ -21,7 +22,8 @@ extension STPAPIClient {
         /// The request requires a session with a verified link account, but the account was found to not be verified.
         case linkAccountNotVerified
 
-        var errorDescription: String? {
+        @_spi(STP)
+        public var errorDescription: String? {
             switch self {
             case .missingConsumerSessionClientSecret:
                 return "No consumer session client secret was found to be associated with the active link account session."
@@ -40,10 +42,6 @@ extension STPAPIClient {
         }
 
         try validateSessionState(using: linkAccountInfo)
-
-        guard case .verified = linkAccountInfo.sessionState else {
-            throw CryptoOnrampAPIError.linkAccountNotVerified
-        }
 
         let endpoint = "crypto/internal/customers"
         let requestObject = CustomerRequest(consumerSessionClientSecret: consumerSessionClientSecret)

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CheckoutError.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CheckoutError.swift
@@ -8,7 +8,8 @@
 import Foundation
 
 /// Errors that can occur during checkout.
-enum CheckoutError: LocalizedError {
+@_spi(STP)
+public enum CheckoutError: LocalizedError {
 
     /// The payment method is missing from the PaymentIntent.
     case missingPaymentMethod
@@ -22,7 +23,8 @@ enum CheckoutError: LocalizedError {
     /// An unexpected error occurred.
     case unexpectedError
 
-    var errorDescription: String? {
+    @_spi(STP)
+    public var errorDescription: String? {
         switch self {
         case .missingPaymentMethod:
             return "The payment method is missing from the PaymentIntent."


### PR DESCRIPTION
## Summary
Exposes CryptoOnramp-specific error types. 

> [!NOTE]
> `CryptoOnrampCoordinator.Error` is already `public` as a nested type in a `public` extension, so that didn't need to change.  

## Motivation
To provide more specific error codes for certain APIs in the RN SDK. This allows us to match against native types rather than e.g. attempting to match error message strings.

## Testing
Simply built the app.

## Changelog
N/A