### PR TITLE
Re-enable set as default tests

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -1502,82 +1502,81 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
         await fulfillment(of: [expectation])
     }
 
-    // TODO: Re-enable
-//    func testSetAsDefault_CustomerSession() async throws {
-//        let types = ["card"]
-//        let expectation = XCTestExpectation(description: "Check default payment method set")
-//        // Create a new customer and new key
-//        let customerAndEphemeralKey = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(customerID: nil, merchantCountry: nil)
-//        let cscs = try await STPTestingAPIClient.shared().fetchCustomerAndCustomerSessionClientSecret(customerID: customerAndEphemeralKey.customer, merchantCountry: nil, paymentMethodSave: true, paymentMethodRemove: true, paymentMethodSetAsDefault: true)
-//        var configuration = self.configuration
-//        configuration.customer = PaymentSheet.CustomerConfiguration(id: cscs.customer, customerSessionClientSecret: cscs.customerSessionClientSecret)
-//        // Create a new payment method
-//        let defaultPaymentMethod = try await apiClient.createPaymentMethod(with: ._testCardValue(), additionalPaymentUserAgentValues: [])
-//
-//        // Attach the payment method to the customer
-//        try await apiClient.attachPaymentMethod(defaultPaymentMethod.stripeId,
-//                                                customerID: customerAndEphemeralKey.customer,
-//                                                ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret)
-//
-//       // Set the default payment method
-//        _ = try await apiClient.setAsDefaultPaymentMethod(defaultPaymentMethod.stripeId, for: customerAndEphemeralKey.customer, using: customerAndEphemeralKey.ephemeralKeySecret)
-//        // 0. Create a PI on our test backend
-//        STPTestingAPIClient.shared.fetchPaymentIntent(types: types, shouldSavePM: true, customerID: configuration.customer?.id) {
-//            result in
-//            switch result {
-//            case .success(let clientSecret):
-//                // 1. Load the PI
-//                PaymentSheetLoader.load(
-//                    mode: .paymentIntentClientSecret(clientSecret),
-//                    configuration: configuration,
-//                    analyticsHelper: ._testValue(configuration: configuration),
-//                    integrationShape: .complete
-//                ) { result in
-//                    switch result {
-//                    case .success(let loadResult):
-//                        XCTAssertEqual(loadResult.elementsSession.customer?.defaultPaymentMethod, defaultPaymentMethod.stripeId)
-//                        expectation.fulfill()
-//                    case .failure(let error):
-//                        print(error)
-//                    }
-//                }
-//            case .failure(let error):
-//                print(error)
-//            }
-//        }
-//        await fulfillment(of: [expectation], timeout: STPTestingNetworkRequestTimeout)
-//    }
-//
-//    func testSetAsDefault_CustomerSession_CustomerSheetDataSource() async throws {
-//        var configuration = CustomerSheet.Configuration()
-//        configuration.apiClient = apiClient
-//        // Create a new customer and new key
-//        let customerAndEphemeralKey = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(customerID: nil, merchantCountry: nil)
-//        let cscs = try await STPTestingAPIClient.shared().fetchCustomerAndCustomerSessionClientSecretCustomerSheet(customerID: customerAndEphemeralKey.customer, merchantCountry: nil, paymentMethodSave: true, paymentMethodRemove: true, paymentMethodSetAsDefault: true)
-//        // Create a new payment method
-//        let defaultPaymentMethod = try await apiClient.createPaymentMethod(with: ._testCardValue(), additionalPaymentUserAgentValues: [])
-//
-//        // Attach the payment method to the customer
-//        try await apiClient.attachPaymentMethod(defaultPaymentMethod.stripeId,
-//                                                customerID: customerAndEphemeralKey.customer,
-//                                                ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret)
-//        let loadPaymentMethodInfo = expectation(description: "loadPaymentMethodInfo completed")
-//        let customerSheet = CustomerSheet(configuration: configuration,
-//                                          intentConfiguration: .init(setupIntentClientSecretProvider: { return "si_123" }),
-//                                          customerSessionClientSecretProvider: { return .init(customerId: cscs.customer, clientSecret: cscs.customerSessionClientSecret) })
-//        let csDataSource = customerSheet.createCustomerSheetDataSource()!
-//        _ = try await csDataSource.setAsDefaultPaymentMethod(paymentMethodId: defaultPaymentMethod.stripeId)
-//        csDataSource.loadPaymentMethodInfo { result in
-//            guard case .success((_, _, let elementsSession)) = result else {
-//                XCTFail()
-//                return
-//            }
-//            XCTAssertNotNil(elementsSession)
-//            XCTAssertEqual(elementsSession.customer?.defaultPaymentMethod, defaultPaymentMethod.stripeId)
-//            loadPaymentMethodInfo.fulfill()
-//        }
-//        await fulfillment(of: [loadPaymentMethodInfo], timeout: 5.0)
-//    }
+    func testSetAsDefault_CustomerSession() async throws {
+        let types = ["card"]
+        let expectation = XCTestExpectation(description: "Check default payment method set")
+        // Create a new customer and new key
+        let customerAndEphemeralKey = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(customerID: nil, merchantCountry: nil)
+        let cscs = try await STPTestingAPIClient.shared().fetchCustomerAndCustomerSessionClientSecret(customerID: customerAndEphemeralKey.customer, merchantCountry: nil, paymentMethodSave: true, paymentMethodRemove: true, paymentMethodSetAsDefault: true)
+        var configuration = self.configuration
+        configuration.customer = PaymentSheet.CustomerConfiguration(id: cscs.customer, customerSessionClientSecret: cscs.customerSessionClientSecret)
+        // Create a new payment method
+        let defaultPaymentMethod = try await apiClient.createPaymentMethod(with: ._testCardValue(), additionalPaymentUserAgentValues: [])
+
+        // Attach the payment method to the customer
+        try await apiClient.attachPaymentMethod(defaultPaymentMethod.stripeId,
+                                                customerID: customerAndEphemeralKey.customer,
+                                                ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret)
+
+       // Set the default payment method
+        _ = try await apiClient.setAsDefaultPaymentMethod(defaultPaymentMethod.stripeId, for: customerAndEphemeralKey.customer, using: customerAndEphemeralKey.ephemeralKeySecret)
+        // 0. Create a PI on our test backend
+        STPTestingAPIClient.shared.fetchPaymentIntent(types: types, shouldSavePM: true, customerID: configuration.customer?.id) {
+            result in
+            switch result {
+            case .success(let clientSecret):
+                // 1. Load the PI
+                PaymentSheetLoader.load(
+                    mode: .paymentIntentClientSecret(clientSecret),
+                    configuration: configuration,
+                    analyticsHelper: ._testValue(configuration: configuration),
+                    integrationShape: .complete
+                ) { result in
+                    switch result {
+                    case .success(let loadResult):
+                        XCTAssertEqual(loadResult.elementsSession.customer?.defaultPaymentMethod, defaultPaymentMethod.stripeId)
+                        expectation.fulfill()
+                    case .failure(let error):
+                        print(error)
+                    }
+                }
+            case .failure(let error):
+                print(error)
+            }
+        }
+        await fulfillment(of: [expectation], timeout: STPTestingNetworkRequestTimeout)
+    }
+
+    func testSetAsDefault_CustomerSession_CustomerSheetDataSource() async throws {
+        var configuration = CustomerSheet.Configuration()
+        configuration.apiClient = apiClient
+        // Create a new customer and new key
+        let customerAndEphemeralKey = try await STPTestingAPIClient.shared().fetchCustomerAndEphemeralKey(customerID: nil, merchantCountry: nil)
+        let cscs = try await STPTestingAPIClient.shared().fetchCustomerAndCustomerSessionClientSecretCustomerSheet(customerID: customerAndEphemeralKey.customer, merchantCountry: nil, paymentMethodSave: true, paymentMethodRemove: true, paymentMethodSetAsDefault: true)
+        // Create a new payment method
+        let defaultPaymentMethod = try await apiClient.createPaymentMethod(with: ._testCardValue(), additionalPaymentUserAgentValues: [])
+
+        // Attach the payment method to the customer
+        try await apiClient.attachPaymentMethod(defaultPaymentMethod.stripeId,
+                                                customerID: customerAndEphemeralKey.customer,
+                                                ephemeralKeySecret: customerAndEphemeralKey.ephemeralKeySecret)
+        let loadPaymentMethodInfo = expectation(description: "loadPaymentMethodInfo completed")
+        let customerSheet = CustomerSheet(configuration: configuration,
+                                          intentConfiguration: .init(setupIntentClientSecretProvider: { return "si_123" }),
+                                          customerSessionClientSecretProvider: { return .init(customerId: cscs.customer, clientSecret: cscs.customerSessionClientSecret) })
+        let csDataSource = customerSheet.createCustomerSheetDataSource()!
+        _ = try await csDataSource.setAsDefaultPaymentMethod(paymentMethodId: defaultPaymentMethod.stripeId)
+        csDataSource.loadPaymentMethodInfo { result in
+            guard case .success((_, _, let elementsSession)) = result else {
+                XCTFail()
+                return
+            }
+            XCTAssertNotNil(elementsSession)
+            XCTAssertEqual(elementsSession.customer?.defaultPaymentMethod, defaultPaymentMethod.stripeId)
+            loadPaymentMethodInfo.fulfill()
+        }
+        await fulfillment(of: [loadPaymentMethodInfo], timeout: 5.0)
+    }
 }
 
 extension PaymentSheetAPITest: STPAuthenticationContext {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Set as default tests were failing when hitting the live endpoint due to a [flag rollout](https://amp.corp.stripe.com/feature-flags/flag/enable_v2_account_tax_functionality_from_v1_customers?tab=history). It has been [rolled back](https://stripe.slack.com/archives/C049V6TV8NA/p1764060271485919?thread_ts=1764027064.116709&cid=C049V6TV8NA).
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://incident-reporting.corp.stripe.com/wf/incidents/globes-compose
## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Re-ran without mocks.
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A