### PR TITLE
[iOS 26] Skip Fastlane device detection for install tests

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -170,7 +170,8 @@ platform :ios do
     end
     run_tests(
       workspace: './Tests/installation_tests/cocoapods/without_frameworks_objc/CocoapodsTest.xcworkspace',
-      destination: "platform=iOS Simulator,name=#{DEFAULT_TEST_DEVICE},OS=#{DEFAULT_TEST_VERSION}"
+      destination: "platform=iOS Simulator,name=#{DEFAULT_TEST_DEVICE},OS=#{DEFAULT_TEST_VERSION}",
+      skip_detect_devices: true
     )
   end
 
@@ -180,7 +181,8 @@ platform :ios do
     end
     run_tests(
       workspace: './Tests/installation_tests/cocoapods/with_frameworks_objc/CocoapodsTest.xcworkspace',
-      destination: "platform=iOS Simulator,name=#{DEFAULT_TEST_DEVICE},OS=#{DEFAULT_TEST_VERSION}"
+      destination: "platform=iOS Simulator,name=#{DEFAULT_TEST_DEVICE},OS=#{DEFAULT_TEST_VERSION}",
+      skip_detect_devices: true
     )
   end
 
@@ -190,7 +192,8 @@ platform :ios do
     end
     run_tests(
       workspace: './Tests/installation_tests/cocoapods/with_frameworks_swift/CocoapodsTest.xcworkspace',
-      destination: "platform=iOS Simulator,name=#{DEFAULT_TEST_DEVICE},OS=#{DEFAULT_TEST_VERSION}"
+      destination: "platform=iOS Simulator,name=#{DEFAULT_TEST_DEVICE},OS=#{DEFAULT_TEST_VERSION}",
+      skip_detect_devices: true
     )
   end
 
@@ -198,7 +201,8 @@ platform :ios do
     run_tests(
       workspace: './Tests/installation_tests/swift_package_manager/with_objc/SPMTest.xcworkspace',
       destination: "platform=iOS Simulator,name=#{DEFAULT_TEST_DEVICE},OS=#{DEFAULT_TEST_VERSION}",
-      scheme: 'SPMTest'
+      scheme: 'SPMTest',
+      skip_detect_devices: true
     )
   end
 
@@ -206,7 +210,8 @@ platform :ios do
     run_tests(
       workspace: './Tests/installation_tests/swift_package_manager/with_swift/SPMTest.xcworkspace',
       destination: "platform=iOS Simulator,name=#{DEFAULT_TEST_DEVICE},OS=#{DEFAULT_TEST_VERSION}",
-      scheme: 'SPMTest'
+      scheme: 'SPMTest',
+      skip_detect_devices: true
     )
   end
 


### PR DESCRIPTION
## Summary
- pass `skip_detect_devices: true` to the five installation-test Fastlane lanes
- keep the existing explicit simulator destinations unchanged

## Validation
- `ruby -c fastlane/Fastfile`
- `git diff --check`

Note: `bundle exec fastlane lanes` is blocked in this shell because the system Bundler path cannot find Bundler 2.3.3 from Gemfile.lock.