### PR TITLE
don't retain @_spi(STP) public declarations

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -12,8 +12,8 @@ retain_public: true
 retain_objc_accessible: false
 retain_objc_annotated: false
 exclude_tests: true
-
 verbose: true
+no_retain_spi: ["STP"]
 
 build_arguments:
   - -destination


### PR DESCRIPTION
## Summary
Periphery 3.4.0, which is now supported by GitHub actions, includes our very own new feature that allows SPIs of your choice to be excluded from the retain_public behavior! Adding STP since we consider these to be internal declarations and should not be ignored by dead code detection

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
