### PR TITLE
ConfirmButton Refactor 5/6 - Move enums, NotificationCenter, and traitCollection into BuyButton

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
@@ -18,55 +18,9 @@ private let spinnerMoveToCenterAnimationDuration = 0.35
 
 /// Buy or Continue button
 class ConfirmButton: UIView {
-    // MARK: Internal Properties
-    enum Status {
-        case enabled
-        case disabled
-        case processing
-        case spinnerWithInteractionDisabled
-        case succeeded
-    }
-    enum CallToActionType {
-        case pay(amount: Int, currency: String, withLock: Bool = true)
-        case add(paymentMethodType: PaymentSheet.PaymentMethodType)
-        case `continue`
-        case continueWithLock
-        case setup
-        case custom(title: String)
-        case customWithLock(title: String)
 
-        static func makeDefaultTypeForPaymentSheet(intent: Intent) -> CallToActionType {
-            switch intent {
-            case .paymentIntent(let paymentIntent):
-                return .pay(amount: paymentIntent.amount, currency: paymentIntent.currency)
-            case .setupIntent:
-                return .setup
-            case .deferredIntent(let intentConfig):
-                switch intentConfig.mode {
-                case .payment(let amount, let currency, _, _, _):
-                    return .pay(amount: amount, currency: currency)
-                case .setup:
-                    return .setup
-                }
-            }
-        }
-
-        static func makeDefaultTypeForLink(intent: Intent) -> CallToActionType {
-            switch intent {
-            case .paymentIntent(let paymentIntent):
-                return .pay(amount: paymentIntent.amount, currency: paymentIntent.currency, withLock: false)
-            case .setupIntent:
-                return .continue
-            case .deferredIntent(let intentConfig):
-                switch intentConfig.mode {
-                case .payment(let amount, let currency, _, _, _):
-                    return .pay(amount: amount, currency: currency, withLock: false)
-                case .setup:
-                    return .continue
-                }
-            }
-        }
-    }
+    typealias Status = BuyButton.Status
+    typealias CallToActionType = BuyButton.CallToActionType
 
     // MARK: Private Properties
     private let buyButton: BuyButton
@@ -129,6 +83,55 @@ class ConfirmButton: UIView {
     // MARK: - BuyButton
 
     class BuyButton: UIControl {
+
+        enum Status {
+            case enabled
+            case disabled
+            case processing
+            case spinnerWithInteractionDisabled
+            case succeeded
+        }
+        enum CallToActionType {
+            case pay(amount: Int, currency: String, withLock: Bool = true)
+            case add(paymentMethodType: PaymentSheet.PaymentMethodType)
+            case `continue`
+            case continueWithLock
+            case setup
+            case custom(title: String)
+            case customWithLock(title: String)
+
+            static func makeDefaultTypeForPaymentSheet(intent: Intent) -> CallToActionType {
+                switch intent {
+                case .paymentIntent(let paymentIntent):
+                    return .pay(amount: paymentIntent.amount, currency: paymentIntent.currency)
+                case .setupIntent:
+                    return .setup
+                case .deferredIntent(let intentConfig):
+                    switch intentConfig.mode {
+                    case .payment(let amount, let currency, _, _, _):
+                        return .pay(amount: amount, currency: currency)
+                    case .setup:
+                        return .setup
+                    }
+                }
+            }
+
+            static func makeDefaultTypeForLink(intent: Intent) -> CallToActionType {
+                switch intent {
+                case .paymentIntent(let paymentIntent):
+                    return .pay(amount: paymentIntent.amount, currency: paymentIntent.currency, withLock: false)
+                case .setupIntent:
+                    return .continue
+                case .deferredIntent(let intentConfig):
+                    switch intentConfig.mode {
+                    case .payment(let amount, let currency, _, _, _):
+                        return .pay(amount: amount, currency: currency, withLock: false)
+                    case .setup:
+                        return .continue
+                    }
+                }
+            }
+        }
 
         /// Background color for the `.disabled` state.
         var disabledBackgroundColor: UIColor {


### PR DESCRIPTION
## Summary
Part 5/6 of a factor of the ConfirmButton. Previously the ConfirmButton class supported both the Apple Pay button and confirm buttons, but now it only supports confirm buttons and can be simplified, improve code clarity and SDK binary size.
Draft PR showing the whole change: #5678.

This PR moves the enums, NotificationCenter code, and traitCollectionDidChange code into the BuyButton. This sets up the BuyButton implementation to replace the ConfirmButton wrapper and itself become the ConfirmButton

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
