### PR TITLE
Add new CheckoutSession settings pane

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/CheckoutSessionPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CheckoutSessionPlaygroundView.swift
@@ -1,0 +1,104 @@
+//
+//  CheckoutSessionPlaygroundView.swift
+//  PaymentSheet Example
+//
+//  Created by Nick Porter on 4/10/26.
+
+import StripePaymentSheet
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CheckoutSessionPlaygroundView: View {
+    @State var viewModel: PaymentSheetTestPlaygroundSettings
+    var doneAction: ((PaymentSheetTestPlaygroundSettings) -> Void) = { _ in }
+
+    var body: some View {
+        var paymentMethodSaveBinding: Binding<PaymentSheetTestPlaygroundSettings.PaymentMethodSave> {
+            Binding<PaymentSheetTestPlaygroundSettings.PaymentMethodSave> {
+                return viewModel.paymentMethodSave
+            } set: { newValue in
+                if viewModel.paymentMethodSave != newValue {
+                    viewModel.allowRedisplayOverride = .notSet
+                }
+                viewModel.paymentMethodSave = newValue
+            }
+        }
+
+        VStack {
+            HStack {
+                Text("Checkout Session")
+                    .font(.title)
+                    .bold()
+                Spacer()
+                Button("Done") {
+                    doneAction(viewModel)
+                }
+            }.padding()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 16) {
+                    // MARK: - Saved Payment Methods
+                    Group {
+                        Text("Saved Payment Methods")
+                            .font(.headline)
+                        VStack {
+                            SettingPickerView(setting: paymentMethodSaveBinding)
+                            SettingPickerView(setting: $viewModel.paymentMethodRemove)
+                        }
+                    }
+
+                    Divider()
+
+                    // MARK: - Session Features
+                    Group {
+                        Text("Session Features")
+                            .font(.headline)
+                        VStack {
+                            SettingView(setting: $viewModel.csAllowPromotionCodes)
+                            SettingView(setting: $viewModel.csAutomaticTax)
+                            SettingView(setting: $viewModel.csAdaptivePricing)
+                            SettingView(setting: $viewModel.csDisplayShippingRates)
+                            SettingView(setting: $viewModel.csAdjustableQuantity)
+                            SettingView(setting: $viewModel.csManualCapture)
+                        }
+                    }
+
+                    Divider()
+
+                    // MARK: - Advanced
+                    Group {
+                        Text("Advanced")
+                            .font(.headline)
+                        VStack(spacing: 8) {
+                            HStack {
+                                Text("Customer Email")
+                                    .font(.subheadline)
+                                Spacer()
+                            }
+                            TextField("test@example.com", text: Binding(
+                                get: { viewModel.csCustomerEmail ?? "" },
+                                set: { viewModel.csCustomerEmail = $0.isEmpty ? nil : $0 }
+                            ))
+                            .keyboardType(.emailAddress)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+
+                            HStack {
+                                Text("Payment Method Configuration")
+                                    .font(.subheadline)
+                                Spacer()
+                            }
+                            TextField("pmc_...", text: Binding(
+                                get: { viewModel.csPaymentMethodConfiguration ?? "" },
+                                set: { viewModel.csPaymentMethodConfiguration = $0.isEmpty ? nil : $0 }
+                            ))
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                        }
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -210,24 +210,19 @@ struct PaymentSheetTestPlayground: View {
                         }
 
                         if playgroundController.settings.integrationType == .checkoutSession {
-                            if searchText.isEmpty {
-                                Divider()
-                            }
-                            Group {
-                                SearchableSection(
-                                    title: "Checkout Session",
-                                    searchText: $searchText
-                                ) {
-                                    SearchableSettingView(
-                                        setting: paymentMethodSaveBinding,
-                                        title: "Offer Save",
-                                        searchText: $searchText
-                                    )
-                                    SearchableSettingView(
-                                        setting: $playgroundController.settings.paymentMethodRemove,
-                                        title: "Payment Method Remove",
-                                        searchText: $searchText
-                                    )
+                            SearchableView(searchableName: "Checkout Session", searchText: $searchText) {
+                                VStack {
+                                    HStack {
+                                        Text("Checkout Session")
+                                            .font(.subheadline)
+                                        Spacer()
+                                        Button {
+                                            playgroundController.checkoutSessionSettingsTapped()
+                                        } label: {
+                                            Text("CS Settings")
+                                                .font(.callout.smallCaps())
+                                        }.buttonStyle(.bordered)
+                                    }
                                 }
                             }
                         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -685,6 +685,32 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
+    // MARK: - Checkout Session enums
+    enum CSAllowPromotionCodes: String, PickerEnum {
+        static var enumName: String { "Allow Promotion Codes" }
+        case on, off
+    }
+    enum CSAutomaticTax: String, PickerEnum {
+        static var enumName: String { "Automatic Tax" }
+        case on, off
+    }
+    enum CSAdaptivePricing: String, PickerEnum {
+        static var enumName: String { "Adaptive Pricing" }
+        case on, off
+    }
+    enum CSDisplayShippingRates: String, PickerEnum {
+        static var enumName: String { "Display Shipping Rates" }
+        case on, off
+    }
+    enum CSAdjustableQuantity: String, PickerEnum {
+        static var enumName: String { "Adjustable Quantity" }
+        case on, off
+    }
+    enum CSManualCapture: String, PickerEnum {
+        static var enumName: String { "Manual Capture" }
+        case on, off
+    }
+
     var uiStyle: UIStyle
     var layout: Layout
     var mode: Mode
@@ -724,6 +750,17 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var customCtaLabel: String?
     var paymentMethodConfigurationId: String?
     var checkoutEndpoint: String
+
+    // MARK: - Checkout Session settings
+    var csAllowPromotionCodes: CSAllowPromotionCodes
+    var csAutomaticTax: CSAutomaticTax
+    var csAdaptivePricing: CSAdaptivePricing
+    var csDisplayShippingRates: CSDisplayShippingRates
+    var csAdjustableQuantity: CSAdjustableQuantity
+    var csManualCapture: CSManualCapture
+    var csPaymentMethodConfiguration: String?
+    var csCustomerEmail: String?
+
     var autoreload: Autoreload
     var shakeAmbiguousViews: ShakeAmbiguousViews
     var instantDebitsIncentives: InstantDebitsIncentives
@@ -784,6 +821,14 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             customCtaLabel: nil,
             paymentMethodConfigurationId: nil,
             checkoutEndpoint: Self.defaultCheckoutEndpoint,
+            csAllowPromotionCodes: .off,
+            csAutomaticTax: .off,
+            csAdaptivePricing: .off,
+            csDisplayShippingRates: .off,
+            csAdjustableQuantity: .off,
+            csManualCapture: .off,
+            csPaymentMethodConfiguration: nil,
+            csCustomerEmail: nil,
             autoreload: .on,
             shakeAmbiguousViews: .off,
             instantDebitsIncentives: .off,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -762,6 +762,16 @@ import UIKit
         }))
         rootViewController.present(vc, animated: true, completion: nil)
     }
+    func checkoutSessionSettingsTapped() {
+        if #available(iOS 15.0, *) {
+            let vc = UIHostingController(rootView: CheckoutSessionPlaygroundView(viewModel: settings, doneAction: { updatedSettings in
+                self.settings = updatedSettings
+                self.rootViewController.dismiss(animated: true, completion: nil)
+                self.load(reinitializeControllers: true)
+            }))
+            rootViewController.present(vc, animated: true, completion: nil)
+        }
+    }
 
     // Completion
 
@@ -1063,9 +1073,24 @@ extension PlaygroundController {
         // Add CheckoutSession flag if using CheckoutSession integration type
         if settings.integrationType == .checkoutSession {
             body["use_checkout_session"] = true
-            body["customer_email"] = "moblie-test-user@stripe.com"
             body["checkout_session_payment_method_remove"] = settings.paymentMethodRemove.rawValue
             body["checkout_session_payment_method_save"] = settings.paymentMethodSave.rawValue
+            body["allow_promotion_codes"] = settings.csAllowPromotionCodes == .on
+            body["automatic_tax"] = settings.csAutomaticTax == .on
+            body["adaptive_pricing"] = settings.csAdaptivePricing == .on
+            body["display_shipping_rates"] = settings.csDisplayShippingRates == .on
+            body["adjustable_quantity"] = settings.csAdjustableQuantity == .on
+            body["use_manual_capture"] = settings.csManualCapture == .on
+            if let email = settings.csCustomerEmail, !email.isEmpty {
+                body["customer_email"] = email
+            }
+            if let pmc = settings.csPaymentMethodConfiguration, !pmc.isEmpty {
+                body["payment_method_configuration"] = pmc
+            }
+            let sfuDict = settings.paymentMethodOptionsSetupFutureUsage.toDictionary()
+            if !sfuDict.isEmpty {
+                body["payment_method_options_setup_future_usage"] = sfuDict
+            }
         }
 
         // Send custom keys to backend if provided


### PR DESCRIPTION
## Summary
- Adds all the supported CheckoutSessions settings on our backend to the playground so we can configure a checkout session

## Motivation
- CheckoutSessions

## Testing
- Manual

## Changelog
N/A
