### PR TITLE
Show cart in playground for CheckoutSessions

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
@@ -599,3 +599,42 @@ struct CheckoutCartContentView: View {
         }
     }
 }
+
+@available(iOS 15.0, *)
+struct CheckoutCartSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var checkout: Checkout
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationView {
+            ZStack {
+                Color(UIColor.systemGroupedBackground)
+                    .ignoresSafeArea()
+
+                CheckoutCartContentView(
+                    checkout: checkout,
+                    isLoading: $isLoading,
+                    errorMessage: $errorMessage
+                )
+
+                if isLoading {
+                    Color.black.opacity(0.1)
+                        .ignoresSafeArea()
+                    ProgressView()
+                }
+            }
+            .navigationTitle("Cart")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: { dismiss() }) {
+                        Image(systemName: "xmark")
+                            .foregroundColor(.primary)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -484,6 +484,7 @@ struct PaymentSheetButtons: View {
     @State private var embeddedIsPresented: Bool = false
     @State private var psFCOptionsIsPresented: Bool = false
     @State private var psFCIsConfirming: Bool = false
+    @State private var showingCart: Bool = false
 
     func reloadPlaygroundController() {
         playgroundController.load(reinitializeControllers: true)
@@ -494,6 +495,25 @@ struct PaymentSheetButtons: View {
     @ViewBuilder
     var embeddedSettingsView: some View {
         EmbeddedSettingsView()
+    }
+
+    @ViewBuilder
+    var cartButton: some View {
+        if playgroundController.checkout != nil {
+            if #available(iOS 15.0, *) {
+                Button {
+                    showingCart = true
+                } label: {
+                    Label("Cart", systemImage: "cart.fill")
+                        .font(.callout.smallCaps())
+                }
+                .buttonStyle(.bordered)
+            } else {
+                Button("Cart") {
+                    showingCart = true
+                }
+            }
+        }
     }
 
     var titleAndReloadView: some View {
@@ -534,6 +554,7 @@ struct PaymentSheetButtons: View {
                             }
                             .paymentSheet(isPresented: $psIsPresented, paymentSheet: ps, onCompletion: playgroundController.onPSCompletion)
                             Spacer()
+                            cartButton
                             Button {
                                 playgroundController.didTapShippingAddressButton()
                             } label: {
@@ -564,6 +585,7 @@ struct PaymentSheetButtons: View {
                             }
                             .disabled(playgroundController.paymentSheetFlowController == nil)
                             .padding()
+                            cartButton
                             Button {
                                 playgroundController.didTapShippingAddressButton()
                             } label: {
@@ -605,6 +627,7 @@ struct PaymentSheetButtons: View {
                                 Text("Present embedded payment element")
                             }
                             Spacer()
+                            cartButton
                             Button {
                                 playgroundController.didTapShippingAddressButton()
                             } label: {
@@ -622,6 +645,11 @@ struct PaymentSheetButtons: View {
                         ExamplePaymentStatusView(result: result)
                     }
                 }
+            }
+        }
+        .sheet(isPresented: $showingCart) {
+            if #available(iOS 15.0, *), let checkout = playgroundController.checkout {
+                CheckoutCartSheet(checkout: checkout)
             }
         }
     }


### PR DESCRIPTION
## Summary
- Adds a cart button when a user is in CheckoutSession mode in the playground. This button presents a 'cart' like interface where users can modify the checkout session with quantities, promo codes, etc. Already used the in CheckoutSDK playground.