### PR TITLE
fix testLinkPaymentSheetFlowController_returnsCardPaymentOptionDisplayDataForLinkInlineSignup

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITest.swift
@@ -2889,7 +2889,13 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
 
         // Assert that card is the returned payment method type
         app.buttons["Continue"].tap()
-        XCTAssertEqual(app.buttons["Payment method"].label, "•••• 4242, card, 12345, US")
+        let paymentMethodButton = app.buttons["Payment method"]
+        // Sometimes this button takes a short bit to update so we give a second of allowance
+        let labelExpectation = expectation(
+            for: NSPredicate(format: "label == %@", "•••• 4242, card, 12345, US"),
+            evaluatedWith: paymentMethodButton
+        )
+        wait(for: [labelExpectation], timeout: 5)
     }
 
     func testLinkInlineSignup_gb() throws {


### PR DESCRIPTION
## Summary
Add an allowance for the button to update. For similar tests we add a `sleep()` to let the button update, but this should be more efficient since it only takes the actually needed amount of time to continue

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
