### PR TITLE
Speed up checkout action in dead code check

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -175,4 +175,3 @@ let package = Package(
         )
     ]
 )
-


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Update the action version and remove `fetch-depth: 0` to speed up the action.
Reducing the checkout time from averaging ~2m to under 20s.
https://github.com/stripe/stripe-ios/actions/runs/19905920015/job/57061959041

Starting from [checkout-v4](https://github.com/actions/checkout?tab=readme-ov-file#checkout-v4):
> Only a single commit is fetched by default, for the ref/SHA that triggered the workflow. Set fetch-depth: 0 to fetch all history for all branches and tags.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
In the worst scenario, it takes 9 minutes to checkout.
https://stripe.slack.com/archives/C02HQBW38JX/p1764783011920219
