### PR TITLE
[iOS 26] Use keyboard dismiss helper in FinancialConnections UI tests

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/FinancialConnectionsUITests.swift
@@ -488,7 +488,7 @@ final class FinancialConnectionsUITests: XCTestCase {
 
         let notNowButton = app.fc_nativeNetworkingNotNowButton
         XCTAssert(notNowButton.waitForExistence(timeout: 60)) // wait for networking sign up to show
-        app.fc_dismissKeyboard()
+        app.stp_dismissKeyboard()
         notNowButton.waitForExistenceAndTap() // skip networking sign up
 
         // ...the success pane will be skipped...
@@ -518,7 +518,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_nativeConnectAccountsButton.tap()
 
         XCTAssert(app.fc_nativeNetworkingNotNowButton.waitForExistence(timeout: 60)) // wait for networking sign up to show
-        app.fc_dismissKeyboard()
+        app.stp_dismissKeyboard()
         app.fc_nativeNetworkingNotNowButton.waitForExistenceAndTap() // skip networking sign up
 
         app.fc_nativeSuccessDoneButton.tap()
@@ -548,7 +548,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_nativeConnectAccountsButton.tap()
 
         XCTAssert(app.fc_nativeNetworkingNotNowButton.waitForExistence(timeout: 60)) // wait for networking sign up to show
-        app.fc_dismissKeyboard()
+        app.stp_dismissKeyboard()
         app.fc_nativeNetworkingNotNowButton.waitForExistenceAndTap() // skip networking sign up
 
         app.fc_nativeSuccessDoneButton.tap()
@@ -577,7 +577,7 @@ final class FinancialConnectionsUITests: XCTestCase {
 
         // the not now button could appear if networking manual entry is enabled
         if app.fc_nativeNetworkingNotNowButton.waitForExistence(timeout: 5) {
-            app.fc_dismissKeyboard()
+            app.stp_dismissKeyboard()
             app.fc_nativeNetworkingNotNowButton.waitForExistenceAndTap() // skip networking sign up
         }
 
@@ -604,7 +604,7 @@ final class FinancialConnectionsUITests: XCTestCase {
         app.fc_nativeConnectAccountsButton.tap()
 
         XCTAssert(app.fc_nativeNetworkingNotNowButton.waitForExistence(timeout: 60)) // wait for networking sign up to show
-        app.fc_dismissKeyboard()
+        app.stp_dismissKeyboard()
         app.fc_nativeNetworkingNotNowButton.waitForExistenceAndTap() // skip networking sign up
 
         app.fc_nativeSuccessDoneButton.tap()

--- a/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
+++ b/Example/FinancialConnections Example/FinancialConnectionsUITests/XCUIApplication+Extensions.swift
@@ -183,7 +183,7 @@ extension XCUIApplication {
         swipeUp(velocity: .verySlow)
     }
 
-    func fc_dismissKeyboard() {
+    func stp_dismissKeyboard() {
         // Try the toolbar Done button first (iOS 18 and earlier)
         let doneButtonByLabel = toolbars.buttons["Done"]
         if doneButtonByLabel.waitForExistence(timeout: 1) {


### PR DESCRIPTION
## Summary
- rename the FinancialConnections UI-test keyboard dismissal helper to `stp_dismissKeyboard()`
- update the native networking signup callsites to use the renamed helper
- keep the behavior identical while matching the shared iOS 26 UI-test naming pattern

## Validation
- `ci_scripts/run_tests.rb --scheme "FinancialConnections Example" --test FinancialConnectionsUITests/FinancialConnectionsUITests/testNativeConnectMerchantForDataUseCase` passed on rerun
- `git -c core.fsmonitor=false diff --cached --check`

Note: the first run of the same UI test failed waiting for the success pane after tapping Not now; rerunning passed without code changes.