### PR TITLE
[Identity] Updating selfie viewfinder and selfie flow

### DIFF
--- a/StripeIdentity/StripeIdentity/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeIdentity/StripeIdentity/Resources/Localizations/en.lproj/Localizable.strings
@@ -4,6 +4,9 @@
 /* Title for the optional training consent section on the selfie warmup page */
 "Help us improve verifications" = "Help us improve verifications";
 
+/* Link text displayed under the selfie viewfinder */
+"Having Trouble?" = "Having Trouble?";
+
 /* Button text to allow the optional training consent choice */
 "Allow" = "Allow";
 

--- a/StripeIdentity/StripeIdentity/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeIdentity/StripeIdentity/Resources/Localizations/en.lproj/Localizable.strings
@@ -10,6 +10,9 @@
 /* Button text to decline the optional training consent choice */
 "Decline" = "Decline";
 
+/* Status text displayed over the selfie viewfinder while capturing selfies */
+"Hold still" = "Hold still";
+
 /* Title for accepted types of ids */
 "Accepted forms of ID include" = "Accepted forms of ID include";
 
@@ -286,6 +289,9 @@
 /* Title of document upload screen */
 "Upload your photo ID" = "Upload your photo ID";
 
+/* Status text displayed over the blurred selfie while uploading */
+"Uploading" = "Uploading";
+
 /* Accessibility label while photo of back of driver's license, passport, or government issued photo id is uploading */
 "Uploading back %@ photo" = "Uploading back %@ photo";
 
@@ -316,4 +322,3 @@
 
 /* Text for message of warning alert */
 "Your selfie images have not been saved. Do you want to leave?" = "Your selfie images have not been saved. Do you want to leave?";
-

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetController.swift
@@ -119,10 +119,14 @@ protocol VerificationSheetControllerProtocol: AnyObject {
 
     /// Transition to DocumentCaptureViewController without any API request
     func transitionToDocumentCapture()
+
+    /// Transition to the web fallback without any API request
+    func transitionToFallbackUrl()
 }
 
 private enum VerificationSheetControllerError: String, AnalyticLoggableStringErrorV2 {
     case missingVerificationPageResponseForFallbackUpdate
+    case missingVerificationPageResponseForFallbackUrlTransition
     case missingVerificationPageResponseForCountryNotListedTransition
     case missingVerificationPageResponseForIndividualTransition
     case missingVerificationPageResponseForSelfieCaptureTransition
@@ -549,6 +553,20 @@ final class VerificationSheetController: VerificationSheetControllerProtocol {
         }
 
         flowController.transitionToDocumentCaptureScreen(
+            staticContentResult: verificationPageResponse,
+            sheetController: self
+        )
+    }
+
+    func transitionToFallbackUrl() {
+        guard let verificationPageResponse = verificationPageResponseOrLogMissing(
+            .missingVerificationPageResponseForFallbackUrlTransition,
+            assertionMessage: "verificationPageResponse is nil"
+        ) else {
+            return
+        }
+
+        flowController.transitionToFallbackUrlScreen(
             staticContentResult: verificationPageResponse,
             sheetController: self
         )

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -60,6 +60,11 @@ protocol VerificationSheetFlowControllerProtocol: AnyObject {
         sheetController: VerificationSheetControllerProtocol
     )
 
+    func transitionToFallbackUrlScreen(
+        staticContentResult: Result<StripeAPI.VerificationPage, Error>,
+        sheetController: VerificationSheetControllerProtocol
+    )
+
     func transitionToErrorScreen(
         sheetController: VerificationSheetControllerProtocol,
         error: Error,
@@ -257,6 +262,33 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
                     completion: {}
                 )
             }
