### PR TITLE
inject test delays for hcaptcha, check only for success analytic

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ConfirmationChallenge/ConfirmationChallenge.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ConfirmationChallenge/ConfirmationChallenge.swift
@@ -23,8 +23,12 @@ actor ConfirmationChallenge {
 
     // enablePassiveCaptcha and enableAttestation are determined by the playground switches and will be removed on release
     public init(enablePassiveCaptcha: Bool, enableAttestation: Bool, elementsSession: STPElementsSession, stripeAttest: StripeAttest) {
+        self.init(enablePassiveCaptcha: enablePassiveCaptcha, enableAttestation: enableAttestation, elementsSession: elementsSession, stripeAttest: stripeAttest, hcaptchaFactory: PassiveHCaptchaFactory())
+    }
+
+    init(enablePassiveCaptcha: Bool, enableAttestation: Bool, elementsSession: STPElementsSession, stripeAttest: StripeAttest, hcaptchaFactory: HCaptchaFactory) {
         if enablePassiveCaptcha, let passiveCaptchaData = elementsSession.passiveCaptchaData {
-            self.passiveCaptchaChallenge = PassiveCaptchaChallenge(passiveCaptchaData: passiveCaptchaData)
+            self.passiveCaptchaChallenge = PassiveCaptchaChallenge(passiveCaptchaData: passiveCaptchaData, hcaptchaFactory: hcaptchaFactory)
         }
         if enableAttestation, elementsSession.shouldAttestOnConfirmation {
             self.attestationChallenge = AttestationChallenge(stripeAttest: stripeAttest, canSyncState: elementsSession.linkSettings?.attestationStateSyncEnabled ?? false)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ConfirmationChallenge/AttestationChallengeTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ConfirmationChallenge/AttestationChallengeTests.swift
@@ -62,8 +62,7 @@ class AttestationChallengeTests: XCTestCase {
         // didn't take the full timeout time, exited early
         XCTAssertLessThan(Date().timeIntervalSince(startTime), 10)
         XCTAssertNotNil(assertion)
-        let attestationEvents = STPAnalyticsClient.sharedClient._testLogHistory.map({ $0["event"] as? String }).filter({ $0?.starts(with: "elements.attestation.confirmation") ?? false })
-        XCTAssertEqual(attestationEvents, ["elements.attestation.confirmation.prepare", "elements.attestation.confirmation.prepare_succeeded", "elements.attestation.confirmation.request_token", "elements.attestation.confirmation.request_token_succeeded"])
+        XCTAssertTrue(STPAnalyticsClient.sharedClient._testLogHistory.map({ $0["event"] as? String }).contains("elements.attestation.confirmation.request_token_succeeded"))
         await attestationChallenge.complete()
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Added delay injection for HCaptcha (test failures were due to the hcaptcha token being returned in time when we thought it would time out).

Check only for attestation request token success analytic (test failures were because attestation preparation success analytic from other tests were logged in the shared test log, so it occasionally got logged more than once. Succeeded on the rerun)
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4864
## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
CI
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A