### PR TITLE
Fix duplicate success analytic for Link payments

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -644,7 +644,8 @@ extension PaymentSheet {
             case .wallet:
                 let useNativeLink = deviceCanUseNativeLink(elementsSession: elementsSession, configuration: configuration)
                 if useNativeLink {
-                    let linkController = PayWithNativeLinkController(mode: .full, intent: intent, elementsSession: elementsSession, configuration: configuration, logPayment: true, analyticsHelper: analyticsHelper, confirmationChallenge: confirmationChallenge)
+                    // logPayment is false because callers of PaymentSheet.confirm() are responsible for logging the payment result.
+                    let linkController = PayWithNativeLinkController(mode: .full, intent: intent, elementsSession: elementsSession, configuration: configuration, logPayment: false, analyticsHelper: analyticsHelper, confirmationChallenge: confirmationChallenge)
                     linkController.presentAsBottomSheet(from: authenticationContext.authenticationPresentingViewController(), shouldOfferApplePay: false, shouldFinishOnClose: false, completion: { result, confirmationType, _ in
                         completion(result, confirmationType)
                     })


### PR DESCRIPTION
## Summary

When paying with Link via the wallet flow, PaymentSheet.confirm() created a PayWithNativeLinkController with logPayment: true, which logged the payment result internally. All callers of PaymentSheet.confirm() also log the result in their own completion handlers, causing the event to fire twice.

Set logPayment to false so logging responsibility stays with the caller, consistent with how all other payment methods work.

## Motivation
https://go/jira/RUN_LINK_MOBILE-133

## Testing
Ran through all (I believe) the payment flows using Link and verified payment success analytics were only sent once.
