### PR TITLE
Fix flaky testSavedSEPADebitPaymentMethod_FlowController_ShowsMandate

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetStandardLPMUITwoTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetStandardLPMUITwoTests.swift
@@ -102,8 +102,9 @@ class PaymentSheetStandardLPMUITwoTests: PaymentSheetStandardLPMUICase {
         app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
-        // Reload w/ same customer
-        reload(app, settings: settings)
+        // Reload w/ same customer (retry to avoid lock contention on the customer object)
+        sleep(2)
+        reload(app, settings: settings, maxRetries: 5)
         // This time, expect SEPA to be pre-selected as the default
         XCTAssert(paymentMethodButton.label.hasPrefix("••••3201, sepa_debit"))
 
@@ -118,8 +119,9 @@ class PaymentSheetStandardLPMUITwoTests: PaymentSheetStandardLPMUICase {
         app.buttons["Continue"].tap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
 
-        // Reload w/ same customer
-        reload(app, settings: settings)
+        // Reload w/ same customer (retry to avoid lock contention on the customer object)
+        sleep(2)
+        reload(app, settings: settings, maxRetries: 5)
         // If you present the flowcontroller and see the mandate...
         XCTAssert(paymentMethodButton.label.hasPrefix("••••3201, sepa_debit"))
         paymentMethodButton.waitForExistenceAndTap()


### PR DESCRIPTION
## Summary
- Adds `sleep(2)` before each "Reload w/ same customer" call to allow server-side async processing (mandate creation, PM attachment) to release the customer lock
- Increases `maxRetries` from 3 to 5 to give the reload more attempts if lock contention causes a transient failure

## Motivation
This test is flaky due to lock contention on the customer object. After confirming a SEPA payment, server-side async processing holds a lock that can cause subsequent reload calls to fail.

## Test plan
- [ ] Verify the test passes consistently in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)