### PR TITLE
Fix crash in iOS 26 navigation bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## X.Y.Z
 ### PaymentSheet
 * [Fixed] Fixed an issue where async APIs did not run on the main thread.
+* [Fixed] Fixed a crash when presenting PaymentSheet with liquid glass navigation bar style from a view controller not embedded in a UINavigationController.
 
 ## 25.0.0 2025-11-03
 This major version introduces many small breaking changes. Please see [MIGRATING.md](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md) to help you migrate.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/BottomSheetViewController.swift
@@ -398,6 +398,7 @@ class BottomSheetViewController: UIViewController, BottomSheetPresentable {
     func enableNavigationBarBlurInteraction() {
         guard let navigationBarBlur,
             navigationBarBlur.view == nil,
+            navigationController != nil,
         // Hack: This line causes PaymentSheetSnapshotTests to fail on iOS 26 - the sheet becomes transparent. I can't figure out a fix, so just remove it out for tests.
         NSClassFromString("XCTest") == nil else {
             return


### PR DESCRIPTION
## Summary
-  Fixes a crash when presenting PaymentSheet with liquid glass navigation bar style (`applyLiquidGlass = true`) from a view controller not embedded in a `UINavigationController`.

## Motivation
- https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4823

## Testing
- Manual

## Changelog
See diff
