### PR TITLE
Afterpay header modal style overCurrentContext -> formSheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AfterpayPriceBreakdownView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AfterpayPriceBreakdownView.swift
@@ -78,7 +78,7 @@ class AfterpayPriceBreakdownView: UIView {
     private func didTapInfoButton() {
         if let url = infoURL {
             let safariController = SFSafariViewController(url: url)
-            safariController.modalPresentationStyle = .overCurrentContext
+            safariController.modalPresentationStyle = .formSheet
             parentViewController?.present(safariController, animated: true)
         }
     }


### PR DESCRIPTION
## Summary
Use .formSheet instead of .overCurrentContext for afterpay modal 

before:
https://github.com/user-attachments/assets/eb57954d-dae5-48a0-a6c7-016a16821bba

after:
https://github.com/user-attachments/assets/d68af196-2019-428f-aa59-d68404be326a

## Motivation
- https://stripe.slack.com/archives/C09A34R23T4/p1760559196891749?thread_ts=1760381131.106909&cid=C09A34R23T4
- alignment with PMME

## Testing
manual testing

## Changelog
N/A