### PR TITLE
Fix "No data available" message in DocC

### DIFF
--- a/ci_scripts/build_documentation.rb
+++ b/ci_scripts/build_documentation.rb
@@ -183,13 +183,9 @@ def build_index_page(modules, release_version, docs_root_directory)
   temp_docc_dir = Dir.mktmpdir('stripe-docs-index-build')
   `rsync -av "#{$SCRIPT_DIR}/docs/Stripe.docc" "#{temp_docc_dir}/"`
   index_path = "#{temp_docc_dir}/Stripe.docc/Stripe.md"
-  # Add the `@TechnologyRoot` attribute, which instructs docc to make this the landing page.
+  index_2_path = "#{temp_docc_dir}/Stripe.docc/Stripe-module-index.md" # Need a second index, or DocC will show a sidebar that says "No content found".
   index_content = ''"
   # Stripe iOS SDKs
-
-  @Metadata {
-    @TechnologyRoot
-  }
 
   Version #{release_version}
 
@@ -206,6 +202,7 @@ def build_index_page(modules, release_version, docs_root_directory)
   end
 
   File.write(index_path, index_content)
+  File.write(index_2_path, index_content)
   # Build it
   `$(xcrun --find docc) \
    convert "#{temp_docc_dir}/Stripe.docc" \


### PR DESCRIPTION
## Summary

We only have one page in the top-level Stripe bundle, so by default [DocC renders this confusing "No data available" message](https://github.com/swiftlang/swift-docc-render/blob/47119089948ba164da2884083bf4740c8ece78f2/src/components/Navigator/NavigatorCard.vue#L263).
<img width="818" height="300" alt="CleanShot 2025-12-15 at 16 46 36@2x" src="https://github.com/user-attachments/assets/887fe63f-393b-49a8-b1af-232f8de4d264" />

Our flexibility is unfortunately limited here, so we'll work around this by adding a duplicate "Stripe iOS SDKs" page. This adds one page to the sidebar:
<img width="2988" height="1680" alt="CleanShot 2025-12-15 at 16 49 10@2x" src="https://github.com/user-attachments/assets/130f572c-4997-4d52-9af2-ee98ac446e83" />

While we're at it, I removed the `@TechnologyRoot` metadata attribute, as it's [no longer required in Swift 6](https://www.swift.org/documentation/docc/technologyroot).

## Testing
`bundle exec ./ci_scripts/build_documentation.rb --preview`

## Changelog
N/A