### PR TITLE
Disable continuous path keyboard plug in sim

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -599,6 +599,12 @@ workflows:
     - xcode-start-simulator@0:
         inputs:
         - destination: $DEFAULT_TEST_DEVICE
+    - script@1:
+        inputs:
+        - content: |
+            xcrun simctl spawn booted defaults write com.apple.keyboard.preferences DidShowContinuousPathIntroduction -bool true
+            xcrun simctl spawn booted defaults write com.apple.keyboard.preferences DidShowGestureKeyboardIntroduction -bool true
+        title: Disable keyboard introduction popups
     - set-env-var@0:
         inputs:
         - destination_keys: CONFIGURATION_BUILD_DIR


### PR DESCRIPTION
## Summary
Set some internal preferences in the booted simulator before starting the tests, this should remove the little ad for swipe-to-type.

<img width="1125" height="2436" alt="image" src="https://github.com/user-attachments/assets/dcfc8756-dcb0-48a2-8ea1-49ac927e8b7f" />

