### PR TITLE
[link] Use new branding for display labels

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -301,6 +301,7 @@ import UIKit
         }
         configuration.merchantDisplayName = "Example, Inc."
         configuration.applePay = applePayConfiguration
+        configuration.link = linkConfiguration
         configuration.customer = customerConfiguration
         configuration.appearance = appearance
         if settings.userOverrideCountry != .off {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
@@ -133,11 +133,12 @@ class FCLiteUITests: XCTestCase {
         // Continue with Link
         let continueWithLinkButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Continue with Link'") // Link signup pane
         let continueWithLinkButton = app.webViews.firstMatch.buttons.containing(continueWithLinkButtonPredicate).firstMatch
-        XCTAssertTrue(continueWithLinkButton.waitForExistenceAndTap(timeout: 10.0))
-
         // Success bank
         let paymentSuccessBankButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Disputed'") // Institution Picker
         let paymentSuccessBankButton = app.webViews.firstMatch.buttons.containing(paymentSuccessBankButtonPredicate).firstMatch
+        XCTAssertTrue(continueWithLinkButton.waitForExistence(timeout: 10.0))
+        continueWithLinkButton.forceTapElement()
+        XCTAssertTrue(paymentSuccessBankButton.waitForExistence(timeout: 10.0))
         XCTAssertTrue(paymentSuccessBankButton.waitForExistenceAndTap(timeout: 10.0))
 
         // Connect account - wait for button to appear, then tap via coordinate

--- a/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
@@ -137,8 +137,10 @@ class FCLiteUITests: XCTestCase {
         let paymentSuccessBankButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Disputed'") // Institution Picker
         let paymentSuccessBankButton = app.webViews.firstMatch.buttons.containing(paymentSuccessBankButtonPredicate).firstMatch
         XCTAssertTrue(continueWithLinkButton.waitForExistence(timeout: 10.0))
-        continueWithLinkButton.forceTapElement()
-        XCTAssertTrue(paymentSuccessBankButton.waitForExistence(timeout: 10.0))
+        advancePrimaryCTA(
+            continueButton: continueWithLinkButton,
+            nextPaneElement: paymentSuccessBankButton
+        )
         XCTAssertTrue(paymentSuccessBankButton.waitForExistenceAndTap(timeout: 10.0))
 
         // Connect account - wait for button to appear, then tap via coordinate
@@ -175,5 +177,25 @@ class FCLiteUITests: XCTestCase {
 
         // Primary button is at the bottom center of the webview (roughly 95% down, centered)
         app.webViews.firstMatch.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.95)).tap()
+    }
+
+    private func advancePrimaryCTA(
+        continueButton: XCUIElement,
+        nextPaneElement: XCUIElement
+    ) {
+        if app.keyboards.firstMatch.exists || app.toolbars.buttons["Done"].exists {
+            app.typeText(XCUIKeyboardKey.return.rawValue)
+            if nextPaneElement.waitForExistence(timeout: 2.0) {
+                return
+            }
+        }
+
+        if continueButton.waitForExistenceAndTap(timeout: 2.0),
+           nextPaneElement.waitForExistence(timeout: 2.0) {
+            return
+        }
+
+        tapPrimaryButton()
+        XCTAssertTrue(nextPaneElement.waitForExistence(timeout: 10.0))
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
@@ -133,8 +133,7 @@ class FCLiteUITests: XCTestCase {
         // Continue with Link
         let continueWithLinkButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Continue with Link'") // Link signup pane
         let continueWithLinkButton = app.webViews.firstMatch.buttons.containing(continueWithLinkButtonPredicate).firstMatch
-        XCTAssertTrue(continueWithLinkButton.waitForExistence(timeout: 10.0))
-        app.typeText(XCUIKeyboardKey.return.rawValue) // Enter key will continue to the next screen
+        XCTAssertTrue(continueWithLinkButton.waitForExistenceAndTap(timeout: 10.0))
 
         // Success bank
         let paymentSuccessBankButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Disputed'") // Institution Picker

--- a/StripeCore/StripeCore/Source/Connections Bindings/LinkBrand.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/LinkBrand.swift
@@ -32,6 +32,15 @@ import Foundation
         }
     }
 
+    @_spi(STP) public var checkoutURL: URL {
+        switch self {
+        case .link, .unparsable:
+            return URL(string: "https://checkout.link.com/")!
+        case .onelink:
+            return URL(string: "https://checkout.onelink.com/")!
+        }
+    }
+
     @_spi(STP) public var termsURL: URL {
         switch self {
         case .link, .unparsable:

--- a/StripeCore/StripeCore/Source/Connections Bindings/LinkBrand.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/LinkBrand.swift
@@ -121,14 +121,6 @@ import Foundation
             components.scheme = "https"
             components.host = "support.onelink.com"
             return components.url ?? url
-        case "stripe.com", "www.stripe.com":
-            if components.path == "/legal/end-users", components.fragment == "linked-financial-account-terms" {
-                return URL(string: "https://onelink.com/terms#financial-connections-terms")!
-            }
-            if components.path == "/privacy" {
-                return privacyURL
-            }
-            return url
         default:
             return url
         }

--- a/StripeCore/StripeCore/Source/Connections Bindings/LinkBrand.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/LinkBrand.swift
@@ -22,4 +22,106 @@ import Foundation
             return "Onelink"
         }
     }
+
+    @_spi(STP) public var websiteURL: URL {
+        switch self {
+        case .link, .unparsable:
+            return URL(string: "https://link.com")!
+        case .onelink:
+            return URL(string: "https://onelink.com")!
+        }
+    }
+
+    @_spi(STP) public var termsURL: URL {
+        switch self {
+        case .link, .unparsable:
+            return URL(string: "https://link.co/terms")!
+        case .onelink:
+            return URL(string: "https://onelink.com/terms")!
+        }
+    }
+
+    @_spi(STP) public var privacyURL: URL {
+        switch self {
+        case .link, .unparsable:
+            return URL(string: "https://link.co/privacy")!
+        case .onelink:
+            return URL(string: "https://onelink.com/privacy")!
+        }
+    }
+
+    @_spi(STP) public var achAuthorizationURL: URL {
+        switch self {
+        case .link, .unparsable:
+            return URL(string: "https://link.com/terms/ach-authorization")!
+        case .onelink:
+            return URL(string: "https://onelink.com/terms/ach-authorization")!
+        }
+    }
+
+    @_spi(STP) public var promotionTermsURL: URL {
+        switch self {
+        case .link, .unparsable:
+            return URL(string: "https://link.com/promotion-terms")!
+        case .onelink:
+            return URL(string: "https://onelink.com/promotion-terms")!
+        }
+    }
+
+    @_spi(STP) public var supportContactURL: URL {
+        switch self {
+        case .link, .unparsable:
+            return URL(string: "https://support.link.co/contact/email?skipVerification=true")!
+        case .onelink:
+            return URL(string: "https://support.onelink.com/contact/email?skipVerification=true")!
+        }
+    }
+
+    @_spi(STP) public func brandAwareLegalSupportURL(for url: URL) -> URL {
+        guard self == .onelink, var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url
+        }
+
+        let host = components.host?.lowercased()
+        switch host {
+        case "link.co", "www.link.co":
+            switch components.path {
+            case "/terms":
+                return termsURL
+            case "/privacy":
+                return privacyURL
+            default:
+                return url
+            }
+        case "link.com", "www.link.com":
+            switch components.path {
+            case "", "/":
+                return websiteURL
+            case "/terms":
+                return URL(string: "https://onelink.com/terms")!
+            case "/privacy":
+                return privacyURL
+            case "/terms/ach-authorization":
+                return achAuthorizationURL
+            case "/promotion-terms":
+                return promotionTermsURL
+            default:
+                return url
+            }
+        case "support.link.co", "www.support.link.co":
+            components.scheme = "https"
+            components.host = "support.onelink.com"
+            return components.url ?? url
+        case "stripe.com", "www.stripe.com":
+            if components.path == "/legal/end-users", components.fragment == "linked-financial-account-terms" {
+                return URL(string: "https://onelink.com/terms#financial-connections-terms")!
+            }
+            if components.path == "/privacy" {
+                return privacyURL
+            }
+            return url
+        default:
+            return url
+        }
+    }
 }

--- a/StripeCore/StripeCoreTests/Connections Bindings/LinkBrandTests.swift
+++ b/StripeCore/StripeCoreTests/Connections Bindings/LinkBrandTests.swift
@@ -38,10 +38,6 @@ final class LinkBrandTests: XCTestCase {
             LinkBrand.onelink.brandAwareLegalSupportURL(for: URL(string: "https://support.link.co/questions/foo")!).absoluteString,
             "https://support.onelink.com/questions/foo"
         )
