### PR TITLE
Add a reset switch for app attestation

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -608,7 +608,7 @@ struct BillingDetailsView: View {
 struct AttestationResetButtonView: View {
     @State private var presentingAlert = false
     @EnvironmentObject var playgroundController: PlaygroundController
-    
+
     var body: some View {
         if #available(iOS 15.0, *) {
             Button {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -691,7 +691,7 @@ class PlaygroundController: ObservableObject {
         PaymentSheet.resetCustomer()
         self.appearance = PaymentSheet.Appearance.default
     }
-    
+
     func didTapResetAttestation() {
         Task {
             await StripeAttest(apiClient: .shared).resetKey()


### PR DESCRIPTION
## Summary
To test resetting app attestation, we'll add a switch to reset the key.

## Testing
PS Example

## Changelog
N/A