### PR TITLE
README: add note about preview API stability

### DIFF
--- a/.github/workflows/verify-public-interface.yml
+++ b/.github/workflows/verify-public-interface.yml
@@ -71,7 +71,7 @@ jobs:
             If you confirm these APIs need to be added/updated and have undergone necessary review, add the label `modifies public API` to this PR to acknowledge the interface change.
             Additionally, if you modified or removed an existing API, ensure you update the changelog to reflect the necessary version bump for your changes. Regular public API changes require a MAJOR version bump, and SPI API changes (other than `@_spi(STP)`-only declarations) require a MINOR or MAJOR version bump.
 
-            ℹ️ If this comment appears to be left in error, make sure your branch is up-to-date with `master`.
+            ℹ️ See the [Versioning](https://github.com/stripe/stripe-ios#versioning) section of the README for more details. If this comment appears to be left in error, make sure your branch is up-to-date with `master`.
           edit-mode: replace
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/verify-public-interface.yml
+++ b/.github/workflows/verify-public-interface.yml
@@ -71,7 +71,7 @@ jobs:
             If you confirm these APIs need to be added/updated and have undergone necessary review, add the label `modifies public API` to this PR to acknowledge the interface change.
             Additionally, if you modified or removed an existing API, ensure you update the changelog to reflect the necessary version bump for your changes. Regular public API changes require a MAJOR version bump, and SPI API changes (other than `@_spi(STP)`-only declarations) require a MINOR or MAJOR version bump.
 
-            ℹ️ See the [Versioning](https://github.com/stripe/stripe-ios#versioning) section of the README for more details. If this comment appears to be left in error, make sure your branch is up-to-date with `master`.
+            ℹ️ If this comment appears to be left in error, make sure your branch is up-to-date with `master`.
           edit-mode: replace
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ For help with Apple's App Privacy Details form in App Store Connect, visit [Stri
 
 Some modules expose preview APIs via `@_spi` annotations. We aim to make breaking changes to these APIs only in major or minor releases, while retaining API compatibility across patch versions. (For example, a preview API may change when moving from version `12.1.0` to `12.2.0`, but should not change from `12.2.0` to `12.2.1`.) Please see the [Stripe Services Agreement](https://stripe.com/legal/ssa) section on "Preview Services" for more information.
 
+**Note:** `@_spi(STP)` APIs are reserved for internal Stripe use and should not be used by consumers of this SDK.
+
 ## Modules
 <!-- 
   EmergeTools project must be made public before adding to this table:

--- a/README.md
+++ b/README.md
@@ -68,8 +68,6 @@ For help with Apple's App Privacy Details form in App Store Connect, visit [Stri
 
 Some modules expose preview APIs via `@_spi` annotations. We aim to make breaking changes to these APIs only in major or minor releases, while retaining API compatibility across patch versions. (For example, a preview API may change when moving from version `12.1.0` to `12.2.0`, but should not change from `12.2.0` to `12.2.1`.) Please see the [Stripe Services Agreement](https://stripe.com/legal/ssa) section on "Preview Services" for more information.
 
-**Note:** `@_spi(STP)` APIs are reserved for internal Stripe use and should not be used by consumers of this SDK.
-
 ## Modules
 <!-- 
   EmergeTools project must be made public before adding to this table:

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ Table of contents
 <!--ts-->
    * [Features](#Features)
    * [Releases](#Releases)
-   * [Versioning](#Versioning)
    * [Requirements](#Requirements)
    * [Getting started](#Getting-started)
       * [Integration](#Integration)
@@ -111,22 +110,7 @@ For other modules, follow the instructions below:
 
 If you're reading this on GitHub.com, please make sure you are looking at the [tagged version](https://github.com/stripe/stripe-ios/tags) that corresponds to the release you have installed. Otherwise, the instructions and example code may be mismatched with your copy.
 
-## Versioning
-
-All modules in the Stripe iOS SDK share a single version number and roughly follow [Semantic Versioning](https://semver.org/).
-
-There is one notable difference: **changes to `@_spi` APIs (used for beta/preview features) require at least a MINOR version bump**, even if those changes are breaking. This is because our CocoaPods podspecs pin inter-module dependencies using `~> X.Y.Z` (allowing only patch-level increases). Shipping a breaking `@_spi` change in a PATCH release could unexpectedly break consumers—such as `stripe-react-native`—that depend on those APIs.
-
-In summary:
-
-| Change type | Minimum version bump |
-|---|---|
-| Breaking change to public API | **MAJOR** |
-| Breaking change to `@_spi` (beta/preview) API | **MINOR** |
-| New public API or functionality | **MINOR** |
-| Bug fixes, non-breaking changes | **PATCH** |
-
-> **Note:** `@_spi` APIs are pre-release and carry no long-term stability guarantees. Consumers of these APIs should expect breaking changes across minor versions.
+> **Note on preview APIs:** Some modules expose preview/beta APIs via `@_spi` annotations. These carry no stability guarantees and may have breaking changes in minor versions.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ The Stripe iOS SDK collects data to help us improve our products and prevent fra
 
 For help with Apple's App Privacy Details form in App Store Connect, visit [Stripe iOS SDK Privacy Details](https://support.stripe.com/questions/stripe-ios-sdk-privacy-details).
 
+#### Preview APIs
+
+Some modules expose preview APIs via `@_spi` annotations. We aim to make breaking changes to these APIs only in major or minor releases, while retaining API compatibility across patch versions. (For example, a preview API may change when moving from version `12.1.0` to `12.2.0`, but should not change from `12.2.0` to `12.2.1`.) Please see the [Stripe Services Agreement](https://stripe.com/legal/ssa) section on "Preview Services" for more information.
+
 ## Modules
 <!-- 
   EmergeTools project must be made public before adding to this table:
@@ -109,8 +113,6 @@ For other modules, follow the instructions below:
 - [StripePaymentsUI](StripePaymentsUI/README.md#manual-linking)
 
 If you're reading this on GitHub.com, please make sure you are looking at the [tagged version](https://github.com/stripe/stripe-ios/tags) that corresponds to the release you have installed. Otherwise, the instructions and example code may be mismatched with your copy.
-
-> **Note on preview APIs:** Some modules expose preview/beta APIs via `@_spi` annotations. These carry no stability guarantees and may have breaking changes in minor versions.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Table of contents
 <!--ts-->
    * [Features](#Features)
    * [Releases](#Releases)
+   * [Versioning](#Versioning)
    * [Requirements](#Requirements)
    * [Getting started](#Getting-started)
       * [Integration](#Integration)
@@ -109,6 +110,23 @@ For other modules, follow the instructions below:
 - [StripePaymentsUI](StripePaymentsUI/README.md#manual-linking)
 
 If you're reading this on GitHub.com, please make sure you are looking at the [tagged version](https://github.com/stripe/stripe-ios/tags) that corresponds to the release you have installed. Otherwise, the instructions and example code may be mismatched with your copy.
+
+## Versioning
+
+All modules in the Stripe iOS SDK share a single version number and roughly follow [Semantic Versioning](https://semver.org/).
+
+There is one notable difference: **changes to `@_spi` APIs (used for beta/preview features) require at least a MINOR version bump**, even if those changes are breaking. This is because our CocoaPods podspecs pin inter-module dependencies using `~> X.Y.Z` (allowing only patch-level increases). Shipping a breaking `@_spi` change in a PATCH release could unexpectedly break consumers—such as `stripe-react-native`—that depend on those APIs.
+
+In summary:
+
+| Change type | Minimum version bump |
+|---|---|
+| Breaking change to public API | **MAJOR** |
+| Breaking change to `@_spi` (beta/preview) API | **MINOR** |
+| New public API or functionality | **MINOR** |
+| Bug fixes, non-breaking changes | **PATCH** |
+
+> **Note:** `@_spi` APIs are pre-release and carry no long-term stability guarantees. Consumers of these APIs should expect breaking changes across minor versions.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
Adds a small note to the README clarifying that `@_spi` (preview/beta) APIs carry no stability guarantees and may have breaking changes in minor versions.

## Motivation
This came up in #6230 where a contributor was surprised that a breaking `@_spi` change required a MINOR version bump. Discussed in the iOS team [Slack thread](https://stripe.slack.com/archives/C02HQBW38JX/p1775592307855539?thread_ts=1775491216.598509&cid=C02HQBW38JX).

## Testing
Documentation only.

## Changelog
N/A