### PR TITLE
Improve accessibility on AP selector

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CurrencySelectorUtilities.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CurrencySelectorUtilities.swift
@@ -64,6 +64,7 @@ enum CurrencySelectorUtilities {
         return TwoOptionSelectorItem(
             id: currency.apiValue,
             displayText: displayText,
+            accessibilityLabel: "\(amount) \(currency.displayValue)",
             accessibilityIdentifier: "currency_option_\(currency.apiValue)"
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TwoOptionSelectorView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TwoOptionSelectorView.swift
@@ -11,6 +11,7 @@ import UIKit
 struct TwoOptionSelectorItem: Equatable {
     let id: String
     let displayText: NSAttributedString
+    let accessibilityLabel: String
     let accessibilityIdentifier: String
 }
 
@@ -161,6 +162,7 @@ final class TwoOptionSelectorView: UIView {
         button.contentEdgeInsets = UIEdgeInsets(top: 7, left: 16, bottom: 7, right: 16)
         button.backgroundColor = .clear
         button.addTarget(self, action: #selector(buttonTapped(_:)), for: .touchUpInside)
+        button.accessibilityLabel = item.accessibilityLabel
         button.accessibilityIdentifier = item.accessibilityIdentifier
     }
 
@@ -170,6 +172,9 @@ final class TwoOptionSelectorView: UIView {
 
         applyTitleColor(to: leftButton, item: leftItem, color: isLeftSelected ? appearance.colors.componentText : appearance.colors.textSecondary, font: font)
         applyTitleColor(to: rightButton, item: rightItem, color: !isLeftSelected ? appearance.colors.componentText : appearance.colors.textSecondary, font: font)
+
+        leftButton.accessibilityTraits = isLeftSelected ? [.button, .selected] : .button
+        rightButton.accessibilityTraits = !isLeftSelected ? [.button, .selected] : .button
         indicatorLeadingConstraint?.isActive = false
         indicatorTrailingConstraint?.isActive = false
 
@@ -227,6 +232,7 @@ final class TwoOptionSelectorView: UIView {
         if notifyDelegate {
             delegate?.twoOptionSelectorView(self, didSelectItemWithId: itemId)
         }
+        UIAccessibility.post(notification: .layoutChanged, argument: itemId == leftItem.id ? leftButton : rightButton)
     }
 
 #if !os(visionOS)


### PR DESCRIPTION
## Summary
- Add VoiceOver accessibility support to the TwoOptionSelectorView used by the currency selector.
- The currency selector buttons had no accessibilityLabel (only accessibilityIdentifier which is for testing), no .selected trait to indicate the active currency, and no accessibility notification when selection changes.

## Motivation
- CheckoutSessions

## Testing
- Manual

## Changelog
N/A
