### PR TITLE
Add render_error type to EmbeddedComponentError

### DIFF
--- a/StripeConnect/StripeConnect/Source/Helpers/EmbeddedComponentError.swift
+++ b/StripeConnect/StripeConnect/Source/Helpers/EmbeddedComponentError.swift
@@ -20,6 +20,8 @@ public struct EmbeddedComponentError: Error, CustomDebugStringConvertible {
         case invalidRequestError = "invalid_request_error"
         /// Too many requests hit the API too quickly
         case rateLimitError = "rate_limit_error"
+        /// Failure to render the component, typically caused by browser extensions or network issues
+        case renderError = "render_error"
         /// API errors covering any other type of problem (e.g., a temporary problem with Stripe's servers),
         /// and are extremely uncommon
         case apiError = "api_error"


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Adds `render_error` type to `EmbeddedComponentError`

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
This will allow platforms to have visibility into render errors (when components don't render due to things like network errors or browser extensions that block ui frames from loading)

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
