### PR TITLE
Support WalletButtonsView in horizontal PaymentSheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -857,6 +857,7 @@ extension PaymentSheet {
                     configuration: configuration,
                     loadResult: loadResult,
                     analyticsHelper: analyticsHelper,
+                    walletButtonsViewState: walletButtonsViewState,
                     previousPaymentOption: previousPaymentOption
                 )
             case .vertical:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -37,7 +37,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
             } else if let paymentOption = savedPaymentOptionsViewController.selectedPaymentOption {
                 // If no valid payment option from adding, fallback on any saved payment method
                 return paymentOption
-            } else if isApplePayEnabled {
+            } else if shouldShowApplePayInSavedPaymentOptions {
                 return .applePay
             }
             return nil
@@ -91,6 +91,8 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
     private var mode: Mode
     private let isApplePayEnabled: Bool
     private let isLinkEnabled: Bool
+    private let shouldShowApplePayInSavedPaymentOptions: Bool
+    private let shouldShowLinkInSavedPaymentOptions: Bool
     private let couldShowLinkInHeader: Bool
     private var isHackyLinkButtonSelected: Bool = false
     var linkConfirmOption: PaymentSheet.LinkConfirmOption?
@@ -172,6 +174,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         configuration: PaymentSheet.Configuration,
         loadResult: PaymentSheetLoader.LoadResult,
         analyticsHelper: PaymentSheetAnalyticsHelper,
+        walletButtonsViewState: PaymentSheet.WalletButtonsViewState = .hidden,
         previousPaymentOption: PaymentOption? = nil
     ) {
         self.loadResult = loadResult
@@ -179,7 +182,9 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         self.elementsSession = loadResult.elementsSession
         self.isApplePayEnabled = PaymentSheet.isApplePayEnabled(elementsSession: elementsSession, configuration: configuration)
         self.isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
-        self.couldShowLinkInHeader = isLinkEnabled && !isApplePayEnabled
+        self.shouldShowApplePayInSavedPaymentOptions = isApplePayEnabled && PaymentSheetVerticalViewController.walletButtonsViewAllowsExpressType(.applePay, walletButtonsViewState: walletButtonsViewState, configuration: configuration)
+        self.shouldShowLinkInSavedPaymentOptions = isLinkEnabled && PaymentSheetVerticalViewController.walletButtonsViewAllowsExpressType(.link, walletButtonsViewState: walletButtonsViewState, configuration: configuration)
+        self.couldShowLinkInHeader = shouldShowLinkInSavedPaymentOptions && !shouldShowApplePayInSavedPaymentOptions
         self.configuration = configuration
         self.analyticsHelper = analyticsHelper
 
@@ -191,7 +196,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
 
         // Default to saved payment selection mode, as long as we aren't restoring a customer's previous new payment method input
         // and they have saved PMs or Apple Pay or Link is enabled
-        self.mode = (previousConfirmParams == nil) && (loadResult.savedPaymentMethods.count > 0 || isApplePayEnabled || isLinkEnabled)
+        self.mode = (previousConfirmParams == nil) && (loadResult.savedPaymentMethods.count > 0 || shouldShowApplePayInSavedPaymentOptions || shouldShowLinkInSavedPaymentOptions)
                 ? .selectingSaved
                 : .addingNew
 
@@ -199,8 +204,8 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
             savedPaymentMethods: loadResult.savedPaymentMethods,
             configuration: .init(
                 customerID: configuration.customer?.id,
-                showApplePay: isApplePayEnabled,
-                showLink: isLinkEnabled,
+                showApplePay: shouldShowApplePayInSavedPaymentOptions,
+                showLink: shouldShowLinkInSavedPaymentOptions,
                 linkBrand: configuration.resolvedLinkBrand(elementsSession: elementsSession, linkAccount: LinkAccountContext.shared.account),
                 removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                 merchantDisplayName: configuration.merchantDisplayName,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerTests.swift
@@ -1,0 +1,69 @@
+//
+//  PaymentSheetFlowControllerViewControllerTests.swift
+//  StripePaymentSheetTests
+//
+
+import StripeCoreTestUtils
+@_spi(STP) @testable import StripePaymentSheet
+@_spi(STP) import StripeUICore
+import XCTest
+
+final class PaymentSheetFlowControllerViewControllerTests: XCTestCase {
+    override func setUpWithError() throws {
+        let expectation = expectation(description: "Load specs")
+        AddressSpecProvider.shared.loadAddressSpecs {
+            FormSpecProvider.shared.load { _ in
+                expectation.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 1)
+    }
+
+    func testHorizontalWalletButtonsViewPreventsDefaultingToExternalApplePay() {
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive()
+        configuration.willUseWalletButtonsView = true
+
+        let viewController = makeHorizontalViewController(
+            configuration: configuration,
+            walletButtonsViewState: .visible(allowedWallets: ["apple_pay", "link"])
+        )
+
+        XCTAssertNil(viewController.selectedPaymentOption)
+    }
+
+    func testHorizontalWalletButtonsViewRespectsAlwaysPaymentElementVisibility() {
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive()
+        configuration.willUseWalletButtonsView = true
+        configuration.walletButtonsVisibility.paymentElement[.applePay] = .always
+
+        let viewController = makeHorizontalViewController(
+            configuration: configuration,
+            walletButtonsViewState: .visible(allowedWallets: ["apple_pay", "link"])
+        )
+
+        guard case .applePay = viewController.selectedPaymentOption else {
+            return XCTFail("Expected Apple Pay to remain selectable in PaymentSheet")
+        }
+    }
+
+    private func makeHorizontalViewController(
+        configuration: PaymentSheet.Configuration,
+        walletButtonsViewState: PaymentSheet.WalletButtonsViewState
+    ) -> FlowControllerViewControllerProtocol {
+        return PaymentSheet.FlowController.makeViewController(
+            configuration: configuration,
+            loadResult: .init(
+                intent: ._testValue(),
+                elementsSession: ._testValue(
+                    paymentMethodTypes: ["card", "link"],
+                    isLinkPassthroughModeEnabled: false
+                ),
+                savedPaymentMethods: [],
+                paymentMethodTypes: [.stripe(.card)],
+                paymentMethodOrientation: .horizontal
+            ),
+            analyticsHelper: ._testValue(),
+            walletButtonsViewState: walletButtonsViewState
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Pass WalletButtonsView visibility state into horizontal FlowController PaymentSheet
- Hide externally displayed Apple Pay/Link from the horizontal saved payment option carousel by default
- Preserve PaymentSheet visibility when `walletButtonsVisibility.paymentElement` is set to `.always`

## Testing
- `ci_scripts/format_modified_files.sh`
- `ci_scripts/lint_modified_files.sh`
- `ci_scripts/run_tests.rb --test StripePaymentSheetTests/PaymentSheetFlowControllerViewControllerTests`
- `ci_scripts/run_tests.rb --test StripePaymentSheetTests/WalletButtonsViewTests`