### PR TITLE
Make handleCheckScanSubmitted a Void function

### DIFF
--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
@@ -174,7 +174,7 @@ public final class EmbeddedComponentManager {
 
     @_spi(DashboardOnly)
     public func createCheckScanningController(
-        handleCheckScanSubmitted: @escaping (HandleCheckScanSubmittedArgs) async throws -> HandleCheckScanSubmittedReturnValue
+        handleCheckScanSubmitted: @escaping HandleCheckScanSubmittedFn
     ) -> CheckScanningController {
         .init(componentManager: self,
               loadContent: shouldLoadContent,

--- a/StripeConnect/StripeConnect/Source/Internal/Webview/SupplementalFunctions.swift
+++ b/StripeConnect/StripeConnect/Source/Internal/Webview/SupplementalFunctions.swift
@@ -19,7 +19,8 @@ class SupplementalFunctions {
         switch args {
         case .handleCheckScanSubmitted(let value):
             if let fn = self.handleCheckScanSubmitted {
-                return .handleCheckScanSubmitted(try await fn(value))
+                try await fn(value)
+                return .handleCheckScanSubmitted
             }
         }
 
@@ -71,18 +72,21 @@ enum SupplementalFunctionArgs: Equatable {
 }
 
 enum SupplementalFunctionReturnValue: Encodable {
-    case handleCheckScanSubmitted(HandleCheckScanSubmittedReturnValue)
+    case handleCheckScanSubmitted
 
     func encode(to encoder: Encoder) throws {
+        // For future cases with associated values do:
+        // try value.encode(to: encoder)
         switch self {
-        case .handleCheckScanSubmitted(let value):
-            try value.encode(to: encoder)
+        case .handleCheckScanSubmitted:
+            // No data
+            break
         }
     }
 }
 
 @_spi(DashboardOnly)
-public typealias HandleCheckScanSubmittedFn = ((HandleCheckScanSubmittedArgs) async throws -> (HandleCheckScanSubmittedReturnValue))
+public typealias HandleCheckScanSubmittedFn = (HandleCheckScanSubmittedArgs) async throws -> Void
 
 @_spi(DashboardOnly)
 public struct HandleCheckScanSubmittedArgs: Decodable, Equatable {
@@ -91,9 +95,4 @@ public struct HandleCheckScanSubmittedArgs: Decodable, Equatable {
     public init(checkScanToken: String) {
         self.checkScanToken = checkScanToken
     }
-}
-
-@_spi(DashboardOnly)
-public struct HandleCheckScanSubmittedReturnValue: Encodable, Equatable {
-    public init() {}
 }

--- a/StripeConnect/StripeConnectTests/Components/CheckScanningControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/CheckScanningControllerTests.swift
@@ -32,7 +32,7 @@ class CheckScanningControllerTests: XCTestCase {
     @MainActor
     func testDelegate() async throws {
         let delegate = CheckScanningControllerDelegatePassThrough()
-        let controller = componentManager.createCheckScanningController { _ in return HandleCheckScanSubmittedReturnValue() }
+        let controller = componentManager.createCheckScanningController { _ in }
         controller.delegate = delegate
 
         let expectationDidFail = XCTestExpectation(description: "didFail called")
@@ -49,7 +49,7 @@ class CheckScanningControllerTests: XCTestCase {
 
     @MainActor
     func testFetchInitComponentProps() async throws {
-        let controller = componentManager.createCheckScanningController { _ in return HandleCheckScanSubmittedReturnValue() }
+        let controller = componentManager.createCheckScanningController { _ in }
 
         try await controller.webVC.webView.evaluateMessageWithReply(name: "fetchInitComponentProps",
                                                                     json: "{}",

--- a/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/ConnectComponentWebViewControllerTests.swift
@@ -155,7 +155,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
             enum CodingKeys: CodingKey {}
         }
 
-        let supplementalFunctions = SupplementalFunctions(handleCheckScanSubmitted: { _ in return HandleCheckScanSubmittedReturnValue() })
+        let supplementalFunctions = SupplementalFunctions(handleCheckScanSubmitted: { _ in })
 
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
                                                       componentType: .checkScanning,
@@ -264,7 +264,6 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
 
         let supplementalFunctions = SupplementalFunctions(handleCheckScanSubmitted: {payload in
             XCTAssertEqual(payload.checkScanToken, "testToken")
-            return HandleCheckScanSubmittedReturnValue()
         })
 
         let webVC = ConnectComponentWebViewController(componentManager: componentManager,
@@ -286,7 +285,7 @@ class ConnectComponentWebViewControllerTests: XCTestCase {
             sender: SupplementalFunctionCompletedSender(payload: .init(
                 functionName: .handleCheckScanSubmitted,
                 invocationId: "testInvocation",
-                result: .success(.handleCheckScanSubmitted(.init()))
+                result: .success(.handleCheckScanSubmitted)
             ))
         )
 

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchInitComponentPropsMessageHandlerTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageHandlers/FetchInitComponentPropsMessageHandlerTests.swift
@@ -48,9 +48,7 @@ class FetchInitComponentPropsMessageHandlerTests: ScriptWebTestBase {
             enum CodingKeys: CodingKey {}
         }
 
-        let supplementalFunctions: SupplementalFunctions = .init(handleCheckScanSubmitted: { _ in
-            return HandleCheckScanSubmittedReturnValue()
-        })
+        let supplementalFunctions: SupplementalFunctions = .init(handleCheckScanSubmitted: { _ in })
         var registeredSupplementalFunctions: SupplementalFunctions?
 
         webView.addMessageReplyHandler(messageHandler: FetchInitComponentPropsMessageHandler {

--- a/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/SupplementalFunctionCompletedSenderTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/MessageSenders/SupplementalFunctionCompletedSenderTests.swift
@@ -4,7 +4,7 @@ import XCTest
 class SupplementalFunctionCompletedSenderTests: ScriptWebTestBase {
     func testSendMessage_successResult() throws {
         try validateMessageSent(sender: SupplementalFunctionCompletedSender(
-            payload: .init(functionName: .handleCheckScanSubmitted, invocationId: "testInvocationId", result: .success(.handleCheckScanSubmitted(.init())))
+            payload: .init(functionName: .handleCheckScanSubmitted, invocationId: "testInvocationId", result: .success(.handleCheckScanSubmitted))
         ))
     }
 
@@ -17,7 +17,7 @@ class SupplementalFunctionCompletedSenderTests: ScriptWebTestBase {
     func testSenderSignature_successResult() {
         XCTAssertEqual(
             try SupplementalFunctionCompletedSender(
-                payload: .init(functionName: .handleCheckScanSubmitted, invocationId: "testInvocationId", result: .success(.handleCheckScanSubmitted(.init())))
+                payload: .init(functionName: .handleCheckScanSubmitted, invocationId: "testInvocationId", result: .success(.handleCheckScanSubmitted))
             ).javascriptMessage(),
             """
             window.supplementalFunctionCompleted({"functionName":"handleCheckScanSubmitted","invocationId":"testInvocationId","result":"success","returnValue":{}});

--- a/StripeConnect/StripeConnectTests/Internal/Webview/SupplementalFunctionsTests.swift
+++ b/StripeConnect/StripeConnectTests/Internal/Webview/SupplementalFunctionsTests.swift
@@ -3,16 +3,12 @@ import XCTest
 
 final class SupplementalFunctionsTests: XCTestCase {
     func testCallSucceeds() async throws {
-        let handleCheckScanSubmitted: HandleCheckScanSubmittedFn = { _ in HandleCheckScanSubmittedReturnValue() }
+        let handleCheckScanSubmitted: HandleCheckScanSubmittedFn = { _ in }
         let supplementalFunctions = SupplementalFunctions(handleCheckScanSubmitted: handleCheckScanSubmitted)
 
         let result = try await supplementalFunctions.call(.handleCheckScanSubmitted(.init(checkScanToken: "testToken")))
 
-        if case .handleCheckScanSubmitted(let value) = result {
-            XCTAssertEqual(value, HandleCheckScanSubmittedReturnValue())
-        } else {
-            XCTFail("Unexpected result")
-        }
+        XCTAssertEqual(result, SupplementalFunctionReturnValue.handleCheckScanSubmitted)
     }
 
     func testCallNotRegistered() async throws {
@@ -38,7 +34,7 @@ final class SupplementalFunctionsTests: XCTestCase {
             }
         }
 
-        let supplementalFunctions = SupplementalFunctions(handleCheckScanSubmitted: { _ in .init() })
+        let supplementalFunctions = SupplementalFunctions(handleCheckScanSubmitted: { _ in })
         let props = Props(testField: 1, supplementalFunctions: supplementalFunctions)
         let json = String(data: try JSONEncoder().encode(props), encoding: .utf8)
 
@@ -81,10 +77,17 @@ final class SupplementalFunctionsTests: XCTestCase {
                              "Expected a singleton array for handleCheckScanSubmitted, but got length 2")
     }
 
+    // This test case should be updated when there's a function with non-empty return
     func testEncodeReturnValue() throws {
-        let data = try JSONEncoder().encode(SupplementalFunctionReturnValue.handleCheckScanSubmitted(.init()))
+        // Need a wrapper to demonstrate the encoding because .handleCheckScanSubmitted has
+        // no associated value so the encoder complains that nothing was encoded
+        struct Wrapper: Encodable {
+            let value: SupplementalFunctionReturnValue
+        }
+
+        let data = try JSONEncoder().encode(Wrapper(value: .handleCheckScanSubmitted))
         let json = String(data: data, encoding: .utf8)
 
-        XCTAssertEqual(json, "{}")
+        XCTAssertEqual(json, "{\"value\":{}}")
     }
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Make handleCheckScanSubmitted a Void function

Follow-up to https://github.com/stripe/stripe-ios/pull/5721

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
No return value is anticipated and this better matches the internally expected function signature

```
  handleCheckScanSubmitted?: (params: {
    checkScanToken: string;
  }) => Promise<void>;
```

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Updated automated tests, manual test on simulator

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
