### PR TITLE
Fix STPPaymentHandler.inProgress permanently stuck after instance deallocation

### DIFF
--- a/Stripe/StripeiOSTests/STPPaymentHandlerStubbedMockedFilesTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerStubbedMockedFilesTests.swift
@@ -470,6 +470,75 @@ class STPPaymentHandlerStubbedMockedFilesTests: APIStubbedTestCase, STPAuthentic
         XCTAssertGreaterThanOrEqual(retrieveCount, 2, "Should have polled at least once after initial processing status")
     }
 
+    /// Verifies that deallocating an STPPaymentHandler mid-3DS resets the static `inProgress` flag.
+    /// Regression test: PaymentSheet/FlowController create their own STPPaymentHandler instances.
+    /// If deallocated mid-flow, the static `inProgress` flag must be released via deinit to avoid
+    /// permanently blocking all future payment attempts with noConcurrentActionsErrorCode.
+    func testInProgressResetAfterHandlerDeallocated() {
+        let nextActionData = """
+              {
+                "redirect_to_url": {
+                  "return_url": "payments-example://stripe-redirect",
+                  "url": "https://hooks.stripe.com/3d_secure/acct_123/pa_nonce_321/redirect"
+                },
+                "type": "redirect_to_url"
+              }
+            """
+        let paymentMethodData = """
+              {
+                "id": "pm_123",
+                "object": "payment_method",
+                "card": {"brand": "visa", "last4": "4242"},
+                "type": "card"
+              }
+            """
+        stubConfirm(
+            fileMock: .paymentIntentResponse,
+            responseCallback: { data in
+                self.replaceData(data: data, variables: [
+                    "<next_action>": nextActionData,
+                    "<payment_method>": paymentMethodData,
+                    "<status>": "\"requires_action\"",
+                ])
+            }
+        )
+
+        let didRedirect = expectation(description: "didRedirect")
+        weak var weakHandler: STPPaymentHandler?
+
+        // Create a handler and start a 3DS flow
+        var handler: STPPaymentHandler? = STPPaymentHandler(apiClient: stubbedAPIClient())
+        weakHandler = handler
+        handler!._redirectShim = { _, _, _ in
+            didRedirect.fulfill()
+        }
+
+        let params = STPPaymentIntentConfirmParams(clientSecret: "pi_123456_secret_654321")
+        params.returnURL = "payments-example://stripe-redirect"
+        params.paymentMethodParams = STPPaymentMethodParams(
+            card: STPPaymentMethodCardParams(),
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        handler!.confirmPaymentIntent(params: params, authenticationContext: self) { _, _, _ in }
+
+        guard XCTWaiter.wait(for: [didRedirect], timeout: 2.0) != .timedOut else {
+            XCTFail("Unable to redirect")
+            return
+        }
+
+        // Handler is now mid-3DS, inProgress is true
+        XCTAssertTrue(handler!.isInProgress)
+
+        // Deallocate the handler (simulating FlowController being dropped mid-3DS)
+        handler = nil
+
+        // deinit should have reset the static inProgress flag
+        let freshHandler = STPPaymentHandler(apiClient: stubbedAPIClient())
+        XCTAssertFalse(freshHandler.isInProgress, "inProgress should be reset when handler is deallocated mid-flow")
+    }
+
     private func confirmPaymentWithSucceed(
         nextActionData: String,
         paymentMethodData: String,

--- a/Stripe/StripeiOSTests/STPPaymentHandlerStubbedMockedFilesTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerStubbedMockedFilesTests.swift
@@ -470,71 +470,23 @@ class STPPaymentHandlerStubbedMockedFilesTests: APIStubbedTestCase, STPAuthentic
         XCTAssertGreaterThanOrEqual(retrieveCount, 2, "Should have polled at least once after initial processing status")
     }
 
-    /// Verifies that deallocating an STPPaymentHandler mid-3DS resets the static `inProgress` flag.
+    /// Verifies that deallocating an STPPaymentHandler mid-flow resets the static `anyHandlerInProgress` flag.
     /// Regression test: PaymentSheet/FlowController create their own STPPaymentHandler instances.
-    /// If deallocated mid-flow, the static `inProgress` flag must be released via deinit to avoid
-    /// permanently blocking all future payment attempts with noConcurrentActionsErrorCode.
+    /// If deallocated mid-flow, deinit must release the global lock to avoid permanently blocking
+    /// all future payment attempts with noConcurrentActionsErrorCode.
     func testInProgressResetAfterHandlerDeallocated() {
-        let nextActionData = """
-              {
-                "redirect_to_url": {
-                  "return_url": "payments-example://stripe-redirect",
-                  "url": "https://hooks.stripe.com/3d_secure/acct_123/pa_nonce_321/redirect"
-                },
-                "type": "redirect_to_url"
-              }
-            """
-        let paymentMethodData = """
-              {
-                "id": "pm_123",
-                "object": "payment_method",
-                "card": {"brand": "visa", "last4": "4242"},
-                "type": "card"
-              }
-            """
-        stubConfirm(
-            fileMock: .paymentIntentResponse,
-            responseCallback: { data in
-                self.replaceData(data: data, variables: [
-                    "<next_action>": nextActionData,
-                    "<payment_method>": paymentMethodData,
-                    "<status>": "\"requires_action\"",
-                ])
-            }
-        )
+        // Verify we start clean
+        XCTAssertFalse(STPPaymentHandler(apiClient: stubbedAPIClient()).isInProgress)
 
-        let didRedirect = expectation(description: "didRedirect")
-        weak var weakHandler: STPPaymentHandler?
-
-        // Create a handler and start a 3DS flow
+        // Create a handler and simulate it being mid-flow
         var handler: STPPaymentHandler? = STPPaymentHandler(apiClient: stubbedAPIClient())
-        weakHandler = handler
-        handler!._redirectShim = { _, _, _ in
-            didRedirect.fulfill()
-        }
-
-        let params = STPPaymentIntentConfirmParams(clientSecret: "pi_123456_secret_654321")
-        params.returnURL = "payments-example://stripe-redirect"
-        params.paymentMethodParams = STPPaymentMethodParams(
-            card: STPPaymentMethodCardParams(),
-            billingDetails: nil,
-            metadata: nil
-        )
-
-        handler!.confirmPaymentIntent(params: params, authenticationContext: self) { _, _, _ in }
-
-        guard XCTWaiter.wait(for: [didRedirect], timeout: 2.0) != .timedOut else {
-            XCTFail("Unable to redirect")
-            return
-        }
-
-        // Handler is now mid-3DS, inProgress is true
+        handler!.isHandlingAction = true
         XCTAssertTrue(handler!.isInProgress)
 
-        // Deallocate the handler (simulating FlowController being dropped mid-3DS)
+        // Deallocate the handler (simulates FlowController being dropped mid-3DS)
         handler = nil
 
-        // deinit should have reset the static inProgress flag
+        // deinit should have reset the global flag
         let freshHandler = STPPaymentHandler(apiClient: stubbedAPIClient())
         XCTAssertFalse(freshHandler.isInProgress, "inProgress should be reset when handler is deallocated mid-flow")
     }

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -107,11 +107,15 @@ public class STPPaymentHandler: NSObject {
     }
 
     internal var currentAction: STPPaymentHandlerActionParams?
-    /// YES from when a public method is first called until its associated completion handler is called.
-    /// This property guards against simultaneous usage of this class; only one "next action" can be handled at a time.
-    private static var inProgress = false
-    /// Tracks whether this specific instance is the one that set the static `inProgress` flag.
-    private var isHandlingAction = false
+    /// Guards against simultaneous usage — only one "next action" can be handled at a time.
+    /// This is global state across all STPPaymentHandler instances, though we track
+    /// our own state so we can reset it if needed during `dealloc`.
+    internal var isHandlingAction = false {
+        didSet {
+            Self.anyHandlerInProgress = isHandlingAction
+        }
+    }
+    private static var anyHandlerInProgress = false
     private var safariViewController: SFSafariViewController?
     var safariViewControllerDismissedManually = false
     private var asWebAuthenticationSession: ASWebAuthenticationSession?
@@ -136,11 +140,11 @@ public class STPPaymentHandler: NSObject {
     }
 
     deinit {
-        // If this instance set the static inProgress flag, release it.
-        // Without this, deallocating a non-singleton STPPaymentHandler mid-flow
-        // (e.g. when FlowController is dropped) permanently blocks all future payments.
+        // If this instance was mid-flow when deallocated, clear the global lock.
+        // There's nothing else reasonable to do — the action is abandoned and no
+        // completion will ever fire, so we must release the lock to unblock future payments.
         if isHandlingAction {
-            Self.inProgress = false
+            Self.anyHandlerInProgress = false
         }
     }
 
@@ -173,7 +177,7 @@ public class STPPaymentHandler: NSObject {
 
     internal var _redirectShim: ((URL, URL?, Bool) -> Void)?
     internal var isInProgress: Bool {
-        return STPPaymentHandler.inProgress
+        return STPPaymentHandler.anyHandlerInProgress
     }
     internal var analyticsClient: STPAnalyticsClient = .sharedClient
     /// Date at which `confirm` or `handleNextAction` is called. Used to report how long the call took.
@@ -207,7 +211,7 @@ public class STPPaymentHandler: NSObject {
             self?.logConfirmPaymentIntentCompleted(paymentIntentID: paymentIntentID, paymentParams: paymentParams, status: status, error: error)
             completion(status, paymentIntent, error)
         }
-        if Self.inProgress {
+        if Self.anyHandlerInProgress {
             assertionFailure("`STPPaymentHandler.confirmPayment` was called while a previous call is still in progress.")
             completion(.failed, nil, _error(for: .noConcurrentActionsErrorCode))
             return
@@ -216,7 +220,6 @@ public class STPPaymentHandler: NSObject {
             completion(.failed, nil, _error(for: .invalidClientSecret))
             return
         }
-        Self.inProgress = true
         isHandlingAction = true
         // wrappedCompletion ensures we perform some final logic before calling the completion block.
         let wrappedCompletion: STPPaymentHandlerActionPaymentIntentCompletionBlock = { [weak self]
@@ -227,7 +230,6 @@ public class STPPaymentHandler: NSObject {
                 return
             }
             // Reset our internal state
-            Self.inProgress = false
             strongSelf.isHandlingAction = false
 
             // Ensure the .succeeded case returns a PaymentIntent in the expected state.
@@ -453,7 +455,7 @@ public class STPPaymentHandler: NSObject {
             }
             completion(status, paymentIntent, error)
         }
-        if Self.inProgress {
+        if Self.anyHandlerInProgress {
             assertionFailure("`STPPaymentHandler.handleNextAction` was called while a previous call is still in progress.")
             completion(.failed, nil, _error(for: .noConcurrentActionsErrorCode))
             return
@@ -461,7 +463,6 @@ public class STPPaymentHandler: NSObject {
         if paymentIntent.paymentMethodId != nil {
             assert(paymentIntent.paymentMethod != nil, "A PaymentIntent w/ attached paymentMethod must be retrieved w/ an expanded PaymentMethod")
         }
-        Self.inProgress = true
         isHandlingAction = true
 
         // wrappedCompletion ensures we perform some final logic before calling the completion block.
@@ -473,7 +474,6 @@ public class STPPaymentHandler: NSObject {
                 return
             }
             // Reset our internal state
-            Self.inProgress = false
             strongSelf.isHandlingAction = false
             // Ensure the .succeeded case returns a PaymentIntent in the expected state.
             if let paymentIntent = paymentIntent,
@@ -550,7 +550,7 @@ public class STPPaymentHandler: NSObject {
             completion(status, setupIntent, error)
         }
 
-        if Self.inProgress {
+        if Self.anyHandlerInProgress {
             assertionFailure("`STPPaymentHandler.confirmSetupIntent` was called while a previous call is still in progress.")
             completion(.failed, nil, _error(for: .noConcurrentActionsErrorCode))
             return
@@ -562,7 +562,6 @@ public class STPPaymentHandler: NSObject {
             return
         }
 
-        Self.inProgress = true
         isHandlingAction = true
         // wrappedCompletion ensures we perform some final logic before calling the completion block.
         let wrappedCompletion: STPPaymentHandlerActionSetupIntentCompletionBlock = { [weak self]
@@ -573,7 +572,6 @@ public class STPPaymentHandler: NSObject {
                 return
             }
             // Reset our internal state
-            Self.inProgress = false
             self.isHandlingAction = false
 
             if status == .succeeded {
@@ -748,7 +746,7 @@ public class STPPaymentHandler: NSObject {
             }
             completion(status, setupIntent, error)
         }
-        if Self.inProgress {
+        if Self.anyHandlerInProgress {
             assertionFailure("`STPPaymentHandler.confirmPayment` was called while a previous call is still in progress.")
             completion(.failed, nil, _error(for: .noConcurrentActionsErrorCode))
             return
@@ -757,7 +755,6 @@ public class STPPaymentHandler: NSObject {
             assert(setupIntent.paymentMethod != nil, "A SetupIntent w/ attached paymentMethod must be retrieved w/ an expanded PaymentMethod")
         }
 
-        Self.inProgress = true
         isHandlingAction = true
         // wrappedCompletion ensures we perform some final logic before calling the completion block.
         let wrappedCompletion: STPPaymentHandlerActionSetupIntentCompletionBlock = { [weak self]
@@ -768,7 +765,6 @@ public class STPPaymentHandler: NSObject {
                 return
             }
             // Reset our internal state
-            Self.inProgress = false
             strongSelf.isHandlingAction = false
 
             if status == .succeeded {

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -110,6 +110,8 @@ public class STPPaymentHandler: NSObject {
     /// YES from when a public method is first called until its associated completion handler is called.
     /// This property guards against simultaneous usage of this class; only one "next action" can be handled at a time.
     private static var inProgress = false
+    /// Tracks whether this specific instance is the one that set the static `inProgress` flag.
+    private var isHandlingAction = false
     private var safariViewController: SFSafariViewController?
     var safariViewControllerDismissedManually = false
     private var asWebAuthenticationSession: ASWebAuthenticationSession?
@@ -131,6 +133,15 @@ public class STPPaymentHandler: NSObject {
         self.apiClient = apiClient
         self.threeDSCustomizationSettings = threeDSCustomizationSettings
         super.init()
+    }
+
+    deinit {
+        // If this instance set the static inProgress flag, release it.
+        // Without this, deallocating a non-singleton STPPaymentHandler mid-flow
+        // (e.g. when FlowController is dropped) permanently blocks all future payments.
+        if isHandlingAction {
+            Self.inProgress = false
+        }
     }
 
     /// By default `sharedHandler` initializes with STPAPIClient.shared.
@@ -206,6 +217,7 @@ public class STPPaymentHandler: NSObject {
             return
         }
         Self.inProgress = true
+        isHandlingAction = true
         // wrappedCompletion ensures we perform some final logic before calling the completion block.
         let wrappedCompletion: STPPaymentHandlerActionPaymentIntentCompletionBlock = { [weak self]
             status,
@@ -216,6 +228,7 @@ public class STPPaymentHandler: NSObject {
             }
             // Reset our internal state
             Self.inProgress = false
+            strongSelf.isHandlingAction = false
 
             // Ensure the .succeeded case returns a PaymentIntent in the expected state.
             if let paymentIntent = paymentIntent, status == .succeeded {
@@ -449,6 +462,7 @@ public class STPPaymentHandler: NSObject {
             assert(paymentIntent.paymentMethod != nil, "A PaymentIntent w/ attached paymentMethod must be retrieved w/ an expanded PaymentMethod")
         }
         Self.inProgress = true
+        isHandlingAction = true
 
         // wrappedCompletion ensures we perform some final logic before calling the completion block.
         let wrappedCompletion: STPPaymentHandlerActionPaymentIntentCompletionBlock = { [weak self]
@@ -460,6 +474,7 @@ public class STPPaymentHandler: NSObject {
             }
             // Reset our internal state
             Self.inProgress = false
+            strongSelf.isHandlingAction = false
             // Ensure the .succeeded case returns a PaymentIntent in the expected state.
             if let paymentIntent = paymentIntent,
                status == .succeeded
@@ -548,6 +563,7 @@ public class STPPaymentHandler: NSObject {
         }
 
         Self.inProgress = true
+        isHandlingAction = true
         // wrappedCompletion ensures we perform some final logic before calling the completion block.
         let wrappedCompletion: STPPaymentHandlerActionSetupIntentCompletionBlock = { [weak self]
             status,
@@ -558,6 +574,7 @@ public class STPPaymentHandler: NSObject {
             }
             // Reset our internal state
             Self.inProgress = false
+            self.isHandlingAction = false
 
             if status == .succeeded {
                 // Ensure the .succeeded case returns a SetupIntent in the expected state.
@@ -741,6 +758,7 @@ public class STPPaymentHandler: NSObject {
         }
 
         Self.inProgress = true
+        isHandlingAction = true
         // wrappedCompletion ensures we perform some final logic before calling the completion block.
         let wrappedCompletion: STPPaymentHandlerActionSetupIntentCompletionBlock = { [weak self]
             status,
@@ -751,6 +769,7 @@ public class STPPaymentHandler: NSObject {
             }
             // Reset our internal state
             Self.inProgress = false
+            strongSelf.isHandlingAction = false
 
             if status == .succeeded {
                 // Ensure the .succeeded case returns a PaymentIntent in the expected state.


### PR DESCRIPTION
## Summary
- Fix `STPPaymentHandler`'s static lock flag getting permanently stuck when a non-singleton instance is deallocated mid-flow
- Replace scattered `Self.inProgress` assignments with a per-instance `isHandlingAction` property that propagates via `didSet`
- Add `deinit` to release the global lock when an instance is abandoned

## Motivation

PaymentSheet, FlowController, EmbeddedPaymentElement, and CustomerSheet each create their **own** `STPPaymentHandler` instance (not `.sharedHandler`). If such an instance is deallocated mid-3DS flow (e.g. the merchant drops their FlowController reference), `wrappedCompletion` never fires and the static `inProgress` flag is never reset.

Since this flag is shared across **all** instances, this permanently blocks every subsequent `confirmPayment`/`handleNextAction`/`confirmSetupIntent` call on any instance with `noConcurrentActionsErrorCode` (error code 7) for the rest of the app session.

## Approach

Instead of fixing individual instances, we'll always unlock during `didSet`. We also track a per-instance `isHandlingAction` flag (which replaces our former manual setting of `Self.inProgress`) to make sure that we only unset it if we were currently in-flight during dealloc. (Otherwise a deallocating FlowController might accidentally break the inProgress state of a currently active one). I also renamed `Self.inProgress` to make it more clearly global.

## Test plan
- [x] New regression test: sets `isHandlingAction`, deallocates the handler, verifies the global flag is reset
- [x] All existing `STPPaymentHandlerTests`, `STPPaymentHandlerStubbedMockedFilesTests`, and `STPPaymentHandlerRefreshTests` pass
