### PR TITLE
Reuse Link Account Session

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -551,6 +551,21 @@ struct LinkPMDisplayDetails {
             // We don't need to do anything if this fails, the key will expire automatically.
         }
     }
+
+    /// Reuses a previously verified session when a subsequent lookup resolves to the same Link account.
+    func reuseVerifiedSession(from existingAccount: PaymentSheetLinkAccount) {
+        guard
+            sessionState != .verified,
+            isRegistered,
+            existingAccount.sessionState == .verified,
+            email.caseInsensitiveCompare(existingAccount.email) == .orderedSame
+        else {
+            return
+        }
+
+        currentSession = existingAccount.currentSession
+        publishableKey = publishableKey ?? existingAccount.publishableKey
+    }
 }
 
 // MARK: - Equatable

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -367,11 +367,17 @@ final class PaymentSheetLoader {
         }
 
         let linkAccountService = LinkAccountService(apiClient: configuration.apiClient, elementsSession: elementsSession)
-        return try await linkAccountService.lookupAccount(
+        let linkAccount = try await linkAccountService.lookupAccount(
             withEmail: lookupEmail.email,
             emailSource: lookupEmail.source,
             doNotLogConsumerFunnelEvent: doNotLogConsumerFunnelEvent
         )
+        // PaymentSheet can be torn down and rebuilt while the customer is still using the same Link account.
+        // Preserve the verified session across the second lookup so the user does not need to OTP again.
+        if let currentLinkAccount = LinkAccountContext.shared.account {
+            linkAccount?.reuseVerifiedSession(from: currentLinkAccount)
+        }
+        return linkAccount
     }
 
     @MainActor

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -597,6 +597,78 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         wait(for: [loadExpectation], timeout: STPTestingNetworkRequestTimeout)
     }
 
+    // MARK: - Link Lookup Session Preservation
+
+    @MainActor
+    func testLookupLink_preservesVerifiedSessionForMatchingAccountOnReload() async throws {
+        var didCallLookup = false
+        stub { urlRequest in
+            if urlRequest.url?.absoluteString.contains("consumers/sessions/lookup") == true {
+                didCallLookup = true
+                return true
+            }
+            return false
+        } response: { _ in
+            HTTPStubsResponse(data: try! FileMock.consumers_lookup_200.data(), statusCode: 200, headers: nil)
+        }
+
+        LinkAccountContext.shared.account = makeVerifiedLinkAccount(email: "foo@bar.com")
+        defer {
+            LinkAccountContext.shared.account = nil
+        }
+
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
+        configuration.apiClient = stubbedAPIClient()
+        configuration.defaultBillingDetails.email = "foo@bar.com"
+
+        let linkAccount = try await PaymentSheetLoader.lookupLinkAccount(
+            elementsSession: STPElementsSession._testValue(paymentMethodTypes: ["card", "link"]),
+            configuration: configuration,
+            prefetchedEmailAndSource: nil,
+            loadTimings: .init(),
+            isUpdate: false
+        )
+
+        XCTAssertTrue(didCallLookup, "Expected Link lookup to still run when reloading PaymentSheet")
+        XCTAssertEqual(linkAccount?.consumerSessionClientSecret, "pscs_persisted")
+        XCTAssertEqual(linkAccount?.sessionState, .verified)
+    }
+
+    @MainActor
+    func testLookupLink_doesNotPreserveVerifiedSessionForDifferentAccountOnReload() async throws {
+        var didCallLookup = false
+        stub { urlRequest in
+            if urlRequest.url?.absoluteString.contains("consumers/sessions/lookup") == true {
+                didCallLookup = true
+                return true
+            }
+            return false
+        } response: { _ in
+            HTTPStubsResponse(data: try! FileMock.consumers_lookup_200.data(), statusCode: 200, headers: nil)
+        }
+
+        LinkAccountContext.shared.account = makeVerifiedLinkAccount(email: "different@bar.com")
+        defer {
+            LinkAccountContext.shared.account = nil
+        }
+
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
+        configuration.apiClient = stubbedAPIClient()
+        configuration.defaultBillingDetails.email = "foo@bar.com"
+
+        let linkAccount = try await PaymentSheetLoader.lookupLinkAccount(
+            elementsSession: STPElementsSession._testValue(paymentMethodTypes: ["card", "link"]),
+            configuration: configuration,
+            prefetchedEmailAndSource: nil,
+            loadTimings: .init(),
+            isUpdate: false
+        )
+
+        XCTAssertTrue(didCallLookup, "Expected Link lookup to run for the new email")
+        XCTAssertEqual(linkAccount?.consumerSessionClientSecret, "pscs_abc123")
+        XCTAssertEqual(linkAccount?.sessionState, .requiresVerification)
+    }
+
     // MARK: - Link Lookup Holdback Tests
 
     @MainActor
@@ -642,6 +714,34 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         } else {
             XCTAssertFalse(didCallLookup, message)
         }
+    }
+
+    private func makeVerifiedLinkAccount(
+        email: String,
+        clientSecret: String = "pscs_persisted"
+    ) -> PaymentSheetLinkAccount {
+        let verifiedSession = ConsumerSession(
+            clientSecret: clientSecret,
+            emailAddress: email,
+            redactedFormattedPhoneNumber: "(***) *** **12",
+            unredactedPhoneNumber: nil,
+            phoneNumberCountry: nil,
+            verificationSessions: [.init(type: .sms, state: .verified)],
+            supportedPaymentDetailsTypes: [ParsedEnum(.card)],
+            mobileFallbackWebviewParams: nil,
+            currentAuthenticationLevel: .oneFactorAuth,
+            minimumAuthenticationLevel: .oneFactorAuth
+        )
+
+        return PaymentSheetLinkAccount(
+            email: email,
+            session: verifiedSession,
+            publishableKey: "pk_test_persisted",
+            displayablePaymentDetails: nil,
+            apiClient: stubbedAPIClient(),
+            useMobileEndpoints: false,
+            canSyncAttestationState: false
+        )
     }
 
     func testLookupLink_linkDisabled_holdbackGlobal_shouldLookup() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -720,7 +720,7 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         email: String,
         clientSecret: String = "pscs_persisted"
     ) -> PaymentSheetLinkAccount {
-        let verifiedSession = ConsumerSession(
+        let verifiedSession = ConsumerSession.make(
             clientSecret: clientSecret,
             emailAddress: email,
             redactedFormattedPhoneNumber: "(***) *** **12",


### PR DESCRIPTION
## Summary
Reuse the Link account session after Payment Sheet closes if the previously verified account matches the old one. 

## Motivation
If a merchant passes a default value email, the customer opens MPE, OTPs and then closes/reopens MPE, their prompted for OTP again (see before video). Since they've already verified we could reuse they're account session on subsequent look ups.

## Demo





| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/8c3adad1-7ec2-4eb6-a56e-59654644b7b4" width="300" /> | <video src="https://github.com/user-attachments/assets/15f8036c-89a8-49c9-8d46-d9b8ddc1f4e9" width="300" /> |
