### PR TITLE
Fix case compare with CPMs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ MINOR
 
 ## X.Y.Z - changes pending release
 
+### PaymentSheet
+* [Fixed] Fixed an issue where `paymentMethodOrder` did not apply to custom payment methods due to case-sensitive matching.
+
 ## 25.12.0 2026-04-27
 ### Identity
 * [Improved] Improved StripeIdentity analytics with richer error details and screen/camera context to help debug verification flows.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -249,7 +249,7 @@ extension PaymentSheet {
                 recommendedPaymentMethodTypes.append(.linkCardBrand)
             }
 
-            if let merchantPaymentMethodOrder = configuration.paymentMethodOrder?.map({ $0.lowercased() }) {
+            if let merchantPaymentMethodOrder = configuration.paymentMethodOrder {
                 // Order the payment methods according to the merchant's `paymentMethodOrder` configuration:
                 var reorderedPaymentMethodTypes = [PaymentMethodType]()
 
@@ -257,7 +257,7 @@ extension PaymentSheet {
                 for pmIdentifier in merchantPaymentMethodOrder {
                     guard
                         // Ignore the PM if it's not in allPaymentMethodTypes
-                        let index = recommendedPaymentMethodTypes.firstIndex(where: { $0.identifier == pmIdentifier }),
+                        let index = recommendedPaymentMethodTypes.firstIndex(where: { $0.identifier.caseInsensitiveCompare(pmIdentifier) == .orderedSame }),
                         let paymentMethod = recommendedPaymentMethodTypes.stp_boundSafeObject(at: index),
                         // Ignore duplicate PMs
                         !reorderedPaymentMethodTypes.contains(paymentMethod)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetPaymentMethodTypeTest.swift
@@ -916,6 +916,49 @@ class PaymentSheetPaymentMethodTypeTest: XCTestCase {
             ["ideal", "card", "bancontact", "external_paypal"]
         )
     }
+
+    func testPaymentMethodOrderWithCustomPaymentMethods() {
+        let cpmId = "cpmt_1Qzj4rFY0qyl6XeWoHB842bf"
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive()
+        configuration.customPaymentMethodConfiguration = .init(
+            customPaymentMethods: [.init(id: cpmId)],
+            customPaymentMethodConfirmHandler: { _, _ in
+                XCTFail()
+                return .canceled
+            }
+        )
+
+        let elementsSession = STPElementsSession._testValue(
+            orderedPaymentMethodTypes: [.card],
+            customPaymentMethods: [
+                CustomPaymentMethod(
+                    displayName: "Test CPM",
+                    type: cpmId,
+                    logoUrl: URL(string: "https://test.com")!,
+                    isPreset: false,
+                    error: nil
+                ),
+            ]
+        )
+
+        let intent = Intent.deferredIntent(
+            intentConfig: .init(mode: .payment(amount: 1010, currency: "USD"), confirmHandler: { _, _ in return "" })
+        )
+
+        // Mixed-case CPM id in paymentMethodOrder is matched correctly
+        configuration.paymentMethodOrder = [cpmId, "card"]
+        XCTAssertEqual(
+            PaymentSheet.PaymentMethodType.filteredPaymentMethodTypes(from: intent, elementsSession: elementsSession, configuration: configuration).map { $0.identifier },
+            [cpmId, "card"]
+        )
+
+        // Reversed order works too
+        configuration.paymentMethodOrder = ["card", cpmId]
+        XCTAssertEqual(
+            PaymentSheet.PaymentMethodType.filteredPaymentMethodTypes(from: intent, elementsSession: elementsSession, configuration: configuration).map { $0.identifier },
+            ["card", cpmId]
+        )
+    }
 }
 
 extension STPFixtures {


### PR DESCRIPTION
## Summary
- Fixes an issue where CPMs were not ordered properly with the API override.

## Motivation
- https://jira.corp.stripe.com/browse/MOBILESDK-4467

## Testing
- Manual
- New unit test

## Changelog
- See diff
