### PR TITLE
Sort PMs before assert

### DIFF
--- a/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift
@@ -358,9 +358,12 @@ class STPPaymentMethodFunctionalTest: STPNetworkStubbingTestCase {
             ephemeralKey: customerAndEphemeralKey.ephemeralKeySecret
         )
 
+        // Sort by creation date descending (newest first) to ensure consistent ordering
+        let sortedPaymentMethods = fetchedPaymentMethods.sorted { $0.created > $1.created }
+
         // Expect it's [SEPA, card] and in that order (ie newest first)
         XCTAssertEqual(
-            fetchedPaymentMethods.map({ $0.stripeId }),
+            sortedPaymentMethods.map({ $0.stripeId }),
             [paymentMethod2, paymentMethod1]
         )
     }


### PR DESCRIPTION
## Summary
Fixes an issue where payment methods are out of order during comparison

```
Failed to execute Step: command failed with exit status 65 (xcodebuild "-workspace" "/Users/vagrant/git/Stripe.xcworkspace" "-scheme" "AllStripeFrameworks-NoMocks" "test" "-destination" "id=DA3483E5-ECC1-4C9D-8BCD-22C7017E9C3D" "-resultBundlePath" "/var/folders/b8/9zt_tx3s1y37nzh_cs991xyc0000gn/T/XCUITestOutput1162835628/Test-AllStripeFrameworks-NoMocks.xcresult" "-retry-tests-on-failure" "-test-iterations" "2" "-xcconfig" "/var/folders/b8/9zt_tx3s1y37nzh_cs991xyc0000gn/T/2183199898/temp.xcconfig"): /Users/vagrant/git/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift:362: error: -[StripeiOS_Tests.STPPaymentMethodFunctionalTest testListPaymentMethodsWithMultipleTypes] : XCTAssertEqual failed: ("["pm_1SSdkeFY0qyl6XeWXJLQ0mws", "pm_1SSdkeFY0qyl6XeWsvprdJ10"]") is not equal to ("["pm_1SSdkeFY0qyl6XeWsvprdJ10", "pm_1SSdkeFY0qyl6XeWXJLQ0mws"]") /Users/vagrant/git/Stripe/StripeiOSTests/STPPaymentMethodFunctionalTest.swift:362: error: -[StripeiOS_Tests.STPPaymentMethodFunctionalTest testListPaymentMethodsWithMultipleTypes] : XCTAssertEqual failed: ("["pm_1SSdkhFY0qyl6XeWYOgLEkxU", "pm_1SSdkhFY0qyl6XeWCgFfrpXB"]") is not equal to ("["pm_1SSdkhFY0qyl6XeWCgFfrpXB", "pm_1SSdkhFY0qyl6XeWYOgLEkxU"]") (exit code: 1)
```

## Motivation
- https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4853

## Testing
- Re-ran the failing test

## Changelog
N/A
