### PR TITLE
Fix vending card art by fixing pre-caching image

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheet.swift
@@ -373,6 +373,7 @@ extension CustomerSheet {
                 guard let matchingPaymentMethod = paymentMethods.first(where: { $0.stripeId == paymentMethodId }) else {
                     return nil
                 }
+                matchingPaymentMethod.preloadCardArtImage(cardArtEnabled: configuration.appearance.cardArtEnabled)
                 return CustomerSheet.PaymentOptionSelection.paymentMethod(matchingPaymentMethod)
             default:
                 return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSheetConfiguration.swift
@@ -114,7 +114,7 @@ extension CustomerSheet {
         /// Create a PaymentOptionSelection for a saved payment method.
         public static func paymentMethod(_ paymentMethod: STPPaymentMethod) -> PaymentOptionSelection {
             let paymentMethodIcon = paymentMethod.makeIcon()
-            let image = paymentMethod.cardArtImage(cardArtEnabled: _cardArtEnabled) ?? paymentMethodIcon
+            let image = paymentMethod.cachedCardArtImage(cardArtEnabled: _cardArtEnabled) ?? paymentMethodIcon
             let data = PaymentOptionDisplayData(image: image, label: paymentMethod.paymentSheetLabel)
             return .paymentMethod(paymentMethod: paymentMethod, paymentOptionDisplayData: data)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -150,7 +150,7 @@ extension STPPaymentMethod {
     }
 
     func cachedCardArtImage(cardArtEnabled: Bool, downloadManager: DownloadManager = DownloadManager.sharedManager) -> UIImage? {
-        guard let cardArtURL = vendedCardArtURL(cardArtEnabled: cardArtEnabled) else {
+        guard let cardArtURL = cardArtCDNURL(cardArtEnabled: cardArtEnabled) else {
             return nil
         }
         let placeholder = downloadManager.imagePlaceHolder()
@@ -162,23 +162,20 @@ extension STPPaymentMethod {
         return image == placeholder ? nil : image.roundedWithBorder(radius: 3)
     }
 
+    // Populates the in-memory card art cache. Promotes from disk cache if available,
+    // then fires a best-effort network request to fetch the latest image.
     func preloadCardArtImage(cardArtEnabled: Bool, downloadManager: DownloadManager = DownloadManager.sharedManager) {
-        guard let cardArtURL = vendedCardArtURL(cardArtEnabled: cardArtEnabled) else {
+        guard let cardArtURL = cardArtCDNURL(cardArtEnabled: cardArtEnabled) else {
             return
         }
+        // Passing a non-nil updateHandler triggers a best-effort network
+        // download that refreshes the in-memory cache.
         let updateHandler: ((UIImage) -> Void)? = { _ in }
         _ = downloadManager.downloadImage(
             url: cardArtURL,
             placeholder: nil,
             updateHandler: updateHandler
         )
-    }
-
-    func vendedCardArtURL(cardArtEnabled: Bool) -> URL? {
-        guard cardArtEnabled, let cardArtURL = cardArtCDNURL(height: 26) else {
-            return nil
-        }
-        return cardArtURL
     }
 }
 
@@ -198,11 +195,12 @@ extension STPPaymentMethod {
 
 extension STPPaymentMethod {
     /// Returns the card art CDN URL if this is a card payment method with card art available.
-    func cardArtCDNURL(height: Int, dpr: Int = 3) -> URL? {
-        guard let artImageURL = card?.cardArt?.artImage?.url else {
+    static let cardArtHeight: Int = 26
+    func cardArtCDNURL(cardArtEnabled: Bool, dpr: Int = 3) -> URL? {
+        guard cardArtEnabled, let artImageURL = card?.cardArt?.artImage?.url else {
             return nil
         }
-        return URL(string: "https://img.stripecdn.com/cdn-cgi/image/format=auto,height=\(height),dpr=\(dpr)/\(artImageURL.absoluteString)")
+        return URL(string: "https://img.stripecdn.com/cdn-cgi/image/format=auto,height=\(STPPaymentMethod.cardArtHeight),dpr=\(dpr)/\(artImageURL.absoluteString)")
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -27,7 +27,7 @@ extension PaymentOption {
             if let linkedBank = paymentOption?.instantDebitsLinkedBank {
                 return PaymentSheetImageLibrary.bankIcon(for: PaymentSheetImageLibrary.bankIconCode(for: linkedBank.bankName), iconStyle: iconStyle)
             } else {
-                let cardArtImage = paymentMethod.cardArtImage(cardArtEnabled: cardArtEnabled)
+                let cardArtImage = paymentMethod.cachedCardArtImage(cardArtEnabled: cardArtEnabled)
                 return cardArtImage ?? paymentMethod.makeIcon(iconStyle: iconStyle)
             }
         case .new(let confirmParams):
@@ -149,8 +149,8 @@ extension STPPaymentMethod {
         }
     }
 
-    func cardArtImage(cardArtEnabled: Bool, downloadManager: DownloadManager = DownloadManager.sharedManager) -> UIImage? {
-        guard cardArtEnabled, let cardArtURL = cardArtCDNURL(height: 28) else {
+    func cachedCardArtImage(cardArtEnabled: Bool, downloadManager: DownloadManager = DownloadManager.sharedManager) -> UIImage? {
+        guard let cardArtURL = vendedCardArtURL(cardArtEnabled: cardArtEnabled) else {
             return nil
         }
         let placeholder = downloadManager.imagePlaceHolder()
@@ -160,6 +160,25 @@ extension STPPaymentMethod {
             updateHandler: nil
         )
         return image == placeholder ? nil : image.roundedWithBorder(radius: 3)
+    }
+
+    func preloadCardArtImage(cardArtEnabled: Bool, downloadManager: DownloadManager = DownloadManager.sharedManager) {
+        guard let cardArtURL = vendedCardArtURL(cardArtEnabled: cardArtEnabled) else {
+            return
+        }
+        let updateHandler: ((UIImage) -> Void)? = { _ in }
+        _ = downloadManager.downloadImage(
+            url: cardArtURL,
+            placeholder: nil,
+            updateHandler: updateHandler
+        )
+    }
+
+    func vendedCardArtURL(cardArtEnabled: Bool) -> URL? {
+        guard cardArtEnabled, let cardArtURL = cardArtCDNURL(height: 26) else {
+            return nil
+        }
+        return cardArtURL
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -220,7 +220,9 @@ final class PaymentSheetLoader {
                 defaultPaymentMethod: elementsSession.customer?.getDefaultPaymentMethod()
             )
 
-            // Pre-fetch card art without waiting for this to finish
+            // Temporary band-aid for pre-loading card art: fire-and-forget fetch to warm the in-meory cache for PS.FC
+            // and embedded PaymentOptionDisplayData APIs.
+            // TODO: Revisit overall pre-loading approach to make this work for other payment methods
             if let defaultPaymentMethod = paymentOptionsViewModels.stp_boundSafeObject(at: defaultSelectedIndex),
                case .saved(let stpPaymentMethod) = defaultPaymentMethod {
                 stpPaymentMethod.preloadCardArtImage(cardArtEnabled: configuration.appearance.cardArtEnabled)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -219,6 +219,12 @@ final class PaymentSheetLoader {
                 elementsSession: elementsSession,
                 defaultPaymentMethod: elementsSession.customer?.getDefaultPaymentMethod()
             )
+
+            // Pre-fetch card art without waiting for this to finish
+            if let defaultPaymentMethod = paymentOptionsViewModels.stp_boundSafeObject(at: defaultSelectedIndex),
+               case .saved(let stpPaymentMethod) = defaultPaymentMethod {
+                stpPaymentMethod.preloadCardArtImage(cardArtEnabled: configuration.appearance.cardArtEnabled)
+            }
             loadTimings.logEnd("makeViewModels")
 
             // Send load finished analytic

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -359,8 +359,7 @@ extension SavedPaymentMethodCollectionView {
                         selectableRectangle.accessibilityIdentifier = label.text
                         selectableRectangle.accessibilityLabel = paymentMethod.paymentSheetAccessibilityLabel
                         let paymentMethodCellImage = paymentMethod.makeSavedPaymentMethodCellImage(overrideUserInterfaceStyle: overrideUserInterfaceStyle, iconStyle: appearance.iconStyle)
-                        let cardArtHeight: Int = 26
-                        if cardArtEnabled, let cardArtURL = paymentMethod.cardArtCDNURL(height: cardArtHeight) {
+                        if let cardArtURL = paymentMethod.cardArtCDNURL(cardArtEnabled: cardArtEnabled) {
                             paymentMethodLogo.tag = cardArtURL.hashValue
                             paymentMethodLogo.image = nil
                             Task {
@@ -368,7 +367,7 @@ extension SavedPaymentMethodCollectionView {
                                 guard paymentMethodLogo.tag == cardArtURL.hashValue else { return }
                                 if let image {
                                     paymentMethodLogo.image = image.roundedWithBorder(radius: 3)
-                                    paymentMethodLogoHeightConstraint.constant = CGFloat(cardArtHeight)
+                                    paymentMethodLogoHeightConstraint.constant = CGFloat(STPPaymentMethod.cardArtHeight)
                                 } else {
                                     paymentMethodLogo.image = paymentMethodCellImage
                                     paymentMethodLogoHeightConstraint.constant = paymentMethodLogoSize.height

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -552,7 +552,7 @@ extension RowButton {
         imageView.contentMode = .scaleAspectFit
         let savedPaymentMethodRowImage = paymentMethod.makeSavedPaymentMethodRowImage(iconStyle: appearance.iconStyle)
         if appearance.cardArtEnabled {
-            imageView.setImage(with: paymentMethod.cardArtCDNURL(height: 20),
+            imageView.setImage(with: paymentMethod.cardArtCDNURL(cardArtEnabled: appearance.cardArtEnabled),
                                processOnDownloadedImage: { $0.roundedWithBorder(radius: 3) },
                                fallbackImage: savedPaymentMethodRowImage)
         } else {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentOption+ImagesTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentOption+ImagesTest.swift
@@ -23,7 +23,7 @@ final class PaymentOptionImagesTest: XCTestCase {
                 "exp_year": "2030",
             ],
         ])!
-        XCTAssertNil(pm.cardArtCDNURL(height: 40))
+        XCTAssertNil(pm.cardArtCDNURL(cardArtEnabled: true))
     }
 
     func testCardArtURL_nilWhenCardArtHasNoURL() {
@@ -41,9 +41,27 @@ final class PaymentOptionImagesTest: XCTestCase {
                 ],
             ],
         ])!
-        XCTAssertNil(pm.cardArtCDNURL(height: 40))
+        XCTAssertNil(pm.cardArtCDNURL(cardArtEnabled: true))
     }
-
+    func testCardArtURL_nil() {
+        let pm = STPPaymentMethod.decodedObject(fromAPIResponse: [
+            "id": "pm_1",
+            "type": "card",
+            "created": 1651273166,
+            "card": [
+                "last4": "4242",
+                "brand": "visa",
+                "exp_month": "12",
+                "exp_year": "2030",
+                "card_art": [
+                    "payment_method": "pm_1",
+                    "art_image": ["url": "https://b.stripecdn.com/cardart/assets/abc123"],
+                ],
+            ],
+        ])!
+        let url = pm.cardArtCDNURL(cardArtEnabled: false)
+        XCTAssertNil(url)
+    }
     func testCardArtURL_returnsCDNURL() {
         let pm = STPPaymentMethod.decodedObject(fromAPIResponse: [
             "id": "pm_1",
@@ -60,36 +78,12 @@ final class PaymentOptionImagesTest: XCTestCase {
                 ],
             ],
         ])!
-        let url = pm.cardArtCDNURL(height: 40)
+        let url = pm.cardArtCDNURL(cardArtEnabled: true)
         XCTAssertNotNil(url)
 
-        XCTAssertEqual(url!.absoluteString, "https://img.stripecdn.com/cdn-cgi/image/format=auto,height=40,dpr=3/https://b.stripecdn.com/cardart/assets/abc123")
-        XCTAssertTrue(url!.absoluteString.contains("height=40"))
+        XCTAssertEqual(url!.absoluteString, "https://img.stripecdn.com/cdn-cgi/image/format=auto,height=26,dpr=3/https://b.stripecdn.com/cardart/assets/abc123")
+        XCTAssertTrue(url!.absoluteString.contains("height=26"))
         XCTAssertTrue(url!.absoluteString.contains("dpr=3"))
-    }
-
-    func testCardArtURL_respectsHeightParameter() {
-        let pm = STPPaymentMethod.decodedObject(fromAPIResponse: [
-            "id": "pm_1",
-            "type": "card",
-            "created": 1651273166,
-            "card": [
-                "last4": "4242",
-                "brand": "visa",
-                "exp_month": "12",
-                "exp_year": "2030",
-                "card_art": [
-                    "payment_method": "pm_1",
-                    "art_image": ["url": "https://b.stripecdn.com/cardart/assets/abc123"],
-                ],
-            ],
-        ])!
-        let url20 = pm.cardArtCDNURL(height: 20)
-        XCTAssertEqual(url20!.absoluteString, "https://img.stripecdn.com/cdn-cgi/image/format=auto,height=20,dpr=3/https://b.stripecdn.com/cardart/assets/abc123")
-
-        let url40 = pm.cardArtCDNURL(height: 40)
-        XCTAssertEqual(url40!.absoluteString, "https://img.stripecdn.com/cdn-cgi/image/format=auto,height=40,dpr=3/https://b.stripecdn.com/cardart/assets/abc123")
-
     }
 
     func testCardArtURL_nilForNonCardPaymentMethod() {
@@ -102,6 +96,6 @@ final class PaymentOptionImagesTest: XCTestCase {
                 "last4": "6789",
             ],
         ])!
-        XCTAssertNil(pm.cardArtCDNURL(height: 40))
+        XCTAssertNil(pm.cardArtCDNURL(cardArtEnabled: true))
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPPaymentMethod+CardArtImageTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPPaymentMethod+CardArtImageTest.swift
@@ -44,7 +44,7 @@ final class STPPaymentMethodCardArtImageTest: APIStubbedTestCase {
 
     func testCardArtImage_returnsImageWhenCached() {
         let pm = STPPaymentMethod._testCardWithCardArt()
-        let cardArtURL = pm.cardArtCDNURL(height: 26)!
+        let cardArtURL = pm.cardArtCDNURL(cardArtEnabled: true)!
 
         // Pre-seed the URL cache so downloadImage returns the real image
         let imageData = generateUIImage(size: CGSize(width: 100, height: 26)).pngData()!

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPPaymentMethod+CardArtImageTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPPaymentMethod+CardArtImageTest.swift
@@ -29,32 +29,32 @@ final class STPPaymentMethodCardArtImageTest: APIStubbedTestCase {
 
     func testCardArtImage_returnsNilWhenCardArtDisabled() {
         let pm = STPPaymentMethod._testCardWithCardArt()
-        XCTAssertNil(pm.cardArtImage(cardArtEnabled: false, downloadManager: downloadManager))
+        XCTAssertNil(pm.cachedCardArtImage(cardArtEnabled: false, downloadManager: downloadManager))
     }
 
     func testCardArtImage_returnsNilWhenNoCardArt() {
         let pm = STPPaymentMethod._testCard()
-        XCTAssertNil(pm.cardArtImage(cardArtEnabled: true, downloadManager: downloadManager))
+        XCTAssertNil(pm.cachedCardArtImage(cardArtEnabled: true, downloadManager: downloadManager))
     }
 
     func testCardArtImage_returnsNilWhenImageNotCached() {
         let pm = STPPaymentMethod._testCardWithCardArt()
-        XCTAssertNil(pm.cardArtImage(cardArtEnabled: true, downloadManager: downloadManager))
+        XCTAssertNil(pm.cachedCardArtImage(cardArtEnabled: true, downloadManager: downloadManager))
     }
 
     func testCardArtImage_returnsImageWhenCached() {
         let pm = STPPaymentMethod._testCardWithCardArt()
-        let cardArtURL = pm.cardArtCDNURL(height: 28)!
+        let cardArtURL = pm.cardArtCDNURL(height: 26)!
 
         // Pre-seed the URL cache so downloadImage returns the real image
-        let imageData = generateUIImage(size: CGSize(width: 100, height: 28)).pngData()!
+        let imageData = generateUIImage(size: CGSize(width: 100, height: 26)).pngData()!
         seedURLCache(url: cardArtURL, data: imageData)
 
-        let result = pm.cardArtImage(cardArtEnabled: true, downloadManager: downloadManager)
+        let result = pm.cachedCardArtImage(cardArtEnabled: true, downloadManager: downloadManager)
         XCTAssertNotNil(result)
 
         // The returned image should be the same as the one we created
-        XCTAssertEqual(result?.size, CGSize(width: 100, height: 28))
+        XCTAssertEqual(result?.size, CGSize(width: 100, height: 26))
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
Fixes vending card art through our APIs by prefetching on load or when accessed on CustomerSheet retrievePaymentOptionSelection() api.  When vending, APIs return back what we currently have in cache. Approach is "best-effort" to reduce impact on loading payment sheet/customersheet.


## Motivation
Currently working only if the image happens to make itself into the cache

## Testing
Updated tests & manual testing

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
