### PR TITLE
CryptoOnramp SDK: Updates `LinkAppearance` to use vars instead of lets

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkAppearance.swift
@@ -33,10 +33,10 @@ public struct LinkAppearance {
     /// Custom colors used throughout the Link UI. Defaults to Link colors.
     public struct Colors {
         /// The primary color used in the Link UI. Defaults to the Link brand color.
-        public var primary: UIColor? = nil
+        public var primary: UIColor?
 
         /// The border color used for selected elements, such as text fields.
-        public var selectedBorder: UIColor? = nil
+        public var selectedBorder: UIColor?
 
         /// Creates a new instance of `Colors`.
         /// - Parameters:
@@ -49,10 +49,10 @@ public struct LinkAppearance {
     }
 
     /// Custom colors used throughout the Link UI. Defaults to Link colors.
-    public var colors: Colors? = nil
+    public var colors: Colors?
 
     /// Configuration values for the primary button. Uses reasonable defaults if nothing is provided.
-    public var primaryButton: PrimaryButtonConfiguration? = nil
+    public var primaryButton: PrimaryButtonConfiguration?
 
     /// Style options for colors in the Link UI. Defaults to automatic.
     public var style: PaymentSheet.UserInterfaceStyle = .automatic


### PR DESCRIPTION
## Summary
Ensures all values in LinkAppearance can be specified after initialization.

## Motivation
I received a comment on [2026-01-13 - CryptoOnramp SDK (Mobile API Review) Private Preview](https://docs.google.com/document/d/10XEzZ9E_zF6jivC1Mjoh94pSGEabtqgSO4suCTZ6tCY/edit?tab=t.0) requesting this.

## Testing
Modified the code in the example app to change color after initialization to ensure everything worked appropriately.

```swift
var appearance = LinkAppearance(
    //colors: .init(primary: lavenderColor, selectedBorder: .label),
    primaryButton: .init(cornerRadius: 16, height: 56),
    style: .automatic,
    reduceLinkBranding: true
)
appearance.colors = .init(primary: lavenderColor, selectedBorder: .label)
let coordinator = try await CryptoOnrampCoordinator.create(appearance: appearance)
```

## Changelog
N/A
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
