### PR TITLE
CryptoOnramp SDK: KYC Refresh Fix for Empty Fields

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/KYCRefreshRequest.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/KYCRefreshRequest.swift
@@ -41,11 +41,11 @@ struct KYCRefreshRequest: Encodable {
         try container.encode(kycInfo.dateOfBirth, forKey: .dob)
         try container.encode(kycInfo.idNumberLast4, forKey: .idNumberLast4)
         try container.encode(kycInfo.idType, forKey: .idType)
-        try container.encodeIfPresent(kycInfo.address.line1, forKey: .line1)
-        try container.encodeIfPresent(kycInfo.address.line2, forKey: .line2)
-        try container.encodeIfPresent(kycInfo.address.city, forKey: .city)
-        try container.encodeIfPresent(kycInfo.address.state, forKey: .state)
-        try container.encodeIfPresent(kycInfo.address.postalCode, forKey: .zip)
-        try container.encodeIfPresent(kycInfo.address.country, forKey: .country)
+        try container.encode(kycInfo.address.line1 ?? "", forKey: .line1)
+        try container.encode(kycInfo.address.line2 ?? "", forKey: .line2)
+        try container.encode(kycInfo.address.city ?? "", forKey: .city)
+        try container.encode(kycInfo.address.state ?? "", forKey: .state)
+        try container.encode(kycInfo.address.postalCode ?? "", forKey: .zip)
+        try container.encode(kycInfo.address.country ?? "", forKey: .country)
     }
 }


### PR DESCRIPTION
## Summary
Fixes an issue where overwriting an address field by omitting it would not clear the field on the backend. We need to explicitly pass an empty string. See [slack thread](https://lickability.slack.com/archives/C094P3BRBL1/p1762470176535819?thread_ts=1762469531.956239&cid=C094P3BRBL1).

## Motivation
To allow an address change to clear existing values (e.g. address line 2)

## Testing
1. Authenticated in the example app.
2. Set my KYC to include line1 and line2 of the address.
3. From the toolbar, selected the Verify KYC Info menu item.
4. Chose to edit address.
5. Added a new address without line2.
6. Confirmed the address.
7. From the toolbar, selected the Verify KYC Info menu item again.
8. Made sure that on the KYC verification sheet, I no longer had an address line2.

## Changelog
N/A