+        }
+    }
+
+    func transitionToFallbackUrlScreen(
+        staticContentResult: Result<StripeAPI.VerificationPage, Error>,
+        sheetController: VerificationSheetControllerProtocol
+    ) {
+        do {
+            let staticContent = try staticContentResult.get()
+            isUsingWebView = true
+            transition(
+                to: makeWebViewController(
+                    staticContent: staticContent,
+                    sheetController: sheetController
+                ),
+                shouldAnimate: true,
+                completion: {}
+            )
+        } catch {
+            transition(
+                to: ErrorViewController(
+                    sheetController: sheetController,
+                    error: .error(error)
+                ),
+                shouldAnimate: true,
+                completion: {}
+            )
         }
     }
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/SelfieCaptureViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/SelfieCaptureViewController.swift
@@ -116,7 +116,10 @@ final class SelfieCaptureViewController: IdentityFlowViewController {
             return .scan(
                 .init(
                     state: .blank,
-                    instructionalText: SelfieCaptureViewController.initialInstructionText
+                    instructionalText: SelfieCaptureViewController.initialInstructionText,
+                    havingTroubleHandler: { [weak self] in
+                        self?.sheetController?.transitionToFallbackUrl()
+                    }
                 )
             )
         case .scanning(_, let collectedSamples):
@@ -130,7 +133,10 @@ final class SelfieCaptureViewController: IdentityFlowViewController {
                     ),
                     instructionalText: collectedSamples.isEmpty
                         ? SelfieCaptureViewController.initialInstructionText
-                        : SelfieCaptureViewController.capturingInstructionText
+                        : SelfieCaptureViewController.capturingInstructionText,
+                    havingTroubleHandler: { [weak self] in
+                        self?.sheetController?.transitionToFallbackUrl()
+                    }
                 )
             )
         case .scanned(_, let faceCaptureData):

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/SelfieCaptureViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/SelfieCaptureViewController.swift
@@ -125,7 +125,8 @@ final class SelfieCaptureViewController: IdentityFlowViewController {
                 .init(
                     state: .videoPreview(
                         imageScanningSession.cameraSession,
-                        showFlashAnimation: collectedSamples.count == 1
+                        showFlashAnimation: collectedSamples.count == 1,
+                        statusText: collectedSamples.isEmpty ? nil : .holdStill
                     ),
                     instructionalText: collectedSamples.isEmpty
                         ? SelfieCaptureViewController.initialInstructionText
@@ -154,7 +155,10 @@ final class SelfieCaptureViewController: IdentityFlowViewController {
         case .saving(_, let faceCaptureData):
             return .saving(
                 .init(
-                    state: .saving(UIImage(cgImage: faceCaptureData.last.image)),
+                    state: .saving(
+                        UIImage(cgImage: faceCaptureData.last.image),
+                        statusText: .uploading
+                    ),
                     instructionalText: SelfieCaptureViewController.scannedInstructionText
                 )
             )

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/SelfieCaptureViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/SelfieCaptureViewController.swift
@@ -154,10 +154,7 @@ final class SelfieCaptureViewController: IdentityFlowViewController {
         case .saving(_, let faceCaptureData):
             return .saving(
                 .init(
-                    state: .saving(
-                        faceCaptureData.toArray.map { UIImage(cgImage: $0.image) },
-                        consentHTMLText: apiConfig.trainingConsentText
-                    ),
+                    state: .saving(UIImage(cgImage: faceCaptureData.last.image)),
                     instructionalText: SelfieCaptureViewController.scannedInstructionText
                 )
             )
@@ -321,6 +318,9 @@ extension SelfieCaptureViewController {
     func saveDataAndTransitionToNextScreen(
         faceCaptureData: FaceCaptureData
     ) {
+        if case .scanning = imageScanningSession.state {
+            imageScanningSession.stopScanning()
+        }
         imageScanningSession.setStateSaving(
             expectedClassification: .empty,
             capturedData: faceCaptureData

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
@@ -23,6 +23,10 @@ final class SelfieScanningView: UIView {
             IdentityUI.instructionsFont
         }
         static let preferredPreviewHeightToWidthRatio: CGFloat = 4 / 3
+        static let troubleLinkTopPadding: CGFloat = 12
+        static var troubleLinkFont: UIFont {
+            IdentityUI.preferredFont(forTextStyle: .body).withSize(12)
+        }
 
         static let flashAnimationDuration: TimeInterval = 0.2
         static let flashOverlayAlpha: CGFloat = 0.8
@@ -139,6 +143,15 @@ final class SelfieScanningView: UIView {
 
     // MARK: Camera Preview
     private let previewContainerView = CameraPreviewContainerView()
+
+    private lazy var havingTroubleLabel: UILabel = {
+        let label = UILabel()
+        label.adjustsFontForContentSizeCategory = true
+        label.isAccessibilityElement = true
+        label.accessibilityTraits = .link
+        label.isHidden = true
+        return label
+    }()
 
     /// Camera preview
     private let cameraPreviewView = CameraPreviewView()
@@ -289,6 +302,7 @@ final class SelfieScanningView: UIView {
         capturedImageBlurView.isHidden = true
         statusLabelContainerView.isHidden = true
         previewContainerView.isHidden = true
+        havingTroubleLabel.isHidden = true
         scannedImageScrollView.isHidden = true
 
         switch viewModel.state {
@@ -297,11 +311,13 @@ final class SelfieScanningView: UIView {
             consentCheckboxButton.isHidden = true
             retakeSelfieStack.isHidden = true
             previewContainerView.isHidden = false
+            havingTroubleLabel.isHidden = false
 
         case .videoPreview(let cameraSession, let showFlashAnimation, let statusText):
             retakeSelfieStack.isHidden = true
             consentCheckboxButton.isHidden = true
             previewContainerView.isHidden = false
+            havingTroubleLabel.isHidden = false
             cameraPreviewView.isHidden = false
             cameraPreviewView.session = cameraSession
             if let statusText {
@@ -365,6 +381,7 @@ final class SelfieScanningView: UIView {
             self.consentCheckboxButton.theme = Styling.consentCheckboxTheme(
                 tintColor: self.tintColor
             )
+            self.configureHavingTroubleLabel()
         }
     }
 
@@ -379,6 +396,7 @@ extension SelfieScanningView {
 
         vStack.addArrangedSubview(instructionLabelView)
         vStack.addArrangedSubview(previewContainerView)
+        vStack.addArrangedSubview(havingTroubleLabel)
         vStack.addArrangedSubview(scannedImageScrollView)
         vStack.addArrangedSubview(retakeSelfieStack)
         vStack.addArrangedSubview(consentCheckboxButton)
@@ -420,6 +438,8 @@ extension SelfieScanningView {
             Styling.consentTopPadding - Styling.scannedImageScrollIndicatorMargin,
             after: scannedImageScrollView
         )
+        vStack.setCustomSpacing(Styling.troubleLinkTopPadding, after: previewContainerView)
+        configureHavingTroubleLabel()
 
         NSLayoutConstraint.activate([
             previewContainerView.widthAnchor.constraint(
@@ -444,6 +464,10 @@ extension SelfieScanningView {
             widthAnchor.constraint(
                 equalTo: consentCheckboxButton.widthAnchor,
                 constant: Styling.contentInsets.leading + Styling.contentInsets.trailing
+            ),
+            havingTroubleLabel.widthAnchor.constraint(
+                lessThanOrEqualTo: widthAnchor,
+                constant: -(Styling.contentInsets.leading + Styling.contentInsets.trailing)
             ),
 
             // Make scroll view's content full-height
@@ -478,6 +502,20 @@ extension SelfieScanningView {
     fileprivate func configureStatusLabel(_ statusText: ViewModel.StatusText) {
         statusLabel.text = statusText.text
         statusLabelContainerView.isHidden = false
+    }
+
+    fileprivate func configureHavingTroubleLabel() {
+        havingTroubleLabel.attributedText = NSAttributedString(
+            string: STPLocalizedString(
+                "Having Trouble?",
+                "Link text displayed under the selfie viewfinder"
+            ),
+            attributes: [
+                .font: Styling.troubleLinkFont,
+                .foregroundColor: IdentityUI.secondaryLabelColor,
+                .underlineStyle: NSUnderlineStyle.single.rawValue,
+            ]
+        )
     }
 
     fileprivate func rebuildImageHStack(with images: [UIImage]) {

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
@@ -118,6 +118,17 @@ final class SelfieScanningView: UIView {
 
         let state: State
         let instructionalText: String
+        let havingTroubleHandler: (() -> Void)?
+
+        init(
+            state: State,
+            instructionalText: String,
+            havingTroubleHandler: (() -> Void)? = nil
+        ) {
+            self.state = state
+            self.instructionalText = instructionalText
+            self.havingTroubleHandler = havingTroubleHandler
+        }
 
         var instructionalLabelViewModel: BottomAlignedLabel.ViewModel {
             return .init(
@@ -149,7 +160,12 @@ final class SelfieScanningView: UIView {
         label.adjustsFontForContentSizeCategory = true
         label.isAccessibilityElement = true
         label.accessibilityTraits = .link
+        label.isUserInteractionEnabled = true
         label.isHidden = true
+        label.addGestureRecognizer(UITapGestureRecognizer(
+            target: self,
+            action: #selector(didTapHavingTrouble)
+        ))
         return label
     }()
 
@@ -272,6 +288,9 @@ final class SelfieScanningView: UIView {
     /// Called when the user taps on retake selfie button
     private var retakeSelfieHandler: (() -> Void)?
 
+    /// Called when the user taps on the "Having Trouble?" link
+    private var havingTroubleHandler: (() -> Void)?
+
     // MARK: Init
 
     init() {
@@ -292,6 +311,7 @@ final class SelfieScanningView: UIView {
     func configure(with viewModel: ViewModel, sheetController: VerificationSheetControllerProtocol?) {
 
         instructionLabelView.configure(from: viewModel.instructionalLabelViewModel)
+        havingTroubleHandler = viewModel.havingTroubleHandler
 
         let isCurrentlyShowingScanned = !scannedImageScrollView.isHidden
 
@@ -311,13 +331,13 @@ final class SelfieScanningView: UIView {
             consentCheckboxButton.isHidden = true
             retakeSelfieStack.isHidden = true
             previewContainerView.isHidden = false
-            havingTroubleLabel.isHidden = false
+            havingTroubleLabel.isHidden = viewModel.havingTroubleHandler == nil
 
         case .videoPreview(let cameraSession, let showFlashAnimation, let statusText):
             retakeSelfieStack.isHidden = true
             consentCheckboxButton.isHidden = true
             previewContainerView.isHidden = false
-            havingTroubleLabel.isHidden = false
+            havingTroubleLabel.isHidden = viewModel.havingTroubleHandler == nil
             cameraPreviewView.isHidden = false
             cameraPreviewView.session = cameraSession
             if let statusText {
@@ -581,6 +601,10 @@ extension SelfieScanningView {
 
     @objc fileprivate func didTapRetakeSelfie() {
         retakeSelfieHandler?()
+    }
+
+    @objc fileprivate func didTapHavingTrouble() {
+        havingTroubleHandler?()
     }
 }
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
@@ -22,6 +22,7 @@ final class SelfieScanningView: UIView {
         static var labelFont: UIFont {
             IdentityUI.instructionsFont
         }
+        static let preferredPreviewHeightToWidthRatio: CGFloat = 4 / 3
 
         static let flashAnimationDuration: TimeInterval = 0.2
         static let flashOverlayAlpha: CGFloat = 0.8
@@ -128,7 +129,7 @@ final class SelfieScanningView: UIView {
     private let vStack: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.alignment = .fill
+        stackView.alignment = .center
         stackView.spacing = Styling.labelBottomPadding
         return stackView
     }()
@@ -425,6 +426,14 @@ extension SelfieScanningView {
                 equalTo: widthAnchor,
                 constant: -(Styling.contentInsets.leading + Styling.contentInsets.trailing)
             ),
+            {
+                let constraint = previewContainerView.heightAnchor.constraint(
+                    equalTo: previewContainerView.widthAnchor,
+                    multiplier: Styling.preferredPreviewHeightToWidthRatio
+                )
+                constraint.priority = .defaultHigh
+                return constraint
+            }(),
             // Set insets for label
             widthAnchor.constraint(
                 equalTo: instructionLabelView.widthAnchor,

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
@@ -17,8 +17,6 @@ final class SelfieScanningView: UIView {
     struct Styling {
         static let contentInsets = IdentityFlowView.Style.defaultContentViewInsets
 
-        static let viewWidthToContainerHeightRatio = IdentityUI.documentCameraPreviewAspectRatio
-
         static let labelBottomPadding = IdentityUI.scanningViewLabelBottomPadding
         static let labelMinHeightNumberOfLines = IdentityUI.scanningViewLabelMinHeightNumberOfLines
         static var labelFont: UIFont {
@@ -130,7 +128,7 @@ final class SelfieScanningView: UIView {
     private let vStack: UIStackView = {
         let stackView = UIStackView()
         stackView.axis = .vertical
-        stackView.alignment = .center
+        stackView.alignment = .fill
         stackView.spacing = Styling.labelBottomPadding
         return stackView
     }()
@@ -410,6 +408,10 @@ extension SelfieScanningView {
     fileprivate func installConstraints() {
         scannedImageHStack.translatesAutoresizingMaskIntoConstraints = false
         scannedImageScrollView.setContentHuggingPriority(.required, for: .horizontal)
+        previewContainerView.setContentHuggingPriority(.defaultLow, for: .vertical)
+        previewContainerView.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        instructionLabelView.setContentHuggingPriority(.required, for: .vertical)
+        instructionLabelView.setContentCompressionResistancePriority(.required, for: .vertical)
 
         // Adjusts to keep padding visually the same while accounting for scroll
         // indicator margin
@@ -419,16 +421,10 @@ extension SelfieScanningView {
         )
 
         NSLayoutConstraint.activate([
-            // Set the container to the same height as the document scanning preview, but as a square
-            widthAnchor.constraint(
-                equalTo: previewContainerView.widthAnchor,
-                multiplier: Styling.viewWidthToContainerHeightRatio,
-                constant: Styling.contentInsets.leading + Styling.contentInsets.trailing
-            ),
             previewContainerView.widthAnchor.constraint(
-                equalTo: previewContainerView.heightAnchor
+                equalTo: widthAnchor,
+                constant: -(Styling.contentInsets.leading + Styling.contentInsets.trailing)
             ),
-
             // Set insets for label
             widthAnchor.constraint(
                 equalTo: instructionLabelView.widthAnchor,

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
@@ -73,11 +73,35 @@ final class SelfieScanningView: UIView {
     }
 
     struct ViewModel {
+        enum StatusText {
+            case holdStill
+            case uploading
+
+            var text: String {
+                switch self {
+                case .holdStill:
+                    return STPLocalizedString(
+                        "Hold still",
+                        "Status text displayed over the selfie viewfinder while capturing selfies"
+                    )
+                case .uploading:
+                    return STPLocalizedString(
+                        "Uploading",
+                        "Status text displayed over the blurred selfie while uploading"
+                    )
+                }
+            }
+        }
+
         enum State {
             /// Display an empty container when waiting for camera permission prompt
             case blank
             /// Live video feed from the camera while taking selfies
-            case videoPreview(CameraSessionProtocol, showFlashAnimation: Bool)
+            case videoPreview(
+                CameraSessionProtocol,
+                showFlashAnimation: Bool,
+                statusText: StatusText?
+            )
             /// Display scanned selfie images
             case scanned(
                 [UIImage],
@@ -86,7 +110,7 @@ final class SelfieScanningView: UIView {
                 openURLHandler: (URL) -> Void,
                 retakeSelfieHandler: () -> Void
             )
-            case saving(UIImage)
+            case saving(UIImage, statusText: StatusText)
         }
 
         let state: State
@@ -144,6 +168,32 @@ final class SelfieScanningView: UIView {
         let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
         blurView.isHidden = true
         return blurView
+    }()
+
+    private let statusLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 16)
+        label.textColor = .white
+        label.adjustsFontForContentSizeCategory = true
+        label.layer.shadowColor = UIColor.black.cgColor
+        label.layer.shadowOffset = CGSize(width: 0, height: 1)
+        label.layer.shadowRadius = 4
+        label.layer.shadowOpacity = 0.35
+        return label
+    }()
+
+    private let statusLabelContainerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = UIColor(
+            red: 0x21 / 255,
+            green: 0x25 / 255,
+            blue: 0x2C / 255,
+            alpha: 0.6
+        )
+        view.layer.cornerRadius = 8
+        view.isHidden = true
+        view.translatesAutoresizingMaskIntoConstraints = false
+        return view
     }()
 
     // MARK: Scanned Images
@@ -238,6 +288,7 @@ final class SelfieScanningView: UIView {
         capturedImageView.isHidden = true
         capturedImageView.image = nil
         capturedImageBlurView.isHidden = true
+        statusLabelContainerView.isHidden = true
         previewContainerView.isHidden = true
         scannedImageScrollView.isHidden = true
 
@@ -248,12 +299,15 @@ final class SelfieScanningView: UIView {
             retakeSelfieStack.isHidden = true
             previewContainerView.isHidden = false
 
-        case .videoPreview(let cameraSession, let showFlashAnimation):
+        case .videoPreview(let cameraSession, let showFlashAnimation, let statusText):
             retakeSelfieStack.isHidden = true
             consentCheckboxButton.isHidden = true
             previewContainerView.isHidden = false
             cameraPreviewView.isHidden = false
             cameraPreviewView.session = cameraSession
+            if let statusText {
+                configureStatusLabel(statusText)
+            }
             if showFlashAnimation {
                 animateFlash()
             }
@@ -290,11 +344,12 @@ final class SelfieScanningView: UIView {
                     sheetController.analyticsClient.logGenericError(error: error, sheetController: sheetController)
                 }
             }
-        case .saving(let image):
+        case .saving(let image, let statusText):
             previewContainerView.isHidden = false
             capturedImageView.image = image
             capturedImageView.isHidden = false
             capturedImageBlurView.isHidden = false
+            configureStatusLabel(statusText)
             retakeSelfieStack.isHidden = true
             consentCheckboxButton.isHidden = true
         }
@@ -333,6 +388,11 @@ extension SelfieScanningView {
         previewContainerView.contentView.addAndPinSubview(capturedImageView)
         previewContainerView.contentView.addAndPinSubview(capturedImageBlurView)
         previewContainerView.contentView.addAndPinSubview(flashOverlayView)
+        previewContainerView.contentView.addSubview(statusLabelContainerView)
+        statusLabelContainerView.addAndPinSubview(
+            statusLabel,
+            insets: .init(top: 8, leading: 8, bottom: 8, trailing: 8)
+        )
 
         // Add some bottom margin so the scroll indicator doesn't overlay on
         // top of the scanned images
@@ -396,7 +456,23 @@ extension SelfieScanningView {
                 constraint.priority = .defaultHigh
                 return constraint
             }(),
+            statusLabelContainerView.centerXAnchor.constraint(
+                equalTo: previewContainerView.contentView.centerXAnchor
+            ),
+            statusLabelContainerView.bottomAnchor.constraint(
+                equalTo: previewContainerView.contentView.bottomAnchor,
+                constant: -40
+            ),
+            statusLabelContainerView.widthAnchor.constraint(
+                lessThanOrEqualTo: previewContainerView.contentView.widthAnchor,
+                multiplier: 0.8
+            ),
         ])
+    }
+
+    fileprivate func configureStatusLabel(_ statusText: ViewModel.StatusText) {
+        statusLabel.text = statusText.text
+        statusLabelContainerView.isHidden = false
     }
 
     fileprivate func rebuildImageHStack(with images: [UIImage]) {

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/Selfie/SelfieScanningView.swift
@@ -86,10 +86,7 @@ final class SelfieScanningView: UIView {
                 openURLHandler: (URL) -> Void,
                 retakeSelfieHandler: () -> Void
             )
-            case saving(
-                [UIImage],
-                consentHTMLText: String
-            )
+            case saving(UIImage)
         }
 
         let state: State
@@ -129,6 +126,24 @@ final class SelfieScanningView: UIView {
         view.backgroundColor = .white
         view.alpha = 0
         return view
+    }()
+
+    private let capturedImageView: UIImageView = {
+        let imageView = UIImageView()
+        imageView.contentMode = .scaleAspectFill
+        imageView.isHidden = true
+        imageView.isAccessibilityElement = true
+        imageView.accessibilityLabel = STPLocalizedString(
+            "Selfie",
+            "Accessibility label of captured selfie images"
+        )
+        return imageView
+    }()
+
+    private let capturedImageBlurView: UIVisualEffectView = {
+        let blurView = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
+        blurView.isHidden = true
+        return blurView
     }()
 
     // MARK: Scanned Images
@@ -220,6 +235,9 @@ final class SelfieScanningView: UIView {
 
         // Reset values
         cameraPreviewView.isHidden = true
+        capturedImageView.isHidden = true
+        capturedImageView.image = nil
+        capturedImageBlurView.isHidden = true
         previewContainerView.isHidden = true
         scannedImageScrollView.isHidden = true
 
@@ -272,9 +290,11 @@ final class SelfieScanningView: UIView {
                     sheetController.analyticsClient.logGenericError(error: error, sheetController: sheetController)
                 }
             }
-        case .saving(let images, consentHTMLText: _):
-            scannedImageScrollView.isHidden = false
-            rebuildImageHStack(with: images)
+        case .saving(let image):
+            previewContainerView.isHidden = false
+            capturedImageView.image = image
+            capturedImageView.isHidden = false
+            capturedImageBlurView.isHidden = false
             retakeSelfieStack.isHidden = true
             consentCheckboxButton.isHidden = true
         }
@@ -310,6 +330,8 @@ extension SelfieScanningView {
         vStack.addArrangedSubview(consentCheckboxButton)
 
         previewContainerView.contentView.addAndPinSubview(cameraPreviewView)
+        previewContainerView.contentView.addAndPinSubview(capturedImageView)
+        previewContainerView.contentView.addAndPinSubview(capturedImageBlurView)
         previewContainerView.contentView.addAndPinSubview(flashOverlayView)
 
         // Add some bottom margin so the scroll indicator doesn't overlay on

--- a/StripeIdentity/StripeIdentityTests/Helpers/VerificationSheetControllerMock.swift
+++ b/StripeIdentity/StripeIdentityTests/Helpers/VerificationSheetControllerMock.swift
@@ -59,6 +59,7 @@ final class VerificationSheetControllerMock: VerificationSheetControllerProtocol
     var transitionedToSelfieCapture: Bool = false
     var transitionedToSelfieCaptureTrainingConsent: Bool?
     var transitionedToDocumentCapture: Bool = false
+    var transitionedToFallbackUrl: Bool = false
 
     var completeOption: CompleteOptionView.CompleteOption?
 
@@ -200,6 +201,10 @@ final class VerificationSheetControllerMock: VerificationSheetControllerProtocol
 
     func transitionToDocumentCapture() {
         self.transitionedToDocumentCapture = true
+    }
+
+    func transitionToFallbackUrl() {
+        self.transitionedToFallbackUrl = true
     }
 
 }

--- a/StripeIdentity/StripeIdentityTests/Helpers/VerificationSheetFlowControllerMock.swift
+++ b/StripeIdentity/StripeIdentityTests/Helpers/VerificationSheetFlowControllerMock.swift
@@ -31,6 +31,7 @@ final class VerificationSheetFlowControllerMock: VerificationSheetFlowController
     )
     private(set) var transitionedWithStaticContentResult: Result<StripeAPI.VerificationPage, Error>?
     private(set) var transitionedWithUpdateDataResult: Result<StripeAPI.VerificationPageData, Error>?
+    private(set) var didTransitionToFallbackUrlScreen = false
 
     private(set) var replacedWithViewController: UIViewController?
 
@@ -84,6 +85,13 @@ final class VerificationSheetFlowControllerMock: VerificationSheetFlowController
         sheetController: StripeIdentity.VerificationSheetControllerProtocol
     ) {
         // no-op
+    }
+
+    func transitionToFallbackUrlScreen(
+        staticContentResult: Result<StripeAPI.VerificationPage, Error>,
+        sheetController: VerificationSheetControllerProtocol
+    ) {
+        didTransitionToFallbackUrlScreen = true
     }
 
     func transitionToErrorScreen(

--- a/StripeIdentity/StripeIdentityTests/Snapshot/SelfieScanningViewSnapshotTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Snapshot/SelfieScanningViewSnapshotTest.swift
@@ -78,10 +78,7 @@ final class SelfieScanningViewSnapshotTest: STPSnapshotTestCase {
     func testSaving() {
         verifyView(
             with: .init(
-                state: .saving(
-                    Array(repeating: SelfieScanningViewSnapshotTest.mockImage, count: 3),
-                    consentHTMLText: SelfieScanningViewSnapshotTest.consentText
-                ),
+                state: .saving(SelfieScanningViewSnapshotTest.mockImage),
                 instructionalText: SelfieScanningViewSnapshotTest.mockText
             )
         )

--- a/StripeIdentity/StripeIdentityTests/Snapshot/SelfieScanningViewSnapshotTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Snapshot/SelfieScanningViewSnapshotTest.swift
@@ -39,7 +39,11 @@ final class SelfieScanningViewSnapshotTest: STPSnapshotTestCase {
     func testCameraSession() {
         verifyView(
             with: .init(
-                state: .videoPreview(mockCameraSession, showFlashAnimation: false),
+                state: .videoPreview(
+                    mockCameraSession,
+                    showFlashAnimation: false,
+                    statusText: nil
+                ),
                 instructionalText: SelfieScanningViewSnapshotTest.mockText
             )
         )
@@ -78,7 +82,10 @@ final class SelfieScanningViewSnapshotTest: STPSnapshotTestCase {
     func testSaving() {
         verifyView(
             with: .init(
-                state: .saving(SelfieScanningViewSnapshotTest.mockImage),
+                state: .saving(
+                    SelfieScanningViewSnapshotTest.mockImage,
+                    statusText: .uploading
+                ),
                 instructionalText: SelfieScanningViewSnapshotTest.mockText
             )
         )

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/SelfieWarmupViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/SelfieWarmupViewControllerTest.swift
@@ -189,6 +189,17 @@ final class SelfieCaptureViewControllerTest: XCTestCase {
         )
         XCTAssert(analytic: analytic, hasMetadata: "camera_event_kind", withValue: "runtime_error")
     }
+
+    func testHavingTroubleTransitionsToFallbackUrl() {
+        let vc = makeViewController()
+
+        guard case .scan(let viewModel) = vc.selfieCaptureViewModel else {
+            return XCTFail("Expected selfie capture view model to be in scan state")
+        }
+        viewModel.havingTroubleHandler?()
+
+        XCTAssertTrue(mockSheetController.transitionedToFallbackUrl)
+    }
 }
 
 private extension SelfieCaptureViewControllerTest {


### PR DESCRIPTION
This removes the separate “selfie captures complete” review-ish screen.

Once the last selfie is captured, the flow now starts saving automatically and keeps the user on the camera-style view. While capture is still collecting samples, we show a small “Hold still” chip in the viewfinder. 

Then once the final selfie is captured, we freeze that frame, blur it in the viewfinder, swap the chip to “Uploading,” and show the loading button while the upload/save finishes.


New UI:

<img width="642" height="1389" alt="IMG_0076" src="https://github.com/user-attachments/assets/35019e61-1f8b-4608-b79a-5df9650327b7" />

(Red box to obfuscate my face) 

<img width="642" height="1389" alt="IMG_0077" src="https://github.com/user-attachments/assets/a7acf316-83ef-450d-ba23-437c8a7b7889" />

