### PR TITLE
Pass new parameter to API when resending an SMS OTP code

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -212,7 +212,10 @@ struct LinkPMDisplayDetails {
         }
     }
 
-    func startVerification(completion: @escaping (Result<Bool, Error>) -> Void) {
+    func startVerification(
+        isResendingSmsCode: Bool = false,
+        completion: @escaping (Result<Bool, Error>) -> Void
+    ) {
         guard let session = currentSession else {
             stpAssertionFailure()
             DispatchQueue.main.async {
@@ -226,6 +229,7 @@ struct LinkPMDisplayDetails {
         }
 
         session.startVerification(
+            isResendingSmsCode: isResendingSmsCode,
             with: apiClient,
             requestSurface: requestSurface
         ) { [weak self] result in

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/ConsumerSession.swift
@@ -286,6 +286,7 @@ extension ConsumerSession {
     func startVerification(
         type: VerificationSession.SessionType = .sms,
         locale: Locale = .autoupdatingCurrent,
+        isResendingSmsCode: Bool = false,
         with apiClient: STPAPIClient = STPAPIClient.shared,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
@@ -294,6 +295,7 @@ extension ConsumerSession {
             for: clientSecret,
             type: type,
             locale: locale,
+            isResendingSmsCode: isResendingSmsCode,
             requestSurface: requestSurface,
             completion: completion)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/STPAPIClient+Link.swift
@@ -652,6 +652,7 @@ extension STPAPIClient {
         for consumerSessionClientSecret: String,
         type: ConsumerSession.VerificationSession.SessionType,
         locale: Locale,
+        isResendingSmsCode: Bool = false,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<ConsumerSession, Error>) -> Void
     ) {
@@ -667,12 +668,17 @@ extension STPAPIClient {
         }()
         let endpoint: String = "consumers/sessions/start_verification"
 
-        let parameters: [String: Any] = [
+        var parameters: [String: Any] = [
             "credentials": ["consumer_session_client_secret": consumerSessionClientSecret],
             "type": typeString,
             "locale": locale.toLanguageTag(),
             "request_surface": requestSurface.rawValue,
         ]
+
+        // This parameter is specifically when resending SMS codes.
+        if isResendingSmsCode {
+            parameters["is_resend_sms_code"] = true
+        }
 
         makeConsumerSessionRequest(
             endpoint: endpoint,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationViewController.swift
@@ -179,7 +179,7 @@ extension LinkVerificationViewController: LinkVerificationViewDelegate {
         view.errorMessage = nil
 
         // To resend the code we just start a new verification session.
-        linkAccount.startVerification { [weak self] (result) in
+        linkAccount.startVerification(isResendingSmsCode: true) { [weak self] (result) in
             view.sendingCode = false
 
             switch result {


### PR DESCRIPTION
## Summary

Adds a new parameter `is_resend_sms_code=true` to the `/start_verification` API when the 'Resend code' button is tapped for SMS verification.


## Motivation

https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-43

## Testing

Example request: https://admin.corp.stripe.com/request-log/req_m2v6Xne08uTjdf

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
