### PR TITLE
Add experimental logic to control card art

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/CardArtExperiment.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/CardArtExperiment.swift
@@ -1,0 +1,128 @@
+//
+//  CardArtExperiment.swift
+//  StripePaymentSheet
+//
+
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
+
+struct CardArtExperiment: LoggableExperiment {
+    static let experimentName = "ocs_mobile_card_art"
+
+    let name: String = experimentName
+    let arbId: String
+    let group: ExperimentGroup
+
+    var dimensions: [String: String] {
+        var displayedPaymentMethodTypesIncludingWallets: [String] = displayedPaymentMethodTypes
+        displayedPaymentMethodTypesIncludingWallets.append(contentsOf: walletPaymentMethodTypes)
+        return [
+            "displayed_payment_method_types": displayedPaymentMethodTypes.joined(separator: ","),
+            "displayed_payment_method_types_including_wallets": displayedPaymentMethodTypesIncludingWallets.joined(separator: ","),
+            "in_app_elements_integration_type": integrationShape,
+            "in_app_elements_layout": layout,
+            "saved_payment_method_count": String(savedPaymentMethodCount),
+            "saved_card_payment_method_count": String(savedCardPaymentMethodCount),
+            "saved_card_payment_method_with_card_art_count": String(savedCardPaymentMethodWithCardArtCount),
+            "selected_payment_method_type": selectedPaymentMethodType,
+            "selected_payment_method_has_card_art": selectedPaymentMethodHasCardArt.description,
+        ]
+    }
+
+    private let displayedPaymentMethodTypes: [String]
+    private let walletPaymentMethodTypes: [String]
+    private let integrationShape: String
+    private let layout: String
+    private let savedPaymentMethodCount: Int
+    private let savedCardPaymentMethodCount: Int
+    private let savedCardPaymentMethodWithCardArtCount: Int
+    private let selectedPaymentMethodType: String
+    private let selectedPaymentMethodHasCardArt: Bool
+
+    private init(
+        arbId: String,
+        group: ExperimentGroup,
+        displayedPaymentMethodTypes: [String],
+        walletPaymentMethodTypes: [String],
+        integrationShape: String,
+        layout: String,
+        savedPaymentMethodCount: Int,
+        savedCardPaymentMethodCount: Int,
+        savedCardPaymentMethodWithCardArtCount: Int,
+        selectedPaymentMethodType: String,
+        selectedPaymentMethodHasCardArt: Bool
+    ) {
+        self.arbId = arbId
+        self.group = group
+        self.displayedPaymentMethodTypes = displayedPaymentMethodTypes
+        self.walletPaymentMethodTypes = walletPaymentMethodTypes
+        self.integrationShape = integrationShape
+        self.layout = layout
+        self.savedPaymentMethodCount = savedPaymentMethodCount
+        self.savedCardPaymentMethodCount = savedCardPaymentMethodCount
+        self.savedCardPaymentMethodWithCardArtCount = savedCardPaymentMethodWithCardArtCount
+        self.selectedPaymentMethodType = selectedPaymentMethodType
+        self.selectedPaymentMethodHasCardArt = selectedPaymentMethodHasCardArt
+    }
+
+    /// Creates the card art experiment if available, otherwise returns `nil`
+    static func create(
+        elementsSession: STPElementsSession,
+        configuration: PaymentElementConfiguration,
+        analyticsHelper: PaymentSheetAnalyticsHelper,
+        paymentMethodTypes: [PaymentSheet.PaymentMethodType],
+        savedPaymentMethods: [STPPaymentMethod],
+        paymentMethodOrientation: PaymentSheet.PaymentMethodLayout.ResolvedLayout,
+        selectedPaymentOption: SavedPaymentOptionsViewController.Selection?
+    ) -> CardArtExperiment? {
+        guard let arbId = elementsSession.experimentsData?.arbId,
+              let group = elementsSession.experimentsData?.experimentAssignments[experimentName] else {
+            return nil
+        }
+
+        let displayedPaymentMethods = paymentMethodTypes.map { $0.identifier }
+
+        var walletTypes: [String] = []
+        if PaymentSheet.isApplePayEnabled(elementsSession: elementsSession, configuration: configuration) {
+            walletTypes.append("apple_pay")
+        }
+        if PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration) {
+            walletTypes.append("link")
+        }
+
+        let (selectedType, selectedHasCardArt) = selectedPaymentMethodInfo(from: selectedPaymentOption)
+
+        return CardArtExperiment(
+            arbId: arbId,
+            group: group,
+            displayedPaymentMethodTypes: displayedPaymentMethods,
+            walletPaymentMethodTypes: walletTypes,
+            integrationShape: analyticsHelper.integrationShape.analyticsValue,
+            layout: paymentMethodOrientation.rawValue,
+            savedPaymentMethodCount: savedPaymentMethods.count,
+            savedCardPaymentMethodCount: savedPaymentMethods.filter { $0.type == .card }.count,
+            savedCardPaymentMethodWithCardArtCount: savedPaymentMethods.filter { $0.type == .card && $0.cardArtCDNURL() != nil }.count,
+            selectedPaymentMethodType: selectedType,
+            selectedPaymentMethodHasCardArt: selectedHasCardArt
+        )
+    }
+
+    private static func selectedPaymentMethodInfo(
+        from selection: SavedPaymentOptionsViewController.Selection?
+    ) -> (type: String, hasCardArt: Bool) {
+        guard let selection else {
+            return ("none", false)
+        }
+        switch selection {
+        case .applePay:
+            return ("apple_pay", false)
+        case .link:
+            return ("link", false)
+        case .saved(let paymentMethod):
+            let hasCardArt = paymentMethod.cardArtCDNURL() != nil
+            return (paymentMethod.type.identifier, hasCardArt)
+        case .add:
+            return ("new", false)
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
@@ -17,10 +17,14 @@ struct ElementsCustomer: Equatable, Hashable {
     let customerSession: CustomerSession
 
     /// Helper method to decode the `v1/elements/sessions` response's `customer` hash.
-    /// - Parameter response: The value of the `customer` key in the `v1/elements/sessions` response.
+    /// - Parameters:
+    ///   - response: The value of the `customer` key in the `v1/elements/sessions` response.
+    ///   - enableLinkInSPM: Whether Link in saved payment methods is enabled.
+    ///   - includeCardArt: Whether to attach card art data to payment methods.
     public static func decoded(
         fromAPIResponse response: [AnyHashable: Any]?,
-        enableLinkInSPM: Bool
+        enableLinkInSPM: Bool,
+        includeCardArt: Bool
     ) -> ElementsCustomer? {
         guard let response else {
             return nil
@@ -28,7 +32,8 @@ struct ElementsCustomer: Equatable, Hashable {
 
         let paymentMethods = Self.parsePaymentMethods(
             from: response,
-            enableLinkInSPM: enableLinkInSPM
+            enableLinkInSPM: enableLinkInSPM,
+            includeCardArt: includeCardArt
         )
 
         // Required fields
@@ -51,14 +56,14 @@ struct ElementsCustomer: Equatable, Hashable {
         )
     }
 
-    private static func parsePaymentMethods(from response: [AnyHashable: Any], enableLinkInSPM: Bool) -> [STPPaymentMethod]? {
+    private static func parsePaymentMethods(from response: [AnyHashable: Any], enableLinkInSPM: Bool, includeCardArt: Bool) -> [STPPaymentMethod]? {
         guard let paymentMethodsArray = selectPaymentMethods(from: response, enableLinkInSPM: enableLinkInSPM) else {
             return nil
         }
 
         // Build card art lookup for post-deserialization assignment
         var cardArtByPaymentMethodId: [String: STPPaymentMethodCardArt] = [:]
-        if let cardArtArray = response["card_art"] as? [[AnyHashable: Any]] {
+        if includeCardArt, let cardArtArray = response["card_art"] as? [[AnyHashable: Any]] {
             for artJSON in cardArtArray {
                 if let paymentMethodId = artJSON["payment_method"] as? String,
                     let cardArt = STPPaymentMethodCardArt.decodedObject(fromAPIResponse: artJSON) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -184,6 +184,17 @@ extension STPElementsSession: STPAPIResponseDecodable {
         let applePayPreference = response["apple_pay_preference"] as? String
         let isApplePayEnabled = applePayPreference != "disabled"
         let flags = response["flags"] as? [String: Bool] ?? [:]
+        let experimentsData = ExperimentsData.decodedObject(
+            fromAPIResponse: response["experiments_data"] as? [AnyHashable: Any]
+        )
+
+        let cardArtExperimentInTreatment: Bool = {
+            guard let group = experimentsData?.experimentAssignments[CardArtExperiment.experimentName] else {
+                return false
+            }
+            return group == .treatment
+        }()
+
         let customer: ElementsCustomer? = {
             let customerDataKey = "customer"
             guard response[customerDataKey] != nil, !(response[customerDataKey] is NSNull) else {
@@ -191,7 +202,7 @@ extension STPElementsSession: STPAPIResponseDecodable {
             }
             let enableLinkInSPM = flags["elements_enable_link_spm"] ?? false
             guard let customerJSON = response[customerDataKey] as? [AnyHashable: Any],
-                  let decoded = ElementsCustomer.decoded(fromAPIResponse: customerJSON, enableLinkInSPM: enableLinkInSPM) else {
+                  let decoded = ElementsCustomer.decoded(fromAPIResponse: customerJSON, enableLinkInSPM: enableLinkInSPM, includeCardArt: cardArtExperimentInTreatment) else {
                 STPAnalyticsClient.sharedClient.logPaymentSheetEvent(event: .paymentSheetElementsSessionCustomerDeserializeFailed)
                 return nil
             }
@@ -257,9 +268,7 @@ extension STPElementsSession: STPAPIResponseDecodable {
             linkSettings: LinkSettings.decodedObject(
                 fromAPIResponse: response["link_settings"] as? [AnyHashable: Any]
             ),
-            experimentsData: ExperimentsData.decodedObject(
-                fromAPIResponse: response["experiments_data"] as? [AnyHashable: Any]
-            ),
+            experimentsData: experimentsData,
             flags: flags,
             paymentMethodSpecs: response["payment_method_specs"] as? [[AnyHashable: Any]],
             cardBrandChoice: cardBrandChoice,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -222,20 +222,9 @@ final class PaymentSheetLoader {
                 paymentMethodTypes: paymentMethodTypes
             )
 
-            let loadResult = LoadResult(
-                intent: intent,
+            let paymentMethodOrientation = configuration.resolveLayout(
                 elementsSession: elementsSession,
-                savedPaymentMethods: filteredSavedPaymentMethods,
-                paymentMethodTypes: paymentMethodTypes,
-                paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper,
-                paymentMethodOrientation: configuration.resolveLayout(
-                    elementsSession: elementsSession,
-                    paymentMethodTypes: paymentMethodTypes
-                )
-            )
-            let confirmationChallenge = ConfirmationChallenge(
-                elementsSession: elementsSession,
-                stripeAttest: configuration.apiClient.stripeAttest
+                paymentMethodTypes: paymentMethodTypes
             )
 
             // This is hacky; the logic to determine the default selected payment method belongs to the SavedPaymentOptionsViewController. We invoke it here just to report it to analytics before that VC loads.
@@ -249,6 +238,19 @@ final class PaymentSheetLoader {
                 defaultPaymentMethod: elementsSession.customer?.getDefaultPaymentMethod()
             )
 
+            // Log card art experiment exposure
+            if let cardArtExperiment = CardArtExperiment.create(
+                elementsSession: elementsSession,
+                configuration: configuration,
+                analyticsHelper: analyticsHelper,
+                paymentMethodTypes: paymentMethodTypes,
+                savedPaymentMethods: filteredSavedPaymentMethods,
+                paymentMethodOrientation: paymentMethodOrientation,
+                selectedPaymentOption: paymentOptionsViewModels.stp_boundSafeObject(at: defaultSelectedIndex)
+            ) {
+                analyticsHelper.logExposure(experiment: cardArtExperiment)
+            }
+
             // Temporary band-aid for pre-loading card art: fire-and-forget fetch to warm the in-meory cache for PS.FC
             // and embedded PaymentOptionDisplayData APIs.
             // TODO: Revisit overall pre-loading approach to make this work for other payment methods
@@ -257,6 +259,19 @@ final class PaymentSheetLoader {
                 stpPaymentMethod.preloadCardArtImage()
             }
             loadTimings.logEnd("makeViewModels")
+
+            let loadResult = LoadResult(
+                intent: intent,
+                elementsSession: elementsSession,
+                savedPaymentMethods: filteredSavedPaymentMethods,
+                paymentMethodTypes: paymentMethodTypes,
+                paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper,
+                paymentMethodOrientation: paymentMethodOrientation
+            )
+            let confirmationChallenge = ConfirmationChallenge(
+                elementsSession: elementsSession,
+                stripeAttest: configuration.apiClient.stripeAttest
+            )
 
             // Send load finished analytic
             // ⚠️ Important: Log load succeeded at the very end, to ensure it measures the entire amount of time this method took.

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CardArtExperimentTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CardArtExperimentTests.swift
@@ -1,0 +1,148 @@
+//
+//  CardArtExperimentTests.swift
+//  StripePaymentSheetTests
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeCoreTestUtils
+@_spi(STP) import StripePayments
+@testable @_spi(STP) import StripePaymentSheet
+import XCTest
+
+final class CardArtExperimentTests: XCTestCase {
+
+    // MARK: - create() returns nil
+
+    func testCreate_returnsNil_whenNoExperimentsData() {
+        let session = STPElementsSession._testValue(experimentsData: nil)
+        let analyticsHelper = PaymentSheetAnalyticsHelper(
+            integrationShape: .complete,
+            configuration: PaymentSheet.Configuration(),
+            analyticsClient: STPTestingAnalyticsClient(),
+            analyticsClientV2: MockAnalyticsClientV2()
+        )
+        let experiment = CardArtExperiment.create(
+            elementsSession: session,
+            configuration: PaymentSheet.Configuration(),
+            analyticsHelper: analyticsHelper,
+            paymentMethodTypes: [.stripe(.card)],
+            savedPaymentMethods: [],
+            paymentMethodOrientation: .vertical,
+            selectedPaymentOption: nil
+        )
+        XCTAssertNil(experiment)
+    }
+
+    func testCreate_returnsNil_whenExperimentNotInAssignments() {
+        let session = STPElementsSession._testValue(
+            experimentsData: ExperimentsData(
+                arbId: "arb_123",
+                experimentAssignments: ["some_other_experiment": .treatment],
+                allResponseFields: [:]
+            )
+        )
+        let analyticsHelper = PaymentSheetAnalyticsHelper(
+            integrationShape: .complete,
+            configuration: PaymentSheet.Configuration(),
+            analyticsClient: STPTestingAnalyticsClient(),
+            analyticsClientV2: MockAnalyticsClientV2()
+        )
+        let experiment = CardArtExperiment.create(
+            elementsSession: session,
+            configuration: PaymentSheet.Configuration(),
+            analyticsHelper: analyticsHelper,
+            paymentMethodTypes: [.stripe(.card)],
+            savedPaymentMethods: [],
+            paymentMethodOrientation: .vertical,
+            selectedPaymentOption: nil
+        )
+        XCTAssertNil(experiment)
+    }
+
+    // MARK: - create() builds correct dimensions
+
+    func testCreate_dimensions() {
+        let elementsSession = STPElementsSession._testValue(
+            experimentsData: ExperimentsData(
+                arbId: "arb_test",
+                experimentAssignments: [CardArtExperiment.experimentName: .treatment],
+                allResponseFields: [:]
+            )
+        )
+        let analyticsHelper = PaymentSheetAnalyticsHelper(
+            integrationShape: .flowController,
+            configuration: PaymentSheet.Configuration(),
+            analyticsClient: STPTestingAnalyticsClient(),
+            analyticsClientV2: MockAnalyticsClientV2()
+        )
+        let cardWithArt = STPPaymentMethod._testCardWithCardArt()
+        let cardNoArt = STPPaymentMethod._testCard()
+        let bankPM = STPPaymentMethod._testUSBankAccount()
+
+        let experiment = CardArtExperiment.create(
+            elementsSession: elementsSession,
+            configuration: PaymentSheet.Configuration(),
+            analyticsHelper: analyticsHelper,
+            paymentMethodTypes: [.stripe(.card), .stripe(.USBankAccount)],
+            savedPaymentMethods: [cardWithArt, cardNoArt, bankPM],
+            paymentMethodOrientation: .horizontal,
+            selectedPaymentOption: .saved(paymentMethod: cardWithArt)
+        )!
+
+        XCTAssertEqual(experiment.name, "ocs_mobile_card_art")
+        XCTAssertEqual(experiment.arbId, "arb_test")
+        XCTAssertEqual(experiment.group, ExperimentGroup.treatment)
+
+        let dims = experiment.dimensions
+        XCTAssertEqual(dims["displayed_payment_method_types"], "card,us_bank_account")
+        XCTAssertEqual(dims["displayed_payment_method_types_including_wallets"], "card,us_bank_account")
+        XCTAssertEqual(dims["in_app_elements_integration_type"], "flowcontroller")
+        XCTAssertEqual(dims["in_app_elements_layout"], "horizontal")
+        XCTAssertEqual(dims["saved_payment_method_count"], "3")
+        XCTAssertEqual(dims["saved_card_payment_method_count"], "2")
+        XCTAssertEqual(dims["saved_card_payment_method_with_card_art_count"], "1")
+        XCTAssertEqual(dims["selected_payment_method_type"], "card")
+        XCTAssertEqual(dims["selected_payment_method_has_card_art"], "true")
+    }
+
+    // MARK: - selectedPaymentMethodInfo mapping
+
+    func testSelectedPaymentMethodInfo() {
+        let elementsSession = STPElementsSession._testValue(
+            experimentsData: ExperimentsData(
+                arbId: "arb_test",
+                experimentAssignments: [CardArtExperiment.experimentName: .treatment],
+                allResponseFields: [:]
+            )
+        )
+        let analyticsHelper = PaymentSheetAnalyticsHelper(
+            integrationShape: .complete,
+            configuration: PaymentSheet.Configuration(),
+            analyticsClient: STPTestingAnalyticsClient(),
+            analyticsClientV2: MockAnalyticsClientV2()
+        )
+        let cases: [(SavedPaymentOptionsViewController.Selection?, String, String)] = [
+            (.saved(paymentMethod: ._testCard()), "card", "false"),
+            (.saved(paymentMethod: ._testCardWithCardArt()), "card", "true"),
+            (nil, "none", "false"),
+            (.applePay, "apple_pay", "false"),
+            (.link, "link", "false"),
+            (.add, "new", "false"),
+        ]
+
+        for (selection, expectedType, expectedHasArt) in cases {
+            let experiment = CardArtExperiment.create(
+                elementsSession: elementsSession,
+                configuration: PaymentSheet.Configuration(),
+                analyticsHelper: analyticsHelper,
+                paymentMethodTypes: [.stripe(.card)],
+                savedPaymentMethods: [],
+                paymentMethodOrientation: .vertical,
+                selectedPaymentOption: selection
+            )!
+            XCTAssertEqual(experiment.dimensions["selected_payment_method_type"], expectedType)
+            XCTAssertEqual(experiment.dimensions["selected_payment_method_has_card_art"], expectedHasArt)
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -968,9 +968,9 @@ class STPElementsSessionTest: XCTestCase {
             "payment_methods_with_link_details": [linkWrappedUnknownPM(linkPMJSON)],
             "customer_session": customerSessionJSON,
         ]
-
-        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true)
-
+        
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true, includeCardArt: true)
+        
         XCTAssertEqual(customer?.paymentMethods.count, 1)
         let paymentMethod = try XCTUnwrap(customer?.paymentMethods.first)
         XCTAssertEqual(paymentMethod.type, .link)
@@ -980,5 +980,147 @@ class STPElementsSessionTest: XCTestCase {
         }
         XCTAssertEqual(genericDetails.label, "Pix")
         XCTAssertEqual(genericDetails.sublabel, "000••••••••")
+    }
+
+    // MARK: - includeCardArt gating
+
+    func testMergeCardArt_strippedWhenIncludeCardArtIsFalse() {
+        let response: [AnyHashable: Any] = [
+            "payment_methods": [testCardJSON],
+            "card_art": [
+                ["payment_method": "pm_123card",
+                 "art_image": ["url": "https://b.stripecdn.com/cardart/assets/abc123"],
+                 "program_name": "Test Program",
+                ],
+            ],
+            "customer_session": customerSessionJSON,
+        ]
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false, includeCardArt: false)
+        XCTAssertNotNil(customer)
+        XCTAssertNil(customer?.paymentMethods.first?.card?.cardArt)
+    }
+
+    func testMergeCardArt_linkFormat_strippedWhenIncludeCardArtIsFalse() {
+        let response: [AnyHashable: Any] = [
+            "payment_methods_with_link_details": [
+                ["payment_method": testCardJSON],
+            ],
+            "card_art": [
+                ["payment_method": "pm_123card",
+                 "art_image": ["url": "https://b.stripecdn.com/cardart/assets/abc123"],
+                 "program_name": "Test Program",
+                ],
+            ],
+            "customer_session": customerSessionJSON,
+        ]
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true, includeCardArt: false)
+        XCTAssertNotNil(customer)
+        XCTAssertNil(customer?.paymentMethods.first?.card?.cardArt)
+    }
+
+    // MARK: - STPElementsSession experiment-gated card art deserialization
+
+    func testDeserialize_cardArtIncluded_whenExperimentIsTreatment() {
+        var json = STPTestUtils.jsonNamed("ElementsSession")!
+        json["experiments_data"] = [
+            "arb_id": "arb_test",
+            "experiment_assignments": [
+                CardArtExperiment.experimentName: "treatment",
+            ],
+        ] as [AnyHashable: Any]
+        json["customer"] = [
+            "payment_methods": [testCardJSON],
+            "card_art": [
+                ["payment_method": "pm_123card",
+                 "art_image": ["url": "https://b.stripecdn.com/cardart/assets/visa_gold"],
+                 "program_name": "Visa Gold",
+                ] as [AnyHashable: Any],
+            ],
+            "customer_session": customerSessionJSON,
+        ] as [AnyHashable: Any]
+
+        let session = STPElementsSession.decodedObject(fromAPIResponse: json)!
+        XCTAssertNotNil(session.customer, "Customer should be deserialized")
+        let pm = session.customer?.paymentMethods.first
+        XCTAssertNotNil(pm, "Payment method should exist")
+        XCTAssertNotNil(pm?.card?.cardArt, "Card art should be present when experiment is treatment")
+        XCTAssertEqual(pm?.card?.cardArt?.artImage?.url?.absoluteString, "https://b.stripecdn.com/cardart/assets/visa_gold")
+    }
+
+    func testDeserialize_cardArtExcluded_whenExperimentIsControl() {
+        var json = STPTestUtils.jsonNamed("ElementsSession")!
+        json["experiments_data"] = [
+            "arb_id": "arb_test",
+            "experiment_assignments": [
+                CardArtExperiment.experimentName: "control",
+            ],
+        ] as [AnyHashable: Any]
+        json["customer"] = [
+            "payment_methods": [testCardJSON],
+            "card_art": [
+                ["payment_method": "pm_123card",
+                 "art_image": ["url": "https://b.stripecdn.com/cardart/assets/visa_gold"],
+                 "program_name": "Visa Gold",
+                ],
+            ],
+            "customer_session": [
+                "id": "id123",
+                "livemode": false,
+                "api_key": "ek_12345",
+                "api_key_expiry": 12345,
+                "customer": "cus_123",
+                "components": [
+                    "mobile_payment_element": [
+                        "enabled": true,
+                        "features": [
+                            "payment_method_save": "enabled",
+                            "payment_method_remove": "enabled",
+                            "payment_method_set_as_default": "enabled",
+                        ],
+                    ],
+                    "customer_sheet": ["enabled": false],
+                ],
+            ] as [AnyHashable: Any],
+        ] as [AnyHashable: Any]
+
+        let session = STPElementsSession.decodedObject(fromAPIResponse: json)!
+        let pm = session.customer?.paymentMethods.first
+        XCTAssertNil(pm?.card?.cardArt)
+    }
+
+    func testDeserialize_cardArtExcluded_whenNoExperimentAssignment() {
+        var json = STPTestUtils.jsonNamed("ElementsSession")!
+        json["experiments_data"] = nil
+        json["customer"] = [
+            "payment_methods": [testCardJSON],
+            "card_art": [
+                ["payment_method": "pm_123card",
+                 "art_image": ["url": "https://b.stripecdn.com/cardart/assets/visa_gold"],
+                 "program_name": "Visa Gold",
+                ],
+            ],
+            "customer_session": [
+                "id": "id123",
+                "livemode": false,
+                "api_key": "ek_12345",
+                "api_key_expiry": 12345,
+                "customer": "cus_123",
+                "components": [
+                    "mobile_payment_element": [
+                        "enabled": true,
+                        "features": [
+                            "payment_method_save": "enabled",
+                            "payment_method_remove": "enabled",
+                            "payment_method_set_as_default": "enabled",
+                        ],
+                    ],
+                    "customer_sheet": ["enabled": false],
+                ],
+            ] as [AnyHashable: Any],
+        ] as [AnyHashable: Any]
+
+        let session = STPElementsSession.decodedObject(fromAPIResponse: json)!
+        let pm = session.customer?.paymentMethods.first
+        XCTAssertNil(pm?.card?.cardArt)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -789,7 +789,7 @@ class STPElementsSessionTest: XCTestCase {
             ],
             "customer_session": customerSessionJSON,
         ]
-        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false)
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false, includeCardArt: true)
         XCTAssertNotNil(customer)
         let pm = customer?.paymentMethods.first
         XCTAssertNotNil(pm?.card?.cardArt)
@@ -808,7 +808,7 @@ class STPElementsSessionTest: XCTestCase {
             ],
             "customer_session": customerSessionJSON,
         ]
-        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false)
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false, includeCardArt: true)
         XCTAssertNotNil(customer)
         XCTAssertNil(customer?.paymentMethods.first?.card?.cardArt)
     }
@@ -818,7 +818,7 @@ class STPElementsSessionTest: XCTestCase {
             "payment_methods": [testCardJSON],
             "customer_session": customerSessionJSON,
         ]
-        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false)
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false, includeCardArt: true)
         XCTAssertNotNil(customer)
         XCTAssertNil(customer?.paymentMethods.first?.card?.cardArt)
     }
@@ -838,7 +838,7 @@ class STPElementsSessionTest: XCTestCase {
             ],
             "customer_session": customerSessionJSON,
         ]
-        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false)
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false, includeCardArt: true)
         let pms = customer?.paymentMethods
         XCTAssertEqual(pms?.count, 2)
         XCTAssertEqual(pms?[0].card?.cardArt?.artImage?.url?.absoluteString, "https://b.stripecdn.com/cardart/assets/visa")
@@ -856,7 +856,7 @@ class STPElementsSessionTest: XCTestCase {
             ],
             "customer_session": customerSessionJSON,
         ]
-        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false)
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false, includeCardArt: true)
         let pms = customer?.paymentMethods
         XCTAssertEqual(pms?.count, 2)
         XCTAssertNotNil(pms?[0].card?.cardArt)
