### PR TITLE
[link] Clean up `LinkBrand` changes

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundConfiguration.swift
@@ -148,9 +148,9 @@ final class PlaygroundConfiguration {
 
             switch linkBrandString {
             case "link":
-                return .on
-            case "onelink":
                 return .off
+            case "onelink":
+                return .on
             default:
                 return .off
             }
@@ -617,9 +617,9 @@ final class PlaygroundConfiguration {
         } else {
             switch dictionary[Self.linkBrandKey] as? String {
             case "link":
-                self.linkBrand = .on
-            case "onelink":
                 self.linkBrand = .off
+            case "onelink":
+                self.linkBrand = .on
             default:
                 self.linkBrand = .off
             }

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -842,7 +842,7 @@ private func PresentPaymentSheet(
     case .alwaysDark: configuration.style = .alwaysDark
     }
 
-    if config.linkBrand == .off {
+    if config.linkBrand == .on {
         configuration.link.brand = .onelink
     }
 

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -727,7 +727,7 @@ private func PresentFinancialConnectionsSheet(
     let isUITest = (ProcessInfo.processInfo.environment["UITesting"] != nil)
     var configuration = FinancialConnectionsSheet.Configuration()
     configuration.style = style.configurationValue
-    configuration.linkBrand = linkBrand == .off ? .onelink : nil
+    configuration.linkBrand = linkBrand == .on ? .onelink : nil
     let financialConnectionsSheet = FinancialConnectionsSheet(
         financialConnectionsSessionClientSecret: clientSecret,
         // disable app-to-app for UI tests

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPI.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAPI.swift
@@ -8,7 +8,7 @@
 import Foundation
 @_spi(STP) import StripeCore
 
-protocol FinancialConnectionsAPI: AnyObject {
+protocol FinancialConnectionsAPI {
     typealias SaveAccountsToNetworkAndLinkResponse = (
         manifest: FinancialConnectionsSessionManifest,
         customSuccessPaneMessage: String?

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/ConsumerSession/ConsumerSessionModels.swift
@@ -69,33 +69,3 @@ struct ConsumerSessionConfirmVerificationResponse: Decodable {
     let consumerSession: ConsumerSessionData
     let linkBrand: LinkBrand
 }
-
-extension LinkSignUpResponse {
-    private enum CodingKeys: String, CodingKey {
-        case accountId
-        case publishableKey
-        case consumerSession
-        case linkBrand
-    }
-
-    init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.accountId = try container.decode(String.self, forKey: .accountId)
-        self.publishableKey = try container.decode(String.self, forKey: .publishableKey)
-        self.consumerSession = try container.decode(ConsumerSessionData.self, forKey: .consumerSession)
-        self.linkBrand = try container.decode(LinkBrand.self, forKey: .linkBrand)
-    }
-}
-
-extension ConsumerSessionConfirmVerificationResponse {
-    private enum CodingKeys: String, CodingKey {
-        case consumerSession
-        case linkBrand
-    }
-
-    init(from decoder: any Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        self.consumerSession = try container.decode(ConsumerSessionData.self, forKey: .consumerSession)
-        self.linkBrand = try container.decode(LinkBrand.self, forKey: .linkBrand)
-    }
-}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -316,7 +316,7 @@ final public class FinancialConnectionsSheet {
             }
         }
 
-        let financialConnectionsApiClient: any FinancialConnectionsAPI = FinancialConnectionsAsyncAPIClient(apiClient: apiClient)
+        var financialConnectionsApiClient: any FinancialConnectionsAPI = FinancialConnectionsAsyncAPIClient(apiClient: apiClient)
 
         if let existingConsumer {
             let verificationSessions = existingConsumer.verificationSessions.map { verificationSession in

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/FinancialConnectionsAppearance.swift
@@ -78,18 +78,16 @@ struct FinancialConnectionsAppearance: Equatable {
         theme: FinancialConnectionsSessionManifest.Theme?,
         linkBrand: LinkBrand?
     ) -> ResolvedBrand {
-        switch PresentationManager.shared.resolvedLinkBrand(manifestLinkBrand: linkBrand) {
-        case .link:
-            return .link
-        case .onelink:
-            return .onelink
-        case .unparsable, .none:
-            switch theme {
-            case .linkLight:
+        switch theme {
+        case .linkLight:
+            switch PresentationManager.shared.resolvedLinkBrand(manifestLinkBrand: linkBrand) {
+            case .onelink:
+                return .onelink
+            case .link, .unparsable, .none:
                 return .link
-            case .light, .dashboardLight, .unparsable, .none:
-                return .stripe
             }
+        case .light, .dashboardLight, .unparsable, .none:
+            return .stripe
         }
     }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/NetworkingOTPView/NetworkingOTPDataSource.swift
@@ -30,7 +30,7 @@ final class NetworkingOTPDataSourceImplementation: NetworkingOTPDataSource {
     let analyticsClient: FinancialConnectionsAnalyticsClient
     private let customEmailType: String?
     private let connectionsMerchantName: String?
-    private let apiClient: any FinancialConnectionsAPI
+    private var apiClient: any FinancialConnectionsAPI
     private let manifest: FinancialConnectionsSessionManifest
     weak var delegate: NetworkingOTPDataSourceDelegate?
 

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSessionTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSessionTests.swift
@@ -70,23 +70,6 @@ final class FinancialConnectionsSessionTests: XCTestCase {
         )
     }
 
-    func testSynchronizeParsesLinkBrand() throws {
-        let synchronize = try makeSynchronize(brandValue: "link")
-
-        XCTAssertEqual(synchronize.manifest.linkBrand, .link)
-        XCTAssertEqual(synchronize.manifest.appearance.logo, .link_logo)
-        XCTAssertTrue(
-            synchronize.manifest.appearance.colors.primary.isEqual(FinancialConnectionsAppearance.Colors.stripe.primary)
-        )
-    }
-
-    func testSynchronizeParsesOnelinkBrand() throws {
-        let synchronize = try makeSynchronize(brandValue: "onelink")
-
-        XCTAssertEqual(synchronize.manifest.linkBrand, .onelink)
-        XCTAssertEqual(synchronize.manifest.appearance.logo, .onelink_logo)
-    }
-
     func testSynchronizeParsesUnknownBrandAsUnparsable() throws {
         let synchronize = try makeSynchronize(brandValue: "random_brand")
 
@@ -100,13 +83,6 @@ final class FinancialConnectionsSessionTests: XCTestCase {
         XCTAssertNil(manifest.linkBrand)
         XCTAssertEqual(manifest.appearance.logo, .link_logo)
         XCTAssertTrue(manifest.appearance.colors.primary.isEqual(FinancialConnectionsAppearance.Colors.link.primary))
-    }
-
-    func testExplicitBrandOverridesLogoWithoutChangingThemeColors() {
-        let manifest = makeManifest(theme: .light, linkBrand: .onelink)
-
-        XCTAssertEqual(manifest.appearance.logo, .onelink_logo)
-        XCTAssertTrue(manifest.appearance.colors.primary.isEqual(FinancialConnectionsAppearance.Colors.stripe.primary))
     }
 
     private func makeSynchronize(brandValue: String?) throws -> FinancialConnectionsSynchronize {

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/PresentationManagerTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/PresentationManagerTests.swift
@@ -33,35 +33,6 @@ class PresentationManagerTests: XCTestCase {
         XCTAssertEqual(toViewController.traitCollection.userInterfaceStyle, .dark)
     }
 
-    func testLinkBrandOverrideIsAvailableToAppearanceResolution() {
-        var configuration = FinancialConnectionsSheet.Configuration()
-        configuration.linkBrand = .onelink
-        PresentationManager.shared.configuration = configuration
-
-        let appearance = FinancialConnectionsAppearance(theme: .light, linkBrand: nil)
-
-        XCTAssertEqual(appearance.logo, .onelink_logo)
-    }
-
-    func testAuthenticatedLinkBrandOverridesManifestBrand() {
-        PresentationManager.shared.setAuthenticatedLinkBrand(.onelink)
-
-        let appearance = FinancialConnectionsAppearance(theme: .light, linkBrand: .link)
-
-        XCTAssertEqual(appearance.logo, .onelink_logo)
-    }
-
-    func testConfigurationLinkBrandOverridesAuthenticatedLinkBrand() {
-        var configuration = FinancialConnectionsSheet.Configuration()
-        configuration.linkBrand = .link
-        PresentationManager.shared.configuration = configuration
-        PresentationManager.shared.setAuthenticatedLinkBrand(.onelink)
-
-        let appearance = FinancialConnectionsAppearance(theme: .light, linkBrand: nil)
-
-        XCTAssertEqual(appearance.logo, .link_logo)
-    }
-
     func testOnelinkBrandUsesSameTintAsLinkForLightTheme() {
         let onelinkAppearance = FinancialConnectionsAppearance(theme: .light, linkBrand: .onelink)
         let linkAppearance = FinancialConnectionsAppearance(theme: .light, linkBrand: .link)


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Apply fixes to `LinkBrand` flow:
1. Give precedence to `linkTheme` to prevent `linkBrand` from overriding it.
2. Fix inverted example app toggle values
3. Address follow up fixes from previous PR #6489 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
https://jira.corp.stripe.com/browse/LINK_MOBILE-800

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Tested on BrowserStack

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
