### PR TITLE
[iOS 26] Set card form postal code test country directly

### DIFF
--- a/Stripe/StripeiOSTests/STPCardFormViewTests.swift
+++ b/Stripe/StripeiOSTests/STPCardFormViewTests.swift
@@ -73,22 +73,20 @@ class STPCardFormViewTests: XCTestCase {
     }
 
     func testHidingPostalCodeOnInit() {
-        NSLocale.stp_withLocale(as: NSLocale(localeIdentifier: "zh_Hans_HK")) {
-            let cardForm = STPCardFormView()
-            XCTAssertTrue(cardForm.postalCodeField.isHidden)
-        }
+        let cardForm = STPCardFormView()
+        cardForm.countryCode = "HK"
+        XCTAssertTrue(cardForm.postalCodeField.isHidden)
     }
 
     func testHidingPostalUPECodeOnInit() {
-        NSLocale.stp_withLocale(as: NSLocale(localeIdentifier: "zh_Hans_HK")) {
-            let cardForm = STPCardFormView(
-                billingAddressCollection: .automatic,
-                style: .standard,
-                postalCodeRequirement: .upe,
-                prefillDetails: nil
-            )
-            XCTAssertTrue(cardForm.postalCodeField.isHidden)
-        }
+        let cardForm = STPCardFormView(
+            billingAddressCollection: .automatic,
+            style: .standard,
+            postalCodeRequirement: .upe,
+            prefillDetails: nil
+        )
+        cardForm.countryCode = "HK"
+        XCTAssertTrue(cardForm.postalCodeField.isHidden)
     }
 
     func testNotHidingPostalUPECodeOnInit() {


### PR DESCRIPTION
We can't swizzle NSLocale anymore in iOS 26, just set the country code to test this behavior instead.