### PR TITLE
Fix VerticalPaymentMethodListViewControllerSnapshotTest flake

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewControllerSnapshotTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewControllerSnapshotTest.swift
@@ -50,7 +50,11 @@ final class VerticalPaymentMethodListViewControllerSnapshotTest: STPSnapshotTest
 
     override func setUp() {
         super.setUp()
-        DownloadManager.sharedManager.resetCache()
+        let expectation = expectation(description: "Load specs")
+        FormSpecProvider.shared.load { _ in
+            expectation.fulfill()
+        }
+        waitForExpectations(timeout: 1)
     }
 
     func testNoSavedPM_noApplePayLink() {


### PR DESCRIPTION
## Summary
- Fixes `testNoSavedPM_noApplePayLink` flaking ~32% of the time
- Root cause: `DownloadManager.sharedManager.resetCache()` in setUp cleared the in-memory image cache, but `URLCache.removeAllCachedResponses()` is asynchronous. This meant `promoteFromDiskCache()` would non-deterministically find or miss cached images depending on eviction timing, causing the snapshot to sometimes capture downloaded (server) images vs local bundled images.
- Fix: Replace `resetCache()` with deterministic `FormSpecProvider.shared.load()`. This ensures FormSpecProvider is always loaded (removing dependence on test ordering from other test classes) and the in-memory image cache is not cleared, so images are served from a consistent source.

## Jira
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5309

## Test plan
- [x] Verified build compiles successfully
- [ ] CI snapshot tests pass without re-recording reference images (the local bundled placeholder is returned synchronously for the snapshot in all cases)
- [ ] Confirm no more flakes on subsequent CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)