### PR TITLE
CryptoOnramp SDK: Swaps Integration Test Account to Mitigate Demo BE Latency Issue

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITests.swift
+++ b/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITests.swift
@@ -30,7 +30,7 @@ final class CryptoOnrampExampleUITests: XCTestCase {
         XCTAssertTrue(logInLoadingLabel.waitForNonExistence(timeout: .networkTimeout), "Loading indicator should disappear")
 
         emailField.tap()
-        emailField.typeText("onramptest@stripe.com")
+        emailField.typeText("onramptest2@stripe.com")
 
         let passwordField = app.secureTextFields["Enter password"].firstMatch
         XCTAssertTrue(passwordField.exists, "Password field should exist")
@@ -110,7 +110,7 @@ final class CryptoOnrampExampleUITests: XCTestCase {
         logOutMenuItem.tap()
 
         // Step 8: Authenticate again using seamless sign-in (no OTP, stored auth token from prior login).
-        let seamlessSignInLabel = app.staticTexts["Continue as onramptest@stripe.com?"]
+        let seamlessSignInLabel = app.staticTexts["Continue as onramptest2@stripe.com?"]
         XCTAssertTrue(seamlessSignInLabel.waitForExistence(timeout: .networkTimeout), "Seamless sign-in label should exist")
 
         let seamlessSignInLoadingLabel = app.staticTexts["Loading…"].firstMatch


### PR DESCRIPTION
## Summary
This PR swaps in a new account without a long transaction history. The end-to-end integration test that makes use of the demo backend is failing due to increased latency when an account has many transactions. This does not fix the underlying issue, but rather mitigates it for a period of time.

I created a new account for this and tested it locally to ensure the test passes.

## Motivation
https://lickability.slack.com/archives/C094P3BRBL1/p1768508993030539?thread_ts=1768235717.928229&cid=C094P3BRBL1

## Testing
Ran the test locally to ensure it passed.

## Changelog
N/A
