### PR TITLE
Auto announce field when becoming the first responder

### DIFF
--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
@@ -148,6 +148,7 @@ extension TextFieldElement: Element {
 
     @discardableResult
     public func beginEditing() -> Bool {
+        UIAccessibility.post(notification: .announcement, argument: viewModel.accessibilityLabel)
         return textFieldView.textField.becomeFirstResponder()
     }
 


### PR DESCRIPTION
## Summary
Adds a announcement when becoming first responder.

## Motivation
We programmatically select the next field, and in this case, it currently does not announce when VoiceOver is enabled.  We now explicitly send an announcement to tell users that we've selected the next field.

## Testing
On device 26.1

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
