### PR TITLE
Add flag for manual capture, and $1.00 option

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -191,6 +191,7 @@ struct PaymentSheetTestPlayground: View {
                                 }
                             }
                         }
+                        SearchableSettingView(setting: $playgroundController.settings.manualCapture, searchText: $searchText)
                         if playgroundController.settings.customerKeyType == .customerSession {
                             SearchableView(searchableName: "Customer Session", searchText: $searchText) {
                                 VStack {
@@ -377,6 +378,9 @@ struct PaymentSheetTestPlayground: View {
             return playgroundController.settings.customSecretKey ?? ""
         } set: { newString in
             playgroundController.settings.customSecretKey = newString
+            if newString.hasPrefix("sk_live") {
+                playgroundController.settings.manualCapture = .on
+            }
         }
     }
 
@@ -385,6 +389,9 @@ struct PaymentSheetTestPlayground: View {
             return playgroundController.settings.customPublishableKey ?? ""
         } set: { newString in
             playgroundController.settings.customPublishableKey = newString
+            if newString.hasPrefix("pk_live") {
+                playgroundController.settings.manualCapture = .on
+            }
         }
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -111,11 +111,14 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     enum Amount: Int, PickerEnum {
         static var enumName: String { "Amount" }
 
+        case _100 = 100
         case _5099 = 5099
         case _10000 = 10000
 
         var displayName: String {
             switch self {
+            case ._100:
+                return "1.00"
             case ._5099:
                 return "50.99"
             case ._10000:
@@ -628,6 +631,12 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
+    enum ManualCapture: String, PickerEnum {
+        static let enumName: String = "Manual Capture"
+        case on
+        case off
+    }
+
     enum AllowsRemovalOfLastSavedPaymentMethodEnabled: String, PickerEnum {
         static let enumName: String = "allowsRemovalOfLastSavedPaymentMethod"
         case on
@@ -732,6 +741,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var customPaymentMethods: CustomPaymentMethods
     var preferredNetworksEnabled: PreferredNetworksEnabled
     var requireCVCRecollection: RequireCVCRecollectionEnabled
+    var manualCapture: ManualCapture
     var allowsRemovalOfLastSavedPaymentMethod: AllowsRemovalOfLastSavedPaymentMethodEnabled
 
     var attachDefaults: BillingDetailsAttachDefaults
@@ -792,6 +802,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             customPaymentMethods: .off,
             preferredNetworksEnabled: .off,
             requireCVCRecollection: .off,
+            manualCapture: .off,
             allowsRemovalOfLastSavedPaymentMethod: .on,
             attachDefaults: .off,
             collectName: .automatic,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -1060,6 +1060,11 @@ extension PlaygroundController {
             //            "set_shipping_address": true // Uncomment to make server vend PI with shipping address populated
         ] as [String: Any]
 
+        // Send use_manual_capture when toggled on
+        if settings.manualCapture == .on {
+            body["use_manual_capture"] = true
+        }
+
         // Add CheckoutSession flag if using CheckoutSession integration type
         if settings.integrationType == .checkoutSession {
             body["use_checkout_session"] = true

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITests.swift
@@ -186,6 +186,9 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         app.buttons["Pay €50.99"].tap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10))
 
+        // Swipe up just a little bit to expose embedded
+        app.swipeUp(velocity: 100)
+
         // Switch to embedded mode kicks off a reload
         app.buttons["embedded"].waitForExistenceAndTap(timeout: 5)
         app.buttons["Present embedded payment element"].waitForExistenceAndTap()


### PR DESCRIPTION
## Summary
Adds ability to turn on/off manual capture (defaulting to on, when adding a sk_live*/pk_live*). Also adds a $1.00 amount option

## Motivation
Testing in w/ live keys, and minor quality of life improvements

## Testing
Looking at messages passed over the wire.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
