### PR TITLE
Fix flaky network test

### DIFF
--- a/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
@@ -292,7 +292,7 @@ class STPPaymentMethodFunctionalTest: STPNetworkStubbingTestCase {
             customerID: customerAndEphemeralKey.customer,
             ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret
         )
-        
+
         // Wait one second to make sure the ordering is correct (the `created` dates are in seconds)
         try await Task.sleep(nanoseconds: NSEC_PER_SEC)
 


### PR DESCRIPTION
## Summary
This test was flaking on nightly non-network-stubbed runs because it enforces the ordering of the added PaymentMethods, but that ordering is based on `created` (which is a unix timestamp). If both are created within one second, the order is undefined.

## Motivation
Fix a flaky test

## Testing
CI

## Changelog
N/A