### PR TITLE
Payment Sheet Playground - Allow Unset Values for Customer Session Parameters

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -356,6 +356,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     enum PaymentMethodRemoveLast: String, PickerEnum {
         static var enumName: String { "PaymentMethodRemoveLast" }
 
+        case unset
         case enabled
         case disabled
     }
@@ -392,6 +393,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
 
     enum PaymentMethodSetAsDefault: String, PickerEnum {
         static let enumName: String = "PaymentMethodSetAsDefault"
+        case unset
         case enabled
         case disabled
     }


### PR DESCRIPTION
## Summary
This backend sandbox [PR](https://git.corp.stripe.com/stripe-internal/sandbox-apps/pull/1164) enables `unset` values to be passed for `payment_method_set_as_default` and `payment_method_remove_last`. Backend gates need to be enabled for a merchant to use these parameters. If these fields are included in the customer session params and the merchant is not included in those gates, the customer session request fails. There are other features of the customer session that are able to be tested when the merchant is not gated in, so this PR allows these values to remain unset and not sent from the backend sandbox to the customer session endpoint.

## Motivation
Link mobile is working on testing SPMs backed by Link LPM funding sources. Testing for this is (more easily) done using a custom merchant, that is not flagged in to the gates mentioned above.

## Demo

https://github.com/user-attachments/assets/8c196bed-6fd4-49c1-b567-571bf27a52a9


