### PR TITLE
[v25] Add back old intentconfiguration init as deprecated

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleCheckoutDeferredViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleCheckoutDeferredViewController.swift
@@ -47,21 +47,13 @@ class ExampleDeferredCheckoutViewController: UIViewController {
         return .init(mode: .payment(amount: Int(computedTotals.total),
                                     currency: "USD",
                                     setupFutureUsage: subscribeSwitch.isOn ? .offSession : nil)
-        ) { [weak self] paymentMethod, shouldSavePaymentMethod, confirmHandler in
-            self?.serverSideConfirmHandler(paymentMethod.stripeId, shouldSavePaymentMethod) { result in
-                confirmHandler(result)
+        ) { [weak self] paymentMethod, shouldSavePaymentMethod in
+            try await withCheckedThrowingContinuation { continuation in
+                self?.serverSideConfirmHandler(paymentMethod.stripeId, shouldSavePaymentMethod) { result in
+                    continuation.resume(with: result)
+                }
             }
         }
-//        return .init(mode: .payment(amount: Int(computedTotals.total),
-//                                    currency: "USD",
-//                                    setupFutureUsage: subscribeSwitch.isOn ? .offSession : nil)
-//        ) { [weak self] paymentMethod, shouldSavePaymentMethod in
-//            try await withCheckedThrowingContinuation { continuation in
-//                self?.serverSideConfirmHandler(paymentMethod.stripeId, shouldSavePaymentMethod) { result in
-//                    continuation.resume(with: result)
-//                }
-//            }
-//        }
     }
 
     lazy var paymentSheetConfiguration: PaymentSheet.Configuration = {


### PR DESCRIPTION
## Summary
Adds back old IntentConfiguration initializer and marks it as deprecated with a hopefully helpful hint.

## Motivation
Help users migrate.

## Testing
Manually tested using the old initializer - saw the deprecation notice as expected. Ran the code using the old initializer, and observed it worked as expected and that the callback was still called on the main thread.
<img width="1027" height="167" alt="CleanShot 2025-10-31 at 09 46 06" src="https://github.com/user-attachments/assets/87e4ccaf-aeef-4839-8051-54f436a0347d" />
