### PR TITLE
Adding to Change Log for Connect Release (GA new theming tokens)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ MINOR
 * [Fixed] Fixed an issue where `LinkController` used the shared `STPAPIClient` instead of the `apiClient` specified in the caller, affecting apps using multiple API client instances.
 
 ### Connect
-* [Changed] [#66351](https://github.com/stripe/stripe-ios/pull/6351) Changed the types for new theming tokens in Connect Embedded Components from PreviewConnect to fully public (GA).
+* [Changed] [#66351](https://github.com/stripe/stripe-ios/pull/6351) Theming tokens in connect embedded components is now GA.
 
 ## 25.11.0 2026-04-13
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ MINOR
 ### PaymentSheet
 * [Fixed] Fixed an issue where `LinkController` used the shared `STPAPIClient` instead of the `apiClient` specified in the caller, affecting apps using multiple API client instances.
 
+### Connect
+* [Changed] [#66351](https://github.com/stripe/stripe-ios/pull/6351) Changed the types for new theming tokens in Connect Embedded Components from PreviewConnect to fully public (GA).
+
 ## 25.11.0 2026-04-13
 ### PaymentSheet
 * [Added] Added support for Pay by Bank payments (GA in GB, private preview in EU).


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Please refer to this PR for the changes made: https://github.com/stripe/stripe-ios/pull/6351

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

* [Changed] [#66351](https://github.com/stripe/stripe-ios/pull/6351) Changed the types for new theming tokens in Connect Embedded Components from PreviewConnect to fully public (GA).