### PR TITLE
Fix URL handling on Link Account Picker pane

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -212,7 +212,7 @@ final class LinkAccountPickerViewController: UIViewController {
                 }
                 self.didSelectConnectAccounts()
             },
-            didSelectMerchantDataAccessLearnMore: { [weak self] _ in
+            didSelectMerchantDataAccessLearnMore: { [weak self] url in
                 guard let self = self else { return }
                 self.dataSource
                     .analyticsClient
@@ -228,6 +228,8 @@ final class LinkAccountPickerViewController: UIViewController {
                         }
                     )
                     dataAccessNoticeViewController.present(on: self)
+                } else {
+                    self.didSelectURLInTextFromBackend(url)
                 }
             }
         )


### PR DESCRIPTION
## Summary

URLs weren't being properly opened on this pane. It only handled the scenario where we had data access notice pane content

Before: 

https://github.com/user-attachments/assets/8dee6515-6925-4a70-8b02-7b2e8865701f

After:

https://github.com/user-attachments/assets/3988d41f-a8af-431f-b9e8-0c42a28d1b69
