### PR TITLE
Fix AddressViewController opening picker after autocompleting address

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -547,13 +547,12 @@ extension AddressViewController: AutoCompleteViewControllerDelegate {
         }
 
         if let autocompleteCountryIndex = autocompleteCountryIndex {
-            addressSection.country.select(index: autocompleteCountryIndex)
+            addressSection.country.select(index: autocompleteCountryIndex, shouldAutoAdvance: false)
         }
         addressSection.line1?.setText(address.line1 ?? "")
         addressSection.city?.setText(address.city ?? "")
         addressSection.postalCode?.setText(address.postalCode ?? "")
         addressSection.state?.setRawData(address.state ?? "", shouldAutoAdvance: false)
-        addressSection.state?.view.resignFirstResponder()
 
         self.selectedAutoCompleteResult = address
     }


### PR DESCRIPTION
## Summary
Previously we forced a first responder resignation on the picker to stop it from being opened after the customer selects an autocomplete address. However, this is unreliable due to timing issues, causing the picker to quickly open and then close or not close at all. The better way to accomplish this is to not open it in the first place when the customer selects an autocomplete address by turning off `shouldAutoAdvance`.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-4862

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
