### PR TITLE
[iOS 26] Suppress warnings during Periphery builds

### DIFF
--- a/.periphery.yml
+++ b/.periphery.yml
@@ -18,3 +18,6 @@ no_retain_spi: ["STP"]
 build_arguments:
   - -destination
   - 'generic/platform=iOS Simulator'
+  - SWIFT_SUPPRESS_WARNINGS=YES
+  - GCC_TREAT_WARNINGS_AS_ERRORS=NO
+  - SWIFT_TREAT_WARNINGS_AS_ERRORS=NO


### PR DESCRIPTION
## Summary
- add warning-suppression build arguments to the Periphery config
- keep the Xcode 26 dead-code scan focused on unused-code output instead of compiler warnings

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('.periphery.yml'); puts 'yaml ok'"`\n- `git diff --check`\n- `periphery scan --config .periphery.yml --skip-build --retain-codable-properties`