### PR TITLE
Allow for Optional Data Access Notice for Native FC OAuth

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsOAuthPrepane.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsOAuthPrepane.swift
@@ -16,6 +16,8 @@ struct FinancialConnectionsOAuthPrepane: Decodable {
     let body: OauthPrepaneBody
     let partnerNotice: OauthPrepanePartnerNotice?
     let cta: OauthPrepaneCTA
+
+    /// v25.13.0 and earlier (~May 2026) expect this field to be non-optional
     let dataAccessNotice: FinancialConnectionsDataAccessNotice?
 
     struct OauthPrepaneBody: Decodable {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsOAuthPrepane.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsOAuthPrepane.swift
@@ -16,7 +16,7 @@ struct FinancialConnectionsOAuthPrepane: Decodable {
     let body: OauthPrepaneBody
     let partnerNotice: OauthPrepanePartnerNotice?
     let cta: OauthPrepaneCTA
-    let dataAccessNotice: FinancialConnectionsDataAccessNotice
+    let dataAccessNotice: FinancialConnectionsDataAccessNotice?
 
     struct OauthPrepaneBody: Decodable {
         let entries: [OauthPrepaneBodyEntry]?

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsOAuthPrepaneTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsOAuthPrepaneTests.swift
@@ -1,0 +1,40 @@
+//
+//  FinancialConnectionsOAuthPrepaneTests.swift
+//  StripeFinancialConnectionsTests
+//
+
+import Foundation
+@_spi(STP) @testable import StripeCore
+import StripeCoreTestUtils
+@testable import StripeFinancialConnections
+import XCTest
+
+enum FinancialConnectionsOAuthPrepaneMock: String, MockData {
+    typealias ResponseType = FinancialConnectionsOAuthPrepane
+    var bundle: Bundle { return Bundle(for: ClassForBundle.self) }
+
+    case withDataAccessNotice = "FinancialConnectionsOAuthPrepane_with_data_access_notice"
+    case withoutDataAccessNotice = "FinancialConnectionsOAuthPrepane_without_data_access_notice"
+}
+
+// Dummy class to determine this bundle
+private class ClassForBundle {}
+
+final class FinancialConnectionsOAuthPrepaneTests: XCTestCase {
+
+    func testDecodesDataAccessNoticeWhenPresent() throws {
+        let prepane = try FinancialConnectionsOAuthPrepaneMock.withDataAccessNotice.make()
+
+        XCTAssertEqual(prepane.title, "Connect your account")
+        XCTAssertEqual(prepane.dataAccessNotice?.title, "Data sharing")
+        XCTAssertEqual(prepane.dataAccessNotice?.cta, "OK")
+        XCTAssertEqual(prepane.dataAccessNotice?.body.bullets.count, 1)
+    }
+
+    func testDecodesWithoutDataAccessNotice() throws {
+        let prepane = try FinancialConnectionsOAuthPrepaneMock.withoutDataAccessNotice.make()
+
+        XCTAssertEqual(prepane.title, "Connect your account")
+        XCTAssertNil(prepane.dataAccessNotice)
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/MockData/FinancialConnectionsOAuthPrepane_with_data_access_notice.json
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/MockData/FinancialConnectionsOAuthPrepane_with_data_access_notice.json
@@ -1,0 +1,46 @@
+{
+  "institution_icon": {
+    "default": "https://example.com/institution.png"
+  },
+  "title": "Connect your account",
+  "subtitle": "Use your bank to continue",
+  "body": {
+    "entries": [
+      {
+        "type": "text",
+        "content": "Securely sign in with your bank."
+      }
+    ]
+  },
+  "partner_notice": {
+    "partner_icon": {
+      "default": "https://example.com/partner.png"
+    },
+    "text": "You will be redirected to your bank."
+  },
+  "cta": {
+    "text": "Continue",
+    "icon": {
+      "default": "https://example.com/cta.png"
+    }
+  },
+  "data_access_notice": {
+    "icon": {
+      "default": "https://example.com/data.png"
+    },
+    "title": "Data sharing",
+    "subtitle": "Your account data will be shared.",
+    "body": {
+      "bullets": [
+        {
+          "icon": {
+            "default": "https://example.com/bullet.png"
+          },
+          "title": "Account details"
+        }
+      ]
+    },
+    "disclaimer": "You can disconnect at any time.",
+    "cta": "OK"
+  }
+}

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/MockData/FinancialConnectionsOAuthPrepane_without_data_access_notice.json
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/MockData/FinancialConnectionsOAuthPrepane_without_data_access_notice.json
@@ -1,0 +1,27 @@
+{
+  "institution_icon": {
+    "default": "https://example.com/institution.png"
+  },
+  "title": "Connect your account",
+  "subtitle": "Use your bank to continue",
+  "body": {
+    "entries": [
+      {
+        "type": "text",
+        "content": "Securely sign in with your bank."
+      }
+    ]
+  },
+  "partner_notice": {
+    "partner_icon": {
+      "default": "https://example.com/partner.png"
+    },
+    "text": "You will be redirected to your bank."
+  },
+  "cta": {
+    "text": "Continue",
+    "icon": {
+      "default": "https://example.com/cta.png"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
In #ir-frosty-word, we learned that `dataAccessNotice` is becoming optional. This PR makes this field optional (matching [Android](https://stripe.sourcegraphcloud.com/search?autofocus=true&q=%22DataAccessNotice%3F%20%3D%20null%22)). The backend will gate the optionality of this field to support existing SDK versions.

## Motivation
#ir-frosty-word

## Testing
Decoding tests have been added and manual testing.

<details><summary>Demo</summary>
<p>

https://github.com/user-attachments/assets/eb8ac28a-5988-42b7-86b0-b40b044293ce


</p>
</details> 
