### PR TITLE
[Identity] Fix layout issue in Identity flow

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityFlowView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityFlowView.swift
@@ -311,7 +311,7 @@ extension IdentityFlowView {
 
         // Remove old buttons and create new ones and add them to the stack view
         buttons.forEach { $0.removeFromSuperview() }
-        buttons = buttonViewModels.enumerated().map { index, _ in
+        buttons = buttonViewModels.indices.map { index in
             let button = Button(
                 index: index,
                 target: self,


### PR DESCRIPTION
Related to, but does not fix (because that issue specifically is fixed) https://github.com/stripe/stripe-identity-react-native/issues/221

---

This makes sure the views right about the flow buttons do not extend outside of the width of the view.

---

BEFORE:

<img width="472" height="944" alt="Screenshot 2025-10-30 at 10 30 30 AM" src="https://github.com/user-attachments/assets/e85a8c8f-77aa-44da-a392-bc19761e0c57" />


After:

<img width="472" height="944" alt="Screenshot 2025-10-30 at 10 58 13 AM" src="https://github.com/user-attachments/assets/e564b0aa-ecbe-4ddb-b06c-e55bae8e95b5" />


