### PR TITLE
When available, support adding bank accounts as first link payment method

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLinkUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLinkUITests.swift
@@ -601,6 +601,9 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
 
         // Sign up and add a payment method with billing details
         signUpFor(app, email: email)
+        app.otherElements["Stripe.Link.PaymentMethodPicker"].waitForExistenceAndTap(timeout: 10)
+        app.buttons["Add a payment method"].waitForExistenceAndTap()
+        app.buttons["Debit or credit card"].waitForExistenceAndTap()
         fillOutLinkCardData(app, cardNumber: "378282246310005", cvc: cvc, includingBillingDetails: true)
 
         payLink(app)
@@ -620,6 +623,9 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
 
         // Sign up and add a payment method without billing details
         signUpFor(app, email: email)
+        app.otherElements["Stripe.Link.PaymentMethodPicker"].waitForExistenceAndTap(timeout: 10)
+        app.buttons["Add a payment method"].waitForExistenceAndTap()
+        app.buttons["Debit or credit card"].waitForExistenceAndTap()
         fillOutLinkCardData(app, cardNumber: "378282246310005", cvc: cvc, includingBillingDetails: false)
         payLink(app)
         assertLinkPaymentSuccess(app)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -740,7 +740,7 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
         let newPaymentVC = PayWithLinkViewController.NewPaymentViewController(
             linkAccount: linkAccount,
             context: context,
-            isAddingFirstPaymentMethod: false
+            isAddingFirstPaymentMethod: viewModel.paymentMethods.isEmpty
         )
 
         bottomSheetController?.pushContentViewController(newPaymentVC)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -724,7 +724,7 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
         paymentPicker.setAddButtonIsLoading(true)
         coordinator?.startFinancialConnections { [weak self] result in
             let completion = {
-                self?.confirmButton.update(status: .enabled)
+                self?.confirmButton.update(status: self?.viewModel.confirmButtonStatus ?? .disabled)
                 self?.paymentPicker.setAddButtonIsLoading(false)
             }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -57,7 +57,8 @@ extension PayWithLinkViewController {
             compact: viewModel.shouldUseCompactConfirmButton,
             linkAppearance: viewModel.linkAppearance,
             didTapWhenDisabled: { [weak self] in
-                self?.cardDetailsRecollectionSection.showAllValidationErrors()
+                guard let self, self.viewModel.shouldShowRecollectionSection else { return }
+                self.cardDetailsRecollectionSection.showAllValidationErrors()
             }
         ) { [weak self] in
             guard let self else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -480,31 +480,22 @@ private extension PayWithLinkViewController {
         paymentDetails: [ConsumerPaymentDetails]
     ) {
         let viewController: BottomSheetContentViewController
-        if paymentDetails.isEmpty {
-            // Check if only bank accounts are supported - if so, launch Financial Connections directly
-            let supportedTypes = context.getSupportedPaymentDetailsTypes(linkAccount: linkAccount)
-            if supportedTypes == [ParsedEnum(.bankAccount)] {
-                startFinancialConnections { [weak self] result in
-                    guard let self else { return }
-                    switch result {
-                    case .completed:
-                        self.loadAndPresentWallet()
-                    case .canceled:
-                        self.cancel(shouldReturnToPaymentSheet: false)
-                    case .failed(let error):
-                        self.finish(withResult: .failed(error: error), deferredIntentConfirmationType: nil)
-                    }
+        // Check if only bank accounts are supported - if so, launch Financial Connections directly
+        let supportedTypes = context.getSupportedPaymentDetailsTypes(linkAccount: linkAccount)
+        if paymentDetails.isEmpty && supportedTypes == [ParsedEnum(.bankAccount)] {
+            startFinancialConnections { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .completed:
+                    self.loadAndPresentWallet()
+                case .canceled:
+                    self.cancel(shouldReturnToPaymentSheet: false)
+                case .failed(let error):
+                    self.finish(withResult: .failed(error: error), deferredIntentConfirmationType: nil)
                 }
-                // Show a loading view while Financial Connections is being prepared
-                viewController = LoaderViewController(context: context)
-            } else {
-                let addPaymentMethodVC = NewPaymentViewController(
-                    linkAccount: linkAccount,
-                    context: context,
-                    isAddingFirstPaymentMethod: true
-                )
-                viewController = addPaymentMethodVC
             }
+            // Show a loading view while Financial Connections is being prepared
+            viewController = LoaderViewController(context: context)
         } else {
             let walletViewController = WalletViewController(
                 linkAccount: linkAccount,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
@@ -139,7 +139,7 @@ extension Element {
     /// Forces validation errors to be displayed on all TextFieldElements in this element's hierarchy
     public func showAllValidationErrors() {
         for element in getAllUnwrappedSubElements() {
-            if let textFieldElement = element as? TextFieldElement {
+            if let textFieldElement = element as? TextFieldElement, !textFieldElement.view.isHidden {
                 textFieldElement.showValidationErrors()
             }
         }


### PR DESCRIPTION
## Summary

When available as a supported payment method, allow new link users to add a bank account as a payment method, instead of requiring a card first.

## Motivation

When a user creates a new link account, currently we require they add a card as a first payment method, but this requirement doesn't exist on web. On web, if the checkout supports bank accounts, then the user can add a bank account as a first payment method instead.

https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-96

## Testing

Manually testing the flow with a new account
