### PR TITLE
Fix Link branding for passthrough mode cards

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
@@ -66,6 +66,7 @@ struct ElementsCustomer: Equatable, Hashable {
                 }
             } else {
                 if let paymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: json) {
+                    paymentMethod.isLinkPassthroughMode = paymentMethod.card?.wallet?.type == .link
                     paymentMethods.append(paymentMethod)
                 }
             }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes a UI inconsistency for merchants not gated into `enableLinkInSPM` that caused Link-originated passthrough payment methods not to be Link-branded.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Merchant feedback.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

Manually verified.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

N/A
