### PR TITLE
Remove version comparison in changelog_utils

### DIFF
--- a/ci_scripts/changelog_utils.rb
+++ b/ci_scripts/changelog_utils.rb
@@ -71,8 +71,6 @@ module ChangelogUtils
     previous_parts = parse_version(previous_version)
     next_parts = parse_version(next_version)
 
-    raise "Expected #{next_version} to be newer than #{previous_version}." unless next_parts > previous_parts
-
     return 'MAJOR' if next_parts[0] > previous_parts[0]
     return 'MINOR' if next_parts[1] > previous_parts[1]
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Remove version comparison in changelog_utils

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- The deploy-dry-run job is failing because of the '>' comparison between arrays ([run ticket](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5267)).
- We don't need to compare versions in this step, because they are already compared in the preceding step.

This won't actually fix the deploy-dry-run but it does fix the release script, so I think we should merge it to unblock Monday's release

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

