### PR TITLE
RUN_MOBILESDK-5139: Replace verbose server errors with generic messages in live mode

### DIFF
--- a/Stripe/StripeiOSTests/Error+PaymentSheetTests.swift
+++ b/Stripe/StripeiOSTests/Error+PaymentSheetTests.swift
@@ -55,20 +55,58 @@ class Error_PaymentSheetTests: XCTestCase {
         XCTAssertEqual("Your card was declined.", error.nonGenericDescription)
     }
 
-    func testError_InvalidRequestError_ShowsGenericMessage() {
-        // Simulates an invalid_request_error from the Stripe API (e.g. disabled Connect account).
-        // These are developer-facing and should never be shown to end users.
+    func testError_InvalidRequestError_LiveMode_ShowsGenericMessageWithRequestId() {
+        // Non-card errors in live mode should show a generic message with the request ID.
+        let httpResponse = HTTPURLResponse(
+            url: URL(string: "https://api.stripe.com")!,
+            statusCode: 400,
+            httpVersion: nil,
+            headerFields: ["request-id": "req_livetest123"]
+        )
+        let intent: [String: Any] = ["object": "payment_intent", "livemode": true]
         let error = NSError.stp_error(
             errorType: "invalid_request_error",
             stripeErrorCode: nil,
             stripeErrorMessage: "This Connect account cannot currently make live charges.",
             errorParam: nil,
             declineCode: nil,
-            intent: nil,
+            intent: intent,
+            httpResponse: httpResponse
+        )
+
+        XCTAssertEqual("Something went wrong. Request ID: req_livetest123", error.nonGenericDescription)
+    }
+
+    func testError_InvalidRequestError_LiveMode_NoRequestId_ShowsGenericFallback() {
+        // Non-card errors in live mode without a request ID fall back to the generic error string.
+        let intent: [String: Any] = ["object": "payment_intent", "livemode": true]
+        let error = NSError.stp_error(
+            errorType: "invalid_request_error",
+            stripeErrorCode: nil,
+            stripeErrorMessage: "This Connect account cannot currently make live charges.",
+            errorParam: nil,
+            declineCode: nil,
+            intent: intent,
             httpResponse: nil
         )
 
         XCTAssertEqual(NSError.stp_unexpectedErrorMessage(), error.nonGenericDescription)
+    }
+
+    func testError_InvalidRequestError_TestMode_ShowsRawMessage() {
+        // Non-card errors in test mode preserve the raw server message so developers can diagnose issues.
+        let intent: [String: Any] = ["object": "payment_intent", "livemode": false]
+        let error = NSError.stp_error(
+            errorType: "invalid_request_error",
+            stripeErrorCode: nil,
+            stripeErrorMessage: "This Connect account cannot currently make live charges.",
+            errorParam: nil,
+            declineCode: nil,
+            intent: intent,
+            httpResponse: nil
+        )
+
+        XCTAssertEqual("This Connect account cannot currently make live charges.", error.nonGenericDescription)
     }
 
     func testError_NoErrorType_ShowsMessage() {
@@ -87,6 +125,22 @@ class Error_PaymentSheetTests: XCTestCase {
     }
 
     // MARK: - PaymentHandler wrapped errors (from STPPaymentHandler confirmation flow)
+
+    func testError_CardError_LiveMode_StillShowsCardMessage() {
+        // card_error messages should always be shown regardless of live/test mode.
+        let intent: [String: Any] = ["object": "payment_intent", "livemode": true]
+        let error = NSError.stp_error(
+            errorType: "card_error",
+            stripeErrorCode: "card_declined",
+            stripeErrorMessage: "Your card was declined.",
+            errorParam: nil,
+            declineCode: nil,
+            intent: intent,
+            httpResponse: nil
+        )
+
+        XCTAssertEqual("Your card was declined.", error.nonGenericDescription)
+    }
 
     func testError_PaymentHandlerWrapped_CardError_ShowsMessage() {
         // Simulates STPPaymentHandler wrapping a card_error API response as NSUnderlyingError
@@ -109,16 +163,17 @@ class Error_PaymentSheetTests: XCTestCase {
         XCTAssertEqual("Your card has insufficient funds.", error.nonGenericDescription)
     }
 
-    func testError_PaymentHandlerWrapped_NonCardError_ShowsGenericMessage() {
+    func testError_PaymentHandlerWrapped_NonCardError_LiveMode_ShowsGenericMessage() {
         // Simulates STPPaymentHandler wrapping an invalid_request_error as NSUnderlyingError
-        // (e.g. disabled Connect account error during confirmation).
+        // (e.g. disabled Connect account error during confirmation) in live mode.
+        let intent: [String: Any] = ["object": "payment_intent", "livemode": true]
         let underlyingError = NSError.stp_error(
             errorType: "invalid_request_error",
             stripeErrorCode: nil,
             stripeErrorMessage: "This Connect account cannot currently make live charges.",
             errorParam: nil,
             declineCode: nil,
-            intent: nil,
+            intent: intent,
             httpResponse: nil
         )
         let error = NSError(
@@ -128,6 +183,28 @@ class Error_PaymentSheetTests: XCTestCase {
         )
 
         XCTAssertEqual(NSError.stp_unexpectedErrorMessage(), error.nonGenericDescription)
+    }
+
+    func testError_PaymentHandlerWrapped_NonCardError_TestMode_ShowsRawMessage() {
+        // Simulates STPPaymentHandler wrapping an invalid_request_error as NSUnderlyingError
+        // in test mode; the raw server message is preserved for developer debugging.
+        let intent: [String: Any] = ["object": "payment_intent", "livemode": false]
+        let underlyingError = NSError.stp_error(
+            errorType: "invalid_request_error",
+            stripeErrorCode: nil,
+            stripeErrorMessage: "This Connect account cannot currently make live charges.",
+            errorParam: nil,
+            declineCode: nil,
+            intent: intent,
+            httpResponse: nil
+        )
+        let error = NSError(
+            domain: "STPPaymentHandlerErrorDomain",
+            code: 2,
+            userInfo: [NSUnderlyingErrorKey: underlyingError]
+        )
+
+        XCTAssertEqual("This Connect account cannot currently make live charges.", error.nonGenericDescription)
     }
 
     // MARK: - Non-generic localizedDescription

--- a/StripeCore/StripeCore/Source/Helpers/STPError.swift
+++ b/StripeCore/StripeCore/Source/Helpers/STPError.swift
@@ -76,6 +76,9 @@ import Foundation
     /// The HTTP status code of the failed request as an Int e.g. 400.
     @objc public static let httpStatusCodeKey = "com.stripe.lib:HTTPStatusCodeKey"
 
+    /// Whether the error occurred in live mode. `true` for live mode, `false` for test mode.
+    @objc public static let stripeLivemodeKey = "com.stripe.lib:LivemodeKey"
+
     /// Returns a localized user-facing message for a given error code.
     /// This method can be used to display an appropriate error message to the user.
     /// - Parameter errorCode: The error code string from Stripe API (e.g., "incorrect_number", "card_declined")
@@ -217,6 +220,11 @@ extension NSError {
         if let intent = intent,
            let type = intent["object"] as? String {
             userInfo[type] = intent
+        }
+
+        // stripeLivemodeKey
+        if let livemode = intent?["livemode"] as? Bool {
+            userInfo[STPError.stripeLivemodeKey] = livemode
         }
 
         // code

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -540,3 +540,6 @@ the heading the screen itself. */
 /* An error message. */
 "Your IBAN should start with a two-letter country code." = "Your IBAN should start with a two-letter country code.";
 
+/* Error message shown to the user in live mode for non-card API errors, including the request ID for support reference. */
+"Something went wrong. Request ID: %@" = "Something went wrong. Request ID: %@";
+

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Error+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Error+PaymentSheet.swift
@@ -34,16 +34,36 @@ extension Error {
 }
 
 private extension NSError {
-    /// Returns `errorMessageKey` only when the error is a `card_error`, which per Stripe API docs
-    /// is safe to display to end users. All other error types (e.g. `invalid_request_error`)
-    /// contain developer-facing details and fall back to the generic message.
-    /// When `stripeErrorTypeKey` is absent (e.g. SDK-internal connection errors), the message
-    /// is assumed to be intentionally user-facing.
+    /// Returns a user-safe error message applying live/test mode rules:
+    /// - `card_error`: always shows the raw card message (safe per Stripe API docs).
+    /// - Non-card errors in **live mode**: shows a generic message. If a request ID is
+    ///   available it is appended ("Something went wrong. Request ID: req_xxx") so users
+    ///   can reference it with support; otherwise falls back to the generic unexpected-error string.
+    /// - Non-card errors in **test mode**: preserves the raw server message so developers
+    ///   can diagnose issues during integration.
+    /// - When `stripeErrorTypeKey` is absent (e.g. SDK-internal connection errors), the
+    ///   message is assumed to be intentionally user-facing and is returned as-is.
     var userSafeErrorMessage: String {
         let errorType = userInfo[STPError.stripeErrorTypeKey] as? String
-        if let errorType, errorType != "card_error" {
+        guard let errorType else {
+            return userInfo[STPError.errorMessageKey] as? String ?? NSError.stp_unexpectedErrorMessage()
+        }
+        guard errorType != "card_error" else {
+            return userInfo[STPError.errorMessageKey] as? String ?? NSError.stp_unexpectedErrorMessage()
+        }
+        // Non-card server error: apply live/test-mode logic.
+        let isLiveMode = userInfo[STPError.stripeLivemodeKey] as? Bool ?? false
+        if isLiveMode {
+            if let requestId = userInfo[STPError.stripeRequestIDKey] as? String {
+                let format = STPLocalizedString(
+                    "Something went wrong. Request ID: %@",
+                    "Error message shown to the user in live mode for non-card API errors, including the request ID for support reference."
+                )
+                return String(format: format, requestId)
+            }
             return NSError.stp_unexpectedErrorMessage()
         }
+        // Test mode: preserve the raw server message to aid developer debugging.
         return userInfo[STPError.errorMessageKey] as? String ?? NSError.stp_unexpectedErrorMessage()
     }
 }


### PR DESCRIPTION
## Summary
- In live mode, non-card API errors now show "Something went wrong. Request ID: req_xxx" instead of raw server messages (e.g. "This Connect account cannot currently make live charges...")
- In test mode, raw server messages are preserved for developer debugging
- card_error messages continue to be shown as-is in all modes (safe per Stripe API docs)

Mirrors Android parity from stripe-android PR #12431.

## Fixes
- [RUN_MOBILESDK-5139](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5139) — [iOS] Replace verbose server-side errors with more generic user friendly errors
- Related: [RUN_MOBILESDK-5326](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5326) — PaymentSheet displays raw API error messages (fixed in #6370; this PR builds on that fix by adding live/test mode differentiation and request ID)

## Changes
- **STPError.swift**: Add `stripeLivemodeKey`; store `livemode` from intent dictionary in error userInfo
- **Error+PaymentSheet.swift**: Branch `userSafeErrorMessage` on live/test mode for non-card errors
- **en.lproj/Localizable.strings**: Add localization key for "Something went wrong. Request ID: %@"
- **Error+PaymentSheetTests.swift**: Expand from 7 to 12 tests covering live/test mode scenarios

## Test plan
- [x] All 12 unit tests pass (live mode with/without request ID, test mode, card_error in live mode, PaymentHandler wrapped errors in both modes)
- [x] StripePaymentSheet build succeeds
- [x] Lint and format checks pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)