### PR TITLE
Wrap clientContext assignments in DEBUG conditional

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+ConfirmationTokens.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+ConfirmationTokens.swift
@@ -154,6 +154,9 @@ extension PaymentSheet {
         let confirmationTokenParams = STPConfirmationTokenParams()
         confirmationTokenParams.returnURL = configuration.returnURL
         confirmationTokenParams.shipping = configuration.shippingDetails()?.paymentIntentShippingDetailsParams
+        // Only send clientContext in DEBUG to validate client IntentConfiguration matches server intent.
+        // This helps catch integration errors during development (e.g. mismatched currency/amount/SFU)
+        // without breaking production payments if server intent changes after client configuration.
         #if DEBUG
         confirmationTokenParams.clientContext = intentConfig.createClientContext(customerId: configuration.customer?.id)
         #endif

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -136,6 +136,9 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         confirmationTokenParams.paymentMethod = paymentMethod.stripeId
         confirmationTokenParams.returnURL = context.returnUrl
         confirmationTokenParams.clientAttributionMetadata = context.clientAttributionMetadata
+        // Only send clientContext in DEBUG to validate client IntentConfiguration matches server intent.
+        // This helps catch integration errors during development (e.g. mismatched currency/amount/SFU)
+        // without breaking production payments if server intent changes after client configuration.
         #if DEBUG
         confirmationTokenParams.clientContext = intentConfig.createClientContext(customerId: paymentMethod.customerId)
         #endif


### PR DESCRIPTION
## Summary
- Only validate (send client_context) in debug mode, this will serve it’s purpose of helping merchants catch integration errors
- In release mode do not send client_context, to prevent these kind of breakages from happening in production causing failed payments in case of a client/server mismatch

## Motivation
- More stable integrations

## Testing
- Manual

## Changelog
N/A