### PR TITLE
[iOS 26] Stabilize PaymentSheet UI keyboard dismissal

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -436,7 +436,7 @@ class CustomerSheetUITest: XCTestCase {
         // Card brand choice should be enabled
         cardBrandChoiceCB.waitForExistenceAndTap(timeout: timeout)
         // Bug where it autoadvances to the MM / YY field even though it's filled out, have to tap Done again
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         // We should have selected cartes bancaires
         XCTAssertTrue(app.buttons["Cartes Bancaires"].isSelected)
@@ -826,7 +826,7 @@ class CustomerSheetUITest: XCTestCase {
 
         app.textFields["Country or region"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         let zipField = app.textFields["ZIP"]
         XCTAssertTrue(expField.waitForExistence(timeout: 3.0))
@@ -878,11 +878,11 @@ class CustomerSheetUITest: XCTestCase {
 
         app.textFields["Country or region"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         app.textFields["State"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "Alabama")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         let line1Field = app.textFields["Address line 1"]
         XCTAssertTrue(line1Field.waitForExistence(timeout: 3.0))
@@ -947,7 +947,7 @@ class CustomerSheetUITest: XCTestCase {
         let cardNumberField = app.textFields["Card number"]
         cardNumberField.waitForExistenceAndTap(timeout: timeout)
         cardNumberField.typeText("4")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         // Switch to bank form
         app.staticTexts["US bank account"].waitForExistenceAndTap(timeout: timeout)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITests.swift
@@ -32,7 +32,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         cardButton.tap()
         XCTAssertTrue(app.staticTexts["Add card"].waitForExistence(timeout: 10))
         try! fillCardData(app, postalEnabled: true)
-        app.toolbars.buttons["Done"].waitForExistenceAndTap()
+        app.stp_dismissKeyboard()
         XCTAssertTrue(app.buttons["Continue"].isEnabled)
         app.buttons["Continue"].waitForExistenceAndTap()
         sleep(1) // wait for 1 second for the sheet to dismiss
@@ -981,7 +981,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
 
         // Card number from https://docs.stripe.com/testing#regulatory-cards
         try! fillCardData(app, cardNumber: "4000002760003184")
-        app.toolbars.buttons["Done"].waitForExistenceAndTap()
+        app.stp_dismissKeyboard()
         app.buttons["Continue"].waitForExistenceAndTap()
         app.swipeUp() // scroll to see the checkout button
         app.buttons["Checkout"].waitForExistenceAndTap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
@@ -83,12 +83,9 @@ class FCLiteUITests: XCTestCase {
         let autofillButton = app.webViews.firstMatch.buttons.containing(autofillButtonPredicate).firstMatch
         XCTAssertTrue(autofillButton.waitForExistenceAndTap(timeout: 5.0))
 
-        // Dismiss keyboard if open - check for "Done" (iOS 18) or checkmark button (iOS 26)
-        let keyboardDoneButton = app.toolbars.buttons["Done"]
-        if keyboardDoneButton.waitForExistence(timeout: 1.0) {
-            keyboardDoneButton.tap()
-            Thread.sleep(forTimeInterval: 0.5)
-        }
+        // Dismiss keyboard if open
+        app.stp_dismissKeyboard()
+        Thread.sleep(forTimeInterval: 0.5)
 
         // Tap "Save with Link" button (tapPrimaryButton handles keyboard dismissal if needed)
         let saveWithLinkButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Save with Link'")

--- a/Example/PaymentSheet Example/PaymentSheetUITest/LinkTestHelpers.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/LinkTestHelpers.swift
@@ -66,7 +66,7 @@ extension XCTestCase {
         if includingBillingDetails {
             fillOutBillingDetails(app)
         } else {
-            XCTAssertTrue(app.toolbars.buttons["Done"].waitForExistenceAndTap(timeout: 10))
+            app.stp_dismissKeyboard()
         }
     }
 
@@ -97,7 +97,7 @@ extension XCTestCase {
             if stateField.exists {
                 stateField.tap()
                 app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "California")
-                app.toolbars.buttons["Done"].tap()
+                app.stp_dismissKeyboard()
             }
 
             let zipField = app.textFields["ZIP"]
@@ -106,7 +106,7 @@ extension XCTestCase {
                 zipField.typeText("94080")
             }
 
-            XCTAssertTrue(app.toolbars.buttons["Done"].waitForExistenceAndTap(timeout: 10))
+            app.stp_dismissKeyboard()
         }
     }
 

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
@@ -48,7 +48,7 @@ class PaymentSheet_AddressTests: XCTestCase {
 
         app.textFields["State"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: state)
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         app.textFields["ZIP"].tap()
         app.typeText(zip)
@@ -326,7 +326,7 @@ US
         // Set country to New Zealand
         app.textFields["Country or region"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇳🇿 New Zealand")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         // Address line 1 field should not contain an autocomplete affordance b/c autocomplete doesn't support New Zealand
         XCTAssertFalse(app.buttons["autocomplete_affordance"].exists)
@@ -405,8 +405,7 @@ NZ
         app.typeText("San Francisco")
         app.textFields["State"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "California")
-        app.toolbars.buttons["Done"].tap()
-        app.typeText("California")
+        app.stp_dismissKeyboard()
         app.textFields["ZIP"].tap()
         app.typeText("94102")
         app.buttons["Save address"].tap()
@@ -424,7 +423,7 @@ NZ
         app.buttons["Address"].tap()
         app.textFields["Country or region"].waitForExistenceAndTap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇾 Uruguay")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
         app.buttons["Save address"].tap()
 
         // ...should update PaymentSheet.FlowController
@@ -445,10 +444,10 @@ NZ
         app.buttons["Address"].tap()
         app.textFields["Country or region"].waitForExistenceAndTap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
         app.textFields["State"].waitForExistenceAndTap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "California")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
         app.buttons["Save address"].tap()
 
         // ...should not affect your billing address...
@@ -483,7 +482,7 @@ NZ
         // Select UK for phone number country
         app.textFields["United States +1"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇬🇧 United Kingdom +44")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         // Ensure UK is persisted as phone country after tapping done
         XCTAssert(app.textFields["United Kingdom +44"].exists)
@@ -575,7 +574,7 @@ NZ
 
         stateField.tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "New York")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         postalField.tap()
         let existingPostal = postalField.value as? String ?? ""

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUICardTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUICardTests.swift
@@ -51,7 +51,7 @@ class PaymentSheetBillingCollectionUICardTests: PaymentSheetBillingCollectionUIT
         app.typeText("4242424242424242")
         app.typeText("1228") // Expiry
         app.typeText("123") // CVC
-        app.toolbars.buttons["Done"].tap() // Dismiss keyboard.
+        app.stp_dismissKeyboard()
 
         // Dismiss FlowController payment method selector
         continueButton.tap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetCustomerSessionDedupeUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetCustomerSessionDedupeUITests.swift
@@ -358,7 +358,7 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
         }
     }
 
-    func test_updatePaymentMethod() throws {
+    func test_updatePaymentMethod() {
         var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
         settings.layout = .horizontal
         settings.mode = .paymentWithSetup
@@ -399,10 +399,10 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
 
         app.textFields["Country or region"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         let zipField = app.textFields["ZIP"]
-        XCTAssertTrue(expField.waitForExistence(timeout: 3.0))
+        XCTAssertTrue(expField.waitForExistence(timeout: 10.0))
         zipField.tap()
         zipField.typeText("55555")
         XCTAssertTrue(app.buttons["Save"].waitForExistenceAndTap(timeout: 3.0))
@@ -448,11 +448,11 @@ class PaymentSheetCustomerSessionDedupeUITests: PaymentSheetUITestCase {
 
         app.textFields["Country or region"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         app.textFields["State"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "Alabama")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         let line1Field = app.textFields["Address line 1"]
         XCTAssertTrue(line1Field.waitForExistence(timeout: 3.0))

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITestCase+Helpers.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITestCase+Helpers.swift
@@ -326,7 +326,7 @@ extension PaymentSheetUITestCase {
         XCTAssertTrue(countryCodeSelector.waitForExistence(timeout: 10.0), "Failed to find phone text field")
         countryCodeSelector.tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States (+1)")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         sleep(1) // Wait for keyboard to dismiss
         phoneTextField.tap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITests.swift
@@ -454,7 +454,7 @@ class PaymentSheetVerticalUITests: PaymentSheetUITestCase {
         app.buttons["Payment method"].waitForExistenceAndTap()
         app.buttons["Card"].waitForExistenceAndTap()
         try! fillCardData(app)
-        app.buttons["Done"].tap() // Tap done on keyboard, not sure why it doesn't auto dismiss
+        app.stp_dismissKeyboard() // Dismiss keyboard
         app.buttons["Continue"].waitForExistenceAndTap()
         // ...and *updating* to a SetupIntent...
         app.buttons["Setup"].waitForExistenceAndTap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
@@ -106,14 +106,42 @@ extension XCUIApplication {
         coordinate.tap()
     }
 
-    /// Dismisses the keyboard by tapping the Done button on the toolbar, or tapping outside the keyboard.
-    func fc_dismissKeyboard() {
-        // Try the toolbar Done button first (iOS 18 and earlier)
-        let doneButtonByLabel = toolbars.buttons["Done"]
-        if doneButtonByLabel.waitForExistence(timeout: 1) {
-            doneButtonByLabel.tap()
+    /// Dismisses the keyboard or picker wheel by tapping the Done button on the toolbar, or tapping outside.
+    func stp_dismissKeyboard() {
+        let pickerGone = NSPredicate(format: "exists == false")
+        let picker = pickerWheels.firstMatch
+
+        let doneButton = toolbars.buttons["Done"].firstMatch
+        if doneButton.waitForExistence(timeout: 2) {
+            doneButton.tap()
+
+            if picker.exists {
+                let expectation = XCTNSPredicateExpectation(predicate: pickerGone, object: picker)
+                let result = XCTWaiter.wait(for: [expectation], timeout: 3.0)
+                if result != .timedOut {
+                    return
+                }
+
+                if doneButton.exists {
+                    doneButton.tap()
+                    let retryResult = XCTWaiter.wait(
+                        for: [XCTNSPredicateExpectation(predicate: pickerGone, object: picker)],
+                        timeout: 3.0
+                    )
+                    if retryResult != .timedOut {
+                        return
+                    }
+                }
+
+                coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
+                _ = XCTWaiter.wait(
+                    for: [XCTNSPredicateExpectation(predicate: pickerGone, object: picker)],
+                    timeout: 3.0
+                )
+            }
             return
         }
+
         // iOS 26 fallback: tap on the title label to dismiss the keyboard
         // This works for FinancialConnections flows
         let fcTitleLabel = otherElements["fc_pane_title_label"]
@@ -121,8 +149,14 @@ extension XCUIApplication {
             fcTitleLabel.tap()
             return
         }
-        // Last resort: tap near the top of the screen
-        coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1)).tap()
+        // Last resort: tap near the top of the screen.
+        coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
+        if picker.exists {
+            _ = XCTWaiter.wait(
+                for: [XCTNSPredicateExpectation(predicate: pickerGone, object: picker)],
+                timeout: 3.0
+            )
+        }
     }
 }
 
@@ -338,7 +372,7 @@ extension XCTestCase {
         // This handles the FinancialConnections networking Link signup screen
         let notNowButton = app.buttons["networking_link_signup_footer_view.not_now_button"]
         if notNowButton.waitForExistence(timeout: 10.0) {
-            app.fc_dismissKeyboard()
+            app.stp_dismissKeyboard()
             notNowButton.tap()
         }
     }


### PR DESCRIPTION
## Summary
- replace direct PaymentSheet UI test toolbar Done taps with a shared keyboard/picker dismissal helper
- wait for picker wheels to disappear after tapping Done, with retry and tap-outside fallback for iOS 26
- fold in the keyboard-dismiss callsites from Embedded, Billing Card, Link/FCLite, CustomerSession dedupe, and Vertical UI tests
- remove an extra California text entry after selecting the state picker in the shipping update flow

## Validation
- `ci_scripts/run_tests.rb --ui --test PaymentSheetUITest/PaymentSheet_AddressTests/testPaymentSheetFlowControllerUpdatesShipping`
- `ci_scripts/run_tests.rb --ui --test PaymentSheetUITest/CustomerSheetUITest/testUpdatePaymentMethod_fullBilling`
- `ci_scripts/run_tests.rb --ui --test PaymentSheetUITest/CustomerSheetUITest/testUpdatePaymentMethod_auto`
- `ci_scripts/run_tests.rb --ui --test PaymentSheetUITest/EmbeddedUITests/testUpdate`
- `ci_scripts/run_tests.rb --ui --test PaymentSheetUITest/PaymentSheetBillingCollectionUICardTests/testCard_AllFields_flowController_WithDefaults`
- `ci_scripts/run_tests.rb --ui --test PaymentSheetUITest/LinkPaymentControllerUITest/testWebInstantDebitsOnlyLinkPaymentController`
- `git diff --check`
- `git diff --check HEAD~1..HEAD` after folding the extra callsites into this PR

Notes:
- `EmbeddedUITests/test3DS2CardAlwaysAuthenticate`, the CustomerSession dedupe callsites, and the Vertical callsite were folded in but not rerun locally after folding; CI is running on the combined branch.
- `FCLiteUITests/testFCLiteUSBankAccountFlow` failed before reaching the modified code path, at `FCLiteUITests.swift:71` while waiting for the initial PaymentSheet Continue button.
- The Embedded, Billing Card, and Link/FCLite keyboard-dismiss-only PRs were folded into this PR so reviewers have one keyboard-dismiss review surface.