### PR TITLE
Fix tax status decoding

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/STPCheckoutSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/STPCheckoutSession.swift
@@ -398,14 +398,23 @@ extension STPCheckoutSession: STPAPIResponseDecodable {
         let taxStatus: Checkout.TaxStatus = {
             let taxMeta = dict["tax_meta"] as? [String: Any]
             let computationType = taxMeta?["computation_type"] as? String
-            if computationType == "automatic" {
-                let status = taxMeta?["status"] as? String
-                if status == "requires_location_inputs" {
-                    let hasShippingCollection = dict["shipping_address_collection"] != nil
-                    return hasShippingCollection ? .requiresShippingAddress : .requiresBillingAddress
-                }
+            guard computationType == "automatic" else {
+                return .ready
             }
-            return .ready
+
+            let status = taxMeta?["status"] as? String
+            switch status {
+            case "complete":
+                return .ready
+            case "requires_location_inputs":
+                let taxContext = dict["tax_context"] as? [String: Any]
+                let addressSource = taxContext?["automatic_tax_address_source"] as? String
+                return addressSource == "session.shipping" ? .requiresShippingAddress : .requiresBillingAddress
+            case "failed":
+                return .unknown
+            default:
+                return .ready
+            }
         }()
         let tax = Checkout.Tax(
             status: taxStatus,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/STPCheckoutSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/STPCheckoutSessionTest.swift
@@ -518,4 +518,47 @@ class STPCheckoutSessionTest: XCTestCase {
         XCTAssertFalse(Intent.checkoutSession(session).isSetupFutureUsageSet(for: .payPal))
     }
 
+    // MARK: - TaxStatus Tests
+
+    func testTaxStatus_automaticRequiresLocationInputs_usesTaxContextAddressSource() {
+        let taxMeta: [String: Any] = [
+            "computation_type": "automatic",
+            "status": "requires_location_inputs",
+        ]
+        let shipping = makeCheckoutSession([
+            "tax_meta": taxMeta,
+            "tax_context": ["automatic_tax_address_source": "session.shipping"],
+        ])
+        XCTAssertEqual(shipping.tax.status, .requiresShippingAddress)
+
+        let billing = makeCheckoutSession([
+            "tax_meta": taxMeta,
+            "tax_context": ["automatic_tax_address_source": "session.billing"],
+        ])
+        XCTAssertEqual(billing.tax.status, .requiresBillingAddress)
+
+        let missingSource = makeCheckoutSession(["tax_meta": taxMeta])
+        XCTAssertEqual(missingSource.tax.status, .requiresBillingAddress)
+    }
+
+    func testTaxStatus_automaticFailed_returnsUnknown() {
+        let session = makeCheckoutSession([
+            "tax_meta": [
+                "computation_type": "automatic",
+                "status": "failed",
+            ],
+        ])
+        XCTAssertEqual(session.tax.status, .unknown)
+    }
+
+    func testTaxStatus_nonAutomaticComputationType_isReady() {
+        let session = makeCheckoutSession([
+            "tax_meta": [
+                "computation_type": "dynamic",
+                "status": "requires_location_inputs",
+            ],
+        ])
+        XCTAssertEqual(session.tax.status, .ready)
+    }
+
 }


### PR DESCRIPTION
## Summary
Derive tax blocking state from tax_meta only when computation_type == "automatic". For requires_location_inputs, use tax_context.automatic_tax_address_source (session.shipping vs billing) instead of inferring from shipping_address_collection. Map automatic tax failed to .unknown instead of .ready.

## Motivation
- Fix a bug

## Testing
- New tests

## Changelog
N/A
