### PR TITLE
Include Link in Polling Budget

### DIFF
--- a/StripePayments/StripePayments/Source/PaymentHandler/PollingBudget.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/PollingBudget.swift
@@ -43,7 +43,7 @@ final class PollingBudget {
     init?(startDate: Date, paymentMethodType: STPPaymentMethodType) {
         self.startDate = startDate
         switch paymentMethodType {
-        case .amazonPay, .revolutPay, .swish, .twint, .przelewy24, .payPay:
+        case .amazonPay, .revolutPay, .swish, .twint, .przelewy24, .payPay, .link:
             self.duration = 5.0
         case .card:
             self.duration = 15.0


### PR DESCRIPTION
## Summary
Adds Link in Payment Method Mode to the Polling Budget of 5 seconds.

## Motivation
When Link is in Payment Method Mode and using a payment method that supports `next_action_type: redirect_to_url` (eg. Pix in this example), the backend currently does call the `return_url` strictly after the the payment intent succeeds. This results in the web view closing and the payment intent state remaining at `confirm` without an opportunity to refetch status. 

This is a bug in the backend implementation for Pix, but won't be addressed prior to our intended release of Link LPMs on mobile. By adding Payment Method Mode polling for `link` types, we work around this bug and will readdress once this bug is resolved.

## Demos

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/90d040d6-07ae-4a60-8a76-9362025243e7" /> | <video src="https://github.com/user-attachments/assets/36c565bb-4f48-4152-8681-c9bcffe2c807" /> |

