### PR TITLE
[v25] Async everywhere pt 2.2 - STPBankAccountCollector

### DIFF
--- a/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
@@ -490,6 +490,39 @@ public class STPBankAccountCollector: NSObject {
         )
     }
 
+    /// Presents a modal from the viewController to collect bank account
+    /// and if completed successfully, link your bank account to a SetupIntent
+    /// - Parameters:
+    ///   - clientSecret:      Client secret of the setup intent
+    ///   - returnURL:         A URL that redirects back to your app to be used to return after completing authentication in another app (such as bank app or Safari).
+    ///   - params:            Parameters for this call
+    ///   - viewController:    Presenting view controller that will present the modal
+    ///   - onEvent:           The `onEvent` closure is triggered upon the occurrence of specific events during the process of a user connecting their financial accounts.
+    /// - Returns: An `STPSetupIntent` instance with an expanded `paymentMethod` containing detailed payment method information
+    public func collectBankAccountForSetup(
+        clientSecret: String,
+        returnURL: String? = nil,
+        params: STPCollectBankAccountParams,
+        from viewController: UIViewController,
+        onEvent: ((FinancialConnectionsEvent) -> Void)? = nil
+    ) async throws -> STPSetupIntent {
+        return try await withCheckedThrowingContinuation { continuation in
+            collectBankAccountForSetup(
+                clientSecret: clientSecret,
+                returnURL: returnURL,
+                params: params,
+                from: viewController,
+                onEvent: onEvent
+            ) { result, error in
+                guard let result else {
+                    continuation.resume(throwing: error ?? NSError.stp_genericErrorOccurredError())
+                    return
+                }
+                continuation.resume(returning: result)
+            }
+        }
+    }
+
     @_spi(STP) public func collectBankAccountForSetup(
         clientSecret: String,
         returnURL: String?,


### PR DESCRIPTION
## Summary
Adds async variants for STPBankAccountCollector
```
public func collectBankAccountForPayment( clientSecret: String, params: STPCollectBankAccountParams, from viewController: UIViewController, completion: @escaping STPCollectBankAccountForPaymentCompletionBlock )
public func collectBankAccountForPayment( clientSecret: String, returnURL: String?, params: STPCollectBankAccountParams, from viewController: UIViewController, completion: @escaping STPCollectBankAccountForPaymentCompletionBlock )
public func collectBankAccountForPayment( clientSecret: String, returnURL: String?, params: STPCollectBankAccountParams, from viewController: UIViewController, onEvent: ((FinancialConnectionsEvent) -> Void)?, completion: @escaping STPCollectBankAccountForPaymentCompletionBlock )
public func collectBankAccountForSetup( clientSecret: String, params: STPCollectBankAccountParams, from viewController: UIViewController, completion: @escaping STPCollectBankAccountForSetupCompletionBlock )
public func collectBankAccountForSetup( clientSecret: String, returnURL: String?, params: STPCollectBankAccountParams, from viewController: UIViewController, completion: @escaping STPCollectBankAccountForSetupCompletionBlock )
public func collectBankAccountForSetup( clientSecret: String, returnURL: String?, params: STPCollectBankAccountParams, from viewController: UIViewController, onEvent: ((FinancialConnectionsEvent) -> Void)?, completion: @escaping STPCollectBankAccountForSetupCompletionBlock )
```

## Motivation
https://docs.google.com/document/d/16q-KJg_sgl0GSk4SB19fMy8qg1q0f-9SyxElLJKPJn0/edit?tab=t.0

## Testing
See test (just one sanity check since this is a simple wrapper).

## Changelog
Will add in a future PR.
