### PR TITLE
[link] Preliminary update for branded strings to use placeholder

### DIFF
--- a/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
+++ b/Stripe/StripeiOSTests/LinkInlineSignupElementSnapshotTests.swift
@@ -272,6 +272,7 @@ extension LinkInlineSignupElementSnapshotTests {
 
         let viewModel = LinkInlineSignupViewModel(
             configuration: configuration,
+            brand: .link,
             showCheckbox: showCheckbox,
             accountService: MockAccountService(),
             allowsDefaultOptIn: allowsDefaultOptIn,

--- a/Stripe/StripeiOSTests/LinkInlineSignupViewModelTests.swift
+++ b/Stripe/StripeiOSTests/LinkInlineSignupViewModelTests.swift
@@ -356,6 +356,7 @@ extension LinkInlineSignupViewModelTests {
 
         return LinkInlineSignupViewModel(
             configuration: PaymentSheet.Configuration(),
+            brand: .link,
             showCheckbox: showCheckbox,
             accountService: MockAccountService(shouldFailLookup: shouldFailLookup),
             allowsDefaultOptIn: allowsDefaultOptIn,

--- a/StripeCore/StripeCore/Source/Connections Bindings/LinkBrand.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/LinkBrand.swift
@@ -12,4 +12,14 @@ import Foundation
     // Keep the backend-facing raw value unchanged until the rollout is ready.
     case onelink = "notlink"
     case unparsable
+
+    /// Brand names are proper nouns, so keep the source-of-truth user-facing value here.
+    @_spi(STP) public var displayName: String {
+        switch self {
+        case .link, .unparsable:
+            return "Link"
+        case .onelink:
+            return "Onelink"
+        }
+    }
 }

--- a/StripeCore/StripeCoreTests/Connections Bindings/LinkBrandTests.swift
+++ b/StripeCore/StripeCoreTests/Connections Bindings/LinkBrandTests.swift
@@ -1,0 +1,21 @@
+//
+//  LinkBrandTests.swift
+//  StripeCoreTests
+//
+
+@_spi(STP) @testable import StripeCore
+import XCTest
+
+final class LinkBrandTests: XCTestCase {
+    func testDisplayName_forLinkBrand() {
+        XCTAssertEqual(LinkBrand.link.displayName, "Link")
+    }
+
+    func testDisplayName_forOnelinkBrand() {
+        XCTAssertEqual(LinkBrand.onelink.displayName, "Onelink")
+    }
+
+    func testDisplayName_forUnparsableBrandFallsBackToLink() {
+        XCTAssertEqual(LinkBrand.unparsable.displayName, "Link")
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeFinancialConnections/StripeFinancialConnections/Resources/Localizations/en.lproj/Localizable.strings
@@ -263,3 +263,4 @@
 
 /* An error message that instructs the user to keep typing their phone number in a user-input field. */
 "Your mobile phone number is incomplete." = "Your mobile phone number is incomplete.";
+

--- a/StripeFinancialConnections/StripeFinancialConnections/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeFinancialConnections/StripeFinancialConnections/Resources/Localizations/en.lproj/Localizable.strings
@@ -263,4 +263,3 @@
 
 /* An error message that instructs the user to keep typing their phone number in a user-input field. */
 "Your mobile phone number is incomplete." = "Your mobile phone number is incomplete.";
-

--- a/StripeFinancialConnections/StripeFinancialConnections/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeFinancialConnections/StripeFinancialConnections/Resources/Localizations/en.lproj/Localizable.strings
@@ -44,8 +44,9 @@
 "Continue linking your account" = "Continue linking your account";
 
 /* A button title. This button, when pressed, will automatically log-in the user with their e-mail to Link (one-click checkout provider).
-   The title of a screen where users are informed that they can sign-in-to Link. */
-"Continue with Link" = "Continue with Link";
+   The title of a screen where users are informed that they can sign-in-to Link.
+   The placeholder is a Stripe brand name and should not be translated. */
+"Continue with %@" = "Continue with %@";
 
 /* The title of a user-input-field that appears when a user is signing up to Link (a payment service). It instructs user to type an email address. */
 "Email address" = "Email address";
@@ -179,8 +180,8 @@
 /* Part of a subtitle of a notice that appears at the bottom of search results. It appears when a user is searching for their bank, but no results are returned. The '%@' will be replaced by a tappable text that says: 'manually enter details'. */
 "Try searching another bank or %@" = "Try searching another bank or %@";
 
-/* The subtitle/description of a screen where users are informed that they can sign-in-to Link. */
-"Use information you previously saved with your Link account." = "Use information you previously saved with your Link account.";
+/* The subtitle/description of a screen where users are informed that they can sign in to the Link brand. The placeholder is a Stripe brand name and should not be translated. */
+"Use information you previously saved with your %@ account." = "Use information you previously saved with your %@ account.";
 
 /* Label for a button shown to a user who is in test mode, which will give them the option to autofill mock account credentials. */
 "Use test account" = "Use test account";
@@ -239,14 +240,14 @@
 /* An error message that appears when a user is manually entering their bank account information. This error message tells the user that the account number they typed doesn't match a previously typed account number. */
 "Your account numbers don't match." = "Your account numbers don't match.";
 
-/* The subtitle/description of the success screen that appears when a user is done with the process of connecting their bank account to an application. Now that the bank account is connected, the user will be able to use the bank account for payments. */
-"Your account was connected, but couldn't be saved to Link." = "Your account was connected, but couldn't be saved to Link.";
+/* The subtitle/description of the success screen when the user's single connected account could not be saved to the Link brand. The placeholder is a Stripe brand name and should not be translated. */
+"Your account was connected, but couldn't be saved to %@." = "Your account was connected, but couldn't be saved to %@.";
 
 /* The subtitle/description of the success screen that appears when a user is done with the process of connecting their bank account to an application. Now that the bank account is connected (or linked), the user will be able to use the bank account for payments. */
 "Your account was connected." = "Your account was connected.";
 
-/* The subtitle/description of the success screen that appears when a user is done with the process of connecting their bank account to an application. Now that the bank account is connected, the user will be able to use the bank account for payments. */
-"Your accounts were connected, but couldn't be saved to Link." = "Your accounts were connected, but couldn't be saved to Link.";
+/* The subtitle/description of the success screen when the user's connected accounts could not be saved to the Link brand. The placeholder is a Stripe brand name and should not be translated. */
+"Your accounts were connected, but couldn't be saved to %@." = "Your accounts were connected, but couldn't be saved to %@.";
 
 /* The subtitle/description of the success screen that appears when a user is done with the process of connecting their bank accounts to an application. Now that the bank accounts are connected (or linked), the user will be able to use those bank accounts for payments. */
 "Your accounts were connected." = "Your accounts were connected.";

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/String+Localized.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/String+Localized.swift
@@ -11,6 +11,45 @@ import Foundation
 // Localized strings that are used in multiple contexts. Collected here to avoid re-translation
 // We use snake case to make long names easier to read.
 extension String.Localized {
+    static func continue_with_link(brand: LinkBrand) -> String {
+        return String(
+            format: STPLocalizedString(
+                "Continue with %@",
+                "A button title. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
+    }
+
+    static func use_information_you_previously_saved_with_your_brand_account(brand: LinkBrand) -> String {
+        return String(
+            format: STPLocalizedString(
+                "Use information you previously saved with your %@ account.",
+                "The subtitle/description of a screen where users are informed that they can sign in to the Link brand. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
+    }
+
+    static func your_account_was_connected_but_could_not_be_saved_to_brand(brand: LinkBrand) -> String {
+        return String(
+            format: STPLocalizedString(
+                "Your account was connected, but couldn't be saved to %@.",
+                "The subtitle/description of the success screen when the user's single connected account could not be saved to the Link brand. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
+    }
+
+    static func your_accounts_were_connected_but_could_not_be_saved_to_brand(brand: LinkBrand) -> String {
+        return String(
+            format: STPLocalizedString(
+                "Your accounts were connected, but couldn't be saved to %@.",
+                "The subtitle/description of the success screen when the user's connected accounts could not be saved to the Link brand. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
+    }
 
     static var learn_more: String {
         return STPLocalizedString(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/String+Localized.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/String+Localized.swift
@@ -15,7 +15,11 @@ extension String.Localized {
         return String(
             format: STPLocalizedString(
                 "Continue with %@",
-                "A button title. The placeholder is a Stripe brand name and should not be translated."
+                """
+                A button title. This button, when pressed, will automatically log-in the user with their e-mail to Link (one-click checkout provider).
+                   The title of a screen where users are informed that they can sign-in-to Link.
+                   The placeholder is a Stripe brand name and should not be translated.
+                """
             ),
             brand.displayName
         )

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/String+Localized.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/String+Localized.swift
@@ -11,48 +11,75 @@ import Foundation
 // Localized strings that are used in multiple contexts. Collected here to avoid re-translation
 // We use snake case to make long names easier to read.
 extension String.Localized {
-    static func continue_with_link(brand: LinkBrand) -> String {
-        return String(
-            format: STPLocalizedString(
-                "Continue with %@",
-                """
-                A button title. This button, when pressed, will automatically log-in the user with their e-mail to Link (one-click checkout provider).
-                   The title of a screen where users are informed that they can sign-in-to Link.
-                   The placeholder is a Stripe brand name and should not be translated.
-                """
-            ),
-            brand.displayName
+    private static func existingLinkLocalizedString(_ key: String) -> String {
+        STPLocalizationUtils.localizedStripeString(
+            forKey: key,
+            bundleLocator: StripeFinancialConnectionsBundleLocator.self
         )
     }
 
-    static func use_information_you_previously_saved_with_your_brand_account(brand: LinkBrand) -> String {
-        return String(
-            format: STPLocalizedString(
-                "Use information you previously saved with your %@ account.",
-                "The subtitle/description of a screen where users are informed that they can sign in to the Link brand. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+    @_spi(STP) public static func continue_with_link(brand: LinkBrand) -> String {
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("Continue with Link")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "Continue with %@",
+                    """
+                    A button title. This button, when pressed, will automatically log-in the user with their e-mail to Link (one-click checkout provider).
+                       The title of a screen where users are informed that they can sign-in-to Link.
+                       The placeholder is a Stripe brand name and should not be translated.
+                    """
+                ),
+                brand.displayName
+            )
+        }
     }
 
-    static func your_account_was_connected_but_could_not_be_saved_to_brand(brand: LinkBrand) -> String {
-        return String(
-            format: STPLocalizedString(
-                "Your account was connected, but couldn't be saved to %@.",
-                "The subtitle/description of the success screen when the user's single connected account could not be saved to the Link brand. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+    @_spi(STP) public static func use_information_you_previously_saved_with_your_brand_account(brand: LinkBrand) -> String {
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("Use information you previously saved with your Link account.")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "Use information you previously saved with your %@ account.",
+                    "The subtitle/description of a screen where users are informed that they can sign in to the Link brand. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
-    static func your_accounts_were_connected_but_could_not_be_saved_to_brand(brand: LinkBrand) -> String {
-        return String(
-            format: STPLocalizedString(
-                "Your accounts were connected, but couldn't be saved to %@.",
-                "The subtitle/description of the success screen when the user's connected accounts could not be saved to the Link brand. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+    @_spi(STP) public static func your_account_was_connected_but_could_not_be_saved_to_brand(brand: LinkBrand) -> String {
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("Your account was connected, but couldn't be saved to Link.")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "Your account was connected, but couldn't be saved to %@.",
+                    "The subtitle/description of the success screen when the user's single connected account could not be saved to the Link brand. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
+    }
+
+    @_spi(STP) public static func your_accounts_were_connected_but_could_not_be_saved_to_brand(brand: LinkBrand) -> String {
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("Your accounts were connected, but couldn't be saved to Link.")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "Your accounts were connected, but couldn't be saved to %@.",
+                    "The subtitle/description of the success screen when the user's connected accounts could not be saved to the Link brand. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static var learn_more: String {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -42,6 +42,7 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
 
     private let dataSource: NetworkingLinkLoginWarmupDataSource
     weak var delegate: NetworkingLinkLoginWarmupViewControllerDelegate?
+    private var linkBrand: LinkBrand { dataSource.manifest.brand ?? .link }
 
     private lazy var warmupFooterView: NetworkingLinkLoginWarmupFooterView = {
         let secondaryButtonTitle: String
@@ -55,10 +56,7 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
         }
         return PaneLayoutView.createFooterView(
             primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
-                title: STPLocalizedString(
-                    "Continue with Link",
-                    "A button title. This button, when pressed, will automatically log-in the user with their e-mail to Link (one-click checkout provider)."
-                ),
+                title: String.Localized.continue_with_link(brand: linkBrand),
                 accessibilityIdentifier: "link_continue_button",
                 action: { [weak self] in
                     self?.didSelectContinue()
@@ -95,14 +93,8 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
                     style: .circle,
                     appearance: dataSource.manifest.appearance
                 ),
-                title: STPLocalizedString(
-                    "Continue with Link",
-                    "The title of a screen where users are informed that they can sign-in-to Link."
-                ),
-                subtitle: STPLocalizedString(
-                    "Use information you previously saved with your Link account.",
-                    "The subtitle/description of a screen where users are informed that they can sign-in-to Link."
-                ),
+                title: String.Localized.continue_with_link(brand: linkBrand),
+                subtitle: String.Localized.use_information_you_previously_saved_with_your_brand_account(brand: linkBrand),
                 contentView: NetworkingLinkLoginWarmupBodyView(
                     // `email` should always be non-null, and since the email is only used as a visual, it's not worth to throw an error if it is null
                     email: dataSource.email ?? "you"

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
@@ -46,7 +46,8 @@ final class SuccessViewController: UIViewController {
             subtitle: dataSource.customSuccessPaneSubCaption ?? CreateSubtitleText(
                 // manual entry has "0" linked accounts count
                 isLinkingOneAccount: (dataSource.linkedAccountsCount == 0 || dataSource.linkedAccountsCount == 1),
-                showSaveToLinkFailedNotice: showSaveToLinkFailedNotice
+                showSaveToLinkFailedNotice: showSaveToLinkFailedNotice,
+                brand: dataSource.manifest.brand ?? .link
             ),
             appearance: dataSource.manifest.appearance
         )
@@ -211,19 +212,14 @@ private func CreateIconView(appearance: FinancialConnectionsAppearance) -> UIVie
 
 private func CreateSubtitleText(
     isLinkingOneAccount: Bool,
-    showSaveToLinkFailedNotice: Bool
+    showSaveToLinkFailedNotice: Bool,
+    brand: LinkBrand
 ) -> String {
     if showSaveToLinkFailedNotice {
         if isLinkingOneAccount {
-            return STPLocalizedString(
-                "Your account was connected, but couldn't be saved to Link.",
-                "The subtitle/description of the success screen that appears when a user is done with the process of connecting their bank account to an application. Now that the bank account is connected, the user will be able to use the bank account for payments."
-            )
+            return String.Localized.your_account_was_connected_but_could_not_be_saved_to_brand(brand: brand)
         } else { // multiple bank accounts
-            return STPLocalizedString(
-                "Your accounts were connected, but couldn't be saved to Link.",
-                "The subtitle/description of the success screen that appears when a user is done with the process of connecting their bank account to an application. Now that the bank account is connected, the user will be able to use the bank account for payments."
-            )
+            return String.Localized.your_accounts_were_connected_but_could_not_be_saved_to_brand(brand: brand)
         }
     } else if isLinkingOneAccount {
         return STPLocalizedString(

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/StringExtensionsTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/StringExtensionsTests.swift
@@ -6,7 +6,7 @@
 //
 
 @_spi(STP) @testable import StripeCore
-@testable import StripeFinancialConnections
+@testable @_spi(STP) import StripeFinancialConnections
 import XCTest
 
 class StringExtensionsTests: XCTestCase {

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/StringExtensionsTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/StringExtensionsTests.swift
@@ -5,6 +5,7 @@
 //  Created by Krisjanis Gaidis on 7/14/22.
 //
 
+@_spi(STP) @testable import StripeCore
 @testable import StripeFinancialConnections
 import XCTest
 
@@ -46,6 +47,19 @@ class StringExtensionsTests: XCTestCase {
                         String.Link(range: NSRange(location: 17, length: 6), urlString: "https://www.stripe.com/link2"),
                     ]
                 )
+        )
+    }
+
+    func testBrandedLocalizedStrings_useProvidedBrandDisplayName() {
+        XCTAssertEqual(String.Localized.continue_with_link(brand: .link), "Continue with Link")
+        XCTAssertEqual(String.Localized.continue_with_link(brand: .onelink), "Continue with Onelink")
+        XCTAssertEqual(
+            String.Localized.use_information_you_previously_saved_with_your_brand_account(brand: .onelink),
+            "Use information you previously saved with your Onelink account."
+        )
+        XCTAssertEqual(
+            String.Localized.your_account_was_connected_but_could_not_be_saved_to_brand(brand: .onelink),
+            "Your account was connected, but couldn't be saved to Onelink."
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -305,6 +305,9 @@ Pay faster at {Merchant Name} and thousands of businesses
 e.g, 'Pay faster at Example, Inc. and thousands of businesses.' */
 "Pay faster at %@ and thousands of businesses." = "Pay faster at %@ and thousands of businesses.";
 
+/* Subtitle for the Link signup screen. The placeholder is a Stripe brand name and should not be translated. */
+"Pay faster everywhere %@ is accepted." = "Pay faster everywhere %@ is accepted.";
+
 /* Subtitle for the Link signup screen */
 "Pay faster everywhere Link is accepted." = "Pay faster everywhere Link is accepted.";
 
@@ -469,3 +472,4 @@ the heading the screen itself. */
 
 /* An error message. */
 "Your IBAN should start with a two-letter country code." = "Your IBAN should start with a two-letter country code.";
+

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -83,8 +83,8 @@
 /* Text providing link to terms for ACH payments */
 "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>." = "By continuing, you agree to authorize payments pursuant to <terms>these terms</terms>.";
 
-/* Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link. */
-"By continuing, you agree to save your information for future purchases with %@ and <link>Link</link> according to Link <terms>terms</terms> and <privacy>privacy</privacy>." = "By continuing, you agree to save your information for future purchases with %@ and <link>Link</link> according to Link <terms>terms</terms> and <privacy>privacy</privacy>.";
+/* Text displayed below a credit card entry form when the card will be saved with the merchant and saved to the Link brand. The first placeholder is a merchant name. The second placeholder is a Stripe brand name and should not be translated. */
+"By continuing, you agree to save your information for future purchases with %1$@ and <link>%2$@</link> according to %2$@ <terms>terms</terms> and <privacy>privacy</privacy>." = "By continuing, you agree to save your information for future purchases with %1$@ and <link>%2$@</link> according to %2$@ <terms>terms</terms> and <privacy>privacy</privacy>.";
 
 /* Text displayed below a credit card entry form when the card will be saved with the merchant. */
 "By continuing, you agree to save your information for future purchases with %@." = "By continuing, you agree to save your information for future purchases with %@.";
@@ -98,11 +98,11 @@
 /* Cash App mandate text */
 "By continuing, you authorize %@ to debit your Cash App account for this payment and future payments in accordance with %@'s terms, until this authorization is revoked. You can change this anytime in your Cash App Settings." = "By continuing, you authorize %1$@ to debit your Cash App account for this payment and future payments in accordance with %2$@'s terms, until this authorization is revoked. You can change this anytime in your Cash App Settings.";
 
-/* Legal text shown when creating a Link account. */
-"By joining Link, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>." = "By joining Link, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.";
+/* Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated. */
+"By joining %@, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>." = "By joining %@, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.";
 
-/* Legal text shown when creating a Link account. */
-"By providing phone number and email, you agree to create a Link account subject to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>." = "By providing phone number and email, you agree to create a Link account subject to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.";
+/* Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated. */
+"By providing phone number and email, you agree to create a %1$@ account subject to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>." = "By providing phone number and email, you agree to create a %1$@ account subject to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.";
 
 /* Legal text shown when using AUBECS. */
 "By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the <terms>Direct Debit Request service agreement</terms>, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of %@ (the \"Merchant\") for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above." = "By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the <terms>Direct Debit Request service agreement</terms>, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of %@ (the \"Merchant\") for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.";
@@ -110,14 +110,14 @@
 /* Text displayed below a credit card entry form when the card will be saved to make future payments. */
 "By providing your card information, you allow %@ to charge your card for future payments in accordance with their terms." = "By providing your card information, you allow %@ to charge your card for future payments in accordance with their terms.";
 
-/* Legal text shown when creating a Link account. */
-"By providing your email, you agree to create a Link account and save your payment info to Link, according to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>." = "By providing your email, you agree to create a Link account and save your payment info to Link, according to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.";
+/* Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated. */
+"By providing your email, you agree to create a %1$@ account and save your payment info to %1$@, according to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>." = "By providing your email, you agree to create a %1$@ account and save your payment info to %1$@, according to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.";
 
 /* SEPA mandate text */
 "By providing your payment information and confirming this payment, you authorise (A) %@ and Stripe, our payment service provider, to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with those instructions. As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited. Your rights are explained in a statement that you can obtain from your bank. You agree to receive notifications for future debits up to 2 days before they occur." = "By providing your payment information and confirming this payment, you authorise (A) %@ and Stripe, our payment service provider, to send instructions to your bank to debit your account and (B) your bank to debit your account in accordance with those instructions. As part of your rights, you are entitled to a refund from your bank under the terms and conditions of your agreement with your bank. A refund must be claimed within 8 weeks starting from the date on which your account was debited. Your rights are explained in a statement that you can obtain from your bank. You agree to receive notifications for future debits up to 2 days before they occur.";
 
-/* Legal text shown when creating a Link account. */
-"By providing your phone number, you agree to create a Link account and save your payment info to Link, according to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>." = "By providing your phone number, you agree to create a Link account and save your payment info to Link, according to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.";
+/* Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated. */
+"By providing your phone number, you agree to create a %1$@ account and save your payment info to %1$@, according to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>." = "By providing your phone number, you agree to create a %1$@ account and save your payment info to %1$@, according to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.";
 
 /* Mandate text with link to terms when saving a bank account payment method to a merchant (merchant name replaces %@). */
 "By saving your bank account for %@ you agree to authorize payments pursuant to <terms>these terms</terms>." = "By saving your bank account for %@ you agree to authorize payments pursuant to <terms>these terms</terms>.";
@@ -180,9 +180,8 @@ with the transaction. */
 /* Label for CPF/CPNJ (Brazil tax ID) field */
 "CPF/CPNJ" = "CPF/CPNJ";
 
-/* Label for a checkbox that when checked allows the payment information
-to be saved and used in future checkout sessions. */
-"Create an account with Link for faster checkout across the web" = "Create an account with Link for faster checkout across the web";
+/* Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated. */
+"Create an account with %@ for faster checkout across the web" = "Create an account with %@ for faster checkout across the web";
 
 /* Label shown in the payment type picker describing a card payment */
 "Debit or credit card" = "Debit or credit card";
@@ -232,8 +231,8 @@ to be saved and used in future checkout sessions. */
 /* Title for a button that indicates a user can log in or sign up. */
 "Log in or sign up" = "Log in or sign up";
 
-/* Title of the logout action. */
-"Log out of Link" = "Log out of Link";
+/* Title of the logout action. The placeholder is a Stripe brand name and should not be translated. */
+"Log out of %@" = "Log out of %@";
 
 /* Title shown above a view containing the customer's bank account that they can delete */
 "Manage bank account" = "Manage bank account";
@@ -306,8 +305,8 @@ Pay faster at {Merchant Name} and thousands of businesses
 e.g, 'Pay faster at Example, Inc. and thousands of businesses.' */
 "Pay faster at %@ and thousands of businesses." = "Pay faster at %@ and thousands of businesses.";
 
-/* Subtitle for the Link signup screen */
-"Pay faster everywhere Link is accepted." = "Pay faster everywhere Link is accepted.";
+/* Subtitle for the Link signup screen. The placeholder is a Stripe brand name and should not be translated. */
+"Pay faster everywhere %@ is accepted." = "Pay faster everywhere %@ is accepted.";
 
 /* Pay over time with Affirm copy */
 "Pay over time with %@" = "Pay over time with %@";
@@ -315,8 +314,8 @@ e.g, 'Pay faster at Example, Inc. and thousands of businesses.' */
 /* Promotional text for Affirm, displayed in a button that lets the customer pay with Affirm */
 "Pay over time with Affirm" = "Pay over time with Affirm";
 
-/* Text for the 'Pay with Link' button. 'Link' is a Stripe brand, please do not translate the word 'Link'. */
-"Pay with Link" = "Pay with Link";
+/* Text for the 'Pay with Link' button. The placeholder is a Stripe brand name and should not be translated. */
+"Pay with %@" = "Pay with %@";
 
 /* US Bank Account copy title for Mobile payment element form */
 "Pay with your bank account in just a few steps." = "Pay with your bank account in just a few steps.";
@@ -364,9 +363,8 @@ e.g, 'Pay faster at Example, Inc. and thousands of businesses.' */
 /* The label of a switch indicating whether to save the payment method for future payments. */
 "Save for future payments" = "Save for future payments";
 
-/* Label for a checkbox that when checked allows the payment information
-to be saved and used in future checkout sessions. */
-"Save my info for faster checkout with Link" = "Save my info for faster checkout with Link";
+/* Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated. */
+"Save my info for faster checkout with %@" = "Save my info for faster checkout with %@";
 
 /* The label of a switch indicating whether to save the user's payment details for future payment */
 "Save payment details to %@ for future purchases" = "Save payment details to %@ for future purchases";
@@ -377,9 +375,8 @@ to be saved and used in future checkout sessions. */
 /* US Bank Account copy title for Mobile payment element form */
 "Save your bank account in just a few steps." = "Save your bank account in just a few steps.";
 
-/* Label for a checkbox that when checked allows the payment information
-to be saved and used in future checkout sessions. */
-"Save your info for secure 1-click checkout with Link" = "Save your info for secure 1-click checkout with Link";
+/* Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated. */
+"Save your info for secure 1-click checkout with %@" = "Save your info for secure 1-click checkout with %@";
 
 /* Title shown above a button that represents the customer's saved payment method e.g., a saved credit card or bank account. */
 "Saved" = "Saved";
@@ -411,9 +408,6 @@ is not supported by the merchant */
 
 /* Accessibility label for an action or a button that shows a menu. */
 "Show menu" = "Show menu";
-
-/* Subtitle shown on a button allowing a user to select to pay with Link. */
-"Simple, secure one-click payments" = "Simple, secure one-click payments";
 
 /* Error message when an error case happens when linking your account */
 "Something went wrong when linking your account.\nPlease try again later." = "Something went wrong when linking your account.\nPlease try again later.";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -102,7 +102,7 @@
 "By joining %@, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>." = "By joining %@, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.";
 
 /* Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated. */
-"By providing phone number and email, you agree to create a %1$@ account subject to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>." = "By providing phone number and email, you agree to create a %1$@ account subject to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.";
+"By providing phone number and email, you agree to create a %1$@ account subject to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>." = "By providing phone number and email, you agree to create a %1$@ account subject to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.";
 
 /* Legal text shown when using AUBECS. */
 "By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the <terms>Direct Debit Request service agreement</terms>, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of %@ (the \"Merchant\") for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above." = "By providing your bank account details and confirming this payment, you agree to this Direct Debit Request and the <terms>Direct Debit Request service agreement</terms>, and authorise Stripe Payments Australia Pty Ltd ACN 160 180 343 Direct Debit User ID number 507156 (“Stripe”) to debit your account through the Bulk Electronic Clearing System (BECS) on behalf of %@ (the \"Merchant\") for any amounts separately communicated to you by the Merchant. You certify that you are either an account holder or an authorised signatory on the account listed above.";
@@ -305,8 +305,8 @@ Pay faster at {Merchant Name} and thousands of businesses
 e.g, 'Pay faster at Example, Inc. and thousands of businesses.' */
 "Pay faster at %@ and thousands of businesses." = "Pay faster at %@ and thousands of businesses.";
 
-/* Subtitle for the Link signup screen. The placeholder is a Stripe brand name and should not be translated. */
-"Pay faster everywhere %@ is accepted." = "Pay faster everywhere %@ is accepted.";
+/* Subtitle for the Link signup screen */
+"Pay faster everywhere Link is accepted." = "Pay faster everywhere Link is accepted.";
 
 /* Pay over time with Affirm copy */
 "Pay over time with %@" = "Pay over time with %@";
@@ -409,6 +409,9 @@ is not supported by the merchant */
 /* Accessibility label for an action or a button that shows a menu. */
 "Show menu" = "Show menu";
 
+/* Subtitle shown on a button allowing a user to select to pay with Link. */
+"Simple, secure one-click payments" = "Simple, secure one-click payments";
+
 /* Error message when an error case happens when linking your account */
 "Something went wrong when linking your account.\nPlease try again later." = "Something went wrong when linking your account.\nPlease try again later.";
 
@@ -466,4 +469,3 @@ the heading the screen itself. */
 
 /* An error message. */
 "Your IBAN should start with a two-letter country code." = "Your IBAN should start with a two-letter country code.";
-

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -483,7 +483,28 @@ extension String.Localized {
     }
 
     static var link_subtitle_text: String {
-        existingLinkLocalizedString("Simple, secure one-click payments")
+        STPLocalizedString(
+            "Simple, secure one-click payments",
+            "Subtitle shown on a button allowing a user to select to pay with Link."
+        )
+    }
+
+    static func pay_faster_everywhere_brand_is_accepted(brand: LinkBrand) -> String {
+        switch brand {
+        case .link, .unparsable:
+            return STPLocalizedString(
+                "Pay faster everywhere Link is accepted.",
+                "Subtitle for the Link signup screen"
+            )
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "Pay faster everywhere %@ is accepted.",
+                    "Subtitle for the Link signup screen. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static var new_card: String {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -482,19 +482,8 @@ extension String.Localized {
         )
     }
 
-    static func pay_faster_everywhere_brand_is_accepted(brand: LinkBrand) -> String {
-        switch brand {
-        case .link, .unparsable:
-            return existingLinkLocalizedString("Pay faster everywhere Link is accepted.")
-        case .onelink:
-            return String(
-                format: STPLocalizedString(
-                    "Pay faster everywhere %@ is accepted.",
-                    "Subtitle for the Link signup screen. The placeholder is a Stripe brand name and should not be translated."
-                ),
-                brand.displayName
-            )
-        }
+    static var link_subtitle_text: String {
+        existingLinkLocalizedString("Simple, secure one-click payments")
     }
 
     static var new_card: String {
@@ -631,7 +620,7 @@ extension String.Localized {
         case .onelink:
             return String(
                 format: STPLocalizedString(
-                    "By providing phone number and email, you agree to create a %1$@ account subject to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+                    "By providing phone number and email, you agree to create a %1$@ account subject to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
                     "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
                 ),
                 brand.displayName

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -72,8 +72,14 @@ extension String.Localized {
         STPLocalizedString("Bank account", "Title for collected bank account information")
     }
 
-    static var pay_with_link: String {
-        STPLocalizedString("Pay with Link", "Text for the 'Pay with Link' button. 'Link' is a Stripe brand, please do not translate the word 'Link'.")
+    static func pay_with_link(brand: LinkBrand) -> String {
+        String(
+            format: STPLocalizedString(
+                "Pay with %@",
+                "Text for the 'Pay with Link' button. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
     }
 
     static var bank_continue_mandate_text: String {
@@ -464,10 +470,13 @@ extension String.Localized {
         )
     }
 
-    static var link_subtitle_text: String {
-        STPLocalizedString(
-            "Simple, secure one-click payments",
-            "Subtitle shown on a button allowing a user to select to pay with Link."
+    static func pay_faster_everywhere_brand_is_accepted(brand: LinkBrand) -> String {
+        String(
+            format: STPLocalizedString(
+                "Pay faster everywhere %@ is accepted.",
+                "Subtitle for the Link signup screen. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
         )
     }
 
@@ -499,10 +508,97 @@ extension String.Localized {
         )
     }
 
-    static var by_continuing_you_agree_to_save_your_information_to_merchant_and_link: String {
-        STPLocalizedString(
-            "By continuing, you agree to save your information for future purchases with %@ and <link>Link</link> according to Link <terms>terms</terms> and <privacy>privacy</privacy>.",
-            "Text displayed below a credit card entry form when the card will be saved with the merchant and saved to Link."
+    static func by_continuing_you_agree_to_save_your_information_to_merchant_and_link(
+        merchantDisplayName: String,
+        brand: LinkBrand
+    ) -> String {
+        String(
+            format: STPLocalizedString(
+                "By continuing, you agree to save your information for future purchases with %1$@ and <link>%2$@</link> according to %2$@ <terms>terms</terms> and <privacy>privacy</privacy>.",
+                "Text displayed below a credit card entry form when the card will be saved with the merchant and saved to the Link brand. The first placeholder is a merchant name. The second placeholder is a Stripe brand name and should not be translated."
+            ),
+            merchantDisplayName,
+            brand.displayName
+        )
+    }
+
+    static func create_an_account_with_brand_for_faster_checkout_across_the_web(brand: LinkBrand) -> String {
+        String(
+            format: STPLocalizedString(
+                "Create an account with %@ for faster checkout across the web",
+                "Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
+    }
+
+    static func save_my_info_for_faster_checkout(with brand: LinkBrand) -> String {
+        String(
+            format: STPLocalizedString(
+                "Save my info for faster checkout with %@",
+                "Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
+    }
+
+    static func save_your_info_for_secure_1_click_checkout(with brand: LinkBrand) -> String {
+        String(
+            format: STPLocalizedString(
+                "Save your info for secure 1-click checkout with %@",
+                "Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
+    }
+
+    static func log_out_of_brand(_ brand: LinkBrand) -> String {
+        String(
+            format: STPLocalizedString(
+                "Log out of %@",
+                "Title of the logout action. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
+    }
+
+    static func by_joining_brand_you_agree_to_the_terms_and_privacy_policy(brand: LinkBrand) -> String {
+        String(
+            format: STPLocalizedString(
+                "By joining %@, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+                "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
+    }
+
+    static func by_providing_phone_number_and_email_you_agree_to_create_a_brand_account(brand: LinkBrand) -> String {
+        String(
+            format: STPLocalizedString(
+                "By providing phone number and email, you agree to create a %1$@ account subject to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+                "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
+    }
+
+    static func by_providing_your_email_you_agree_to_create_a_brand_account_and_save_your_payment_info(brand: LinkBrand) -> String {
+        String(
+            format: STPLocalizedString(
+                "By providing your email, you agree to create a %1$@ account and save your payment info to %1$@, according to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+                "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
+        )
+    }
+
+    static func by_providing_your_phone_number_you_agree_to_create_a_brand_account_and_save_your_payment_info(brand: LinkBrand) -> String {
+        String(
+            format: STPLocalizedString(
+                "By providing your phone number, you agree to create a %1$@ account and save your payment info to %1$@, according to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+                "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
+            ),
+            brand.displayName
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -12,6 +12,13 @@ import Foundation
 // Localized strings that are used in multiple contexts. Collected here to avoid re-translation
 // We use snake case to make long names easier to read.
 extension String.Localized {
+    private static func existingLinkLocalizedString(_ key: String) -> String {
+        STPLocalizationUtils.localizedStripeString(
+            forKey: key,
+            bundleLocator: StripePaymentSheetBundleLocator.self
+        )
+    }
+
     static var add_new_payment_method: String {
         STPLocalizedString(
             "Add new payment method",
@@ -73,13 +80,18 @@ extension String.Localized {
     }
 
     static func pay_with_link(brand: LinkBrand) -> String {
-        String(
-            format: STPLocalizedString(
-                "Pay with %@",
-                "Text for the 'Pay with Link' button. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("Pay with Link")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "Pay with %@",
+                    "Text for the 'Pay with Link' button. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static var bank_continue_mandate_text: String {
@@ -471,13 +483,18 @@ extension String.Localized {
     }
 
     static func pay_faster_everywhere_brand_is_accepted(brand: LinkBrand) -> String {
-        String(
-            format: STPLocalizedString(
-                "Pay faster everywhere %@ is accepted.",
-                "Subtitle for the Link signup screen. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("Pay faster everywhere Link is accepted.")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "Pay faster everywhere %@ is accepted.",
+                    "Subtitle for the Link signup screen. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static var new_card: String {
@@ -512,94 +529,144 @@ extension String.Localized {
         merchantDisplayName: String,
         brand: LinkBrand
     ) -> String {
-        String(
-            format: STPLocalizedString(
-                "By continuing, you agree to save your information for future purchases with %1$@ and <link>%2$@</link> according to %2$@ <terms>terms</terms> and <privacy>privacy</privacy>.",
-                "Text displayed below a credit card entry form when the card will be saved with the merchant and saved to the Link brand. The first placeholder is a merchant name. The second placeholder is a Stripe brand name and should not be translated."
-            ),
-            merchantDisplayName,
-            brand.displayName
-        )
+        switch brand {
+        case .link, .unparsable:
+            return String(
+                format: existingLinkLocalizedString(
+                    "By continuing, you agree to save your information for future purchases with %@ and <link>Link</link> according to Link <terms>terms</terms> and <privacy>privacy</privacy>."
+                ),
+                merchantDisplayName
+            )
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "By continuing, you agree to save your information for future purchases with %1$@ and <link>%2$@</link> according to %2$@ <terms>terms</terms> and <privacy>privacy</privacy>.",
+                    "Text displayed below a credit card entry form when the card will be saved with the merchant and saved to the Link brand. The first placeholder is a merchant name. The second placeholder is a Stripe brand name and should not be translated."
+                ),
+                merchantDisplayName,
+                brand.displayName
+            )
+        }
     }
 
     static func create_an_account_with_brand_for_faster_checkout_across_the_web(brand: LinkBrand) -> String {
-        String(
-            format: STPLocalizedString(
-                "Create an account with %@ for faster checkout across the web",
-                "Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("Create an account with Link for faster checkout across the web")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "Create an account with %@ for faster checkout across the web",
+                    "Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static func save_my_info_for_faster_checkout(with brand: LinkBrand) -> String {
-        String(
-            format: STPLocalizedString(
-                "Save my info for faster checkout with %@",
-                "Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("Save my info for faster checkout with Link")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "Save my info for faster checkout with %@",
+                    "Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static func save_your_info_for_secure_1_click_checkout(with brand: LinkBrand) -> String {
-        String(
-            format: STPLocalizedString(
-                "Save your info for secure 1-click checkout with %@",
-                "Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("Save your info for secure 1-click checkout with Link")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "Save your info for secure 1-click checkout with %@",
+                    "Label for a checkbox that when checked allows payment information to be saved and used in future checkout sessions. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static func log_out_of_brand(_ brand: LinkBrand) -> String {
-        String(
-            format: STPLocalizedString(
-                "Log out of %@",
-                "Title of the logout action. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("Log out of Link")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "Log out of %@",
+                    "Title of the logout action. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static func by_joining_brand_you_agree_to_the_terms_and_privacy_policy(brand: LinkBrand) -> String {
-        String(
-            format: STPLocalizedString(
-                "By joining %@, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
-                "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("By joining Link, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "By joining %@, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+                    "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static func by_providing_phone_number_and_email_you_agree_to_create_a_brand_account(brand: LinkBrand) -> String {
-        String(
-            format: STPLocalizedString(
-                "By providing phone number and email, you agree to create a %1$@ account subject to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
-                "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("By providing phone number and email, you agree to create a Link account subject to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "By providing phone number and email, you agree to create a %1$@ account subject to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+                    "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static func by_providing_your_email_you_agree_to_create_a_brand_account_and_save_your_payment_info(brand: LinkBrand) -> String {
-        String(
-            format: STPLocalizedString(
-                "By providing your email, you agree to create a %1$@ account and save your payment info to %1$@, according to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
-                "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("By providing your email, you agree to create a Link account and save your payment info to Link, according to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "By providing your email, you agree to create a %1$@ account and save your payment info to %1$@, according to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+                    "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static func by_providing_your_phone_number_you_agree_to_create_a_brand_account_and_save_your_payment_info(brand: LinkBrand) -> String {
-        String(
-            format: STPLocalizedString(
-                "By providing your phone number, you agree to create a %1$@ account and save your payment info to %1$@, according to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
-                "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
-            ),
-            brand.displayName
-        )
+        switch brand {
+        case .link, .unparsable:
+            return existingLinkLocalizedString("By providing your phone number, you agree to create a Link account and save your payment info to Link, according to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.")
+        case .onelink:
+            return String(
+                format: STPLocalizedString(
+                    "By providing your phone number, you agree to create a %1$@ account and save your payment info to %1$@, according to the %1$@ <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
+                    "Legal text shown when creating an account with the Link brand. The placeholder is a Stripe brand name and should not be translated."
+                ),
+                brand.displayName
+            )
+        }
     }
 
     static var confirm_your_cvc: String {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-SignUpViewController.swift
@@ -23,6 +23,7 @@ extension PayWithLinkViewController {
             let viewController = LinkSignUpViewController(
                 accountService: accountService,
                 linkAccount: linkAccount,
+                brand: context.configuration.resolvedLinkBrand(elementsSession: context.elementsSession),
                 country: context.elementsSession.countryCode,
                 defaultBillingDetails: context.configuration.defaultBillingDetails
             )

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -759,7 +759,7 @@ extension PayWithLinkViewController.WalletViewController: LinkPaymentMethodPicke
         actionSheet.popoverPresentationController?.sourceRect = sourceRect
 
         actionSheet.addAction(UIAlertAction(
-            title: STPLocalizedString("Log out of Link", "Title of the logout action."),
+            title: String.Localized.log_out_of_brand(context.configuration.resolvedLinkBrand(elementsSession: context.elementsSession)),
             style: .destructive,
             handler: { [weak self] _ in
                 self?.coordinator?.logout(cancel: true)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupElement.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
+@_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
 import UIKit
 
@@ -37,6 +38,7 @@ final class LinkInlineSignupElement: Element {
 
     convenience init(
         configuration: PaymentElementConfiguration,
+        brand: LinkBrand,
         linkAccount: PaymentSheetLinkAccount?,
         country: String?,
         showCheckbox: Bool,
@@ -48,6 +50,7 @@ final class LinkInlineSignupElement: Element {
     ) {
         self.init(viewModel: LinkInlineSignupViewModel(
             configuration: configuration,
+            brand: brand,
             showCheckbox: showCheckbox,
             accountService: accountService,
             allowsDefaultOptIn: allowsDefaultOptIn,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView-CheckboxElement.swift
@@ -19,6 +19,7 @@ extension LinkInlineSignupView {
         weak var delegate: ElementDelegate?
 
         private let mode: LinkInlineSignupViewModel.Mode
+        private let brand: LinkBrand
         private let merchantName: String
         private let appearance: PaymentSheet.Appearance
         /// Controls the stroke color of the checkbox
@@ -49,29 +50,11 @@ extension LinkInlineSignupView {
             let text = {
                 switch mode {
                 case .signupOptIn:
-                    return STPLocalizedString(
-                        "Create an account with Link for faster checkout across the web",
-                        """
-                        Label for a checkbox that when checked allows the payment information
-                        to be saved and used in future checkout sessions.
-                        """
-                    )
+                    return String.Localized.create_an_account_with_brand_for_faster_checkout_across_the_web(brand: brand)
                 case .checkbox, .checkboxWithDefaultOptIn:
-                    return STPLocalizedString(
-                        "Save my info for faster checkout with Link",
-                        """
-                        Label for a checkbox that when checked allows the payment information
-                        to be saved and used in future checkout sessions.
-                        """
-                    )
+                    return String.Localized.save_my_info_for_faster_checkout(with: brand)
                 case .textFieldsOnlyEmailFirst, .textFieldsOnlyPhoneFirst:
-                    return STPLocalizedString(
-                        "Save your info for secure 1-click checkout with Link",
-                        """
-                        Label for a checkbox that when checked allows the payment information
-                        to be saved and used in future checkout sessions.
-                        """
-                    )
+                    return String.Localized.save_your_info_for_secure_1_click_checkout(with: brand)
                 }
             }()
 
@@ -87,8 +70,8 @@ extension LinkInlineSignupView {
 
             let result: NSAttributedString = {
                 if let leadingIcon {
-                    // Handle the case with a Link logo
-                    let linkRange = (text as NSString).range(of: "Link")
+                    // Handle the case with a leading brand logo
+                    let linkRange = (text as NSString).range(of: brand.displayName)
                     if linkRange.location != NSNotFound {
                         let mutableResult = NSMutableAttributedString(string: text)
 
@@ -99,8 +82,7 @@ extension LinkInlineSignupView {
                             textStyle: .caption
                         )
 
-                        // Replace "Link" with the icon
-                        let attachmentString = NSAttributedString(attachment: leadingIcon)
+                        // Replace the brand name with the icon
                         mutableResult.replaceCharacters(in: linkRange, with: NSAttributedString(attachment: leadingIcon))
 
                         mutableResult.addAttributes(
@@ -149,11 +131,13 @@ extension LinkInlineSignupView {
 
         init(
             mode: LinkInlineSignupViewModel.Mode,
+            brand: LinkBrand,
             merchantName: String,
             appearance: PaymentSheet.Appearance,
             borderColor: UIColor
         ) {
             self.mode = mode
+            self.brand = brand
             self.merchantName = merchantName
             self.appearance = appearance
             self.borderColor = borderColor

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
@@ -44,6 +44,7 @@ final class LinkInlineSignupView: UIView {
 
     private(set) lazy var checkboxElement = CheckboxElement(
         mode: viewModel.mode,
+        brand: viewModel.brand,
         merchantName: viewModel.configuration.merchantDisplayName,
         appearance: viewModel.configuration.appearance,
         borderColor: borderColor
@@ -100,6 +101,7 @@ final class LinkInlineSignupView: UIView {
         }
         let legalView = LinkLegalTermsView(textAlignment: .left,
                                            mode: viewModel.mode,
+                                           brand: viewModel.brand,
                                            delegate: self)
 
         legalView.font = theme.fonts.caption

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewController.swift
@@ -62,7 +62,7 @@ final class LinkSignUpViewController: UIViewController {
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         label.textAlignment = .center
-        label.text = String.Localized.pay_faster_everywhere_brand_is_accepted(brand: brand)
+        label.text = String.Localized.link_subtitle_text
         return label
     }()
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewController.swift
@@ -62,7 +62,7 @@ final class LinkSignUpViewController: UIViewController {
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         label.textAlignment = .center
-        label.text = String.Localized.link_subtitle_text
+        label.text = String.Localized.pay_faster_everywhere_brand_is_accepted(brand: brand)
         return label
     }()
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewController.swift
@@ -33,6 +33,7 @@ final class LinkSignUpViewController: UIViewController {
 
     private let viewModel: LinkSignUpViewModel
     private let defaultBillingDetails: PaymentSheet.BillingDetails?
+    private let brand: LinkBrand
     private let theme = LinkUI.appearance.asElementsTheme
 
     private lazy var selectionBehavior: SelectionBehavior = {
@@ -61,10 +62,7 @@ final class LinkSignUpViewController: UIViewController {
         label.adjustsFontForContentSizeCategory = true
         label.numberOfLines = 0
         label.textAlignment = .center
-        label.text = STPLocalizedString(
-            "Pay faster everywhere Link is accepted.",
-            "Subtitle for the Link signup screen"
-        )
+        label.text = String.Localized.pay_faster_everywhere_brand_is_accepted(brand: brand)
         return label
     }()
 
@@ -107,7 +105,7 @@ final class LinkSignUpViewController: UIViewController {
     )
 
     private lazy var legalTermsView: LinkLegalTermsView = {
-        let legalTermsView = LinkLegalTermsView(textAlignment: .center, isStandalone: true)
+        let legalTermsView = LinkLegalTermsView(textAlignment: .center, brand: brand, isStandalone: true)
         legalTermsView.tintColor = .linkTextBrand
         legalTermsView.delegate = self
         return legalTermsView
@@ -171,6 +169,7 @@ final class LinkSignUpViewController: UIViewController {
     init(
         accountService: LinkAccountServiceProtocol,
         linkAccount: PaymentSheetLinkAccount?,
+        brand: LinkBrand = .link,
         country: String? = nil,
         defaultBillingDetails: PaymentSheet.BillingDetails?
     ) {
@@ -181,6 +180,7 @@ final class LinkSignUpViewController: UIViewController {
             country: country ?? defaultBillingDetails?.address.country
         )
         self.defaultBillingDetails = defaultBillingDetails
+        self.brand = brand
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/ViewModels/LinkInlineSignupViewModel.swift
@@ -40,6 +40,7 @@ final class LinkInlineSignupViewModel {
     private let country: String?
 
     let configuration: PaymentElementConfiguration
+    let brand: LinkBrand
 
     let mode: Mode
 
@@ -395,6 +396,7 @@ final class LinkInlineSignupViewModel {
 
     init(
         configuration: PaymentElementConfiguration,
+        brand: LinkBrand,
         showCheckbox: Bool,
         accountService: LinkAccountServiceProtocol,
         allowsDefaultOptIn: Bool,
@@ -405,6 +407,7 @@ final class LinkInlineSignupViewModel {
         analyticsHelper: PaymentSheetAnalyticsHelper? = nil
     ) {
         self.configuration = configuration
+        self.brand = brand
         self.accountService = accountService
         self.analyticsHelper = analyticsHelper
         self.linkAccount = linkAccount

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
@@ -39,6 +39,7 @@ final class LinkLegalTermsView: UIView {
 
     weak var delegate: LinkLegalTermsViewDelegate?
     private let mode: LinkInlineSignupViewModel.Mode
+    private let brand: LinkBrand
     /// If true, we're in a separate Link VC (instead of the inline PS one)
     private let isStandalone: Bool
     private let emailWasPrefilled: Bool
@@ -79,10 +80,12 @@ final class LinkLegalTermsView: UIView {
 
     init(textAlignment: NSTextAlignment = .left,
          mode: LinkInlineSignupViewModel.Mode = .checkbox,
+         brand: LinkBrand = .link,
          emailWasPrefilled: Bool = false,
          isStandalone: Bool = false,
          delegate: LinkLegalTermsViewDelegate? = nil) {
         self.mode = mode
+        self.brand = brand
         self.emailWasPrefilled = emailWasPrefilled
         self.isStandalone = isStandalone
         super.init(frame: .zero)
@@ -105,25 +108,13 @@ final class LinkLegalTermsView: UIView {
             }
             switch mode {
             case .checkbox:
-                return STPLocalizedString(
-                    "By joining Link, you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
-                    "Legal text shown when creating a Link account."
-                )
+                return String.Localized.by_joining_brand_you_agree_to_the_terms_and_privacy_policy(brand: brand)
             case .checkboxWithDefaultOptIn:
-                return STPLocalizedString(
-                    "By providing phone number and email, you agree to create a Link account subject to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
-                    "Legal text shown when creating a Link account."
-                )
+                return String.Localized.by_providing_phone_number_and_email_you_agree_to_create_a_brand_account(brand: brand)
             case .textFieldsOnlyEmailFirst:
-                return STPLocalizedString(
-                    "By providing your email, you agree to create a Link account and save your payment info to Link, according to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
-                    "Legal text shown when creating a Link account."
-                )
+                return String.Localized.by_providing_your_email_you_agree_to_create_a_brand_account_and_save_your_payment_info(brand: brand)
             case .textFieldsOnlyPhoneFirst:
-                return STPLocalizedString(
-                    "By providing your phone number, you agree to create a Link account and save your payment info to Link, according to the Link <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
-                    "Legal text shown when creating a Link account."
-                )
+                return String.Localized.by_providing_your_phone_number_you_agree_to_create_a_brand_account_and_save_your_payment_info(brand: brand)
             case .signupOptIn:
                 stpAssertionFailure("LinkLegalTermsView should not be available in signup opt-in mode")
                 return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -68,6 +68,7 @@ extension EmbeddedPaymentElement {
             appearance: configuration.appearance,
             shouldShowApplePay: shouldShowApplePay,
             shouldShowLink: shouldShowLink,
+            linkBrand: configuration.resolvedLinkBrand(elementsSession: loadResult.elementsSession),
             savedPaymentMethodAccessoryType: savedPaymentMethodAccessoryType,
             mandateProvider: mandateProvider,
             shouldShowMandate: configuration.embeddedViewDisplaysMandateText,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -316,7 +316,7 @@ class EmbeddedPaymentMethodsView: UIView {
             return
         }
 
-        var sublabel = String.Localized.pay_faster_everywhere_brand_is_accepted(brand: linkBrand)
+        var sublabel = String.Localized.link_subtitle_text
 
         if let linkAccount, linkAccount.isRegistered {
             sublabel = linkAccount.email

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -79,7 +79,6 @@ class EmbeddedPaymentMethodsView: UIView {
     private let shouldShowMandate: Bool
     private let analyticsHelper: PaymentSheetAnalyticsHelper
     private let incentive: PaymentMethodIncentive?
-    private let linkBrand: LinkBrand
     /// A bit hacky; this is the mandate text for the given payment method, *regardless* of whether it is shown in the view.
     /// It'd be better if the source of truth of mandate text was not the view and instead an independent `func mandateText(...) -> NSAttributedString` function, but this is hard b/c US Bank Account doesn't show mandate in certain states.
     var mandateText: NSAttributedString? {
@@ -133,7 +132,6 @@ class EmbeddedPaymentMethodsView: UIView {
         self.currency = currency
         self.analyticsHelper = analyticsHelper
         self.incentive = incentive
-        self.linkBrand = linkBrand
         self.delegate = delegate
         self.rowButtons = []
         super.init(frame: .zero)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -79,6 +79,7 @@ class EmbeddedPaymentMethodsView: UIView {
     private let shouldShowMandate: Bool
     private let analyticsHelper: PaymentSheetAnalyticsHelper
     private let incentive: PaymentMethodIncentive?
+    private let linkBrand: LinkBrand
     /// A bit hacky; this is the mandate text for the given payment method, *regardless* of whether it is shown in the view.
     /// It'd be better if the source of truth of mandate text was not the view and instead an independent `func mandateText(...) -> NSAttributedString` function, but this is hard b/c US Bank Account doesn't show mandate in certain states.
     var mandateText: NSAttributedString? {
@@ -114,6 +115,7 @@ class EmbeddedPaymentMethodsView: UIView {
         appearance: PaymentSheet.Appearance,
         shouldShowApplePay: Bool,
         shouldShowLink: Bool,
+        linkBrand: LinkBrand = .link,
         savedPaymentMethodAccessoryType: RowButton.RightAccessoryButton.AccessoryType?,
         mandateProvider: MandateTextProvider,
         shouldShowMandate: Bool = true,
@@ -131,6 +133,7 @@ class EmbeddedPaymentMethodsView: UIView {
         self.currency = currency
         self.analyticsHelper = analyticsHelper
         self.incentive = incentive
+        self.linkBrand = linkBrand
         self.delegate = delegate
         self.rowButtons = []
         super.init(frame: .zero)
@@ -164,7 +167,7 @@ class EmbeddedPaymentMethodsView: UIView {
         }
 
         if shouldShowLink {
-            let linkRowButton = RowButton.makeForLink(appearance: appearance, isEmbedded: true) { [weak self] rowButton in
+            let linkRowButton = RowButton.makeForLink(appearance: appearance, linkBrand: linkBrand, isEmbedded: true) { [weak self] rowButton in
                 CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: customer?.id)
                 self?.didTap(rowButton: rowButton)
             }
@@ -313,7 +316,7 @@ class EmbeddedPaymentMethodsView: UIView {
             return
         }
 
-        var sublabel = String.Localized.link_subtitle_text
+        var sublabel = String.Localized.pay_faster_everywhere_brand_is_accepted(brand: linkBrand)
 
         if let linkAccount, linkAccount.isRegistered {
             sublabel = linkAccount.email

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/MandateVariant.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/MandateVariant.swift
@@ -15,19 +15,27 @@ enum MandateVariant {
     // The updated mandate that describes reuse of the payment method by the merchant and optional Link signup.
     case updated(shouldSignUpToLink: Bool)
 
-    func create(forMerchant merchant: String) -> NSAttributedString {
+    func create(forMerchant merchant: String, brand: LinkBrand) -> NSAttributedString {
         let formatText = switch self {
         case .original:
             String.Localized.by_providing_your_card_information_text
         case .updated(let shouldSaveToLink):
             if shouldSaveToLink {
-                String.Localized.by_continuing_you_agree_to_save_your_information_to_merchant_and_link
+                String.Localized.by_continuing_you_agree_to_save_your_information_to_merchant_and_link(
+                    merchantDisplayName: merchant,
+                    brand: brand
+                )
             } else {
                 String.Localized.by_continuing_you_agree_to_save_your_information_to_merchant
             }
         }
 
-        let terms = String(format: formatText, merchant).removeTrailingDots()
+        let terms = {
+            if case .updated(true) = self {
+                return formatText.removeTrailingDots()
+            }
+            return String(format: formatText, merchant).removeTrailingDots()
+        }()
 
         if case .updated(true) = self {
             let links = [

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -143,6 +143,7 @@ extension PaymentSheetFormFactory {
             let signupOptInInitialValue = signupOptInInitialValue || previouslyHadLinkSignupSelected
             let inlineSignupElement = LinkInlineSignupElement(
                 configuration: configuration,
+                brand: linkBrand,
                 linkAccount: linkAccount,
                 country: countryCode,
                 showCheckbox: !shouldDisplaySaveCheckbox,
@@ -189,14 +190,19 @@ extension PaymentSheetFormFactory {
         let variant: MandateVariant = forceSaveFutureUseBehavior
             ? .updated(shouldSignUpToLink: shouldSignUpToLink)
             : .original
-        let mandateText = Self.makeMandateText(variant: variant, merchantName: configuration.merchantDisplayName)
+        let mandateText = Self.makeMandateText(
+            variant: variant,
+            merchantName: configuration.merchantDisplayName,
+            brand: linkBrand
+        )
         return makeMandate(mandateText: mandateText)
     }
 
     static func makeMandateText(
         variant: MandateVariant,
-        merchantName: String
+        merchantName: String,
+        brand: LinkBrand = .link
     ) -> NSAttributedString {
-        return variant.create(forMerchant: merchantName)
+        return variant.create(forMerchant: merchantName, brand: brand)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -121,6 +121,14 @@ class PaymentSheetFormFactory {
                 return .unknown
             }
         }()
+        let linkBrand: LinkBrand = {
+            switch configuration {
+            case .paymentElement(let configuration, _):
+                return configuration.resolvedLinkBrand(elementsSession: elementsSession)
+            case .customerSheet:
+                return .link
+            }
+        }()
         self.init(configuration: configuration,
                   paymentMethod: paymentMethod,
                   previousCustomerInput: previousCustomerInput,
@@ -143,14 +151,7 @@ class PaymentSheetFormFactory {
                   analyticsHelper: analyticsHelper,
                   paymentMethodIncentive: elementsSession.incentive,
                   linkAppearance: linkAppearance,
-                  linkBrand: {
-                      switch configuration {
-                      case .paymentElement(let configuration, _):
-                          return configuration.resolvedLinkBrand(elementsSession: elementsSession)
-                      case .customerSheet:
-                          return .link
-                      }
-                  }(),
+                  linkBrand: linkBrand,
                   sellerName: intent.sellerDetails?.businessName,
                   previousLinkInlineSignupAction: previousLinkInlineSignupAction,
                   cardFundingFilter: configuration.cardFundingFilter(for: elementsSession)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -29,6 +29,7 @@ class PaymentSheetFormFactory {
     let showLinkInlineCardSignup: Bool
     let linkAccount: PaymentSheetLinkAccount?
     let linkAppearance: LinkAppearance?
+    let linkBrand: LinkBrand
     let accountService: LinkAccountServiceProtocol?
     let previousCustomerInput: IntentConfirmParams?
 
@@ -142,6 +143,14 @@ class PaymentSheetFormFactory {
                   analyticsHelper: analyticsHelper,
                   paymentMethodIncentive: elementsSession.incentive,
                   linkAppearance: linkAppearance,
+                  linkBrand: {
+                      switch configuration {
+                      case .paymentElement(let configuration, _):
+                          return configuration.resolvedLinkBrand(elementsSession: elementsSession)
+                      case .customerSheet:
+                          return .link
+                      }
+                  }(),
                   sellerName: intent.sellerDetails?.businessName,
                   previousLinkInlineSignupAction: previousLinkInlineSignupAction,
                   cardFundingFilter: configuration.cardFundingFilter(for: elementsSession)
@@ -171,6 +180,7 @@ class PaymentSheetFormFactory {
         analyticsHelper: PaymentSheetAnalyticsHelper?,
         paymentMethodIncentive: PaymentMethodIncentive?,
         linkAppearance: LinkAppearance? = nil,
+        linkBrand: LinkBrand = .link,
         sellerName: String? = nil,
         previousLinkInlineSignupAction: LinkInlineSignupViewModel.Action? = nil,
         cardFundingFilter: CardFundingFilter = .default
@@ -202,6 +212,7 @@ class PaymentSheetFormFactory {
         self.analyticsHelper = analyticsHelper
         self.paymentMethodIncentive = paymentMethodIncentive
         self.linkAppearance = linkAppearance
+        self.linkBrand = linkBrand
         self.sellerName = sellerName
         self.previousLinkInlineSignupAction = previousLinkInlineSignupAction
         self.cardFundingFilter = cardFundingFilter

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -108,15 +108,6 @@ enum PaymentSheetFormFactoryConfig {
         }
     }
 
-    func resolvedLinkBrand(elementsSession: STPElementsSession) -> LinkBrand {
-        switch self {
-        case .paymentElement(let config, _):
-            return config.resolvedLinkBrand(elementsSession: elementsSession)
-        case .customerSheet:
-            return .link
-        }
-    }
-
     var linkPaymentMethodsOnly: Bool {
         switch self {
         case .paymentElement(let config, _):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactoryConfig.swift
@@ -6,6 +6,7 @@
 import Foundation
 import UIKit
 
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 
 enum PaymentSheetFormFactoryConfig {
@@ -104,6 +105,15 @@ enum PaymentSheetFormFactoryConfig {
             // CustomerSheet does not yet support card funding filtering
             // Just return the default filter (none)
             return .default
+        }
+    }
+
+    func resolvedLinkBrand(elementsSession: STPElementsSession) -> LinkBrand {
+        switch self {
+        case .paymentElement(let config, _):
+            return config.resolvedLinkBrand(elementsSession: elementsSession)
+        case .customerSheet:
+            return .link
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -468,6 +468,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
             paymentMethodTypes: paymentMethodTypes,
             shouldShowApplePay: shouldShowApplePayInList,
             shouldShowLink: shouldShowLinkInList,
+            linkBrand: configuration.resolvedLinkBrand(elementsSession: elementsSession),
             savedPaymentMethodAccessoryType: savedPaymentMethodAccessoryType,
             overrideHeaderView: makeWalletHeaderView(),
             appearance: configuration.appearance,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -543,7 +543,7 @@ extension RowButton {
     ) -> RowButton {
         let imageView = UIImageView(image: Image.link_icon.makeImage())
         imageView.contentMode = .scaleAspectFit
-        var subtext = String.Localized.pay_faster_everywhere_brand_is_accepted(brand: linkBrand)
+        var subtext = String.Localized.link_subtitle_text
         if let linkAccount = LinkAccountContext.shared.account, linkAccount.isRegistered {
             subtext = linkAccount.email
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -535,15 +535,20 @@ extension RowButton {
         return RowButton.create(appearance: appearance, type: .applePay, imageView: imageView, text: String.Localized.apple_pay, isEmbedded: isEmbedded, didTap: didTap)
     }
 
-    static func makeForLink(appearance: PaymentSheet.Appearance, isEmbedded: Bool = false, didTap: @escaping DidTapClosure) -> RowButton {
+    static func makeForLink(
+        appearance: PaymentSheet.Appearance,
+        linkBrand: LinkBrand,
+        isEmbedded: Bool = false,
+        didTap: @escaping DidTapClosure
+    ) -> RowButton {
         let imageView = UIImageView(image: Image.link_icon.makeImage())
         imageView.contentMode = .scaleAspectFit
-        var subtext = String.Localized.link_subtitle_text
+        var subtext = String.Localized.pay_faster_everywhere_brand_is_accepted(brand: linkBrand)
         if let linkAccount = LinkAccountContext.shared.account, linkAccount.isRegistered {
             subtext = linkAccount.email
         }
-        let button = RowButton.create(appearance: appearance, type: .link, imageView: imageView, text: STPPaymentMethodType.link.displayName, subtext: subtext, isEmbedded: isEmbedded, didTap: didTap)
-        button.accessibilityHelperView.accessibilityLabel = String.Localized.pay_with_link
+        let button = RowButton.create(appearance: appearance, type: .link, imageView: imageView, text: linkBrand.displayName, subtext: subtext, isEmbedded: isEmbedded, didTap: didTap)
+        button.accessibilityHelperView.accessibilityLabel = String.Localized.pay_with_link(brand: linkBrand)
         return button
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
@@ -37,6 +37,7 @@ class VerticalPaymentMethodListViewController: UIViewController {
     private var savedPaymentMethodAccessoryType: RowButton.RightAccessoryButton.AccessoryType?
     private var shouldShowApplePay: Bool
     private var shouldShowLink: Bool
+    private var linkBrand: LinkBrand
     private var paymentMethodTypes: [PaymentSheet.PaymentMethodType]
 
     required init?(coder: NSCoder) {
@@ -55,6 +56,7 @@ class VerticalPaymentMethodListViewController: UIViewController {
         paymentMethodTypes: [PaymentSheet.PaymentMethodType],
         shouldShowApplePay: Bool,
         shouldShowLink: Bool,
+        linkBrand: LinkBrand = .link,
         savedPaymentMethodAccessoryType: RowButton.RightAccessoryButton.AccessoryType?,
         overrideHeaderView: UIView?,
         appearance: PaymentSheet.Appearance,
@@ -73,6 +75,7 @@ class VerticalPaymentMethodListViewController: UIViewController {
         self.savedPaymentMethodAccessoryType = savedPaymentMethodAccessoryType
         self.shouldShowApplePay = shouldShowApplePay
         self.shouldShowLink = shouldShowLink
+        self.linkBrand = linkBrand
         self.paymentMethodTypes = paymentMethodTypes
 
         super.init(nibName: nil, bundle: nil)
@@ -141,7 +144,7 @@ class VerticalPaymentMethodListViewController: UIViewController {
         let link: RowButton? = {
             guard shouldShowLink else { return nil }
             let selection = RowButtonType.link
-            let rowButton = RowButton.makeForLink(appearance: appearance) { [weak self] in
+            let rowButton = RowButton.makeForLink(appearance: appearance, linkBrand: linkBrand) { [weak self] in
                 self?.didTap(rowButton: $0, selection: .link)
             }
             if initialSelection == selection {
@@ -222,7 +225,7 @@ class VerticalPaymentMethodListViewController: UIViewController {
             return
         }
 
-        let sublabel = linkAccount?.email ?? .Localized.link_subtitle_text
+        let sublabel = linkAccount?.email ?? .Localized.pay_faster_everywhere_brand_is_accepted(brand: linkBrand)
         linkRowButton.setSublabel(text: sublabel)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
@@ -225,7 +225,7 @@ class VerticalPaymentMethodListViewController: UIViewController {
             return
         }
 
-        let sublabel = linkAccount?.email ?? .Localized.pay_faster_everywhere_brand_is_accepted(brand: linkBrand)
+        let sublabel = linkAccount?.email ?? .Localized.link_subtitle_text
         linkRowButton.setSublabel(text: sublabel)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -240,7 +240,8 @@ extension PaymentMethodFormViewController: ElementDelegate {
             let variant = MandateVariant.updated(shouldSignUpToLink: linkSignup.viewModel.saveCheckboxChecked)
             let text = PaymentSheetFormFactory.makeMandateText(
                 variant: variant,
-                merchantName: configuration.merchantDisplayName
+                merchantName: configuration.merchantDisplayName,
+                brand: configuration.resolvedLinkBrand(elementsSession: elementsSession)
             )
             mandateElement.mandateTextView.attributedText = text
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PayWithLinkButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/PayWithLinkButton.swift
@@ -120,7 +120,7 @@ final class PayWithLinkButton: UIControl {
         linkView.font = UIFont.systemFont(ofSize: 20, weight: .medium)
             .scaled(withTextStyle: .callout, maximumPointSize: 21)
 
-        let payWithLinkString = NSMutableAttributedString(string: String.Localized.pay_with_link)
+        let payWithLinkString = NSMutableAttributedString(string: String.Localized.pay_with_link(brand: brand))
 
         // Create the Link logo attachment
         let linkImage = primaryLinkLogoImage
@@ -136,13 +136,13 @@ final class PayWithLinkButton: UIControl {
         linkAttachment.bounds = CGRect(x: 0, y: -linkY, width: linkLogoHeight * linkLogoRatio, height: linkLogoHeight)
 
         // Add a spacer before the Link logo and after the Link logo
-        let range = payWithLinkString.mutableString.range(of: "Link")
+        let range = payWithLinkString.mutableString.range(of: brand.displayName)
         if range.location != NSNotFound {
             payWithLinkString.insert(Self.makeSpacerString(width: 1), at: range.location + range.length)
             payWithLinkString.insert(Self.makeSpacerString(width: 1), at: range.location)
 
             // Add the Link attachment
-            payWithLinkString.replaceOccurrences(of: "Link", with: linkAttachment)
+            payWithLinkString.replaceOccurrences(of: brand.displayName, with: linkAttachment)
         }
 
         linkView.attributedText = payWithLinkString
@@ -449,7 +449,7 @@ private extension PayWithLinkButton {
         }
 
         // To use Xcode SwiftUI Previews, comment out the following `accessibilityLabel` setter:
-        accessibilityLabel = String.Localized.pay_with_link
+        accessibilityLabel = String.Localized.pay_with_link(brand: brand)
 
         switch linkAccountState {
         case .hasCard(let last4, let brand):

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FormMandateProviderTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FormMandateProviderTests.swift
@@ -169,4 +169,17 @@ class FormMandateProviderTests: XCTestCase {
         XCTAssertNil(result)
     }
 
+    func testMakeMandateText_usesProvidedBrandName() {
+        let result = PaymentSheetFormFactory.makeMandateText(
+            variant: .updated(shouldSignUpToLink: true),
+            merchantName: "Test Merchant",
+            brand: .onelink
+        )
+
+        XCTAssertEqual(
+            result.string,
+            "By continuing, you agree to save your information for future purchases with Test Merchant and Onelink according to Onelink terms and privacy."
+        )
+    }
+
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkSignUpViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkSignUpViewControllerSnapshotTests.swift
@@ -76,6 +76,7 @@ extension LinkSignUpViewControllerSnapshotTests {
         return LinkSignUpViewController(
             accountService: LinkAccountService(elementsSession: elementsSession),
             linkAccount: linkAccount,
+            brand: .link,
             defaultBillingDetails: nil
         )
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PayWithLinkButtonTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PayWithLinkButtonTests.swift
@@ -58,6 +58,14 @@ final class PayWithLinkButtonTests: XCTestCase {
         XCTAssertEqual(String.Localized.pay_with_link(brand: .onelink), "Pay with Onelink")
         XCTAssertEqual(String.Localized.link_subtitle_text, "Simple, secure one-click payments")
         XCTAssertEqual(
+            String.Localized.pay_faster_everywhere_brand_is_accepted(brand: .link),
+            "Pay faster everywhere Link is accepted."
+        )
+        XCTAssertEqual(
+            String.Localized.pay_faster_everywhere_brand_is_accepted(brand: .onelink),
+            "Pay faster everywhere Onelink is accepted."
+        )
+        XCTAssertEqual(
             String.Localized.save_my_info_for_faster_checkout(with: .onelink),
             "Save my info for faster checkout with Onelink"
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PayWithLinkButtonTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PayWithLinkButtonTests.swift
@@ -42,8 +42,28 @@ final class PayWithLinkButtonTests: XCTestCase {
 
         XCTAssertEqual(onelinkButton.brand, .onelink)
         XCTAssertTrue(linkButton.backgroundColor?.isEqual(onelinkButton.backgroundColor) ?? false)
-        XCTAssertEqual(linkButton.accessibilityLabel, onelinkButton.accessibilityLabel)
         XCTAssertEqual(linkButton.intrinsicContentSize, onelinkButton.intrinsicContentSize)
+    }
+
+    func testBrandUpdatesAccessibilityLabel() {
+        let linkButton = PayWithLinkButton(brand: .link)
+        let onelinkButton = PayWithLinkButton(brand: .onelink)
+
+        XCTAssertEqual(linkButton.accessibilityLabel, "Pay with Link")
+        XCTAssertEqual(onelinkButton.accessibilityLabel, "Pay with Onelink")
+    }
+
+    func testLocalizedBrandStrings_useProvidedBrandDisplayName() {
+        XCTAssertEqual(String.Localized.pay_with_link(brand: .link), "Pay with Link")
+        XCTAssertEqual(String.Localized.pay_with_link(brand: .onelink), "Pay with Onelink")
+        XCTAssertEqual(
+            String.Localized.pay_faster_everywhere_brand_is_accepted(brand: .onelink),
+            "Pay faster everywhere Onelink is accepted."
+        )
+        XCTAssertEqual(
+            String.Localized.save_my_info_for_faster_checkout(with: .onelink),
+            "Save my info for faster checkout with Onelink"
+        )
     }
 
     func testLoggedInStateSizesLogoViewToMatchBrandAsset() throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PayWithLinkButtonTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PayWithLinkButtonTests.swift
@@ -56,10 +56,7 @@ final class PayWithLinkButtonTests: XCTestCase {
     func testLocalizedBrandStrings_useProvidedBrandDisplayName() {
         XCTAssertEqual(String.Localized.pay_with_link(brand: .link), "Pay with Link")
         XCTAssertEqual(String.Localized.pay_with_link(brand: .onelink), "Pay with Onelink")
-        XCTAssertEqual(
-            String.Localized.pay_faster_everywhere_brand_is_accepted(brand: .onelink),
-            "Pay faster everywhere Onelink is accepted."
-        )
+        XCTAssertEqual(String.Localized.link_subtitle_text, "Simple, secure one-click payments")
         XCTAssertEqual(
             String.Localized.save_my_info_for_faster_checkout(with: .onelink),
             "Save my info for faster checkout with Onelink"


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Replace existing branded strings to use a placeholder that accommodates `LinkBrand` value. Remaining strings that require more refactoring/threading will be replaced in a future PR

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/LINK_MOBILE-853

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Modified and added tests to check if strings are branded correctly.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
