### PR TITLE
Add FC Lite UI tests that complete a purchase

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
@@ -80,10 +80,11 @@ class FCLiteUITests: XCTestCase {
         let autofillButton = app.webViews.firstMatch.buttons.containing(autofillButtonPredicate).firstMatch
         XCTAssertTrue(autofillButton.waitForExistenceAndTap(timeout: 5.0))
 
-        // Tap "Not now" button
-        let notNowButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Save with Link'")
-        let notNowButton = app.webViews.firstMatch.buttons.containing(notNowButtonPredicate).firstMatch
-        XCTAssertTrue(notNowButton.waitForExistenceAndTap(timeout: 5.0))
+        // Tap "Save with Link" button (tapPrimaryButton handles keyboard dismissal if needed)
+        let saveWithLinkButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Save with Link'")
+        let saveWithLinkButton = app.webViews.firstMatch.buttons.containing(saveWithLinkButtonPredicate).firstMatch
+        XCTAssertTrue(saveWithLinkButton.waitForExistence(timeout: 5.0))
+        tapPrimaryButton()
 
         // Tap "Done" button
         let doneButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Done'")
@@ -156,7 +157,16 @@ class FCLiteUITests: XCTestCase {
 
     /// Taps the primary CTA button at the bottom of the FC webview.
     /// Webview accessibility frames are unreliable, so we tap at a fixed coordinate.
+    /// If the keyboard is open, it dismisses it first.
     private func tapPrimaryButton() {
+        // Dismiss keyboard if open - check for "Done" (iOS 18) or checkmark button (iOS 26)
+        let keyboardDoneButton = app.toolbars.buttons["Done"]
+
+        if keyboardDoneButton.waitForExistence(timeout: 1.0) {
+            keyboardDoneButton.tap()
+            Thread.sleep(forTimeInterval: 0.5)
+        }
+
         // Primary button is at the bottom center of the webview (roughly 90% down, centered)
         app.webViews.firstMatch.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.9)).tap()
     }


### PR DESCRIPTION
## Summary

Adds some FC Lite UI tests to go through the US Bank Account and Instant Debits flow, and complete a purchase. This should help catch any regressions that might impact FC Lite or the web FC flow in general.

## Motivation

ir-auburn-proof

## Testing

`testFCLiteUSBankAccountFlow()`:


https://github.com/user-attachments/assets/9ee7b4d8-c6f7-4e75-b5bc-2da01e8d308c

`testFCLiteInstantDebitsFlow()`:


https://github.com/user-attachments/assets/d8370332-3b23-4121-ac32-f9514b671f88


