### PR TITLE
[iOS 26] Fix invalid string test on iOS 17+

### DIFF
--- a/Stripe/StripeiOSTests/Dictionary+StripeTests.swift
+++ b/Stripe/StripeiOSTests/Dictionary+StripeTests.swift
@@ -245,7 +245,7 @@ class Dictionary_StripeTests: XCTestCase {
         let dict =
             [
                 "a": "https://example.com",
-                "b": "not a url",
+                "b": "http://%",
             ] as [AnyHashable: Any]
         XCTAssertEqual(dict.stp_url(forKey: "a"), URL(string: "https://example.com"))
         XCTAssertNil(dict.stp_url(forKey: "b"))

--- a/Stripe/StripeiOSTests/STPIntentActionTest.swift
+++ b/Stripe/StripeiOSTests/STPIntentActionTest.swift
@@ -40,7 +40,7 @@ class STPIntentActionTest: XCTestCase {
             [
                         "type": "redirect_to_url",
                         "redirect_to_url": [
-                        "url": "not a url"
+                        "url": "http://%"
                     ],
                     ])
         XCTAssertNotNil(badURL)
@@ -72,7 +72,7 @@ class STPIntentActionTest: XCTestCase {
                         "type": "redirect_to_url",
                         "redirect_to_url": [
                         "url": "https://stripe.com/",
-                        "return_url": "not a url",
+                        "return_url": "http://%",
                     ],
                     ])
         XCTAssertNotNil(badReturnURL)


### PR DESCRIPTION
This test doesn't pass on iOS 17+ because [NSURL attempts to escape the URL](https://developer.apple.com/documentation/foundation/nsurl/urlwithstring:?language=objc#Discussion). We'll use a different known invalid string to support running on both iOS 16 and 26.