### PR TITLE
[iOS 26] Use keyboard dismiss helper in billing card UI test

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUICardTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetBillingCollectionUICardTests.swift
@@ -51,7 +51,7 @@ class PaymentSheetBillingCollectionUICardTests: PaymentSheetBillingCollectionUIT
         app.typeText("4242424242424242")
         app.typeText("1228") // Expiry
         app.typeText("123") // CVC
-        app.toolbars.buttons["Done"].tap() // Dismiss keyboard.
+        app.stp_dismissKeyboard()
 
         // Dismiss FlowController payment method selector
         continueButton.tap()


### PR DESCRIPTION
## Summary
- replace the billing card UI test toolbar Done tap with `stp_dismissKeyboard()`
- keep the change to a single test callsite

## Validation
- `ci_scripts/run_tests.rb --ui --test PaymentSheetUITest/PaymentSheetBillingCollectionUICardTests/testCard_AllFields_flowController_WithDefaults`
- `git diff --check`

Stacked on #6477 for the shared keyboard dismissal helper.