### PR TITLE
[iOS 26] Allow passive captcha timeout error analytic

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ConfirmationChallenge/PassiveCaptchaChallengeTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ConfirmationChallenge/PassiveCaptchaChallengeTests.swift
@@ -73,7 +73,11 @@ class PassiveCaptchaChallengeTests: XCTestCase {
         XCTAssertFalse(hcaptchaTokenResult.success)
         XCTAssertThrowsError(try hcaptchaTokenResult.get())
         let passiveCaptchaEvents = STPAnalyticsClient.sharedClient._testLogHistory.map({ $0["event"] as? String }).filter({ $0?.starts(with: "elements.captcha.passive") ?? false })
-        XCTAssertEqual(passiveCaptchaEvents, ["elements.captcha.passive.init", "elements.captcha.passive.execute"])
+        XCTAssertEqual(Array(passiveCaptchaEvents.prefix(2)), ["elements.captcha.passive.init", "elements.captcha.passive.execute"])
+        XCTAssertTrue(
+            passiveCaptchaEvents.count == 2 ||
+            passiveCaptchaEvents == ["elements.captcha.passive.init", "elements.captcha.passive.execute", "elements.captcha.passive.error"]
+        )
     }
 
     func testPassiveCaptchaLongTimeout() async throws {


### PR DESCRIPTION
## Summary
- allow `testPassiveCaptchaTimeout` to accept the timeout error analytic emitted on newer runtimes
- still require the passive captcha `init` and `execute` events in order

## Validation
- `ci_scripts/run_tests.rb --test StripePaymentSheetTests/PassiveCaptchaChallengeTests/testPassiveCaptchaTimeout`
- `git diff --check`