### PR TITLE
Update radar options to include iOS verification object

### DIFF
--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPRadarOptions.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPRadarOptions.swift
@@ -6,15 +6,18 @@
 //
 
 import Foundation
+@_spi(STP) import StripeCore
 
 /// Values for STPRadarOptions
 @_spi(STP) public class STPRadarOptions: NSObject {
     public var additionalAPIParameters: [AnyHashable: Any] = [:]
 
     @objc public var hcaptchaToken: String?
+    @objc public var iosVerificationObject: [String: String]?
 
-    public init(hcaptchaToken: String? = nil) {
+    public init(hcaptchaToken: String? = nil, assertion: StripeAttest.Assertion? = nil) {
         self.hcaptchaToken = hcaptchaToken
+        self.iosVerificationObject = assertion?.requestFields
     }
 }
 
@@ -31,6 +34,7 @@ extension STPRadarOptions: STPFormEncodable {
     public class func propertyNamesToFormFieldNamesMapping() -> [String: String] {
         return [
             NSStringFromSelector(#selector(getter: hcaptchaToken)): "hcaptcha_token",
+            NSStringFromSelector(#selector(getter: iosVerificationObject)): "ios_verification_object",
         ]
     }
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Add iOS verification object to STPRadarOptions
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Attestation support
## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Stub
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A