### PR TITLE
CryptoOnramp SDK: Removes unused `Calendar` references

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/KYCDataCollectionRequest.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/KYCDataCollectionRequest.swift
@@ -16,9 +16,6 @@ struct KYCDataCollectionRequest: Encodable {
     /// KYC information required for crypto operations.
     let kycInfo: KycInfo
 
-    /// The calendar to use to convert the user’s date of birth (`KycInfo.dateOfBirth`) to components compatible with the API.
-    let calendar: Calendar
-
     // MARK: - Encodable
 
     enum CodingKeys: String, CodingKey {

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -52,11 +52,10 @@ extension STPAPIClient {
     /// - Parameters:
     ///   - info: The collected customer information.
     ///   - linkAccountInfo: Information associated with the link account including the client secret and whether the account has been verified.
-    ///   - calendar: The calendar to use to convert the user’s date of birth (`KycInfo.dateOfBirth`) to components compatible with the API. Defaults to `calendar.current`.
     /// - Returns: A response object containing the user’s identifier.
     /// Throws if `linkAccountSessionState` is not verified, a client secret doesn’t exist, or if an API error occurs.
     @discardableResult
-    func collectKycInfo(info: KycInfo, linkAccountInfo: PaymentSheetLinkAccountInfoProtocol, calendar: Calendar = .current) async throws -> KYCDataCollectionResponse {
+    func collectKycInfo(info: KycInfo, linkAccountInfo: PaymentSheetLinkAccountInfoProtocol) async throws -> KYCDataCollectionResponse {
         guard let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret else {
             throw CryptoOnrampAPIError.missingConsumerSessionClientSecret
         }
@@ -66,8 +65,7 @@ extension STPAPIClient {
         let endpoint = "crypto/internal/kyc_data_collection"
         let requestObject = KYCDataCollectionRequest(
             credentials: Credentials(consumerSessionClientSecret: consumerSessionClientSecret),
-            kycInfo: info,
-            calendar: calendar
+            kycInfo: info
         )
 
         return try await post(resource: endpoint, object: requestObject)

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
@@ -193,13 +193,9 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         }
 
         let apiClient = stubbedAPIClient()
-        guard let fixedGMTCalendar = Calendar.makeFixedTimeZoneCalendar(hoursFromGMT: 0) else {
-            XCTFail("Failed to create a fixed-timezone calendar.")
-            return
-        }
 
         do {
-            let response = try await apiClient.collectKycInfo(info: Constant.validKycInfo, linkAccountInfo: Constant.validLinkAccountInfo, calendar: fixedGMTCalendar)
+            let response = try await apiClient.collectKycInfo(info: Constant.validKycInfo, linkAccountInfo: Constant.validLinkAccountInfo)
             XCTAssertEqual(response.personId, "person_1A2BcD345EFg6HiJ")
             XCTAssertEqual(response.firstName, "John")
             XCTAssertEqual(response.lastName, "Smith")
@@ -493,17 +489,5 @@ private extension String {
             guard splitPair.count == 2 else { return }
             result[splitPair[0]] = splitPair[1]
         }
-    }
-}
-
-private extension Calendar {
-    static func makeFixedTimeZoneCalendar(hoursFromGMT: Int) -> Calendar? {
-        guard let timeZone = TimeZone(secondsFromGMT: hoursFromGMT * 3600) else {
-            return nil
-        }
-
-        var calendar = Calendar(identifier: .gregorian)
-        calendar.timeZone = timeZone
-        return calendar
     }
 }


### PR DESCRIPTION
## Summary
A while back, we simplified how dates of birth were being encoded/decoded and stored. That was done here: https://github.com/stripe/stripe-ios/pull/5351

Today, I noticed some lingering references to a `Calendar` being specified, but not used. This removes that unused code.

## Motivation
Cleanup of unused code.

## Testing
Made sure the project built and the existing tests still passed.

## Changelog
N/A
