### PR TITLE
Dedicated BIN controller for funding filtering

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
@@ -45,6 +45,9 @@ final class CardSectionElement: ContainerElement {
     let analyticsHelper: PaymentSheetAnalyticsHelper?
     let cardBrandFilter: CardBrandFilter
     let cardFundingFilter: CardFundingFilter
+    /// Separate BIN controller for funding filtering to avoid polluting
+    /// See: https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5052
+    private let fundingBinController: STPBINController = STPBINController()
     private let opensCardScannerAutomatically: Bool
 
     private let linkAppearance: LinkAppearance?
@@ -120,7 +123,8 @@ final class CardSectionElement: ContainerElement {
             defaultValue: defaultValues.pan,
             cardBrandDropDown: cardBrandDropDown?.element,
             cardBrandFilter: cardBrandFilter,
-            cardFundingFilter: cardFundingFilter
+            cardFundingFilter: cardFundingFilter,
+            fundingBinController: fundingBinController
         ), theme: theme) { field, params in
             cardParams(for: params).number = field.text
             return params
@@ -249,7 +253,7 @@ final class CardSectionElement: ContainerElement {
             return
         }
 
-        STPBINController.shared.retrieveBINRanges(
+        fundingBinController.retrieveBINRanges(
             forPrefix: binPrefix,
             recordErrorsAsSuccess: false,
             onlyFetchForVariableLengthBINs: false

--- a/StripePayments/StripePayments/Source/Helpers/STPBINController.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBINController.swift
@@ -156,6 +156,8 @@ extension STPBINRange {
 @_spi(STP) public class STPBINController {
     @_spi(STP) public static let shared = STPBINController()
 
+    @_spi(STP) public init() {}
+
     /// For testing
     @_spi(STP) public func reset() {
         _performSync {


### PR DESCRIPTION
## Summary
- Use a separate STPBINController instance for card funding filtering instead of the shared singleton.
- https://stripe.slack.com/archives/CFA2HJ99A/p1768610671441349

## Motivation
- Bug bash feedback

## Testing
- Manual

## Changelog
N/A