### PR TITLE
Add client attribution metadata for Link webview flow and double-send on confirmation for Link native

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -526,7 +526,7 @@ extension PaymentSheet {
                                 ) { result in
                                     switch result {
                                     case .success(let paymentDetailsShareResponse):
-                                        confirmWithPaymentMethod(paymentDetailsShareResponse.paymentMethod, linkAccount, shouldSave, clientAttributionMetadata) // don't need to send client attribution metadata here because we sent it on /v1/payment_details/share
+                                        confirmWithPaymentMethod(paymentDetailsShareResponse.paymentMethod, linkAccount, shouldSave, clientAttributionMetadata)
                                     case .failure(let error):
                                         STPAnalyticsClient.sharedClient.logLinkSharePaymentDetailsFailure(error: error)
                                         // If this fails, confirm directly
@@ -615,7 +615,7 @@ extension PaymentSheet {
                     ) { result in
                         switch result {
                         case .success(let paymentDetailsShareResponse):
-                            confirmWithPaymentMethod(paymentDetailsShareResponse.paymentMethod, linkAccount, shouldSave, nil) // don't need to send client attribution metadata here because we sent it on /v1/payment_details/share
+                            confirmWithPaymentMethod(paymentDetailsShareResponse.paymentMethod, linkAccount, shouldSave, clientAttributionMetadata)
                         case .failure(let error):
                             STPAnalyticsClient.sharedClient.logLinkSharePaymentDetailsFailure(error: error)
                             paymentHandlerCompletion(.failed, error as NSError)


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Added clientAttributionMetadata on the Link confirmWithPaymentMethod function and attached to the intent params.
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Link web controller wasn't sending CAM, and we [decided](https://stripe.slack.com/archives/C07PXHWQMP0/p1760539405668019?thread_ts=1760449818.955979&cid=C07PXHWQMP0) to double-send it for the native Link confirmWithPaymentMethod flows even though it's already sent on `/v1/consumers/payment_details/share`.
## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
CI, manually
Link web controller confirm call (csc, not ct): https://admin.corp.stripe.com/request-log/req_vQHL3Bktq2RuRR
Link web controller confirmation tokens call: https://admin.corp.stripe.com/request-log/req_oapYCde9CEZSAE
Link native passthrough confirm call (csc, not ct): https://admin.corp.stripe.com/request-log/req_u2xy9TrXIr5xcx
Link native confirmation tokens call: https://admin.corp.stripe.com/request-log/req_SCdYgX9ovadaKj
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A