### PR TITLE
[iOS 26] Use keyboard dismiss helper in Link UI tests

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/FCLiteUITests.swift
@@ -83,12 +83,9 @@ class FCLiteUITests: XCTestCase {
         let autofillButton = app.webViews.firstMatch.buttons.containing(autofillButtonPredicate).firstMatch
         XCTAssertTrue(autofillButton.waitForExistenceAndTap(timeout: 5.0))
 
-        // Dismiss keyboard if open - check for "Done" (iOS 18) or checkmark button (iOS 26)
-        let keyboardDoneButton = app.toolbars.buttons["Done"]
-        if keyboardDoneButton.waitForExistence(timeout: 1.0) {
-            keyboardDoneButton.tap()
-            Thread.sleep(forTimeInterval: 0.5)
-        }
+        // Dismiss keyboard if open
+        app.stp_dismissKeyboard()
+        Thread.sleep(forTimeInterval: 0.5)
 
         // Tap "Save with Link" button (tapPrimaryButton handles keyboard dismissal if needed)
         let saveWithLinkButtonPredicate = NSPredicate(format: "label CONTAINS[cd] 'Save with Link'")

--- a/Example/PaymentSheet Example/PaymentSheetUITest/LinkTestHelpers.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/LinkTestHelpers.swift
@@ -66,7 +66,7 @@ extension XCTestCase {
         if includingBillingDetails {
             fillOutBillingDetails(app)
         } else {
-            XCTAssertTrue(app.toolbars.buttons["Done"].waitForExistenceAndTap(timeout: 10))
+            app.stp_dismissKeyboard()
         }
     }
 
@@ -97,7 +97,7 @@ extension XCTestCase {
             if stateField.exists {
                 stateField.tap()
                 app.pickerWheels.firstMatch.adjust(toPickerWheelValue: "California")
-                app.toolbars.buttons["Done"].tap()
+                app.stp_dismissKeyboard()
             }
 
             let zipField = app.textFields["ZIP"]
@@ -106,7 +106,7 @@ extension XCTestCase {
                 zipField.typeText("94080")
             }
 
-            XCTAssertTrue(app.toolbars.buttons["Done"].waitForExistenceAndTap(timeout: 10))
+            app.stp_dismissKeyboard()
         }
     }
 


### PR DESCRIPTION
## Summary
- replace toolbar Done taps in Link UI test helpers with the shared `stp_dismissKeyboard()` helper
- use the same helper in the FCLite US bank autofill flow
- keep this test-only and stacked on #6477

## Testing
- `ci_scripts/run_tests.rb --ui --test PaymentSheetUITest/LinkPaymentControllerUITest/testWebInstantDebitsOnlyLinkPaymentController`
- `git diff --cached --check`

Note: `ci_scripts/run_tests.rb --ui --test PaymentSheetUITest/FCLiteUITests/testFCLiteUSBankAccountFlow` failed before reaching the modified code path, at `FCLiteUITests.swift:71` while waiting for the initial PaymentSheet Continue button.