### PR TITLE
Filter card funding types in Link

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
@@ -69,7 +69,8 @@ extension ConsumerPaymentDetails {
     func isSupported(linkAccount: PaymentSheetLinkAccount,
                      elementsSession: STPElementsSession,
                      configuration: PaymentElementConfiguration,
-                     cardBrandFilter: CardBrandFilter) -> Bool {
+                     cardBrandFilter: CardBrandFilter,
+                     cardFundingFilter: CardFundingFilter) -> Bool {
         guard linkAccount.supportedPaymentDetailsTypes(for: elementsSession).contains(type) else {
             return false
         }
@@ -77,6 +78,12 @@ extension ConsumerPaymentDetails {
         if case let .card(details) = details,
            !cardBrandFilter.isAccepted(cardBrand: details.stpBrand),
            elementsSession.linkCardBrandFilteringEnabled {
+            return false
+        }
+
+        // Check if card funding type is accepted
+        if case let .card(details) = details,
+           !cardFundingFilter.isAccepted(cardFundingType: details.funding.stpFundingType) {
             return false
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -318,7 +318,7 @@ extension PayWithLinkViewController {
         }
 
         func isPaymentMethodSupported(paymentMethod: ConsumerPaymentDetails?) -> Bool {
-            paymentMethod?.isSupported(linkAccount: linkAccount, elementsSession: context.elementsSession, configuration: context.configuration, cardBrandFilter: context.configuration.cardBrandFilter) ?? false
+            paymentMethod?.isSupported(linkAccount: linkAccount, elementsSession: context.elementsSession, configuration: context.configuration, cardBrandFilter: context.configuration.cardBrandFilter, cardFundingFilter: context.configuration.cardFundingFilter) ?? false
         }
     }
 }


### PR DESCRIPTION
## Summary
- Forward funding type filter to Link so we can filter saved Link cards

## Motivation
- Card funding filtering

## Testing
- Manual
- New tests

## Changelog
N/A
