### PR TITLE
[link] Propagate `LinkBrand` through Financial Connections flow

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -145,8 +145,7 @@ final class PlaygroundConfiguration {
                 return forceOnelink
             }
 
-            // Backward compatibility for older stored values.
-            if linkBrandString == "onelink" {
+            if configurationStore[Self.linkBrandKey] as? String == "onelink" {
                 return .on
             }
 

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -116,9 +116,9 @@ final class PlaygroundConfiguration {
 
     // MARK: - Link Brand
 
-    enum LinkBrand: String, CaseIterable, Identifiable, Hashable {
-        case link = "link"
-        case onelink = "onelink"
+    enum ForceOnelink: String, CaseIterable, Identifiable, Hashable {
+        case on = "on"
+        case off = "off"
 
         var id: String {
             return rawValue
@@ -126,26 +126,31 @@ final class PlaygroundConfiguration {
 
         var displayName: String {
             switch self {
-            case .link:
-                return "Link"
-            case .onelink:
-                return "Onelink"
+            case .on:
+                return "On"
+            case .off:
+                return "Off"
             }
         }
     }
 
     private static let linkBrandKey = "link_brand"
 
-    var linkBrand: LinkBrand {
+    var forceOnelink: ForceOnelink {
         get {
             if
                 let linkBrandString = configurationStore[Self.linkBrandKey] as? String,
-                let linkBrand = LinkBrand(rawValue: linkBrandString)
+                let forceOnelink = ForceOnelink(rawValue: linkBrandString)
             {
-                return linkBrand
-            } else {
-                return .link
+                return forceOnelink
             }
+
+            // Backward compatibility for older stored values.
+            if linkBrandString == "onelink" {
+                return .on
+            }
+
+            return .off
         }
         set {
             configurationStore[Self.linkBrandKey] = newValue.rawValue
@@ -603,11 +608,13 @@ final class PlaygroundConfiguration {
 
         if
             let linkBrandString = dictionary[Self.linkBrandKey] as? String,
-            let linkBrand = LinkBrand(rawValue: linkBrandString)
+            let forceOnelink = ForceOnelink(rawValue: linkBrandString)
         {
-            self.linkBrand = linkBrand
+            self.forceOnelink = forceOnelink
+        } else if dictionary[Self.linkBrandKey] as? String == "onelink" {
+            self.forceOnelink = .on
         } else {
-            self.linkBrand = .link
+            self.forceOnelink = .off
         }
 
         if

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundView.swift
@@ -131,10 +131,10 @@ struct PlaygroundView: View {
                         if !(viewModel.integrationType.wrappedValue == .standalone
                             && viewModel.experience.wrappedValue == .financialConnections) {
                             HStack {
-                                Text("Link brand")
+                                Text("Force onelink")
                                     .font(.subheadline)
-                                Picker("Link brand", selection: viewModel.linkBrand) {
-                                    ForEach(PlaygroundConfiguration.LinkBrand.allCases) {
+                                Picker("Force onelink", selection: viewModel.forceOnelink) {
+                                    ForEach(PlaygroundConfiguration.ForceOnelink.allCases) {
                                         Text($0.displayName)
                                             .tag($0)
                                     }

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -63,13 +63,13 @@ final class PlaygroundViewModel: ObservableObject {
         )
     }
 
-    var linkBrand: Binding<PlaygroundConfiguration.LinkBrand> {
+    var forceOnelink: Binding<PlaygroundConfiguration.ForceOnelink> {
         Binding(
             get: {
-                self.playgroundConfiguration.linkBrand
+                self.playgroundConfiguration.forceOnelink
             },
             set: {
-                self.playgroundConfiguration.linkBrand = $0
+                self.playgroundConfiguration.forceOnelink = $0
                 self.objectWillChange.send()
             }
         )
@@ -380,7 +380,7 @@ final class PlaygroundViewModel: ObservableObject {
                     stripeAccount: self.playgroundConfiguration.merchant.stripeAccount,
                     setupPlaygroundResponseJSON: setupPlaygroundResponse,
                     style: self.playgroundConfiguration.style,
-                    linkBrand: self.playgroundConfiguration.linkBrand,
+                    forceOnelink: self.playgroundConfiguration.forceOnelink,
                     onEvent: { event in
                         if self.liveEvents.wrappedValue == true {
                             let message = "\(event.name.rawValue); \(event.metadata.dictionary)"
@@ -685,7 +685,7 @@ private func PresentFinancialConnectionsSheet(
     stripeAccount: String?,
     setupPlaygroundResponseJSON: [String: String],
     style: PlaygroundConfiguration.Style,
-    linkBrand: PlaygroundConfiguration.LinkBrand,
+    forceOnelink: PlaygroundConfiguration.ForceOnelink,
     onEvent: @escaping (FinancialConnectionsEvent) -> Void,
     completionHandler: @escaping (HostControllerResult) -> Void
 ) {
@@ -727,7 +727,7 @@ private func PresentFinancialConnectionsSheet(
     let isUITest = (ProcessInfo.processInfo.environment["UITesting"] != nil)
     var configuration = FinancialConnectionsSheet.Configuration()
     configuration.style = style.configurationValue
-    configuration.linkBrand = linkBrand == .onelink ? .onelink : nil
+    configuration.linkBrand = forceOnelink == .on ? .onelink : nil
     let financialConnectionsSheet = FinancialConnectionsSheet(
         financialConnectionsSessionClientSecret: clientSecret,
         // disable app-to-app for UI tests
@@ -842,7 +842,7 @@ private func PresentPaymentSheet(
     case .alwaysDark: configuration.style = .alwaysDark
     }
 
-    if config.linkBrand == .onelink {
+    if config.forceOnelink == .on {
         configuration.link.brand = .onelink
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -73,6 +73,7 @@ struct PaymentSheetTestPlayground: View {
         SearchableSettingView(setting: $playgroundController.settings.shakeAmbiguousViews, searchText: searchText)
         SearchableSettingView(setting: $playgroundController.settings.instantDebitsIncentives, searchText: searchText)
         SearchableSettingView(setting: $playgroundController.settings.fcLiteEnabled, searchText: searchText)
+        SearchableSettingView(setting: $playgroundController.settings.forceFCNative, searchText: searchText)
         SearchableSettingView(setting: $playgroundController.settings.opensCardScannerAutomatically, searchText: searchText)
         SearchableSettingView(setting: $playgroundController.settings.termsDisplay, searchText: searchText)
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -333,6 +333,13 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case off
     }
 
+    enum ForceFCNative: String, PickerEnum {
+        static var enumName: String { "Force FC native" }
+
+        case on
+        case off
+    }
+
     enum AllowsDelayedPMs: String, PickerEnum {
         static var enumName: String { "allowsDelayedPMs" }
 
@@ -764,6 +771,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
     var linkDisplay: LinkDisplay
     var forceOnelink: ForceOnelink
     var forceOnelinkConsumer: ForceOnelinkConsumer
+    var forceFCNative: ForceFCNative
     var userOverrideCountry: UserOverrideCountry
     var customCtaLabel: String?
     var paymentMethodConfigurationId: String?
@@ -837,6 +845,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
             linkDisplay: .automatic,
             forceOnelink: .off,
             forceOnelinkConsumer: .off,
+            forceFCNative: .off,
             userOverrideCountry: .off,
             customCtaLabel: nil,
             paymentMethodConfigurationId: nil,

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -635,16 +635,10 @@ import UIKit
         // Enable experimental payment methods.
         //        PaymentSheet.supportedPaymentMethods += [.link]
 
-        // Hack to ensure we don't force the native flow unless we're in a UI test
-        if ProcessInfo.processInfo.environment["UITesting"] == nil {
-            UserDefaults.standard.removeObject(forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
-        } else {
-            // This makes the Financial Connections SDK use the native UI instead of webview. Native is much easier to test.
-            UserDefaults.standard.set(true, forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
-        }
         self.settings = settings
         self.appearance = appearance
         self.currentlyRenderedSettings = .defaultValues()
+        updateFinancialConnectionsNativeOverride(settings)
         updateForcedConsumerLinkBrand(settings)
 
         $settings.removeDuplicates().sink { [weak self] newValue in
@@ -670,6 +664,7 @@ import UIKit
             let enableFcLite = newValue.fcLiteEnabled == .on
             FinancialConnectionsSDKAvailability.localFcLiteOverride = enableFcLite
 
+            self?.updateFinancialConnectionsNativeOverride(newValue)
             self?.updateForcedConsumerLinkBrand(newValue)
         }.store(in: &subscribers)
 
@@ -687,6 +682,19 @@ import UIKit
     private func updateForcedConsumerLinkBrand(_ settings: PaymentSheetTestPlaygroundSettings) {
         PaymentSheetLinkAccount.forcedConsumerLinkBrandForTesting =
             settings.forceOnelinkConsumer == .on ? .onelink : nil
+    }
+
+    private func updateFinancialConnectionsNativeOverride(_ settings: PaymentSheetTestPlaygroundSettings) {
+        let shouldForceNative =
+            settings.forceFCNative == .on
+            || ProcessInfo.processInfo.environment["UITesting"] != nil
+
+        if shouldForceNative {
+            // This makes the Financial Connections SDK use the native UI instead of webview.
+            UserDefaults.standard.set(true, forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
+        } else {
+            UserDefaults.standard.removeObject(forKey: "FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE")
+        }
     }
 
     func buildPaymentSheet() {

--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -560,9 +560,9 @@ extension STPAPIClient {
             } else {
                 // Return decoding error directly
                 return .failure(error)
-            }
         }
     }
+}
 
     /// Decodes request data to see if it can be parsed as a Stripe error.
     static func decodeStripeErrorResponse(

--- a/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsConsumer.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/FinancialConnectionsConsumer.swift
@@ -13,19 +13,22 @@ import Foundation
     @_spi(STP) public let emailAddress: String
     @_spi(STP) public let redactedFormattedPhoneNumber: String
     @_spi(STP) public let verificationSessions: [VerificationSession]
+    @_spi(STP) public let linkBrand: LinkBrand?
 
     @_spi(STP) public init(
         publishableKey: String?,
         clientSecret: String,
         emailAddress: String,
         redactedFormattedPhoneNumber: String,
-        verificationSessions: [VerificationSession]
+        verificationSessions: [VerificationSession],
+        linkBrand: LinkBrand? = nil
     ) {
         self.publishableKey = publishableKey
         self.clientSecret = clientSecret
         self.emailAddress = emailAddress
         self.redactedFormattedPhoneNumber = redactedFormattedPhoneNumber
         self.verificationSessions = verificationSessions
+        self.linkBrand = linkBrand
     }
 }
 

--- a/StripeCore/StripeCore/Source/Connections Bindings/LinkBrand.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/LinkBrand.swift
@@ -10,7 +10,7 @@ import Foundation
 @_spi(STP) @frozen public enum LinkBrand: String, SafeEnumCodable, Equatable {
     case link = "link"
     // Keep the backend-facing raw value unchanged until the rollout is ready.
-    case onelink = "notlink"
+    case onelink = "onelink"
     case unparsable
 
     /// Brand names are proper nouns, so keep the source-of-truth user-facing value here.

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
@@ -13,7 +13,7 @@ struct ConsumerSessionData: Decodable {
     let emailAddress: String
     let redactedFormattedPhoneNumber: String
     let verificationSessions: [VerificationSession]
-    let linkBrand: LinkBrand? = nil
+    let linkBrand: LinkBrand?
 
     private enum CodingKeys: String, CodingKey {
         case clientSecret

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
@@ -28,6 +28,16 @@ struct ConsumerSessionData: Decodable {
         verificationSessions.contains(where: { $0.state == .verified })
         || verificationSessions.contains(where: { $0.type == .signUp })
     }
+
+    func overridingLinkBrand(_ linkBrand: LinkBrand?) -> ConsumerSessionData {
+        ConsumerSessionData(
+            clientSecret: clientSecret,
+            emailAddress: emailAddress,
+            redactedFormattedPhoneNumber: redactedFormattedPhoneNumber,
+            verificationSessions: verificationSessions,
+            linkBrand: linkBrand ?? self.linkBrand
+        )
+    }
 }
 
 struct VerificationSession: Decodable {
@@ -71,4 +81,14 @@ struct AttachLinkConsumerToLinkAccountSessionResponse: Decodable {
 
 struct ConsumerSessionResponse: Decodable {
     let consumerSession: ConsumerSessionData
+    let linkBrand: LinkBrand?
+
+    var resolvedConsumerSession: ConsumerSessionData {
+        consumerSession.overridingLinkBrand(linkBrand)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case consumerSession
+        case linkBrand = "link_brand"
+    }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
@@ -13,6 +13,15 @@ struct ConsumerSessionData: Decodable {
     let emailAddress: String
     let redactedFormattedPhoneNumber: String
     let verificationSessions: [VerificationSession]
+    let linkBrand: LinkBrand? = nil
+
+    private enum CodingKeys: String, CodingKey {
+        case clientSecret
+        case emailAddress
+        case redactedFormattedPhoneNumber
+        case verificationSessions
+        case linkBrand = "link_brand"
+    }
 
     /// A consumer session is considered verified if the `state == .verified` or the `type == .signUp`.
     var isVerified: Bool {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -82,7 +82,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
     let allowManualEntry: Bool
     let appVerificationEnabled: Bool?
     let assignmentEventId: String?
-    let brand: LinkBrand?
+    let link_brand: LinkBrand?
     let businessName: String?
     let cancelUrl: String?
     let consentAcquiredAt: String?
@@ -114,7 +114,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
     let theme: Theme?
 
     var appearance: FinancialConnectionsAppearance {
-        FinancialConnectionsAppearance(theme: theme, brand: brand)
+        FinancialConnectionsAppearance(theme: theme, brand: link_brand)
     }
 
     var shouldAttachLinkedPaymentMethod: Bool {
@@ -141,7 +141,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
 extension FinancialConnectionsSessionManifest {
     init(
         allowManualEntry: Bool,
-        brand: LinkBrand? = nil,
+        link_brand: LinkBrand? = nil,
         consentRequired: Bool,
         customManualEntryHandling: Bool,
         disableLinkMoreAccounts: Bool,
@@ -171,7 +171,7 @@ extension FinancialConnectionsSessionManifest {
             allowManualEntry: allowManualEntry,
             appVerificationEnabled: nil,
             assignmentEventId: nil,
-            brand: brand,
+            link_brand: link_brand,
             businessName: nil,
             cancelUrl: nil,
             consentAcquiredAt: nil,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/FinancialConnectionsSDKImplementation.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSDK/FinancialConnectionsSDKImplementation.swift
@@ -34,7 +34,7 @@ public class FinancialConnectionsSDKImplementation: FinancialConnectionsSDKInter
         case .alwaysLight: configuration.style = .alwaysLight
         case .alwaysDark: configuration.style = .alwaysDark
         }
-        configuration.linkBrand = brand ?? elementsSessionContext?.linkSettings?.brand
+        configuration.linkBrand = brand
 
         let financialConnectionsSheet = FinancialConnectionsSheet(
             financialConnectionsSessionClientSecret: clientSecret,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -167,6 +167,7 @@ final public class FinancialConnectionsSheet {
         analyticsClient.addClass(toProductUsageIfNecessary: FinancialConnectionsSheet.self)
         APIVersion.configureFinancialConnectionsAPIVersion(apiClient: apiClient)
         PresentationManager.shared.configuration = configuration
+        PresentationManager.shared.consumerLinkBrand = nil
     }
 
     // MARK: - Public

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -330,7 +330,8 @@ final public class FinancialConnectionsSheet {
                 clientSecret: existingConsumer.clientSecret,
                 emailAddress: existingConsumer.emailAddress,
                 redactedFormattedPhoneNumber: existingConsumer.redactedFormattedPhoneNumber,
-                verificationSessions: verificationSessions
+                verificationSessions: verificationSessions,
+                linkBrand: existingConsumer.linkBrand
             )
             financialConnectionsApiClient.isLinkWithStripe = true
             financialConnectionsApiClient.consumerSession = consumerSession

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
@@ -78,21 +78,14 @@ struct FinancialConnectionsAppearance: Equatable {
         theme: FinancialConnectionsSessionManifest.Theme?,
         brand: LinkBrand?
     ) -> ResolvedBrand {
-        switch PresentationManager.shared.configuration.linkBrand {
+        switch PresentationManager.shared.resolvedLinkBrand(manifestLinkBrand: brand) {
         case .link:
             return .link
         case .onelink:
             return .onelink
-        case .unparsable, .none:
-            break
-        }
-
-        switch brand {
-        case .link:
-            return .link
-        case .onelink:
-            return .onelink
-        case .unparsable, .none:
+        case .unparsable:
+            fallthrough
+        case .none:
             switch theme {
             case .linkLight:
                 return .link

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -108,6 +108,7 @@ final class AccountPickerViewController: UIViewController {
                                 url: url,
                                 pane: .accountPicker,
                                 analyticsClient: self.dataSource.analyticsClient,
+                                linkBrand: self.dataSource.manifest.link_brand,
                                 handleURL: { _, _ in }
                             )
                         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentDataSource.swift
@@ -44,7 +44,7 @@ final class ConsentDataSourceImplementation: ConsentDataSource {
     private let elementsSessionContext: ElementsSessionContext?
 
     var email: String? {
-        elementsSessionContext?.prefillDetails?.email
+        apiClient.consumerSession?.emailAddress ?? elementsSessionContext?.prefillDetails?.email
     }
 
     init(
@@ -67,7 +67,23 @@ final class ConsentDataSourceImplementation: ConsentDataSource {
 
     func markConsentAcquired() -> Future<ConsentAcquiredResult> {
         return apiClient.markConsentAcquired(clientSecret: clientSecret).chained { [weak self] manifest in
-            guard let self, manifest.shouldLookupConsumerSession, let email else {
+            guard let self else {
+                let result = ConsentAcquiredResult(manifest: manifest)
+                return Promise(value: result)
+            }
+
+            if let consumerSession = apiClient.consumerSession,
+                let consumerPublishableKey = apiClient.consumerPublishableKey
+            {
+                let result = ConsentAcquiredResult(
+                    manifest: manifest,
+                    consumerSession: consumerSession,
+                    consumerPublishableKey: consumerPublishableKey
+                )
+                return Promise(value: result)
+            }
+
+            guard manifest.shouldLookupConsumerSession, let email else {
                 let result = ConsentAcquiredResult(manifest: manifest)
                 return Promise(value: result)
             }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Consent/ConsentViewController.swift
@@ -181,6 +181,7 @@ class ConsentViewController: UIViewController {
             url: url,
             pane: .consent,
             analyticsClient: dataSource.analyticsClient,
+            linkBrand: dataSource.manifest.link_brand,
             handleURL: { urlHost, nextPaneOrDrawerOnSecondaryCta in
                 guard let urlHost, let address = StripeSchemeAddress(rawValue: urlHost) else {
                     self.dataSource

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/IDConsentContent/IDConsentContentViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/IDConsentContent/IDConsentContentViewController.swift
@@ -127,6 +127,7 @@ class IDConsentContentViewController: UIViewController {
             url: url,
             pane: .idConsentContent,
             analyticsClient: dataSource.analyticsClient,
+            linkBrand: dataSource.manifest.link_brand,
             handleURL: { urlHost, _ in
                 guard let urlHost, let address = StripeSchemeAddress(rawValue: urlHost) else {
                     self.dataSource

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkAccountPicker/LinkAccountPickerViewController.swift
@@ -558,6 +558,7 @@ final class LinkAccountPickerViewController: UIViewController {
             url: url,
             pane: .linkAccountPicker,
             analyticsClient: self.dataSource.analyticsClient,
+            linkBrand: dataSource.manifest.link_brand,
             handleURL: { _, _ in }
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/LinkLogin/LinkLoginViewController.swift
@@ -255,6 +255,7 @@ final class LinkLoginViewController: UIViewController {
             url: url,
             pane: .linkLogin,
             analyticsClient: dataSource.analyticsClient,
+            linkBrand: dataSource.manifest.link_brand,
             handleURL: { _, _ in /* Stripe scheme URLs are not expected. */ }
         )
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -155,7 +155,9 @@ class NativeFlowController {
     }
 
     @objc private func linkBrandDidChange() {
-        refreshNavigationBranding()
+        DispatchQueue.main.async { [weak self] in
+            self?.refreshNavigationBranding()
+        }
     }
 }
 
@@ -180,6 +182,9 @@ extension NativeFlowController {
             )
         }
 
+        navigationController.navigationBar.setNeedsLayout()
+        navigationController.navigationBar.layoutIfNeeded()
+
         if let presentedViewController = navigationController.presentedViewController {
             FinancialConnectionsNavigationController.configureNavigationItemForNative(
                 presentedViewController.navigationItem,
@@ -192,6 +197,8 @@ extension NativeFlowController {
                 appearance: appearance,
                 isTestMode: isTestMode
             )
+            navigationController.navigationBar.setNeedsLayout()
+            navigationController.navigationBar.layoutIfNeeded()
         }
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -65,6 +65,16 @@ class NativeFlowController {
             name: UIApplication.didEnterBackgroundNotification,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(linkBrandDidChange),
+            name: PresentationManager.linkBrandDidChangeNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     func startFlow() {
@@ -143,11 +153,47 @@ class NativeFlowController {
                     .paneFromViewController(navigationController.topViewController)
             )
     }
+
+    @objc private func linkBrandDidChange() {
+        refreshNavigationBranding()
+    }
 }
 
 // MARK: - Core Navigation Helpers
 
 extension NativeFlowController {
+    private func refreshNavigationBranding() {
+        let appearance = dataManager.manifest.appearance
+        let isTestMode = dataManager.manifest.isTestMode
+
+        navigationController.viewControllers.forEach { viewController in
+            FinancialConnectionsNavigationController.configureNavigationItemForNative(
+                viewController.navigationItem,
+                closeItem: navigationBarCloseBarButtonItem,
+                shouldHideLogo: ShouldHideLogoInNavigationBar(
+                    forViewController: viewController,
+                    reducedBranding: dataManager.reducedBranding,
+                    merchantLogo: dataManager.merchantLogo
+                ),
+                appearance: appearance,
+                isTestMode: isTestMode
+            )
+        }
+
+        if let presentedViewController = navigationController.presentedViewController {
+            FinancialConnectionsNavigationController.configureNavigationItemForNative(
+                presentedViewController.navigationItem,
+                closeItem: navigationBarCloseBarButtonItem,
+                shouldHideLogo: ShouldHideLogoInNavigationBar(
+                    forViewController: presentedViewController,
+                    reducedBranding: dataManager.reducedBranding,
+                    merchantLogo: dataManager.merchantLogo
+                ),
+                appearance: appearance,
+                isTestMode: isTestMode
+            )
+        }
+    }
 
     private func setNavigationControllerViewControllers(
         _ viewControllers: [UIViewController],

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -113,6 +113,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
                 consumerSession = oldValue
             }
             apiClient.consumerSession = consumerSession
+            PresentationManager.shared.consumerLinkBrand = consumerSession?.linkBrand
         }
     }
     var consumerPublishableKey: String? {
@@ -153,6 +154,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         // Use consumer properties from the API client, if available.
         self.consumerSession = apiClient.consumerSession
         self.consumerPublishableKey = apiClient.consumerPublishableKey
+        PresentationManager.shared.consumerLinkBrand = self.consumerSession?.linkBrand
         didUpdateManifest()
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowDataManager.swift
@@ -113,7 +113,7 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
                 consumerSession = oldValue
             }
             apiClient.consumerSession = consumerSession
-            PresentationManager.shared.consumerLinkBrand = consumerSession?.linkBrand
+            PresentationManager.shared.setConsumerLinkBrand(from: consumerSession)
         }
     }
     var consumerPublishableKey: String? {
@@ -154,7 +154,9 @@ class NativeFlowAPIDataManager: NativeFlowDataManager {
         // Use consumer properties from the API client, if available.
         self.consumerSession = apiClient.consumerSession
         self.consumerPublishableKey = apiClient.consumerPublishableKey
-        PresentationManager.shared.consumerLinkBrand = self.consumerSession?.linkBrand
+        // Reset brand for each new FC session before setting from the initial consumer state.
+        PresentationManager.shared.resetConsumerLinkBrand()
+        PresentationManager.shared.setConsumerLinkBrand(from: self.consumerSession)
         didUpdateManifest()
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupDataSource.swift
@@ -32,7 +32,9 @@ final class NetworkingLinkLoginWarmupDataSourceImplementation: NetworkingLinkLog
     private let elementsSessionContext: ElementsSessionContext?
 
     var email: String? {
-        manifest.accountholderCustomerEmailAddress ?? elementsSessionContext?.prefillDetails?.email
+        apiClient.consumerSession?.emailAddress
+            ?? manifest.accountholderCustomerEmailAddress
+            ?? elementsSessionContext?.prefillDetails?.email
     }
 
     var hasConsumerSession: Bool {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -43,7 +43,7 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
     private let dataSource: NetworkingLinkLoginWarmupDataSource
     weak var delegate: NetworkingLinkLoginWarmupViewControllerDelegate?
     private var linkBrand: LinkBrand {
-        PresentationManager.shared.configuration.linkBrand ?? dataSource.manifest.brand ?? .link
+        PresentationManager.shared.configuration.linkBrand ?? dataSource.manifest.link_brand ?? .link
     }
 
     private lazy var warmupFooterView: NetworkingLinkLoginWarmupFooterView = {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkLoginWarmup/NetworkingLinkLoginWarmupViewController.swift
@@ -43,7 +43,7 @@ final class NetworkingLinkLoginWarmupViewController: SheetViewController {
     private let dataSource: NetworkingLinkLoginWarmupDataSource
     weak var delegate: NetworkingLinkLoginWarmupViewControllerDelegate?
     private var linkBrand: LinkBrand {
-        PresentationManager.shared.configuration.linkBrand ?? dataSource.manifest.link_brand ?? .link
+        PresentationManager.shared.resolvedLinkBrand(manifestLinkBrand: dataSource.manifest.link_brand) ?? .link
     }
 
     private lazy var warmupFooterView: NetworkingLinkLoginWarmupFooterView = {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NetworkingLinkSignupPane/NetworkingLinkSignupViewController.swift
@@ -269,6 +269,7 @@ final class NetworkingLinkSignupViewController: UIViewController {
             url: url,
             pane: .networkingLinkSignupPane,
             analyticsClient: dataSource.analyticsClient,
+            linkBrand: dataSource.manifest.link_brand,
             handleURL: { urlHost, _ in
                 if urlHost == "legal-details-notice", let legalDetailsNotice {
                     let legalDetailsNoticeViewController = LegalDetailsNoticeViewController(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -582,6 +582,7 @@ final class PartnerAuthViewController: SheetViewController {
             url: url,
             pane: .partnerAuth,
             analyticsClient: dataSource.analyticsClient,
+            linkBrand: dataSource.manifest.link_brand,
             handleURL: { urlHost, _ in
                 if urlHost == "data-access-notice" {
                     if let dataAccessNoticeModel = dataSource.pendingAuthSession?.display?.text?.oauthPrepane?.dataAccessNotice {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
@@ -110,20 +110,6 @@ final class AuthFlowHelpers {
     }
 
     private static func resolvedLinkBrand(_ manifestBrand: LinkBrand?) -> LinkBrand {
-        switch PresentationManager.shared.configuration.linkBrand {
-        case .link:
-            return .link
-        case .onelink:
-            return .onelink
-        case .unparsable, .none:
-            switch manifestBrand {
-            case .link:
-                return .link
-            case .onelink:
-                return .onelink
-            case .unparsable, .none:
-                return .link
-            }
-        }
+        PresentationManager.shared.resolvedLinkBrand(manifestLinkBrand: manifestBrand) ?? .link
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/AuthFlowHelpers.swift
@@ -36,6 +36,7 @@ final class AuthFlowHelpers {
         url: URL,
         pane: FinancialConnectionsSessionManifest.NextPane,
         analyticsClient: FinancialConnectionsAnalyticsClient,
+        linkBrand: LinkBrand? = nil,
         handleURL: (_ urlHost: String?, _ nextPaneOrDrawerOnSecondaryCta: String?) -> Void
     ) {
         let internalLinkToPaneId: [String: String] = [
@@ -68,14 +69,14 @@ final class AuthFlowHelpers {
         if url.scheme == "stripe" {
             handleURL(url.host, nextPaneOrDrawerOnSecondaryCta)
         } else {
-            let brand = PresentationManager.shared.configuration.linkBrand ?? .link
-            SFSafariViewController.present(url: brand.brandAwareLegalSupportURL(for: url))
+            SFSafariViewController.present(url: resolvedLinkBrand(linkBrand).brandAwareLegalSupportURL(for: url))
         }
     }
 
     static func networkingOTPErrorMessage(
         fromError error: Error,
-        otpType: String
+        otpType: String,
+        linkBrand: LinkBrand? = nil
     ) -> String? {
         if
             let error = error as? StripeError,
@@ -92,7 +93,7 @@ final class AuthFlowHelpers {
                 let trailingMessage = (otpType == "EMAIL") ? STPLocalizedString("Click “Resend code” and try again, or %@.", "Text as part of an error message that shows up when user entered an invalid one-time-passcode (OTP). '%@' will be replaced by text with a link: 'contact us'") : STPLocalizedString("Try again, or %@.", "Text as part of an error message that shows up when user entered an invalid one-time-passcode (OTP). '%@' will be replaced by text with a link: 'contact us'")
 
                 let contactUsText = STPLocalizedString("contact us", "A link/button inside of text that can be tapped to visit a support website. This link will be embedded inside of larger text: 'It looks like the verification code you provided is not valid anymore. Try again, or contact us.'")
-                let contactUsUrlString = (PresentationManager.shared.configuration.linkBrand ?? .link).supportContactURL.absoluteString
+                let contactUsUrlString = resolvedLinkBrand(linkBrand).supportContactURL.absoluteString
                 let contactUsWithUrlText = "[\(contactUsText)](\(contactUsUrlString))"
 
                 return leadingMessage + " " + String(format: trailingMessage, contactUsWithUrlText)
@@ -106,5 +107,23 @@ final class AuthFlowHelpers {
 
     static func formatRedactedPhoneNumber(_ redactedPhoneNumber: String) -> String {
         return redactedPhoneNumber.replacingOccurrences(of: "*", with: "•")
+    }
+
+    private static func resolvedLinkBrand(_ manifestBrand: LinkBrand?) -> LinkBrand {
+        switch PresentationManager.shared.configuration.linkBrand {
+        case .link:
+            return .link
+        case .onelink:
+            return .onelink
+        case .unparsable, .none:
+            switch manifestBrand {
+            case .link:
+                return .link
+            case .onelink:
+                return .onelink
+            case .unparsable, .none:
+                return .link
+            }
+        }
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -31,12 +31,14 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
     let analyticsClient: FinancialConnectionsAnalyticsClient
     private let customEmailType: String?
     private let connectionsMerchantName: String?
-    private let apiClient: any FinancialConnectionsAPI
+    private var apiClient: any FinancialConnectionsAPI
     private let manifest: FinancialConnectionsSessionManifest
     weak var delegate: NetworkingOTPDataSourceDelegate?
 
     private var consumerSession: ConsumerSessionData {
         didSet {
+            apiClient.consumerSession = consumerSession
+            PresentationManager.shared.setConsumerLinkBrand(from: consumerSession)
             delegate?.networkingOTPDataSource(self, didUpdateConsumerSession: consumerSession)
         }
     }
@@ -71,6 +73,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
         self.consumerSession = consumerSession
         self.apiClient = apiClient
         self.analyticsClient = analyticsClient
+        self.apiClient.consumerSession = consumerSession
     }
 
     func startVerificationSession() -> Future<ConsumerSessionResponse> {
@@ -80,7 +83,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
             connectionsMerchantName: connectionsMerchantName,
             consumerSessionClientSecret: consumerSession.clientSecret
         ).chained { [weak self] consumerSessionResponse in
-            self?.consumerSession = consumerSessionResponse.consumerSession
+            self?.consumerSession = consumerSessionResponse.resolvedConsumerSession
             return Promise(value: consumerSessionResponse)
         }
     }
@@ -91,7 +94,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
             otpType: otpType,
             consumerSessionClientSecret: consumerSession.clientSecret
         ).chained { [weak self] consumerSessionResponse in
-            self?.consumerSession = consumerSessionResponse.consumerSession
+            self?.consumerSession = consumerSessionResponse.resolvedConsumerSession
             return Promise(value: consumerSessionResponse)
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -17,6 +17,7 @@ protocol NetworkingOTPDataSource: AnyObject {
     var analyticsClient: FinancialConnectionsAnalyticsClient { get }
     var isTestMode: Bool { get }
     var appearance: FinancialConnectionsAppearance { get }
+    var linkBrand: LinkBrand? { get }
     var pane: FinancialConnectionsSessionManifest.NextPane { get }
 
     func startVerificationSession() -> Future<ConsumerSessionResponse>
@@ -46,6 +47,10 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
 
     var appearance: FinancialConnectionsAppearance {
         manifest.appearance
+    }
+
+    var linkBrand: LinkBrand? {
+        manifest.link_brand
     }
 
     init(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -183,7 +183,11 @@ final class NetworkingOTPView: UIView {
                     self.delegate?.networkingOTPViewDidConfirmVerification(self)
                 case .failure(let error):
                     let isTerminal: Bool
-                    if let errorMessage = AuthFlowHelpers.networkingOTPErrorMessage(fromError: error, otpType: self.dataSource.otpType) {
+                    if let errorMessage = AuthFlowHelpers.networkingOTPErrorMessage(
+                        fromError: error,
+                        otpType: self.dataSource.otpType,
+                        linkBrand: self.dataSource.linkBrand
+                    ) {
                         self.dataSource
                             .analyticsClient
                             .logExpectedError(

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPView.swift
@@ -258,7 +258,8 @@ private struct NetowrkingOTPViewRepresentable: UIViewRepresentable {
                 clientSecret: "cs_123",
                 emailAddress: "email@email.com",
                 redactedFormattedPhoneNumber: "(•••) ••• ••55",
-                verificationSessions: []
+                verificationSessions: [],
+                linkBrand: nil
             ),
             apiClient: FinancialConnectionsAsyncAPIClient(apiClient: .shared),
             analyticsClient: FinancialConnectionsAnalyticsClient()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PresentationManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PresentationManager.swift
@@ -21,8 +21,24 @@ class PresentationManager {
         }
     }
 
+    /// Updates `consumerLinkBrand` from a consumer session, but only when the session is
+    /// verified and carries a non-nil brand. Unverified sessions (e.g. from
+    /// `startVerificationSession`) must not clear a brand set by a prior `confirm_verification`.
+    func setConsumerLinkBrand(from consumerSession: ConsumerSessionData?) {
+        guard consumerSession?.isVerified == true, let brand = consumerSession?.linkBrand else {
+            return
+        }
+        consumerLinkBrand = brand
+    }
+
+    /// Explicitly resets the consumer brand. Call this at the start of a new FC session so
+    /// a stale brand from a previous presentation does not bleed in.
+    func resetConsumerLinkBrand() {
+        consumerLinkBrand = nil
+    }
+
     func resolvedLinkBrand(manifestLinkBrand: LinkBrand?) -> LinkBrand? {
-        switch configuration.linkBrand {
+        switch consumerLinkBrand {
         case .link:
             return .link
         case .onelink:
@@ -31,7 +47,7 @@ class PresentationManager {
             break
         }
 
-        switch consumerLinkBrand {
+        switch configuration.linkBrand {
         case .link:
             return .link
         case .onelink:

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PresentationManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PresentationManager.swift
@@ -5,6 +5,7 @@
 //  Created by Mat Schmid on 2025-01-30.
 //
 
+@_spi(STP) import StripeCore
 import UIKit
 
 /// Handles applying the current style configuration to each view controller presented.
@@ -12,6 +13,36 @@ class PresentationManager {
     static let shared = PresentationManager()
 
     var configuration: FinancialConnectionsSheet.Configuration = .init()
+    var consumerLinkBrand: LinkBrand?
+
+    func resolvedLinkBrand(manifestLinkBrand: LinkBrand?) -> LinkBrand? {
+        switch configuration.linkBrand {
+        case .link:
+            return .link
+        case .onelink:
+            return .onelink
+        case .unparsable, .none:
+            break
+        }
+
+        switch consumerLinkBrand {
+        case .link:
+            return .link
+        case .onelink:
+            return .onelink
+        case .unparsable, .none:
+            break
+        }
+
+        switch manifestLinkBrand {
+        case .link:
+            return .link
+        case .onelink:
+            return .onelink
+        case .unparsable, .none:
+            return nil
+        }
+    }
 
     func present(
         _ viewControllerToPresent: UIViewController,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PresentationManager.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PresentationManager.swift
@@ -11,9 +11,15 @@ import UIKit
 /// Handles applying the current style configuration to each view controller presented.
 class PresentationManager {
     static let shared = PresentationManager()
+    static let linkBrandDidChangeNotification = Notification.Name("com.stripe.financialconnections.linkBrandDidChange")
 
     var configuration: FinancialConnectionsSheet.Configuration = .init()
-    var consumerLinkBrand: LinkBrand?
+    var consumerLinkBrand: LinkBrand? {
+        didSet {
+            guard consumerLinkBrand != oldValue else { return }
+            NotificationCenter.default.post(name: Self.linkBrandDidChangeNotification, object: nil)
+        }
+    }
 
     func resolvedLinkBrand(manifestLinkBrand: LinkBrand?) -> LinkBrand? {
         switch configuration.linkBrand {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
@@ -19,7 +19,7 @@ final class SuccessViewController: UIViewController {
     private let dataSource: SuccessDataSource
     weak var delegate: SuccessViewControllerDelegate?
     private var linkBrand: LinkBrand {
-        PresentationManager.shared.configuration.linkBrand ?? dataSource.manifest.link_brand ?? .link
+        PresentationManager.shared.resolvedLinkBrand(manifestLinkBrand: dataSource.manifest.link_brand) ?? .link
     }
 
     init(dataSource: SuccessDataSource) {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Success/SuccessViewController.swift
@@ -19,7 +19,7 @@ final class SuccessViewController: UIViewController {
     private let dataSource: SuccessDataSource
     weak var delegate: SuccessViewControllerDelegate?
     private var linkBrand: LinkBrand {
-        PresentationManager.shared.configuration.linkBrand ?? dataSource.manifest.brand ?? .link
+        PresentationManager.shared.configuration.linkBrand ?? dataSource.manifest.link_brand ?? .link
     }
 
     init(dataSource: SuccessDataSource) {

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAsyncAPIClientTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAsyncAPIClientTests.swift
@@ -81,7 +81,8 @@ class FinancialConnectionsAsyncAPIClientTests: XCTestCase {
             clientSecret: "clientSecret",
             emailAddress: "emailAddress",
             redactedFormattedPhoneNumber: "redactedFormattedPhoneNumber",
-            verificationSessions: []
+            verificationSessions: [],
+            linkBrand: nil
         )
         apiClient.consumerSession = unverifiedConsumerSession
         XCTAssertNil(apiClient.consumerPublishableKeyProvider(canUseConsumerKey: true))
@@ -95,7 +96,8 @@ class FinancialConnectionsAsyncAPIClientTests: XCTestCase {
                     type: .sms,
                     state: .verified
                 ),
-            ]
+            ],
+            linkBrand: nil
         )
         apiClient.consumerSession = verifiedConsumerSession
         XCTAssertEqual(apiClient.consumerPublishableKeyProvider(canUseConsumerKey: true), consumerPublishableKey)

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAsyncAPIClientTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAsyncAPIClientTests.swift
@@ -154,6 +154,30 @@ class FinancialConnectionsAsyncAPIClientTests: XCTestCase {
         XCTAssertEqual(encodedBillingAddress?["country_code"] as? String, "US")
     }
 
+    func testConsumerSessionResponseUsesTopLevelLinkBrandOverride() throws {
+        let payload = """
+        {
+          "consumer_session": {
+            "client_secret": "cs_test",
+            "email_address": "user@example.com",
+            "redacted_formatted_phone_number": "(•••) ••• ••55",
+            "verification_sessions": [
+              {
+                "type": "SMS",
+                "state": "VERIFIED"
+              }
+            ]
+          },
+          "link_brand": "onelink"
+        }
+        """
+
+        let response = try StripeJSONDecoder().decode(ConsumerSessionResponse.self, from: Data(payload.utf8))
+
+        XCTAssertEqual(response.linkBrand, .onelink)
+        XCTAssertEqual(response.resolvedConsumerSession.linkBrand, .onelink)
+    }
+
     func testApplyAttestationParameters() async {
         // Mark API client as testmode to use a mock assertion
         mockApiClient.publishableKey = "pk_test"

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSessionTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSessionTests.swift
@@ -81,7 +81,7 @@ final class FinancialConnectionsSessionTests: XCTestCase {
     }
 
     func testSynchronizeParsesNotlinkBrand() throws {
-        let synchronize = try makeSynchronize(brandValue: "notlink")
+        let synchronize = try makeSynchronize(brandValue: "onelink")
 
         XCTAssertEqual(synchronize.manifest.brand, .onelink)
         XCTAssertEqual(synchronize.manifest.appearance.logo, .onelink_logo)

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSessionTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSessionTests.swift
@@ -62,7 +62,7 @@ final class FinancialConnectionsSessionTests: XCTestCase {
     func testSynchronizeWithoutBrandPreservesExistingStripeBranding() throws {
         let synchronize = try FinancialConnectionsSynchronizeMock.synchronize.make()
 
-        XCTAssertNil(synchronize.manifest.brand)
+        XCTAssertNil(synchronize.manifest.link_brand)
         XCTAssertEqual(synchronize.manifest.theme, .light)
         XCTAssertEqual(synchronize.manifest.appearance.logo, .stripe_logo)
         XCTAssertTrue(
@@ -73,7 +73,7 @@ final class FinancialConnectionsSessionTests: XCTestCase {
     func testSynchronizeParsesLinkBrand() throws {
         let synchronize = try makeSynchronize(brandValue: "link")
 
-        XCTAssertEqual(synchronize.manifest.brand, .link)
+        XCTAssertEqual(synchronize.manifest.link_brand, .link)
         XCTAssertEqual(synchronize.manifest.appearance.logo, .link_logo)
         XCTAssertTrue(
             synchronize.manifest.appearance.colors.primary.isEqual(FinancialConnectionsAppearance.Colors.stripe.primary)
@@ -83,27 +83,27 @@ final class FinancialConnectionsSessionTests: XCTestCase {
     func testSynchronizeParsesNotlinkBrand() throws {
         let synchronize = try makeSynchronize(brandValue: "onelink")
 
-        XCTAssertEqual(synchronize.manifest.brand, .onelink)
+        XCTAssertEqual(synchronize.manifest.link_brand, .onelink)
         XCTAssertEqual(synchronize.manifest.appearance.logo, .onelink_logo)
     }
 
     func testSynchronizeParsesUnknownBrandAsUnparsable() throws {
         let synchronize = try makeSynchronize(brandValue: "random_brand")
 
-        XCTAssertEqual(synchronize.manifest.brand, .unparsable)
+        XCTAssertEqual(synchronize.manifest.link_brand, .unparsable)
         XCTAssertEqual(synchronize.manifest.appearance.logo, .stripe_logo)
     }
 
     func testLinkThemeWithoutBrandPreservesExistingLinkBranding() {
         let manifest = makeManifest(theme: .linkLight)
 
-        XCTAssertNil(manifest.brand)
+        XCTAssertNil(manifest.link_brand)
         XCTAssertEqual(manifest.appearance.logo, .link_logo)
         XCTAssertTrue(manifest.appearance.colors.primary.isEqual(FinancialConnectionsAppearance.Colors.link.primary))
     }
 
     func testExplicitBrandOverridesLogoWithoutChangingThemeColors() {
-        let manifest = makeManifest(theme: .light, brand: .onelink)
+        let manifest = makeManifest(theme: .light, link_brand: .onelink)
 
         XCTAssertEqual(manifest.appearance.logo, .onelink_logo)
         XCTAssertTrue(manifest.appearance.colors.primary.isEqual(FinancialConnectionsAppearance.Colors.stripe.primary))
@@ -113,7 +113,7 @@ final class FinancialConnectionsSessionTests: XCTestCase {
         var payload = try JSONSerialization.jsonObject(with: FinancialConnectionsSynchronizeMock.synchronize.data()) as? [String: Any]
         var manifest = payload?["manifest"] as? [String: Any]
 
-        manifest?["brand"] = brandValue
+        manifest?["link_brand"] = brandValue
         payload?["manifest"] = manifest
 
         let data = try JSONSerialization.data(withJSONObject: payload ?? [:])
@@ -142,11 +142,11 @@ final class FinancialConnectionsSessionTests: XCTestCase {
 
     private func makeManifest(
         theme: FinancialConnectionsSessionManifest.Theme,
-        brand: LinkBrand? = nil
+        link_brand: LinkBrand? = nil
     ) -> FinancialConnectionsSessionManifest {
         FinancialConnectionsSessionManifest(
             allowManualEntry: false,
-            brand: brand,
+            link_brand: link_brand,
             consentRequired: false,
             customManualEntryHandling: false,
             disableLinkMoreAccounts: false,

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/PresentationManagerTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/PresentationManagerTests.swift
@@ -65,6 +65,39 @@ class PresentationManagerTests: XCTestCase {
         XCTAssertTrue(onelinkAppearance.logoTintColor.isEqual(linkAppearance.logoTintColor))
     }
 
+    func testSetConsumerLinkBrandSetsWhenVerifiedWithBrand() throws {
+        let session = try makeConsumerSession(smsState: "VERIFIED", brand: "link")
+        PresentationManager.shared.setConsumerLinkBrand(from: session)
+        XCTAssertEqual(PresentationManager.shared.consumerLinkBrand, .link)
+    }
+
+    func testSetConsumerLinkBrandDoesNotClearWhenSessionIsUnverified() throws {
+        // Simulate prior confirm_verification having set the brand.
+        PresentationManager.shared.consumerLinkBrand = .onelink
+
+        // Simulate startVerificationSession returning an unverified (STARTED) session.
+        let startedSession = try makeConsumerSession(smsState: "STARTED", brand: "link")
+        PresentationManager.shared.setConsumerLinkBrand(from: startedSession)
+
+        // The brand from the prior confirm_verification must be preserved.
+        XCTAssertEqual(PresentationManager.shared.consumerLinkBrand, .onelink)
+    }
+
+    func testSetConsumerLinkBrandDoesNotClearWhenSessionHasNoBrand() throws {
+        PresentationManager.shared.consumerLinkBrand = .link
+
+        let verifiedNoBrandSession = try makeConsumerSession(smsState: "VERIFIED", brand: nil)
+        PresentationManager.shared.setConsumerLinkBrand(from: verifiedNoBrandSession)
+
+        XCTAssertEqual(PresentationManager.shared.consumerLinkBrand, .link)
+    }
+
+    func testResetConsumerLinkBrandClearsBrand() {
+        PresentationManager.shared.consumerLinkBrand = .link
+        PresentationManager.shared.resetConsumerLinkBrand()
+        XCTAssertNil(PresentationManager.shared.consumerLinkBrand)
+    }
+
     func testLinkBrandStillUsesThemeTinting() {
         let linkAppearance = FinancialConnectionsAppearance(theme: .light, brand: .link)
         let stripeAppearance = FinancialConnectionsAppearance(theme: .light, brand: nil)
@@ -72,4 +105,18 @@ class PresentationManagerTests: XCTestCase {
         XCTAssertFalse(linkAppearance.logoTintColor.isEqual(UIColor.clear))
         XCTAssertFalse(stripeAppearance.logoTintColor.isEqual(UIColor.clear))
     }
+}
+
+private func makeConsumerSession(smsState: String, brand: String?) throws -> ConsumerSessionData {
+    var json: [String: Any] = [
+        "clientSecret": "cs_test",
+        "emailAddress": "test@example.com",
+        "redactedFormattedPhoneNumber": "+1 (***) *** 1234",
+        "verificationSessions": [["type": "SMS", "state": smsState]],
+    ]
+    if let brand {
+        json["link_brand"] = brand
+    }
+    let data = try JSONSerialization.data(withJSONObject: json)
+    return try JSONDecoder().decode(ConsumerSessionData.self, from: data)
 }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/PresentationManagerTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/PresentationManagerTests.swift
@@ -13,6 +13,7 @@ class PresentationManagerTests: XCTestCase {
     override func tearDown() {
         super.tearDown()
         PresentationManager.shared.configuration = .init()
+        PresentationManager.shared.consumerLinkBrand = nil
     }
 
     func testConfigurationIsApplied() {
@@ -38,6 +39,14 @@ class PresentationManagerTests: XCTestCase {
         PresentationManager.shared.configuration = configuration
 
         let appearance = FinancialConnectionsAppearance(theme: .light, brand: nil)
+
+        XCTAssertEqual(appearance.logo, .onelink_logo)
+    }
+
+    func testConsumerSessionBrandOverridesManifestBrandForAppearanceResolution() {
+        PresentationManager.shared.consumerLinkBrand = .onelink
+
+        let appearance = FinancialConnectionsAppearance(theme: .light, brand: .link)
 
         XCTAssertEqual(appearance.logo, .onelink_logo)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -630,7 +630,8 @@ extension PayWithLinkViewController: PayWithLinkCoordinating {
             clientSecret: consumerSession.clientSecret,
             emailAddress: consumerSession.emailAddress,
             redactedFormattedPhoneNumber: consumerSession.redactedFormattedPhoneNumber,
-            verificationSessions: verificationSessions
+            verificationSessions: verificationSessions,
+            linkBrand: consumerSession.linkBrand
         )
 
         let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadataIfNecessary(analyticsHelper: context.analyticsHelper, intent: context.intent, elementsSession: context.elementsSession)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/ConsumerSessionLookupResponseTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/ConsumerSessionLookupResponseTests.swift
@@ -15,7 +15,7 @@ final class ConsumerSessionLookupResponseTests: XCTestCase {
           "exists": false,
           "error_message": "No consumer found",
           "suggested_email": "user@example.com",
-          "link_brand": "notlink"
+          "link_brand": "onelink"
         }
         """
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -81,11 +81,11 @@ class STPElementsSessionTest: XCTestCase {
 
     func testDecodedObjectFromAPIResponseMapping_linkBrandNotlink() {
         var elementsSessionJson = STPTestUtils.jsonNamed("ElementsSession")!
-        elementsSessionJson[jsonDict: "link_settings"]?["link_brand"] = "notlink"
+        elementsSessionJson[jsonDict: "link_settings"]?["link_brand"] = "onelink"
 
         let elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
 
-        XCTAssertEqual(LinkBrand.onelink.rawValue, "notlink")
+        XCTAssertEqual(LinkBrand.onelink.rawValue, "onelink")
         XCTAssertEqual(elementsSession.linkSettings?.brand, .onelink)
         XCTAssertEqual(elementsSession.linkBrand, .onelink)
     }

--- a/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
@@ -305,7 +305,7 @@ public class STPBankAccountCollector: NSObject {
                 existingConsumer: nil,
                 style: self.style.asFinancialConnectionsConfigurationStyle,
                 elementsSessionContext: elementsSessionContext,
-                brand: elementsSessionContext?.linkSettings?.brand,
+                brand: nil,
                 onEvent: onEvent,
                 from: viewController
             ) { result in
@@ -599,7 +599,7 @@ public class STPBankAccountCollector: NSObject {
                 existingConsumer: nil,
                 style: self.style.asFinancialConnectionsConfigurationStyle,
                 elementsSessionContext: elementsSessionContext,
-                brand: elementsSessionContext?.linkSettings?.brand,
+                brand: nil,
                 onEvent: onEvent,
                 from: viewController
             ) { result in
@@ -695,7 +695,7 @@ public class STPBankAccountCollector: NSObject {
                 existingConsumer: nil,
                 style: self.style.asFinancialConnectionsConfigurationStyle,
                 elementsSessionContext: elementsSessionContext,
-                brand: elementsSessionContext?.linkSettings?.brand,
+                brand: nil,
                 onEvent: onEvent,
                 from: viewController
             ) { result in


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
  - Use `synchronize.manifest.link_brand` as the base FC-native brand source, and override with a logged-in consumer session’s `link_brand` when available.
  - Remove stale ElementsSession-based brand fallback from FC entry points
  - Update naming for Financial Connections playground app toggle
  - Update parsed backend response for `LinkBrand`

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/LINK_MOBILE-800

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->


## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
