### PR TITLE
Fix Spacing in Link Checkbox

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/Checkbox/CheckboxButton.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Checkbox/CheckboxButton.swift
@@ -63,7 +63,6 @@ import UIKit
         let stackView = UIStackView(arrangedSubviews: [textView, descriptionLabel])
         stackView.spacing = 4
         stackView.axis = .vertical
-        stackView.distribution = .equalSpacing
         stackView.alignment = .leading
         stackView.translatesAutoresizingMaskIntoConstraints = false
         return stackView


### PR DESCRIPTION
## Summary
Fix spacing layout in the Link checkbox view, similar to #5653.

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/d323a3ee-330d-4867-93b4-ba8c434d56a2" width="300" /> | <img src="https://github.com/user-attachments/assets/19e3f283-eb87-4ad2-9f73-a1dcd0700806" width="300" /> |

Here's an image of the problematic view in the View Debugger:
<img height="600" alt="problamatic view" src="https://github.com/user-attachments/assets/4e86bb7e-81a4-4f15-9372-0b1d698c44d1" />

## Motivation
@gbirch-stripe found this issue on [iPhone](https://github.com/user-attachments/assets/75e9f8a8-f662-42dd-bdb5-e59ca043788e) and @mats-stripe recreated on [iPad](https://github.com/user-attachments/assets/9aaa9b21-6884-49bd-a9f0-1f686d225627)

## Testing
Manual testing since we don't have snapshots for iPad.

