### PR TITLE
Add refresh API

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+State.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+State.swift
@@ -14,7 +14,7 @@ extension Checkout {
     public enum State {
         /// The session is loaded and ready.
         case loaded(Session)
-        /// A mutation is in progress. The associated session is the
+        /// A mutation or refresh is in progress. The associated session is the
         /// most recently loaded value and may be stale.
         case loading(Session)
     }
@@ -22,10 +22,10 @@ extension Checkout {
 
 @_spi(CheckoutSessionsPreview)
 extension Checkout.State {
-    /// The most recent session data, regardless of whether a mutation is in flight.
+    /// The most recent session data, regardless of whether a mutation or refresh is in flight.
     ///
     /// In the ``Checkout/State/loading(_:)`` state the session may be stale
-    /// until the in-flight mutation completes.
+    /// until the in-flight operation completes.
     public var session: Checkout.Session {
         switch self {
         case .loaded(let session), .loading(let session):
@@ -33,7 +33,7 @@ extension Checkout.State {
         }
     }
 
-    /// Whether a mutation is in progress.
+    /// Whether a mutation or refresh is in progress.
     public var isLoading: Bool {
         if case .loading = self { return true }
         return false

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -31,7 +31,7 @@ public final class Checkout: ObservableObject {
     /// The current state of the checkout session.
     ///
     /// After initialization this is always ``State.loaded(_:)``. It transitions to
-    /// ``State.loading(_:)`` while a mutation (e.g. applying a promo code) is in flight.
+    /// ``State.loading(_:)`` while a mutation or refresh is in flight.
     @Published public private(set) var state: State
 
     /// The configuration supplied at initialization.
@@ -53,12 +53,12 @@ public final class Checkout: ObservableObject {
     private let clientSecret: String
     private let apiClient: STPAPIClient
 
-    /// Number of session-mutating API calls currently in flight.
+    /// Number of session mutations or refreshes currently in flight.
     /// Used by `withSessionUpdateGuard` to keep state as `.loading`
-    /// until all overlapping mutations complete.
+    /// until all overlapping operations complete.
     private var sessionUpdateCount = 0
 
-    /// Sets the session on `state`, using `.loading` if another update is in flight.
+    /// Sets the session on `state`, using `.loading` if another operation is in flight.
     private func setSession(_ session: Checkout.Session) {
         state = sessionUpdateCount > 0 ? .loading(session) : .loaded(session)
     }
@@ -112,6 +112,24 @@ public final class Checkout: ObservableObject {
         self.state = .loaded(session)
         session.onConfirmed = { [weak self] response in
             self?.updateSession(response)
+        }
+    }
+
+    // MARK: - Session
+
+    /// Refreshes the session by fetching the latest copy from Stripe.
+    ///
+    /// Call this after making server-side changes to the Checkout Session so
+    /// the local ``state`` stays in sync with Stripe.
+    ///
+    /// - Throws: ``CheckoutError`` if checkout UI is currently presented or the
+    ///   latest session cannot be fetched.
+    public func refresh() async throws {
+        guard integrationDelegate?.isSheetPresented != true else {
+            throw CheckoutError.sheetCurrentlyPresented
+        }
+        try await withSessionUpdateGuard {
+            try await refreshSession()
         }
     }
 
@@ -266,7 +284,7 @@ public final class Checkout: ObservableObject {
 
     // MARK: - Private Methods
 
-    /// Tracks that a session update is in progress for the duration of `body`.
+    /// Tracks that a session mutation or refresh is in progress for the duration of `body`.
     /// Transitions state to `.loading` while the body executes.
     /// Uses a counter so overlapping calls don't clear the flag early.
     /// Note: an actor wouldn't help — actors are reentrant at suspension points,
@@ -331,6 +349,18 @@ public final class Checkout: ObservableObject {
                 checkoutSessionId: sessionId,
                 parameters: update.parameters
             )
+        } catch {
+            throw CheckoutError.apiError(message: error.nonGenericDescription)
+        }
+        try await refreshSession(applyOverrides: applyOverrides)
+    }
+
+    /// Fetches the latest Checkout Session from Stripe and publishes it to observers.
+    private func refreshSession(
+        applyOverrides: ((STPCheckoutSession) -> Void)? = nil
+    ) async throws {
+        do {
+            let sessionId = Self.extractSessionId(from: clientSecret)
             let refreshedCheckoutSession = try await apiClient.initCheckoutSession(
                 checkoutSessionId: sessionId,
                 adaptivePricingAllowed: configuration.adaptivePricing.allowed

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
@@ -34,6 +34,39 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         XCTAssertFalse(checkout.state.isLoading)
     }
 
+    func testRefreshFetchesLatestServerState() async throws {
+        let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
+            allowPromotionCodes: true
+        )
+        let apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        let checkout = try await Checkout(
+            clientSecret: checkoutSessionResponse.clientSecret,
+            apiClient: apiClient
+        )
+        let delegate = MockCheckoutDelegate()
+        checkout.delegate = delegate
+
+        XCTAssertNil(checkout.state.session.appliedPromotionCode)
+        XCTAssertEqual(checkout.state.session.totals?.total, 2000)
+
+        _ = try await apiClient.updateCheckoutSession(
+            checkoutSessionId: checkoutSessionResponse.id,
+            parameters: ["promotion_code": "SAVE25"]
+        )
+
+        // The local copy remains stale until refresh() fetches the latest session snapshot.
+        XCTAssertNil(checkout.state.session.appliedPromotionCode)
+        XCTAssertEqual(checkout.state.session.totals?.total, 2000)
+
+        try await checkout.refresh()
+
+        XCTAssertEqual(checkout.state.session.appliedPromotionCode, "SAVE25")
+        XCTAssertEqual(checkout.state.session.totals?.total, 1500)
+        XCTAssertFalse(checkout.state.isLoading)
+        XCTAssertTrue(delegate.didChangeStateCalled)
+        XCTAssertEqual(delegate.lastState?.session.appliedPromotionCode, "SAVE25")
+    }
+
     func testDelegateCalledOnPromotionCodeApply() async throws {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             allowPromotionCodes: true

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -201,6 +201,25 @@ final class CheckoutUnitTests: XCTestCase {
         }
     }
 
+    func testRefreshThrowsWhenSheetPresentedEvenIfSessionIsClosed() async {
+        let checkout = makeCheckoutWithClosedSession()
+        let integrationDelegate = MockCheckoutIntegrationDelegate()
+        integrationDelegate.isSheetPresented = true
+        checkout.integrationDelegate = integrationDelegate
+
+        do {
+            try await checkout.refresh()
+            XCTFail("Expected CheckoutError.sheetCurrentlyPresented")
+        } catch let error as CheckoutError {
+            guard case .sheetCurrentlyPresented = error else {
+                XCTFail("Expected .sheetCurrentlyPresented, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
     // MARK: - Address Collection Decoding Tests
 
     func testRequiresBillingAddress_whenRequired() {

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CheckoutTests/testRefreshFetchesLatestServerState/0000_post_create_checkout_session.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CheckoutTests/testRefreshFetchesLatestServerState/0000_post_create_checkout_session.tail
@@ -1,0 +1,17 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_checkout_session$
+200
+text/html
+x-content-type-options: nosniff
+x-cloud-trace-context: 882ae97765a43940588dca24cb9ba142;o=1
+Content-Type: text/html;charset=utf-8
+Set-Cookie: rack.session=6U27wJxDJZqnpsx%2Br6GwE4Z3RFwgqftmyGJUqhA1xy%2Bifw9hTS1mt%2B%2BEjnPy1AD7M4QfZeGpj3m%2FX0XEhSv1m5sQ7F4Gh41PhpaIAQo88SNrgOrAtXGXP8oVbFup8ofgZaM29oTAu6tsHEUFOgXQYK0INvcLaTVB7qxKWTgfuDzaJbEhevNG%2BGf1HkgAFDBvH3dEWbwSsmAFa0v9uZWpOOFGfM1%2BO6zM%2Fmlksl87Li0%3D; path=/
+Server: Google Frontend
+Via: 1.1 google
+Date: Mon, 20 Apr 2026 15:29:46 GMT
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+Content-Length: 293
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+
+{"id":"cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx","client_secret":"cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx_secret_fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdwbEhqYWAnPydmcHZxamgneCUl","publishable_key":"pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CheckoutTests/testRefreshFetchesLatestServerState/0001_post_v1_payment_pages_cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx_init.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CheckoutTests/testRefreshFetchesLatestServerState/0001_post_v1_payment_pages_cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx_init.tail
@@ -1,0 +1,882 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_pages\/cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx\/init$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=M1SoV2_X2FNE67MuWeTqi0uR667d3brSLGr-NYko22TKujS-5WMG1E24ZKCu9CLiSXXCr0FtRCZbYg5l
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=M1SoV2_X2FNE67MuWeTqi0uR667d3brSLGr-NYko22TKujS-5WMG1E24ZKCu9CLiSXXCr0FtRCZbYg5l&t=1"
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=M1SoV2_X2FNE67MuWeTqi0uR667d3brSLGr-NYko22TKujS-5WMG1E24ZKCu9CLiSXXCr0FtRCZbYg5l&t=1"}],"include_subdomains":true}
+request-id: req_X5qeoaKkldEpHz
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 30321
+Vary: Origin
+Date: Mon, 20 Apr 2026 15:29:47 GMT
+original-request: req_X5qeoaKkldEpHz
+stripe-version: 2020-08-27
+idempotency-key: 5e0dd4f3-5529-456b-984b-2113411d8cf7
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: adaptive_pricing\[allowed]=true&browser_locale=.*&browser_timezone=.*&eid=.*&elements_session_client\[is_aggregation_expected]=true&elements_session_client\[locale]=.*&elements_session_client\[mobile_app_id]=.*&redirect_type=embedded
+
+{
+  "lpm_settings" : null,
+  "sepa_debit_info" : null,
+  "automatic_payment_method_types" : false,
+  "tax_context" : {
+    "automatic_tax_error" : null,
+    "automatic_tax_enabled" : false,
+    "automatic_tax_taxability_reason" : null,
+    "dynamic_tax_enabled" : false,
+    "tax_id_collection_enabled" : false,
+    "automatic_tax_exempt" : "none",
+    "customer_tax_country" : null,
+    "tax_id_collection_required" : "never",
+    "has_maximum_tax_ids" : false,
+    "automatic_tax_address_source" : null
+  },
+  "payment_method_types" : [
+    "card"
+  ],
+  "payment_method_options" : {
+    "card" : {
+      "request_three_d_secure" : "automatic"
+    }
+  },
+  "bnpl_in_link_ui_enabled" : false,
+  "consent_collection" : null,
+  "origin_context" : null,
+  "use_payment_methods" : true,
+  "enforcement_mode" : "open",
+  "blocked_billing_address_countries" : [
+
+  ],
+  "id" : "ppage_1TOJleFY0qyl6XeWk1KoVXfE",
+  "subscription_settings" : null,
+  "consent" : null,
+  "application" : null,
+  "payment_method_collection" : "if_required",
+  "setup_intent" : null,
+  "shipping_options" : [
+
+  ],
+  "setup_future_usage_for_payment_method_type" : {
+
+  },
+  "capture_method" : "automatic_async",
+  "statement_descriptor" : "mobile",
+  "allow_promotion_codes" : true,
+  "session_id" : "cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx",
+  "shipping_address_collection" : null,
+  "konbini_confirmation_number" : null,
+  "setup_future_usage" : null,
+  "invoice_creation" : {
+    "enabled" : false
+  },
+  "has_dynamic_tax_rates" : false,
+  "receipt_emails_enabled" : false,
+  "link_settings" : {
+    "link_consumer_incentive" : null,
+    "link_payment_session_context" : null,
+    "consumer_found" : null,
+    "hcaptcha_rqdata" : null,
+    "link_supported_payment_methods_onboarding_enabled" : [
+
+    ],
+    "enable_partner_lookup" : false,
+    "link_us_bank_account_funding_source_enabled" : false,
+    "link_funding_sources" : [
+
+    ],
+    "hcaptcha_site_key" : null,
+    "link_brand" : "link",
+    "link_mode" : null,
+    "link_supported_payment_methods" : [
+
+    ]
+  },
+  "object" : "checkout.session",
+  "customer" : null,
+  "shipping_rate" : null,
+  "success_url" : null,
+  "utm_codes" : null,
+  "beta_versions" : null,
+  "has_async_attached_payment_method" : false,
+  "feature_flags" : {
+    "checkout_enable_pay_by_bank_remember_bank_selection" : true,
+    "checkout_link_phone_registration_treatment_1_enabled" : true,
+    "smor_checkout_ui_iteration" : true,
+    "checkout_link_purchase_protections_rollout" : true,
+    "checkout_link_enable_mfa" : true,
+    "checkout_optional_items" : true,
+    "checkout_link_in_habanero_enabled" : true,
+    "checkout_passive_captcha" : true,
+    "adaptive_pricing_buyer_currency_expansion" : true,
+    "checkout_custom_enable_clover_warning" : true,
+    "checkout_enable_link_api_passive_hcaptcha" : true,
+    "checkout_address_autocomplete_enabled" : true,
+    "checkout_enable_link_api_hcaptcha_rqdata" : true,
+    "checkout_hcaptcha_redundancy_control_enabled" : true,
+    "checkout_show_swish_factoring_notice" : true
+  },
+  "locale" : null,
+  "custom_text" : {
+    "shipping_address" : null,
+    "terms_of_service_acceptance" : null,
+    "submit" : null,
+    "after_submit" : null
+  },
+  "route_to_orchestration_interface" : false,
+  "customer_email" : null,
+  "payment_method_filtering" : null,
+  "custom_components" : [
+
+  ],
+  "ui_mode" : "custom",
+  "url" : null,
+  "developer_tool_context" : {
+    "disabled_third_party_wallets" : {
+      "LINK_BUTTON" : {
+        "disabled_reason" : "merchant_payment_methods_settings"
+      },
+      "KLARNA_EXPRESS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "PAYPAL_ECS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "AMAZON_PAY" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      }
+    },
+    "adaptive_pricing" : {
+      "reason" : "customer_not_cross_border",
+      "active" : false
+    },
+    "payment_method_configuration_details" : null
+  },
+  "token_notification_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "init_checksum" : "JCjn6H8HWdyZzlgEglG916Bjz3w66t3S",
+  "bnpl_link_experiment_payment_method_type" : null,
+  "tax_meta" : {
+    "status" : "complete",
+    "error_reason" : null,
+    "computation_type" : "manual",
+    "customer_tax_exempt" : "none"
+  },
+  "payment_status" : "unpaid",
+  "enabled_third_party_wallets" : [
+    {
+      "apple_pay" : {
+        "required_version" : 2
+      },
+      "id" : "APPLE_PAY",
+      "enabled" : true,
+      "carousel_enabled" : true
+    },
+    {
+      "id" : "GOOGLE_PAY",
+      "enabled" : true,
+      "google_pay" : {
+        "id" : "GOOGLE_PAY",
+        "version_minor" : 0,
+        "version_major" : 2
+      },
+      "carousel_enabled" : false
+    },
+    {
+      "id" : "AMAZON_PAY",
+      "carousel_enabled" : false,
+      "enabled" : false
+    },
+    {
+      "id" : "KLARNA_EXPRESS",
+      "carousel_enabled" : false,
+      "enabled" : false
+    }
+  ],
+  "klarna_info" : null,
+  "visible_custom_component_locations" : [
+    "checkout_form_before",
+    "checkout_form_after",
+    "submit_button_before",
+    "submit_button_after",
+    "contact_before",
+    "contact_after",
+    "express_checkout_before",
+    "express_checkout_after",
+    "payment_details_before",
+    "payment_details_after"
+  ],
+  "display_consent_collection_promotions" : false,
+  "policies" : {
+    "contacts" : {
+      "display_phone" : true,
+      "display_url" : true,
+      "enabled" : false,
+      "display_email" : true
+    },
+    "legal" : {
+      "agreement_required" : false,
+      "enabled" : false
+    },
+    "returns" : {
+      "custom_message" : null,
+      "exchanges_accepted" : false,
+      "returns_accepted" : null,
+      "fee_type" : null,
+      "fee_required" : null,
+      "policy_url" : null,
+      "window_start" : null,
+      "refunds_accepted" : null,
+      "window" : null,
+      "enabled" : false,
+      "exceptions_apply" : false,
+      "logistics" : [
+
+      ]
+    }
+  },
+  "card_brands" : {
+    "mastercard" : true,
+    "link" : true,
+    "carnet" : false,
+    "accel" : false,
+    "elo" : false,
+    "rupay" : false,
+    "maestro" : false,
+    "unionpay" : true,
+    "amex" : true,
+    "conecs" : false,
+    "jcb" : true,
+    "visa" : true,
+    "cartes_bancaires" : false,
+    "pulse" : false,
+    "discover" : true,
+    "star" : false,
+    "eftpos_au" : false,
+    "diners" : true,
+    "girocard" : false,
+    "nyce" : false
+  },
+  "geocoding" : {
+    "country_code" : "US",
+    "region_name" : "UT"
+  },
+  "account_settings" : {
+    "assets" : {
+      "use_logo" : false,
+      "icon" : null,
+      "logo" : null
+    },
+    "specified_commercial_transactions_act_url" : null,
+    "business_url" : "https:\/\/github.com\/stripe\/stripe-ios",
+    "privacy_policy_url" : null,
+    "branding" : {
+      "button_color" : "#0074d4",
+      "background_color" : "#ffffff",
+      "border_style" : "default",
+      "font_family" : "default"
+    },
+    "statement_descriptor" : "mobile",
+    "support_email" : null,
+    "display_name" : "CI Stuff",
+    "merchant_of_record_country" : "US",
+    "order_summary_display_name" : "CI Stuff",
+    "support_phone" : "+12105550123",
+    "merchant_of_record_display_name" : "CI Stuff",
+    "support_url" : null,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "country" : "US",
+    "terms_of_service_url" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "server_built_elements_session_params" : {
+    "client_betas" : [
+
+    ],
+    "expand" : [
+
+    ],
+    "checkout_session_id" : "cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx",
+    "locale" : "en-US",
+    "mobile_app_id" : "com.stripe.StripeiOSTestHostApp",
+    "type" : "deferred_intent",
+    "deferred_intent" : {
+      "amount" : 2000,
+      "capture_method" : "automatic_async",
+      "currency" : "usd",
+      "payment_method_types" : [
+        "card"
+      ],
+      "mode" : "payment"
+    }
+  },
+  "shipping_tax_amounts" : [
+
+  ],
+  "billing_address_collection" : null,
+  "experiments_data" : {
+    "event_id" : "502fc743-d385-444a-8b8f-bcc6c79caae6",
+    "experiment_metadata" : {
+      "ocs_buyer_xp_cpl_lpm_holdback" : {
+        "heldback_special_wallets" : [
+
+        ]
+      }
+    },
+    "experiment_assignments" : {
+      "emea_wallets_ideal_wero_rebranding" : "control",
+      "ocs_buyer_xp_cpl_progressive_ece" : "control",
+      "ocs_buyer_xp_cpl_embedded_pay_button" : "control",
+      "cpl_spicy_guacamole" : "control",
+      "connections_checkout_us_bank_account_picker_icons" : "control",
+      "checkout_li_larger_image_size" : "control",
+      "link_ab_test_aa" : "control",
+      "ocs_buyer_xp_cpl_terms_above_submit" : "control",
+      "ocs_buyer_xp_cpl_saved_payment_display" : "control",
+      "ocs_buyer_xp_cpl_discover_card_icon_removal" : "control",
+      "ocs_buyer_xp_cpl_currency_symbol_optimization" : "control",
+      "ocs_buyer_xp_cpl_remove_link_sign_up_box_when_no_pm_selected" : "control",
+      "smor_checkout_ui_iteration" : "control",
+      "checkout_link_instant_debits_accordion_logos" : "control",
+      "checkout_enable_real_time_tax_id_verification_experiment" : "control",
+      "ff_checkout_test_frontend_eff" : "control",
+      "ocs_buyer_xp_cpl_link_signup_in_form" : "control",
+      "ocs_buyer_xp_remove_name_field_guac_related_pms" : "control",
+      "link_risk_based_disable_auto_prompting_checkout" : "control",
+      "ocs_buyer_xp_cpl_iap_apple_pay_exclusivity" : "control",
+      "ocs_buyer_xp_cpl_ap_currency_non_default_select_phase_1" : "control",
+      "ocs_buyer_xp_cpl_iap_apple_pay_and_link_exclusivity" : "control",
+      "checkout_es_la_locale_fallback" : "control",
+      "cpl_guacamole" : "control",
+      "ocs_buyer_xp_cpl_lpm_content_simplification" : "control"
+    }
+  },
+  "return_url" : "https:\/\/example.com\/return",
+  "mode" : "payment",
+  "cancel_url" : null,
+  "elements_session" : {
+    "payment_method_preference" : {
+      "country_code" : "US",
+      "object" : "payment_method_preference",
+      "type" : "deferred_intent",
+      "ordered_payment_method_types" : [
+        "card"
+      ]
+    },
+    "capability_enabled_card_networks" : [
+      "cartes_bancaires",
+      "jcb",
+      "diners",
+      "discover"
+    ],
+    "flags" : {
+      "enable_tax_id_suspicious_pattern_check" : false,
+      "elements_easel_enable_elements_inspector_for_advanced_integrations_backend" : false,
+      "elements_enable_acss_debit_spm" : true,
+      "elements_enable_bizum_custom_payment_form" : true,
+      "financial_connections_enable_deferred_intent_flow" : true,
+      "elements_enable_remove_last_validation" : true,
+      "link_enable_signup_in_summary_in_habanero" : false,
+      "ocs_payment_prompt_for_agents" : false,
+      "apple_pay_prb_killswitch" : false,
+      "elements_enable_easel_for_pi" : true,
+      "elements_enable_ephemeral_key_for_confirmation_token_creation" : true,
+      "elements_enable_fraud_signal_data_transfer_to_hcaptcha" : false,
+      "elements_mobile_card_funding_filtering" : true,
+      "link_payment_element_minor_signup_ui_updates" : false,
+      "link_enable_ncdv_usage_id_selectors_l3" : true,
+      "elements_disable_express_checkout_button_amazon_pay" : false,
+      "elements_easel_disable_appearance_api" : false,
+      "link_auth_partner_enable_link_auth_token_login" : true,
+      "link_enable_ncdv_recall_id_selectors_l3" : true,
+      "elements_disable_link_email_otp" : false,
+      "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
+      "ocs_buyer_xp_elements_card_brand_choice_toggle" : false,
+      "paypal_billing_address_support_in_ece" : true,
+      "elements_enable_pay_by_bank_remember_bank_selection" : true,
+      "link_auth_partner_enable_ios_instagram" : true,
+      "link_user_action_attempt_login_using_stored_credentials" : true,
+      "elements_disable_sepa_debit_eea_address_requirement" : false,
+      "elements_enable_instant_debits_postal_code_collection" : false,
+      "elements_easel_disable_feedback" : false,
+      "elements_extend_hcaptcha_refresh_time" : true,
+      "link_auth_partner_consume_link_auth_intent" : true,
+      "ocs_buyer_xp_elements_remove_cpm_redirect_text" : false,
+      "elements_enable_south_korea_market_underlying_pms" : false,
+      "link_payment_element_steerage_enabled" : true,
+      "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text" : false,
+      "elements_disable_payment_element_card_country_zip_validations" : false,
+      "link_payment_element_default_value_auto_open_modal" : true,
+      "elements_enable_link_card_brand_in_saved_payment_methods" : true,
+      "elements_disable_link_global_holdback_lookup" : false,
+      "financial_connections_enable_ca_accounts" : false,
+      "elements_easel_disable_address_fill" : false,
+      "ocs_buyer_xp_elements_remove_redirect_lpm_content" : false,
+      "elements_enable_payment_method_options_setup_future_usage" : true,
+      "enable_custom_checkout_currency_selector_element" : false,
+      "elements_mobile_android_tap_to_add_enabled" : false,
+      "link_enable_address_country_restrictions" : false,
+      "link_auth_partner_enable_android_fb" : true,
+      "elements_easel_disable_health_check" : false,
+      "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
+      "elements_disable_paypal_express" : false,
+      "elements_enable_au_becs_debit_spm" : true,
+      "elements_enable_write_allow_redisplay" : false,
+      "legacy_customer_session_payment_element_features" : false,
+      "elements_easel_enable_lpm_autofills" : true,
+      "link_auth_partner_enable_authentication_element" : true,
+      "elements_enable_payment_method_logo_position_killswitch" : false,
+      "elements_allow_manual_payment_method_creation_with_spm" : false,
+      "elements_easel_disable" : false,
+      "link_enable_auth_partner_communication" : true,
+      "elements_apply_amex_icon_sorting" : false,
+      "elements_hide_card_brand_icons" : false,
+      "link_auth_partner_enable_distinctly_link_ios_facebook" : true,
+      "elements_easel_disable_customer_location_mocking" : false,
+      "elements_easel_disable_position_customization" : false,
+      "elements_enable_appearance_recompute" : false,
+      "elements_enable_19_digit_pans" : false,
+      "always_show_ece_paypal_recurring_button" : false,
+      "elements_enable_interac_apple_pay" : false,
+      "enable_payment_method_api_shop_pay" : true,
+      "enable_elements_tax_id_type_filtering" : false,
+      "elements_human_security_enabled" : false,
+      "link_enable_white_ece_button_theme" : false,
+      "link_in_accordion_layout_available_in_stripejs" : false,
+      "link_payment_element_widget_view_enabled" : true,
+      "elements_easel_disable_magic_fill" : false,
+      "avoid_redundant_billing_details_for_klarna" : false,
+      "distinctly_link_payment_element_ramp" : true,
+      "link_auth_partner_bypass_bridge_check" : false,
+      "elements_disable_express_checkout_button_shop_pay" : false,
+      "payment_element_link_modal_preload_killswitch" : false,
+      "link_enable_pass_checkout_session_id_to_signup" : true,
+      "elements_enable_jp_card_installments" : true,
+      "elements_show_expanded_spm" : false,
+      "disable_payment_element_if_required_billing_config" : false,
+      "elements_enable_read_allow_redisplay" : false,
+      "elements_enable_link_spm" : true,
+      "elements_enable_save_for_future_payments_pre_check" : false,
+      "link_forest_enable_ece_bank_use_shipping_as_billing" : false,
+      "elements_disable_express_checkout_button_klarna" : false,
+      "distinctly_link_cbc_killswitch" : false,
+      "elements_prefer_fc_lite" : false,
+      "elements_disable_payment_element_custom_payment_methods_byof" : false,
+      "elements_mobile_cardscan_use_mlkit" : false,
+      "elements_enable_link_takeover_in_guacamole" : false,
+      "link_disable_auth_partner_ua_check" : false,
+      "abstracted_adaptive_pricing_should_show_markup_disclosure_percentage" : false,
+      "elements_easel_disable_optimizations_check" : false,
+      "elements_enable_passive_captcha" : false,
+      "distinctly_link_payment_element_opt_out_merchant_blocklist" : false,
+      "link_ewcs_email_and_cookie_lookup_enabled" : false,
+      "enable_custom_checkout_apple_pay_on_chrome" : true,
+      "elements_enable_new_google_places_api" : true,
+      "elements_enable_express_checkout_button_demo_pay" : false,
+      "elements_enable_installments_on_deferred_intents" : true,
+      "disable_cbc_in_link_popup" : false,
+      "ocs_buyer_xp_elements_remove_generic_footer" : false,
+      "elements_spm_set_as_default" : true,
+      "elements_does_not_collect_postal_code_for_non_us_card_transactions_killswitch" : false,
+      "link_disable_login_if_signed_up_outside_of_elements" : true,
+      "elements_enable_link_autofill_prompt_padding_fix" : false,
+      "elements_mobile_attest_on_intent_confirmation" : false,
+      "elements_stop_move_focus_to_first_errored_field" : true,
+      "ocs_buyer_xp_enable_payment_element_accordion_box_shadow" : false,
+      "elements_mobile_allow_stripecardscan" : false,
+      "elements_enable_nz_bank_account_spm" : true,
+      "elements_use_checkout_app_id_for_human_security" : true,
+      "sandboxes_rebrand_testmode" : false,
+      "link_enable_card_brand_choice" : true,
+      "link_payment_element_keep_optional_doi_open_rollout" : true,
+      "adaptive_pricing_for_elements_with_payment_intents" : false,
+      "elements_allow_custom_payment_method_creation" : false,
+      "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+      "show_swish_factoring_notice" : true,
+      "link_purchase_protections_rollout" : true,
+      "elements_disable_fc_lite" : false,
+      "link_auth_partner_delay_recognition" : true,
+      "elements_enable_invalid_country_for_pm_error" : true,
+      "elements_enable_payment_element_custom_payment_methods_byof" : false,
+      "ocs_buyer_xp_elements_remove_wallets_redirect_text" : false,
+      "elements_easel_enable_elements_inspector" : true,
+      "apple_pay_pe_killswitch" : false,
+      "elements_hcaptcha_in_payment_method_data_radar_options" : false,
+      "paypal_phone_number_support_in_ece" : false,
+      "elements_enable_pay_by_bank_multi_country_bank_selector_rollout_countries" : false,
+      "elements_easel_disable_payment_fill" : false,
+      "elements_easel_disable_tax_id_fill" : false,
+      "elements_spm_max_visible_payment_methods" : false,
+      "elements_enable_bacs_debit_spm" : true,
+      "id_bank_transfers_v1_integration" : false,
+      "elements_enable_mx_card_installments" : true,
+      "elements_easel_disable_appearance_api_per_element_options" : true,
+      "elements_enable_easel_for_pi_killswitch" : false,
+      "elements_enable_google_pay_webview_heuristics" : true,
+      "elements_spm_messages" : false,
+      "elements_easel_disable_session_summary" : false,
+      "apple_pay_ece_killswitch" : false,
+      "distinctly_link_pe_purchase_protection" : true,
+      "link_enable_link_session_key_consumer_person_details" : false,
+      "link_auth_partner_enable_distinctly_link_android_fb" : true,
+      "link_auth_partner_delay_android_fb_cookie_login" : false,
+      "legacy_confirmation_tokens" : false,
+      "link_auth_partner_enable_distinctly_link_ios_instagram" : false,
+      "elements_easel_disable_elements_inspector_for_pi" : true,
+      "link_auth_partner_enable_ece" : true,
+      "distinctly_link_pe_backup_payment_method" : true,
+      "link_dedupe_shipping_address_creation" : true,
+      "ece_apple_pay_payment_request_passthrough" : false,
+      "link_enable_link_session_key_link_onboarding_session" : false,
+      "elements_enable_billing_details_in_pe_change_event" : true,
+      "networked_business_profile_demo" : false,
+      "elements_enable_payment_method_logo_position" : true,
+      "payto_enable_modal_in_payment_element" : true,
+      "checkout_link_in_habanero_enabled" : true,
+      "checkout_enable_bank_payment_method_spm" : true,
+      "elements_checkout_form_enable_new_amount_summary" : false,
+      "elements_disable_progressive_cursor" : false,
+      "enable_checkout_session_update_customer" : false,
+      "link_enable_auth_partner_sizing_logging" : true
+    },
+    "merchant_logo_url" : null,
+    "session_id" : "elements_session_1lZCXjmDV85",
+    "card_installments_enabled" : false,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "config_id" : "4c9e7903-2a67-4b63-874c-12336d74caa7",
+    "merchant_currency" : "usd",
+    "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+    "card_brand_choice" : {
+      "eligible" : false,
+      "preferred_networks" : [
+        "cartes_bancaires"
+      ],
+      "supported_cobranded_networks" : {
+        "cartes_bancaires" : false
+      }
+    },
+    "shipping_address_settings" : {
+      "autocomplete_allowed" : false
+    },
+    "external_payment_method_data" : null,
+    "custom_payment_method_data" : null,
+    "meta_pay_signed_container_context" : null,
+    "apple_pay_preference" : "enabled",
+    "payment_method_configuration_id" : null,
+    "merchant_country" : "US",
+    "google_pay_preference" : "enabled",
+    "paypal_express_config" : {
+      "client_id" : null,
+      "client_token" : null,
+      "paypal_merchant_id" : null
+    },
+    "experiments_data" : {
+      "arb_id" : "ff0e23f0-9e5b-476c-98b4-5b6756ed1b4a",
+      "experiment_metadata" : {
+        "seed" : "597f3afdf87ff8efe231b32325f0803fe969e25a82a472ed14e4ec96a18a4939",
+        "semi_dominant_payment_methods" : [
+
+        ],
+        "lpm_holdback_t1_payment_methods" : [
+
+        ],
+        "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false,
+        "lpm_holdback_t2_payment_methods" : [
+
+        ]
+      },
+      "experiment_assignments" : {
+        "ocs_mobile_horizontal_mode_aa" : "control",
+        "link_ce_conversion_cookie_aa" : "control",
+        "ff_elements_test_frontend_eff" : "control",
+        "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : "control",
+        "elements_hcaptcha_init_timeout" : "control",
+        "link_pe_signup_prominence" : "control",
+        "link_ce_conversion_unrecognized_aa" : "control",
+        "link_ab_test_aa" : "control",
+        "link_default_opt_in_disable_blocking" : "control",
+        "link_default_opt_in_disable_blocking_aa" : "control",
+        "connections_elements_incentive_shorten_promo_banner_text" : "control",
+        "link_dl_pe_inline_entrypoint" : "control",
+        "link_popup_browser_support" : "control",
+        "link_ulm_conversion_unrecognized_copy_change" : "control",
+        "ocs_mobile_horizontal_mode" : "control",
+        "paypal_payment_handler" : "control",
+        "link_ce_conversion_brand_change" : "control",
+        "link_dl_pe_inline_entrypoint_aa" : "control",
+        "link_popup_browser_support_aa" : "control",
+        "link_ewcs_clover_latency" : "control",
+        "link_ce_conversion_unrecognized_post_entry_aa" : "control",
+        "link_ce_conversion_ncdv_aa" : "control",
+        "connections_elements_variable_incentives_for_ibp_recurring_payments" : "control",
+        "ocs_buyer_xp_elements_discover_card_icon_removal" : "control",
+        "link_pe_signup_prominence_aa" : "control"
+      }
+    },
+    "legacy_customer" : null,
+    "link_settings" : {
+      "link_passthrough_mode_enabled" : false,
+      "link_payment_element_smart_defaults_enabled" : false,
+      "link_mobile_attestation_state_sync_enabled" : false,
+      "link_no_code_default_values_recall" : true,
+      "link_funding_sources" : [
+
+      ],
+      "link_crypto_onramp_force_cvc_reverification" : false,
+      "link_enable_signup_in_express_checkout_element" : false,
+      "link_wanderlust_in_elements_enabled" : false,
+      "link_consumer_incentive" : null,
+      "link_crypto_onramp_bank_upsell" : false,
+      "link_ece_browser_compatibility_override" : false,
+      "link_enable_email_otp_for_link_popup" : false,
+      "link_crypto_onramp_elements_logout_disabled" : false,
+      "link_no_code_default_values_identification" : true,
+      "link_pay_button_element_enabled" : true,
+      "link_payment_element_enable_webauthn_login" : false,
+      "link_bank_onboarding_enabled" : false,
+      "link_enable_instant_debits_in_testmode" : false,
+      "link_payment_element_disabled_by_targeting" : false,
+      "link_sign_up_opt_in_feature_enabled" : false,
+      "link_only_for_payment_method_types_enabled" : false,
+      "link_disabled_reasons" : {
+        "payment_element_payment_method_mode" : [
+          "link_not_specified_in_payment_method_types"
+        ],
+        "payment_element_passthrough_mode" : [
+          "link_not_enabled_on_payment_config"
+        ]
+      },
+      "link_sign_up_opt_in_initial_value" : false,
+      "link_mobile_use_attestation_endpoints" : false,
+      "link_elements_pageload_sign_up_disabled" : false,
+      "link_disable_pe_signup_prompt" : false,
+      "link_elements_is_crypto_onramp" : false,
+      "link_no_code_default_values_usage" : true,
+      "link_enable_webauthn_for_link_popup" : false,
+      "link_email_verification_login_enabled" : false,
+      "link_popup_webview_option" : "shared",
+      "link_targeting_results" : {
+        "payment_element_passthrough_mode" : null
+      },
+      "link_trusted_merchant_check_enabled" : false,
+      "link_global_holdback_on" : false,
+      "link_show_prefer_debit_card_hint" : false,
+      "link_local_storage_login_enabled" : false,
+      "link_payment_session_context" : null,
+      "link_session_storage_login_enabled" : false,
+      "link_brand" : "link",
+      "link_disable_in_safari_private_browsing" : false,
+      "link_mobile_disable_rux_in_flow_controller" : false,
+      "link_authenticated_change_event_enabled" : false,
+      "link_pm_killswitch_on_in_elements" : false,
+      "link_supported_payment_methods_onboarding_enabled" : [
+
+      ],
+      "link_hcaptcha_site_key" : null,
+      "link_payment_element_disable_signup" : false,
+      "link_enable_displayable_default_values_in_ece" : false,
+      "link_disable_email_otp" : false,
+      "link_hcaptcha_rqdata" : null,
+      "link_default_opt_in" : "NONE",
+      "link_supported_payment_methods" : [
+
+      ],
+      "link_mobile_disable_default_opt_in" : false,
+      "link_mode" : null,
+      "link_mobile_disable_signup" : false,
+      "link_popup_smart_defaults_enabled" : false
+    },
+    "passive_captcha" : null,
+    "payment_method_specs" : [
+      {
+        "async" : false,
+        "type" : "card",
+        "fields" : [
+
+        ]
+      }
+    ],
+    "prefill_selectors" : {
+      "default_values" : {
+        "email" : [
+
+        ],
+        "merchant_provides_default_values_on_update" : true
+      }
+    },
+    "unactivated_payment_method_types" : [
+
+    ],
+    "unverified_payment_methods_on_domain" : [
+      "apple_pay"
+    ],
+    "order" : null,
+    "link_purchase_protections_data" : {
+      "type" : null,
+      "is_eligible" : false
+    },
+    "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+    "customer" : null,
+    "klarna_express_config" : {
+      "klarna_mid" : null
+    },
+    "lpm_killswitches" : {
+      "express_checkout" : [
+
+      ],
+      "payment_element" : [
+
+      ]
+    },
+    "business_name" : "CI Stuff",
+    "ordered_payment_method_types_and_wallets" : [
+      "card",
+      "apple_pay",
+      "google_pay"
+    ],
+    "customer_error" : null
+  },
+  "stripe_hosted_url" : "https:\/\/checkout.stripe.com\/c\/pay\/cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWkB3dnxIQEpRcGFWb1RXPW1tNVN3VHcwXTU1PXZHXUJKcDMnKSdjd2poVmB3c2B3Jz9xd3BgKSdnZGZuYndqcGthRmppancnPycmY2NjY2NjJyknaWR8anBxUXx1YCc%2FJ2hwaXFsWmxxYGgnKSdga2RnaWBVaWRmYG1qaWFgd3YnP3F3cGB4JSUl",
+  "prefilled" : null,
+  "redirect_on_completion" : null,
+  "blob" : null,
+  "client_reference_id" : null,
+  "status" : "open",
+  "submit_type" : null,
+  "email_collection" : "always",
+  "permissions" : null,
+  "custom_fields" : [
+
+  ],
+  "phone_number_collection" : {
+    "enabled" : false
+  },
+  "livemode" : false,
+  "ordered_payment_method_types" : [
+    "card",
+    "apple_pay",
+    "google_pay"
+  ],
+  "state" : "active",
+  "currency" : "usd",
+  "subscription_data" : null,
+  "customer_managed_saved_payment_methods_offer_save" : null,
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping" : null,
+  "crypto_in_link_ui_enabled" : false,
+  "rqdata" : "n2Ca1NZzc35Bo3DoSwoDEIeQvmnPDAYu+IyGMd9DwpMcqxfUwi8uPmN89UiOzZ4BbZh2mtinv4rdjyHL41jYCdLwJMoGfnMs4m\/0XY\/ShKT25wEzUhoEeqef3pU5ZGzBGRm8QwF+yAIviBrex8qkB58ux\/k1pVkXbLh6ExgqUp0H4azWXs1cWGa2ng7swgeQcgKhRdvVL9DeirGpKG58Z6gSi8oBwwIqoOsMsNfIuEYe+DVlHW8p8PMz7LzTDIgzCN1zOjT\/zs2mSSrAIlX+iwML5zXlYbIEM8Nogf19aI9O6nepeO8x\/uAzcA==HRIwQUk48kirClJW",
+  "total_summary" : {
+    "due" : 2000,
+    "subtotal" : 2000,
+    "total" : 2000
+  },
+  "on_behalf_of" : null,
+  "cross_sell_group" : null,
+  "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+  "checkout_multistep_ui" : false,
+  "eid" : "C82934D3-8489-472A-B19C-319EF8646511",
+  "line_item_group" : {
+    "total" : 2000,
+    "line_items" : [
+      {
+        "id" : "li_1TOJleFY0qyl6XeWjmHBI7N5",
+        "description" : null,
+        "discount_amounts" : [
+
+        ],
+        "quantity" : 1,
+        "is_removable" : false,
+        "total" : 2000,
+        "tax_amounts" : [
+
+        ],
+        "subtotal" : 2000,
+        "cross_sell_from" : null,
+        "object" : "item",
+        "price" : {
+          "id" : "price_1TOJleFY0qyl6XeWDd2bwG1k",
+          "livemode" : false,
+          "active" : false,
+          "product" : {
+            "object" : "product",
+            "active" : false,
+            "addons" : null,
+            "id" : "prod_TnUMNVDoRiDXJx",
+            "images" : [
+
+            ],
+            "livemode" : false,
+            "url" : null,
+            "attributes" : [
+
+            ],
+            "description" : null,
+            "name" : "Test",
+            "unit_label" : null
+          },
+          "tax_behavior" : "exclusive",
+          "custom_unit_amount" : null,
+          "transform_quantity" : null,
+          "type" : "one_time",
+          "unit_amount" : 2000,
+          "unit_amount_decimal" : "2000",
+          "object" : "price",
+          "billing_scheme" : "per_unit",
+          "recurring" : null,
+          "currency" : "usd",
+          "tiers_mode" : null
+        },
+        "adjustable_quantity" : null,
+        "images" : null,
+        "unit_amount_override" : null,
+        "name" : "Test"
+      }
+    ],
+    "shipping_rate" : null,
+    "applied_credits" : [
+
+    ],
+    "subtotal" : 2000,
+    "discount_amounts" : [
+
+    ],
+    "currency" : "usd",
+    "tax_amounts" : [
+
+    ],
+    "due" : 2000
+  },
+  "managed_payments" : {
+    "enabled" : false
+  },
+  "name_collection" : null,
+  "payment_intent" : null,
+  "config_id" : "3490d33a-a4a4-49b6-b93c-77e01260bc02",
+  "is_sandbox_merchant" : false
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CheckoutTests/testRefreshFetchesLatestServerState/0002_post_v1_payment_pages_cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CheckoutTests/testRefreshFetchesLatestServerState/0002_post_v1_payment_pages_cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx.tail
@@ -1,0 +1,916 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_pages\/cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=tM_ySX22GoGkd218QayFOnlKw1SzITuKfE8R78cOcA28wGRxNZWFJ6ex0QYge1EIkcjCB2PQask-BA89
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=tM_ySX22GoGkd218QayFOnlKw1SzITuKfE8R78cOcA28wGRxNZWFJ6ex0QYge1EIkcjCB2PQask-BA89&t=1"
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=tM_ySX22GoGkd218QayFOnlKw1SzITuKfE8R78cOcA28wGRxNZWFJ6ex0QYge1EIkcjCB2PQask-BA89&t=1"}],"include_subdomains":true}
+request-id: req_Ysr0Xtj0xbHNBb
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 31306
+Vary: Origin
+Date: Mon, 20 Apr 2026 15:29:48 GMT
+original-request: req_Ysr0Xtj0xbHNBb
+stripe-version: 2020-08-27
+idempotency-key: 8d101ff6-774c-4ec4-91b1-91138bb4e81e
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: promotion_code=SAVE25
+
+{
+  "lpm_settings" : null,
+  "sepa_debit_info" : null,
+  "automatic_payment_method_types" : false,
+  "tax_context" : {
+    "automatic_tax_error" : null,
+    "automatic_tax_enabled" : false,
+    "automatic_tax_taxability_reason" : null,
+    "dynamic_tax_enabled" : false,
+    "tax_id_collection_enabled" : false,
+    "automatic_tax_exempt" : "none",
+    "customer_tax_country" : null,
+    "tax_id_collection_required" : "never",
+    "has_maximum_tax_ids" : false,
+    "automatic_tax_address_source" : null
+  },
+  "payment_method_types" : [
+    "card"
+  ],
+  "payment_method_options" : {
+    "card" : {
+      "request_three_d_secure" : "automatic"
+    }
+  },
+  "bnpl_in_link_ui_enabled" : false,
+  "consent_collection" : null,
+  "origin_context" : null,
+  "use_payment_methods" : true,
+  "enforcement_mode" : "open",
+  "blocked_billing_address_countries" : [
+
+  ],
+  "id" : "ppage_1TOJleFY0qyl6XeWk1KoVXfE",
+  "subscription_settings" : null,
+  "consent" : null,
+  "application" : null,
+  "payment_method_collection" : "if_required",
+  "setup_intent" : null,
+  "shipping_options" : [
+
+  ],
+  "setup_future_usage_for_payment_method_type" : {
+
+  },
+  "capture_method" : "automatic_async",
+  "statement_descriptor" : "mobile",
+  "allow_promotion_codes" : true,
+  "session_id" : "cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx",
+  "shipping_address_collection" : null,
+  "konbini_confirmation_number" : null,
+  "setup_future_usage" : null,
+  "invoice_creation" : {
+    "enabled" : false
+  },
+  "has_dynamic_tax_rates" : false,
+  "receipt_emails_enabled" : false,
+  "link_settings" : {
+    "link_consumer_incentive" : null,
+    "link_payment_session_context" : null,
+    "consumer_found" : null,
+    "hcaptcha_rqdata" : null,
+    "link_supported_payment_methods_onboarding_enabled" : [
+
+    ],
+    "enable_partner_lookup" : false,
+    "link_us_bank_account_funding_source_enabled" : false,
+    "link_funding_sources" : [
+
+    ],
+    "hcaptcha_site_key" : null,
+    "link_brand" : "link",
+    "link_mode" : null,
+    "link_supported_payment_methods" : [
+
+    ]
+  },
+  "object" : "checkout.session",
+  "customer" : null,
+  "shipping_rate" : null,
+  "success_url" : null,
+  "utm_codes" : null,
+  "beta_versions" : null,
+  "has_async_attached_payment_method" : false,
+  "feature_flags" : {
+    "checkout_enable_pay_by_bank_remember_bank_selection" : true,
+    "checkout_link_phone_registration_treatment_1_enabled" : true,
+    "smor_checkout_ui_iteration" : true,
+    "checkout_link_purchase_protections_rollout" : true,
+    "checkout_link_enable_mfa" : true,
+    "checkout_optional_items" : true,
+    "checkout_link_in_habanero_enabled" : true,
+    "checkout_passive_captcha" : true,
+    "adaptive_pricing_buyer_currency_expansion" : true,
+    "checkout_custom_enable_clover_warning" : true,
+    "checkout_enable_link_api_passive_hcaptcha" : true,
+    "checkout_address_autocomplete_enabled" : true,
+    "checkout_enable_link_api_hcaptcha_rqdata" : true,
+    "checkout_hcaptcha_redundancy_control_enabled" : true,
+    "checkout_show_swish_factoring_notice" : true
+  },
+  "locale" : null,
+  "custom_text" : {
+    "shipping_address" : null,
+    "terms_of_service_acceptance" : null,
+    "submit" : null,
+    "after_submit" : null
+  },
+  "route_to_orchestration_interface" : false,
+  "customer_email" : null,
+  "payment_method_filtering" : null,
+  "custom_components" : [
+
+  ],
+  "ui_mode" : "custom",
+  "url" : null,
+  "developer_tool_context" : {
+    "disabled_third_party_wallets" : {
+      "LINK_BUTTON" : {
+        "disabled_reason" : "merchant_payment_methods_settings"
+      },
+      "KLARNA_EXPRESS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "PAYPAL_ECS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "AMAZON_PAY" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      }
+    },
+    "adaptive_pricing" : {
+      "reason" : "customer_not_cross_border",
+      "active" : false
+    },
+    "payment_method_configuration_details" : null
+  },
+  "token_notification_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "init_checksum" : "JCjn6H8HWdyZzlgEglG916Bjz3w66t3S",
+  "bnpl_link_experiment_payment_method_type" : null,
+  "tax_meta" : {
+    "status" : "complete",
+    "error_reason" : null,
+    "computation_type" : "manual",
+    "customer_tax_exempt" : "none"
+  },
+  "payment_status" : "unpaid",
+  "enabled_third_party_wallets" : [
+    {
+      "apple_pay" : {
+        "required_version" : 2
+      },
+      "id" : "APPLE_PAY",
+      "enabled" : true,
+      "carousel_enabled" : true
+    },
+    {
+      "id" : "GOOGLE_PAY",
+      "enabled" : true,
+      "google_pay" : {
+        "id" : "GOOGLE_PAY",
+        "version_minor" : 0,
+        "version_major" : 2
+      },
+      "carousel_enabled" : false
+    },
+    {
+      "id" : "AMAZON_PAY",
+      "carousel_enabled" : false,
+      "enabled" : false
+    },
+    {
+      "id" : "KLARNA_EXPRESS",
+      "carousel_enabled" : false,
+      "enabled" : false
+    }
+  ],
+  "klarna_info" : null,
+  "visible_custom_component_locations" : [
+    "checkout_form_before",
+    "checkout_form_after",
+    "submit_button_before",
+    "submit_button_after",
+    "contact_before",
+    "contact_after",
+    "express_checkout_before",
+    "express_checkout_after",
+    "payment_details_before",
+    "payment_details_after"
+  ],
+  "display_consent_collection_promotions" : false,
+  "policies" : {
+    "contacts" : {
+      "display_phone" : true,
+      "display_url" : true,
+      "enabled" : false,
+      "display_email" : true
+    },
+    "legal" : {
+      "agreement_required" : false,
+      "enabled" : false
+    },
+    "returns" : {
+      "custom_message" : null,
+      "exchanges_accepted" : false,
+      "returns_accepted" : null,
+      "fee_type" : null,
+      "fee_required" : null,
+      "policy_url" : null,
+      "window_start" : null,
+      "refunds_accepted" : null,
+      "window" : null,
+      "enabled" : false,
+      "exceptions_apply" : false,
+      "logistics" : [
+
+      ]
+    }
+  },
+  "card_brands" : {
+    "mastercard" : true,
+    "link" : true,
+    "carnet" : false,
+    "accel" : false,
+    "elo" : false,
+    "rupay" : false,
+    "maestro" : false,
+    "unionpay" : true,
+    "amex" : true,
+    "conecs" : false,
+    "jcb" : true,
+    "visa" : true,
+    "cartes_bancaires" : false,
+    "pulse" : false,
+    "discover" : true,
+    "star" : false,
+    "eftpos_au" : false,
+    "diners" : true,
+    "girocard" : false,
+    "nyce" : false
+  },
+  "geocoding" : {
+    "country_code" : "US",
+    "region_name" : "UT"
+  },
+  "account_settings" : {
+    "assets" : {
+      "use_logo" : false,
+      "icon" : null,
+      "logo" : null
+    },
+    "specified_commercial_transactions_act_url" : null,
+    "business_url" : "https:\/\/github.com\/stripe\/stripe-ios",
+    "privacy_policy_url" : null,
+    "branding" : {
+      "button_color" : "#0074d4",
+      "background_color" : "#ffffff",
+      "border_style" : "default",
+      "font_family" : "default"
+    },
+    "statement_descriptor" : "mobile",
+    "support_email" : null,
+    "display_name" : "CI Stuff",
+    "merchant_of_record_country" : "US",
+    "order_summary_display_name" : "CI Stuff",
+    "support_phone" : "+12105550123",
+    "merchant_of_record_display_name" : "CI Stuff",
+    "support_url" : null,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "country" : "US",
+    "terms_of_service_url" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "server_built_elements_session_params" : {
+    "expand" : [
+
+    ],
+    "checkout_session_id" : "cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx",
+    "client_betas" : [
+
+    ],
+    "deferred_intent" : {
+      "amount" : 1500,
+      "capture_method" : "automatic_async",
+      "currency" : "usd",
+      "payment_method_types" : [
+        "card"
+      ],
+      "mode" : "payment"
+    },
+    "type" : "deferred_intent"
+  },
+  "shipping_tax_amounts" : [
+
+  ],
+  "billing_address_collection" : null,
+  "experiments_data" : {
+    "event_id" : "027d2f3a-98e5-42ee-919a-6fdb5a44ef96",
+    "experiment_metadata" : {
+      "ocs_buyer_xp_cpl_lpm_holdback" : {
+        "heldback_special_wallets" : [
+
+        ]
+      }
+    },
+    "experiment_assignments" : {
+      "emea_wallets_ideal_wero_rebranding" : "control",
+      "ocs_buyer_xp_cpl_progressive_ece" : "control",
+      "ocs_buyer_xp_cpl_embedded_pay_button" : "control",
+      "cpl_spicy_guacamole" : "control",
+      "connections_checkout_us_bank_account_picker_icons" : "control",
+      "checkout_li_larger_image_size" : "control",
+      "link_ab_test_aa" : "control",
+      "ocs_buyer_xp_cpl_terms_above_submit" : "control",
+      "ocs_buyer_xp_cpl_saved_payment_display" : "control",
+      "ocs_buyer_xp_cpl_discover_card_icon_removal" : "control",
+      "ocs_buyer_xp_cpl_currency_symbol_optimization" : "control",
+      "ocs_buyer_xp_cpl_remove_link_sign_up_box_when_no_pm_selected" : "control",
+      "smor_checkout_ui_iteration" : "control",
+      "checkout_link_instant_debits_accordion_logos" : "control",
+      "checkout_enable_real_time_tax_id_verification_experiment" : "control",
+      "ff_checkout_test_frontend_eff" : "control",
+      "ocs_buyer_xp_cpl_link_signup_in_form" : "control",
+      "ocs_buyer_xp_remove_name_field_guac_related_pms" : "control",
+      "link_risk_based_disable_auto_prompting_checkout" : "control",
+      "ocs_buyer_xp_cpl_iap_apple_pay_exclusivity" : "control",
+      "ocs_buyer_xp_cpl_ap_currency_non_default_select_phase_1" : "control",
+      "ocs_buyer_xp_cpl_iap_apple_pay_and_link_exclusivity" : "control",
+      "checkout_es_la_locale_fallback" : "control",
+      "cpl_guacamole" : "control",
+      "ocs_buyer_xp_cpl_lpm_content_simplification" : "control"
+    }
+  },
+  "return_url" : "https:\/\/example.com\/return",
+  "mode" : "payment",
+  "cancel_url" : null,
+  "elements_session" : {
+    "payment_method_preference" : {
+      "country_code" : "US",
+      "object" : "payment_method_preference",
+      "type" : "deferred_intent",
+      "ordered_payment_method_types" : [
+        "card"
+      ]
+    },
+    "capability_enabled_card_networks" : [
+      "cartes_bancaires",
+      "jcb",
+      "diners",
+      "discover"
+    ],
+    "flags" : {
+      "enable_tax_id_suspicious_pattern_check" : false,
+      "elements_easel_enable_elements_inspector_for_advanced_integrations_backend" : false,
+      "elements_enable_acss_debit_spm" : true,
+      "elements_enable_bizum_custom_payment_form" : true,
+      "financial_connections_enable_deferred_intent_flow" : true,
+      "elements_enable_remove_last_validation" : true,
+      "link_enable_signup_in_summary_in_habanero" : false,
+      "ocs_payment_prompt_for_agents" : false,
+      "apple_pay_prb_killswitch" : false,
+      "elements_enable_easel_for_pi" : true,
+      "elements_enable_ephemeral_key_for_confirmation_token_creation" : true,
+      "elements_enable_fraud_signal_data_transfer_to_hcaptcha" : false,
+      "elements_mobile_card_funding_filtering" : true,
+      "link_payment_element_minor_signup_ui_updates" : false,
+      "link_enable_ncdv_usage_id_selectors_l3" : true,
+      "elements_disable_express_checkout_button_amazon_pay" : false,
+      "elements_easel_disable_appearance_api" : false,
+      "link_auth_partner_enable_link_auth_token_login" : true,
+      "link_enable_ncdv_recall_id_selectors_l3" : true,
+      "elements_disable_link_email_otp" : false,
+      "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
+      "ocs_buyer_xp_elements_card_brand_choice_toggle" : false,
+      "paypal_billing_address_support_in_ece" : true,
+      "elements_enable_pay_by_bank_remember_bank_selection" : true,
+      "link_auth_partner_enable_ios_instagram" : true,
+      "link_user_action_attempt_login_using_stored_credentials" : true,
+      "elements_disable_sepa_debit_eea_address_requirement" : false,
+      "elements_enable_instant_debits_postal_code_collection" : false,
+      "elements_easel_disable_feedback" : false,
+      "elements_extend_hcaptcha_refresh_time" : true,
+      "link_auth_partner_consume_link_auth_intent" : true,
+      "ocs_buyer_xp_elements_remove_cpm_redirect_text" : false,
+      "elements_enable_south_korea_market_underlying_pms" : false,
+      "link_payment_element_steerage_enabled" : true,
+      "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text" : false,
+      "elements_disable_payment_element_card_country_zip_validations" : false,
+      "link_payment_element_default_value_auto_open_modal" : true,
+      "elements_enable_link_card_brand_in_saved_payment_methods" : true,
+      "elements_disable_link_global_holdback_lookup" : false,
+      "financial_connections_enable_ca_accounts" : false,
+      "elements_easel_disable_address_fill" : false,
+      "ocs_buyer_xp_elements_remove_redirect_lpm_content" : false,
+      "elements_enable_payment_method_options_setup_future_usage" : true,
+      "enable_custom_checkout_currency_selector_element" : false,
+      "elements_mobile_android_tap_to_add_enabled" : false,
+      "link_enable_address_country_restrictions" : false,
+      "link_auth_partner_enable_android_fb" : true,
+      "elements_easel_disable_health_check" : false,
+      "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
+      "elements_disable_paypal_express" : false,
+      "elements_enable_au_becs_debit_spm" : true,
+      "elements_enable_write_allow_redisplay" : false,
+      "legacy_customer_session_payment_element_features" : false,
+      "elements_easel_enable_lpm_autofills" : true,
+      "link_auth_partner_enable_authentication_element" : true,
+      "elements_enable_payment_method_logo_position_killswitch" : false,
+      "elements_allow_manual_payment_method_creation_with_spm" : false,
+      "elements_easel_disable" : false,
+      "link_enable_auth_partner_communication" : true,
+      "elements_apply_amex_icon_sorting" : false,
+      "elements_hide_card_brand_icons" : false,
+      "link_auth_partner_enable_distinctly_link_ios_facebook" : true,
+      "elements_easel_disable_customer_location_mocking" : false,
+      "elements_easel_disable_position_customization" : false,
+      "elements_enable_appearance_recompute" : false,
+      "elements_enable_19_digit_pans" : false,
+      "always_show_ece_paypal_recurring_button" : false,
+      "elements_enable_interac_apple_pay" : false,
+      "enable_payment_method_api_shop_pay" : true,
+      "enable_elements_tax_id_type_filtering" : false,
+      "elements_human_security_enabled" : false,
+      "link_enable_white_ece_button_theme" : false,
+      "link_in_accordion_layout_available_in_stripejs" : false,
+      "link_payment_element_widget_view_enabled" : true,
+      "elements_easel_disable_magic_fill" : false,
+      "avoid_redundant_billing_details_for_klarna" : false,
+      "distinctly_link_payment_element_ramp" : true,
+      "link_auth_partner_bypass_bridge_check" : false,
+      "elements_disable_express_checkout_button_shop_pay" : false,
+      "payment_element_link_modal_preload_killswitch" : false,
+      "link_enable_pass_checkout_session_id_to_signup" : true,
+      "elements_enable_jp_card_installments" : true,
+      "elements_show_expanded_spm" : false,
+      "disable_payment_element_if_required_billing_config" : false,
+      "elements_enable_read_allow_redisplay" : false,
+      "elements_enable_link_spm" : true,
+      "elements_enable_save_for_future_payments_pre_check" : false,
+      "link_forest_enable_ece_bank_use_shipping_as_billing" : false,
+      "elements_disable_express_checkout_button_klarna" : false,
+      "distinctly_link_cbc_killswitch" : false,
+      "elements_prefer_fc_lite" : false,
+      "elements_disable_payment_element_custom_payment_methods_byof" : false,
+      "elements_mobile_cardscan_use_mlkit" : false,
+      "elements_enable_link_takeover_in_guacamole" : false,
+      "link_disable_auth_partner_ua_check" : false,
+      "abstracted_adaptive_pricing_should_show_markup_disclosure_percentage" : false,
+      "elements_easel_disable_optimizations_check" : false,
+      "elements_enable_passive_captcha" : false,
+      "distinctly_link_payment_element_opt_out_merchant_blocklist" : false,
+      "link_ewcs_email_and_cookie_lookup_enabled" : false,
+      "enable_custom_checkout_apple_pay_on_chrome" : true,
+      "elements_enable_new_google_places_api" : true,
+      "elements_enable_express_checkout_button_demo_pay" : false,
+      "elements_enable_installments_on_deferred_intents" : true,
+      "disable_cbc_in_link_popup" : false,
+      "ocs_buyer_xp_elements_remove_generic_footer" : false,
+      "elements_spm_set_as_default" : true,
+      "elements_does_not_collect_postal_code_for_non_us_card_transactions_killswitch" : false,
+      "link_disable_login_if_signed_up_outside_of_elements" : true,
+      "elements_enable_link_autofill_prompt_padding_fix" : false,
+      "elements_mobile_attest_on_intent_confirmation" : false,
+      "elements_stop_move_focus_to_first_errored_field" : true,
+      "ocs_buyer_xp_enable_payment_element_accordion_box_shadow" : false,
+      "elements_mobile_allow_stripecardscan" : false,
+      "elements_enable_nz_bank_account_spm" : true,
+      "elements_use_checkout_app_id_for_human_security" : true,
+      "sandboxes_rebrand_testmode" : false,
+      "link_enable_card_brand_choice" : true,
+      "link_payment_element_keep_optional_doi_open_rollout" : true,
+      "adaptive_pricing_for_elements_with_payment_intents" : false,
+      "elements_allow_custom_payment_method_creation" : false,
+      "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+      "show_swish_factoring_notice" : true,
+      "link_purchase_protections_rollout" : true,
+      "elements_disable_fc_lite" : false,
+      "link_auth_partner_delay_recognition" : true,
+      "elements_enable_invalid_country_for_pm_error" : true,
+      "elements_enable_payment_element_custom_payment_methods_byof" : false,
+      "ocs_buyer_xp_elements_remove_wallets_redirect_text" : false,
+      "elements_easel_enable_elements_inspector" : true,
+      "apple_pay_pe_killswitch" : false,
+      "elements_hcaptcha_in_payment_method_data_radar_options" : false,
+      "paypal_phone_number_support_in_ece" : false,
+      "elements_enable_pay_by_bank_multi_country_bank_selector_rollout_countries" : false,
+      "elements_easel_disable_payment_fill" : false,
+      "elements_easel_disable_tax_id_fill" : false,
+      "elements_spm_max_visible_payment_methods" : false,
+      "elements_enable_bacs_debit_spm" : true,
+      "id_bank_transfers_v1_integration" : false,
+      "elements_enable_mx_card_installments" : true,
+      "elements_easel_disable_appearance_api_per_element_options" : true,
+      "elements_enable_easel_for_pi_killswitch" : false,
+      "elements_enable_google_pay_webview_heuristics" : true,
+      "elements_spm_messages" : false,
+      "elements_easel_disable_session_summary" : false,
+      "apple_pay_ece_killswitch" : false,
+      "distinctly_link_pe_purchase_protection" : true,
+      "link_enable_link_session_key_consumer_person_details" : false,
+      "link_auth_partner_enable_distinctly_link_android_fb" : true,
+      "link_auth_partner_delay_android_fb_cookie_login" : false,
+      "legacy_confirmation_tokens" : false,
+      "link_auth_partner_enable_distinctly_link_ios_instagram" : false,
+      "elements_easel_disable_elements_inspector_for_pi" : true,
+      "link_auth_partner_enable_ece" : true,
+      "distinctly_link_pe_backup_payment_method" : true,
+      "link_dedupe_shipping_address_creation" : true,
+      "ece_apple_pay_payment_request_passthrough" : false,
+      "link_enable_link_session_key_link_onboarding_session" : false,
+      "elements_enable_billing_details_in_pe_change_event" : true,
+      "networked_business_profile_demo" : false,
+      "elements_enable_payment_method_logo_position" : true,
+      "payto_enable_modal_in_payment_element" : true,
+      "checkout_link_in_habanero_enabled" : true,
+      "checkout_enable_bank_payment_method_spm" : true,
+      "elements_checkout_form_enable_new_amount_summary" : false,
+      "elements_disable_progressive_cursor" : false,
+      "enable_checkout_session_update_customer" : false,
+      "link_enable_auth_partner_sizing_logging" : true
+    },
+    "merchant_logo_url" : null,
+    "session_id" : "elements_session_1cLz3AKMdB7",
+    "card_installments_enabled" : false,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "config_id" : "09922386-dce0-4f4f-87ca-6825486b89b8",
+    "merchant_currency" : "usd",
+    "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+    "card_brand_choice" : {
+      "eligible" : false,
+      "preferred_networks" : [
+        "cartes_bancaires"
+      ],
+      "supported_cobranded_networks" : {
+        "cartes_bancaires" : false
+      }
+    },
+    "shipping_address_settings" : {
+      "autocomplete_allowed" : false
+    },
+    "external_payment_method_data" : null,
+    "custom_payment_method_data" : null,
+    "meta_pay_signed_container_context" : null,
+    "apple_pay_preference" : "enabled",
+    "payment_method_configuration_id" : null,
+    "merchant_country" : "US",
+    "google_pay_preference" : "enabled",
+    "paypal_express_config" : {
+      "client_id" : null,
+      "client_token" : null,
+      "paypal_merchant_id" : null
+    },
+    "experiments_data" : {
+      "arb_id" : "8d6486f8-fe4b-4afa-a403-d2482b528796",
+      "experiment_metadata" : {
+        "seed" : "597f3afdf87ff8efe231b32325f0803fe969e25a82a472ed14e4ec96a18a4939",
+        "semi_dominant_payment_methods" : [
+
+        ],
+        "lpm_holdback_t1_payment_methods" : [
+
+        ],
+        "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false,
+        "lpm_holdback_t2_payment_methods" : [
+
+        ]
+      },
+      "experiment_assignments" : {
+        "ocs_mobile_horizontal_mode_aa" : "control",
+        "link_ce_conversion_cookie_aa" : "control",
+        "ff_elements_test_frontend_eff" : "control",
+        "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : "control",
+        "elements_hcaptcha_init_timeout" : "control",
+        "link_pe_signup_prominence" : "control",
+        "link_ce_conversion_unrecognized_aa" : "control",
+        "link_ab_test_aa" : "control",
+        "link_default_opt_in_disable_blocking" : "control",
+        "link_default_opt_in_disable_blocking_aa" : "control",
+        "connections_elements_incentive_shorten_promo_banner_text" : "control",
+        "link_dl_pe_inline_entrypoint" : "control",
+        "link_popup_browser_support" : "control",
+        "link_ulm_conversion_unrecognized_copy_change" : "control",
+        "ocs_mobile_horizontal_mode" : "control",
+        "paypal_payment_handler" : "control",
+        "link_ce_conversion_brand_change" : "control",
+        "link_dl_pe_inline_entrypoint_aa" : "control",
+        "link_popup_browser_support_aa" : "control",
+        "link_ewcs_clover_latency" : "control",
+        "link_ce_conversion_unrecognized_post_entry_aa" : "control",
+        "link_ce_conversion_ncdv_aa" : "control",
+        "connections_elements_variable_incentives_for_ibp_recurring_payments" : "control",
+        "ocs_buyer_xp_elements_discover_card_icon_removal" : "control",
+        "link_pe_signup_prominence_aa" : "control"
+      }
+    },
+    "legacy_customer" : null,
+    "link_settings" : {
+      "link_passthrough_mode_enabled" : false,
+      "link_payment_element_smart_defaults_enabled" : false,
+      "link_mobile_attestation_state_sync_enabled" : false,
+      "link_no_code_default_values_recall" : true,
+      "link_funding_sources" : [
+
+      ],
+      "link_crypto_onramp_force_cvc_reverification" : false,
+      "link_enable_signup_in_express_checkout_element" : false,
+      "link_wanderlust_in_elements_enabled" : false,
+      "link_consumer_incentive" : null,
+      "link_crypto_onramp_bank_upsell" : false,
+      "link_ece_browser_compatibility_override" : false,
+      "link_enable_email_otp_for_link_popup" : false,
+      "link_crypto_onramp_elements_logout_disabled" : false,
+      "link_no_code_default_values_identification" : true,
+      "link_pay_button_element_enabled" : true,
+      "link_payment_element_enable_webauthn_login" : false,
+      "link_bank_onboarding_enabled" : false,
+      "link_enable_instant_debits_in_testmode" : false,
+      "link_payment_element_disabled_by_targeting" : false,
+      "link_sign_up_opt_in_feature_enabled" : false,
+      "link_only_for_payment_method_types_enabled" : false,
+      "link_disabled_reasons" : {
+        "payment_element_payment_method_mode" : [
+          "link_not_specified_in_payment_method_types"
+        ],
+        "payment_element_passthrough_mode" : [
+          "link_not_enabled_on_payment_config"
+        ]
+      },
+      "link_sign_up_opt_in_initial_value" : false,
+      "link_mobile_use_attestation_endpoints" : false,
+      "link_elements_pageload_sign_up_disabled" : false,
+      "link_disable_pe_signup_prompt" : false,
+      "link_elements_is_crypto_onramp" : false,
+      "link_no_code_default_values_usage" : true,
+      "link_enable_webauthn_for_link_popup" : false,
+      "link_email_verification_login_enabled" : false,
+      "link_popup_webview_option" : "shared",
+      "link_targeting_results" : {
+        "payment_element_passthrough_mode" : null
+      },
+      "link_trusted_merchant_check_enabled" : false,
+      "link_global_holdback_on" : false,
+      "link_show_prefer_debit_card_hint" : false,
+      "link_local_storage_login_enabled" : false,
+      "link_payment_session_context" : null,
+      "link_session_storage_login_enabled" : false,
+      "link_brand" : "link",
+      "link_disable_in_safari_private_browsing" : false,
+      "link_mobile_disable_rux_in_flow_controller" : false,
+      "link_authenticated_change_event_enabled" : false,
+      "link_pm_killswitch_on_in_elements" : false,
+      "link_supported_payment_methods_onboarding_enabled" : [
+
+      ],
+      "link_hcaptcha_site_key" : null,
+      "link_payment_element_disable_signup" : false,
+      "link_enable_displayable_default_values_in_ece" : false,
+      "link_disable_email_otp" : false,
+      "link_hcaptcha_rqdata" : null,
+      "link_default_opt_in" : "NONE",
+      "link_supported_payment_methods" : [
+
+      ],
+      "link_mobile_disable_default_opt_in" : false,
+      "link_mode" : null,
+      "link_mobile_disable_signup" : false,
+      "link_popup_smart_defaults_enabled" : false
+    },
+    "passive_captcha" : null,
+    "payment_method_specs" : [
+      {
+        "async" : false,
+        "type" : "card",
+        "fields" : [
+
+        ]
+      }
+    ],
+    "prefill_selectors" : {
+      "default_values" : {
+        "email" : [
+
+        ],
+        "merchant_provides_default_values_on_update" : true
+      }
+    },
+    "unactivated_payment_method_types" : [
+
+    ],
+    "unverified_payment_methods_on_domain" : [
+      "apple_pay"
+    ],
+    "order" : null,
+    "link_purchase_protections_data" : {
+      "type" : null,
+      "is_eligible" : false
+    },
+    "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+    "customer" : null,
+    "klarna_express_config" : {
+      "klarna_mid" : null
+    },
+    "lpm_killswitches" : {
+      "express_checkout" : [
+
+      ],
+      "payment_element" : [
+
+      ]
+    },
+    "business_name" : "CI Stuff",
+    "ordered_payment_method_types_and_wallets" : [
+      "card",
+      "apple_pay",
+      "google_pay"
+    ],
+    "customer_error" : null
+  },
+  "stripe_hosted_url" : "https:\/\/checkout.stripe.com\/c\/pay\/cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWkB3dnxIQEpRcGFWb1RXPW1tNVN3VHcwXTU1PXZHXUJKcDMnKSdjd2poVmB3c2B3Jz9xd3BgKSdnZGZuYndqcGthRmppancnPycmY2NjY2NjJyknaWR8anBxUXx1YCc%2FJ2hwaXFsWmxxYGgnKSdga2RnaWBVaWRmYG1qaWFgd3YnP3F3cGB4JSUl",
+  "prefilled" : null,
+  "redirect_on_completion" : null,
+  "blob" : null,
+  "client_reference_id" : null,
+  "status" : "open",
+  "submit_type" : null,
+  "email_collection" : "always",
+  "permissions" : null,
+  "custom_fields" : [
+
+  ],
+  "phone_number_collection" : {
+    "enabled" : false
+  },
+  "livemode" : false,
+  "ordered_payment_method_types" : [
+    "card",
+    "apple_pay",
+    "google_pay"
+  ],
+  "state" : "active",
+  "currency" : "usd",
+  "subscription_data" : null,
+  "customer_managed_saved_payment_methods_offer_save" : null,
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping" : null,
+  "crypto_in_link_ui_enabled" : false,
+  "rqdata" : "Vfu33YajXUJO1sjLU3r8tyclpMI8yo5QGdARlvNmWf9pxmpQ\/Ph5LV9AISLieiZX3eJeRjHQw4iCEruGGhyvILde0c9J41cCgjNKTS+lC5bx6iBAKM2vwkqbBQeH9xoAYzVLolQ7gurngWSKJQavjdvgHBBXwBmxyqVsRVIB9hK6jZGTySNl51g+23zNvJkoxFV0PYGy7Lj5+jtRlo44k77Na6vDSNlTZzhk4tG99ptDZQkbr6OtzFgjnU1z\/RzozPlba8qv2ndPPtenZbv9IRXax6cDTalw3DejFr2gCUB0dbMH2DXQ6CSwdg==LllssOd2XwBT2Epk",
+  "total_summary" : {
+    "due" : 1500,
+    "subtotal" : 2000,
+    "total" : 1500
+  },
+  "on_behalf_of" : null,
+  "cross_sell_group" : null,
+  "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+  "checkout_multistep_ui" : false,
+  "eid" : "62ae2470-8247-40c3-8da7-6dae6e2825e6",
+  "line_item_group" : {
+    "total" : 1500,
+    "line_items" : [
+      {
+        "id" : "li_1TOJleFY0qyl6XeWjmHBI7N5",
+        "description" : null,
+        "discount_amounts" : [
+          {
+            "amount" : 500,
+            "coupon" : {
+              "object" : "coupon",
+              "amount_off" : null,
+              "percent_off" : 25,
+              "has_applies_to_products" : false,
+              "duration" : "once",
+              "currency" : null,
+              "duration_in_months" : null,
+              "name" : "Save 25%"
+            },
+            "currency" : "usd",
+            "intervals" : null,
+            "promotion_code" : {
+              "object" : "promotion_code",
+              "code" : "SAVE25"
+            }
+          }
+        ],
+        "quantity" : 1,
+        "is_removable" : false,
+        "total" : 1500,
+        "tax_amounts" : [
+
+        ],
+        "subtotal" : 2000,
+        "cross_sell_from" : null,
+        "object" : "item",
+        "price" : {
+          "id" : "price_1TOJleFY0qyl6XeWDd2bwG1k",
+          "livemode" : false,
+          "active" : false,
+          "product" : {
+            "object" : "product",
+            "active" : false,
+            "addons" : null,
+            "id" : "prod_TnUMNVDoRiDXJx",
+            "images" : [
+
+            ],
+            "livemode" : false,
+            "url" : null,
+            "attributes" : [
+
+            ],
+            "description" : null,
+            "name" : "Test",
+            "unit_label" : null
+          },
+          "tax_behavior" : "exclusive",
+          "custom_unit_amount" : null,
+          "transform_quantity" : null,
+          "type" : "one_time",
+          "unit_amount" : 2000,
+          "unit_amount_decimal" : "2000",
+          "object" : "price",
+          "billing_scheme" : "per_unit",
+          "recurring" : null,
+          "currency" : "usd",
+          "tiers_mode" : null
+        },
+        "adjustable_quantity" : null,
+        "images" : null,
+        "unit_amount_override" : null,
+        "name" : "Test"
+      }
+    ],
+    "shipping_rate" : null,
+    "applied_credits" : [
+
+    ],
+    "subtotal" : 2000,
+    "discount_amounts" : [
+      {
+        "amount" : 500,
+        "coupon" : {
+          "object" : "coupon",
+          "amount_off" : null,
+          "percent_off" : 25,
+          "has_applies_to_products" : false,
+          "duration" : "once",
+          "currency" : null,
+          "duration_in_months" : null,
+          "name" : "Save 25%"
+        },
+        "currency" : "usd",
+        "intervals" : null,
+        "promotion_code" : {
+          "object" : "promotion_code",
+          "code" : "SAVE25"
+        }
+      }
+    ],
+    "currency" : "usd",
+    "tax_amounts" : [
+
+    ],
+    "due" : 1500
+  },
+  "managed_payments" : {
+    "enabled" : false
+  },
+  "name_collection" : null,
+  "payment_intent" : null,
+  "config_id" : "bafac2eb-5a6d-45bd-8224-11ef91edff91",
+  "is_sandbox_merchant" : false
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CheckoutTests/testRefreshFetchesLatestServerState/0003_post_v1_payment_pages_cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx_init.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/CheckoutTests/testRefreshFetchesLatestServerState/0003_post_v1_payment_pages_cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx_init.tail
@@ -1,0 +1,918 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_pages\/cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx\/init$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=95kcZaFP5ls-XlYpAhM5p5esRCwqWMUbtY0pHlQ3zq1hHz2BWP1-ZaH5X5LvBNpoUY6ABaNckhTnRUo2
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=95kcZaFP5ls-XlYpAhM5p5esRCwqWMUbtY0pHlQ3zq1hHz2BWP1-ZaH5X5LvBNpoUY6ABaNckhTnRUo2&t=1"
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=95kcZaFP5ls-XlYpAhM5p5esRCwqWMUbtY0pHlQ3zq1hHz2BWP1-ZaH5X5LvBNpoUY6ABaNckhTnRUo2&t=1"}],"include_subdomains":true}
+request-id: req_HmpMfWfBt47gB9
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 31385
+Vary: Origin
+Date: Mon, 20 Apr 2026 15:29:48 GMT
+original-request: req_HmpMfWfBt47gB9
+stripe-version: 2020-08-27
+idempotency-key: 64450a08-b68c-4acd-8b62-9a1f5e9b7e67
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: adaptive_pricing\[allowed]=true&browser_locale=.*&browser_timezone=.*&eid=.*&elements_session_client\[is_aggregation_expected]=true&elements_session_client\[locale]=.*&elements_session_client\[mobile_app_id]=.*&redirect_type=embedded
+
+{
+  "lpm_settings" : null,
+  "sepa_debit_info" : null,
+  "automatic_payment_method_types" : false,
+  "tax_context" : {
+    "automatic_tax_error" : null,
+    "automatic_tax_enabled" : false,
+    "automatic_tax_taxability_reason" : null,
+    "dynamic_tax_enabled" : false,
+    "tax_id_collection_enabled" : false,
+    "automatic_tax_exempt" : "none",
+    "customer_tax_country" : null,
+    "tax_id_collection_required" : "never",
+    "has_maximum_tax_ids" : false,
+    "automatic_tax_address_source" : null
+  },
+  "payment_method_types" : [
+    "card"
+  ],
+  "payment_method_options" : {
+    "card" : {
+      "request_three_d_secure" : "automatic"
+    }
+  },
+  "bnpl_in_link_ui_enabled" : false,
+  "consent_collection" : null,
+  "origin_context" : null,
+  "use_payment_methods" : true,
+  "enforcement_mode" : "open",
+  "blocked_billing_address_countries" : [
+
+  ],
+  "id" : "ppage_1TOJleFY0qyl6XeWk1KoVXfE",
+  "subscription_settings" : null,
+  "consent" : null,
+  "application" : null,
+  "payment_method_collection" : "if_required",
+  "setup_intent" : null,
+  "shipping_options" : [
+
+  ],
+  "setup_future_usage_for_payment_method_type" : {
+
+  },
+  "capture_method" : "automatic_async",
+  "statement_descriptor" : "mobile",
+  "allow_promotion_codes" : true,
+  "session_id" : "cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx",
+  "shipping_address_collection" : null,
+  "konbini_confirmation_number" : null,
+  "setup_future_usage" : null,
+  "invoice_creation" : {
+    "enabled" : false
+  },
+  "has_dynamic_tax_rates" : false,
+  "receipt_emails_enabled" : false,
+  "link_settings" : {
+    "link_consumer_incentive" : null,
+    "link_payment_session_context" : null,
+    "consumer_found" : null,
+    "hcaptcha_rqdata" : null,
+    "link_supported_payment_methods_onboarding_enabled" : [
+
+    ],
+    "enable_partner_lookup" : false,
+    "link_us_bank_account_funding_source_enabled" : false,
+    "link_funding_sources" : [
+
+    ],
+    "hcaptcha_site_key" : null,
+    "link_brand" : "link",
+    "link_mode" : null,
+    "link_supported_payment_methods" : [
+
+    ]
+  },
+  "object" : "checkout.session",
+  "customer" : null,
+  "shipping_rate" : null,
+  "success_url" : null,
+  "utm_codes" : null,
+  "beta_versions" : null,
+  "has_async_attached_payment_method" : false,
+  "feature_flags" : {
+    "checkout_enable_pay_by_bank_remember_bank_selection" : true,
+    "checkout_link_phone_registration_treatment_1_enabled" : true,
+    "smor_checkout_ui_iteration" : true,
+    "checkout_link_purchase_protections_rollout" : true,
+    "checkout_link_enable_mfa" : true,
+    "checkout_optional_items" : true,
+    "checkout_link_in_habanero_enabled" : true,
+    "checkout_passive_captcha" : true,
+    "adaptive_pricing_buyer_currency_expansion" : true,
+    "checkout_custom_enable_clover_warning" : true,
+    "checkout_enable_link_api_passive_hcaptcha" : true,
+    "checkout_address_autocomplete_enabled" : true,
+    "checkout_enable_link_api_hcaptcha_rqdata" : true,
+    "checkout_hcaptcha_redundancy_control_enabled" : true,
+    "checkout_show_swish_factoring_notice" : true
+  },
+  "locale" : null,
+  "custom_text" : {
+    "shipping_address" : null,
+    "terms_of_service_acceptance" : null,
+    "submit" : null,
+    "after_submit" : null
+  },
+  "route_to_orchestration_interface" : false,
+  "customer_email" : null,
+  "payment_method_filtering" : null,
+  "custom_components" : [
+
+  ],
+  "ui_mode" : "custom",
+  "url" : null,
+  "developer_tool_context" : {
+    "disabled_third_party_wallets" : {
+      "LINK_BUTTON" : {
+        "disabled_reason" : "merchant_payment_methods_settings"
+      },
+      "KLARNA_EXPRESS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "PAYPAL_ECS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "AMAZON_PAY" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      }
+    },
+    "adaptive_pricing" : {
+      "reason" : "customer_not_cross_border",
+      "active" : false
+    },
+    "payment_method_configuration_details" : null
+  },
+  "token_notification_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "init_checksum" : "JCjn6H8HWdyZzlgEglG916Bjz3w66t3S",
+  "bnpl_link_experiment_payment_method_type" : null,
+  "tax_meta" : {
+    "status" : "complete",
+    "error_reason" : null,
+    "computation_type" : "manual",
+    "customer_tax_exempt" : "none"
+  },
+  "payment_status" : "unpaid",
+  "enabled_third_party_wallets" : [
+    {
+      "apple_pay" : {
+        "required_version" : 2
+      },
+      "id" : "APPLE_PAY",
+      "enabled" : true,
+      "carousel_enabled" : true
+    },
+    {
+      "id" : "GOOGLE_PAY",
+      "enabled" : true,
+      "google_pay" : {
+        "id" : "GOOGLE_PAY",
+        "version_minor" : 0,
+        "version_major" : 2
+      },
+      "carousel_enabled" : false
+    },
+    {
+      "id" : "AMAZON_PAY",
+      "carousel_enabled" : false,
+      "enabled" : false
+    },
+    {
+      "id" : "KLARNA_EXPRESS",
+      "carousel_enabled" : false,
+      "enabled" : false
+    }
+  ],
+  "klarna_info" : null,
+  "visible_custom_component_locations" : [
+    "checkout_form_before",
+    "checkout_form_after",
+    "submit_button_before",
+    "submit_button_after",
+    "contact_before",
+    "contact_after",
+    "express_checkout_before",
+    "express_checkout_after",
+    "payment_details_before",
+    "payment_details_after"
+  ],
+  "display_consent_collection_promotions" : false,
+  "policies" : {
+    "contacts" : {
+      "display_phone" : true,
+      "display_url" : true,
+      "enabled" : false,
+      "display_email" : true
+    },
+    "legal" : {
+      "agreement_required" : false,
+      "enabled" : false
+    },
+    "returns" : {
+      "custom_message" : null,
+      "exchanges_accepted" : false,
+      "returns_accepted" : null,
+      "fee_type" : null,
+      "fee_required" : null,
+      "policy_url" : null,
+      "window_start" : null,
+      "refunds_accepted" : null,
+      "window" : null,
+      "enabled" : false,
+      "exceptions_apply" : false,
+      "logistics" : [
+
+      ]
+    }
+  },
+  "card_brands" : {
+    "mastercard" : true,
+    "link" : true,
+    "carnet" : false,
+    "accel" : false,
+    "elo" : false,
+    "rupay" : false,
+    "maestro" : false,
+    "unionpay" : true,
+    "amex" : true,
+    "conecs" : false,
+    "jcb" : true,
+    "visa" : true,
+    "cartes_bancaires" : false,
+    "pulse" : false,
+    "discover" : true,
+    "star" : false,
+    "eftpos_au" : false,
+    "diners" : true,
+    "girocard" : false,
+    "nyce" : false
+  },
+  "geocoding" : {
+    "country_code" : "US",
+    "region_name" : "UT"
+  },
+  "account_settings" : {
+    "assets" : {
+      "use_logo" : false,
+      "icon" : null,
+      "logo" : null
+    },
+    "specified_commercial_transactions_act_url" : null,
+    "business_url" : "https:\/\/github.com\/stripe\/stripe-ios",
+    "privacy_policy_url" : null,
+    "branding" : {
+      "button_color" : "#0074d4",
+      "background_color" : "#ffffff",
+      "border_style" : "default",
+      "font_family" : "default"
+    },
+    "statement_descriptor" : "mobile",
+    "support_email" : null,
+    "display_name" : "CI Stuff",
+    "merchant_of_record_country" : "US",
+    "order_summary_display_name" : "CI Stuff",
+    "support_phone" : "+12105550123",
+    "merchant_of_record_display_name" : "CI Stuff",
+    "support_url" : null,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "country" : "US",
+    "terms_of_service_url" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "server_built_elements_session_params" : {
+    "client_betas" : [
+
+    ],
+    "expand" : [
+
+    ],
+    "checkout_session_id" : "cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx",
+    "locale" : "en-US",
+    "mobile_app_id" : "com.stripe.StripeiOSTestHostApp",
+    "type" : "deferred_intent",
+    "deferred_intent" : {
+      "amount" : 1500,
+      "capture_method" : "automatic_async",
+      "currency" : "usd",
+      "payment_method_types" : [
+        "card"
+      ],
+      "mode" : "payment"
+    }
+  },
+  "shipping_tax_amounts" : [
+
+  ],
+  "billing_address_collection" : null,
+  "experiments_data" : {
+    "event_id" : "d4f5e56a-1f90-4308-85b7-10ec2ce5abe9",
+    "experiment_metadata" : {
+      "ocs_buyer_xp_cpl_lpm_holdback" : {
+        "heldback_special_wallets" : [
+
+        ]
+      }
+    },
+    "experiment_assignments" : {
+      "emea_wallets_ideal_wero_rebranding" : "control",
+      "ocs_buyer_xp_cpl_progressive_ece" : "control",
+      "ocs_buyer_xp_cpl_embedded_pay_button" : "control",
+      "cpl_spicy_guacamole" : "control",
+      "connections_checkout_us_bank_account_picker_icons" : "control",
+      "checkout_li_larger_image_size" : "control",
+      "link_ab_test_aa" : "control",
+      "ocs_buyer_xp_cpl_terms_above_submit" : "control",
+      "ocs_buyer_xp_cpl_saved_payment_display" : "control",
+      "ocs_buyer_xp_cpl_discover_card_icon_removal" : "control",
+      "ocs_buyer_xp_cpl_currency_symbol_optimization" : "control",
+      "ocs_buyer_xp_cpl_remove_link_sign_up_box_when_no_pm_selected" : "control",
+      "smor_checkout_ui_iteration" : "control",
+      "checkout_link_instant_debits_accordion_logos" : "control",
+      "checkout_enable_real_time_tax_id_verification_experiment" : "control",
+      "ff_checkout_test_frontend_eff" : "control",
+      "ocs_buyer_xp_cpl_link_signup_in_form" : "control",
+      "ocs_buyer_xp_remove_name_field_guac_related_pms" : "control",
+      "link_risk_based_disable_auto_prompting_checkout" : "control",
+      "ocs_buyer_xp_cpl_iap_apple_pay_exclusivity" : "control",
+      "ocs_buyer_xp_cpl_ap_currency_non_default_select_phase_1" : "control",
+      "ocs_buyer_xp_cpl_iap_apple_pay_and_link_exclusivity" : "control",
+      "checkout_es_la_locale_fallback" : "control",
+      "cpl_guacamole" : "control",
+      "ocs_buyer_xp_cpl_lpm_content_simplification" : "control"
+    }
+  },
+  "return_url" : "https:\/\/example.com\/return",
+  "mode" : "payment",
+  "cancel_url" : null,
+  "elements_session" : {
+    "payment_method_preference" : {
+      "country_code" : "US",
+      "object" : "payment_method_preference",
+      "type" : "deferred_intent",
+      "ordered_payment_method_types" : [
+        "card"
+      ]
+    },
+    "capability_enabled_card_networks" : [
+      "cartes_bancaires",
+      "jcb",
+      "diners",
+      "discover"
+    ],
+    "flags" : {
+      "enable_tax_id_suspicious_pattern_check" : false,
+      "elements_easel_enable_elements_inspector_for_advanced_integrations_backend" : false,
+      "elements_enable_acss_debit_spm" : true,
+      "elements_enable_bizum_custom_payment_form" : true,
+      "financial_connections_enable_deferred_intent_flow" : true,
+      "elements_enable_remove_last_validation" : true,
+      "link_enable_signup_in_summary_in_habanero" : false,
+      "ocs_payment_prompt_for_agents" : false,
+      "apple_pay_prb_killswitch" : false,
+      "elements_enable_easel_for_pi" : true,
+      "elements_enable_ephemeral_key_for_confirmation_token_creation" : true,
+      "elements_enable_fraud_signal_data_transfer_to_hcaptcha" : false,
+      "elements_mobile_card_funding_filtering" : true,
+      "link_payment_element_minor_signup_ui_updates" : false,
+      "link_enable_ncdv_usage_id_selectors_l3" : true,
+      "elements_disable_express_checkout_button_amazon_pay" : false,
+      "elements_easel_disable_appearance_api" : false,
+      "link_auth_partner_enable_link_auth_token_login" : true,
+      "link_enable_ncdv_recall_id_selectors_l3" : true,
+      "elements_disable_link_email_otp" : false,
+      "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
+      "ocs_buyer_xp_elements_card_brand_choice_toggle" : false,
+      "paypal_billing_address_support_in_ece" : true,
+      "elements_enable_pay_by_bank_remember_bank_selection" : true,
+      "link_auth_partner_enable_ios_instagram" : true,
+      "link_user_action_attempt_login_using_stored_credentials" : true,
+      "elements_disable_sepa_debit_eea_address_requirement" : false,
+      "elements_enable_instant_debits_postal_code_collection" : false,
+      "elements_easel_disable_feedback" : false,
+      "elements_extend_hcaptcha_refresh_time" : true,
+      "link_auth_partner_consume_link_auth_intent" : true,
+      "ocs_buyer_xp_elements_remove_cpm_redirect_text" : false,
+      "elements_enable_south_korea_market_underlying_pms" : false,
+      "link_payment_element_steerage_enabled" : true,
+      "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text" : false,
+      "elements_disable_payment_element_card_country_zip_validations" : false,
+      "link_payment_element_default_value_auto_open_modal" : true,
+      "elements_enable_link_card_brand_in_saved_payment_methods" : true,
+      "elements_disable_link_global_holdback_lookup" : false,
+      "financial_connections_enable_ca_accounts" : false,
+      "elements_easel_disable_address_fill" : false,
+      "ocs_buyer_xp_elements_remove_redirect_lpm_content" : false,
+      "elements_enable_payment_method_options_setup_future_usage" : true,
+      "enable_custom_checkout_currency_selector_element" : false,
+      "elements_mobile_android_tap_to_add_enabled" : false,
+      "link_enable_address_country_restrictions" : false,
+      "link_auth_partner_enable_android_fb" : true,
+      "elements_easel_disable_health_check" : false,
+      "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
+      "elements_disable_paypal_express" : false,
+      "elements_enable_au_becs_debit_spm" : true,
+      "elements_enable_write_allow_redisplay" : false,
+      "legacy_customer_session_payment_element_features" : false,
+      "elements_easel_enable_lpm_autofills" : true,
+      "link_auth_partner_enable_authentication_element" : true,
+      "elements_enable_payment_method_logo_position_killswitch" : false,
+      "elements_allow_manual_payment_method_creation_with_spm" : false,
+      "elements_easel_disable" : false,
+      "link_enable_auth_partner_communication" : true,
+      "elements_apply_amex_icon_sorting" : false,
+      "elements_hide_card_brand_icons" : false,
+      "link_auth_partner_enable_distinctly_link_ios_facebook" : true,
+      "elements_easel_disable_customer_location_mocking" : false,
+      "elements_easel_disable_position_customization" : false,
+      "elements_enable_appearance_recompute" : false,
+      "elements_enable_19_digit_pans" : false,
+      "always_show_ece_paypal_recurring_button" : false,
+      "elements_enable_interac_apple_pay" : false,
+      "enable_payment_method_api_shop_pay" : true,
+      "enable_elements_tax_id_type_filtering" : false,
+      "elements_human_security_enabled" : false,
+      "link_enable_white_ece_button_theme" : false,
+      "link_in_accordion_layout_available_in_stripejs" : false,
+      "link_payment_element_widget_view_enabled" : true,
+      "elements_easel_disable_magic_fill" : false,
+      "avoid_redundant_billing_details_for_klarna" : false,
+      "distinctly_link_payment_element_ramp" : true,
+      "link_auth_partner_bypass_bridge_check" : false,
+      "elements_disable_express_checkout_button_shop_pay" : false,
+      "payment_element_link_modal_preload_killswitch" : false,
+      "link_enable_pass_checkout_session_id_to_signup" : true,
+      "elements_enable_jp_card_installments" : true,
+      "elements_show_expanded_spm" : false,
+      "disable_payment_element_if_required_billing_config" : false,
+      "elements_enable_read_allow_redisplay" : false,
+      "elements_enable_link_spm" : true,
+      "elements_enable_save_for_future_payments_pre_check" : false,
+      "link_forest_enable_ece_bank_use_shipping_as_billing" : false,
+      "elements_disable_express_checkout_button_klarna" : false,
+      "distinctly_link_cbc_killswitch" : false,
+      "elements_prefer_fc_lite" : false,
+      "elements_disable_payment_element_custom_payment_methods_byof" : false,
+      "elements_mobile_cardscan_use_mlkit" : false,
+      "elements_enable_link_takeover_in_guacamole" : false,
+      "link_disable_auth_partner_ua_check" : false,
+      "abstracted_adaptive_pricing_should_show_markup_disclosure_percentage" : false,
+      "elements_easel_disable_optimizations_check" : false,
+      "elements_enable_passive_captcha" : false,
+      "distinctly_link_payment_element_opt_out_merchant_blocklist" : false,
+      "link_ewcs_email_and_cookie_lookup_enabled" : false,
+      "enable_custom_checkout_apple_pay_on_chrome" : true,
+      "elements_enable_new_google_places_api" : true,
+      "elements_enable_express_checkout_button_demo_pay" : false,
+      "elements_enable_installments_on_deferred_intents" : true,
+      "disable_cbc_in_link_popup" : false,
+      "ocs_buyer_xp_elements_remove_generic_footer" : false,
+      "elements_spm_set_as_default" : true,
+      "elements_does_not_collect_postal_code_for_non_us_card_transactions_killswitch" : false,
+      "link_disable_login_if_signed_up_outside_of_elements" : true,
+      "elements_enable_link_autofill_prompt_padding_fix" : false,
+      "elements_mobile_attest_on_intent_confirmation" : false,
+      "elements_stop_move_focus_to_first_errored_field" : true,
+      "ocs_buyer_xp_enable_payment_element_accordion_box_shadow" : false,
+      "elements_mobile_allow_stripecardscan" : false,
+      "elements_enable_nz_bank_account_spm" : true,
+      "elements_use_checkout_app_id_for_human_security" : true,
+      "sandboxes_rebrand_testmode" : false,
+      "link_enable_card_brand_choice" : true,
+      "link_payment_element_keep_optional_doi_open_rollout" : true,
+      "adaptive_pricing_for_elements_with_payment_intents" : false,
+      "elements_allow_custom_payment_method_creation" : false,
+      "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+      "show_swish_factoring_notice" : true,
+      "link_purchase_protections_rollout" : true,
+      "elements_disable_fc_lite" : false,
+      "link_auth_partner_delay_recognition" : true,
+      "elements_enable_invalid_country_for_pm_error" : true,
+      "elements_enable_payment_element_custom_payment_methods_byof" : false,
+      "ocs_buyer_xp_elements_remove_wallets_redirect_text" : false,
+      "elements_easel_enable_elements_inspector" : true,
+      "apple_pay_pe_killswitch" : false,
+      "elements_hcaptcha_in_payment_method_data_radar_options" : false,
+      "paypal_phone_number_support_in_ece" : false,
+      "elements_enable_pay_by_bank_multi_country_bank_selector_rollout_countries" : false,
+      "elements_easel_disable_payment_fill" : false,
+      "elements_easel_disable_tax_id_fill" : false,
+      "elements_spm_max_visible_payment_methods" : false,
+      "elements_enable_bacs_debit_spm" : true,
+      "id_bank_transfers_v1_integration" : false,
+      "elements_enable_mx_card_installments" : true,
+      "elements_easel_disable_appearance_api_per_element_options" : true,
+      "elements_enable_easel_for_pi_killswitch" : false,
+      "elements_enable_google_pay_webview_heuristics" : true,
+      "elements_spm_messages" : false,
+      "elements_easel_disable_session_summary" : false,
+      "apple_pay_ece_killswitch" : false,
+      "distinctly_link_pe_purchase_protection" : true,
+      "link_enable_link_session_key_consumer_person_details" : false,
+      "link_auth_partner_enable_distinctly_link_android_fb" : true,
+      "link_auth_partner_delay_android_fb_cookie_login" : false,
+      "legacy_confirmation_tokens" : false,
+      "link_auth_partner_enable_distinctly_link_ios_instagram" : false,
+      "elements_easel_disable_elements_inspector_for_pi" : true,
+      "link_auth_partner_enable_ece" : true,
+      "distinctly_link_pe_backup_payment_method" : true,
+      "link_dedupe_shipping_address_creation" : true,
+      "ece_apple_pay_payment_request_passthrough" : false,
+      "link_enable_link_session_key_link_onboarding_session" : false,
+      "elements_enable_billing_details_in_pe_change_event" : true,
+      "networked_business_profile_demo" : false,
+      "elements_enable_payment_method_logo_position" : true,
+      "payto_enable_modal_in_payment_element" : true,
+      "checkout_link_in_habanero_enabled" : true,
+      "checkout_enable_bank_payment_method_spm" : true,
+      "elements_checkout_form_enable_new_amount_summary" : false,
+      "elements_disable_progressive_cursor" : false,
+      "enable_checkout_session_update_customer" : false,
+      "link_enable_auth_partner_sizing_logging" : true
+    },
+    "merchant_logo_url" : null,
+    "session_id" : "elements_session_1TWznjf96zc",
+    "card_installments_enabled" : false,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "config_id" : "fe50bc0a-5b0e-45be-ab81-237e0bf645ba",
+    "merchant_currency" : "usd",
+    "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+    "card_brand_choice" : {
+      "eligible" : false,
+      "preferred_networks" : [
+        "cartes_bancaires"
+      ],
+      "supported_cobranded_networks" : {
+        "cartes_bancaires" : false
+      }
+    },
+    "shipping_address_settings" : {
+      "autocomplete_allowed" : false
+    },
+    "external_payment_method_data" : null,
+    "custom_payment_method_data" : null,
+    "meta_pay_signed_container_context" : null,
+    "apple_pay_preference" : "enabled",
+    "payment_method_configuration_id" : null,
+    "merchant_country" : "US",
+    "google_pay_preference" : "enabled",
+    "paypal_express_config" : {
+      "client_id" : null,
+      "client_token" : null,
+      "paypal_merchant_id" : null
+    },
+    "experiments_data" : {
+      "arb_id" : "dea5388d-a02e-4a16-ae3f-9b3c0dace0af",
+      "experiment_metadata" : {
+        "seed" : "597f3afdf87ff8efe231b32325f0803fe969e25a82a472ed14e4ec96a18a4939",
+        "semi_dominant_payment_methods" : [
+
+        ],
+        "lpm_holdback_t1_payment_methods" : [
+
+        ],
+        "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false,
+        "lpm_holdback_t2_payment_methods" : [
+
+        ]
+      },
+      "experiment_assignments" : {
+        "ocs_mobile_horizontal_mode_aa" : "control",
+        "link_ce_conversion_cookie_aa" : "control",
+        "ff_elements_test_frontend_eff" : "control",
+        "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : "control",
+        "elements_hcaptcha_init_timeout" : "control",
+        "link_pe_signup_prominence" : "control",
+        "link_ce_conversion_unrecognized_aa" : "control",
+        "link_ab_test_aa" : "control",
+        "link_default_opt_in_disable_blocking" : "control",
+        "link_default_opt_in_disable_blocking_aa" : "control",
+        "connections_elements_incentive_shorten_promo_banner_text" : "control",
+        "link_dl_pe_inline_entrypoint" : "control",
+        "link_popup_browser_support" : "control",
+        "link_ulm_conversion_unrecognized_copy_change" : "control",
+        "ocs_mobile_horizontal_mode" : "control",
+        "paypal_payment_handler" : "control",
+        "link_ce_conversion_brand_change" : "control",
+        "link_dl_pe_inline_entrypoint_aa" : "control",
+        "link_popup_browser_support_aa" : "control",
+        "link_ewcs_clover_latency" : "control",
+        "link_ce_conversion_unrecognized_post_entry_aa" : "control",
+        "link_ce_conversion_ncdv_aa" : "control",
+        "connections_elements_variable_incentives_for_ibp_recurring_payments" : "control",
+        "ocs_buyer_xp_elements_discover_card_icon_removal" : "control",
+        "link_pe_signup_prominence_aa" : "control"
+      }
+    },
+    "legacy_customer" : null,
+    "link_settings" : {
+      "link_passthrough_mode_enabled" : false,
+      "link_payment_element_smart_defaults_enabled" : false,
+      "link_mobile_attestation_state_sync_enabled" : false,
+      "link_no_code_default_values_recall" : true,
+      "link_funding_sources" : [
+
+      ],
+      "link_crypto_onramp_force_cvc_reverification" : false,
+      "link_enable_signup_in_express_checkout_element" : false,
+      "link_wanderlust_in_elements_enabled" : false,
+      "link_consumer_incentive" : null,
+      "link_crypto_onramp_bank_upsell" : false,
+      "link_ece_browser_compatibility_override" : false,
+      "link_enable_email_otp_for_link_popup" : false,
+      "link_crypto_onramp_elements_logout_disabled" : false,
+      "link_no_code_default_values_identification" : true,
+      "link_pay_button_element_enabled" : true,
+      "link_payment_element_enable_webauthn_login" : false,
+      "link_bank_onboarding_enabled" : false,
+      "link_enable_instant_debits_in_testmode" : false,
+      "link_payment_element_disabled_by_targeting" : false,
+      "link_sign_up_opt_in_feature_enabled" : false,
+      "link_only_for_payment_method_types_enabled" : false,
+      "link_disabled_reasons" : {
+        "payment_element_payment_method_mode" : [
+          "link_not_specified_in_payment_method_types"
+        ],
+        "payment_element_passthrough_mode" : [
+          "link_not_enabled_on_payment_config"
+        ]
+      },
+      "link_sign_up_opt_in_initial_value" : false,
+      "link_mobile_use_attestation_endpoints" : false,
+      "link_elements_pageload_sign_up_disabled" : false,
+      "link_disable_pe_signup_prompt" : false,
+      "link_elements_is_crypto_onramp" : false,
+      "link_no_code_default_values_usage" : true,
+      "link_enable_webauthn_for_link_popup" : false,
+      "link_email_verification_login_enabled" : false,
+      "link_popup_webview_option" : "shared",
+      "link_targeting_results" : {
+        "payment_element_passthrough_mode" : null
+      },
+      "link_trusted_merchant_check_enabled" : false,
+      "link_global_holdback_on" : false,
+      "link_show_prefer_debit_card_hint" : false,
+      "link_local_storage_login_enabled" : false,
+      "link_payment_session_context" : null,
+      "link_session_storage_login_enabled" : false,
+      "link_brand" : "link",
+      "link_disable_in_safari_private_browsing" : false,
+      "link_mobile_disable_rux_in_flow_controller" : false,
+      "link_authenticated_change_event_enabled" : false,
+      "link_pm_killswitch_on_in_elements" : false,
+      "link_supported_payment_methods_onboarding_enabled" : [
+
+      ],
+      "link_hcaptcha_site_key" : null,
+      "link_payment_element_disable_signup" : false,
+      "link_enable_displayable_default_values_in_ece" : false,
+      "link_disable_email_otp" : false,
+      "link_hcaptcha_rqdata" : null,
+      "link_default_opt_in" : "NONE",
+      "link_supported_payment_methods" : [
+
+      ],
+      "link_mobile_disable_default_opt_in" : false,
+      "link_mode" : null,
+      "link_mobile_disable_signup" : false,
+      "link_popup_smart_defaults_enabled" : false
+    },
+    "passive_captcha" : null,
+    "payment_method_specs" : [
+      {
+        "async" : false,
+        "type" : "card",
+        "fields" : [
+
+        ]
+      }
+    ],
+    "prefill_selectors" : {
+      "default_values" : {
+        "email" : [
+
+        ],
+        "merchant_provides_default_values_on_update" : true
+      }
+    },
+    "unactivated_payment_method_types" : [
+
+    ],
+    "unverified_payment_methods_on_domain" : [
+      "apple_pay"
+    ],
+    "order" : null,
+    "link_purchase_protections_data" : {
+      "type" : null,
+      "is_eligible" : false
+    },
+    "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+    "customer" : null,
+    "klarna_express_config" : {
+      "klarna_mid" : null
+    },
+    "lpm_killswitches" : {
+      "express_checkout" : [
+
+      ],
+      "payment_element" : [
+
+      ]
+    },
+    "business_name" : "CI Stuff",
+    "ordered_payment_method_types_and_wallets" : [
+      "card",
+      "apple_pay",
+      "google_pay"
+    ],
+    "customer_error" : null
+  },
+  "stripe_hosted_url" : "https:\/\/checkout.stripe.com\/c\/pay\/cs_test_b1Beesjcxz4KDbT5v6Bciqz8PfpOXhuaQQ9dUR1YMwPruOmaXSoT7qCEkx#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWkB3dnxIQEpRcGFWb1RXPW1tNVN3VHcwXTU1PXZHXUJKcDMnKSdjd2poVmB3c2B3Jz9xd3BgKSdnZGZuYndqcGthRmppancnPycmY2NjY2NjJyknaWR8anBxUXx1YCc%2FJ2hwaXFsWmxxYGgnKSdga2RnaWBVaWRmYG1qaWFgd3YnP3F3cGB4JSUl",
+  "prefilled" : null,
+  "redirect_on_completion" : null,
+  "blob" : null,
+  "client_reference_id" : null,
+  "status" : "open",
+  "submit_type" : null,
+  "email_collection" : "always",
+  "permissions" : null,
+  "custom_fields" : [
+
+  ],
+  "phone_number_collection" : {
+    "enabled" : false
+  },
+  "livemode" : false,
+  "ordered_payment_method_types" : [
+    "card",
+    "apple_pay",
+    "google_pay"
+  ],
+  "state" : "active",
+  "currency" : "usd",
+  "subscription_data" : null,
+  "customer_managed_saved_payment_methods_offer_save" : null,
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping" : null,
+  "crypto_in_link_ui_enabled" : false,
+  "rqdata" : "l\/E6CAowUU33DsJnA+wQcjNCmqk0E4a8M7gbI5H00XVzX8cAx3OfVb0NkCC4q62OTHwgT5uMy0GyhR8ciftwRGeflu1wno0JczRdr02S0EKQa61CPFQHsXYMj7gB1hni0wVEz7JXsJeSdIy3IPQBMuivdCxis0iBL\/XxDQBcVFqUbcQZb9AK2afgREcuD1IKZzcsM9eXGKub5eYergjRpdQJXWXKHBZSL0ViTGbCsFUjxgInNTCaznw1KsFMVlPwHtCwcx\/S2GRBydrJDLil3lnfuE1NXV2OD50RgZBmcfAcsdTit\/r3Of26hw==uWpPJQaNaFQmMd\/\/",
+  "total_summary" : {
+    "due" : 1500,
+    "subtotal" : 2000,
+    "total" : 1500
+  },
+  "on_behalf_of" : null,
+  "cross_sell_group" : null,
+  "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+  "checkout_multistep_ui" : false,
+  "eid" : "DF1F6BA0-BA18-4B74-96B5-E9BC69CC96E9",
+  "line_item_group" : {
+    "total" : 1500,
+    "line_items" : [
+      {
+        "id" : "li_1TOJleFY0qyl6XeWjmHBI7N5",
+        "description" : null,
+        "discount_amounts" : [
+          {
+            "amount" : 500,
+            "coupon" : {
+              "object" : "coupon",
+              "amount_off" : null,
+              "percent_off" : 25,
+              "has_applies_to_products" : false,
+              "duration" : "once",
+              "currency" : null,
+              "duration_in_months" : null,
+              "name" : "Save 25%"
+            },
+            "currency" : "usd",
+            "intervals" : null,
+            "promotion_code" : {
+              "object" : "promotion_code",
+              "code" : "SAVE25"
+            }
+          }
+        ],
+        "quantity" : 1,
+        "is_removable" : false,
+        "total" : 1500,
+        "tax_amounts" : [
+
+        ],
+        "subtotal" : 2000,
+        "cross_sell_from" : null,
+        "object" : "item",
+        "price" : {
+          "id" : "price_1TOJleFY0qyl6XeWDd2bwG1k",
+          "livemode" : false,
+          "active" : false,
+          "product" : {
+            "object" : "product",
+            "active" : false,
+            "addons" : null,
+            "id" : "prod_TnUMNVDoRiDXJx",
+            "images" : [
+
+            ],
+            "livemode" : false,
+            "url" : null,
+            "attributes" : [
+
+            ],
+            "description" : null,
+            "name" : "Test",
+            "unit_label" : null
+          },
+          "tax_behavior" : "exclusive",
+          "custom_unit_amount" : null,
+          "transform_quantity" : null,
+          "type" : "one_time",
+          "unit_amount" : 2000,
+          "unit_amount_decimal" : "2000",
+          "object" : "price",
+          "billing_scheme" : "per_unit",
+          "recurring" : null,
+          "currency" : "usd",
+          "tiers_mode" : null
+        },
+        "adjustable_quantity" : null,
+        "images" : null,
+        "unit_amount_override" : null,
+        "name" : "Test"
+      }
+    ],
+    "shipping_rate" : null,
+    "applied_credits" : [
+
+    ],
+    "subtotal" : 2000,
+    "discount_amounts" : [
+      {
+        "amount" : 500,
+        "coupon" : {
+          "object" : "coupon",
+          "amount_off" : null,
+          "percent_off" : 25,
+          "has_applies_to_products" : false,
+          "duration" : "once",
+          "currency" : null,
+          "duration_in_months" : null,
+          "name" : "Save 25%"
+        },
+        "currency" : "usd",
+        "intervals" : null,
+        "promotion_code" : {
+          "object" : "promotion_code",
+          "code" : "SAVE25"
+        }
+      }
+    ],
+    "currency" : "usd",
+    "tax_amounts" : [
+
+    ],
+    "due" : 1500
+  },
+  "managed_payments" : {
+    "enabled" : false
+  },
+  "name_collection" : null,
+  "payment_intent" : null,
+  "config_id" : "6212a945-8e21-4a57-a61e-69802c6983f4",
+  "is_sandbox_merchant" : false
+}


### PR DESCRIPTION
## Summary
- Adds a refresh API to CheckoutSessions, this is useful if a merchant makes a change to the session on their backend and wants the client to update it.

## Motivation
- CheckoutSessions

## Testing
- New tests

## Changelog
N/A