### PR TITLE
Remove PreviewConnect from new theming tokens

### DIFF
--- a/Example/StripeConnectExample/StripeConnectExample/Settings/Appearance/AppSettings+AppearanceInfo.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Settings/Appearance/AppSettings+AppearanceInfo.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(PreviewConnect) @_spi(STP) import StripeConnect
+@_spi(STP) import StripeConnect
 import UIKit
 
 extension AppSettings {

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager+Appearance.swift
@@ -194,8 +194,6 @@ extension EmbeddedComponentManager {
             public init() { }
         }
 
-        @_spi(PreviewConnect)
-        @_documentation(visibility: public)
         /// Describes the appearance of all button types used in embedded components
         public struct ButtonDefaults {
             /// The horizontal padding for all buttons
@@ -226,8 +224,6 @@ extension EmbeddedComponentManager {
             public init() {}
         }
 
-        @_spi(PreviewConnect)
-        @_documentation(visibility: public)
         /// Describes the appearance of all badge types used in embedded components.
         public struct BadgeDefaults {
             /// The horizontal padding for all badges
@@ -262,8 +258,6 @@ extension EmbeddedComponentManager {
             public init() {}
         }
 
-        @_spi(PreviewConnect)
-        @_documentation(visibility: public)
         /// Describes the appearance of a form type used in embedded components.
         public struct Form {
             /// The text placeholder color for this form type.
@@ -281,8 +275,6 @@ extension EmbeddedComponentManager {
             public init() {}
         }
 
-        @_spi(PreviewConnect)
-        @_documentation(visibility: public)
         /// Describes the appearance of an Action type used in embedded components.
         public struct Action {
             /// The text transform for this action type
@@ -307,12 +299,8 @@ extension EmbeddedComponentManager {
         /// Describes the appearance of the secondary button
         public var buttonSecondary: Button  = .init()
         /// Describes the appearance of the danger button
-        @_spi(PreviewConnect)
-        @_documentation(visibility: public)
         public var buttonDanger: Button  = .init()
         /// Describes the padding and label typography shared by all button variants
-        @_spi(PreviewConnect)
-        @_documentation(visibility: public)
         public var buttonDefaults: ButtonDefaults = .init()
         /// Describes the appearance used to represent neutral
         /// state or lack of state in status badges.
@@ -328,27 +316,17 @@ extension EmbeddedComponentManager {
         /// indicate failed or unsuccessful outcomes.
         public var badgeDanger: Badge  = .init()
         /// Describes the padding and label typography shared by all badge variants
-        @_spi(PreviewConnect)
-        @_documentation(visibility: public)
         public var badgeDefaults: BadgeDefaults = .init()
         /// Describes the corner radius used in embedded components.
         public var cornerRadius: CornerRadius = .init()
         /// Describes the appearance of a form used in embedded components.
-        @_spi(PreviewConnect)
-        @_documentation(visibility: public)
         public var form: Form  = .init()
         /// Describes the vertical padding for table rows
         /// The default is calculated based on the spacingUnit when unspecified.
-        @_spi(PreviewConnect)
-        @_documentation(visibility: public)
         public var tableRowPaddingY: CGFloat?
         /// Describes the appearance of primary links
-        @_spi(PreviewConnect)
-        @_documentation(visibility: public)
         public var actionPrimaryStyle: Action  = .init()
         /// Describes the appearance of secondary links
-        @_spi(PreviewConnect)
-        @_documentation(visibility: public)
         public var actionSecondaryStyle: Action  = .init()
 
         /// Creates a `EmbeddedComponentManager.Appearance` with default values

--- a/StripeConnect/StripeConnectTests/AppearanceTests.swift
+++ b/StripeConnect/StripeConnectTests/AppearanceTests.swift
@@ -5,7 +5,7 @@
 //  Created by Chris Mays on 9/4/24.
 //
 
-@_spi(PreviewConnect) @testable import StripeConnect
+@testable import StripeConnect
 import UIKit
 import XCTest
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Removing `@spi(PreviewConnect)` from the new theming tokens added in this PR: https://github.com/stripe/stripe-ios/pull/6201

The new tokens have been fully rolled out on ConnectJS, Android SDK, and React Native. The new types on iOS can now be GA'd as well.

Here is the API Review for these changes: https://docs.google.com/document/d/1yYG006Aawzujw03HxBN9FeRm-LdwMOfQQxFtUEu0Tkw/edit?usp=sharing

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Please refer to https://github.com/stripe/stripe-ios/pull/6201

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

I tested the new tokens on the StripeConnect Example App and the build succeeded and all theming tokens were still in effect.

https://github.com/user-attachments/assets/1a45ce51-3d92-4bf0-9775-3318327a5112

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
