### PR TITLE
Suppress Link OTP if Customer has SPMs

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -38,13 +38,22 @@ extension STPElementsSession {
         linkSettings?.popupWebviewOption ?? .shared
     }
 
-    func shouldShowLink2FABeforePaymentSheet(for linkAccount: PaymentSheetLinkAccount) -> Bool {
+    func shouldShowLink2FABeforePaymentSheet(
+        for linkAccount: PaymentSheetLinkAccount,
+        merchantProvidedEmail: Bool,
+        savedPaymentMethods: [STPPaymentMethod]
+    ) -> Bool {
+        let shouldSuppressForCustomerSessionSavedPaymentMethods =
+            merchantProvidedEmail &&
+            !savedPaymentMethods.isEmpty
+
         return self.supportsLink &&
         linkAccount.sessionState == .requiresVerification &&
         !linkAccount.hasStartedSMSVerification &&
         linkAccount.useMobileEndpoints &&
         self.linkSettings?.suppress2FAModal != true &&
-        linkAccount.currentSession?.mobileFallbackWebviewParams?.webviewRequirementType != .required
+        linkAccount.currentSession?.mobileFallbackWebviewParams?.webviewRequirementType != .required &&
+        !shouldSuppressForCustomerSessionSavedPaymentMethods
     }
 
     var linkFlags: [String: Bool] {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -40,11 +40,9 @@ extension STPElementsSession {
 
     func shouldShowLink2FABeforePaymentSheet(
         for linkAccount: PaymentSheetLinkAccount,
-        merchantProvidedEmail: Bool,
         savedPaymentMethods: [STPPaymentMethod]
     ) -> Bool {
         let shouldSuppressForCustomerSessionSavedPaymentMethods =
-            merchantProvidedEmail &&
             !savedPaymentMethods.isEmpty
 
         return self.supportsLink &&

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -42,16 +42,13 @@ extension STPElementsSession {
         for linkAccount: PaymentSheetLinkAccount,
         savedPaymentMethods: [STPPaymentMethod]
     ) -> Bool {
-        let shouldSuppressForCustomerSessionSavedPaymentMethods =
-            !savedPaymentMethods.isEmpty
-
-        return self.supportsLink &&
+        self.supportsLink &&
         linkAccount.sessionState == .requiresVerification &&
         !linkAccount.hasStartedSMSVerification &&
         linkAccount.useMobileEndpoints &&
         self.linkSettings?.suppress2FAModal != true &&
         linkAccount.currentSession?.mobileFallbackWebviewParams?.webviewRequirementType != .required &&
-        !shouldSuppressForCustomerSessionSavedPaymentMethods
+        savedPaymentMethods.isEmpty
     }
 
     var linkFlags: [String: Bool] {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/Intent+Link.swift
@@ -48,7 +48,7 @@ extension STPElementsSession {
         linkAccount.useMobileEndpoints &&
         self.linkSettings?.suppress2FAModal != true &&
         linkAccount.currentSession?.mobileFallbackWebviewParams?.webviewRequirementType != .required &&
-        savedPaymentMethods.isEmpty
+        savedPaymentMethods.isEmpty // prefer MPE checkout when SPMs are present 
     }
 
     var linkFlags: [String: Bool] {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -192,7 +192,6 @@ public class PaymentSheet {
                     if let linkAccount = LinkAccountContext.shared.account,
                        loadResult.elementsSession.shouldShowLink2FABeforePaymentSheet(
                            for: linkAccount,
-                           merchantProvidedEmail: self.configuration.defaultBillingDetails.email != nil,
                            savedPaymentMethods: loadResult.savedPaymentMethods
                        ) {
                         let verificationController = LinkVerificationController(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -189,7 +189,12 @@ public class PaymentSheet {
                         )
                         self.bottomSheetViewController.setViewControllers([paymentSheetVC])
                     }
-                    if let linkAccount = LinkAccountContext.shared.account, loadResult.elementsSession.shouldShowLink2FABeforePaymentSheet(for: linkAccount) {
+                    if let linkAccount = LinkAccountContext.shared.account,
+                       loadResult.elementsSession.shouldShowLink2FABeforePaymentSheet(
+                           for: linkAccount,
+                           merchantProvidedEmail: self.configuration.defaultBillingDetails.email != nil,
+                           savedPaymentMethods: loadResult.savedPaymentMethods
+                       ) {
                         let verificationController = LinkVerificationController(
                             mode: .inlineLogin,
                             linkAccount: linkAccount,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
@@ -6,7 +6,9 @@
 //
 
 @testable @_spi(STP) import StripeCore
+@testable @_spi(STP) import StripePayments
 @testable @_spi(STP) import StripePaymentSheet
+@testable @_spi(STP) import StripePaymentsTestUtils
 import XCTest
 
 final class PaymentMethodAvailabilityTests: XCTestCase {
@@ -191,6 +193,51 @@ final class PaymentMethodAvailabilityTests: XCTestCase {
         let isLinkSignupEnabled = PaymentSheet.isLinkSignupEnabled(elementsSession: elementsSession, configuration: configuration)
         XCTAssertFalse(isLinkSignupEnabled, "Link inline signup should be disabled for linkSignupOptInFeatureEnabled if no email was provided")
     }
+
+    func testShouldShowLink2FABeforePaymentSheet_suppressesForMerchantEmailCustomerSessionWithSavedPaymentMethods() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card", "link"],
+            customerSessionData: mobilePaymentElementCustomerSessionData
+        )
+
+        XCTAssertFalse(
+            elementsSession.shouldShowLink2FABeforePaymentSheet(
+                for: makeLinkAccountRequiringVerification(),
+                merchantProvidedEmail: true,
+                savedPaymentMethods: [STPPaymentMethod._testCard()]
+            )
+        )
+    }
+
+    func testShouldShowLink2FABeforePaymentSheet_doesNotSuppressWithoutSavedPaymentMethods() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card", "link"],
+            customerSessionData: mobilePaymentElementCustomerSessionData
+        )
+
+        XCTAssertTrue(
+            elementsSession.shouldShowLink2FABeforePaymentSheet(
+                for: makeLinkAccountRequiringVerification(),
+                merchantProvidedEmail: true,
+                savedPaymentMethods: []
+            )
+        )
+    }
+
+    func testShouldShowLink2FABeforePaymentSheet_doesNotSuppressWithoutMerchantProvidedEmail() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card", "link"],
+            customerSessionData: mobilePaymentElementCustomerSessionData
+        )
+
+        XCTAssertTrue(
+            elementsSession.shouldShowLink2FABeforePaymentSheet(
+                for: makeLinkAccountRequiringVerification(),
+                merchantProvidedEmail: false,
+                savedPaymentMethods: [STPPaymentMethod._testCard()]
+            )
+        )
+    }
 }
 
 extension LinkSettings {
@@ -218,6 +265,45 @@ extension LinkSettings {
             attestationStateSyncEnabled: nil,
             linkSupportedPaymentMethodsOnboardingEnabled: linkSupportedPaymentMethodsOnboardingEnabled,
             allResponseFields: [:]
+        )
+    }
+}
+
+private extension PaymentMethodAvailabilityTests {
+    var mobilePaymentElementCustomerSessionData: [String: Any] {
+        [
+            "mobile_payment_element": [
+                "enabled": true,
+                "features": [
+                    "payment_method_save": "enabled",
+                    "payment_method_remove": "enabled",
+                ],
+            ],
+            "customer_sheet": [
+                "enabled": false,
+            ],
+        ]
+    }
+
+    func makeLinkAccountRequiringVerification() -> PaymentSheetLinkAccount {
+        let consumerSession = ConsumerSession(
+            clientSecret: "client_secret",
+            emailAddress: "test@example.com",
+            redactedFormattedPhoneNumber: "+1********55",
+            unredactedPhoneNumber: nil,
+            phoneNumberCountry: nil,
+            verificationSessions: [],
+            supportedPaymentDetailsTypes: [ParsedEnum(.card)],
+            mobileFallbackWebviewParams: nil
+        )
+
+        return PaymentSheetLinkAccount(
+            email: consumerSession.emailAddress,
+            session: consumerSession,
+            publishableKey: "pk_123",
+            displayablePaymentDetails: nil,
+            useMobileEndpoints: true,
+            canSyncAttestationState: false
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
@@ -203,7 +203,6 @@ final class PaymentMethodAvailabilityTests: XCTestCase {
         XCTAssertFalse(
             elementsSession.shouldShowLink2FABeforePaymentSheet(
                 for: makeLinkAccountRequiringVerification(),
-                merchantProvidedEmail: true,
                 savedPaymentMethods: [STPPaymentMethod._testCard()]
             )
         )
@@ -218,23 +217,7 @@ final class PaymentMethodAvailabilityTests: XCTestCase {
         XCTAssertTrue(
             elementsSession.shouldShowLink2FABeforePaymentSheet(
                 for: makeLinkAccountRequiringVerification(),
-                merchantProvidedEmail: true,
                 savedPaymentMethods: []
-            )
-        )
-    }
-
-    func testShouldShowLink2FABeforePaymentSheet_doesNotSuppressWithoutMerchantProvidedEmail() {
-        let elementsSession = STPElementsSession._testValue(
-            paymentMethodTypes: ["card", "link"],
-            customerSessionData: mobilePaymentElementCustomerSessionData
-        )
-
-        XCTAssertTrue(
-            elementsSession.shouldShowLink2FABeforePaymentSheet(
-                for: makeLinkAccountRequiringVerification(),
-                merchantProvidedEmail: false,
-                savedPaymentMethods: [STPPaymentMethod._testCard()]
             )
         )
     }


### PR DESCRIPTION
## Summary
Suppresses Link automatic OTP if:
1) default values (email) and a customer ID are passed by the merchant to payment sheet 
2) a Link account is recognized with the passed email
3) the customer has saved payment methods 

Link OTP is still required, this PR only suppresses the automatic presentation of OTP.

## Motivation
Web prefers easy use of saved payment methods by suppressing OTP when the customer has SPMs. This PR matches web's behaviors. 

## Testing
Unit tests have been added.
