### PR TITLE
Update sanitizekey logic for to only allow pk_

### DIFF
--- a/StripeCore/StripeCore/Source/Categories/String+StripeCore.swift
+++ b/StripeCore/StripeCore/Source/Categories/String+StripeCore.swift
@@ -20,9 +20,9 @@ import Foundation
     public var nonEmpty: String? {
         stringIfHasContentsElseNil(self)
     }
-    
+
     @_spi(STP) public var sanitizedKey: String {
-        return (self.isSecretKey || self.hasPrefix("uk_"))
+        return (!self.hasPrefix("pk_"))
             ? "[REDACTED_LIVE_KEY]" : self
     }
 }


### PR DESCRIPTION
## Summary
Updates the sanitizekeylogic to only allow "pk_*"

## Motivation
Better than being specific about each type of key.

## Testing
Relying on existing unit tests
