### PR TITLE
Fix Japan address form missing city field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ The next release's version bump will so far be:
 PATCH
 
 ## X.Y.Z - changes pending release
+### PaymentSheet
+* [Fixed] Fixed Japan address form missing the city field. ([#6506](https://github.com/stripe/stripe-ios/issues/6506))
+
+### Address Element
+* [Fixed] Fixed Japan address form missing the city field. ([#6506](https://github.com/stripe/stripe-ios/issues/6506))
 
 ## 25.15.0 2026-05-18
 * Added support for [Onelink](https://support.stripe.com/questions/what-is-onelink).

--- a/Example/PaymentSheet Example/PaymentSheet Example/AddressElementExample.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/AddressElementExample.swift
@@ -19,7 +19,7 @@ public struct AddressElementExampleView: View {
         STPAPIClient.shared.publishableKey = "pk_test"
 
         var config = AddressElement.Configuration()
-        config.allowedCountries = ["US", "CA", "GB", "AU"]
+        config.allowedCountries = ["US", "CA", "GB", "AU", "JP"]
         config.buttonTitle = "Save Address"
 
         // Pre-populate with existing address if available

--- a/StripeUICore/StripeUICore/Resources/JSON/localized_address_data.json
+++ b/StripeUICore/StripeUICore/Resources/JSON/localized_address_data.json
@@ -555,10 +555,11 @@
       "zip":"\\d{5}"
    },
    "JP":{
-      "fmt":"〒%Z%n%S%n%A%n%O%n%N",
-      "lfmt":"%N%n%O%n%A, %S%n%Z",
-      "require":"ASZ",
+      "fmt":"〒%Z%n%S%C%n%A%n%O%n%N",
+      "lfmt":"%N%n%O%n%A, %C, %S%n%Z",
+      "require":"ACSZ",
       "state_name_type":"prefecture",
+      "locality_name_type":"city",
       "zip":"\\d{3}-?\\d{4}"
    },
    "KE":{

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
@@ -268,6 +268,59 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertEqual(sut.addressDetails.address.state, "CA")
     }
 
+    func testJapanAddressIncludesCityField() {
+        // Verify that Japan's address spec includes a city field and that it's required.
+        // This is a regression test for a bug where the JP entry in localized_address_data.json
+        // was missing the %C token, causing the city field to not render.
+        let specProvider = AddressSpecProvider()
+        specProvider.addressSpecs = [
+            "JP": AddressSpec(
+                format: "〒%Z%n%S%C%n%A%n%O%n%N",
+                require: "ACSZ",
+                cityNameType: .city,
+                stateNameType: .prefecture,
+                zip: "\\d{3}-?\\d{4}",
+                zipNameType: .zip
+            ),
+        ]
+        let sut = AddressSectionElement(
+            title: "",
+            countries: ["JP"],
+            locale: locale_enUS,
+            addressSpecProvider: specProvider
+        )
+        let section = sut.addressSection
+
+        // Verify that the city field exists
+        XCTAssertNotNil(sut.city, "Japan address should include a city field")
+
+        // Verify the field ordering contains .city
+        let spec = specProvider.addressSpecs["JP"]!
+        XCTAssertTrue(spec.fieldOrdering.contains(.city), "JP field ordering should contain .city")
+        XCTAssertTrue(spec.requiredFields.contains(.city), "JP required fields should contain .city")
+
+        // Verify city field is not optional (it's required)
+        let textFields = section.elements.compactMap { $0 as? TextFieldElement }
+        let cityField = textFields.first { $0.configuration.label == "City" }
+        XCTAssertNotNil(cityField, "City text field should be present in JP address form")
+        XCTAssertFalse(cityField?.configuration.isOptional ?? true, "City should be required for JP addresses")
+    }
+
+    func testJapanAddressSpecFromJSON() {
+        // Verify the actual JSON data includes city for JP by loading the real spec provider
+        let specProvider = AddressSpecProvider()
+        let expectation = expectation(description: "Address specs loaded")
+        specProvider.loadAddressSpecs {
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 5.0)
+        guard let jpSpec = specProvider.addressSpecs["JP"] else {
+            return XCTFail("JP address spec should exist")
+        }
+        XCTAssertTrue(jpSpec.fieldOrdering.contains(.city), "JP field ordering should include city")
+        XCTAssertTrue(jpSpec.requiredFields.contains(.city), "JP required fields should include city")
+    }
+
     func testConvertLinkBillingAddressToAddressDetails() {
         let linkBillingDetails = BillingAddress(
             name: "Test Testerson",

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
@@ -269,9 +269,16 @@ class AddressSectionElementTest: XCTestCase {
     }
 
     func testJapanAddressIncludesCityField() {
-        // Verify that Japan's address spec includes a city field and that it's required.
-        // This is a regression test for a bug where the JP entry in localized_address_data.json
-        // was missing the %C token, causing the city field to not render.
+        // Japan addresses are:
+        // - Postcode
+        // - Prefecture (state)
+        // - Municipality
+        // - Ward/chome
+        // - Banchi/go (line1)
+        // - Building name (line2)
+        //
+        // Users are expected to enter municipality and ward/chome into the city field,
+        // so it should be required.
         let specProvider = AddressSpecProvider()
         specProvider.addressSpecs = [
             "JP": AddressSpec(
@@ -294,10 +301,16 @@ class AddressSectionElementTest: XCTestCase {
         // Verify that the city field exists
         XCTAssertNotNil(sut.city, "Japan address should include a city field")
 
-        // Verify the field ordering contains .city
+        // Verify the field ordering contains .city after .state
         let spec = specProvider.addressSpecs["JP"]!
         XCTAssertTrue(spec.fieldOrdering.contains(.city), "JP field ordering should contain .city")
         XCTAssertTrue(spec.requiredFields.contains(.city), "JP required fields should contain .city")
+        if let stateIndex = spec.fieldOrdering.firstIndex(of: .state),
+           let cityIndex = spec.fieldOrdering.firstIndex(of: .city) {
+            XCTAssertTrue(cityIndex > stateIndex, "City should come after state/prefecture in JP address")
+        } else {
+            XCTFail("Both .state and .city should be in JP field ordering")
+        }
 
         // Verify city field is not optional (it's required)
         let textFields = section.elements.compactMap { $0 as? TextFieldElement }


### PR DESCRIPTION
## Summary
Japan's entry in localized_address_data.json was missing the %C (city) field token in its format string. This caused AddressSpec to produce a fieldOrdering without .city, so the city field was never rendered for Japanese addresses.

Changes:
- fmt: Add %C between %S and %n%A so city renders after prefecture
- lfmt: Add %C in the Latin format string
- require: Change ASZ to ACSZ so city is validated as required
- Add locality_name_type: city for proper field labeling

<img width="300" height="650" alt="Simulator Screenshot - Snapshot - 2026-05-20 at 09 31 04" src="https://github.com/user-attachments/assets/721d6f87-29d3-4f7f-bac2-5745d051fb22" />
<img width="300" height="650" alt="Simulator Screenshot - Snapshot - 2026-05-20 at 09 30 28" src="https://github.com/user-attachments/assets/1d002c05-e8d9-4cb0-8f90-1821bfcb2bde" />


## Motivation
- https://github.com/stripe/stripe-ios/issues/6506

## Testing
- New unit test
- Manual

## Changelog
See diff
