### PR TITLE
Revert "Require merchants be verified to use native IBP"

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/AppDelegate+BrokenConstraints.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/AppDelegate+BrokenConstraints.swift
@@ -29,10 +29,6 @@ extension AppDelegate {
     }
 
     @objc func didReceiveBrokenConstraintNotification(notification: NSNotification) {
-        // Ignore during UI tests
-        guard ProcessInfo.processInfo.environment["UITesting"] == nil else {
-            return
-        }
         guard let constraint = notification.object as? NSLayoutConstraint else {
             return
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Common/FlowRouter.swift
@@ -96,7 +96,7 @@ class FlowRouter {
             return exampleAppSdkOverride.shouldUseNativeFlow
         }
 
-        return !killswitchActive && synchronizePayload.manifest.verified
+        return !killswitchActive
     }
 
     private var experimentVariant: String? {

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FlowRouterTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FlowRouterTests.swift
@@ -112,27 +112,12 @@ class FlowRouterTests: XCTestCase {
         XCTAssertEqual(flowRouter.flow, .webInstantDebits)
     }
 
-    func testInstantDebitsKillswitchNotActiveNotVerified() {
+    func testInstantDebitsKillswitchNotActive() {
         flowRouter = FlowRouter(
             synchronizePayload: synchronizePayload(
                 experience: .instantDebits,
                 killswitchActive: false,
-                nativeExperimentEnabled: true,
-                verified: false
-            ),
-            analyticsClient: mockAnalyticsClient
-        )
-
-        XCTAssertEqual(flowRouter.flow, .webInstantDebits)
-    }
-
-    func testInstantDebitsKillswitchNotActiveVerified() {
-        flowRouter = FlowRouter(
-            synchronizePayload: synchronizePayload(
-                experience: .instantDebits,
-                killswitchActive: false,
-                nativeExperimentEnabled: true,
-                verified: true
+                nativeExperimentEnabled: true
             ),
             analyticsClient: mockAnalyticsClient
         )
@@ -172,11 +157,10 @@ class FlowRouterTests: XCTestCase {
 
     // MARK: Helpers
 
-    private func synchronizePayload(experience: Experience, killswitchActive: Bool, nativeExperimentEnabled: Bool, verified: Bool = false) -> FinancialConnectionsSynchronize {
+    private func synchronizePayload(experience: Experience, killswitchActive: Bool, nativeExperimentEnabled: Bool) -> FinancialConnectionsSynchronize {
         FinancialConnectionsSynchronize(
             manifest: FinancialConnectionsSessionManifest(
                 allowManualEntry: false,
-                appVerificationEnabled: verified,
                 consentRequired: false,
                 customManualEntryHandling: false,
                 disableLinkMoreAccounts: false,


### PR DESCRIPTION
Reverts stripe/stripe-ios#5884

The secure webview version of Instant Debits is pretty buggy, so let's keep the original native instant debits eligibility checks.