### PR TITLE
Add payload for card funding acceptance to mpe config

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/PaymentSheetAnalyticsHelper.swift
@@ -555,6 +555,7 @@ extension PaymentElementConfiguration {
         payload["billing_details_collection_configuration"] = billingDetailsCollectionConfiguration.analyticPayload
         payload["preferred_networks"] = preferredNetworks?.map({ STPCardBrandUtilities.apiValue(from: $0) }).joined(separator: ", ")
         payload["card_brand_acceptance"] = cardBrandAcceptance != .all
+        payload["card_funding_acceptance"] = allowedCardFundingTypes != .all
         if let cpms = customPaymentMethodConfiguration?.customPaymentMethods {
             payload["custom_payment_methods"] = cpms.map { $0.id }
         }


### PR DESCRIPTION
## Summary
- Let's us monitor usage of the API

## Motivation
- Eng readiness for card funding filtering