### PR TITLE
[iOS 26] Use keyboard dismiss helper in Embedded UI tests

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITests.swift
@@ -32,7 +32,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         cardButton.tap()
         XCTAssertTrue(app.staticTexts["Add card"].waitForExistence(timeout: 10))
         try! fillCardData(app, postalEnabled: true)
-        app.toolbars.buttons["Done"].waitForExistenceAndTap()
+        app.stp_dismissKeyboard()
         XCTAssertTrue(app.buttons["Continue"].isEnabled)
         app.buttons["Continue"].waitForExistenceAndTap()
         sleep(1) // wait for 1 second for the sheet to dismiss
@@ -981,7 +981,7 @@ class EmbeddedUITests: PaymentSheetUITestCase {
 
         // Card number from https://docs.stripe.com/testing#regulatory-cards
         try! fillCardData(app, cardNumber: "4000002760003184")
-        app.toolbars.buttons["Done"].waitForExistenceAndTap()
+        app.stp_dismissKeyboard()
         app.buttons["Continue"].waitForExistenceAndTap()
         app.swipeUp() // scroll to see the checkout button
         app.buttons["Checkout"].waitForExistenceAndTap()


### PR DESCRIPTION
## Summary
- replace two toolbar Done taps in Embedded UI tests with `stp_dismissKeyboard()`
- keep the change test-only and stacked on the shared keyboard helper

## Validation
- `ci_scripts/run_tests.rb --ui --test PaymentSheetUITest/EmbeddedUITests/testUpdate`
- `git diff --check`

Note: the same callsite pattern in `test3DS2CardAlwaysAuthenticate` changed too, but I did not rerun that heavier 3DS path locally.