### PR TITLE
Sort swiftinterface files when diffing

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -3,7 +3,7 @@
 //  StripePaymentSheet
 //
 //  Created by Yuki Tokuhiro on 9/3/20.
-//  Copyright © 2020 Stripe, Inc. All rights reserved.
+//  Copyright © 2025 Stripe, Inc. All rights reserved.
 //
 
 import Foundation

--- a/ci_scripts/api_diff/diff_public_interface.rb
+++ b/ci_scripts/api_diff/diff_public_interface.rb
@@ -1,18 +1,39 @@
 require 'open3'
+require 'tempfile'
 require_relative 'get_frameworks'
 
 def diff(old_path, new_path)
-  stdout, _stderr, _status = Open3.capture3("diff", "-u", old_path, new_path)
+  # Read and sort both files alphabetically
+  old_lines = File.readlines(old_path).sort
+  new_lines = File.readlines(new_path).sort
 
-  diff_string = stdout.lines.map do |line|
-    case line[0..1]
-    when "+ " then "+ #{line[2..-1].strip}"
-    when "- " then "- #{line[2..-1].strip}"
-    else nil
-    end
-  end.compact.join("\n")
+  # Create temporary files with sorted content
+  old_temp = Tempfile.new(['sorted_old', '.swiftinterface'])
+  new_temp = Tempfile.new(['sorted_new', '.swiftinterface'])
 
-  return diff_string
+  begin
+    old_temp.write(old_lines.join)
+    old_temp.flush
+    new_temp.write(new_lines.join)
+    new_temp.flush
+
+    stdout, _stderr, _status = Open3.capture3("diff", "-u", old_temp.path, new_temp.path)
+
+    diff_string = stdout.lines.map do |line|
+      case line[0..1]
+      when "+ " then "+ #{line[2..-1].strip}"
+      when "- " then "- #{line[2..-1].strip}"
+      else nil
+      end
+    end.compact.join("\n")
+
+    return diff_string
+  ensure
+    old_temp.close
+    old_temp.unlink
+    new_temp.close
+    new_temp.unlink
+  end
 end
 
 final_diff_string = ""


### PR DESCRIPTION
## Summary
The API checker has false positives if the ordering of the API functions in the `.swiftinterface` file changes, and Xcode seems to be compiling these files in a non-deterministic order now that we're using folder references. To work around this, try sorting them all before diffing. This makes the files semantically meaningless, but it *does* catch changes!

## Motivation
Fixing the API checker

## Testing
CI

## Changelog
N/A