### PR TITLE
Add placeholder for missing localized string

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -456,6 +456,7 @@
 				it,
 				"fr-CA",
 				"pt-BR",
+				"zh-Hant",
 			);
 			mainGroup = 0B42927B2E1EC57600012FB8;
 			minimizedProjectReferenceProxies = 1;

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Resources/Localizations/zh-HK.lproj/Localizable.strings
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Resources/Localizations/zh-HK.lproj/Localizable.strings
@@ -1,2 +1,1 @@
-/* Label shown in the Link UI indicating that debit cards are more likely to be accepted */
 "Debit cards are most likely to be accepted." = "扣賬卡最有可能獲接受。";

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Resources/Localizations/zh-Hant.lproj/Localizable.strings
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Resources/Localizations/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,1 @@
+"Debit cards are most likely to be accepted." = "Debit cards are most likely to be accepted.";


### PR DESCRIPTION
## Summary

Adds a placeholder for the missing Chinese Traditional string in the crypto onramp SDK. Also put it a request to have this string localized https://jira.corp.stripe.com/browse/L10N-7764 which should override this value once it's ready.

## Motivation

Release script has been bothering us that this is missing.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
