### PR TITLE
CryptoOnramp SDK: Example App: Removes Header to Fetch `kyc_region`

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Crypto_V1.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Example API Bindings/APIClient+Crypto_V1.swift
@@ -10,14 +10,7 @@ import Foundation
 extension APIClient {
     func fetchCustomerInfo() async throws -> CustomerInformationResponse {
         guard let token = authTokenWithLAI else { throw APIError.missingAuthTokenWithLAI }
-        return try await request(
-            "v1/customer_info",
-            bearerToken: token,
-            headers: [
-                // Makes `kyc_region` available in the response.
-                "Stripe-Feature": "identifier_type_lifecycle=v1",
-            ]
-        )
+        return try await request("v1/customer_info", bearerToken: token)
     }
 
     func fetchCustomerWallets() async throws -> CustomerWalletsResponse {


### PR DESCRIPTION
## Summary
Removes an HTTP header from the demo backend `v1/customer_information` request that was used to obtain the `kyc_region` field. This is no longer needed.
## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Cleanup. See [discussion in Slack](https://lickability.slack.com/archives/C094P3BRBL1/p1778677562503699?thread_ts=1778162661.994059&cid=C094P3BRBL1) (this links to a shared Stripe+Lickability channel. To open in Stripe slack, paste the link into a conversation with Slackbot, and it should resolve to a proper link in Stripe Slack).

## Testing
1. Logged in to an EU user account.
2. Tapped the bar button item and selected the option to fetch customer info.
3. Saw that the `kyc_region` parameter value region was still specified.

<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-05-19 at 09 45 35" src="https://github.com/user-attachments/assets/f50a751b-8b09-450b-83de-ccbc5d0c6f24" />


## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A