### PR TITLE
Add Link funding sources picker on playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -51,6 +51,7 @@ struct PaymentSheetTestPlayground: View {
             if playgroundController.settings.merchantCountryCode == .US {
                 SearchableSettingView(setting: linkEnabledModeBinding, searchText: searchText)
             }
+            SearchableSettingView(setting: $playgroundController.settings.linkFundingSources, searchText: $searchText)
             SearchableSettingView(setting: $playgroundController.settings.linkPassthroughMode, searchText: searchText)
             SearchableSettingView(setting: $playgroundController.settings.linkDisplay, searchText: searchText)
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 @_spi(STP) import StripePayments
-@_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
+@_spi(STP) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
 
 struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     enum UIStyle: String, PickerEnum {
@@ -419,6 +419,47 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
+    enum LinkFundingSources: String, PickerEnum {
+        static var enumName: String { "Link funding sources" }
+
+        case all
+        case card
+        case bank
+
+        var displayName: String {
+            switch self {
+            case .all:
+                return "All"
+            case .card:
+                return "Card"
+            case .bank:
+                return "Bank"
+            }
+        }
+
+        var requestValue: [String]? {
+            switch self {
+            case .all:
+                return nil
+            case .card:
+                return ["CARD"]
+            case .bank:
+                return ["BANK_ACCOUNT"]
+            }
+        }
+
+        var supportedPaymentMethodTypes: [LinkPaymentMethodType]? {
+            switch self {
+            case .all:
+                return nil
+            case .card:
+                return [.card]
+            case .bank:
+                return [.bankAccount]
+            }
+        }
+    }
+
     enum UserOverrideCountry: String, PickerEnum {
         static var enumName: String { "UserOverrideCountry (debug only)" }
 
@@ -719,6 +760,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var customEmail: String?
     var linkPassthroughMode: LinkPassthroughMode
     var linkEnabledMode: LinkEnabledMode
+    var linkFundingSources: LinkFundingSources
     var linkDisplay: LinkDisplay
     var userOverrideCountry: UserOverrideCountry
     var customCtaLabel: String?
@@ -779,6 +821,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             customEmail: nil,
             linkPassthroughMode: .passthrough,
             linkEnabledMode: .native,
+            linkFundingSources: .all,
             linkDisplay: .automatic,
             userOverrideCountry: .off,
             customCtaLabel: nil,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -136,12 +136,17 @@ import UIKit
     private var currentTaxRate: (String, Double)?
 
     var linkConfiguration: PaymentSheet.LinkConfiguration {
+        let brand: LinkBrand? = settings.linkBrand == .onelink ? .onelink : nil
+
+        var linkConfiguration: PaymentSheet.LinkConfiguration
         switch settings.linkDisplay {
         case .automatic:
-            PaymentSheet.LinkConfiguration(display: .automatic)
+            linkConfiguration = PaymentSheet.LinkConfiguration(display: .automatic, brand: brand)
         case .never:
-            PaymentSheet.LinkConfiguration(display: .never)
+            linkConfiguration = PaymentSheet.LinkConfiguration(display: .never, brand: brand)
         }
+        linkConfiguration.supportedPaymentMethodTypes = settings.linkFundingSources.supportedPaymentMethodTypes
+        return linkConfiguration
     }
     var customerConfiguration: PaymentSheet.CustomerConfiguration? {
         guard settings.customerMode != .guest,
@@ -1061,6 +1066,14 @@ extension PlaygroundController {
             //            "set_shipping_address": true // Uncomment to make server vend PI with shipping address populated
         ] as [String: Any]
 
+        // Send use_manual_capture when toggled on
+        if settings.manualCapture == .on {
+            body["use_manual_capture"] = true
+        }
+
+        if let linkFundingSources = settings.linkFundingSources.requestValue {
+            body["link_funding_sources"] = linkFundingSources
+        }
         // Add CheckoutSession flag if using CheckoutSession integration type
         if settings.integrationType == .checkoutSession {
             body["use_checkout_session"] = true

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLinkUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLinkUITests.swift
@@ -601,6 +601,9 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
 
         // Sign up and add a payment method with billing details
         signUpFor(app, email: email)
+        app.otherElements["Stripe.Link.PaymentMethodPicker"].waitForExistenceAndTap(timeout: 10)
+        app.buttons["Add a payment method"].waitForExistenceAndTap()
+        app.buttons["Debit or credit card"].waitForExistenceAndTap()
         fillOutLinkCardData(app, cardNumber: "378282246310005", cvc: cvc, includingBillingDetails: true)
 
         payLink(app)
@@ -620,6 +623,9 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
 
         // Sign up and add a payment method without billing details
         signUpFor(app, email: email)
+        app.otherElements["Stripe.Link.PaymentMethodPicker"].waitForExistenceAndTap(timeout: 10)
+        app.buttons["Add a payment method"].waitForExistenceAndTap()
+        app.buttons["Debit or credit card"].waitForExistenceAndTap()
         fillOutLinkCardData(app, cardNumber: "378282246310005", cvc: cvc, includingBillingDetails: false)
         payLink(app)
         assertLinkPaymentSuccess(app)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -740,7 +740,7 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
         let newPaymentVC = PayWithLinkViewController.NewPaymentViewController(
             linkAccount: linkAccount,
             context: context,
-            isAddingFirstPaymentMethod: false
+            isAddingFirstPaymentMethod: viewModel.paymentMethods.isEmpty
         )
 
         bottomSheetController?.pushContentViewController(newPaymentVC)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -724,7 +724,7 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
         paymentPicker.setAddButtonIsLoading(true)
         coordinator?.startFinancialConnections { [weak self] result in
             let completion = {
-                self?.confirmButton.update(status: .enabled)
+                self?.confirmButton.update(status: self?.viewModel.confirmButtonStatus ?? .disabled)
                 self?.paymentPicker.setAddButtonIsLoading(false)
             }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -57,7 +57,8 @@ extension PayWithLinkViewController {
             compact: viewModel.shouldUseCompactConfirmButton,
             linkAppearance: viewModel.linkAppearance,
             didTapWhenDisabled: { [weak self] in
-                self?.cardDetailsRecollectionSection.showAllValidationErrors()
+                guard let self, self.viewModel.shouldShowRecollectionSection else { return }
+                self.cardDetailsRecollectionSection.showAllValidationErrors()
             }
         ) { [weak self] in
             guard let self else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -499,31 +499,22 @@ private extension PayWithLinkViewController {
         paymentDetails: [ConsumerPaymentDetails]
     ) {
         let viewController: BottomSheetContentViewController
-        if paymentDetails.isEmpty {
-            // Check if only bank accounts are supported - if so, launch Financial Connections directly
-            let supportedTypes = context.getSupportedPaymentDetailsTypes(linkAccount: linkAccount)
-            if supportedTypes == [.bankAccount] {
-                startFinancialConnections { [weak self] result in
-                    guard let self else { return }
-                    switch result {
-                    case .completed:
-                        self.loadAndPresentWallet()
-                    case .canceled:
-                        self.cancel(shouldReturnToPaymentSheet: false)
-                    case .failed(let error):
-                        self.finish(withResult: .failed(error: error), deferredIntentConfirmationType: nil)
-                    }
+        // Check if only bank accounts are supported - if so, launch Financial Connections directly
+        let supportedTypes = context.getSupportedPaymentDetailsTypes(linkAccount: linkAccount)
+        if paymentDetails.isEmpty && supportedTypes == [.bankAccount] {
+            startFinancialConnections { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .completed:
+                    self.loadAndPresentWallet()
+                case .canceled:
+                    self.cancel(shouldReturnToPaymentSheet: false)
+                case .failed(let error):
+                    self.finish(withResult: .failed(error: error), deferredIntentConfirmationType: nil)
                 }
-                // Show a loading view while Financial Connections is being prepared
-                viewController = LoaderViewController(context: context)
-            } else {
-                let addPaymentMethodVC = NewPaymentViewController(
-                    linkAccount: linkAccount,
-                    context: context,
-                    isAddingFirstPaymentMethod: true
-                )
-                viewController = addPaymentMethodVC
             }
+            // Show a loading view while Financial Connections is being prepared
+            viewController = LoaderViewController(context: context)
         } else {
             let walletViewController = WalletViewController(
                 linkAccount: linkAccount,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
@@ -139,7 +139,7 @@ extension Element {
     /// Forces validation errors to be displayed on all TextFieldElements in this element's hierarchy
     public func showAllValidationErrors() {
         for element in getAllUnwrappedSubElements() {
-            if let textFieldElement = element as? TextFieldElement {
+            if let textFieldElement = element as? TextFieldElement, !textFieldElement.view.isHidden {
                 textFieldElement.showValidationErrors()
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -25,13 +25,14 @@ extension UIViewController {
         intent: Intent,
         elementsSession: STPElementsSession,
         analyticsHelper: PaymentSheetAnalyticsHelper,
-        supportedPaymentMethodTypes: [LinkPaymentMethodType] = LinkPaymentMethodType.allCases,
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
         shouldShowSecondaryCta: Bool = true,
         confirmationChallenge: ConfirmationChallenge? = nil,
         callback: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
     ) {
+        let effectiveSupportedPaymentMethodTypes = supportedPaymentMethodTypes ?? configuration.link.supportedPaymentMethodTypes ?? LinkPaymentMethodType.allCases
         let payWithLinkController = PayWithNativeLinkController(
             mode: .paymentMethodSelection,
             intent: intent,
@@ -39,7 +40,7 @@ extension UIViewController {
             configuration: configuration,
             logPayment: false,
             analyticsHelper: analyticsHelper,
-            supportedPaymentMethodTypes: supportedPaymentMethodTypes,
+            supportedPaymentMethodTypes: effectiveSupportedPaymentMethodTypes,
             linkAppearance: linkAppearance,
             linkConfiguration: linkConfiguration,
             confirmationChallenge: confirmationChallenge

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -635,7 +635,18 @@ extension PaymentSheet {
             case .wallet:
                 let useNativeLink = deviceCanUseNativeLink(elementsSession: elementsSession, configuration: configuration)
                 if useNativeLink {
-                    let linkController = PayWithNativeLinkController(mode: .full, intent: intent, elementsSession: elementsSession, configuration: configuration, logPayment: true, analyticsHelper: analyticsHelper, confirmationChallenge: confirmationChallenge)
+                    // logPayment is false because callers of PaymentSheet.confirm() are responsible for logging the payment result.
+                    let supportedPaymentMethodTypes = configuration.link.supportedPaymentMethodTypes ?? LinkPaymentMethodType.allCases
+                    let linkController = PayWithNativeLinkController(
+                        mode: .full,
+                        intent: intent,
+                        elementsSession: elementsSession,
+                        configuration: configuration,
+                        logPayment: false,
+                        analyticsHelper: analyticsHelper,
+                        supportedPaymentMethodTypes: supportedPaymentMethodTypes,
+                        confirmationChallenge: confirmationChallenge
+                    )
                     linkController.presentAsBottomSheet(from: authenticationContext.authenticationPresentingViewController(), shouldOfferApplePay: false, shouldFinishOnClose: false, completion: { result, confirmationType, _ in
                         completion(result, confirmationType)
                     })

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -67,7 +67,16 @@ extension PaymentSheet {
         shouldFinishOnClose: Bool,
         onClose: (() -> Void)? = nil
     ) {
-        let payWithNativeLink = PayWithNativeLinkController(mode: .full, intent: intent, elementsSession: elementsSession, configuration: configuration, analyticsHelper: analyticsHelper, confirmationChallenge: confirmationChallenge)
+        let supportedPaymentMethodTypes = configuration.link.supportedPaymentMethodTypes ?? LinkPaymentMethodType.allCases
+        let payWithNativeLink = PayWithNativeLinkController(
+            mode: .full,
+            intent: intent,
+            elementsSession: elementsSession,
+            configuration: configuration,
+            analyticsHelper: analyticsHelper,
+            supportedPaymentMethodTypes: supportedPaymentMethodTypes,
+            confirmationChallenge: confirmationChallenge
+        )
 
         payWithNativeLink.presentAsBottomSheet(from: presentingController, shouldOfferApplePay: shouldOfferApplePay, shouldFinishOnClose: shouldFinishOnClose, completion: { result, _, didFinish in
             if case let .failed(error) = result {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -534,6 +534,10 @@ extension PaymentSheet {
         /// The Link funding sources that should be disabled. Defaults to an empty set.
         @_spi(STP) public var disallowFundingSourceCreation: Set<String> = []
 
+        /// Debug-only override for the Link payment method types shown in native Link.
+        /// When unset, native Link uses its default supported types derived from server state.
+        @_spi(STP) public var supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil
+
         /// Whether missing billing details should be collected for existing Link payment methods.
         @_spi(CollectMissingLinkBillingDetailsPreview) public var collectMissingBillingDetailsForExistingPaymentMethods: Bool = true
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -536,7 +536,7 @@ extension PaymentSheet {
 
         /// Debug-only override for the Link payment method types shown in native Link.
         /// When unset, native Link uses its default supported types derived from server state.
-        @_spi(STP) public var supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil
+        @_spi(STP) public var supportedPaymentMethodTypes: [LinkPaymentMethodType]?
 
         /// Whether missing billing details should be collected for existing Link payment methods.
         @_spi(CollectMissingLinkBillingDetailsPreview) public var collectMissingBillingDetailsForExistingPaymentMethods: Bool = true

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -158,12 +158,14 @@ typealias ExpressType = PaymentSheet.WalletButtonsVisibility.ExpressType
                 confirmHandler(result)
             }
         case .link:
+            let supportedPaymentMethodTypes = flowController.configuration.link.supportedPaymentMethodTypes ?? LinkPaymentMethodType.allCases
             let linkController = PayWithNativeLinkController(
                 mode: .paymentMethodSelection,
                 intent: flowController.intent,
                 elementsSession: flowController.elementsSession,
                 configuration: flowController.configuration,
-                analyticsHelper: flowController.analyticsHelper
+                analyticsHelper: flowController.analyticsHelper,
+                supportedPaymentMethodTypes: supportedPaymentMethodTypes
             )
             linkController.presentForPaymentMethodSelection(
                 from: WindowAuthenticationContext().authenticationPresentingViewController(),


### PR DESCRIPTION
## Summary

Adds a Link funding sources picker on the payment sheet playground to test payment method type filtering

## Motivation

Testing payment method type filtering

## Testing


https://github.com/user-attachments/assets/e79eccd0-061f-4553-b1fe-4c7d9d56fb21



## Changelog

N/a
