### PR TITLE
Use Nil as Default Value for Link Supported Payment Methods

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -88,7 +88,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         let launchedFromFlowController: Bool
         let initiallySelectedPaymentDetailsID: String?
         let callToAction: ConfirmButton.CallToActionType
-        let supportedPaymentMethodTypes: [LinkPaymentMethodType]
+        let supportedPaymentMethodTypes: [LinkPaymentMethodType]?
         var lastAddedPaymentDetails: ConsumerPaymentDetails?
         var analyticsHelper: PaymentSheetAnalyticsHelper
         let linkAppearance: LinkAppearance?
@@ -115,7 +115,8 @@ final class PayWithLinkViewController: BottomSheetViewController {
         /// Returns [.card] as fallback if no types are supported after filtering.
         func getSupportedPaymentDetailsTypes(linkAccount: PaymentSheetLinkAccount) -> Set<ConsumerPaymentDetails.DetailsType> {
             let allSupportedPaymentDetailsTypes = linkAccount.supportedPaymentDetailsTypes(for: elementsSession)
-            let filteredSupportedPaymentDetailsTypes = allSupportedPaymentDetailsTypes.intersection(supportedPaymentMethodTypes.detailsTypes)
+            let supportedPaymentDetailsTypes = supportedPaymentMethodTypes?.detailsTypes ?? Set(ConsumerPaymentDetails.DetailsType.allCases)
+            let filteredSupportedPaymentDetailsTypes = allSupportedPaymentDetailsTypes.intersection(supportedPaymentDetailsTypes)
 
             if !filteredSupportedPaymentDetailsTypes.isEmpty {
                 return filteredSupportedPaymentDetailsTypes
@@ -136,7 +137,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         ///   - launchedFromFlowController: Whether the flow was opened from `FlowController`.
         ///   - initiallySelectedPaymentDetailsID: The ID of an initially selected payment method. This is set when opened instead of FlowController.
         ///   - callToAction: A custom CTA to display on the confirm button. If `nil`, will display `intent`'s default CTA.
-        ///   - supportedPaymentMethodTypes: The payment method types to support in the Link sheet. Defaults to all available types.
+        ///   - supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil`, all available types are supported.
         ///   - analyticsHelper: An instance of `AnalyticsHelper` to use for logging.
         ///   - linkAppearance: Optional appearance overrides for Link UI.
         ///   - linkConfiguration: Configuration for Link behavior and content.
@@ -150,7 +151,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
             launchedFromFlowController: Bool = false,
             initiallySelectedPaymentDetailsID: String?,
             callToAction: ConfirmButton.CallToActionType?,
-            supportedPaymentMethodTypes: [LinkPaymentMethodType] = LinkPaymentMethodType.allCases,
+            supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
             analyticsHelper: PaymentSheetAnalyticsHelper,
             linkAppearance: LinkAppearance? = nil,
             linkConfiguration: LinkConfiguration? = nil
@@ -211,7 +212,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         initiallySelectedPaymentDetailsID: String? = nil,
         callToAction: ConfirmButton.CallToActionType? = nil,
         analyticsHelper: PaymentSheetAnalyticsHelper,
-        supportedPaymentMethodTypes: [LinkPaymentMethodType] = LinkPaymentMethodType.allCases,
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil
     ) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -360,13 +360,13 @@ import UIKit
     ///
     /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
     /// - Parameter email: The email address to pre-fill in the Link sheet. If `nil`, the email field will be empty.
-    /// - Parameter supportedPaymentMethodTypes: The payment method types to support in the Link sheet. Defaults to all available types.
+    /// - Parameter supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil`, all available types are supported.
     /// - Parameter collectName: Whether or not we should collect the user's name and attach it to the billing details.
     /// - Parameter completion: A closure that is called when the user has selected a payment method or canceled the sheet. If the user selects a payment method, the `paymentMethodPreview` will be updated accordingly.
     @_spi(STP) public func collectPaymentMethod(
         from presentingViewController: UIViewController,
         with email: String?,
-        supportedPaymentMethodTypes: [LinkPaymentMethodType] = LinkPaymentMethodType.allCases,
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         collectName: Bool = false,
         completion: @escaping () -> Void
     ) {
@@ -1021,13 +1021,13 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
     ///
     /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
     /// - Parameter email: The email address to pre-fill in the Link sheet. If `nil`, the email field will be empty.
-    /// - Parameter supportedPaymentMethodTypes: The payment method types to support in the Link sheet. Defaults to all available types.
+    /// - Parameter supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil`, all available types are supported.
     /// - Parameter collectName: Whether or not we should collect the user's name and attach it to the billing details.
     /// - Returns: A `PaymentMethodDisplayData` if the user selected a payment method, or `nil` otherwise.
     func collectPaymentMethod(
         from presentingViewController: UIViewController,
         with email: String?,
-        supportedPaymentMethodTypes: [LinkPaymentMethodType] = LinkPaymentMethodType.allCases,
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         collectName: Bool = false
     ) async -> LinkController.PaymentMethodPreview? {
         return await withCheckedContinuation { continuation in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -25,7 +25,7 @@ extension UIViewController {
         intent: Intent,
         elementsSession: STPElementsSession,
         analyticsHelper: PaymentSheetAnalyticsHelper,
-        supportedPaymentMethodTypes: [LinkPaymentMethodType] = LinkPaymentMethodType.allCases,
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
         shouldShowSecondaryCta: Bool = true,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -54,7 +54,7 @@ final class PayWithNativeLinkController {
     let configuration: PaymentElementConfiguration
     let logPayment: Bool
     let analyticsHelper: PaymentSheetAnalyticsHelper
-    let supportedPaymentMethodTypes: [LinkPaymentMethodType]
+    let supportedPaymentMethodTypes: [LinkPaymentMethodType]?
 
     private let linkAppearance: LinkAppearance?
     private let linkConfiguration: LinkConfiguration?
@@ -67,7 +67,7 @@ final class PayWithNativeLinkController {
         configuration: PaymentElementConfiguration,
         logPayment: Bool = true,
         analyticsHelper: PaymentSheetAnalyticsHelper,
-        supportedPaymentMethodTypes: [LinkPaymentMethodType] = LinkPaymentMethodType.allCases,
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
         confirmationChallenge: ConfirmationChallenge? = nil

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
@@ -180,6 +180,16 @@ class PayWithLinkViewController_WalletViewModelTests: XCTestCase {
         )
     }
 
+    func test_supportedPaymentMethodTypes_whenFilterIsNil_usesAllCasesAtIntersection() throws {
+        let sut = try makeSUT(
+            supportedPaymentDetailsTypes: [.bankAccount],
+            supportedPaymentMethodTypes: nil,
+            linkFundingSources: ["BANK_ACCOUNT"]
+        )
+
+        XCTAssertEqual(sut.supportedPaymentMethodTypes, [.bankAccount])
+    }
+
     func test_cardBrandFiltering_passThroughEnabled() throws {
         let sut = try makeSUT(supportedPaymentDetailsTypes: [.card],
                               linkFundingSources: ["CARD"],
@@ -368,6 +378,7 @@ extension PayWithLinkViewController_WalletViewModelTests {
     func makeSUT(
         paymentMethods: [ConsumerPaymentDetails] = LinkStubs.paymentMethods(),
         supportedPaymentDetailsTypes: Set<ConsumerPaymentDetails.DetailsType> = [.card, .bankAccount],
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         linkFundingSources: [String] = ["CARD"],
         cardBrandAcceptance: PaymentSheet.CardBrandAcceptance = .all,
         allowedCardFundingTypes: PaymentSheet.CardFundingType = .all,
@@ -415,6 +426,7 @@ extension PayWithLinkViewController_WalletViewModelTests {
                 shouldShowSecondaryCta: shouldShowSecondaryCta,
                 initiallySelectedPaymentDetailsID: nil,
                 callToAction: nil,
+                supportedPaymentMethodTypes: supportedPaymentMethodTypes,
                 analyticsHelper: ._testValue()
             ),
             paymentMethods: paymentMethods


### PR DESCRIPTION
## Summary
  Modifies the default value of `supportedPaymentMethodTypes`

## Motivation
In #5309, we introduced parametric filtering of supported payment methods. We used a default value of `allCases`, which works for our current feature set. However, in #6342, we'll want to remove the `intersection` on these filtered payment methods if none are provided to allow for unknown PMs to be included in the list. In this PR, we'll keep the same intersection functionality of all cases, but modify the piping of these values to use `nil` instead of `allCases` as the default value.  In #6342, we [remove the allCases intersection](https://github.com/stripe/stripe-ios/pull/6342/changes#diff-7d5339851903df687dc841f3deb388ba566a2f0b319c57c38671cb529b80e7a4R119) entirely if `nil` filtered payment methods are passed in.

## Demos
| Test Harness  | MPE |
| ------------- | ------------- |
| <video src="https://github.com/user-attachments/assets/3a09ccb5-59c1-4cfb-aa7f-273776a8e6f8" />  | <video src="https://github.com/user-attachments/assets/8f798fe5-ecc1-4ee9-9d7a-ba532421d354" /> |






