### PR TITLE
Update check-docs to use iOS 26 test device

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,7 +5,7 @@ app:
   envs:
   - FASTLANE_XCODE_LIST_TIMEOUT: "120"
   - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.4
-  - DEFAULT_TEST_DEVICE_26_0: platform=iOS Simulator,name=iPhone 12 mini,OS=26.1
+  - DEFAULT_TEST_DEVICE_26_1: platform=iOS Simulator,name=iPhone 12 mini,OS=26.1
   - BITRISE_PROJECT_PATH: Stripe.xcworkspace
   - GIT_AUTHOR_NAME: Bitrise CI
   - GIT_AUTHOR_EMAIL: mobile-sdk-team@stripe.com
@@ -98,7 +98,7 @@ workflows:
       bitrise.io:
         stack: osx-xcode-26.1.x
     envs:
-    - DEFAULT_TEST_DEVICE: $DEFAULT_TEST_DEVICE_26_0
+    - DEFAULT_TEST_DEVICE: $DEFAULT_TEST_DEVICE_26_1
   deploy-docs:
     steps:
     - activate-ssh-key@4: {}
@@ -132,7 +132,7 @@ workflows:
       bitrise.io:
         stack: osx-xcode-26.1.x
     envs:
-    - DEFAULT_TEST_DEVICE: $DEFAULT_TEST_DEVICE_26_0
+    - DEFAULT_TEST_DEVICE: $DEFAULT_TEST_DEVICE_26_1
   deploy-dry-run:
     steps:
     - script@1:
@@ -368,7 +368,7 @@ workflows:
         title: Generate iOS 26 test plan
     - xcode-test@4:
         inputs:
-        - destination: $DEFAULT_TEST_DEVICE_26_0
+        - destination: $DEFAULT_TEST_DEVICE_26_1
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "2"
         - scheme: AllStripeFrameworks-iOS26
@@ -383,7 +383,7 @@ workflows:
         stack: osx-xcode-26.1.x
         machine_type_id: g2.mac.large
     envs:
-    - DEFAULT_TEST_DEVICE: $DEFAULT_TEST_DEVICE_26_0
+    - DEFAULT_TEST_DEVICE: $DEFAULT_TEST_DEVICE_26_1
   framework-tests-no-mocks:
     steps:
     - fastlane@3:


### PR DESCRIPTION
## Summary
bitrise stack osx-xcode-26.0.x and later have dropped support for iOS 16.4, so check-docs was failing since it was using the default iOS 16.4 test device and this workflow just got updated to use osx-xcode-26.1.x

Updated deploy-docs to use the iOS 26 test device too b/c it was also just updated to use osx-xcode-26.1.x

Workflows complete successfully with new test device

[Check-docs](https://app.bitrise.io/build/ab0ce119-a95d-42d8-b057-e3a83aae3585)
[Deploy-docs](https://app.bitrise.io/build/557e3460-7d29-4a5a-97b8-f422ff24392b)

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4966

## Testing
N.A.

## Changelog
N.A.