### PR TITLE
Payment Sheet Playground - Allow Custom Customer ID for Customer Sessions

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -148,9 +148,9 @@ struct PaymentSheetTestPlayground: View {
                                 }
                                 SearchableSettingView(setting: customerKeyTypeBinding, searchText: $searchText)
                                 SearchableSettingView(setting: customerModeBinding, searchText: $searchText)
-                                if playgroundController.settings.customerMode == .customID {
+                                if playgroundController.settings.customerMode == .custom {
                                     SearchableView(searchableName: "Customer ID", searchText: $searchText) {
-                                        TextField("CustomerId", text: customerIdBinding)
+                                        TextField("cus_...", text: customerIdBinding)
                                             .autocorrectionDisabled()
                                     }
                                 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -148,6 +148,12 @@ struct PaymentSheetTestPlayground: View {
                                 }
                                 SearchableSettingView(setting: customerKeyTypeBinding, searchText: $searchText)
                                 SearchableSettingView(setting: customerModeBinding, searchText: $searchText)
+                                if playgroundController.settings.customerMode == .customID {
+                                    SearchableView(searchableName: "Customer ID", searchText: $searchText) {
+                                        TextField("CustomerId", text: customerIdBinding)
+                                            .autocorrectionDisabled()
+                                    }
+                                }
                                 SearchableView(searchableName: "Amount Currency", searchText: $searchText) {
                                     HStack {
                                         SettingPickerView(setting: $playgroundController.settings.amount, customDisplayName: { amount in
@@ -339,6 +345,15 @@ struct PaymentSheetTestPlayground: View {
             playgroundController.settings.paymentMethodConfigurationId = (newString != "") ? newString : nil
         }
     }
+
+    var customerIdBinding: Binding<String> {
+        Binding<String> {
+            return playgroundController.settings.customerId ?? ""
+        } set: { newString in
+            playgroundController.settings.customerId = (newString != "") ? newString : nil
+        }
+    }
+
     var customerModeBinding: Binding<PaymentSheetTestPlaygroundSettings.CustomerMode> {
         Binding<PaymentSheetTestPlaygroundSettings.CustomerMode> {
             return playgroundController.settings.customerMode

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -100,7 +100,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case guest
         case new
         case returning
-        case customID
+        case custom
     }
     enum CustomerKeyType: String, PickerEnum {
         static var enumName: String { "CustomerKeyType" }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -100,6 +100,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case guest
         case new
         case returning
+        case customID
     }
     enum CustomerKeyType: String, PickerEnum {
         static var enumName: String { "CustomerKeyType" }
@@ -741,6 +742,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var currency: Currency
     var amount: Amount
     var merchantCountryCode: MerchantCountry
+    var customerId: String?
     // For testing purposes only; keys should typically not be defined on the client
     var customSecretKey: String?
     var customPublishableKey: String?
@@ -819,6 +821,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             currency: .usd,
             amount: ._5099,
             merchantCountryCode: .US,
+            customerId: nil,
             apmsEnabled: .on,
             paymentMethodOptionsSetupFutureUsage: PaymentMethodOptionsSetupFutureUsage.defaultValues(),
             shippingInfo: .off,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -506,7 +506,7 @@ import UIKit
             return "new"
         case .returning:
             return "returning"
-        case .customID:
+        case .custom:
             return settings.customerId ?? ""
         }
     }
@@ -1359,7 +1359,7 @@ extension PlaygroundController {
     }
 
     func loadLastSavedCustomer() {
-        if settings.customerMode == .customID {
+        if settings.customerMode == .custom {
             self.customerId = settings.customerId
             return
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -503,9 +503,9 @@ import UIKit
         case .guest:
             return "guest"
         case .new:
-            return "new"
+            return customerId ?? "new"
         case .returning:
-            return "returning"
+            return customerId ?? "returning"
         case .custom:
             return settings.customerId ?? ""
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -507,7 +507,7 @@ import UIKit
         case .returning:
             return customerId ?? "returning"
         case .custom:
-            return settings.customerId ?? ""
+            return customerId ?? "custom"
         }
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -503,9 +503,11 @@ import UIKit
         case .guest:
             return "guest"
         case .new:
-            return customerId ?? "new"
+            return "new"
         case .returning:
-            return customerId ?? "returning"
+            return "returning"
+        case .customID:
+            return settings.customerId ?? ""
         }
     }
 
@@ -626,6 +628,7 @@ import UIKit
             await MainActor.run {
                 self.settings = settings
                 self.appearance = appearance
+                self.customerId = settings.customerId
                 self.loadLastSavedCustomer()
             }
         }
@@ -1356,6 +1359,10 @@ extension PlaygroundController {
     }
 
     func loadLastSavedCustomer() {
+        if settings.customerMode == .customID {
+            self.customerId = settings.customerId
+            return
+        }
         if let customerIdData = UserDefaults.standard.value(forKey: PaymentSheetTestPlaygroundSettings.nsUserDefaultsCustomerIDKey) as? Data {
             do {
                 self.customerId = try JSONDecoder().decode(String.self, from: customerIdData)


### PR DESCRIPTION
## Summary
This PR adds a `custom` customer ID text field to the playground sample app. This allows for testing with known customers IDs in the playground. 

## Motivation
Testing Link LPM-funded SPMs was a little tricky without creating a customer in CD2 and using it here. This textfield makes testing easier.

## Screenshot

<img width="630" height="118" alt="CleanShot 2026-05-06 at 13 19 52" src="https://github.com/user-attachments/assets/7eb2217e-d70f-4598-af2d-1b25ba07ee01" />

Demo video found [here](https://git.corp.stripe.com/stripe-internal/sandbox-apps/pull/1164).
