### PR TITLE
Add `LinkController.present` API & demo

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
@@ -53,6 +53,14 @@ struct ExampleLinkControllerView: View {
                                 .focused($isEmailFieldFocused)
                         }
 
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Phone Number (optional)")
+                                .font(.subheadline)
+                            TextField("Enter phone number (E.164 format)", text: $phone)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .keyboardType(.phonePad)
+                        }
+
                         if userExists == false {
                             VStack(alignment: .leading, spacing: 8) {
                                 Text("Full Name")
@@ -83,6 +91,34 @@ struct ExampleLinkControllerView: View {
                     .padding()
                     .background(Color.gray.opacity(0.1))
                     .cornerRadius(8)
+                    
+                    // Payment Method Types Configuration
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("Supported Payment Method Types")
+                            .font(.headline)
+
+                        VStack(spacing: 8) {
+                            ForEach(LinkPaymentMethodType.allCases, id: \.self) { paymentMethodType in
+                                HStack {
+                                    Button(action: {
+                                        togglePaymentMethodType(paymentMethodType)
+                                    }) {
+                                        HStack {
+                                            Image(systemName: selectedPaymentMethodTypes.contains(paymentMethodType) ? "checkmark.square.fill" : "square")
+                                                .foregroundColor(selectedPaymentMethodTypes.contains(paymentMethodType) ? .blue : .gray)
+                                            Text(paymentMethodType.displayName)
+                                                .foregroundColor(.primary)
+                                            Spacer()
+                                        }
+                                    }
+                                    .buttonStyle(PlainButtonStyle())
+                                }
+                            }
+                        }
+                    }
+                    .padding()
+                    .background(Color.gray.opacity(0.1))
+                    .cornerRadius(8)
 
                     // User Lookup Section
                     VStack(spacing: 12) {
@@ -98,40 +134,12 @@ struct ExampleLinkControllerView: View {
 
                     // Action Buttons
                     VStack(spacing: 12) {
+                        presentButton
+
                         registerNewUserButton
                         verifyUserButton
 
                         collectPaymentMethodButton
-
-                        // Payment Method Types Configuration - only show when user lookup has been performed
-                        if userExists != nil {
-                            VStack(alignment: .leading, spacing: 16) {
-                                Text("Supported Payment Method Types")
-                                    .font(.headline)
-
-                                VStack(spacing: 8) {
-                                    ForEach(LinkPaymentMethodType.allCases, id: \.self) { paymentMethodType in
-                                        HStack {
-                                            Button(action: {
-                                                togglePaymentMethodType(paymentMethodType)
-                                            }) {
-                                                HStack {
-                                                    Image(systemName: selectedPaymentMethodTypes.contains(paymentMethodType) ? "checkmark.square.fill" : "square")
-                                                        .foregroundColor(selectedPaymentMethodTypes.contains(paymentMethodType) ? .blue : .gray)
-                                                    Text(paymentMethodType.displayName)
-                                                        .foregroundColor(.primary)
-                                                    Spacer()
-                                                }
-                                            }
-                                            .buttonStyle(PlainButtonStyle())
-                                        }
-                                    }
-                                }
-                            }
-                            .padding()
-                            .background(Color.gray.opacity(0.1))
-                            .cornerRadius(8)
-                        }
 
                         createPaymentMethodButton
 
@@ -284,6 +292,15 @@ struct ExampleLinkControllerView: View {
             .buttonStyle(SecondaryButtonStyle())
             .disabled(isLoading)
         }
+    }
+
+    @ViewBuilder
+    private var presentButton: some View {
+        Button("Present") {
+            Task { await presentLinkFlow() }
+        }
+        .buttonStyle(PrimaryButtonStyle())
+        .disabled(isLoading)
     }
 
     @ViewBuilder
@@ -486,6 +503,55 @@ struct ExampleLinkControllerView: View {
                 self.statusMessage = "Payment method collected successfully"
             } else {
                 self.statusMessage = "Payment method collection canceled"
+            }
+        }
+    }
+
+    private func presentLinkFlow() async {
+        guard let linkController else {
+            await MainActor.run {
+                self.errorMessage = "LinkController not initialized"
+            }
+            return
+        }
+
+        await MainActor.run {
+            self.isEmailFieldFocused = false
+            self.isLoading = true
+            self.errorMessage = nil
+            self.statusMessage = "Presenting Link flow..."
+        }
+
+        guard let rootViewController = findViewController() else {
+            await MainActor.run {
+                self.isLoading = false
+                self.errorMessage = "Could not find root view controller"
+                self.statusMessage = nil
+            }
+            return
+        }
+
+        do {
+            let result = try await linkController.present(
+                email: email,
+                phoneNumber: phone.isEmpty ? nil : phone,
+                supportedPaymentMethodTypes: Array(selectedPaymentMethodTypes),
+                from: rootViewController
+            )
+            await MainActor.run {
+                self.isLoading = false
+                switch result {
+                case .completed(let paymentMethod):
+                    self.statusMessage = "Payment method created (ID: \(paymentMethod.stripeId))"
+                case .canceled:
+                    self.statusMessage = "Present flow canceled"
+                }
+            }
+        } catch {
+            await MainActor.run {
+                self.isLoading = false
+                self.errorMessage = "Present flow failed: \(error.localizedDescription)"
+                self.statusMessage = nil
             }
         }
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
@@ -91,7 +91,7 @@ struct ExampleLinkControllerView: View {
                     .padding()
                     .background(Color.gray.opacity(0.1))
                     .cornerRadius(8)
-                    
+
                     // Payment Method Types Configuration
                     VStack(alignment: .leading, spacing: 16) {
                         Text("Supported Payment Method Types")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -49,6 +49,13 @@ import UIKit
         case canceled
     }
 
+    @frozen @_spi(STP) public enum PaymentMethodResult {
+        /// The user selected a payment method. The associated value is the resulting `STPPaymentMethod`.
+        case completed(STPPaymentMethod)
+        /// The user dismissed the flow without selecting a payment method.
+        case canceled
+    }
+
     @frozen @_spi(STP) public enum AuthorizationResult {
         /// Authorization was consented by the user.
         case consented
@@ -401,6 +408,81 @@ import UIKit
 
             self?.internalPaymentOption = .link(option: confirmOption)
             completion(true)
+        }
+    }
+
+    /// Presents the full Link payment method selection flow, handling lookup, authentication or signup,
+    /// wallet display, and payment method creation in a single call.
+    ///
+    /// Under the hood, this method:
+    /// 1. Looks up the consumer by email, unless an authenticated session for that email already exists.
+    /// 2. Presents the Link sheet, routing to signup, OTP verification, or the wallet based on account state.
+    ///    If `phoneNumber` is provided, it is prefilled in the signup form.
+    /// 3. Once the user selects a payment method, converts the selection to an `STPPaymentMethod`.
+    ///
+    /// - Parameter email: The email address to look up and associate with the Link account.
+    /// - Parameter phoneNumber: Optional phone number in E.164 format to prefill during signup.
+    /// - Parameter supportedPaymentMethodTypes: The payment method types to support. If `nil`, all available types are shown.
+    /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
+    /// - Parameter completion: A closure called with `.success(.completed(paymentMethod))` on selection,
+    ///   `.success(.canceled)` if the user dismisses the flow, or `.failure(error)` on API or network errors.
+    @_spi(STP) public func present(
+        email: String,
+        phoneNumber: String? = nil,
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
+        from presentingViewController: UIViewController,
+        completion: @escaping (Result<PaymentMethodResult, Error>) -> Void
+    ) {
+        let alreadyAuthenticated = linkAccount?.sessionState == .verified
+            && linkAccount?.email.lowercased() == email.lowercased()
+
+        let presentWallet = { [weak self] in
+            guard let self else { return }
+            var configuration = self.configuration
+            configuration.defaultBillingDetails.email = email
+            if let phoneNumber {
+                configuration.defaultBillingDetails.phone = phoneNumber
+            }
+
+            presentingViewController.presentNativeLink(
+                selectedPaymentDetailsID: nil,
+                configuration: configuration,
+                intent: self.intent,
+                elementsSession: self.elementsSession,
+                analyticsHelper: self.analyticsHelper,
+                supportedPaymentMethodTypes: supportedPaymentMethodTypes,
+                linkAppearance: self.appearance,
+                linkConfiguration: self.linkConfiguration,
+                shouldShowSecondaryCta: false
+            ) { [weak self] confirmOption, _ in
+                guard let self else { return }
+                guard let confirmOption else {
+                    completion(.success(.canceled))
+                    return
+                }
+                self.internalPaymentOption = .link(option: confirmOption)
+                self.createPaymentMethod { result in
+                    switch result {
+                    case .success(let paymentMethod):
+                        completion(.success(.completed(paymentMethod)))
+                    case .failure(let error):
+                        completion(.failure(error))
+                    }
+                }
+            }
+        }
+
+        if alreadyAuthenticated {
+            presentWallet()
+        } else {
+            lookupConsumer(with: email) { result in
+                switch result {
+                case .failure(let error):
+                    completion(.failure(error))
+                case .success:
+                    presentWallet()
+                }
+            }
         }
     }
 
@@ -1086,6 +1168,44 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
                 switch result {
                 case .success:
                     continuation.resume(returning: ())
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Presents the full Link payment method selection flow, handling lookup, authentication or signup,
+    /// wallet display, and payment method creation in a single call.
+    ///
+    /// Under the hood, this method:
+    /// 1. Looks up the consumer by email.
+    /// 2. Presents the Link sheet, routing to signup, OTP verification, or the wallet based on account state.
+    ///    If `phoneNumber` is provided, it is prefilled in the signup form.
+    /// 3. Once the user selects a payment method, converts the selection to an `STPPaymentMethod`.
+    ///
+    /// - Parameter email: The email address to look up and associate with the Link account.
+    /// - Parameter phoneNumber: Optional phone number in E.164 format to prefill during signup.
+    /// - Parameter supportedPaymentMethodTypes: The payment method types to support. If `nil`, all available types are shown.
+    /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
+    /// - Returns: `.completed(paymentMethod)` on selection, or `.canceled` if the user dismisses the flow.
+    /// - Throws: An error if the lookup or payment method creation fails.
+    func present(
+        email: String,
+        phoneNumber: String? = nil,
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
+        from presentingViewController: UIViewController
+    ) async throws -> PaymentMethodResult {
+        try await withCheckedThrowingContinuation { continuation in
+            present(
+                email: email,
+                phoneNumber: phoneNumber,
+                supportedPaymentMethodTypes: supportedPaymentMethodTypes,
+                from: presentingViewController
+            ) { result in
+                switch result {
+                case .success(let paymentMethodResult):
+                    continuation.resume(returning: paymentMethodResult)
                 case .failure(let error):
                     continuation.resume(throwing: error)
                 }


### PR DESCRIPTION
## Summary

Adds a new internally-public `present` API for the `LinkController` that handles:
1. Consumer lookup
2. Authentication
3. Payment method selection
4. Payment method creation

Full implementation plan is here: https://git.corp.stripe.com/gist/mats/dfd8299b4382fca63e18a98baf835099

This currently has no usage, besides the LinkController demo app.

## Motivation

https://docs.google.com/document/d/1b5gHtHsxE2Rl_YXvcJswcfPz2P0AtRSciAvpaqa_WKk/edit?tab=t.0#bookmark=id.v6evombxv9i3

## Testing

https://github.com/user-attachments/assets/a88cd7f2-c9e7-463e-b969-d341a5887a9d


## Changelog

N/a
