### PR TITLE
[iOS 26] Use structurally invalid merchant logo URL

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -148,7 +148,7 @@ class STPElementsSessionTest: XCTestCase {
         XCTAssertNil(elementsSession.merchantLogoUrl)
 
         // invalid URL string
-        elementsSessionJson["merchant_logo_url"] = "invalid url"
+        elementsSessionJson["merchant_logo_url"] = "http://%"
         elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
         XCTAssertNil(elementsSession.merchantLogoUrl)
 


### PR DESCRIPTION
## Summary
- use a structurally invalid URL for the merchant logo URL decoding test
- keeps the test expectation stable on URL parsers that accept strings with spaces

## Testing
- ci_scripts/run_tests.rb --test StripePaymentSheetTests/STPElementsSessionTest/testDecodedObjectFromAPIResponseMapping_merchantLogoUrl
- git diff --check