-        XCTAssertEqual(
-            LinkBrand.onelink.brandAwareLegalSupportURL(for: URL(string: "https://stripe.com/legal/end-users#linked-financial-account-terms")!).absoluteString,
-            "https://onelink.com/terms#financial-connections-terms"
-        )
     }
 
     func testBrandAwareLegalSupportURL_forLinkLeavesURLUnchanged() {

--- a/StripeCore/StripeCoreTests/Connections Bindings/LinkBrandTests.swift
+++ b/StripeCore/StripeCoreTests/Connections Bindings/LinkBrandTests.swift
@@ -21,6 +21,7 @@ final class LinkBrandTests: XCTestCase {
 
     func testLegalURLs_forOnelinkBrand() {
         XCTAssertEqual(LinkBrand.onelink.websiteURL.absoluteString, "https://onelink.com")
+        XCTAssertEqual(LinkBrand.onelink.checkoutURL.absoluteString, "https://checkout.onelink.com/")
         XCTAssertEqual(LinkBrand.onelink.termsURL.absoluteString, "https://onelink.com/terms")
         XCTAssertEqual(LinkBrand.onelink.privacyURL.absoluteString, "https://onelink.com/privacy")
         XCTAssertEqual(LinkBrand.onelink.achAuthorizationURL.absoluteString, "https://onelink.com/terms/ach-authorization")

--- a/StripeCore/StripeCoreTests/Connections Bindings/LinkBrandTests.swift
+++ b/StripeCore/StripeCoreTests/Connections Bindings/LinkBrandTests.swift
@@ -18,4 +18,34 @@ final class LinkBrandTests: XCTestCase {
     func testDisplayName_forUnparsableBrandFallsBackToLink() {
         XCTAssertEqual(LinkBrand.unparsable.displayName, "Link")
     }
+
+    func testLegalURLs_forOnelinkBrand() {
+        XCTAssertEqual(LinkBrand.onelink.websiteURL.absoluteString, "https://onelink.com")
+        XCTAssertEqual(LinkBrand.onelink.termsURL.absoluteString, "https://onelink.com/terms")
+        XCTAssertEqual(LinkBrand.onelink.privacyURL.absoluteString, "https://onelink.com/privacy")
+        XCTAssertEqual(LinkBrand.onelink.achAuthorizationURL.absoluteString, "https://onelink.com/terms/ach-authorization")
+        XCTAssertEqual(LinkBrand.onelink.promotionTermsURL.absoluteString, "https://onelink.com/promotion-terms")
+        XCTAssertEqual(LinkBrand.onelink.supportContactURL.absoluteString, "https://support.onelink.com/contact/email?skipVerification=true")
+    }
+
+    func testBrandAwareLegalSupportURL_forOnelinkRewritesKnownLinkURLs() {
+        XCTAssertEqual(
+            LinkBrand.onelink.brandAwareLegalSupportURL(for: URL(string: "https://link.co/terms")!).absoluteString,
+            "https://onelink.com/terms"
+        )
+        XCTAssertEqual(
+            LinkBrand.onelink.brandAwareLegalSupportURL(for: URL(string: "https://support.link.co/questions/foo")!).absoluteString,
+            "https://support.onelink.com/questions/foo"
+        )
+        XCTAssertEqual(
+            LinkBrand.onelink.brandAwareLegalSupportURL(for: URL(string: "https://stripe.com/legal/end-users#linked-financial-account-terms")!).absoluteString,
+            "https://onelink.com/terms#financial-connections-terms"
+        )
+    }
+
+    func testBrandAwareLegalSupportURL_forLinkLeavesURLUnchanged() {
+        let url = URL(string: "https://link.co/privacy")!
+        XCTAssertEqual(LinkBrand.link.brandAwareLegalSupportURL(for: url), url)
+        XCTAssertEqual(LinkBrand.unparsable.brandAwareLegalSupportURL(for: url), url)
+    }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -277,6 +277,8 @@
 				"zh-Hans",
 				"zh-Hant",
 				Base,
+				"nn-NO",
+				th,
 			);
 			mainGroup = 7879CBA341D7E807714A831B;
 			packageReferences = (

--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -277,8 +277,6 @@
 				"zh-Hans",
 				"zh-Hant",
 				Base,
-				"nn-NO",
-				th,
 			);
 			mainGroup = 7879CBA341D7E807714A831B;
 			packageReferences = (

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
@@ -68,7 +68,8 @@ final class AuthFlowHelpers {
         if url.scheme == "stripe" {
             handleURL(url.host, nextPaneOrDrawerOnSecondaryCta)
         } else {
-            SFSafariViewController.present(url: url)
+            let brand = PresentationManager.shared.configuration.linkBrand ?? .link
+            SFSafariViewController.present(url: brand.brandAwareLegalSupportURL(for: url))
         }
     }
 
@@ -91,7 +92,7 @@ final class AuthFlowHelpers {
                 let trailingMessage = (otpType == "EMAIL") ? STPLocalizedString("Click “Resend code” and try again, or %@.", "Text as part of an error message that shows up when user entered an invalid one-time-passcode (OTP). '%@' will be replaced by text with a link: 'contact us'") : STPLocalizedString("Try again, or %@.", "Text as part of an error message that shows up when user entered an invalid one-time-passcode (OTP). '%@' will be replaced by text with a link: 'contact us'")
 
                 let contactUsText = STPLocalizedString("contact us", "A link/button inside of text that can be tapped to visit a support website. This link will be embedded inside of larger text: 'It looks like the verification code you provided is not valid anymore. Try again, or contact us.'")
-                let contactUsUrlString = "https://support.link.co/contact/email?skipVerification=true"
+                let contactUsUrlString = (PresentationManager.shared.configuration.linkBrand ?? .link).supportContactURL.absoluteString
                 let contactUsWithUrlText = "[\(contactUsText)](\(contactUsUrlString))"
 
                 return leadingMessage + " " + String(format: trailingMessage, contactUsWithUrlText)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
@@ -64,62 +64,6 @@ extension STPPaymentMethod {
         }
     }
 
-    func paymentOptionLabel(confirmParams: IntentConfirmParams?) -> String {
-        return paymentOptionLabel(confirmParams: confirmParams, brand: .link)
-    }
-
-    func paymentOptionLabel(confirmParams: IntentConfirmParams?, brand: LinkBrand) -> String {
-        if let instantDebitsLinkedBank = confirmParams?.instantDebitsLinkedBank {
-            return "••••\(instantDebitsLinkedBank.last4 ?? "")"
-        } else {
-            return paymentSheetLabel(brand: brand)
-        }
-    }
-
-    var expandedPaymentSheetLabel: String {
-        return expandedPaymentSheetLabel(brand: .link)
-    }
-
-    func expandedPaymentSheetLabel(brand: LinkBrand) -> String {
-        switch type {
-        case .card:
-            if isLinkPaymentMethod || isLinkPassthroughMode {
-                return brand.displayName
-            } else if let card {
-                return STPCardBrandUtilities.stringFrom(card.preferredDisplayBrand) ?? STPPaymentMethodType.card.displayName
-            } else {
-                return STPPaymentMethodType.card.displayName
-            }
-        case .USBankAccount:
-            if isLinkPassthroughMode {
-                return brand.displayName
-            } else {
-                return usBankAccount?.bankName ?? type.displayName
-            }
-        case .link:
-            return brand.displayName
-        default:
-            return type.displayName
-        }
-    }
-
-    var paymentSheetSublabel: String? {
-        return paymentSheetSublabel(brand: .link)
-    }
-
-    func paymentSheetSublabel(brand: LinkBrand) -> String? {
-        switch type {
-        case .card:
-            return linkPaymentDetailsFormattedString ?? paymentSheetLabel(brand: brand)
-        case .USBankAccount:
-            return paymentSheetLabel(brand: brand)
-        case .link:
-            return linkPaymentDetailsFormattedString
-        default:
-            return nil
-        }
-    }
-
     var linkPaymentDetailsFormattedString: String? {
         guard let linkPaymentDetails else {
             return nil
@@ -190,4 +134,48 @@ private func makeCardAccessibilityLabel(cardBrand: STPCardBrand, last4: String) 
     let last4Spaced = last4.map { String($0) }.joined(separator: " ")
     let localized = String.Localized.card_brand_ending_in_last_4
     return String(format: localized, brand, last4Spaced)
+}
+
+func paymentOptionLabel(for paymentMethod: STPPaymentMethod, confirmParams: IntentConfirmParams?, brand: LinkBrand) -> String {
+    if let instantDebitsLinkedBank = confirmParams?.instantDebitsLinkedBank {
+        return "••••\(instantDebitsLinkedBank.last4 ?? "")"
+    } else {
+        return paymentMethod.paymentSheetLabel(brand: brand)
+    }
+}
+
+func expandedPaymentSheetLabel(for paymentMethod: STPPaymentMethod, brand: LinkBrand) -> String {
+    switch paymentMethod.type {
+    case .card:
+        if paymentMethod.isLinkPaymentMethod || paymentMethod.isLinkPassthroughMode {
+            return brand.displayName
+        } else if let card = paymentMethod.card {
+            return STPCardBrandUtilities.stringFrom(card.preferredDisplayBrand) ?? STPPaymentMethodType.card.displayName
+        } else {
+            return STPPaymentMethodType.card.displayName
+        }
+    case .USBankAccount:
+        if paymentMethod.isLinkPassthroughMode {
+            return brand.displayName
+        } else {
+            return paymentMethod.usBankAccount?.bankName ?? paymentMethod.type.displayName
+        }
+    case .link:
+        return brand.displayName
+    default:
+        return paymentMethod.type.displayName
+    }
+}
+
+func paymentSheetSublabel(for paymentMethod: STPPaymentMethod, brand: LinkBrand) -> String? {
+    switch paymentMethod.type {
+    case .card:
+        return paymentMethod.linkPaymentDetailsFormattedString ?? paymentMethod.paymentSheetLabel(brand: brand)
+    case .USBankAccount:
+        return paymentMethod.paymentSheetLabel(brand: brand)
+    case .link:
+        return paymentMethod.linkPaymentDetailsFormattedString
+    default:
+        return nil
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
@@ -13,6 +13,10 @@ import Foundation
 
 extension STPPaymentMethod {
     var paymentSheetLabel: String {
+        return paymentSheetLabel(brand: .link)
+    }
+
+    func paymentSheetLabel(brand: LinkBrand) -> String {
         switch type {
         case .card:
             // Link payment details here are for Link card brand
@@ -24,7 +28,7 @@ extension STPPaymentMethod {
             // The missing space is not an oversight, but on purpose
             return "••••\(usBankAccount?.last4 ?? "")"
         case .link:
-            return linkPaymentDetails?.label ?? type.displayName
+            return linkPaymentDetails?.label ?? brand.displayName
         default:
             return type.displayName
         }
@@ -61,18 +65,26 @@ extension STPPaymentMethod {
     }
 
     func paymentOptionLabel(confirmParams: IntentConfirmParams?) -> String {
+        return paymentOptionLabel(confirmParams: confirmParams, brand: .link)
+    }
+
+    func paymentOptionLabel(confirmParams: IntentConfirmParams?, brand: LinkBrand) -> String {
         if let instantDebitsLinkedBank = confirmParams?.instantDebitsLinkedBank {
             return "••••\(instantDebitsLinkedBank.last4 ?? "")"
         } else {
-            return paymentSheetLabel
+            return paymentSheetLabel(brand: brand)
         }
     }
 
     var expandedPaymentSheetLabel: String {
+        return expandedPaymentSheetLabel(brand: .link)
+    }
+
+    func expandedPaymentSheetLabel(brand: LinkBrand) -> String {
         switch type {
         case .card:
             if isLinkPaymentMethod || isLinkPassthroughMode {
-                return STPPaymentMethodType.link.displayName
+                return brand.displayName
             } else if let card {
                 return STPCardBrandUtilities.stringFrom(card.preferredDisplayBrand) ?? STPPaymentMethodType.card.displayName
             } else {
@@ -80,21 +92,27 @@ extension STPPaymentMethod {
             }
         case .USBankAccount:
             if isLinkPassthroughMode {
-                return STPPaymentMethodType.link.displayName
+                return brand.displayName
             } else {
                 return usBankAccount?.bankName ?? type.displayName
             }
+        case .link:
+            return brand.displayName
         default:
             return type.displayName
         }
     }
 
     var paymentSheetSublabel: String? {
+        return paymentSheetSublabel(brand: .link)
+    }
+
+    func paymentSheetSublabel(brand: LinkBrand) -> String? {
         switch type {
         case .card:
-            return linkPaymentDetailsFormattedString ?? paymentSheetLabel
+            return linkPaymentDetailsFormattedString ?? paymentSheetLabel(brand: brand)
         case .USBankAccount:
-            return paymentSheetLabel
+            return paymentSheetLabel(brand: brand)
         case .link:
             return linkPaymentDetailsFormattedString
         default:

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
@@ -114,6 +114,50 @@ extension STPPaymentMethod {
 
         return updatedLine1 || updatedLine2 || updatedCity || updatedState || updatedCountry || updatedPostalCode
     }
+
+    func paymentOptionLabel(confirmParams: IntentConfirmParams?, brand: LinkBrand) -> String {
+        if let instantDebitsLinkedBank = confirmParams?.instantDebitsLinkedBank {
+            return "••••\(instantDebitsLinkedBank.last4 ?? "")"
+        } else {
+            return paymentSheetLabel(brand: brand)
+        }
+    }
+
+    func expandedPaymentSheetLabel(brand: LinkBrand) -> String {
+        switch type {
+        case .card:
+            if isLinkPaymentMethod || isLinkPassthroughMode {
+                return brand.displayName
+            } else if let card {
+                return STPCardBrandUtilities.stringFrom(card.preferredDisplayBrand) ?? STPPaymentMethodType.card.displayName
+            } else {
+                return STPPaymentMethodType.card.displayName
+            }
+        case .USBankAccount:
+            if isLinkPassthroughMode {
+                return brand.displayName
+            } else {
+                return usBankAccount?.bankName ?? type.displayName
+            }
+        case .link:
+            return brand.displayName
+        default:
+            return type.displayName
+        }
+    }
+
+    func paymentSheetSublabel(brand: LinkBrand) -> String? {
+        switch type {
+        case .card:
+            return linkPaymentDetailsFormattedString ?? paymentSheetLabel(brand: brand)
+        case .USBankAccount:
+            return paymentSheetLabel(brand: brand)
+        case .link:
+            return linkPaymentDetailsFormattedString
+        default:
+            return nil
+        }
+    }
 }
 
 private extension LinkPaymentDetails {
@@ -134,48 +178,4 @@ private func makeCardAccessibilityLabel(cardBrand: STPCardBrand, last4: String) 
     let last4Spaced = last4.map { String($0) }.joined(separator: " ")
     let localized = String.Localized.card_brand_ending_in_last_4
     return String(format: localized, brand, last4Spaced)
-}
-
-func paymentOptionLabel(for paymentMethod: STPPaymentMethod, confirmParams: IntentConfirmParams?, brand: LinkBrand) -> String {
-    if let instantDebitsLinkedBank = confirmParams?.instantDebitsLinkedBank {
-        return "••••\(instantDebitsLinkedBank.last4 ?? "")"
-    } else {
-        return paymentMethod.paymentSheetLabel(brand: brand)
-    }
-}
-
-func expandedPaymentSheetLabel(for paymentMethod: STPPaymentMethod, brand: LinkBrand) -> String {
-    switch paymentMethod.type {
-    case .card:
-        if paymentMethod.isLinkPaymentMethod || paymentMethod.isLinkPassthroughMode {
-            return brand.displayName
-        } else if let card = paymentMethod.card {
-            return STPCardBrandUtilities.stringFrom(card.preferredDisplayBrand) ?? STPPaymentMethodType.card.displayName
-        } else {
-            return STPPaymentMethodType.card.displayName
-        }
-    case .USBankAccount:
-        if paymentMethod.isLinkPassthroughMode {
-            return brand.displayName
-        } else {
-            return paymentMethod.usBankAccount?.bankName ?? paymentMethod.type.displayName
-        }
-    case .link:
-        return brand.displayName
-    default:
-        return paymentMethod.type.displayName
-    }
-}
-
-func paymentSheetSublabel(for paymentMethod: STPPaymentMethod, brand: LinkBrand) -> String? {
-    switch paymentMethod.type {
-    case .card:
-        return paymentMethod.linkPaymentDetailsFormattedString ?? paymentMethod.paymentSheetLabel(brand: brand)
-    case .USBankAccount:
-        return paymentMethod.paymentSheetLabel(brand: brand)
-    case .link:
-        return paymentMethod.linkPaymentDetailsFormattedString
-    default:
-        return nil
-    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
@@ -7,6 +7,7 @@
 
 @_spi(STP) import StripeUICore
 import UIKit
+@_spi(STP) import StripeCore
 
 /// The content view of `CRSCARFDeclarationViewController`, which displays CRS/CARF declaration text with a confirmation button.
 final class CRSCARFDeclarationContentViewController: UIViewController, BottomSheetContentViewController {
@@ -17,6 +18,7 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         let navigationBar = LinkSheetNavigationBar(
             isTestMode: false,
             appearance: .default,
+            brand: brand,
             shouldLogPaymentSheetAnalyticsOnDismissal: false
         )
         navigationBar.setStyle(.close(showAdditionalButton: false))
@@ -30,6 +32,7 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
 
     private let text: String
     private let appearance: LinkAppearance
+    private let brand: LinkBrand
 
     /// Closure called when a user confirms or cancels the declaration.
     var onResult: ((LinkController.CRSCARFDeclarationResult) -> Void)?
@@ -38,9 +41,10 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
     /// - Parameters:
     ///   - text: The declaration text to display.
     ///   - appearance: Determines the colors, corner radius, and height of the confirmation button.
-    init(text: String, appearance: LinkAppearance) {
+    init(text: String, appearance: LinkAppearance, brand: LinkBrand) {
         self.text = text
         self.appearance = appearance
+        self.brand = brand
         super.init(nibName: nil, bundle: nil)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
@@ -5,9 +5,9 @@
 //  Created by Michael Liberatore on 4/23/26.
 //
 
+@_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
 import UIKit
-@_spi(STP) import StripeCore
 
 /// The content view of `CRSCARFDeclarationViewController`, which displays CRS/CARF declaration text with a confirmation button.
 final class CRSCARFDeclarationContentViewController: UIViewController, BottomSheetContentViewController {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+@_spi(STP) import StripeCore
 
 /// Container view controller that displays the CRS/CARF declaration in a Link-styled bottom sheet.
 final class CRSCARFDeclarationViewController: BottomSheetViewController {
@@ -26,8 +27,8 @@ final class CRSCARFDeclarationViewController: BottomSheetViewController {
     /// - Parameters:
     ///   - text: The declaration text to display.
     ///   - appearance: Determines the colors, corner radius, and height of the confirmation button and the user interface style.
-    init(text: String, appearance: LinkAppearance) {
-        let contentViewController = CRSCARFDeclarationContentViewController(text: text, appearance: appearance)
+    init(text: String, appearance: LinkAppearance, brand: LinkBrand) {
+        let contentViewController = CRSCARFDeclarationContentViewController(text: text, appearance: appearance, brand: brand)
         self.contentViewController = contentViewController
 
         super.init(

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationViewController.swift
@@ -5,8 +5,8 @@
 //  Created by Michael Liberatore on 4/23/26.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
+import UIKit
 
 /// Container view controller that displays the CRS/CARF declaration in a Link-styled bottom sheet.
 final class CRSCARFDeclarationViewController: BottomSheetViewController {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/Consent/LinkFullConsentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/Consent/LinkFullConsentViewController.swift
@@ -136,6 +136,7 @@ extension LinkFullConsentViewController {
         let navBar = LinkSheetNavigationBar(
             isTestMode: false,
             appearance: LinkUI.appearance,
+            brand: .link,
             shouldLogPaymentSheetAnalyticsOnDismissal: false
         )
         navBar.setStyle(.close(showAdditionalButton: false))

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/Consent/LinkFullConsentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/Consent/LinkFullConsentViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Mat Schmid on 8/23/25.
 //
 
+@_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
 import UIKit
 
@@ -139,7 +140,7 @@ extension LinkFullConsentViewController {
             brand: .link,
             shouldLogPaymentSheetAnalyticsOnDismissal: false
         )
-        navBar.setStyle(.close(showAdditionalButton: false))
+        navBar.setStyle(SheetNavigationBar.Style.close(showAdditionalButton: false))
         navBar.delegate = self
         return navBar
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/NavigationBar/LinkSheetNavigationBar.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/NavigationBar/LinkSheetNavigationBar.swift
@@ -15,12 +15,14 @@ import UIKit
 /// For internal SDK use only
 @objc(STP_Internal_LinkSheetNavigationBar)
 class LinkSheetNavigationBar: SheetNavigationBar {
-    private let logoView: UIImageView = {
+    private let brand: LinkBrand
+
+    private lazy var logoView: UIImageView = {
         let imageView = UIImageView(image: Image.link_logo.makeImage(template: false))
         imageView.tintColor = .linkIconBrand
         imageView.isAccessibilityElement = true
         imageView.accessibilityTraits = .header
-        imageView.accessibilityLabel = STPPaymentMethodType.link.displayName
+        imageView.accessibilityLabel = brand.displayName
         imageView.translatesAutoresizingMaskIntoConstraints = false
         return imageView
     }()
@@ -56,7 +58,8 @@ class LinkSheetNavigationBar: SheetNavigationBar {
         return super.leftmostElement
     }
 
-    override init(isTestMode: Bool, appearance: PaymentSheet.Appearance, shouldLogPaymentSheetAnalyticsOnDismissal: Bool = true) {
+    init(isTestMode: Bool, appearance: PaymentSheet.Appearance, brand: LinkBrand = .link, shouldLogPaymentSheetAnalyticsOnDismissal: Bool = true) {
+        self.brand = brand
         super.init(
             isTestMode: isTestMode,
             appearance: appearance,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/NavigationBar/LinkSheetNavigationBar.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Components/NavigationBar/LinkSheetNavigationBar.swift
@@ -58,7 +58,7 @@ class LinkSheetNavigationBar: SheetNavigationBar {
         return super.leftmostElement
     }
 
-    init(isTestMode: Bool, appearance: PaymentSheet.Appearance, brand: LinkBrand = .link, shouldLogPaymentSheetAnalyticsOnDismissal: Bool = true) {
+    init(isTestMode: Bool, appearance: PaymentSheet.Appearance, brand: LinkBrand, shouldLogPaymentSheetAnalyticsOnDismissal: Bool = true) {
         self.brand = brand
         super.init(
             isTestMode: isTestMode,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-BaseViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-BaseViewController.swift
@@ -65,6 +65,7 @@ extension PayWithLinkViewController {
             let navBar = LinkSheetNavigationBar(
                 isTestMode: false,
                 appearance: LinkUI.appearance,
+                brand: context.configuration.resolvedLinkBrand(elementsSession: context.elementsSession),
                 shouldLogPaymentSheetAnalyticsOnDismissal: false
             )
             navBar.title = navigationTitle

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-VerifyAccountViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-VerifyAccountViewController.swift
@@ -18,7 +18,11 @@ extension PayWithLinkViewController {
         private var isUsingWebviewFallback: Bool = false
 
         private lazy var verificationVC: LinkVerificationViewController = {
-            let vc = LinkVerificationViewController(mode: .embedded, linkAccount: linkAccount)
+            let vc = LinkVerificationViewController(
+                mode: .embedded,
+                linkAccount: linkAccount,
+                brand: context.configuration.resolvedLinkBrand(elementsSession: context.elementsSession)
+            )
             vc.delegate = self
             vc.view.backgroundColor = .clear
             return vc

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -87,7 +87,8 @@ extension PayWithLinkViewController {
                 return PaymentSheetFormFactory.makeBankMandateText(
                     isSettingUp: isSettingUp || context.elementsSession.forceSaveFutureUseBehaviorAndNewMandateText,
                     merchantName: context.configuration.merchantDisplayName,
-                    sellerName: context.intent.sellerDetails?.businessName
+                    sellerName: context.intent.sellerDetails?.businessName,
+                    brand: context.configuration.resolvedLinkBrand(elementsSession: context.elementsSession)
                 )
             default:
                 return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -814,6 +814,7 @@ extension PayWithLinkViewController: PaymentSheetLinkAccountDelegate {
                     let verificationController = LinkVerificationController(
                         mode: .modal,
                         linkAccount: account,
+                        brand: self.context.configuration.resolvedLinkBrand(elementsSession: self.context.elementsSession),
                         configuration: self.context.configuration
                     )
                     verificationController.present(from: self) { result in

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkWebController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkWebController.swift
@@ -126,7 +126,10 @@ final class PayWithLinkWebController: NSObject, ASWebAuthenticationPresentationC
         do {
             // Generate Link URL, fetching the customer if needed
             let linkPopupParams = try LinkURLGenerator.linkParams(configuration: self.context.configuration, intent: self.context.intent, elementsSession: self.context.elementsSession)
-            let linkPopupUrl = try LinkURLGenerator.url(params: linkPopupParams)
+            let linkPopupUrl = try LinkURLGenerator.url(
+                params: linkPopupParams,
+                brand: context.configuration.resolvedLinkBrand(elementsSession: context.elementsSession)
+            )
 
             let webAuthSession = ASWebAuthenticationSession(url: linkPopupUrl, callbackURLScheme: "link-popup") { returnURL, error in
                 self.handleWebAuthenticationSessionCompletion(returnURL: returnURL, error: error)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
@@ -54,7 +54,8 @@ final class LinkInlineSignupView: UIView {
         let element = LinkEmailElement(defaultValue: viewModel.emailAddress,
                                        isOptional: viewModel.isEmailOptional,
                                        showLogo: viewModel.showLogoInEmailField,
-                                       theme: theme)
+                                       theme: theme,
+                                       brand: viewModel.brand)
         element.indicatorTintColor = theme.colors.primary
         return element
     }()
@@ -77,7 +78,11 @@ final class LinkInlineSignupView: UIView {
         case .textFieldsOnlyEmailFirst:
             return PhoneNumberElement(isOptional: viewModel.isPhoneNumberOptional, theme: theme)
         case .textFieldsOnlyPhoneFirst:
-            return PhoneNumberElement(isOptional: viewModel.isPhoneNumberOptional, infoView: LinkMoreInfoView(), theme: theme)
+            return PhoneNumberElement(
+                isOptional: viewModel.isPhoneNumberOptional,
+                infoView: LinkMoreInfoView(brand: viewModel.brand),
+                theme: theme
+            )
         }
     }()
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkEmailElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkEmailElement.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
+@_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
 import UIKit
 
@@ -89,11 +90,11 @@ class LinkEmailElement: Element {
         }
     }
 
-    public init(defaultValue: String? = nil, isOptional: Bool = false, showLogo: Bool, theme: ElementsAppearance = .default) {
+    public init(defaultValue: String? = nil, isOptional: Bool = false, showLogo: Bool, theme: ElementsAppearance = .default, brand: LinkBrand = .link) {
         self.theme = theme
 
         if showLogo {
-            self.infoView = LinkMoreInfoView(theme: theme)
+            self.infoView = LinkMoreInfoView(theme: theme, brand: brand)
         }
         emailAddressElement = TextFieldElement.makeEmail(defaultValue: defaultValue,
                                                          isOptional: isOptional,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkEmailElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkEmailElement.swift
@@ -90,7 +90,7 @@ class LinkEmailElement: Element {
         }
     }
 
-    public init(defaultValue: String? = nil, isOptional: Bool = false, showLogo: Bool, theme: ElementsAppearance = .default, brand: LinkBrand = .link) {
+    public init(defaultValue: String? = nil, isOptional: Bool = false, showLogo: Bool, theme: ElementsAppearance = .default, brand: LinkBrand) {
         self.theme = theme
 
         if showLogo {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/SignUp/LinkSignUpViewController.swift
@@ -67,7 +67,7 @@ final class LinkSignUpViewController: UIViewController {
     }()
 
     private lazy var emailElement = {
-        let element = LinkEmailElement(defaultValue: viewModel.emailAddress, showLogo: false, theme: theme)
+        let element = LinkEmailElement(defaultValue: viewModel.emailAddress, showLogo: false, theme: theme, brand: .link)
         element.indicatorTintColor = .linkIconBrand
         return element
     }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Utils/LinkURLGenerator.swift
@@ -121,8 +121,8 @@ class LinkURLGenerator {
                              clientAttributionMetadata: clientAttributionMetadata)
     }
 
-    static func url(params: LinkURLParams) throws -> URL {
-        var components = URLComponents(string: "https://checkout.link.com/")!
+    static func url(params: LinkURLParams, brand: LinkBrand) throws -> URL {
+        var components = URLComponents(url: brand.checkoutURL, resolvingAgainstBaseURL: false)!
         components.fragment = try params.toURLEncodedBase64()
         guard let url = components.url else {
             throw LinkURLGeneratorError.urlCreationFailed

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
@@ -23,7 +23,7 @@ final class LinkVerificationController {
     init(
         mode: LinkVerificationView.Mode = .modal,
         linkAccount: PaymentSheetLinkAccount,
-        brand: LinkBrand = .link,
+        brand: LinkBrand,
         configuration: PaymentElementConfiguration,
         appearance: LinkAppearance? = nil,
         allowLogoutInDialog: Bool = false,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
@@ -6,8 +6,8 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
-import UIKit
 @_spi(STP) import StripeCore
+import UIKit
 
 /// Standalone verification controller.
 final class LinkVerificationController {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+@_spi(STP) import StripeCore
 
 /// Standalone verification controller.
 final class LinkVerificationController {
@@ -22,6 +23,7 @@ final class LinkVerificationController {
     init(
         mode: LinkVerificationView.Mode = .modal,
         linkAccount: PaymentSheetLinkAccount,
+        brand: LinkBrand = .link,
         configuration: PaymentElementConfiguration,
         appearance: LinkAppearance? = nil,
         allowLogoutInDialog: Bool = false,
@@ -33,6 +35,7 @@ final class LinkVerificationController {
         self.verificationViewController = LinkVerificationViewController(
             mode: mode,
             linkAccount: linkAccount,
+            brand: brand,
             appearance: appearance,
             allowLogoutInDialog: allowLogoutInDialog,
             consentViewModel: consentViewModel

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationView-Header.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationView-Header.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripeUICore
 import UIKit
@@ -17,12 +18,14 @@ extension LinkVerificationView {
             static let logoHeight: CGFloat = 24
         }
 
-        private let logoView: UIImageView = {
+        private let brand: LinkBrand
+
+        private lazy var logoView: UIImageView = {
             let logoView = UIImageView(image: Image.link_logo.makeImage(template: false))
             logoView.translatesAutoresizingMaskIntoConstraints = false
             logoView.isAccessibilityElement = true
             logoView.accessibilityTraits = .header
-            logoView.accessibilityLabel = STPPaymentMethodType.link.displayName
+            logoView.accessibilityLabel = brand.displayName
             return logoView
         }()
 
@@ -37,7 +40,8 @@ extension LinkVerificationView {
             return CGSize(width: 72, height: 32)
         }
 
-        init() {
+        init(brand: LinkBrand = .link) {
+            self.brand = brand
             super.init(frame: .zero)
 
             addSubview(logoView)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationView.swift
@@ -39,6 +39,7 @@ final class LinkVerificationView: UIView {
     let linkAccount: PaymentSheetLinkAccountInfoProtocol
 
     private let appearance: LinkAppearance?
+    private let brand: LinkBrand
     private let allowLogoutInDialog: Bool
     private let consentViewModel: LinkConsentViewModel?
 
@@ -56,7 +57,7 @@ final class LinkVerificationView: UIView {
     }
 
     private lazy var header: Header = {
-        let header = Header()
+        let header = Header(brand: brand)
         header.closeButton.addTarget(self, action: #selector(didSelectCancel), for: .touchUpInside)
         return header
     }()
@@ -149,12 +150,14 @@ final class LinkVerificationView: UIView {
     required init(
         mode: Mode,
         linkAccount: PaymentSheetLinkAccountInfoProtocol,
+        brand: LinkBrand = .link,
         appearance: LinkAppearance? = nil,
         allowLogoutInDialog: Bool,
         consentViewModel: LinkConsentViewModel? = nil
     ) {
         self.mode = mode
         self.linkAccount = linkAccount
+        self.brand = brand
         self.appearance = appearance
         self.allowLogoutInDialog = allowLogoutInDialog
         self.consentViewModel = consentViewModel

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verification/LinkVerificationViewController.swift
@@ -37,6 +37,7 @@ final class LinkVerificationViewController: UIViewController {
     let mode: LinkVerificationView.Mode
     let linkAccount: PaymentSheetLinkAccount
 
+    private let brand: LinkBrand
     private let appearance: LinkAppearance?
     private let allowLogoutInDialog: Bool
     private let consentViewModel: LinkConsentViewModel?
@@ -49,6 +50,7 @@ final class LinkVerificationViewController: UIViewController {
         let verificationView = LinkVerificationView(
             mode: mode,
             linkAccount: linkAccount,
+            brand: brand,
             appearance: appearance,
             allowLogoutInDialog: allowLogoutInDialog,
             consentViewModel: consentViewModel
@@ -74,12 +76,14 @@ final class LinkVerificationViewController: UIViewController {
     required init(
         mode: LinkVerificationView.Mode = .modal,
         linkAccount: PaymentSheetLinkAccount,
+        brand: LinkBrand = .link,
         appearance: LinkAppearance? = nil,
         allowLogoutInDialog: Bool = false,
         consentViewModel: LinkConsentViewModel? = nil
     ) {
         self.mode = mode
         self.linkAccount = linkAccount
+        self.brand = brand
         self.appearance = appearance
         self.allowLogoutInDialog = allowLogoutInDialog
         self.consentViewModel = consentViewModel

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verify KYC/VerifyKYCContentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Verify KYC/VerifyKYCContentViewController.swift
@@ -18,6 +18,7 @@ final class VerifyKYCContentViewController: UIViewController, BottomSheetContent
         let navigationBar = LinkSheetNavigationBar(
             isTestMode: false,
             appearance: .default,
+            brand: .link,
             shouldLogPaymentSheetAnalyticsOnDismissal: false
         )
         navigationBar.setStyle(.close(showAdditionalButton: false))

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
@@ -32,10 +32,12 @@ final class LinkLegalTermsView: UIView {
         static let lineHeight: CGFloat = 1.0
     }
 
-    private let links: [String: URL] = [
-        "terms": URL(string: "https://link.co/terms")!,
-        "privacy": URL(string: "https://link.co/privacy")!,
-    ]
+    private var links: [String: URL] {
+        [
+            "terms": brand.termsURL,
+            "privacy": brand.privacyURL,
+        ]
+    }
 
     weak var delegate: LinkLegalTermsViewDelegate?
     private let mode: LinkInlineSignupViewModel.Mode

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMoreInfoView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkMoreInfoView.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2022 Stripe, Inc. All rights reserved.
 //
 
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripeUICore
@@ -26,14 +27,16 @@ final class LinkMoreInfoView: UIView {
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFit
         imageView.isAccessibilityElement = true
-        imageView.accessibilityLabel = STPPaymentMethodType.link.displayName
+        imageView.accessibilityLabel = brand.displayName
         return imageView
     }()
 
     private let theme: ElementsAppearance
+    private let brand: LinkBrand
 
-    init(theme: ElementsAppearance = .default) {
+    init(theme: ElementsAppearance = .default, brand: LinkBrand = .link) {
         self.theme = theme
+        self.brand = brand
         super.init(frame: .zero)
         let stackView = UIStackView(arrangedSubviews: [logoView])
         stackView.axis = .horizontal

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -367,7 +367,7 @@ extension EmbeddedPaymentElement: VerticalSavedPaymentMethodsViewControllerDeleg
 // MARK: - EmbeddedPaymentElement.PaymentOptionDisplayData
 
 extension EmbeddedPaymentElement.PaymentOptionDisplayData {
-    init(paymentOption: PaymentOption, mandateText: NSAttributedString?, currency: String?, iconStyle: PaymentSheet.Appearance.IconStyle, cardArtEnabled: Bool = false) {
+    init(paymentOption: PaymentOption, mandateText: NSAttributedString?, currency: String?, iconStyle: PaymentSheet.Appearance.IconStyle, cardArtEnabled: Bool = false, linkBrand: LinkBrand = .link) {
         self.mandateText = mandateText
         self.image = paymentOption.makeIcon(currency: currency, iconStyle: iconStyle, cardArtEnabled: cardArtEnabled) // TODO: https://jira.corp.stripe.com/browse/MOBILESDK-2604 Refactor this!
         switch paymentOption {
@@ -377,7 +377,7 @@ extension EmbeddedPaymentElement.PaymentOptionDisplayData {
             billingDetails = nil
             shippingDetails = nil
         case .saved(let paymentMethod, let confirmParams):
-            label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams)
+            label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams, brand: linkBrand)
             paymentMethodType = paymentMethod.type.identifier
             billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
             shippingDetails = nil
@@ -387,7 +387,7 @@ extension EmbeddedPaymentElement.PaymentOptionDisplayData {
             billingDetails = confirmParams.paymentMethodParams.billingDetails?.toPaymentSheetBillingDetails()
             shippingDetails = nil
         case .link(let option):
-            label = option.paymentSheetLabel
+            label = option.paymentSheetLabel(brand: linkBrand)
             paymentMethodType = STPPaymentMethodType.link.identifier
             billingDetails = option.billingDetails?.toPaymentSheetBillingDetails()
             shippingDetails = option.shippingAddress

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -377,7 +377,7 @@ extension EmbeddedPaymentElement.PaymentOptionDisplayData {
             billingDetails = nil
             shippingDetails = nil
         case .saved(let paymentMethod, let confirmParams):
-            label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams, brand: linkBrand)
+            label = paymentOptionLabel(for: paymentMethod, confirmParams: confirmParams, brand: linkBrand)
             paymentMethodType = paymentMethod.type.identifier
             billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
             shippingDetails = nil
@@ -387,7 +387,7 @@ extension EmbeddedPaymentElement.PaymentOptionDisplayData {
             billingDetails = confirmParams.paymentMethodParams.billingDetails?.toPaymentSheetBillingDetails()
             shippingDetails = nil
         case .link(let option):
-            label = option.paymentSheetLabel(brand: linkBrand)
+            label = paymentSheetLabel(for: option, brand: linkBrand)
             paymentMethodType = STPPaymentMethodType.link.identifier
             billingDetails = option.billingDetails?.toPaymentSheetBillingDetails()
             shippingDetails = option.shippingAddress

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -382,7 +382,7 @@ extension EmbeddedPaymentElement.PaymentOptionDisplayData {
             billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
             shippingDetails = nil
         case .new(let confirmParams):
-            label = confirmParams.paymentSheetLabel
+            label = confirmParams.paymentSheetLabel(brand: linkBrand)
             paymentMethodType = confirmParams.paymentMethodType.identifier
             billingDetails = confirmParams.paymentMethodParams.billingDetails?.toPaymentSheetBillingDetails()
             shippingDetails = nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -377,7 +377,7 @@ extension EmbeddedPaymentElement.PaymentOptionDisplayData {
             billingDetails = nil
             shippingDetails = nil
         case .saved(let paymentMethod, let confirmParams):
-            label = paymentOptionLabel(for: paymentMethod, confirmParams: confirmParams, brand: linkBrand)
+            label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams, brand: linkBrand)
             paymentMethodType = paymentMethod.type.identifier
             billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
             shippingDetails = nil
@@ -387,7 +387,7 @@ extension EmbeddedPaymentElement.PaymentOptionDisplayData {
             billingDetails = confirmParams.paymentMethodParams.billingDetails?.toPaymentSheetBillingDetails()
             shippingDetails = nil
         case .link(let option):
-            label = paymentSheetLabel(for: option, brand: linkBrand)
+            label = option.paymentSheetLabel(brand: linkBrand)
             paymentMethodType = STPPaymentMethodType.link.identifier
             billingDetails = option.billingDetails?.toPaymentSheetBillingDetails()
             shippingDetails = option.shippingAddress

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -55,7 +55,14 @@ public final class EmbeddedPaymentElement {
         guard let _paymentOption else {
             return nil
         }
-        return .init(paymentOption: _paymentOption, mandateText: embeddedPaymentMethodsView.mandateText, currency: intent.currency, iconStyle: configuration.appearance.iconStyle, cardArtEnabled: configuration.appearance.cardArtEnabled)
+        return .init(
+            paymentOption: _paymentOption,
+            mandateText: embeddedPaymentMethodsView.mandateText,
+            currency: intent.currency,
+            iconStyle: configuration.appearance.iconStyle,
+            cardArtEnabled: configuration.appearance.cardArtEnabled,
+            linkBrand: configuration.resolvedLinkBrand(elementsSession: elementsSession)
+        )
     }
 
     /// An asynchronous failable initializer

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -483,6 +483,7 @@ class EmbeddedPaymentMethodsView: UIView {
             appearance: appearance,
             accessoryView: accessoryButton,
             isEmbedded: true,
+            linkBrand: linkBrand,
             didTap: { [weak self] rowButton in
                 CustomerPaymentOption.setDefaultPaymentMethod(
                     .stripeId(savedPaymentMethod.stripeId),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -79,6 +79,7 @@ class EmbeddedPaymentMethodsView: UIView {
     private let shouldShowMandate: Bool
     private let analyticsHelper: PaymentSheetAnalyticsHelper
     private let incentive: PaymentMethodIncentive?
+    private let linkBrand: LinkBrand
     /// A bit hacky; this is the mandate text for the given payment method, *regardless* of whether it is shown in the view.
     /// It'd be better if the source of truth of mandate text was not the view and instead an independent `func mandateText(...) -> NSAttributedString` function, but this is hard b/c US Bank Account doesn't show mandate in certain states.
     var mandateText: NSAttributedString? {
@@ -134,6 +135,7 @@ class EmbeddedPaymentMethodsView: UIView {
         self.paymentMethodMessagingPromotionsHelper = paymentMethodMessagingPromotionsHelper
         self.analyticsHelper = analyticsHelper
         self.incentive = incentive
+        self.linkBrand = linkBrand
         self.delegate = delegate
         self.rowButtons = []
         super.init(frame: .zero)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -38,8 +38,14 @@ final class IntentConfirmParams {
     var instantDebitsLinkedBank: InstantDebitsLinkedBank?
 
     var paymentSheetLabel: String {
+        return paymentSheetLabel(brand: .link)
+    }
+
+    func paymentSheetLabel(brand: LinkBrand) -> String {
         if let last4 = (financialConnectionsLinkedBank?.last4 ?? instantDebitsLinkedBank?.last4) {
             return "••••\(last4)"
+        } else if paymentMethodType == .instantDebits || paymentMethodType == .linkCardBrand {
+            return brand.displayName
         } else {
             return paymentMethodParams.paymentSheetLabel
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -46,6 +46,10 @@ final class IntentConfirmParams {
     }
 
     var expandedPaymentSheetLabel: String {
+        return expandedPaymentSheetLabel(brand: .link)
+    }
+
+    func expandedPaymentSheetLabel(brand: LinkBrand) -> String {
         switch paymentMethodType {
         case .stripe(let stpPaymentMethodType):
             switch stpPaymentMethodType {
@@ -62,9 +66,9 @@ final class IntentConfirmParams {
         case .external:
             return paymentSheetLabel
         case .instantDebits:
-            return STPPaymentMethodType.link.displayName
+            return brand.displayName
         case .linkCardBrand:
-            return STPPaymentMethodType.link.displayName
+            return brand.displayName
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -177,6 +177,27 @@ final class IntentConfirmParams {
         }
     }
 
+    func expandedPaymentSheetLabel(brand: LinkBrand) -> String {
+        switch paymentMethodType {
+        case .stripe(let stpPaymentMethodType):
+            switch stpPaymentMethodType {
+            case .card:
+                let cardBrand = STPCardValidator.brand(for: paymentMethodParams.card)
+                return STPCardBrandUtilities.stringFrom(cardBrand) ?? STPPaymentMethodType.card.displayName
+            case .USBankAccount:
+                // Use linked bank name if available, otherwise fallback to generic display name for bank
+                return financialConnectionsLinkedBank?.displayName ?? STPPaymentMethodType.USBankAccount.displayName
+            default:
+                // For all other payment method types just use the default label
+                return paymentSheetLabel
+            }
+        case .external:
+            return paymentSheetLabel
+        case .instantDebits, .linkCardBrand:
+            return brand.displayName
+        }
+    }
+
     func setAllowRedisplayForCheckoutSession(merchantWillSavePaymentMethod: Bool) {
         switch saveForFutureUseCheckboxState {
         case .selected:
@@ -192,27 +213,6 @@ final class IntentConfirmParams {
         } else if savePaymentMethodConsentBehavior == .customerSheetWithCustomerSession {
             paymentMethodParams.allowRedisplay = .always
         }
-    }
-}
-
-func expandedPaymentSheetLabel(for confirmParams: IntentConfirmParams, brand: LinkBrand) -> String {
-    switch confirmParams.paymentMethodType {
-    case .stripe(let stpPaymentMethodType):
-        switch stpPaymentMethodType {
-        case .card:
-            let cardBrand = STPCardValidator.brand(for: confirmParams.paymentMethodParams.card)
-            return STPCardBrandUtilities.stringFrom(cardBrand) ?? STPPaymentMethodType.card.displayName
-        case .USBankAccount:
-            // Use linked bank name if available, otherwise fallback to generic display name for bank
-            return confirmParams.financialConnectionsLinkedBank?.displayName ?? STPPaymentMethodType.USBankAccount.displayName
-        default:
-            // For all other payment method types just use the default label
-            return confirmParams.paymentSheetLabel
-        }
-    case .external:
-        return confirmParams.paymentSheetLabel
-    case .instantDebits, .linkCardBrand:
-        return brand.displayName
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -51,33 +51,6 @@ final class IntentConfirmParams {
         }
     }
 
-    var expandedPaymentSheetLabel: String {
-        return expandedPaymentSheetLabel(brand: .link)
-    }
-
-    func expandedPaymentSheetLabel(brand: LinkBrand) -> String {
-        switch paymentMethodType {
-        case .stripe(let stpPaymentMethodType):
-            switch stpPaymentMethodType {
-            case .card:
-                let brand = STPCardValidator.brand(for: paymentMethodParams.card)
-                return STPCardBrandUtilities.stringFrom(brand) ?? STPPaymentMethodType.card.displayName
-            case .USBankAccount:
-                // Use linked bank name if available, otherwise fallback to generic display name for bank
-                return financialConnectionsLinkedBank?.displayName ?? STPPaymentMethodType.USBankAccount.displayName
-            default:
-                // For all other payment method types just use the default label
-                return paymentSheetLabel
-            }
-        case .external:
-            return paymentSheetLabel
-        case .instantDebits:
-            return brand.displayName
-        case .linkCardBrand:
-            return brand.displayName
-        }
-    }
-
     var paymentSheetSublabel: String? {
         switch paymentMethodType {
         case .stripe(let stpPaymentMethodType):
@@ -219,6 +192,27 @@ final class IntentConfirmParams {
         } else if savePaymentMethodConsentBehavior == .customerSheetWithCustomerSession {
             paymentMethodParams.allowRedisplay = .always
         }
+    }
+}
+
+func expandedPaymentSheetLabel(for confirmParams: IntentConfirmParams, brand: LinkBrand) -> String {
+    switch confirmParams.paymentMethodType {
+    case .stripe(let stpPaymentMethodType):
+        switch stpPaymentMethodType {
+        case .card:
+            let cardBrand = STPCardValidator.brand(for: confirmParams.paymentMethodParams.card)
+            return STPCardBrandUtilities.stringFrom(cardBrand) ?? STPPaymentMethodType.card.displayName
+        case .USBankAccount:
+            // Use linked bank name if available, otherwise fallback to generic display name for bank
+            return confirmParams.financialConnectionsLinkedBank?.displayName ?? STPPaymentMethodType.USBankAccount.displayName
+        default:
+            // For all other payment method types just use the default label
+            return confirmParams.paymentSheetLabel
+        }
+    case .external:
+        return confirmParams.paymentSheetLabel
+    case .instantDebits, .linkCardBrand:
+        return brand.displayName
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -721,7 +721,11 @@ import UIKit
     ) async throws -> CRSCARFDeclarationResult {
         return try await withCheckedThrowingContinuation { continuation in
             Task { @MainActor in
-                let declarationViewController = CRSCARFDeclarationViewController(text: text, appearance: appearance)
+                let declarationViewController = CRSCARFDeclarationViewController(
+                    text: text,
+                    appearance: appearance,
+                    brand: configuration.resolvedLinkBrand(elementsSession: elementsSession)
+                )
                 declarationViewController.onResult = { [weak declarationViewController] result in
                     declarationViewController?.onResult = nil
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -354,6 +354,7 @@ import UIKit
         let verificationController = LinkVerificationController(
             mode: .inlineLogin,
             linkAccount: linkAccount,
+            brand: configuration.resolvedLinkBrand(elementsSession: elementsSession),
             configuration: configuration,
             appearance: appearance
         )
@@ -808,6 +809,7 @@ import UIKit
         let verificationController = LinkVerificationController(
             mode: .inlineLogin,
             linkAccount: linkAccount,
+            brand: configuration.resolvedLinkBrand(elementsSession: elementsSession),
             configuration: configuration,
             appearance: appearance,
             consentViewModel: consentViewModel

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -137,7 +137,7 @@ import UIKit
             paymentMethodPreview = .init(
                 paymentMethodType: type,
                 icon: iconForPaymentDetails(selectedPaymentDetails),
-                label: STPPaymentMethodType.link.displayName,
+                label: configuration.resolvedLinkBrand(elementsSession: elementsSession).displayName,
                 sublabel: selectedPaymentDetails.linkPaymentDetailsFormattedString
             )
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -20,6 +20,7 @@ import UIKit
 
     private var payWithLinkContinuation: CheckedContinuation<Void, Swift.Error>?
     private var paymentMethodId: String?
+    private var fetchedLinkBrand: LinkBrand?
     private var instantDebitsOnlyAuthenticationSessionManager: InstantDebitsOnlyAuthenticationSessionManager? {
         willSet {
             instantDebitsOnlyAuthenticationSessionManager?.cancel()
@@ -54,7 +55,7 @@ import UIKit
     }
 
     private var resolvedLinkBrand: LinkBrand {
-        configuration.link.brand ?? .link
+        .onelink
     }
 
     /// The parent view controller to present
@@ -228,14 +229,15 @@ import UIKit
                     case .success(let successResult):
                         switch successResult {
                         case .success(let details):
-                            self.continueWithPaymentMethod(details.paymentMethodID)
+                            Task { [weak self] in
+                                await self?.continueWithPaymentMethod(details.paymentMethodID)
+                            }
                         case.canceled:
                             self.continueWithFailure(Error.canceled)
                         }
                     case .failure(let error):
                         self.continueWithFailure(error)
                     }
-                    self.payWithLinkContinuation = nil
                 }
         }
     }
@@ -372,7 +374,9 @@ import UIKit
         switch result {
         case .completed(let result):
             if case let .instantDebits(linkedBank) = result {
-                continueWithPaymentMethod(linkedBank.paymentMethod.id)
+                Task { [weak self] in
+                    await self?.continueWithPaymentMethod(linkedBank.paymentMethod.id)
+                }
             } else {
                 continueWithFailure(Error.canceled)
             }
@@ -383,14 +387,58 @@ import UIKit
         }
     }
 
-    private func continueWithPaymentMethod(_ paymentMethodId: String) {
+    private func continueWithPaymentMethod(_ paymentMethodId: String) async {
+        await fetchLinkBrandIfNeeded()
         self.paymentMethodId = paymentMethodId
-        payWithLinkContinuation?.resume(returning: ())
+        let continuation = payWithLinkContinuation
+        payWithLinkContinuation = nil
+        continuation?.resume(returning: ())
     }
 
     private func continueWithFailure(_ error: Swift.Error) {
         paymentMethodId = nil
-        payWithLinkContinuation?.resume(throwing: error)
+        let continuation = payWithLinkContinuation
+        payWithLinkContinuation = nil
+        continuation?.resume(throwing: error)
+    }
+
+    private func fetchLinkBrandIfNeeded() async {
+        guard configuration.link.brand == nil, fetchedLinkBrand == nil else {
+            return
+        }
+
+        do {
+            let linkBrand: LinkBrand?
+            switch mode {
+            case .paymentIntentClientSecret(let clientSecret):
+                let (_, elementsSession) = try await configuration.apiClient.retrieveElementsSession(
+                    paymentIntentClientSecret: clientSecret,
+                    clientDefaultPaymentMethod: nil,
+                    configuration: configuration
+                )
+                linkBrand = elementsSession.linkBrand
+            case .setupIntentClientSecret(let clientSecret):
+                let (_, elementsSession) = try await configuration.apiClient.retrieveElementsSession(
+                    setupIntentClientSecret: clientSecret,
+                    clientDefaultPaymentMethod: nil,
+                    configuration: configuration
+                )
+                linkBrand = elementsSession.linkBrand
+            case .deferredIntent(let intentConfiguration):
+                let elementsSession = try await configuration.apiClient.retrieveDeferredElementsSession(
+                    withIntentConfig: intentConfiguration,
+                    clientDefaultPaymentMethod: nil,
+                    configuration: configuration
+                )
+                linkBrand = elementsSession.linkBrand
+            case .checkoutSession:
+                linkBrand = nil
+            }
+
+            fetchedLinkBrand = linkBrand
+        } catch {
+            // Fall back to the explicit override or Link if the elements session lookup fails.
+        }
     }
 
     private func generateManifest(continuation: CheckedContinuation<Manifest, Swift.Error>,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -15,14 +15,8 @@ import UIKit
 /// `LinkPaymentController` encapsulates the Link payment flow, allowing you to let your customers pay with their Link account.
 /// This feature is currently invite-only. To accept payments, [use the Mobile Payment Element.](https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet)
 @_spi(LinkOnly) public class LinkPaymentController: NSObject {
-    private struct LoadContext {
-        let elementsSession: STPElementsSession?
-        let linkBrand: LinkBrand
-    }
-
     private let mode: PaymentSheet.InitializationMode
     private let configuration: PaymentSheet.Configuration
-    private var loadContext: LoadContext?
 
     private var payWithLinkContinuation: CheckedContinuation<Void, Swift.Error>?
     private var paymentMethodId: String?
@@ -60,7 +54,7 @@ import UIKit
     }
 
     private var resolvedLinkBrand: LinkBrand {
-        loadContext?.linkBrand ?? configuration.link.brand ?? .link
+        configuration.link.brand ?? .link
     }
 
     /// The parent view controller to present
@@ -138,8 +132,6 @@ import UIKit
     /// - Throws: Either `LinkPaymentController.Error.canceled`, meaning the customer canceled the flow, or an error describing what went wrong.
     @MainActor
     @_spi(LinkOnly) public func present(from presentingViewController: UIViewController) async throws {
-        _ = await loadContextIfNeeded()
-
         guard FinancialConnectionsSDKAvailability.isFinancialConnectionsSDKAvailable else {
             return try await presentWebFlow(from: presentingViewController)
         }
@@ -399,60 +391,6 @@ import UIKit
     private func continueWithFailure(_ error: Swift.Error) {
         paymentMethodId = nil
         payWithLinkContinuation?.resume(throwing: error)
-    }
-
-    @MainActor
-    private func loadContextIfNeeded() async -> LoadContext {
-        if let loadContext {
-            return loadContext
-        }
-
-        let resolvedFromOverride = configuration.link.brand.map { LoadContext(elementsSession: nil, linkBrand: $0) }
-        if let resolvedFromOverride {
-            loadContext = resolvedFromOverride
-            return resolvedFromOverride
-        }
-
-        do {
-            let elementsSession: STPElementsSession?
-            switch mode {
-            case .paymentIntentClientSecret(let clientSecret):
-                let (_, session) = try await configuration.apiClient.retrieveElementsSession(
-                    paymentIntentClientSecret: clientSecret,
-                    clientDefaultPaymentMethod: nil,
-                    configuration: configuration
-                )
-                elementsSession = session
-            case .setupIntentClientSecret(let clientSecret):
-                let (_, session) = try await configuration.apiClient.retrieveElementsSession(
-                    setupIntentClientSecret: clientSecret,
-                    clientDefaultPaymentMethod: nil,
-                    configuration: configuration
-                )
-                elementsSession = session
-            case .deferredIntent(let intentConfiguration):
-                elementsSession = try await configuration.apiClient.retrieveDeferredElementsSession(
-                    withIntentConfig: intentConfiguration,
-                    clientDefaultPaymentMethod: nil,
-                    configuration: configuration
-                )
-            case .checkoutSession:
-                elementsSession = nil
-            }
-
-            let resolved = LoadContext(
-                elementsSession: elementsSession,
-                linkBrand: configuration.link.brand ?? elementsSession?.linkBrand ?? .link
-            )
-            loadContext = resolved
-            return resolved
-        } catch {
-            // Headless Link can still proceed without this secondary fetch; fallback remains `.link`
-            // unless the merchant explicitly set `configuration.link.brand`.
-            let fallback = LoadContext(elementsSession: nil, linkBrand: .link)
-            loadContext = fallback
-            return fallback
-        }
     }
 
     private func generateManifest(continuation: CheckedContinuation<Manifest, Swift.Error>,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -15,8 +15,14 @@ import UIKit
 /// `LinkPaymentController` encapsulates the Link payment flow, allowing you to let your customers pay with their Link account.
 /// This feature is currently invite-only. To accept payments, [use the Mobile Payment Element.](https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet)
 @_spi(LinkOnly) public class LinkPaymentController: NSObject {
+    private struct LoadContext {
+        let elementsSession: STPElementsSession?
+        let linkBrand: LinkBrand
+    }
+
     private let mode: PaymentSheet.InitializationMode
     private let configuration: PaymentSheet.Configuration
+    private var loadContext: LoadContext?
 
     private var payWithLinkContinuation: CheckedContinuation<Void, Swift.Error>?
     private var paymentMethodId: String?
@@ -47,7 +53,14 @@ import UIKit
     @_spi(LinkOnly) public var paymentOption: PaymentOptionDisplayData? {
         if paymentMethodId == nil { return nil }
 
-        return PaymentOptionDisplayData(image: Image.link_logo.makeImage(), label: STPPaymentMethodType.link.displayName)
+        return PaymentOptionDisplayData(
+            image: Image.link_logo.makeImage(),
+            label: resolvedLinkBrand.displayName
+        )
+    }
+
+    private var resolvedLinkBrand: LinkBrand {
+        loadContext?.linkBrand ?? configuration.link.brand ?? .link
     }
 
     /// The parent view controller to present
@@ -125,6 +138,8 @@ import UIKit
     /// - Throws: Either `LinkPaymentController.Error.canceled`, meaning the customer canceled the flow, or an error describing what went wrong.
     @MainActor
     @_spi(LinkOnly) public func present(from presentingViewController: UIViewController) async throws {
+        _ = await loadContextIfNeeded()
+
         guard FinancialConnectionsSDKAvailability.isFinancialConnectionsSDKAvailable else {
             return try await presentWebFlow(from: presentingViewController)
         }
@@ -384,6 +399,60 @@ import UIKit
     private func continueWithFailure(_ error: Swift.Error) {
         paymentMethodId = nil
         payWithLinkContinuation?.resume(throwing: error)
+    }
+
+    @MainActor
+    private func loadContextIfNeeded() async -> LoadContext {
+        if let loadContext {
+            return loadContext
+        }
+
+        let resolvedFromOverride = configuration.link.brand.map { LoadContext(elementsSession: nil, linkBrand: $0) }
+        if let resolvedFromOverride {
+            loadContext = resolvedFromOverride
+            return resolvedFromOverride
+        }
+
+        do {
+            let elementsSession: STPElementsSession?
+            switch mode {
+            case .paymentIntentClientSecret(let clientSecret):
+                let (_, session) = try await configuration.apiClient.retrieveElementsSession(
+                    paymentIntentClientSecret: clientSecret,
+                    clientDefaultPaymentMethod: nil,
+                    configuration: configuration
+                )
+                elementsSession = session
+            case .setupIntentClientSecret(let clientSecret):
+                let (_, session) = try await configuration.apiClient.retrieveElementsSession(
+                    setupIntentClientSecret: clientSecret,
+                    clientDefaultPaymentMethod: nil,
+                    configuration: configuration
+                )
+                elementsSession = session
+            case .deferredIntent(let intentConfiguration):
+                elementsSession = try await configuration.apiClient.retrieveDeferredElementsSession(
+                    withIntentConfig: intentConfiguration,
+                    clientDefaultPaymentMethod: nil,
+                    configuration: configuration
+                )
+            case .checkoutSession:
+                elementsSession = nil
+            }
+
+            let resolved = LoadContext(
+                elementsSession: elementsSession,
+                linkBrand: configuration.link.brand ?? elementsSession?.linkBrand ?? .link
+            )
+            loadContext = resolved
+            return resolved
+        } catch {
+            // Headless Link can still proceed without this secondary fetch; fallback remains `.link`
+            // unless the merchant explicitly set `configuration.link.brand`.
+            let fallback = LoadContext(elementsSession: nil, linkBrand: .link)
+            loadContext = fallback
+            return fallback
+        }
     }
 
     private func generateManifest(continuation: CheckedContinuation<Manifest, Swift.Error>,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -55,7 +55,7 @@ import UIKit
     }
 
     private var resolvedLinkBrand: LinkBrand {
-        .onelink
+        configuration.link.brand ?? fetchedLinkBrand ?? .link
     }
 
     /// The parent view controller to present

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -46,10 +46,11 @@ extension PaymentSheet {
 
 extension PaymentSheet.LinkConfirmOption {
     func paymentSheetSubLabel(brand: LinkBrand) -> String? {
-        let sublabel = paymentSheetSubLabel
-        switch sublabel {
-        case nil:
+        guard let sublabel = paymentSheetSubLabel else {
             return nil
+        }
+
+        switch sublabel {
         // Suppress the redundant sublabel both for the resolved brand name and for
         // the legacy "Link" fallback that some lower-level paths can still return.
         case brand.displayName, STPPaymentMethodType.link.displayName:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -50,7 +50,7 @@ extension PaymentSheet.LinkConfirmOption {
         case .wallet, .withPaymentDetails:
             return brand.displayName
         case .signUp(_, _, _, _, let intentConfirmParams):
-            return intentConfirmParams.paymentMethodParams.paymentSheetLabel
+            return intentConfirmParams.paymentSheetLabel(brand: brand)
         case .withPaymentMethod(let paymentMethod):
             return paymentMethod.paymentSheetLabel(brand: brand)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @_spi(STP) import StripeUICore
 
@@ -44,6 +45,28 @@ extension PaymentSheet {
 // MARK: - Helpers
 
 extension PaymentSheet.LinkConfirmOption {
+    func paymentSheetLabel(brand: LinkBrand) -> String {
+        switch self {
+        case .wallet, .withPaymentDetails:
+            return brand.displayName
+        case .signUp(_, _, _, _, let intentConfirmParams):
+            return intentConfirmParams.paymentMethodParams.paymentSheetLabel
+        case .withPaymentMethod(let paymentMethod):
+            return paymentMethod.paymentSheetLabel(brand: brand)
+        }
+    }
+
+    func paymentSheetSubLabel(brand: LinkBrand) -> String? {
+        let sublabel = paymentSheetSubLabel
+        switch sublabel {
+        case nil:
+            return nil
+        case brand.displayName, STPPaymentMethodType.link.displayName:
+            return nil
+        default:
+            return sublabel
+        }
+    }
 
     var account: PaymentSheetLinkAccount? {
         switch self {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -138,15 +138,15 @@ extension PaymentSheet.LinkConfirmOption {
             return nil
         }
     }
-}
 
-func paymentSheetLabel(for option: PaymentSheet.LinkConfirmOption, brand: LinkBrand) -> String {
-    switch option {
-    case .wallet, .withPaymentDetails:
-        return brand.displayName
-    case .signUp(_, _, _, _, let intentConfirmParams):
-        return intentConfirmParams.paymentSheetLabel(brand: brand)
-    case .withPaymentMethod(let paymentMethod):
-        return paymentMethod.paymentSheetLabel(brand: brand)
+    func paymentSheetLabel(brand: LinkBrand) -> String {
+        switch self {
+        case .wallet, .withPaymentDetails:
+            return brand.displayName
+        case .signUp(_, _, _, _, let intentConfirmParams):
+            return intentConfirmParams.paymentSheetLabel(brand: brand)
+        case .withPaymentMethod(let paymentMethod):
+            return paymentMethod.paymentSheetLabel(brand: brand)
+        }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PaymentSheet-LinkConfirmOption.swift
@@ -45,22 +45,13 @@ extension PaymentSheet {
 // MARK: - Helpers
 
 extension PaymentSheet.LinkConfirmOption {
-    func paymentSheetLabel(brand: LinkBrand) -> String {
-        switch self {
-        case .wallet, .withPaymentDetails:
-            return brand.displayName
-        case .signUp(_, _, _, _, let intentConfirmParams):
-            return intentConfirmParams.paymentSheetLabel(brand: brand)
-        case .withPaymentMethod(let paymentMethod):
-            return paymentMethod.paymentSheetLabel(brand: brand)
-        }
-    }
-
     func paymentSheetSubLabel(brand: LinkBrand) -> String? {
         let sublabel = paymentSheetSubLabel
         switch sublabel {
         case nil:
             return nil
+        // Suppress the redundant sublabel both for the resolved brand name and for
+        // the legacy "Link" fallback that some lower-level paths can still return.
         case brand.displayName, STPPaymentMethodType.link.displayName:
             return nil
         default:
@@ -78,17 +69,6 @@ extension PaymentSheet.LinkConfirmOption {
             return nil
         case .withPaymentDetails(let account, _, _, _):
             return account
-        }
-    }
-
-    var paymentSheetLabel: String {
-        switch self {
-        case .wallet, .withPaymentDetails:
-            return STPPaymentMethodType.link.displayName
-        case .signUp(_, _, _, _, let intentConfirmParams):
-            return intentConfirmParams.paymentMethodParams.paymentSheetLabel
-        case .withPaymentMethod(let paymentMethod):
-            return paymentMethod.paymentSheetLabel
         }
     }
 
@@ -157,5 +137,16 @@ extension PaymentSheet.LinkConfirmOption {
         case .wallet, .withPaymentDetails, .withPaymentMethod:
             return nil
         }
+    }
+}
+
+func paymentSheetLabel(for option: PaymentSheet.LinkConfirmOption, brand: LinkBrand) -> String {
+    switch option {
+    case .wallet, .withPaymentDetails:
+        return brand.displayName
+    case .signUp(_, _, _, _, let intentConfirmParams):
+        return intentConfirmParams.paymentSheetLabel(brand: brand)
+    case .withPaymentMethod(let paymentMethod):
+        return paymentMethod.paymentSheetLabel(brand: brand)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -193,6 +193,7 @@ public class PaymentSheet {
                         let verificationController = LinkVerificationController(
                             mode: .inlineLogin,
                             linkAccount: linkAccount,
+                            brand: self.configuration.resolvedLinkBrand(elementsSession: loadResult.elementsSession),
                             configuration: self.configuration
                         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -205,7 +205,7 @@ extension PaymentSheet {
                     billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
                     shippingDetails = nil
                 case .new(let confirmParams):
-                    label = confirmParams.paymentSheetLabel
+                    label = confirmParams.paymentSheetLabel(brand: linkBrand)
                     labels = Labels(
                         label: confirmParams.expandedPaymentSheetLabel(brand: linkBrand),
                         sublabel: confirmParams.paymentSheetSublabel

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -196,18 +196,18 @@ extension PaymentSheet {
                         labels = Labels(label: linkedBank.bankName ?? .Localized.bank, sublabel: sublabel)
                     } else {
                         labels = Labels(
-                            label: paymentMethod.expandedPaymentSheetLabel(brand: linkBrand),
-                            sublabel: paymentMethod.paymentSheetSublabel(brand: linkBrand)
+                            label: expandedPaymentSheetLabel(for: paymentMethod, brand: linkBrand),
+                            sublabel: paymentSheetSublabel(for: paymentMethod, brand: linkBrand)
                         )
                     }
-                    label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams, brand: linkBrand)
+                    label = paymentOptionLabel(for: paymentMethod, confirmParams: confirmParams, brand: linkBrand)
                     paymentMethodType = paymentMethod.type.identifier
                     billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
                     shippingDetails = nil
                 case .new(let confirmParams):
                     label = confirmParams.paymentSheetLabel(brand: linkBrand)
                     labels = Labels(
-                        label: confirmParams.expandedPaymentSheetLabel(brand: linkBrand),
+                        label: expandedPaymentSheetLabel(for: confirmParams, brand: linkBrand),
                         sublabel: confirmParams.paymentSheetSublabel
                     )
                     paymentMethodType = confirmParams.paymentMethodType.identifier
@@ -216,13 +216,13 @@ extension PaymentSheet {
                 case .link(let option):
                     if case let .signUp(_, _, _, _, confirmParams) = option {
                         labels = Labels(
-                            label: confirmParams.expandedPaymentSheetLabel(brand: linkBrand),
+                            label: expandedPaymentSheetLabel(for: confirmParams, brand: linkBrand),
                             sublabel: confirmParams.paymentSheetSublabel
                         )
                     } else {
                         labels = Labels(label: linkBrand.displayName, sublabel: option.paymentSheetSubLabel(brand: linkBrand))
                     }
-                    label = option.paymentSheetLabel(brand: linkBrand)
+                    label = paymentSheetLabel(for: option, brand: linkBrand)
                     paymentMethodType = option.paymentMethodType
                     billingDetails = option.billingDetails?.toPaymentSheetBillingDetails()
                     shippingDetails = option.shippingAddress

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -180,7 +180,7 @@ extension PaymentSheet {
                 }
             }
 
-            init(paymentOption: PaymentOption, currency: String?, iconStyle: PaymentSheet.Appearance.IconStyle, cardArtEnabled: Bool = false) {
+            init(paymentOption: PaymentOption, currency: String?, iconStyle: PaymentSheet.Appearance.IconStyle, cardArtEnabled: Bool = false, linkBrand: LinkBrand = .link) {
                 image = paymentOption.makeIcon(currency: currency, iconStyle: iconStyle, cardArtEnabled: cardArtEnabled)
                 switch paymentOption {
                 case .applePay:
@@ -195,25 +195,34 @@ extension PaymentSheet {
                         let sublabel = linkedBank.last4.flatMap { "••••\($0)" }
                         labels = Labels(label: linkedBank.bankName ?? .Localized.bank, sublabel: sublabel)
                     } else {
-                        labels = Labels(label: paymentMethod.expandedPaymentSheetLabel, sublabel: paymentMethod.paymentSheetSublabel)
+                        labels = Labels(
+                            label: paymentMethod.expandedPaymentSheetLabel(brand: linkBrand),
+                            sublabel: paymentMethod.paymentSheetSublabel(brand: linkBrand)
+                        )
                     }
-                    label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams)
+                    label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams, brand: linkBrand)
                     paymentMethodType = paymentMethod.type.identifier
                     billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
                     shippingDetails = nil
                 case .new(let confirmParams):
                     label = confirmParams.paymentSheetLabel
-                    labels = Labels(label: confirmParams.expandedPaymentSheetLabel, sublabel: confirmParams.paymentSheetSublabel)
+                    labels = Labels(
+                        label: confirmParams.expandedPaymentSheetLabel(brand: linkBrand),
+                        sublabel: confirmParams.paymentSheetSublabel
+                    )
                     paymentMethodType = confirmParams.paymentMethodType.identifier
                     billingDetails = confirmParams.paymentMethodParams.billingDetails?.toPaymentSheetBillingDetails()
                     shippingDetails = nil
                 case .link(let option):
                     if case let .signUp(_, _, _, _, confirmParams) = option {
-                        labels = Labels(label: confirmParams.expandedPaymentSheetLabel, sublabel: confirmParams.paymentSheetSublabel)
+                        labels = Labels(
+                            label: confirmParams.expandedPaymentSheetLabel(brand: linkBrand),
+                            sublabel: confirmParams.paymentSheetSublabel
+                        )
                     } else {
-                        labels = Labels(label: STPPaymentMethodType.link.displayName, sublabel: option.paymentSheetSubLabel)
+                        labels = Labels(label: linkBrand.displayName, sublabel: option.paymentSheetSubLabel(brand: linkBrand))
                     }
-                    label = option.paymentSheetLabel
+                    label = option.paymentSheetLabel(brand: linkBrand)
                     paymentMethodType = option.paymentMethodType
                     billingDetails = option.billingDetails?.toPaymentSheetBillingDetails()
                     shippingDetails = option.shippingAddress
@@ -759,7 +768,13 @@ extension PaymentSheet {
         /// Updates the published paymentOption property based on the current state
         func updatePaymentOption() {
             if let selectedPaymentOption = internalPaymentOption {
-                paymentOption = PaymentOptionDisplayData(paymentOption: selectedPaymentOption, currency: intent.currency, iconStyle: configuration.appearance.iconStyle, cardArtEnabled: configuration.appearance.cardArtEnabled)
+                paymentOption = PaymentOptionDisplayData(
+                    paymentOption: selectedPaymentOption,
+                    currency: intent.currency,
+                    iconStyle: configuration.appearance.iconStyle,
+                    cardArtEnabled: configuration.appearance.cardArtEnabled,
+                    linkBrand: configuration.resolvedLinkBrand(elementsSession: elementsSession)
+                )
             } else {
                 paymentOption = nil
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -196,18 +196,18 @@ extension PaymentSheet {
                         labels = Labels(label: linkedBank.bankName ?? .Localized.bank, sublabel: sublabel)
                     } else {
                         labels = Labels(
-                            label: expandedPaymentSheetLabel(for: paymentMethod, brand: linkBrand),
-                            sublabel: paymentSheetSublabel(for: paymentMethod, brand: linkBrand)
+                            label: paymentMethod.expandedPaymentSheetLabel(brand: linkBrand),
+                            sublabel: paymentMethod.paymentSheetSublabel(brand: linkBrand)
                         )
                     }
-                    label = paymentOptionLabel(for: paymentMethod, confirmParams: confirmParams, brand: linkBrand)
+                    label = paymentMethod.paymentOptionLabel(confirmParams: confirmParams, brand: linkBrand)
                     paymentMethodType = paymentMethod.type.identifier
                     billingDetails = paymentMethod.billingDetails?.toPaymentSheetBillingDetails()
                     shippingDetails = nil
                 case .new(let confirmParams):
                     label = confirmParams.paymentSheetLabel(brand: linkBrand)
                     labels = Labels(
-                        label: expandedPaymentSheetLabel(for: confirmParams, brand: linkBrand),
+                        label: confirmParams.expandedPaymentSheetLabel(brand: linkBrand),
                         sublabel: confirmParams.paymentSheetSublabel
                     )
                     paymentMethodType = confirmParams.paymentMethodType.identifier
@@ -216,13 +216,13 @@ extension PaymentSheet {
                 case .link(let option):
                     if case let .signUp(_, _, _, _, confirmParams) = option {
                         labels = Labels(
-                            label: expandedPaymentSheetLabel(for: confirmParams, brand: linkBrand),
+                            label: confirmParams.expandedPaymentSheetLabel(brand: linkBrand),
                             sublabel: confirmParams.paymentSheetSublabel
                         )
                     } else {
                         labels = Labels(label: linkBrand.displayName, sublabel: option.paymentSheetSubLabel(brand: linkBrand))
                     }
-                    label = paymentSheetLabel(for: option, brand: linkBrand)
+                    label = option.paymentSheetLabel(brand: linkBrand)
                     paymentMethodType = option.paymentMethodType
                     billingDetails = option.billingDetails?.toPaymentSheetBillingDetails()
                     shippingDetails = option.shippingAddress

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/MandateVariant.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/MandateVariant.swift
@@ -30,21 +30,22 @@ enum MandateVariant {
             }
         }
 
-        let terms = {
-            if case .updated(true) = self {
-                return formatText.removeTrailingDots()
-            }
-            return String(format: formatText, merchant).removeTrailingDots()
-        }()
+        let terms = switch self {
+        case .original, .updated(false):
+            String(format: formatText, merchant).removeTrailingDots()
+        case .updated(true):
+            formatText.removeTrailingDots()
+        }
 
-        if case .updated(true) = self {
+        switch self {
+        case .updated(true):
             let links = [
                 "link": URL(string: "https://link.com")!,
                 "terms": URL(string: "https://link.com/terms")!,
                 "privacy": URL(string: "https://link.com/privacy")!,
             ]
             return STPStringUtils.applyLinksToString(template: terms, links: links)
-        } else {
+        case .original, .updated(false):
             return NSAttributedString(string: terms)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/MandateVariant.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/MandateVariant.swift
@@ -40,9 +40,9 @@ enum MandateVariant {
         switch self {
         case .updated(true):
             let links = [
-                "link": URL(string: "https://link.com")!,
-                "terms": URL(string: "https://link.com/terms")!,
-                "privacy": URL(string: "https://link.com/privacy")!,
+                "link": brand.websiteURL,
+                "terms": brand.termsURL,
+                "privacy": brand.privacyURL,
             ]
             return STPStringUtils.applyLinksToString(template: terms, links: links)
         case .original, .updated(false):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -583,9 +583,10 @@ extension PaymentSheetFormFactory {
     static func makeBankMandateText(
         isSettingUp: Bool,
         merchantName: String,
-        sellerName: String?
+        sellerName: String?,
+        brand: LinkBrand
     ) -> NSAttributedString {
-        let links = ["terms": URL(string: "https://link.com/terms/ach-authorization")!]
+        let links = ["terms": brand.achAuthorizationURL]
 
         let string = if let sellerName, isSettingUp {
             String(
@@ -903,6 +904,7 @@ extension PaymentSheetFormFactory {
             isPaymentIntent: isPaymentIntent,
             sellerName: sellerName,
             isSettingUp: isSettingUp || forceSaveFutureUseBehavior,
+            linkBrand: linkBrand,
             appearance: configuration.appearance
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -150,6 +150,7 @@ extension SavedPaymentMethodCollectionView {
         var needsVerticalPaddingForBadge: Bool = false
         var showDefaultPMBadge: Bool = false
         var cardArtEnabled: Bool = false
+        var linkBrand: LinkBrand = .link
 
         /// Indicates whether the cell for a saved payment method should display the edit icon.
         /// True if payment methods can be removed or edited
@@ -265,7 +266,7 @@ extension SavedPaymentMethodCollectionView {
         }()
 
         // MARK: - Internal Methods
-        func setViewModel(_ viewModel: SavedPaymentOptionsViewController.Selection, cbcEligible: Bool, allowsPaymentMethodRemoval: Bool, allowsPaymentMethodUpdate: Bool, allowsSetAsDefaultPM: Bool = false, needsVerticalPaddingForBadge: Bool = false, showDefaultPMBadge: Bool = false, cardArtEnabled: Bool = false) {
+        func setViewModel(_ viewModel: SavedPaymentOptionsViewController.Selection, cbcEligible: Bool, allowsPaymentMethodRemoval: Bool, allowsPaymentMethodUpdate: Bool, allowsSetAsDefaultPM: Bool = false, needsVerticalPaddingForBadge: Bool = false, showDefaultPMBadge: Bool = false, cardArtEnabled: Bool = false, linkBrand: LinkBrand = .link) {
             paymentMethodLogo.isHidden = false
             plus.isHidden = true
             selectableRectangle.isHidden = false
@@ -277,6 +278,7 @@ extension SavedPaymentMethodCollectionView {
             self.needsVerticalPaddingForBadge = needsVerticalPaddingForBadge
             self.showDefaultPMBadge = showDefaultPMBadge
             self.cardArtEnabled = cardArtEnabled
+            self.linkBrand = linkBrand
             update()
         }
 
@@ -352,7 +354,7 @@ extension SavedPaymentMethodCollectionView {
                         } else if let linkPaymentDetails = paymentMethod.linkPaymentDetails {
                             label.text = linkPaymentDetails.formattedLast4
                         } else {
-                            label.text = paymentMethod.paymentSheetLabel
+                            label.text = paymentMethod.paymentSheetLabel(brand: linkBrand)
                         }
                         accessibilityIdentifier = label.text
                         selectableRectangle.accessibilityIdentifier = label.text
@@ -392,7 +394,7 @@ extension SavedPaymentMethodCollectionView {
                         paymentMethodLogo.tag = paymentMethodLogoImage.hashValue
                         paymentMethodLogoHeightConstraint.constant = paymentMethodLogoSize.height
                     case .link:
-                        label.text = STPPaymentMethodType.link.displayName
+                        label.text = linkBrand.displayName
                         accessibilityIdentifier = label.text
                         selectableRectangle.accessibilityIdentifier = label.text
                         selectableRectangle.accessibilityLabel = label.text

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -100,6 +100,7 @@ class SavedPaymentOptionsViewController: UIViewController {
         let customerID: String?
         let showApplePay: Bool
         let showLink: Bool
+        let linkBrand: LinkBrand
         let removeSavedPaymentMethodMessage: String?
         let merchantDisplayName: String
         let isCVCRecollectionEnabled: Bool
@@ -535,7 +536,8 @@ extension SavedPaymentOptionsViewController: UICollectionViewDataSource, UIColle
                           allowsSetAsDefaultPM: configuration.allowsSetAsDefaultPM,
                           needsVerticalPaddingForBadge: hasDefault,
                           showDefaultPMBadge: isDefaultPaymentMethod(savedPaymentMethodId: viewModel.savedPaymentMethod?.stripeId),
-                          cardArtEnabled: appearance.cardArtEnabled)
+                          cardArtEnabled: appearance.cardArtEnabled,
+                          linkBrand: configuration.linkBrand)
         cell.delegate = self
         cell.isRemovingPaymentMethods = self.collectionView.isRemovingPaymentMethods
         cell.appearance = appearance

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -40,6 +40,7 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
     private let incentive: PaymentMethodIncentive?
     private let isSettingUp: Bool
     private let sellerName: String?
+    private let linkBrand: LinkBrand
 
     weak var delegate: ElementDelegate?
     var view: UIView {
@@ -55,7 +56,8 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
             attributedString: PaymentSheetFormFactory.makeBankMandateText(
                 isSettingUp: isSettingUp,
                 merchantName: configuration.merchantDisplayName,
-                sellerName: sellerName
+                sellerName: sellerName,
+                brand: linkBrand
             )
         )
         let style = NSMutableParagraphStyle()
@@ -191,11 +193,13 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
         isPaymentIntent: Bool,
         sellerName: String?,
         isSettingUp: Bool,
+        linkBrand: LinkBrand,
         appearance: PaymentSheet.Appearance = .default
     ) {
         let theme = appearance.asElementsTheme
 
         self.configuration = configuration
+        self.linkBrand = linkBrand
         self.linkedBankInfoView = BankAccountInfoView(frame: .zero, appearance: appearance, incentive: incentive)
         self.linkedBankInfoSectionElement = SectionElement(
             title: String.Localized.bank_account_sentence_case,
@@ -214,7 +218,7 @@ final class InstantDebitsPaymentMethodElement: ContainerElement {
         self.theme = theme
         self.promoDisclaimerElement = incentive.flatMap {
             let label = ElementsUI.makeNoticeTextField(theme: theme)
-            label.attributedText = $0.promoDisclaimerText(with: theme, isPaymentIntent: isPaymentIntent)
+            label.attributedText = $0.promoDisclaimerText(with: theme, isPaymentIntent: isPaymentIntent, brand: linkBrand)
             label.textContainerInset = .zero
             label.textContainer.lineFragmentPadding = 0
             return StaticElement(view: label)
@@ -363,7 +367,8 @@ private extension PaymentMethodIncentive {
 
     func promoDisclaimerText(
         with appearance: ElementsAppearance,
-        isPaymentIntent: Bool
+        isPaymentIntent: Bool,
+        brand: LinkBrand
     ) -> NSAttributedString {
         let baseString = if isPaymentIntent {
             STPLocalizedString(
@@ -380,7 +385,7 @@ private extension PaymentMethodIncentive {
         let string = String(format: baseString, displayText)
 
         let links = [
-            "terms": URL(string: "https://link.com/promotion-terms")!,
+            "terms": brand.promotionTermsURL,
         ]
 
         let formattedString = STPStringUtils.applyLinksToString(template: string, links: links)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -580,12 +580,6 @@ extension RowButton {
             didTap: didTap
         )
         button.accessibilityHelperView.accessibilityLabel = {
-            if paymentMethod.isLinkPassthroughMode {
-                if let badgeText {
-                    return "\(linkBrand.displayName), \(badgeText)"
-                }
-                return linkBrand.displayName
-            }
             if let badgeText {
                 if let accessibilityLabel = paymentMethod.paymentSheetAccessibilityLabel {
                     return "\(accessibilityLabel), \(badgeText)"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -573,7 +573,7 @@ extension RowButton {
             type: .saved(paymentMethod: paymentMethod),
             imageView: imageView,
             text: text,
-            subtext: paymentMethod.linkSpecificSublabel ?? subtext,
+            subtext: paymentMethod.linkSpecificSublabel(brand: linkBrand) ?? subtext,
             badgeText: badgeText,
             accessoryView: accessoryView,
             isEmbedded: isEmbedded,
@@ -676,14 +676,14 @@ extension PaymentSheet.Appearance {
 
 private extension STPPaymentMethod {
 
-    var linkSpecificSublabel: String? {
+    func linkSpecificSublabel(brand: LinkBrand) -> String? {
         if let linkPaymentDetails {
             return linkPaymentDetails.sublabel
         }
         if isLinkPassthroughMode {
-            // We render "Link" as the label, so use the original label
+            // We render the Link brand as the label, so use the original label
             // as the sublabel.
-            return paymentSheetLabel
+            return paymentSheetLabel(brand: brand)
         }
         return nil
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -552,7 +552,7 @@ extension RowButton {
         return button
     }
 
-    static func makeForSavedPaymentMethod(paymentMethod: STPPaymentMethod, appearance: PaymentSheet.Appearance, subtext: String? = nil, badgeText: String? = nil, accessoryView: UIView? = nil, isEmbedded: Bool = false, didTap: @escaping DidTapClosure) -> RowButton {
+    static func makeForSavedPaymentMethod(paymentMethod: STPPaymentMethod, appearance: PaymentSheet.Appearance, subtext: String? = nil, badgeText: String? = nil, accessoryView: UIView? = nil, isEmbedded: Bool = false, linkBrand: LinkBrand = .link, didTap: @escaping DidTapClosure) -> RowButton {
         let imageView = UIImageView()
         imageView.contentMode = .scaleAspectFit
         let savedPaymentMethodRowImage = paymentMethod.makeSavedPaymentMethodRowImage(iconStyle: appearance.iconStyle)
@@ -565,8 +565,8 @@ extension RowButton {
             imageView.image = savedPaymentMethodRowImage
         }
         let text = paymentMethod.isLinkPassthroughMode
-            ? STPPaymentMethodType.link.displayName
-            : paymentMethod.paymentSheetLabel
+            ? linkBrand.displayName
+            : paymentMethod.paymentSheetLabel(brand: linkBrand)
 
         let button = RowButton.create(
             appearance: appearance,
@@ -580,6 +580,12 @@ extension RowButton {
             didTap: didTap
         )
         button.accessibilityHelperView.accessibilityLabel = {
+            if paymentMethod.isLinkPassthroughMode {
+                if let badgeText {
+                    return "\(linkBrand.displayName), \(badgeText)"
+                }
+                return linkBrand.displayName
+            }
             if let badgeText {
                 if let accessibilityLabel = paymentMethod.paymentSheetAccessibilityLabel {
                     return "\(accessibilityLabel), \(badgeText)"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
@@ -115,7 +115,8 @@ class VerticalPaymentMethodListViewController: UIViewController {
             let savedPaymentMethodButton = RowButton.makeForSavedPaymentMethod(
                 paymentMethod: firstSavedPaymentMethod,
                 appearance: appearance,
-                accessoryView: accessoryButton
+                accessoryView: accessoryButton,
+                linkBrand: linkBrand
             ) { [weak self] in
                 self?.didTap(rowButton: $0, selection: selection)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/SavedPaymentMethodRowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/SavedPaymentMethodRowButton.swift
@@ -53,6 +53,7 @@ final class SavedPaymentMethodRowButton: UIView {
     // MARK: - Private properties
 
     private let appearance: PaymentSheet.Appearance
+    private let linkBrand: LinkBrand
 
     private var isEditing: Bool {
         switch state {
@@ -74,7 +75,14 @@ final class SavedPaymentMethodRowButton: UIView {
     }()
 
     private(set) lazy var rowButton: RowButton = {
-        let button: RowButton = .makeForSavedPaymentMethod(paymentMethod: paymentMethod, appearance: appearance, badgeText: badgeText, accessoryView: chevronButton, didTap: handleRowButtonTapped)
+        let button: RowButton = .makeForSavedPaymentMethod(
+            paymentMethod: paymentMethod,
+            appearance: appearance,
+            badgeText: badgeText,
+            accessoryView: chevronButton,
+            linkBrand: linkBrand,
+            didTap: handleRowButtonTapped
+        )
 
         return button
     }()
@@ -85,11 +93,13 @@ final class SavedPaymentMethodRowButton: UIView {
 
     init(paymentMethod: STPPaymentMethod,
          appearance: PaymentSheet.Appearance,
+         linkBrand: LinkBrand = .link,
          showDefaultPMBadge: Bool = false,
          previousSelectedState: State = .unselected,
          currentState: State = .unselected) {
         self.paymentMethod = paymentMethod
         self.appearance = appearance
+        self.linkBrand = linkBrand
         self.showDefaultPMBadge = showDefaultPMBadge
         self.previousSelectedState = previousSelectedState
         self.state = currentState

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -205,6 +205,7 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         return paymentMethods.map { paymentMethod in
             let button = SavedPaymentMethodRowButton(paymentMethod: paymentMethod,
                                                      appearance: configuration.appearance,
+                                                     linkBrand: configuration.resolvedLinkBrand(elementsSession: elementsSession),
                                                      showDefaultPMBadge: isDefaultPaymentMethod(paymentMethodId: paymentMethod.stripeId))
             button.delegate = self
             return button
@@ -474,6 +475,7 @@ extension VerticalSavedPaymentMethodsViewController: UpdatePaymentMethodViewCont
         let isDefaultPaymentMethod = isDefaultPaymentMethod(paymentMethodId: updatedPaymentMethod.stripeId)
         let newButton = SavedPaymentMethodRowButton(paymentMethod: updatedPaymentMethod,
                                                     appearance: configuration.appearance,
+                                                    linkBrand: configuration.resolvedLinkBrand(elementsSession: elementsSession),
                                                     showDefaultPMBadge: isDefaultPaymentMethod,
                                                     previousSelectedState: selectedState ?? oldButton.previousSelectedState,
                                                     currentState: oldButton.state)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -198,6 +198,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
                 customerID: configuration.customer?.id,
                 showApplePay: isApplePayEnabled,
                 showLink: isLinkEnabled,
+                linkBrand: configuration.resolvedLinkBrand(elementsSession: elementsSession),
                 removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                 merchantDisplayName: configuration.merchantDisplayName,
                 isCVCRecollectionEnabled: false,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -162,6 +162,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
                 customerID: configuration.customer?.id,
                 showApplePay: false,
                 showLink: false,
+                linkBrand: configuration.resolvedLinkBrand(elementsSession: elementsSession),
                 removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                 merchantDisplayName: configuration.merchantDisplayName,
                 isCVCRecollectionEnabled: isCVCRecollectionEnabled,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -396,6 +396,23 @@ class EmbeddedPaymentElementTest: XCTestCase {
         await fulfillment(of: [rowSelectionBehaviorExpectation])
     }
 
+    func testPaymentOptionDisplayData_linkCardBrandUsesOnelinkLabel() {
+        let confirmParams = IntentConfirmParams(type: .linkCardBrand)
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        confirmParams.paymentMethodParams.card = cardParams
+
+        let displayData = EmbeddedPaymentElement.PaymentOptionDisplayData(
+            paymentOption: .new(confirmParams: confirmParams),
+            mandateText: nil,
+            currency: "usd",
+            iconStyle: .filled,
+            linkBrand: .onelink
+        )
+
+        XCTAssertEqual(displayData.label, "Onelink")
+    }
+
     func testClearPaymentOptionAfterSelection() async throws {
         let rowSelectionBehaviorExpectation = XCTestExpectation(description: "immediateAction handler is only called once.")
         rowSelectionBehaviorExpectation.expectedFulfillmentCount = 1

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -406,7 +406,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
             paymentOption: .new(confirmParams: confirmParams),
             mandateText: nil,
             currency: "usd",
-            iconStyle: .filled,
+            iconStyle: configuration.appearance.iconStyle,
             linkBrand: .onelink
         )
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -7,7 +7,7 @@
 
 @testable@_spi(STP) import StripeCore
 import StripeCoreTestUtils
-@_spi(STP) @testable import StripePaymentSheet
+@_spi(AppearanceAPIAdditionsPreview) @_spi(STP) @testable import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsTestUtils
 @testable@_spi(STP) import StripeUICore
 import XCTest

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkNavigationBarSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkNavigationBarSnapshotTests.swift
@@ -59,7 +59,7 @@ class LinkNavigationBarSnapshotTests: STPSnapshotTestCase {
     }
 
     func testBackStyleThenTruncatingTitle() {
-        let sut = LinkSheetNavigationBar(isTestMode: false, appearance: LinkUI.appearance)
+        let sut = LinkSheetNavigationBar(isTestMode: false, appearance: LinkUI.appearance, brand: .link)
         sut.setStyle(.back(showAdditionalButton: false))
         sut.title = "Test title that is pretty long and should wrap"
         verify(sut)
@@ -86,7 +86,7 @@ class LinkNavigationBarSnapshotTests: STPSnapshotTestCase {
     }
 
     func testCloseStyleThenTruncatingTitle() {
-        let sut = LinkSheetNavigationBar(isTestMode: false, appearance: LinkUI.appearance)
+        let sut = LinkSheetNavigationBar(isTestMode: false, appearance: LinkUI.appearance, brand: .link)
         sut.setStyle(.close(showAdditionalButton: false))
         sut.title = "Test title that is pretty long and should wrap"
         verify(sut)
@@ -132,7 +132,7 @@ extension LinkNavigationBarSnapshotTests {
     }
 
     fileprivate func makeSUT(title: String? = nil) -> LinkSheetNavigationBar {
-        let sut = LinkSheetNavigationBar(isTestMode: false, appearance: LinkUI.appearance)
+        let sut = LinkSheetNavigationBar(isTestMode: false, appearance: LinkUI.appearance, brand: .link)
         sut.title = title
         return sut
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
@@ -33,7 +33,7 @@ class LinkURLGeneratorTests: XCTestCase {
     )
 
     func testURLCreation() {
-        let url = try! LinkURLGenerator.url(params: testParams)
+        let url = try! LinkURLGenerator.url(params: testParams, brand: .link)
 
         // Build expected JSON with dynamic SDK version
         let expectedJSON: [String: Any] = [
@@ -79,10 +79,56 @@ class LinkURLGeneratorTests: XCTestCase {
         XCTAssertEqual(url.absoluteString, expectedURLString)
     }
 
+    func testURLCreation_forOnelinkBrandUsesOnelinkCheckoutHost() {
+        let url = try! LinkURLGenerator.url(params: testParams, brand: .onelink)
+
+        let expectedJSON: [String: Any] = [
+            "clientAttributionMetadata": [
+                "elements_session_config_id": "123",
+                "merchant_integration_source": "elements",
+                "merchant_integration_subtype": "mobile",
+                "merchant_integration_version": "stripe-ios/\(StripeAPIConfiguration.STPSDKVersion)",
+                "payment_intent_creation_flow": "standard",
+                "payment_method_selection_flow": "merchant_specified",
+            ],
+            "customerInfo": [
+                "country": "US",
+                "email": "test@example.com",
+            ],
+            "experiments": [:] as [String: Any],
+            "flags": [:] as [String: Any],
+            "integrationType": "mobile",
+            "intentMode": "payment",
+            "linkFundingSources": ["CARD"],
+            "locale": "en-US",
+            "loggerMetadata": [:] as [String: Any],
+            "merchantInfo": [
+                "businessName": "Test test",
+                "country": "US",
+            ],
+            "path": "mobile_pay",
+            "paymentInfo": [
+                "amount": 100,
+                "currency": "USD",
+            ],
+            "paymentObject": "link_payment_method",
+            "paymentUserAgent": "test",
+            "publishableKey": "pk_test_123",
+            "setupFutureUsage": false,
+            "stripeAccount": "acct_1234",
+        ]
+
+        let jsonData = try! JSONSerialization.data(withJSONObject: expectedJSON, options: [.sortedKeys])
+        let expectedBase64 = jsonData.base64EncodedString()
+        let expectedURLString = "https://checkout.onelink.com/#\(expectedBase64)"
+
+        XCTAssertEqual(url.absoluteString, expectedURLString)
+    }
+
     func testURLCreationRegularUnicode() {
         var params = testParams
         params.customerInfo.email = "유니코드"
-        _ = try! LinkURLGenerator.url(params: params)
+        _ = try! LinkURLGenerator.url(params: params, brand: .link)
         // Just make sure it doesn't fail
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkVerificationViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkVerificationViewSnapshotTests.swift
@@ -16,6 +16,12 @@ import UIKit
 @testable@_spi(STP) import StripeUICore
 
 class LinkVerificationViewSnapshotTests: STPSnapshotTestCase {
+    func testHeader_usesProvidedBrandForAccessibilityLabel() {
+        let sut = LinkVerificationView.Header(brand: .onelink)
+        let logoView = sut.subviews.compactMap { $0 as? UIImageView }.first
+
+        XCTAssertEqual(logoView?.accessibilityLabel, "Onelink")
+    }
 
     func testModal() {
         let sut = makeSUT(mode: .modal)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkVerificationViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkVerificationViewSnapshotTests.swift
@@ -8,6 +8,7 @@
 
 import StripeCoreTestUtils
 import UIKit
+import XCTest
 
 @testable@_spi(STP) import StripeCore
 @testable@_spi(STP) import StripePayments

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkVerificationViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkVerificationViewSnapshotTests.swift
@@ -21,7 +21,7 @@ class LinkVerificationViewSnapshotTests: STPSnapshotTestCase {
         let sut = LinkVerificationView.Header(brand: .onelink)
         let logoView = sut.subviews.compactMap { $0 as? UIImageView }.first
 
-        XCTAssertTrue(logoView?.accessibilityLabel == "Onelink")
+        XCTAssertEqual(logoView?.accessibilityLabel, "Onelink")
     }
 
     func testModal() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkVerificationViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkVerificationViewSnapshotTests.swift
@@ -20,7 +20,7 @@ class LinkVerificationViewSnapshotTests: STPSnapshotTestCase {
         let sut = LinkVerificationView.Header(brand: .onelink)
         let logoView = sut.subviews.compactMap { $0 as? UIImageView }.first
 
-        XCTAssertEqual(logoView?.accessibilityLabel, "Onelink")
+        XCTAssertTrue(logoView?.accessibilityLabel == "Onelink")
     }
 
     func testModal() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -302,7 +302,7 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         paymentMethod.linkPaymentDetails = nil
 
         XCTAssertEqual(paymentMethod.paymentSheetLabel(brand: .onelink), "Onelink")
-        XCTAssertEqual(paymentMethod.expandedPaymentSheetLabel(brand: .onelink), "Onelink")
+        XCTAssertEqual(expandedPaymentSheetLabel(for: paymentMethod, brand: .onelink), "Onelink")
     }
 
     func testPaymentOptionDisplayData_SavedLinkFallbackUsesOnelinkLabels() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -206,6 +206,7 @@ class PaymentSheetFlowControllerTests: XCTestCase {
             linkBrand: .onelink
         )
 
+        XCTAssertEqual(displayData.label, "Onelink")
         XCTAssertEqual(displayData.labels.label, "Onelink")
     }
 
@@ -229,6 +230,7 @@ class PaymentSheetFlowControllerTests: XCTestCase {
             linkBrand: .onelink
         )
 
+        XCTAssertEqual(displayData.label, "Onelink")
         XCTAssertEqual(displayData.labels.label, "Onelink")
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -302,7 +302,7 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         paymentMethod.linkPaymentDetails = nil
 
         XCTAssertEqual(paymentMethod.paymentSheetLabel(brand: .onelink), "Onelink")
-        XCTAssertEqual(expandedPaymentSheetLabel(for: paymentMethod, brand: .onelink), "Onelink")
+        XCTAssertEqual(paymentMethod.expandedPaymentSheetLabel(brand: .onelink), "Onelink")
     }
 
     func testPaymentOptionDisplayData_SavedLinkFallbackUsesOnelinkLabels() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -5,7 +5,7 @@
 //  Created by Nick Porter on 6/13/25.
 //
 
-@testable import StripeCore
+@_spi(STP) @testable import StripeCore
 @testable @_spi(STP) import StripePayments
 @testable @_spi(AppearanceAPIAdditionsPreview) @_spi(STP) import StripePaymentSheet
 @testable @_spi(STP) import StripePaymentsTestUtils
@@ -177,6 +177,61 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         XCTAssertNil(displayData.labels.sublabel)
     }
 
+    func testPaymentOptionDisplayData_OnelinkLabels() {
+        let linkOption = PaymentSheet.LinkConfirmOption.wallet
+        let paymentOption = PaymentSheet.PaymentOption.link(option: linkOption)
+        let displayData = PaymentSheet.FlowController.PaymentOptionDisplayData(
+            paymentOption: paymentOption,
+            currency: "usd",
+            iconStyle: .filled,
+            linkBrand: .onelink
+        )
+
+        XCTAssertEqual(displayData.label, "Onelink")
+        XCTAssertEqual(displayData.labels.label, "Onelink")
+        XCTAssertNil(displayData.labels.sublabel)
+    }
+
+    func testPaymentOptionDisplayData_NewLinkCardBrandUsesOnelinkLabel() {
+        let confirmParams = IntentConfirmParams(type: .linkCardBrand)
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        confirmParams.paymentMethodParams.card = cardParams
+
+        let paymentOption = PaymentSheet.PaymentOption.new(confirmParams: confirmParams)
+        let displayData = PaymentSheet.FlowController.PaymentOptionDisplayData(
+            paymentOption: paymentOption,
+            currency: "usd",
+            iconStyle: .filled,
+            linkBrand: .onelink
+        )
+
+        XCTAssertEqual(displayData.labels.label, "Onelink")
+    }
+
+    func testPaymentOptionDisplayData_LinkSignUpUsesOnelinkLabel() {
+        let confirmParams = IntentConfirmParams(type: .linkCardBrand)
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        confirmParams.paymentMethodParams.card = cardParams
+        let linkOption = PaymentSheet.LinkConfirmOption.signUp(
+            account: makeSUT(),
+            phoneNumber: nil,
+            consentAction: .implied_v0,
+            legalName: nil,
+            intentConfirmParams: confirmParams
+        )
+        let paymentOption = PaymentSheet.PaymentOption.link(option: linkOption)
+        let displayData = PaymentSheet.FlowController.PaymentOptionDisplayData(
+            paymentOption: paymentOption,
+            currency: "usd",
+            iconStyle: .filled,
+            linkBrand: .onelink
+        )
+
+        XCTAssertEqual(displayData.labels.label, "Onelink")
+    }
+
     func testPaymentOptionDisplayData_ExternalPaymentMethodLabels() {
         // Create an external payment method (e.g., PayPal)
         let externalPaymentMethod = ExternalPaymentMethod(
@@ -238,6 +293,48 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         // Test labels for saved Link payment method - display name is nil on fixture so should show "Link"
         XCTAssertEqual(displayData.labels.label, "Link")
         XCTAssertEqual(displayData.labels.sublabel, "TEST DISPLAY NAME •••• 4242")
+    }
+
+    func testPaymentSheetLabel_SavedLinkFallbackUsesOnelinkBrand() {
+        let paymentMethod = STPPaymentMethod._testLink()
+        paymentMethod.linkPaymentDetails = nil
+
+        XCTAssertEqual(paymentMethod.paymentSheetLabel(brand: .onelink), "Onelink")
+        XCTAssertEqual(paymentMethod.expandedPaymentSheetLabel(brand: .onelink), "Onelink")
+    }
+
+    func testPaymentOptionDisplayData_SavedLinkFallbackUsesOnelinkLabels() {
+        let paymentMethod = STPPaymentMethod._testLink()
+        paymentMethod.linkPaymentDetails = nil
+
+        let paymentOption = PaymentSheet.PaymentOption.saved(paymentMethod: paymentMethod, confirmParams: nil)
+        let displayData = PaymentSheet.FlowController.PaymentOptionDisplayData(
+            paymentOption: paymentOption,
+            currency: "usd",
+            iconStyle: .filled,
+            linkBrand: .onelink
+        )
+
+        XCTAssertEqual(displayData.label, "Onelink")
+        XCTAssertEqual(displayData.labels.label, "Onelink")
+        XCTAssertNil(displayData.labels.sublabel)
+    }
+
+    func testPaymentOptionDisplayData_SavedLinkPassthroughUsesOnelinkLabel() {
+        let paymentMethod = STPPaymentMethod._testCard()
+        paymentMethod.isLinkPassthroughMode = true
+
+        let paymentOption = PaymentSheet.PaymentOption.saved(paymentMethod: paymentMethod, confirmParams: nil)
+        let displayData = PaymentSheet.FlowController.PaymentOptionDisplayData(
+            paymentOption: paymentOption,
+            currency: "usd",
+            iconStyle: .filled,
+            linkBrand: .onelink
+        )
+
+        XCTAssertEqual(displayData.label, "•••• 4242")
+        XCTAssertEqual(displayData.labels.label, "Onelink")
+        XCTAssertEqual(displayData.labels.sublabel, "•••• 4242")
     }
 
     func testPaymentOptionDisplayData_LinkWithPaymentDetailsLabels() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
@@ -157,4 +157,22 @@ final class SavedPaymentMethodRowButtonTests: XCTestCase {
         XCTAssertEqual(sut.rowButton.sublabel.text, "Onelink")
     }
 
+    func testLinkPassthroughPreservesFundingDetailsInAccessibilityLabel() {
+        let paymentMethod = STPPaymentMethod._testCard()
+        paymentMethod.isLinkPassthroughMode = true
+
+        let sut = SavedPaymentMethodRowButton(
+            paymentMethod: paymentMethod,
+            appearance: appearance,
+            linkBrand: .onelink
+        )
+
+        XCTAssertEqual(sut.rowButton.label.text, "Onelink")
+        XCTAssertEqual(sut.rowButton.sublabel.text, "•••• 4242")
+        XCTAssertEqual(
+            sut.rowButton.accessibilityHelperView.accessibilityLabel,
+            paymentMethod.paymentSheetAccessibilityLabel
+        )
+    }
+
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@testable import StripePaymentSheet
+@_spi(STP) @testable import StripePaymentSheet
 import XCTest
 
 final class SavedPaymentMethodRowButtonTests: XCTestCase {
@@ -140,6 +140,21 @@ final class SavedPaymentMethodRowButtonTests: XCTestCase {
         XCTAssertTrue(sut.isSelected)
         XCTAssertEqual(sut.previousSelectedState, .unselected)
         XCTAssertTrue(sut.chevronButton.isHidden)
+    }
+
+    func testLinkPassthroughUsesConfiguredBrandForSublabel() {
+        let paymentMethod = STPPaymentMethod._testLink()
+        paymentMethod.linkPaymentDetails = nil
+        paymentMethod.isLinkPassthroughMode = true
+
+        let sut = SavedPaymentMethodRowButton(
+            paymentMethod: paymentMethod,
+            appearance: appearance,
+            linkBrand: .onelink
+        )
+
+        XCTAssertEqual(sut.rowButton.label.text, "Onelink")
+        XCTAssertEqual(sut.rowButton.sublabel.text, "Onelink")
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
@@ -169,8 +169,9 @@ final class SavedPaymentMethodRowButtonTests: XCTestCase {
 
         XCTAssertEqual(sut.rowButton.label.text, "Onelink")
         XCTAssertEqual(sut.rowButton.sublabel.text, "•••• 4242")
+        let accessibilityLabel = (sut.rowButton.accessibilityElements?.first as? UIView)?.accessibilityLabel
         XCTAssertEqual(
-            sut.rowButton.accessibilityHelperView.accessibilityLabel,
+            accessibilityLabel,
             paymentMethod.paymentSheetAccessibilityLabel
         )
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerSnapshotTests.swift
@@ -5,6 +5,7 @@
 //  Created by Yuki Tokuhiro on 10/13/23.
 //
 
+@_spi(STP) @testable import StripeCore
 import StripeCoreTestUtils
 @_spi(STP) @testable import StripePayments
 @_spi(STP) @testable import StripePaymentSheet
@@ -38,7 +39,7 @@ final class SavedPaymentOptionsViewControllerSnapshotTests: STPSnapshotTestCase 
             STPPaymentMethod._testUSBankAccount(),
             STPPaymentMethod._testSEPA(),
         ]
-        let config = SavedPaymentOptionsViewController.Configuration(customerID: "cus_123", showApplePay: true, showLink: true, removeSavedPaymentMethodMessage: nil, merchantDisplayName: "Test Merchant", isCVCRecollectionEnabled: false, isTestMode: false, allowsRemovalOfLastSavedPaymentMethod: false, allowsRemovalOfPaymentMethods: true, allowsSetAsDefaultPM: showDefaultPMBadge, allowsUpdatePaymentMethod: false)
+        let config = SavedPaymentOptionsViewController.Configuration(customerID: "cus_123", showApplePay: true, showLink: true, linkBrand: .link, removeSavedPaymentMethodMessage: nil, merchantDisplayName: "Test Merchant", isCVCRecollectionEnabled: false, isTestMode: false, allowsRemovalOfLastSavedPaymentMethod: false, allowsRemovalOfPaymentMethods: true, allowsSetAsDefaultPM: showDefaultPMBadge, allowsUpdatePaymentMethod: false)
         let intent = Intent.deferredIntent(intentConfig: .init(mode: .payment(amount: 0, currency: "USD", setupFutureUsage: nil, captureMethod: .automatic), confirmHandler: { _, _ in return "" }))
         let sut = SavedPaymentOptionsViewController(
             savedPaymentMethods: paymentMethods,
@@ -92,6 +93,7 @@ final class SavedPaymentOptionsViewControllerSnapshotTests: STPSnapshotTestCase 
             customerID: "cus_123",
             showApplePay: false,
             showLink: false,
+            linkBrand: .link,
             removeSavedPaymentMethodMessage: nil,
             merchantDisplayName: "Test Merchant",
             isCVCRecollectionEnabled: true,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
@@ -196,6 +196,21 @@ class SavedPaymentOptionsViewControllerTests: XCTestCase {
         XCTAssertEqual(removalMessage.title, "Remove payment method?")
         XCTAssertEqual(removalMessage.message, "Pix 000••••••••")
     }
+    
+    func testPaymentOptionCell_usesProvidedLinkBrandForLinkLabel() {
+        let cell = SavedPaymentMethodCollectionView.PaymentOptionCell(frame: .zero)
+
+        cell.setViewModel(
+            .link,
+            cbcEligible: false,
+            allowsPaymentMethodRemoval: false,
+            allowsPaymentMethodUpdate: false,
+            linkBrand: .onelink
+        )
+
+        XCTAssertEqual(cell.label.text, "Onelink")
+        XCTAssertEqual(cell.selectableRectangle.accessibilityLabel, "Onelink")
+    }
 
     // MARK: Helpers
     func _testCanEditPaymentMethods(removePM: Bool,
@@ -207,6 +222,7 @@ class SavedPaymentOptionsViewControllerTests: XCTestCase {
         let configuration = SavedPaymentOptionsViewController.Configuration(customerID: "cus_123",
                                                                             showApplePay: true,
                                                                             showLink: true,
+                                                                            linkBrand: .link,
                                                                             removeSavedPaymentMethodMessage: nil,
                                                                             merchantDisplayName: "abc",
                                                                             isCVCRecollectionEnabled: true,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentOptionsViewControllerTests.swift
@@ -196,7 +196,7 @@ class SavedPaymentOptionsViewControllerTests: XCTestCase {
         XCTAssertEqual(removalMessage.title, "Remove payment method?")
         XCTAssertEqual(removalMessage.message, "Pix 000••••••••")
     }
-    
+
     func testPaymentOptionCell_usesProvidedLinkBrandForLinkLabel() {
         let cell = SavedPaymentMethodCollectionView.PaymentOptionCell(frame: .zero)
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Consider branding in display label logic (i.e. display data) for the Link payment method option. Also redirect URLs (e.g. terms and privacy, checkout).

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/LINK_MOBILE-800

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Click around all Link surfaces within `PaymentSheet Example` app playground with `Link brand` configured, and ensure all branded strings are surfacing the correct brand. Also check for regressions in the default branding case.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
