### PR TITLE
Set payment in flight false after we finish animating

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -637,13 +637,14 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                     deferredIntentConfirmationType: deferredIntentConfirmationType
                 )
 
-                self.isPaymentInFlight = false
                 switch result {
                 case .canceled:
+                    self.isPaymentInFlight = false
                     // Keep customer on payment sheet
                     self.updatePrimaryButton()
                     self.isUserInteractionEnabled = true
                 case .failed(let error):
+                    self.isPaymentInFlight = false
 #if !os(visionOS)
                     UINotificationFeedbackGenerator().notificationOccurred(.error)
 #endif
@@ -672,6 +673,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                         UINotificationFeedbackGenerator().notificationOccurred(.success)
 #endif
                         self.primaryButton.update(state: .succeeded, animated: true) {
+                            self.isPaymentInFlight = false
                             self.paymentSheetDelegate?.paymentSheetViewControllerDidFinish(self, result: .completed)
                         }
                     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -454,12 +454,13 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                     result: result,
                     deferredIntentConfirmationType: deferredIntentConfirmationType
                 )
-                self.isPaymentInFlight = false
                 switch result {
                 case .canceled:
+                    self.isPaymentInFlight = false
                     // Do nothing, keep customer on payment sheet
                     self.updateUI()
                 case .failed(let error):
+                    self.isPaymentInFlight = false
                     #if !os(visionOS)
                     UINotificationFeedbackGenerator().notificationOccurred(.error)
                     #endif
@@ -477,6 +478,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
 #endif
                         self.buyButton.update(state: .succeeded, animated: true) {
                             // Wait a bit before closing the sheet
+                            self.isPaymentInFlight = false
                             self.delegate?.paymentSheetViewControllerDidFinish(self, result: .completed)
                         }
                     }


### PR DESCRIPTION
## Summary
- Fix a issue where we can dismiss payment sheet while animating into success

## Motivation
- https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4806

## Testing
- Manual

## Changelog
N/A