### PR TITLE
Force vertical row button to new size

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -65,12 +65,7 @@ class RowButton: UIView, EventHandler {
     }
 
     var imageViewSize: CGSize {
-        if appearance.cardArtEnabled {
-            // When card art is enabled, allow images to grow in width to 30px
-            return CGSize(width: 30, height: 20)
-        } else {
-            return CGSize(width: 24, height: 20)
-        }
+        return CGSize(width: 30, height: 20)
     }
 
     // MARK: Internal properties


### PR DESCRIPTION
## Summary
Defaults vertical button icon size to 30x20

## Motivation
In preparation for card art

## Testing
Updating existing snapshot tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
