### PR TITLE
[link] Use previous string for branded legal terms

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -641,6 +641,10 @@ extension String.Localized {
         }
     }
 
+    static var by_continuing_you_agree_to_the_terms_and_privacy_policy: String {
+        existingLinkLocalizedString("By continuing you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.")
+    }
+
     static func by_providing_phone_number_and_email_you_agree_to_create_a_brand_account(brand: LinkBrand) -> String {
         switch brand {
         case .link, .unparsable:

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Views/LinkLegalTermsView.swift
@@ -103,10 +103,7 @@ final class LinkLegalTermsView: UIView {
     private func formattedLegalText() -> NSAttributedString? {
         let string: String? = {
             if isStandalone {
-                return STPLocalizedString(
-                    "By continuing you agree to the <terms>Terms</terms> and <privacy>Privacy Policy</privacy>.",
-                    "Legal text shown when creating a Link account."
-                )
+                return String.Localized.by_continuing_you_agree_to_the_terms_and_privacy_policy
             }
             switch mode {
             case .checkbox:


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Legal terms is incorrectly using an unlocalized string. This PR only conditionally presents the new string.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
