### PR TITLE
Add AP currency appearance playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 @available(iOS 15.0, *)
 struct CheckoutCartContentView: View {
     @ObservedObject var checkout: Checkout
+    var currencySelectorAppearance = Checkout.CurrencySelectorView.Appearance()
     @Binding var isLoading: Bool
     @Binding var errorMessage: String?
 
@@ -422,7 +423,7 @@ struct CheckoutCartContentView: View {
 
     @ViewBuilder
     private var currencySelectorSection: some View {
-        Checkout.CurrencySelectorElement(checkout: checkout)
+        Checkout.CurrencySelectorElement(checkout: checkout, appearance: currencySelectorAppearance)
             .padding(.horizontal)
     }
 
@@ -643,17 +644,19 @@ struct CheckoutCartContentView: View {
 struct CheckoutCartSheet: View {
     @Environment(\.dismiss) private var dismiss
     @ObservedObject var checkout: Checkout
+    var currencySelectorAppearance = Checkout.CurrencySelectorView.Appearance()
     @State private var isLoading = false
     @State private var errorMessage: String?
 
     var body: some View {
         NavigationView {
             ZStack {
-                Color(UIColor.systemGroupedBackground)
+                Color(UIColor.systemBackground)
                     .ignoresSafeArea()
 
                 CheckoutCartContentView(
                     checkout: checkout,
+                    currencySelectorAppearance: currencySelectorAppearance,
                     isLoading: $isLoading,
                     errorMessage: $errorMessage
                 )

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
@@ -651,7 +651,7 @@ struct CheckoutCartSheet: View {
     var body: some View {
         NavigationView {
             ZStack {
-                Color(UIColor.systemBackground)
+                Color(UIColor.systemGroupedBackground)
                     .ignoresSafeArea()
 
                 CheckoutCartContentView(

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -19,16 +19,18 @@ struct CheckoutCartView: View {
 
     let clientSecret: String
     let adaptivePricing: Bool
+    var currencySelectorAppearance = Checkout.CurrencySelectorView.Appearance()
 
     var body: some View {
         NavigationView {
             ZStack {
-                Color(UIColor.systemGroupedBackground)
+                Color(UIColor.systemBackground)
                     .ignoresSafeArea()
 
                 if let checkout {
                     CheckoutCartContentView(
                         checkout: checkout,
+                        currencySelectorAppearance: currencySelectorAppearance,
                         isLoading: $isLoading,
                         errorMessage: $errorMessage
                     )

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 @available(iOS 15.0, *)
 struct CheckoutPlaygroundView: View {
     @StateObject private var viewModel = CheckoutPlayground.ViewModel()
+    @State private var showCurrencySelectorAppearance = false
 
     var body: some View {
         Group {
@@ -55,6 +56,10 @@ struct CheckoutPlaygroundView: View {
                             adaptivePricingCountry: $viewModel.adaptivePricingCountry
                         )
 
+                        if viewModel.adaptivePricing {
+                            currencySelectorAppearanceSection
+                        }
+
                         CheckoutPlaygroundPaymentMethodSection(
                             selectedMethods: $viewModel.paymentMethodTypes,
                             availableMethods: CheckoutPlayground.ViewModel.availablePaymentMethods
@@ -79,9 +84,51 @@ struct CheckoutPlaygroundView: View {
             .navigationBarTitleDisplayMode(.inline)
             .sheet(isPresented: $viewModel.navigateToCheckout) {
                 if let clientSecret = viewModel.clientSecret {
-                    CheckoutCartView(clientSecret: clientSecret, adaptivePricing: viewModel.adaptivePricing)
+                    CheckoutCartView(
+                        clientSecret: clientSecret,
+                        adaptivePricing: viewModel.adaptivePricing,
+                        currencySelectorAppearance: viewModel.currencySelectorAppearance
+                    )
                 }
             }
+            .sheet(isPresented: $showCurrencySelectorAppearance) {
+                CurrencySelectorAppearancePlaygroundView(
+                    appearance: viewModel.currencySelectorAppearance,
+                    doneAction: { updatedAppearance in
+                        viewModel.currencySelectorAppearance = updatedAppearance
+                        showCurrencySelectorAppearance = false
+                    }
+                )
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var currencySelectorAppearanceSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            CheckoutPlayground.SectionHeader(title: "Currency Selector", icon: "paintbrush.fill")
+            Button {
+                showCurrencySelectorAppearance = true
+            } label: {
+                HStack {
+                    Image(systemName: "slider.horizontal.3")
+                        .font(.system(size: 16))
+                        .frame(width: 24)
+                        .foregroundColor(.blue)
+                    Text("Customize Appearance")
+                        .font(.subheadline)
+                        .foregroundColor(.primary)
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding(.vertical, 12)
+                .padding(.horizontal, 16)
+                .background(Color(uiColor: .secondarySystemGroupedBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+            }
+            .buttonStyle(PlainButtonStyle())
         }
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Nick Porter on 2/24/26.
 
-import StripePaymentSheet
+@_spi(STP) import StripePaymentSheet
 import SwiftUI
 
 @available(iOS 15.0, *)
@@ -30,6 +30,7 @@ extension CheckoutPlayground {
         @Published var checkoutSessionPaymentMethodRemove = true
         @Published var adaptivePricingCountry: AdaptivePricingCountry = .none
         @Published var paymentMethodTypes: Set<String> = ["card"]
+        @Published var currencySelectorAppearance = Checkout.CurrencySelectorView.Appearance()
         @Published var checkoutEndpointOption: EndpointOption = .hosted
         @Published var checkoutEndpoint = EndpointOption.hosted.endpoint ?? ""
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CurrencySelectorAppearancePlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CurrencySelectorAppearancePlaygroundView.swift
@@ -1,0 +1,161 @@
+//
+//  CurrencySelectorAppearancePlaygroundView.swift
+//  PaymentSheet Example
+//
+//  Created by Nick Porter on 5/18/26.
+//
+
+@_spi(STP) import StripePaymentSheet
+import SwiftUI
+
+@available(iOS 15.0, *)
+struct CurrencySelectorAppearancePlaygroundView: View {
+    @State var appearance: Checkout.CurrencySelectorView.Appearance
+    var doneAction: ((Checkout.CurrencySelectorView.Appearance) -> Void)
+
+    static let fonts = ["System Default", "AvenirNext-Regular", "PingFangHK-Regular", "ChalkboardSE-Light"]
+
+    var body: some View {
+        NavigationView {
+            List {
+                dimensionsSection
+                colorsSection
+                typographySection
+                contentSection
+                resetSection
+            }
+            .navigationTitle("Currency Selector")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        doneAction(appearance)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Dimensions
+
+    @ViewBuilder
+    private var dimensionsSection: some View {
+        Section("Dimensions") {
+            VStack(alignment: .leading) {
+                Text("Height: \(appearance.height, specifier: "%.0f")")
+                Slider(value: $appearance.height, in: 24...60, step: 1)
+            }
+            VStack(alignment: .leading) {
+                Text("Corner Radius: \(appearance.cornerRadius, specifier: "%.0f")")
+                Slider(value: $appearance.cornerRadius, in: 0...30, step: 1)
+            }
+            VStack(alignment: .leading) {
+                Text("Border Width: \(appearance.borderWidth, specifier: "%.1f")")
+                Slider(value: $appearance.borderWidth, in: 0...4, step: 0.5)
+            }
+        }
+    }
+
+    // MARK: - Colors
+
+    @ViewBuilder
+    private var colorsSection: some View {
+        let borderBinding = Binding(
+            get: { Color(appearance.border) },
+            set: { appearance.border = UIColor($0) }
+        )
+        let backgroundBinding = Binding(
+            get: { Color(appearance.background) },
+            set: { appearance.background = UIColor($0) }
+        )
+        let selectedBackgroundBinding = Binding(
+            get: { Color(appearance.selectedBackground) },
+            set: { appearance.selectedBackground = UIColor($0) }
+        )
+        let textBinding = Binding(
+            get: { Color(appearance.text) },
+            set: { appearance.text = UIColor($0) }
+        )
+        let selectedTextBinding = Binding(
+            get: { Color(appearance.selectedText) },
+            set: { appearance.selectedText = UIColor($0) }
+        )
+        let textSecondaryBinding = Binding(
+            get: { Color(appearance.textSecondary) },
+            set: { appearance.textSecondary = UIColor($0) }
+        )
+        let dangerBinding = Binding(
+            get: { Color(appearance.danger) },
+            set: { appearance.danger = UIColor($0) }
+        )
+
+        Section("Colors") {
+            ColorPicker("Border", selection: borderBinding)
+            ColorPicker("Background", selection: backgroundBinding)
+            ColorPicker("Selected Background", selection: selectedBackgroundBinding)
+            ColorPicker("Text", selection: textBinding)
+            ColorPicker("Selected Text", selection: selectedTextBinding)
+            ColorPicker("Text Secondary", selection: textSecondaryBinding)
+            ColorPicker("Danger", selection: dangerBinding)
+        }
+    }
+
+    // MARK: - Typography
+
+    @ViewBuilder
+    private var typographySection: some View {
+        Section("Typography") {
+            VStack(alignment: .leading) {
+                Text("Size Scale Factor: \(appearance.sizeScaleFactor, specifier: "%.2f")")
+                Slider(value: $appearance.sizeScaleFactor, in: 0.5...2.0, step: 0.05)
+            }
+            Picker("Font", selection: Binding(
+                get: { fontName(from: appearance.font) },
+                set: { newValue in
+                    if newValue == "System Default" {
+                        appearance.font = .systemFont(ofSize: 14, weight: .medium)
+                    } else {
+                        appearance.font = UIFont(name: newValue, size: 14) ?? .systemFont(ofSize: 14, weight: .medium)
+                    }
+                }
+            )) {
+                ForEach(Self.fonts, id: \.self) { font in
+                    Text(font).tag(font)
+                }
+            }
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var contentSection: some View {
+        Section("Content") {
+            Picker("Label Content", selection: $appearance.labelContent) {
+                Text("Currency Code").tag(Checkout.CurrencySelectorView.Appearance.LabelContent.currencyCode)
+                Text("Amount").tag(Checkout.CurrencySelectorView.Appearance.LabelContent.amount)
+            }
+        }
+    }
+
+    // MARK: - Reset
+
+    @ViewBuilder
+    private var resetSection: some View {
+        Section {
+            Button("Reset to Defaults") {
+                withAnimation {
+                    appearance = Checkout.CurrencySelectorView.Appearance()
+                }
+            }
+            .foregroundColor(.red)
+        }
+    }
+
+    private func fontName(from font: UIFont) -> String {
+        if font.fontName.hasPrefix(".SFUI") || font.fontName.hasPrefix(".AppleSystemUI") {
+            return "System Default"
+        }
+        return font.fontName
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/CheckoutSessionPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CheckoutSessionPlaygroundView.swift
@@ -4,12 +4,14 @@
 //
 //  Created by Nick Porter on 4/10/26.
 
-import StripePaymentSheet
+@_spi(STP) import StripePaymentSheet
 import SwiftUI
 
 @available(iOS 15.0, *)
 struct CheckoutSessionPlaygroundView: View {
     @State var viewModel: PaymentSheetTestPlaygroundSettings
+    @Binding var currencySelectorAppearance: Checkout.CurrencySelectorView.Appearance
+    @State private var showCurrencySelectorAppearance = false
     var doneAction: ((PaymentSheetTestPlaygroundSettings) -> Void) = { _ in }
 
     var body: some View {
@@ -63,6 +65,53 @@ struct CheckoutSessionPlaygroundView: View {
                         }
                     }
 
+                    if viewModel.csAdaptivePricing == .on {
+                        Divider()
+
+                        // MARK: - Adaptive Pricing
+                        Group {
+                            Text("Adaptive Pricing")
+                                .font(.headline)
+
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Simulate Customer Country")
+                                    .font(.subheadline)
+                                ScrollView(.horizontal, showsIndicators: false) {
+                                    HStack(spacing: 8) {
+                                        ForEach(Self.adaptivePricingCountries, id: \.code) { country in
+                                            Button(country.label) {
+                                                if country.code.isEmpty {
+                                                    viewModel.csCustomerEmail = nil
+                                                } else {
+                                                    viewModel.csCustomerEmail = "test+location_\(country.code)@example.com"
+                                                }
+                                            }
+                                            .font(.caption.weight(.medium))
+                                            .padding(.horizontal, 12)
+                                            .padding(.vertical, 6)
+                                            .background(isCountrySelected(country.code) ? Color.blue : Color.blue.opacity(0.1))
+                                            .foregroundColor(isCountrySelected(country.code) ? .white : .blue)
+                                            .cornerRadius(12)
+                                        }
+                                    }
+                                }
+                            }
+
+                            Button("Customize Currency Selector Appearance") {
+                                showCurrencySelectorAppearance = true
+                            }
+                        }
+                        .sheet(isPresented: $showCurrencySelectorAppearance) {
+                            CurrencySelectorAppearancePlaygroundView(
+                                appearance: currencySelectorAppearance,
+                                doneAction: { updatedAppearance in
+                                    currencySelectorAppearance = updatedAppearance
+                                    showCurrencySelectorAppearance = false
+                                }
+                            )
+                        }
+                    }
+
                     Divider()
 
                     // MARK: - Advanced
@@ -100,5 +149,23 @@ struct CheckoutSessionPlaygroundView: View {
                 .padding()
             }
         }
+    }
+
+    private static let adaptivePricingCountries: [(label: String, code: String)] = [
+        ("None", ""),
+        ("US", "US"),
+        ("DE", "DE"),
+        ("JP", "JP"),
+        ("GB", "GB"),
+    ]
+
+    private func isCountrySelected(_ code: String) -> Bool {
+        guard let email = viewModel.csCustomerEmail else {
+            return code.isEmpty
+        }
+        if code.isEmpty {
+            return !email.contains("+location_")
+        }
+        return email.contains("+location_\(code)@")
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -652,7 +652,7 @@ struct PaymentSheetButtons: View {
         }
         .sheet(isPresented: $showingCart) {
             if #available(iOS 15.0, *), let checkout = playgroundController.checkout {
-                CheckoutCartSheet(checkout: checkout)
+                CheckoutCartSheet(checkout: checkout, currencySelectorAppearance: playgroundController.currencySelectorAppearance)
             }
         }
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -588,6 +588,7 @@ import UIKit
     var paymentMethodTypes: [String]?
     var addressViewController: AddressViewController?
     var appearance = PaymentSheet.Appearance.default
+    var currencySelectorAppearance = Checkout.CurrencySelectorView.Appearance()
     var currentDataTask: URLSessionDataTask?
 
     var checkoutEndpoint: String {
@@ -767,11 +768,19 @@ import UIKit
     }
     func checkoutSessionSettingsTapped() {
         if #available(iOS 15.0, *) {
-            let vc = UIHostingController(rootView: CheckoutSessionPlaygroundView(viewModel: settings, doneAction: { updatedSettings in
-                self.settings = updatedSettings
-                self.rootViewController.dismiss(animated: true, completion: nil)
-                self.load(reinitializeControllers: true)
-            }))
+            let appearanceBinding = Binding(
+                get: { self.currencySelectorAppearance },
+                set: { self.currencySelectorAppearance = $0 }
+            )
+            let vc = UIHostingController(rootView: CheckoutSessionPlaygroundView(
+                viewModel: settings,
+                currencySelectorAppearance: appearanceBinding,
+                doneAction: { updatedSettings in
+                    self.settings = updatedSettings
+                    self.rootViewController.dismiss(animated: true, completion: nil)
+                    self.load(reinitializeControllers: true)
+                }
+            ))
             rootViewController.present(vc, animated: true, completion: nil)
         }
     }
@@ -1089,9 +1098,8 @@ extension PlaygroundController {
             body["display_shipping_rates"] = settings.csDisplayShippingRates == .on
             body["adjustable_quantity"] = settings.csAdjustableQuantity == .on
             body["use_manual_capture"] = settings.csManualCapture == .on
-            if let email = settings.csCustomerEmail, !email.isEmpty {
-                body["customer_email"] = email
-            }
+            let email = settings.csCustomerEmail ?? "test@example.com"
+            body["customer_email"] = email.isEmpty ? "test@example.com" : email
             if let pmc = settings.csPaymentMethodConfiguration, !pmc.isEmpty {
                 body["payment_method_configuration"] = pmc
             }


### PR DESCRIPTION
## Summary
- Adds an Appearance API playground view to customize the currency selector

<img width="300" height="652" alt="Simulator Screenshot - iPhone 17 Pro Max - 2026-05-18 at 09 36 48" src="https://github.com/user-attachments/assets/c6d9aab6-85aa-4994-a124-230eb3ccfb89" />


## Motivation
CheckoutSessions

## Testing
- Manual

## Changelog
N/A
