### PR TITLE
Throw error and log analytics for non-200 HTTP responses in DownloadM…

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/DownloadManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/DownloadManager.swift
@@ -16,6 +16,7 @@ import UIKit
 
     enum Error: Swift.Error {
         case failedToMakeImageFromData
+        case non200ResponseCode(statusCode: Int)
     }
 
     public static let sharedManager = DownloadManager()
@@ -94,7 +95,11 @@ extension DownloadManager {
 
     private func downloadImageSkippingCacheRead(url: URL) async throws -> UIImage {
         do {
-            let (data, _) = try await session.data(from: url)
+            let (data, response) = try await session.data(from: url)
+            let httpStatusCode = (response as? HTTPURLResponse)?.statusCode ?? -1
+            guard httpStatusCode == 200 else {
+                throw Error.non200ResponseCode(statusCode: httpStatusCode)
+            }
             let image = try UIImage.from(imageData: data) // Throws a Error.failedToMakeImageFromData
             Task {
                 // Cache the image in memory


### PR DESCRIPTION
…anager

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4997

Images failing to decode here are likely caused by non-200 responses.

## Testing
See test

## Changelog
Not user facing
