### PR TITLE
Add Checkout.runServerUpdate

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -60,6 +60,9 @@ public final class Checkout: ObservableObject {
     /// Default timeout used by ``awaitPendingOperations(timeout:)``.
     nonisolated static let defaultPendingOperationsTimeout: TimeInterval = 30
 
+    /// Timeout enforced on the merchant's closure in ``runServerUpdate(_:)``.
+    nonisolated static let serverUpdateTimeout: TimeInterval = 20
+
     /// The single state writer. Publishes `.loading` if any op is queued, else `.loaded`.
     func setSession(_ session: Checkout.Session) {
         state = pendingOperations.isEmpty ? .loaded(session) : .loading(session)
@@ -292,6 +295,36 @@ public final class Checkout: ObservableObject {
                 self.setSession(session)
                 self.delegate?.checkout(self, didChangeState: self.state)
             }
+        }
+    }
+
+    // MARK: - Server Updates
+
+    /// Runs an async function that calls your server to update the Checkout Session,
+    /// then automatically refreshes ``state`` with the latest session data.
+    ///
+    /// A 20-second timeout is enforced. If `updateFunction` doesn't complete
+    /// within 20 seconds, this method throws ``CheckoutError/timedOut``.
+    ///
+    /// - Parameter updateFunction: An async throwing function that makes a request
+    ///   to your server to update the Checkout Session.
+    /// - Throws: ``CheckoutError`` if the function times out, the session is not
+    ///   open, or the refresh fails.
+    public func runServerUpdate(
+        _ updateFunction: @escaping () async throws -> Void
+    ) async throws {
+        try requireOpenSession()
+        try await enqueueSessionUpdate {
+            let result = await withTimeout(Self.serverUpdateTimeout) {
+                try await updateFunction()
+            }
+            if case .failure(let error) = result {
+                if error is TimeoutError {
+                    throw CheckoutError.timedOut
+                }
+                throw CheckoutError.apiError(message: error.localizedDescription)
+            }
+            try await self.refreshSession()
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -304,7 +304,7 @@ public final class Checkout: ObservableObject {
     /// then automatically refreshes ``state`` with the latest session data.
     ///
     /// A 20-second timeout is enforced. If `updateFunction` doesn't complete
-    /// within 20 seconds, this method throws ``CheckoutError/timedOut``.
+    /// within 20 seconds, this method throws ``CheckoutError.timedOut``.
     ///
     /// - Parameter updateFunction: An async throwing function that makes a request
     ///   to your server to update the Checkout Session.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -324,6 +324,7 @@ public final class Checkout: ObservableObject {
                 }
                 throw CheckoutError.apiError(message: error.localizedDescription)
             }
+            try self.requireOpenSession()
             try await self.refreshSession()
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -148,41 +148,6 @@ final class CheckoutUnitTests: XCTestCase {
 
     // MARK: - runServerUpdate Tests
 
-    func testRunServerUpdateRequiresOpenSession() async {
-        let checkout = makeCheckoutWithClosedSession()
-
-        do {
-            try await checkout.runServerUpdate { }
-            XCTFail("Expected CheckoutError.sessionNotOpen")
-        } catch let error as CheckoutError {
-            guard case .sessionNotOpen = error else {
-                XCTFail("Expected .sessionNotOpen, got \(error)")
-                return
-            }
-        } catch {
-            XCTFail("Unexpected error type: \(error)")
-        }
-    }
-
-    func testRunServerUpdateThrowsWhenSheetPresented() async {
-        let checkout = makeCheckoutWithOpenSession()
-        let integrationDelegate = MockCheckoutIntegrationDelegate()
-        integrationDelegate.isSheetPresented = true
-        checkout.integrationDelegate = integrationDelegate
-
-        do {
-            try await checkout.runServerUpdate { }
-            XCTFail("Expected CheckoutError.sheetCurrentlyPresented")
-        } catch let error as CheckoutError {
-            guard case .sheetCurrentlyPresented = error else {
-                XCTFail("Expected .sheetCurrentlyPresented, got \(error)")
-                return
-            }
-        } catch {
-            XCTFail("Unexpected error type: \(error)")
-        }
-    }
-
     func testRunServerUpdateWrapsClosureError() async {
         let checkout = makeCheckoutWithOpenSession()
         let expectedMessage = "Server returned 500"
@@ -198,6 +163,43 @@ final class CheckoutUnitTests: XCTestCase {
                 return
             }
             XCTAssertEqual(message, expectedMessage)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRunServerUpdateWrapsTimeoutError() async {
+        let checkout = makeCheckoutWithOpenSession()
+
+        do {
+            try await checkout.runServerUpdate {
+                throw TimeoutError()
+            }
+            XCTFail("Expected CheckoutError.timedOut")
+        } catch let error as CheckoutError {
+            guard case .timedOut = error else {
+                XCTFail("Expected .timedOut, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRunServerUpdateWrapsGenericError() async {
+        let checkout = makeCheckoutWithOpenSession()
+
+        do {
+            try await checkout.runServerUpdate {
+                throw URLError(.notConnectedToInternet)
+            }
+            XCTFail("Expected CheckoutError.apiError")
+        } catch let error as CheckoutError {
+            guard case .apiError(let message) = error else {
+                XCTFail("Expected .apiError, got \(error)")
+                return
+            }
+            XCTAssertEqual(message, URLError(.notConnectedToInternet).localizedDescription)
         } catch {
             XCTFail("Unexpected error type: \(error)")
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -146,7 +146,64 @@ final class CheckoutUnitTests: XCTestCase {
         }
     }
 
-    // MARK: - Address Override Tests
+    // MARK: - runServerUpdate Tests
+
+    func testRunServerUpdateRequiresOpenSession() async {
+        let checkout = makeCheckoutWithClosedSession()
+
+        do {
+            try await checkout.runServerUpdate { }
+            XCTFail("Expected CheckoutError.sessionNotOpen")
+        } catch let error as CheckoutError {
+            guard case .sessionNotOpen = error else {
+                XCTFail("Expected .sessionNotOpen, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRunServerUpdateThrowsWhenSheetPresented() async {
+        let checkout = makeCheckoutWithOpenSession()
+        let integrationDelegate = MockCheckoutIntegrationDelegate()
+        integrationDelegate.isSheetPresented = true
+        checkout.integrationDelegate = integrationDelegate
+
+        do {
+            try await checkout.runServerUpdate { }
+            XCTFail("Expected CheckoutError.sheetCurrentlyPresented")
+        } catch let error as CheckoutError {
+            guard case .sheetCurrentlyPresented = error else {
+                XCTFail("Expected .sheetCurrentlyPresented, got \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+    func testRunServerUpdateWrapsClosureError() async {
+        let checkout = makeCheckoutWithOpenSession()
+        let expectedMessage = "Server returned 500"
+
+        do {
+            try await checkout.runServerUpdate {
+                throw NSError(domain: "test", code: 500, userInfo: [NSLocalizedDescriptionKey: expectedMessage])
+            }
+            XCTFail("Expected CheckoutError.apiError")
+        } catch let error as CheckoutError {
+            guard case .apiError(let message) = error else {
+                XCTFail("Expected .apiError, got \(error)")
+                return
+            }
+            XCTAssertEqual(message, expectedMessage)
+        } catch {
+            XCTFail("Unexpected error type: \(error)")
+        }
+    }
+
+// MARK: - Address Override Tests
 
     func testUpdateBillingAddress_noTax_setsLocallyAndNotifiesDelegate() async throws {
         let checkout = makeCheckoutWithOpenSession()


### PR DESCRIPTION
## Summary
- Adds `runServerUpdate`, similar to web: https://docs.stripe.com/js/custom_checkout/run_server_update

## Motivation
- CheckoutSessions

## Testing
- New unit tests

## Changelog
N/A