### PR TITLE
Fix testDeferredPaymentIntent_ClientSideConfirmation

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetDeferredUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetDeferredUITests.swift
@@ -15,6 +15,8 @@ class PaymentSheetDeferredUITests: PaymentSheetUITestCase {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.layout = .horizontal
         settings.integrationType = .deferred_csc
+        settings.apmsEnabled = .off
+        settings.supportedPaymentMethods = "card, us_bank_account"
         loadPlayground(app, settings)
 
         app.buttons["Present PaymentSheet"].tap()
@@ -27,16 +29,13 @@ class PaymentSheetDeferredUITests: PaymentSheetUITestCase {
             ["mc_complete_init_applepay", "mc_load_started", "mc_load_succeeded", "mc_complete_sheet_newpm_show", "mc_initial_displayed_payment_methods", "mc_form_shown", "link.inline_signup.shown"]
         )
         let initialDisplayedPaymentMethodsEvent = analyticsLog.first(where: { $0[string: "event"] == "mc_initial_displayed_payment_methods" })
-        // two wallet pms and >= 2 in the carousel
-        XCTAssertGreaterThanOrEqual(
-            (initialDisplayedPaymentMethodsEvent.map { $0["visible_payment_methods"] } as? [String])?.count ?? 0,
+        // two wallet pms and 2 in the carousel
+        XCTAssertEqual(
+            (initialDisplayedPaymentMethodsEvent.map { $0["visible_payment_methods"] } as? [String])?.count,
             4
         )
-        // the rest are hidden
-        XCTAssertLessThanOrEqual(
-            (initialDisplayedPaymentMethodsEvent.map { $0["hidden_payment_methods"] } as? [String])?.count ?? 0,
-            7
-        )
+        // there are no hidden pms
+        XCTAssertNil(initialDisplayedPaymentMethodsEvent.map { $0["hidden_payment_methods"] } as? [String])
         XCTAssertEqual(
             initialDisplayedPaymentMethodsEvent.map { $0[string: "payment_method_layout"] },
             "horizontal"

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetDeferredUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetDeferredUITests.swift
@@ -27,14 +27,14 @@ class PaymentSheetDeferredUITests: PaymentSheetUITestCase {
             ["mc_complete_init_applepay", "mc_load_started", "mc_load_succeeded", "mc_complete_sheet_newpm_show", "mc_initial_displayed_payment_methods", "mc_form_shown", "link.inline_signup.shown"]
         )
         let initialDisplayedPaymentMethodsEvent = analyticsLog.first(where: { $0[string: "event"] == "mc_initial_displayed_payment_methods" })
-        // two wallet pms and 3 in the carousel
-        XCTAssertEqual(
-            (initialDisplayedPaymentMethodsEvent.map { $0["visible_payment_methods"] } as? [String])?.count,
+        // two wallet pms and >= 2 in the carousel
+        XCTAssertGreaterThanOrEqual(
+            (initialDisplayedPaymentMethodsEvent.map { $0["visible_payment_methods"] } as? [String])?.count ?? 0,
             4
         )
         // the rest are hidden
-        XCTAssertEqual(
-            (initialDisplayedPaymentMethodsEvent.map { $0["hidden_payment_methods"] } as? [String])?.count,
+        XCTAssertLessThanOrEqual(
+            (initialDisplayedPaymentMethodsEvent.map { $0["hidden_payment_methods"] } as? [String])?.count ?? 0,
             7
         )
         XCTAssertEqual(


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Only supporting 2 payment methods because the order of the payment methods in the carousel can change, so the number of visible pms may change too. With 2 payment methods, we can assert the number of visible pms.

<img width="1125" height="2436" alt="image" src="https://github.com/user-attachments/assets/352ad14a-cba2-4394-b856-918d63eb6b2b" />

<img width="1080" height="2340" alt="image" src="https://github.com/user-attachments/assets/ea2f7386-2ec2-421c-a532-8e8adeeb473e" />

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Fix test
## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
CI
## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A