### PR TITLE
[iOS 26] Increase CustomerSheet update wait

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -787,7 +787,7 @@ class CustomerSheetUITest: XCTestCase {
         XCTAssertTrue(app.staticTexts["•••• 4242"].waitForExistence(timeout: timeout))
     }
 
-    func testUpdatePaymentMethod_auto() throws {
+    func testUpdatePaymentMethod_auto() {
         var settings = CustomerSheetTestPlaygroundSettings.defaultValues()
         settings.customerMode = .returning
         settings.customerKeyType = .customerSession
@@ -807,7 +807,7 @@ class CustomerSheetUITest: XCTestCase {
         editPMButton.tap()
 
         let expField = app.textFields["expiration date"]
-        XCTAssertTrue(expField.waitForExistence(timeout: 3.0))
+        XCTAssertTrue(expField.waitForExistence(timeout: 10.0))
         expField.tap()
         expField.typeText(XCUIKeyboardKey.delete.rawValue)
         expField.typeText(XCUIKeyboardKey.delete.rawValue)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CustomerSheetUITest.swift
@@ -436,7 +436,7 @@ class CustomerSheetUITest: XCTestCase {
         // Card brand choice should be enabled
         cardBrandChoiceCB.waitForExistenceAndTap(timeout: timeout)
         // Bug where it autoadvances to the MM / YY field even though it's filled out, have to tap Done again
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         // We should have selected cartes bancaires
         XCTAssertTrue(app.buttons["Cartes Bancaires"].isSelected)
@@ -826,7 +826,7 @@ class CustomerSheetUITest: XCTestCase {
 
         app.textFields["Country or region"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         let zipField = app.textFields["ZIP"]
         XCTAssertTrue(expField.waitForExistence(timeout: 3.0))
@@ -878,11 +878,11 @@ class CustomerSheetUITest: XCTestCase {
 
         app.textFields["Country or region"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         app.textFields["State"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "Alabama")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         let line1Field = app.textFields["Address line 1"]
         XCTAssertTrue(line1Field.waitForExistence(timeout: 3.0))
@@ -947,7 +947,7 @@ class CustomerSheetUITest: XCTestCase {
         let cardNumberField = app.textFields["Card number"]
         cardNumberField.waitForExistenceAndTap(timeout: timeout)
         cardNumberField.typeText("4")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         // Switch to bank form
         app.staticTexts["US bank account"].waitForExistenceAndTap(timeout: timeout)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
@@ -48,7 +48,7 @@ class PaymentSheet_AddressTests: XCTestCase {
 
         app.textFields["State"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: state)
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         app.textFields["ZIP"].tap()
         app.typeText(zip)
@@ -326,7 +326,7 @@ US
         // Set country to New Zealand
         app.textFields["Country or region"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇳🇿 New Zealand")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         // Address line 1 field should not contain an autocomplete affordance b/c autocomplete doesn't support New Zealand
         XCTAssertFalse(app.buttons["autocomplete_affordance"].exists)
@@ -405,8 +405,7 @@ NZ
         app.typeText("San Francisco")
         app.textFields["State"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "California")
-        app.toolbars.buttons["Done"].tap()
-        app.typeText("California")
+        app.stp_dismissKeyboard()
         app.textFields["ZIP"].tap()
         app.typeText("94102")
         app.buttons["Save address"].tap()
@@ -424,7 +423,7 @@ NZ
         app.buttons["Address"].tap()
         app.textFields["Country or region"].waitForExistenceAndTap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇾 Uruguay")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
         app.buttons["Save address"].tap()
 
         // ...should update PaymentSheet.FlowController
@@ -445,10 +444,10 @@ NZ
         app.buttons["Address"].tap()
         app.textFields["Country or region"].waitForExistenceAndTap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇺🇸 United States")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
         app.textFields["State"].waitForExistenceAndTap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "California")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
         app.buttons["Save address"].tap()
 
         // ...should not affect your billing address...
@@ -483,7 +482,7 @@ NZ
         // Select UK for phone number country
         app.textFields["United States +1"].tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "🇬🇧 United Kingdom +44")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         // Ensure UK is persisted as phone country after tapping done
         XCTAssert(app.textFields["United Kingdom +44"].exists)
@@ -575,7 +574,7 @@ NZ
 
         stateField.tap()
         app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "New York")
-        app.toolbars.buttons["Done"].tap()
+        app.stp_dismissKeyboard()
 
         postalField.tap()
         let existingPostal = postalField.value as? String ?? ""

--- a/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/XCUITest+Utilities.swift
@@ -106,14 +106,42 @@ extension XCUIApplication {
         coordinate.tap()
     }
 
-    /// Dismisses the keyboard by tapping the Done button on the toolbar, or tapping outside the keyboard.
-    func fc_dismissKeyboard() {
-        // Try the toolbar Done button first (iOS 18 and earlier)
-        let doneButtonByLabel = toolbars.buttons["Done"]
-        if doneButtonByLabel.waitForExistence(timeout: 1) {
-            doneButtonByLabel.tap()
+    /// Dismisses the keyboard or picker wheel by tapping the Done button on the toolbar, or tapping outside.
+    func stp_dismissKeyboard() {
+        let pickerGone = NSPredicate(format: "exists == false")
+        let picker = pickerWheels.firstMatch
+
+        let doneButton = toolbars.buttons["Done"].firstMatch
+        if doneButton.waitForExistence(timeout: 2) {
+            doneButton.tap()
+
+            if picker.exists {
+                let expectation = XCTNSPredicateExpectation(predicate: pickerGone, object: picker)
+                let result = XCTWaiter.wait(for: [expectation], timeout: 3.0)
+                if result != .timedOut {
+                    return
+                }
+
+                if doneButton.exists {
+                    doneButton.tap()
+                    let retryResult = XCTWaiter.wait(
+                        for: [XCTNSPredicateExpectation(predicate: pickerGone, object: picker)],
+                        timeout: 3.0
+                    )
+                    if retryResult != .timedOut {
+                        return
+                    }
+                }
+
+                coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
+                _ = XCTWaiter.wait(
+                    for: [XCTNSPredicateExpectation(predicate: pickerGone, object: picker)],
+                    timeout: 3.0
+                )
+            }
             return
         }
+
         // iOS 26 fallback: tap on the title label to dismiss the keyboard
         // This works for FinancialConnections flows
         let fcTitleLabel = otherElements["fc_pane_title_label"]
@@ -121,8 +149,14 @@ extension XCUIApplication {
             fcTitleLabel.tap()
             return
         }
-        // Last resort: tap near the top of the screen
-        coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.1)).tap()
+        // Last resort: tap near the top of the screen.
+        coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2)).tap()
+        if picker.exists {
+            _ = XCTWaiter.wait(
+                for: [XCTNSPredicateExpectation(predicate: pickerGone, object: picker)],
+                timeout: 3.0
+            )
+        }
     }
 }
 
@@ -338,7 +372,7 @@ extension XCTestCase {
         // This handles the FinancialConnections networking Link signup screen
         let notNowButton = app.buttons["networking_link_signup_footer_view.not_now_button"]
         if notNowButton.waitForExistence(timeout: 10.0) {
-            app.fc_dismissKeyboard()
+            app.stp_dismissKeyboard()
             notNowButton.tap()
         }
     }


### PR DESCRIPTION
## Summary
- give `testUpdatePaymentMethod_auto` more time to find the expiration-date field after opening edit mode
- remove the unused throwing signature while touching the test

## Validation
- `ci_scripts/run_tests.rb --ui --test PaymentSheetUITest/CustomerSheetUITest/testUpdatePaymentMethod_auto`
- `git diff --check`

Stacked on #6477 for the shared `stp_dismissKeyboard()` helper.