### PR TITLE
Add `LinkControllerPreview` annotation to some LinkController APIs

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
@@ -1,0 +1,385 @@
+//
+//  ExampleLinkControllerPreviewView.swift
+//  PaymentSheet Example
+//
+
+import SwiftUI
+import UIKit
+
+@_spi(LinkControllerPreview) import StripePaymentSheet
+
+@available(iOS 16.0, *)
+struct ExampleLinkControllerPreviewView: View {
+    private static let publishableKey = "pk_test_51K9W3OHMaDsveWq0oLP0ZjldetyfHIqyJcz27k2BpMGHxu9v9Cei2tofzoHncPyk3A49jMkFEgTOBQyAMTUffRLa00xzzARtZO"
+
+    @State private var linkController: LinkController?
+    @State private var email: String = ""
+    @State private var phone: String = ""
+    @State private var isLoading: Bool = false
+    @State private var errorMessage: String?
+    @State private var statusMessage: String?
+    @State private var selectedPaymentMethodTypes: Set<LinkPaymentMethodType> = Set(LinkPaymentMethodType.allCases)
+    @FocusState private var isEmailFieldFocused: Bool
+
+    private var supportedPaymentMethodTypes: [LinkPaymentMethodType] {
+        LinkPaymentMethodType.allCases.filter(selectedPaymentMethodTypes.contains)
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("LinkControllerPreview Demo")
+                        .font(.system(size: 34, weight: .bold))
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+                DemoSection(title: "User Information") {
+                    VStack(alignment: .leading, spacing: 16) {
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Email")
+                                .font(.subheadline)
+                            TextField("Enter email address", text: $email)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .keyboardType(.emailAddress)
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                                .focused($isEmailFieldFocused)
+                        }
+
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Phone Number (optional)")
+                                .font(.subheadline)
+                            TextField("Enter phone number (E.164 format)", text: $phone)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .keyboardType(.phonePad)
+                        }
+                    }
+                }
+
+                DemoSection(title: "Supported Payment Method Types") {
+                    VStack(alignment: .leading, spacing: 16) {
+                        ForEach(LinkPaymentMethodType.allCases, id: \.self) { paymentMethodType in
+                            Button {
+                                togglePaymentMethodType(paymentMethodType)
+                            } label: {
+                                HStack(spacing: 12) {
+                                    Image(systemName: selectedPaymentMethodTypes.contains(paymentMethodType) ? "checkmark.square.fill" : "square")
+                                        .foregroundColor(selectedPaymentMethodTypes.contains(paymentMethodType) ? .blue : .gray)
+                                    Text(paymentMethodTypeTitle(paymentMethodType))
+                                        .foregroundColor(.primary)
+                                    Spacer()
+                                }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+
+                VStack(spacing: 16) {
+                    Button("Present") {
+                        Task { @MainActor in
+                            await presentLinkFlow()
+                        }
+                    }
+                    .buttonStyle(PreviewPrimaryButtonStyle())
+                    .disabled(isLoading || email.isEmpty || linkController == nil || supportedPaymentMethodTypes.isEmpty)
+
+                    Button("Reset LinkController") {
+                        Task { @MainActor in
+                            await resetLinkController()
+                        }
+                    }
+                    .buttonStyle(PreviewTextButtonStyle())
+                    .disabled(isLoading)
+                }
+
+                if let errorMessage {
+                    MessageBanner(text: errorMessage, tint: .red)
+                }
+
+                if let statusMessage {
+                    MessageBanner(text: statusMessage, tint: .green)
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Payment Method Preview")
+                        .font(.headline)
+                    if let linkController {
+                        LinkControllerPreviewPaymentMethodView(linkController: linkController)
+                    } else {
+                        StatusCard(
+                            text: "No payment method preview available",
+                            isPlaceholder: true
+                        )
+                    }
+                }
+            }
+            .padding()
+        }
+        .task {
+            guard linkController == nil, !isLoading else {
+                return
+            }
+            await initializeLinkController()
+        }
+        .overlay {
+            if isLoading {
+                ZStack {
+                    Color.black.opacity(0.2)
+                        .ignoresSafeArea()
+                    ProgressView("Loading...")
+                        .padding(20)
+                        .background(Color(UIColor.systemBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func initializeLinkController() async {
+        STPAPIClient.shared.publishableKey = Self.publishableKey
+
+        isLoading = true
+        errorMessage = nil
+        statusMessage = "Initializing LinkController..."
+
+        do {
+            linkController = try await LinkController.create(mode: .setup)
+            isLoading = false
+            statusMessage = "LinkController initialized successfully"
+        } catch {
+            isLoading = false
+            statusMessage = nil
+            errorMessage = "Failed to initialize LinkController: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func presentLinkFlow() async {
+        guard let linkController else {
+            errorMessage = "LinkController not initialized"
+            return
+        }
+
+        guard !email.isEmpty else {
+            errorMessage = "Please enter an email address"
+            return
+        }
+
+        guard let rootViewController = findViewController() else {
+            errorMessage = "Could not find root view controller"
+            return
+        }
+
+        isEmailFieldFocused = false
+        isLoading = true
+        errorMessage = nil
+        statusMessage = "Presenting Link flow..."
+
+        do {
+            let result = try await linkController.present(
+                email: email,
+                phoneNumber: phone.isEmpty ? nil : phone,
+                supportedPaymentMethodTypes: supportedPaymentMethodTypes,
+                from: rootViewController
+            )
+
+            isLoading = false
+
+            switch result {
+            case .completed(let paymentMethod):
+                statusMessage = "Payment method created (ID: \(paymentMethod.stripeId))"
+            case .canceled:
+                statusMessage = "Present flow canceled"
+            }
+        } catch {
+            isLoading = false
+            statusMessage = nil
+            errorMessage = "Present flow failed: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func resetLinkController() async {
+        linkController = nil
+        errorMessage = nil
+        statusMessage = nil
+        email = ""
+        phone = ""
+        selectedPaymentMethodTypes = Set(LinkPaymentMethodType.allCases)
+
+        await initializeLinkController()
+    }
+
+    private func togglePaymentMethodType(_ paymentMethodType: LinkPaymentMethodType) {
+        if selectedPaymentMethodTypes.contains(paymentMethodType) {
+            selectedPaymentMethodTypes.remove(paymentMethodType)
+        } else {
+            selectedPaymentMethodTypes.insert(paymentMethodType)
+        }
+    }
+
+    private func paymentMethodTypeTitle(_ paymentMethodType: LinkPaymentMethodType) -> String {
+        switch paymentMethodType {
+        case .card:
+            return "Card"
+        case .bankAccount:
+            return "Bank Account"
+        @unknown default:
+            fatalError()
+        }
+    }
+
+    private func findViewController() -> UIViewController? {
+        let keyWindow = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .flatMap(\.windows)
+            .first(where: \.isKeyWindow)
+
+        var topController = keyWindow?.rootViewController
+        while let presentedViewController = topController?.presentedViewController {
+            topController = presentedViewController
+        }
+        return topController
+    }
+}
+
+@available(iOS 16.0, *)
+private struct LinkControllerPreviewPaymentMethodView: View {
+    @ObservedObject var linkController: LinkController
+
+    var body: some View {
+        if let paymentMethodPreview = linkController.paymentMethodPreview {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack {
+                    Text("Icon:")
+                        .fontWeight(.medium)
+                    Spacer()
+                    Image(uiImage: paymentMethodPreview.icon)
+                        .resizable()
+                        .frame(width: 24, height: 24)
+                }
+                PreviewInfoRow(label: "Label", value: paymentMethodPreview.label)
+                PreviewInfoRow(label: "Sublabel", value: paymentMethodPreview.sublabel ?? "N/A")
+            }
+            .padding()
+            .background(Color(UIColor.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+        } else {
+            StatusCard(
+                text: "No payment method preview available",
+                isPlaceholder: true
+            )
+        }
+    }
+}
+
+private struct DemoSection<Content: View>: View {
+    let title: String
+    let content: Content
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(title)
+                .font(.headline)
+            content
+        }
+        .padding(20)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(UIColor.secondarySystemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+    }
+}
+
+@available(iOS 16.0, *)
+private struct PreviewInfoRow: View {
+    let label: String
+    let value: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text("\(label):")
+                .fontWeight(.medium)
+            Spacer(minLength: 12)
+            Text(value)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(2)
+                .truncationMode(.middle)
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+private struct StatusCard: View {
+    let text: String
+    let isPlaceholder: Bool
+
+    var body: some View {
+        Group {
+            if isPlaceholder {
+                Text(text)
+                    .italic()
+            } else {
+                Text(text)
+            }
+        }
+            .foregroundColor(isPlaceholder ? .secondary : .primary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(Color(UIColor.secondarySystemBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+@available(iOS 16.0, *)
+private struct MessageBanner: View {
+    let text: String
+    let tint: Color
+
+    var body: some View {
+        Text(text)
+            .font(.subheadline)
+            .foregroundColor(tint)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
+            .background(tint.opacity(0.12))
+            .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+}
+
+@available(iOS 16.0, *)
+private struct PreviewPrimaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(configuration.isPressed ? Color.blue.opacity(0.8) : Color.blue)
+            .foregroundColor(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .scaleEffect(configuration.isPressed ? 0.98 : 1.0)
+    }
+}
+
+@available(iOS 16.0, *)
+private struct PreviewTextButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .frame(maxWidth: .infinity)
+            .foregroundColor(.primary)
+            .padding(.vertical, 8)
+            .opacity(configuration.isPressed ? 0.6 : 1.0)
+    }
+}
+
+@available(iOS 16.0, *)
+#Preview {
+    ExampleLinkControllerPreviewView()
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
@@ -85,6 +85,7 @@ struct PaymentSheetExampleAppRootView: View {
         case customerSheet_swiftUI
         case instantBankPaymentsController
         case linkController
+        case linkControllerPreviewDemo
         case linkStandaloneDemo
         case linkPayoutsDemo
         case embeddedPaymentElement
@@ -116,6 +117,7 @@ struct PaymentSheetExampleAppRootView: View {
                      .customerSheet_swiftUI,
                      .instantBankPaymentsController,
                      .linkController,
+                     .linkControllerPreviewDemo,
                      .linkStandaloneDemo,
                      .linkPayoutsDemo,
                      .embeddedPaymentElement,
@@ -155,6 +157,8 @@ struct PaymentSheetExampleAppRootView: View {
                 return "InstantBankPaymentsController"
             case .linkController:
                 return "LinkController (SwiftUI)"
+            case .linkControllerPreviewDemo:
+                return "LinkControllerPreview Demo"
             case .linkStandaloneDemo:
                 return "Link Standalone Demo"
             case .linkPayoutsDemo:
@@ -230,6 +234,13 @@ struct PaymentSheetExampleAppRootView: View {
         case .linkController:
             if #available(iOS 16.0, *) {
                 ExampleLinkControllerView()
+            } else {
+                Text("Sorry, only available on >= iOS 16.0")
+                    .font(.title2)
+            }
+        case .linkControllerPreviewDemo:
+            if #available(iOS 16.0, *) {
+                ExampleLinkControllerPreviewView()
             } else {
                 Text("Sorry, only available on >= iOS 16.0")
                     .font(.title2)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
@@ -123,11 +123,6 @@ class PaymentSheet_AddressTests: PaymentSheetUITestCase {
         XCTAssertTrue(app.staticTexts["Country: \(country)"].exists)
     }
 
-    private func scrollDown() {
-        let verySlowVelocity: XCUIGestureVelocity = XCUIGestureVelocity(300)
-        app.swipeUp(velocity: verySlowVelocity)
-    }
-
     /// Helper function to navigate to address collection for shipping
     private func navigateToShippingAddress() {
         let shippingButton = app.buttons["Address"]
@@ -145,10 +140,7 @@ class PaymentSheet_AddressTests: PaymentSheetUITestCase {
             return
         }
         let addressButton = app.staticTexts["AddressElement (SwiftUI)"]
-        if !addressButton.exists {
-            scrollDown()
-        }
-        XCTAssertTrue(addressButton.waitForExistenceAndTap())
+        addressButton.scrollToAndTap(in: app)
         XCTAssertTrue(app.buttons["Collect Address"].waitForExistenceAndTap())
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/LinkPaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/LinkPaymentMethodType.swift
@@ -9,6 +9,7 @@ import Foundation
 
 @_spi(STP) import StripeCore
 
+/// The payment method types supported by the Link flow.
 @_spi(STP) @_spi(LinkControllerPreview) public enum LinkPaymentMethodType: String, CaseIterable {
     case card = "CARD"
     case bankAccount = "BANK_ACCOUNT"

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/LinkPaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/LinkPaymentMethodType.swift
@@ -9,7 +9,7 @@ import Foundation
 
 @_spi(STP) import StripeCore
 
-@_spi(STP) public enum LinkPaymentMethodType: String, CaseIterable {
+@_spi(STP) @_spi(LinkControllerPreview) public enum LinkPaymentMethodType: String, CaseIterable {
     case card = "CARD"
     case bankAccount = "BANK_ACCOUNT"
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -17,10 +17,10 @@ import UIKit
 @MainActor @_spi(STP) @_spi(LinkControllerPreview) public class LinkController: ObservableObject {
 
     /// Represents the payment method currently selected by the user.
-    @_spi(STP) public struct PaymentMethodPreview {
+    @_spi(STP) @_spi(LinkControllerPreview) public struct PaymentMethodPreview {
 
         /// Represents the type of selected payment method.
-        @_spi(STP) public enum PaymentMethodType {
+        @_spi(STP) @_spi(LinkControllerPreview) public enum PaymentMethodType {
 
             /// The user chose a card-based payment method, such as a debit or credit card.
             case card
@@ -30,16 +30,16 @@ import UIKit
         }
 
         /// The type of the selected payment method.
-        @_spi(STP) public let paymentMethodType: PaymentMethodType
+        @_spi(STP) @_spi(LinkControllerPreview) public let paymentMethodType: PaymentMethodType
 
         /// The Link icon to render in your screen.
-        @_spi(STP) public let icon: UIImage
+        @_spi(STP) @_spi(LinkControllerPreview) public let icon: UIImage
 
         /// The Link label to render in your screen.
-        @_spi(STP) public let label: String
+        @_spi(STP) @_spi(LinkControllerPreview) public let label: String
 
         /// Details about the selected Link payment method. This will typically render the display name of the payment method followed by the last four digits, e.g. `Visa Credit •••• 4242`.
-        @_spi(STP) public let sublabel: String?
+        @_spi(STP) @_spi(LinkControllerPreview) public let sublabel: String?
     }
 
     @frozen @_spi(STP) public enum VerificationResult {
@@ -131,7 +131,7 @@ import UIKit
     @Published @_spi(STP) public private(set) var linkAccount: PaymentSheetLinkAccount?
 
     /// A preview of the currently selected Link payment method.
-    @Published @_spi(STP) public private(set) var paymentMethodPreview: PaymentMethodPreview?
+    @Published @_spi(STP) @_spi(LinkControllerPreview) public private(set) var paymentMethodPreview: PaymentMethodPreview?
 
     private var resolvedLinkBrand: LinkBrand {
         linkAccount?.linkBrand ?? LinkAccountContext.shared.account?.linkBrand ?? initialLinkBrand
@@ -456,7 +456,7 @@ import UIKit
     /// 1. Looks up the consumer by email, unless an authenticated session for that email already exists.
     /// 2. Presents the Link sheet, routing to signup, OTP verification, or the wallet based on account state.
     ///    If `phoneNumber` is provided, it is prefilled in the signup form.
-    /// 3. Once the user selects a payment method, converts the selection to an `STPPaymentMethod`.
+    /// 3. Once the user selects a payment method, creates and returns an `STPPaymentMethod`.
     ///
     /// - Parameter email: The email address to look up and associate with the Link account.
     /// - Parameter phoneNumber: Optional phone number in E.164 format to prefill during signup.
@@ -1275,7 +1275,7 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
 }
 
 @_spi(LinkControllerPreview) public extension LinkController {
-
+    
     /// Creates a `LinkController` for the specified `mode`.
     ///
     /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
@@ -1296,6 +1296,9 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
             }
         }
     }
+}
+
+@_spi(STP) @_spi(LinkControllerPreview) public extension LinkController {
 
     /// Presents the full Link payment method selection flow, handling lookup, authentication or signup,
     /// wallet display, and payment method creation in a single call.
@@ -1304,14 +1307,14 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
     /// 1. Looks up the consumer by email.
     /// 2. Presents the Link sheet, routing to signup, OTP verification, or the wallet based on account state.
     ///    If `phoneNumber` is provided, it is prefilled in the signup form.
-    /// 3. Once the user selects a payment method, converts the selection to an `STPPaymentMethod`.
+    /// 3. Once the user selects a payment method, creates and returns an `STPPaymentMethod`.
     ///
     /// - Parameter email: The email address to look up and associate with the Link account.
     /// - Parameter phoneNumber: Optional phone number in E.164 format to prefill during signup.
     /// - Parameter supportedPaymentMethodTypes: The payment method types to support. If `nil`, all available types are shown.
     /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
     /// - Returns: `.completed(paymentMethod)` on selection, or `.canceled` if the user dismisses the flow.
-    /// - Throws: An error if the lookup or payment method creation fails.
+    /// - Throws: An error if the lookup fails or payment method creation fails.
     func present(
         email: String,
         phoneNumber: String? = nil,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -49,6 +49,7 @@ import UIKit
         case canceled
     }
 
+    /// The result of presenting Link to collect a payment method.
     @frozen @_spi(STP) @_spi(LinkControllerPreview) public enum PaymentMethodResult {
         /// The user selected a payment method. The associated value is the resulting `STPPaymentMethod`.
         case completed(STPPaymentMethod)
@@ -90,6 +91,7 @@ import UIKit
         }
     }
 
+    /// The intent for which the `LinkController` collects a payment method.
     @_spi(STP) @_spi(LinkControllerPreview) public enum Mode {
         case payment
         case paymentAndSetupFutureUse

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -14,7 +14,7 @@ import UIKit
 @_spi(STP) import StripeUICore
 
 /// A controller that presents a Link sheet to collect a customer's payment method.
-@MainActor @_spi(STP) public class LinkController: ObservableObject {
+@MainActor @_spi(STP) @_spi(LinkControllerPreview) public class LinkController: ObservableObject {
 
     /// Represents the payment method currently selected by the user.
     @_spi(STP) public struct PaymentMethodPreview {
@@ -49,7 +49,7 @@ import UIKit
         case canceled
     }
 
-    @frozen @_spi(STP) public enum PaymentMethodResult {
+    @frozen @_spi(STP) @_spi(LinkControllerPreview) public enum PaymentMethodResult {
         /// The user selected a payment method. The associated value is the resulting `STPPaymentMethod`.
         case completed(STPPaymentMethod)
         /// The user dismissed the flow without selecting a payment method.
@@ -90,7 +90,7 @@ import UIKit
         }
     }
 
-    @_spi(STP) public enum Mode {
+    @_spi(STP) @_spi(LinkControllerPreview) public enum Mode {
         case payment
         case paymentAndSetupFutureUse
         case setup
@@ -267,6 +267,24 @@ import UIKit
                 completion(.failure(error))
             }
         }
+    }
+
+    /// Creates a `LinkController` for the specified `mode`.
+    ///
+    /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
+    /// - Parameter mode: The mode in which the Link payment method controller should operate, either `payment` or `setup`.
+    /// - Parameter completion: A closure that is called with the result of the creation. It returns a `LinkController` if successful, or an error if the creation failed.
+    @_spi(LinkControllerPreview) public static func create(
+        apiClient: STPAPIClient = .shared,
+        mode: LinkController.Mode,
+        completion: @escaping (Result<LinkController, Error>) -> Void
+    ) {
+        self.create(
+            apiClient: apiClient,
+            mode: mode,
+            linkConfiguration: nil,
+            completion: completion
+        )
     }
 
     /// Looks up whether the provided email is associated with an existing Link consumer.
@@ -446,7 +464,7 @@ import UIKit
     /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
     /// - Parameter completion: A closure called with `.success(.completed(paymentMethod))` on selection,
     ///   `.success(.canceled)` if the user dismisses the flow, or `.failure(error)` on API or network errors.
-    @_spi(STP) public func present(
+    @_spi(STP) @_spi(LinkControllerPreview) public func present(
         email: String,
         phoneNumber: String? = nil,
         supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
@@ -1248,6 +1266,30 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
                 switch result {
                 case .success:
                     continuation.resume(returning: ())
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+@_spi(LinkControllerPreview) public extension LinkController {
+
+    /// Creates a `LinkController` for the specified `mode`.
+    ///
+    /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
+    /// - Parameter mode: The mode in which the Link payment method controller should operate, either `payment` or `setup`.
+    /// - Returns: A `LinkController` if successful, or throws an error if the creation failed.
+    static func create(
+        apiClient: STPAPIClient = .shared,
+        mode: LinkController.Mode
+    ) async throws -> LinkController {
+        return try await withCheckedThrowingContinuation { continuation in
+            create(apiClient: apiClient, mode: mode) { result in
+                switch result {
+                case .success(let controller):
+                    continuation.resume(returning: controller)
                 case .failure(let error):
                     continuation.resume(throwing: error)
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -1277,7 +1277,7 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
 }
 
 @_spi(LinkControllerPreview) public extension LinkController {
-    
+
     /// Creates a `LinkController` for the specified `mode`.
     ///
     /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -13,7 +13,7 @@ import UIKit
 @_spi(STP) import StripePaymentsUI
 @_spi(STP) import StripeUICore
 
-/// A controller that presents a Link sheet to collect a customer's payment method.
+/// A controller that presents the Link flow to collect and create a customer's payment method.
 @MainActor @_spi(STP) @_spi(LinkControllerPreview) public class LinkController: ObservableObject {
 
     /// Represents the payment method currently selected by the user.

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
@@ -21,6 +21,7 @@ final class LinkControllerPreviewAPITests: XCTestCase {
 
             Task { @MainActor in
                 let controller = try await LinkController.create(mode: .payment)
+                _ = controller.paymentMethodPreview
 
                 controller.present(
                     email: "jenny.rosen@example.com",

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
@@ -1,0 +1,43 @@
+//
+//  LinkControllerPreviewAPITests.swift
+//  StripePaymentSheetTests
+
+import UIKit
+@testable @_spi(LinkControllerPreview) import StripePaymentSheet
+import XCTest
+
+final class LinkControllerPreviewAPITests: XCTestCase {
+    @MainActor
+    func testPreviewSPISurfaceCompiles() {
+        _ = LinkPaymentMethodType.card
+
+        let result: LinkController.PaymentMethodResult = .canceled
+        _ = result
+
+        if false {
+            LinkController.create(mode: .payment) { result in
+                _ = result
+            }
+
+            Task { @MainActor in
+                let controller = try await LinkController.create(mode: .payment)
+
+                controller.present(
+                    email: "jenny.rosen@example.com",
+                    phoneNumber: "+14155551234",
+                    supportedPaymentMethodTypes: [.card],
+                    from: UIViewController()
+                ) { result in
+                    _ = result
+                }
+
+                _ = try await controller.present(
+                    email: "jenny.rosen@example.com",
+                    phoneNumber: "+14155551234",
+                    supportedPaymentMethodTypes: [.card],
+                    from: UIViewController()
+                )
+            }
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
@@ -2,8 +2,8 @@
 //  LinkControllerPreviewAPITests.swift
 //  StripePaymentSheetTests
 
-import UIKit
 @testable @_spi(LinkControllerPreview) import StripePaymentSheet
+import UIKit
 import XCTest
 
 final class LinkControllerPreviewAPITests: XCTestCase {


### PR DESCRIPTION
## Summary

Adds a new annotation `@_spi(LinkControllerPreview)` to APIs in the `LinkController` that we're releasing as part of the L0/L1 private preview integration.

## Motivation

https://docs.google.com/document/d/1VoMxNhXmKix5kiFzWO3eJc2YzE3dpEO63rKp_Kb9F6E/edit?usp=sharing

## Testing

Added tests and a demo app

## Changelog

N/a - only changes private preview APIs
