### PR TITLE
Fix command injection vulnerability in release script

### DIFF
--- a/ci_scripts/release_common.rb
+++ b/ci_scripts/release_common.rb
@@ -126,7 +126,7 @@ def changelog(version)
 end
 
 def update_placeholder(version, filename)
-  changelog = IO.readlines(filename).map do |line|
+  changelog = File.readlines(filename).map do |line|
     if line.upcase.start_with?('## X')
       "## #{version} #{Time.now.strftime('%Y-%m-%d')}\n"
     elsif line.start_with?('### Migrating from versions < X')


### PR DESCRIPTION
Replace IO.readlines with File.readlines to prevent potential shell command execution from filenames starting with |, addressing CodeQL security warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Committed-By-Agent: claude

## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://stripe.slack.com/archives/C01CY476ESJ/p1760457701992969
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4764

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
