### PR TITLE
Fix flaky PMMENetworkInitializationTests by pinning locale

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PMMENetworkInitializationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PMMENetworkInitializationTests.swift
@@ -52,6 +52,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: 5000,
             currency: "usd",
             apiClient: apiClient,
+            locale: "en-US",
             appearance: appearance
         )
 
@@ -141,6 +142,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: 5000,
             currency: "usd",
             apiClient: connectedAPIClient,
+            locale: "en-US",
             appearance: appearance
         )
 
@@ -204,6 +206,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: 5000,
             currency: "usd",
             apiClient: apiClient,
+            locale: "en-US",
             appearance: appearance
         )
 
@@ -272,6 +275,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: 5000,
             currency: "usd",
             apiClient: apiClient,
+            locale: "en-US",
             appearance: appearance
         )
 
@@ -340,6 +344,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: 5000,
             currency: "usd",
             apiClient: apiClient,
+            locale: "en-US",
             appearance: appearance
         )
         configuration.paymentMethodTypes = [.klarna]
@@ -392,6 +397,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: 5000,
             currency: "gel",  // Georgian Lari - supported by Stripe but not PMME
             apiClient: apiClient,
+            locale: "en-US",
             appearance: appearance
         )
 
@@ -437,6 +443,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: 5000,
             currency: "usd",
             apiClient: apiClient,
+            locale: "en-US",
             appearance: appearance
         )
         configuration.countryCode = "ZZ"  // Invalid country code
@@ -480,6 +487,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: -1000,
             currency: "usd",
             apiClient: apiClient,
+            locale: "en-US",
             appearance: appearance
         )
 
@@ -515,6 +523,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: 5000,
             currency: "usd",
             apiClient: invalidAPIClient,
+            locale: "en-US",
             appearance: appearance
         )
 
@@ -554,6 +563,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: 5000,
             currency: "usd",
             apiClient: apiClient,
+            locale: "en-US",
             appearance: appearance
         )
         configuration.countryCode = "FR"
@@ -590,6 +600,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: 5000,
             currency: "eur",
             apiClient: frenchAPIClient,
+            locale: "en-US",
             appearance: appearance
         )
         configuration.countryCode = "FR"
@@ -783,6 +794,7 @@ class PMMENetworkInitializationTests: STPNetworkStubbingTestCase {
             amount: 5000,
             currency: "gbp",
             apiClient: ukAPIClient,
+            locale: "en-US",
             countryCode: "GB",
             appearance: appearance
         )


### PR DESCRIPTION
## Summary
- Explicitly set `locale: "en-US"` in all PMME test configurations that previously relied on `Locale.current.identifier`
- The recorded network stubs match `locale=en-US$` exactly, so any machine with a different locale would fail to match the stub

## Motivation
`testCreate_multiPartner_automatic` (and potentially other PMME tests) flake when the CI machine's locale differs from `en-US`. The stub regex anchors on `locale=en-US$` but the test used the system default locale which varies by environment.

https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5366

## Test plan
- [x] All 14 `PMMENetworkInitializationTests` pass locally with recorded stubs
- [x] No re-recording needed — the stubs already expected `en-US`

🤖 Generated with [Claude Code](https://claude.com/claude-code)