### PR TITLE
[iOS 26] Avoid WKScriptMessage subclassing in ECE tests

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/ECE/ECEViewController.swift
@@ -342,7 +342,7 @@ extension ECEViewController: WKScriptMessageHandlerWithReply {
 
         Task {
             do {
-                let response = try await handleMessage(message: message)
+                let response = try await handleMessage(name: message.name, body: message.body)
                 replyHandler(response, nil)
             } catch {
                 replyHandler(nil, error.localizedDescription)
@@ -350,8 +350,7 @@ extension ECEViewController: WKScriptMessageHandlerWithReply {
         }
     }
 
-    func handleMessage(message: WKScriptMessage) async throws -> Any? {
-        let messageBody = message.body
+    func handleMessage(name: String, body messageBody: Any) async throws -> Any? {
         guard let expressCheckoutDelegate = expressCheckoutWebviewDelegate else {
             throw BridgeError("ExpressCheckoutWebviewDelegate not set")
         }
@@ -359,7 +358,7 @@ extension ECEViewController: WKScriptMessageHandlerWithReply {
             throw BridgeError("Invalid message format \(messageBody)")
         }
 
-        switch message.name {
+        switch name {
         case "calculateShipping":
             if let shippingAddress = messageDict["shippingAddress"] as? [String: Any] {
                 return try await expressCheckoutDelegate.eceView(self, didReceiveShippingAddressChange: shippingAddress)
@@ -389,7 +388,7 @@ extension ECEViewController: WKScriptMessageHandlerWithReply {
             }
 
         default:
-            throw BridgeError("Unknown message type: \(message.name)")
+            throw BridgeError("Unknown message type: \(name)")
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEIntegrationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEIntegrationTests.swift
@@ -338,10 +338,10 @@ class ECEIntegrationTests: XCTestCase {
         ]
 
         for testCase in testCases {
-            let message = MockWKScriptMessage(name: testCase.name, body: testCase.body)
+            let message = MockScriptMessage(name: testCase.name, body: testCase.body)
 
             do {
-                let response = try await eceViewController.handleMessage(message: message)
+                let response = try await eceViewController.handleMessage(name: message.name, body: message.body)
                 if testCase.expectedError {
                     XCTFail("Expected error for message: \(testCase.name)")
                 } else {
@@ -514,13 +514,9 @@ class ECEIntegrationTests: XCTestCase {
             ],
         ]
 
-        _ = try await eceViewController.userContentController(
-            WKUserContentController(),
-            didReceive: MockWKScriptMessage(
-                name: "calculateShipping",
-                body: ["shippingAddress": firstAddress]
-            ), replyHandler: { _, _ in
-            }
+        _ = try await eceViewController.handleMessage(
+            name: "calculateShipping",
+            body: ["shippingAddress": firstAddress]
         )
 
         // Second address change
@@ -534,13 +530,9 @@ class ECEIntegrationTests: XCTestCase {
             ],
         ]
 
-        _ = try await eceViewController.userContentController(
-            WKUserContentController(),
-            didReceive: MockWKScriptMessage(
-                name: "calculateShipping",
-                body: ["shippingAddress": secondAddress]
-            ), replyHandler: { _, _ in
-            }
+        _ = try await eceViewController.handleMessage(
+            name: "calculateShipping",
+            body: ["shippingAddress": secondAddress]
         )
 
         // Then

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECETestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECETestHelpers.swift
@@ -408,6 +408,14 @@ class MockExpressCheckoutWebviewDelegate: ExpressCheckoutWebviewDelegate {
 }
 
 @available(iOS 16.0, *)
+struct MockScriptMessage {
+    let name: String
+    let body: Any
+}
+
+/// WKScriptMessage subclass for integration tests that call userContentController(_:didReceive:).
+/// WKScriptMessage can crash on dealloc in async test contexts, so prefer handleMessage(name:body:) directly when possible.
+@available(iOS 16.0, *)
 class MockWKScriptMessage: WKScriptMessage {
     private let _name: String
     private let _body: Any
@@ -424,17 +432,9 @@ class MockWKScriptMessage: WKScriptMessage {
         super.init()
     }
 
-    override var name: String {
-        return _name
-    }
-
-    override var body: Any {
-        return _body
-    }
-
-    override var frameInfo: WKFrameInfo {
-        return _frameInfo
-    }
+    override var name: String { _name }
+    override var body: Any { _body }
+    override var frameInfo: WKFrameInfo { _frameInfo }
 }
 
 @available(iOS 16.0, *)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEViewControllerTests.swift
@@ -78,7 +78,7 @@ class ECEViewControllerTests: XCTestCase {
                 "country": "US",
             ],
         ]
-        let message = MockWKScriptMessage(
+        let message = MockScriptMessage(
             name: "calculateShipping",
             body: ["shippingAddress": shippingAddress]
         )
@@ -90,7 +90,7 @@ class ECEViewControllerTests: XCTestCase {
         ]
 
         // When
-        let response = try await sut.handleMessage(message: message)
+        let response = try await sut.handleMessage(name: message.name, body: message.body)
 
         // Then
         XCTAssertNotNil(response)
@@ -105,7 +105,7 @@ class ECEViewControllerTests: XCTestCase {
     func testHandleMessage_CalculateShippingRateChange() async throws {
         // Given
         let shippingRate: [String: Any] = ["id": "rate1", "displayName": "Express", "amount": 1000]
-        let message = MockWKScriptMessage(
+        let message = MockScriptMessage(
             name: "calculateShippingRateChange",
             body: ["shippingRate": shippingRate]
         )
@@ -117,7 +117,7 @@ class ECEViewControllerTests: XCTestCase {
         ]
 
         // When
-        let response = try await sut.handleMessage(message: message)
+        let response = try await sut.handleMessage(name: message.name, body: message.body)
 
         // Then
         XCTAssertNotNil(response)
@@ -135,7 +135,7 @@ class ECEViewControllerTests: XCTestCase {
             "billingDetails": ["email": "test@example.com", "name": "Test User"],
             "shippingAddress": ["address1": "123 Main St"],
         ]
-        let message = MockWKScriptMessage(
+        let message = MockScriptMessage(
             name: "confirmPayment",
             body: ["paymentDetails": paymentDetails]
         )
@@ -146,7 +146,7 @@ class ECEViewControllerTests: XCTestCase {
         ]
 
         // When
-        let response = try await sut.handleMessage(message: message)
+        let response = try await sut.handleMessage(name: message.name, body: message.body)
 
         // Then
         XCTAssertNotNil(response)
@@ -161,14 +161,14 @@ class ECEViewControllerTests: XCTestCase {
 
     func testHandleMessage_InvalidMessageFormat() async {
         // Given
-        let message = MockWKScriptMessage(
+        let message = MockScriptMessage(
             name: "calculateShipping",
             body: "invalid body" // Not a dictionary
         )
 
         // When/Then
         do {
-            _ = try await sut.handleMessage(message: message)
+            _ = try await sut.handleMessage(name: message.name, body: message.body)
             XCTFail("Should have thrown an error")
         } catch {
             XCTAssertTrue(error.localizedDescription.contains("Invalid message format"))
@@ -178,14 +178,14 @@ class ECEViewControllerTests: XCTestCase {
     func testHandleMessage_MissingDelegate() async {
         // Given
         sut.expressCheckoutWebviewDelegate = nil
-        let message = MockWKScriptMessage(
+        let message = MockScriptMessage(
             name: "calculateShipping",
             body: ["shippingAddress": [:]]
         )
 
         // When/Then
         do {
-            _ = try await sut.handleMessage(message: message)
+            _ = try await sut.handleMessage(name: message.name, body: message.body)
             XCTFail("Should have thrown an error")
         } catch {
             XCTAssertTrue(error.localizedDescription.contains("ExpressCheckoutWebviewDelegate not set"))


### PR DESCRIPTION
## Summary
- avoid WKScriptMessage subclassing in async ECE tests
- change ECE handleMessage to accept name/body directly so tests can bypass WKScriptMessage allocation
- route the multi-address integration test through handleMessage directly

## Testing
- ci_scripts/run_tests.rb --test StripePaymentSheetTests/ECEViewControllerTests --test StripePaymentSheetTests/ECEIntegrationTests/testWebViewMessageHandling --test StripePaymentSheetTests/ECEIntegrationTests/testShippingAddressChangeHandler_MultipleCalls
- git diff --check