### PR TITLE
Add pinning/auto-open feature to example app

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
@@ -29,8 +29,6 @@ struct PaymentSheetExampleAppRootView: View {
                     }
                 }
             }
-            .navigationTitle("Examples")
-            .navigationBarTitleDisplayMode(.inline)
         }
         .onAppear {
             // Load pinned destination from UserDefaults and auto-open it


### PR DESCRIPTION
## Summary
Add "pin" button to Payment Sheet Example app pages. Pinning a view causes it to be automatically opened when the app loads. Propagated via UserDefaults

## Motivation
Remove developer friction
https://jira.corp.stripe.com/browse/MOBILESDK-4287

## Testing
https://github.com/user-attachments/assets/a3246dff-94dd-42da-a04f-10a4859d86f8

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
