### PR TITLE
Remove Link LPMs Changelog Entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ MINOR
 * [Added] Added API models for upcoming EU support. 
 * [Added] Added `birthCountry`, `birthCity`, and `nationalities` properties to `KycInfo`, required for EU customers.
 
-### PaymentSheet
-* [Added] Added support for new and upcoming payment methods in native Link, such as UPI, Pix, and Crypto
-
 ## 25.13.0 2026-05-04
 ### PaymentSheet
 * [Fixed] Fixed an issue where `paymentMethodOrder` did not apply to custom payment methods due to case-sensitive matching.


### PR DESCRIPTION
## Summary
Removes the Link LPMs changelog entry added in #6342. This was only added to flag that we should do a release.