@@ -870,7 +870,7 @@ class STPElementsSessionTest: XCTestCase {
             "card_art": [] as [[AnyHashable: Any]],
             "customer_session": customerSessionJSON,
         ]
-        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false)
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false, includeCardArt: true)
         XCTAssertNotNil(customer)
         XCTAssertNil(customer?.paymentMethods.first?.card?.cardArt)
     }
@@ -908,7 +908,7 @@ class STPElementsSessionTest: XCTestCase {
             ],
             "customer_session": customerSessionJSON,
         ]
-        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true)
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true, includeCardArt: true)
         XCTAssertNotNil(customer)
         let pm = customer?.paymentMethods.first
         XCTAssertNotNil(pm?.card?.cardArt)
@@ -926,7 +926,7 @@ class STPElementsSessionTest: XCTestCase {
             ],
             "customer_session": customerSessionJSON,
         ]
-        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true)
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true, includeCardArt: true)
         XCTAssertNotNil(customer)
         XCTAssertNil(customer?.paymentMethods.first?.card?.cardArt)
     }
@@ -946,7 +946,7 @@ class STPElementsSessionTest: XCTestCase {
             ],
             "customer_session": customerSessionJSON,
         ]
-        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true)
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true, includeCardArt: true)
         let pms = customer?.paymentMethods
         XCTAssertEqual(pms?.count, 2)
         XCTAssertEqual(pms?[0].card?.cardArt?.artImage?.url?.absoluteString, "https://b.stripecdn.com/cardart/assets/visa")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -968,9 +968,8 @@ class STPElementsSessionTest: XCTestCase {
             "payment_methods_with_link_details": [linkWrappedUnknownPM(linkPMJSON)],
             "customer_session": customerSessionJSON,
         ]
-        
+
         let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true, includeCardArt: true)
-        
         XCTAssertEqual(customer?.paymentMethods.count, 1)
         let paymentMethod = try XCTUnwrap(customer?.paymentMethods.first)
         XCTAssertEqual(paymentMethod.type, .link)


### PR DESCRIPTION
## Summary
Puts card art behind a server-side experiment flag to support A/A and A/B testing

## Motivation
Exercising experimentation framework

## Testing
Will add tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
