### PR TITLE
Deflake IBP native test

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
@@ -105,6 +105,7 @@ class LinkPaymentControllerUITest: XCTestCase {
     }
 
     func testNativeInstantDebitsOnlyLinkPaymentController() {
+        app.launchArguments += ["-FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE", "YES"]
         app.launchEnvironment["FinancialConnectionsSDKAvailable"] = "true"
         app.launch()
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -3692,6 +3692,7 @@ extension PaymentSheetUITestCase {
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States (+1)")
         app.toolbars.buttons["Done"].tap()
 
+        sleep(1) // Wait for keyboard to dismiss
         phoneTextField.tap()
         phoneTextField.typeText("4015006000")
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
@@ -65,12 +65,14 @@ class FlowRouter {
 
     /// Returns `.native` if the FC example app has the native SDK selected, `.web` if the web SDK is selected, and `.none` otherwise.
     private var exampleAppSdkOverride: ExampleAppOverride {
-        if let nativeOverride = UserDefaults.standard.value(
-            forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE"
-        ) as? Bool {
-            return nativeOverride ? .native : .web
+        let key = "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE"
+        guard let value = UserDefaults.standard.object(forKey: key) else {
+            return .none
         }
-        return .none
+
+        // Launch arguments pass values as strings; direct sets use Bool
+        let isNative = (value as? Bool) ?? (value as? NSString)?.boolValue ?? false
+        return isNative ? .native : .web
     }
 
     private var shouldUseNativeFinancialConnections: Bool {


### PR DESCRIPTION
## Summary

Deflakes the `testNativeInstantDebitsOnlyLinkPaymentController` which was unexpectedly not using the native flow https://app.bitrise.io/build/3b0c8c0e-105b-4154-85d3-1ca1b6b51063?tab=tests&tests_filter_status=failed

These changes should force the native flow in that test.

## Motivation

Keeping master green!

