### PR TITLE
Remove unused UPE postal code formatter

### DIFF
--- a/Stripe/StripeiOSTests/STPCardFormViewTests.swift
+++ b/Stripe/StripeiOSTests/STPCardFormViewTests.swift
@@ -79,36 +79,11 @@ class STPCardFormViewTests: XCTestCase {
         }
     }
 
-    func testHidingPostalUPECodeOnInit() {
-        NSLocale.stp_withLocale(as: NSLocale(localeIdentifier: "zh_Hans_HK")) {
-            let cardForm = STPCardFormView(
-                billingAddressCollection: .automatic,
-                style: .standard,
-                postalCodeRequirement: .upe,
-                prefillDetails: nil
-            )
-            XCTAssertTrue(cardForm.postalCodeField.isHidden)
-        }
-    }
-
-    func testNotHidingPostalUPECodeOnInit() {
-        NSLocale.stp_withLocale(as: NSLocale(localeIdentifier: "en_US")) {
-            let cardForm = STPCardFormView(
-                billingAddressCollection: .automatic,
-                style: .standard,
-                postalCodeRequirement: .upe,
-                prefillDetails: nil
-            )
-            XCTAssertFalse(cardForm.postalCodeField.isHidden)
-        }
-    }
-
     func testPanLockedOnInit() {
         NSLocale.stp_withLocale(as: NSLocale(localeIdentifier: "en_US")) {
             let cardForm = STPCardFormView(
                 billingAddressCollection: .automatic,
                 style: .standard,
-                postalCodeRequirement: .upe,
                 prefillDetails: nil,
                 inputMode: .panLocked
             )
@@ -127,7 +102,6 @@ class STPCardFormViewTests: XCTestCase {
             let cardForm = STPCardFormView(
                 billingAddressCollection: .automatic,
                 style: .standard,
-                postalCodeRequirement: .upe,
                 prefillDetails: prefillDeatils,
                 inputMode: .panLocked
             )

--- a/Stripe/StripeiOSTests/STPPostalCodeInputTextFieldSnapshotTests.swift
+++ b/Stripe/StripeiOSTests/STPPostalCodeInputTextFieldSnapshotTests.swift
@@ -18,7 +18,7 @@ import StripeCoreTestUtils
 class STPPostalCodeInputTextFieldSnapshotTests: STPSnapshotTestCase {
 
     func testEmpty() {
-        let field = STPPostalCodeInputTextField(postalCodeRequirement: .standard)
+        let field = STPPostalCodeInputTextField()
         field.sizeToFit()
         field.frame.size.width = 200
 
@@ -26,7 +26,7 @@ class STPPostalCodeInputTextFieldSnapshotTests: STPSnapshotTestCase {
     }
 
     func testIncomplete() {
-        let field = STPPostalCodeInputTextField(postalCodeRequirement: .standard)
+        let field = STPPostalCodeInputTextField()
         field.sizeToFit()
         field.frame.size.width = 200
         field.countryCode = "US"
@@ -37,7 +37,7 @@ class STPPostalCodeInputTextFieldSnapshotTests: STPSnapshotTestCase {
     }
 
     func testValidUS() {
-        let field = STPPostalCodeInputTextField(postalCodeRequirement: .standard)
+        let field = STPPostalCodeInputTextField()
         field.sizeToFit()
         field.frame.size.width = 200
         field.countryCode = "US"
@@ -48,7 +48,7 @@ class STPPostalCodeInputTextFieldSnapshotTests: STPSnapshotTestCase {
     }
 
     func testValidUK() {
-        let field = STPPostalCodeInputTextField(postalCodeRequirement: .standard)
+        let field = STPPostalCodeInputTextField()
         field.sizeToFit()
         field.frame.size.width = 200
         field.countryCode = "UK"
@@ -59,7 +59,7 @@ class STPPostalCodeInputTextFieldSnapshotTests: STPSnapshotTestCase {
     }
 
     func testInvalid() {
-        let field = STPPostalCodeInputTextField(postalCodeRequirement: .standard)
+        let field = STPPostalCodeInputTextField()
         field.sizeToFit()
         field.frame.size.width = 200
         field.countryCode = "US"

--- a/Stripe/StripeiOSTests/STPPostalCodeInputTextFieldTests.swift
+++ b/Stripe/StripeiOSTests/STPPostalCodeInputTextFieldTests.swift
@@ -17,7 +17,7 @@ import XCTest
 class STPPostalCodeInputTextFieldTests: XCTestCase {
 
     func testClearingInvalidPostalCodeAfterCountryChange() {
-        let postalCodeField = STPPostalCodeInputTextField(postalCodeRequirement: .standard)
+        let postalCodeField = STPPostalCodeInputTextField()
         postalCodeField.countryCode = "UK"
         postalCodeField.text = "DL12"  // valid UK post code, invalid US ZIP Code
 
@@ -32,7 +32,7 @@ class STPPostalCodeInputTextFieldTests: XCTestCase {
     }
 
     func testPreservingValidPostalCodeAfterCountryChange() {
-        let postalCodeField = STPPostalCodeInputTextField(postalCodeRequirement: .standard)
+        let postalCodeField = STPPostalCodeInputTextField()
         postalCodeField.countryCode = "US"
         postalCodeField.text = "10010"  // valid US and HR ZIP/postal code
 
@@ -47,7 +47,7 @@ class STPPostalCodeInputTextFieldTests: XCTestCase {
     }
 
     func testChangeToNonRequiredPostalCodeIsValid() {
-        let postalCodeField = STPPostalCodeInputTextField(postalCodeRequirement: .upe)
+        let postalCodeField = STPPostalCodeInputTextField()
         // given that the postal code field is empty...
 
         // when

--- a/Stripe/StripeiOSTests/STPPostalCodeInputTextFieldValidatorTests.swift
+++ b/Stripe/StripeiOSTests/STPPostalCodeInputTextFieldValidatorTests.swift
@@ -17,7 +17,7 @@ import XCTest
 class STPPostalCodeInputTextFieldValidatorTests: XCTestCase {
 
     func testValidation() {
-        let validator = STPPostalCodeInputTextFieldValidator(postalCodeRequirement: .standard)
+        let validator = STPPostalCodeInputTextFieldValidator()
         validator.countryCode = "US"
 
         validator.inputValue = nil

--- a/Stripe/StripeiOSTests/STPPostalCodeValidatorTest.swift
+++ b/Stripe/StripeiOSTests/STPPostalCodeValidatorTest.swift
@@ -76,28 +76,4 @@ class STPPostalCodeValidatorTest: XCTestCase {
             )
         }
     }
-
-    func testPostalCodeIsRequiredForUPE_nil() {
-        XCTAssertFalse(STPPostalCodeValidator.postalCodeIsRequiredForUPE(forCountryCode: nil))
-    }
-
-    func testPostalCodeIsRequiredForUPE_empty() {
-        XCTAssertFalse(STPPostalCodeValidator.postalCodeIsRequiredForUPE(forCountryCode: ""))
-    }
-
-    func testPostalCodeIsRequiredForUPE_CA() {
-        XCTAssertTrue(STPPostalCodeValidator.postalCodeIsRequiredForUPE(forCountryCode: "CA"))
-    }
-
-    func testPostalCodeIsRequiredForUPE_GB() {
-        XCTAssertTrue(STPPostalCodeValidator.postalCodeIsRequiredForUPE(forCountryCode: "GB"))
-    }
-
-    func testPostalCodeIsRequiredForUPE_US() {
-        XCTAssertTrue(STPPostalCodeValidator.postalCodeIsRequiredForUPE(forCountryCode: "CA"))
-    }
-
-    func testPostalCodeIsRequiredForUPE_DK() {
-        XCTAssertFalse(STPPostalCodeValidator.postalCodeIsRequiredForUPE(forCountryCode: "DK"))
-    }
 }

--- a/StripePaymentsUI/StripePaymentsUI/Source/Helpers/STPPostalCodeValidator.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Helpers/STPPostalCodeValidator.swift
@@ -17,11 +17,6 @@ import Foundation
     case cardField
 }
 
-@objc @_spi(STP) public enum STPPostalCodeRequirement: Int {
-    case standard
-    case upe
-}
-
 @_spi(STP) public class STPPostalCodeValidator: NSObject {
     @_spi(STP) public class func postalCodeIsRequired(forCountryCode countryCode: String?) -> Bool {
         if countryCode == nil {
@@ -33,30 +28,12 @@ import Foundation
         }
     }
 
-    class func postalCodeIsRequiredForUPE(forCountryCode countryCode: String?) -> Bool {
-        guard let countryCode = countryCode else { return false }
-        return self.countriesWithPostalRequiredForUPE().contains(countryCode.uppercased())
-    }
-
-    class func postalCodeIsRequired(
-        forCountryCode countryCode: String?,
-        with postalRequirement: STPPostalCodeRequirement
-    ) -> Bool {
-        switch postalRequirement {
-        case .standard:
-            return postalCodeIsRequired(forCountryCode: countryCode)
-        case .upe:
-            return postalCodeIsRequiredForUPE(forCountryCode: countryCode)
-        }
-    }
-
     @_spi(STP) public class func validationState(
         forPostalCode postalCode: String?,
-        countryCode: String?,
-        with postalRequirement: STPPostalCodeRequirement = .standard
+        countryCode: String?
     ) -> STPCardValidationState {
         let sanitizedCountryCode = countryCode?.uppercased()
-        if self.postalCodeIsRequired(forCountryCode: countryCode, with: postalRequirement) {
+        if self.postalCodeIsRequired(forCountryCode: countryCode) {
             if sanitizedCountryCode == STPCountryCodeUnitedStates {
                 return self.validationState(forUSPostalCode: postalCode)
             } else {
@@ -213,10 +190,6 @@ import Foundation
         }
 
         return formattedString
-    }
-
-    class func countriesWithPostalRequiredForUPE() -> [AnyHashable] {
-        return ["CA", "GB", "US"]
     }
 
     class func countriesWithNoPostalCodes() -> [AnyHashable]? {

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/Card/STPPostalCodeInputTextField.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/Card/STPPostalCodeInputTextField.swift
@@ -26,14 +26,10 @@ import UIKit
         return validator.inputValue
     }
 
-    public convenience init(
-        postalCodeRequirement: STPPostalCodeRequirement
-    ) {
+    public convenience init() {
         self.init(
             formatter: STPPostalCodeInputTextFieldFormatter(),
-            validator: STPPostalCodeInputTextFieldValidator(
-                postalCodeRequirement: postalCodeRequirement
-            )
+            validator: STPPostalCodeInputTextFieldValidator()
         )
     }
 

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/Card/STPPostalCodeInputTextFieldValidator.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/Inputs/Card/STPPostalCodeInputTextFieldValidator.swift
@@ -32,21 +32,11 @@ class STPPostalCodeInputTextFieldValidator: STPInputTextFieldValidator {
         }
     }
 
-    let postalCodeRequirement: STPPostalCodeRequirement
-
-    required init(
-        postalCodeRequirement: STPPostalCodeRequirement
-    ) {
-        self.postalCodeRequirement = postalCodeRequirement
-        super.init()
-    }
-
     private func updateValidationState() {
 
         switch STPPostalCodeValidator.validationState(
             forPostalCode: inputValue,
-            countryCode: countryCode,
-            with: postalCodeRequirement
+            countryCode: countryCode
         )
         {
         case .valid:

--- a/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPCardFormView.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/UI Components/STPCardFormView.swift
@@ -52,7 +52,6 @@ public class STPCardFormView: STPFormView {
     let expiryField: STPCardExpiryInputTextField
 
     let billingAddressSubForm: BillingAddressSubForm
-    let postalCodeRequirement: STPPostalCodeRequirement
     let inputMode: STPCardNumberInputTextField.InputMode
 
     @_spi(STP) public var countryField: STPCountryPickerInputField {
@@ -78,8 +77,7 @@ public class STPCardFormView: STPFormView {
         set(
             textField: postalCodeField,
             isHidden: !STPPostalCodeValidator.postalCodeIsRequired(
-                forCountryCode: countryCode,
-                with: postalCodeRequirement
+                forCountryCode: countryCode
             ),
             animated: window != nil
         )
@@ -313,7 +311,6 @@ public class STPCardFormView: STPFormView {
     @_spi(STP) public convenience init(
         billingAddressCollection: BillingAddressCollectionLevel,
         style: STPCardFormViewStyle = .standard,
-        postalCodeRequirement: STPPostalCodeRequirement = .standard,
         prefillDetails: PrefillDetails? = nil,
         inputMode: STPCardNumberInputTextField.InputMode = .standard,
         cbcEnabledOverride: Bool? = nil
@@ -327,11 +324,9 @@ public class STPCardFormView: STPFormView {
             cvcField: STPCardCVCInputTextField(prefillDetails: prefillDetails),
             expiryField: STPCardExpiryInputTextField(prefillDetails: prefillDetails),
             billingAddressSubForm: BillingAddressSubForm(
-                billingAddressCollection: billingAddressCollection,
-                postalCodeRequirement: postalCodeRequirement
+                billingAddressCollection: billingAddressCollection
             ),
             style: style,
-            postalCodeRequirement: postalCodeRequirement,
             prefillDetails: prefillDetails,
             inputMode: inputMode
         )
@@ -343,7 +338,6 @@ public class STPCardFormView: STPFormView {
         expiryField: STPCardExpiryInputTextField,
         billingAddressSubForm: BillingAddressSubForm,
         style: STPCardFormViewStyle = .standard,
-        postalCodeRequirement: STPPostalCodeRequirement = .standard,
         prefillDetails: PrefillDetails? = nil,
         inputMode: STPCardNumberInputTextField.InputMode = .standard
     ) {
@@ -352,7 +346,6 @@ public class STPCardFormView: STPFormView {
         self.expiryField = expiryField
         self.billingAddressSubForm = billingAddressSubForm
         self.style = style
-        self.postalCodeRequirement = postalCodeRequirement
         self.inputMode = inputMode
 
         if inputMode == .panLocked {
@@ -473,8 +466,7 @@ public class STPCardFormView: STPFormView {
             let shouldFocusOnPostalCode =
                 countryChanged
                 && STPPostalCodeValidator.postalCodeIsRequired(
-                    forCountryCode: countryCode,
-                    with: postalCodeRequirement
+                    forCountryCode: countryCode
                 )
 
             if shouldFocusOnPostalCode {
@@ -714,12 +706,9 @@ extension STPCardFormView {
         }
 
         required init(
-            billingAddressCollection: BillingAddressCollectionLevel,
-            postalCodeRequirement: STPPostalCodeRequirement
+            billingAddressCollection: BillingAddressCollectionLevel
         ) {
-            postalCodeField = STPPostalCodeInputTextField(
-                postalCodeRequirement: postalCodeRequirement
-            )
+            postalCodeField = STPPostalCodeInputTextField()
 
             let rows: [[STPInputTextField]]
             let title: String


### PR DESCRIPTION
## Summary
PaymentSheet (fka UPE) no longer uses this form, so we can remove support for .upe from the postal code validation logic.

## Motivation
Cleaning up unused code

## Testing
CI

## Changelog
N/A, internal