### PR TITLE
Move CI xcode from 26.1-edge to 26.1

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -354,7 +354,7 @@ workflows:
     - notify_ci
     meta:
       bitrise.io:
-        stack: osx-xcode-26.1.x-edge
+        stack: osx-xcode-26.1.x
         machine_type_id: g2.mac.large
     envs:
     - DEFAULT_TEST_DEVICE: $DEFAULT_TEST_DEVICE_26_0
@@ -420,7 +420,7 @@ workflows:
     - prep_all
     meta:
       bitrise.io:
-        stack: osx-xcode-26.1.x-edge
+        stack: osx-xcode-26.1.x
   test-builds-xcode-26-release:
     steps:
     - script@1:
@@ -433,7 +433,7 @@ workflows:
     - prep_all
     meta:
       bitrise.io:
-        stack: osx-xcode-26.1.x-edge
+        stack: osx-xcode-26.1.x
   install-tests:
     steps:
     - fastlane@3:


### PR DESCRIPTION
## Summary
Bitrise 26.1 edge contains a bug where the iOS 26.1 simulator can't be found

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
