### PR TITLE
CryptoOnramp SDK: Exposes StripeCryptoOnramp via SPM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ MINOR
 ### Connect
 * [Changed] [#66351](https://github.com/stripe/stripe-ios/pull/6351) Theming tokens in connect embedded components is now GA.
 
+### CryptoOnramp (Alpha)
+* [Fixed] Fixed an issue (#6363) in which StripeCryptoOnramp was not properly exposed via Swift Package Manager.
+
 ## 25.11.0 2026-04-13
 ### PaymentSheet
 * [Added] Added support for Pay by Bank payments (GA in GB, private preview in EU).

--- a/Package.swift
+++ b/Package.swift
@@ -47,6 +47,10 @@ let package = Package(
         .library(
             name: "StripeConnect",
             targets: ["StripeConnect"]
+        ),
+        .library(
+            name: "StripeCryptoOnramp",
+            targets: ["StripeCryptoOnramp"]
         )
     ],
     targets: [
@@ -173,6 +177,15 @@ let package = Package(
             name: "StripeConnect",
             dependencies: ["StripeCore", "StripeUICore", "StripeFinancialConnections"],
             path: "StripeConnect/StripeConnect"
+        ),
+        .target(
+            name: "StripeCryptoOnramp",
+            dependencies: ["StripeApplePay", "StripeCore", "StripeIdentity", "StripePayments", "StripePaymentSheet", "StripePaymentsUI", "StripeUICore"],
+            path: "StripeCryptoOnramp/StripeCryptoOnramp",
+            exclude: ["StripeCryptoOnramp.h"],
+            resources: [
+                .process("Resources/StripeCryptoOnramp.xcassets")
+            ]
         )
     ]
 )

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -5,6 +5,7 @@
 //  Created by Michael Liberatore on 7/17/25.
 //
 
+import Foundation
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePaymentSheet
 


### PR DESCRIPTION
## Summary
Early in development, `StripeCryptoOnramp` got removed from `Package.swift` before it was ready for public use. (#5185). This adds it back with its current dependencies.

## Motivation
Fixes #6363

## Testing
1. Created a test project.
2. File → Add Package Dependencies…
3. Add Local…
4. Selected my clone of `stripe-ios` pointed at this PR's branch.
5. Selected `StripeCryptoOnramp` to include.
6. Added `@_spi(CryptoOnrampAlpha) import StripeCryptoOnramp` to `ContentView.swift` and a call to `CryptoOnrampCoordinator.create()`.
7. Ran the app to ensure there were no linking errors and the dependency properly logged to the console.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
Added.
