### PR TITLE
Add kSecAttrAccessibleWhenUnlockedThisDeviceOnly to keychain items

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/CookieStore/LinkSecureCookieStore.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/CookieStore/LinkSecureCookieStore.swift
@@ -25,6 +25,7 @@ final class LinkSecureCookieStore: LinkCookieStore {
         let query = queryForKey(key, additionalParams: [
             kSecValueData as String: data,
             kSecAttrSynchronizable as String: allowSync ? kCFBooleanTrue as Any : kCFBooleanFalse as Any,
+            kSecAttrAccessible as String: allowSync ? kSecAttrAccessibleWhenUnlocked : kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
         ])
 
         delete(key: key)


### PR DESCRIPTION
## Summary
- Sets `kSecAttrAccessible` attribute on keychain items in `LinkSecureCookieStore`
- When `allowSync=true`: uses `kSecAttrAccessibleWhenUnlocked` (allows secure backup)
- When `allowSync=false`: uses `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` (prevents backup)


This makes the `allowSync` parameter semantically more accurate by ensuring items aren't backed up during secure backups. All current items are set to `allowSync: false` (despite being relatively non-sensitive), so no items will be backed up.

## Test plan
- Verify existing keychain tests pass
- Manual testing of Link cookie storage functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)