### PR TITLE
Fix flaky testPreservesFormDetails

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITests.swift
@@ -434,7 +434,8 @@ class PaymentSheetVerticalUITests: PaymentSheetUITestCase {
 
         // PaymentSheet.FlowController + Vertical
         app.buttons["flowController"].waitForExistenceAndTap()
-        app.buttons["Payment method"].waitForExistenceAndTap()
+        XCTAssertTrue(app.buttons["Confirm"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.buttons["Payment method"].waitForExistenceAndTap(timeout: 10))
         _testVerticalPreservesFormDetails()
     }
 


### PR DESCRIPTION
## Summary
- After switching to flowController mode via the segmented control, the test immediately tried to tap the "Payment method" button with a 4s default timeout
- The mode switch triggers a backend network call + FlowController creation that can exceed 4s, causing the button to not exist yet and the test to proceed in a broken state
- Added an explicit wait for the "Confirm" button (the signal `waitForReload` uses for flowController mode) and increased the timeout with an assertion so failures are immediate and clear

## Test plan
- [ ] CI passes without flakiness on this test

🤖 Generated with [Claude Code](https://claude.com/claude-code)