### PR TITLE
Fix Test Compilation Error on Xcode 26.4.1 

### DIFF
--- a/Stripe3DS2/Stripe3DS2Tests/STDSTransactionTest.m
+++ b/Stripe3DS2/Stripe3DS2Tests/STDSTransactionTest.m
@@ -55,7 +55,7 @@
     STDSChallengeParameters *challengeParameters = [[STDSChallengeParameters alloc] init];
     
     // Assert timer is scheduled to fire 5 minutes from now, give or take 1 second
-    NSInteger timeout = 300;
+    NSTimeInterval timeout = 300;
     [transaction doChallengeWithViewController:[UIViewController new]
                            challengeParameters:challengeParameters
                        challengeStatusReceiver:self


### PR DESCRIPTION
## Summary
When running `AllStripeFramework` tests, there is a compilation warning marked as an error in `testTimeoutFires` in Xcode 26.4.1. This PR resolves this by using `NSTimeInterval`.

<img width="1992" height="374" alt="image" src="https://github.com/user-attachments/assets/dd840cbb-fa43-491f-a239-0baa06a80d17" />