### PR TITLE
Extract FC Lite into its own module

### DIFF
--- a/.github/workflows/verify-public-interface.yml
+++ b/.github/workflows/verify-public-interface.yml
@@ -71,7 +71,7 @@ jobs:
             If you confirm these APIs need to be added/updated and have undergone necessary review, add the label `modifies public API` to this PR to acknowledge the interface change.
             Additionally, if you modified or removed an existing API, ensure you update the changelog to reflect the necessary version bump for your changes. Regular public API changes require a MAJOR version bump, and SPI API changes (other than declarations using only `@_spi(STP)` and/or `@_spi(ReactNativeSDK)`) require a MINOR or MAJOR version bump.
 
-            ℹ️ If this comment appears to be left in error, make sure your branch is up-to-date with `master`.
+            ℹ️ If this comment appears to be left in error, make sure your branch is up-to-date with `master`. If it still appears spurious, you can ignore this optional check.
           edit-mode: replace
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ MINOR
 * [Added] Added support for registering wallet addresses on the Tempo network.
 
 ### PaymentSheet
+* [Added] StripePaymentSheet now depends on `StripeFinancialConnectionsLite` to support lightweight bank payment flows. If you use StripePaymentSheet with Carthage or by manually embedding the .xcframeworks, [you must also embed StripeFinancialConnectionsLite.xcframework](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md#migrating-from-versions--2650) in your app. No action is required for CocoaPods or Swift Package Manager users.
 * [Added] Added `billingDetailsCollectionConfiguration` to `LinkConfiguration`, allowing `LinkControllerPreview` consumers to configure billing details collection in the Link sheet (private preview).
 * [Added] `LinkController` now supports appearance customization via `LinkAppearance` (private preview).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 The next release's version bump will so far be:
-PATCH
+MINOR
 
 ## X.Y.Z - changes pending release
+### PaymentSheet
+* [Added] StripePaymentSheet now depends on `StripeFinancialConnectionsLite` to support lightweight bank payment flows. If you use StripePaymentSheet with Carthage or by manually embedding the .xcframeworks, [you must also embed StripeFinancialConnectionsLite.xcframework](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md#migrating-from-versions--2670) in your app. No action is required for CocoaPods or Swift Package Manager users.
 
 ## 26.6.0 2026-08-10
 ### PaymentSheet
@@ -19,7 +21,6 @@ PATCH
 * [Added] Added support for registering wallet addresses on the Tempo network.
 
 ### PaymentSheet
-* [Added] StripePaymentSheet now depends on `StripeFinancialConnectionsLite` to support lightweight bank payment flows. If you use StripePaymentSheet with Carthage or by manually embedding the .xcframeworks, [you must also embed StripeFinancialConnectionsLite.xcframework](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md#migrating-from-versions--2650) in your app. No action is required for CocoaPods or Swift Package Manager users.
 * [Added] Added `billingDetailsCollectionConfiguration` to `LinkConfiguration`, allowing `LinkControllerPreview` consumers to configure billing details collection in the Link sheet (private preview).
 * [Added] `LinkController` now supports appearance customization via `LinkAppearance` (private preview).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ PATCH
 * [Added] Added support for registering wallet addresses on the Tempo network.
 
 ### PaymentSheet
+* [Added] StripePaymentSheet now depends on `StripeFinancialConnectionsLite` to support lightweight bank payment flows. If you use StripePaymentSheet with Carthage or by manually embedding the .xcframeworks, [you must also embed StripeFinancialConnectionsLite.xcframework](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md#migrating-from-versions--2650) in your app. No action is required for CocoaPods or Swift Package Manager users.
 * [Added] Added `billingDetailsCollectionConfiguration` to `LinkConfiguration`, allowing `LinkControllerPreview` consumers to configure billing details collection in the Link sheet (private preview).
 * [Added] `LinkController` now supports appearance customization via `LinkAppearance` (private preview).
 

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -10,6 +10,7 @@ import Combine
 import Foundation
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeFinancialConnections
+@_spi(STP) import StripeFinancialConnectionsLite
 @_spi(STP) import StripePayments
 @_spi(STP) import StripePaymentSheet
 import SwiftUI

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,5 +1,5 @@
 ## Migration Guides
-### Migrating from versions < 26.5.0
+### Migrating from versions < 26.7.0
 * StripePaymentSheet now depends on `StripeFinancialConnectionsLite`. If you manually link StripePaymentSheet or use Carthage, you must also embed `StripeFinancialConnectionsLite.xcframework` in your app. No action is required for CocoaPods or Swift Package Manager users.
 
 ### Migrating from versions < 26.0.0

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -1,4 +1,7 @@
 ## Migration Guides
+### Migrating from versions < 26.5.0
+* StripePaymentSheet now depends on `StripeFinancialConnectionsLite`. If you manually link StripePaymentSheet or use Carthage, you must also embed `StripeFinancialConnectionsLite.xcframework` in your app. No action is required for CocoaPods or Swift Package Manager users.
+
 ### Migrating from versions < 26.0.0
 * [Changed] The minimum iOS version is now 15.0, as Xcode 27 no longer supports building for iOS 13 or iOS 14. If you'd like to deploy for iOS versions below iOS 15, please use Stripe SDK 25.17.0.
 

--- a/Package.swift
+++ b/Package.swift
@@ -45,6 +45,10 @@ let package = Package(
             targets: ["StripeFinancialConnections"]
         ),
         .library(
+            name: "StripeFinancialConnectionsLite",
+            targets: ["StripeFinancialConnectionsLite"]
+        ),
+        .library(
             name: "StripeConnect",
             targets: ["StripeConnect"]
         ),
@@ -154,13 +158,19 @@ let package = Package(
         ),
         .target(
             name: "StripePaymentSheet",
-            dependencies: ["StripePaymentsUI", "StripeApplePay", "StripePayments", "StripeCore", "StripeUICore"],
+            dependencies: ["StripePaymentsUI", "StripeApplePay", "StripePayments", "StripeCore", "StripeUICore", "StripeFinancialConnectionsLite"],
             path: "StripePaymentSheet/StripePaymentSheet",
             exclude: ["Info.plist"],
             resources: [
                 .process("Resources/StripePaymentSheet.xcassets"),
                 .process("PrivacyInfo.xcprivacy")
             ]
+        ),
+        .target(
+            name: "StripeFinancialConnectionsLite",
+            dependencies: ["StripeCore"],
+            path: "StripeFinancialConnectionsLite/StripeFinancialConnectionsLite",
+            exclude: ["Info.plist"]
         ),
         .target(
             name: "StripeFinancialConnections",

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ For the `Stripe` module, link the following frameworks:
 - `StripeApplePay.xcframework`
 - `StripePayments.xcframework`
 - `StripePaymentsUI.xcframework`
+- `StripeFinancialConnectionsLite.xcframework`
 - `StripeIssuing.xcframework`
 - `StripeCore.xcframework`
 - `StripeUICore.xcframework`

--- a/Stripe.xcworkspace/contents.xcworkspacedata
+++ b/Stripe.xcworkspace/contents.xcworkspacedata
@@ -63,6 +63,9 @@
       location = "group:StripeFinancialConnections/StripeFinancialConnections.xcodeproj">
    </FileRef>
    <FileRef
+      location = "group:StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj">
+   </FileRef>
+   <FileRef
       location = "group:StripeIdentity/StripeIdentity.xcodeproj">
    </FileRef>
    <FileRef

--- a/Stripe.xcworkspace/contents.xcworkspacedata
+++ b/Stripe.xcworkspace/contents.xcworkspacedata
@@ -63,9 +63,6 @@
       location = "group:StripeFinancialConnections/StripeFinancialConnections.xcodeproj">
    </FileRef>
    <FileRef
-      location = "group:StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj">
-   </FileRef>
-   <FileRef
       location = "group:StripeIdentity/StripeIdentity.xcodeproj">
    </FileRef>
    <FileRef

--- a/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworks-NetworkRecordMode.xcscheme
+++ b/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworks-NetworkRecordMode.xcscheme
@@ -168,6 +168,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F60009A1B2C3D4"
+               BuildableName = "StripeFinancialConnectionsLite.framework"
+               BlueprintName = "StripeFinancialConnectionsLite"
+               ReferencedContainer = "container:StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "57AEC53510AE0DC0539730F3"
                BuildableName = "Stripe3DS2.framework"
                BlueprintName = "Stripe3DS2"
@@ -311,6 +325,16 @@
                BuildableName = "StripeFinancialConnectionsTests.xctest"
                BlueprintName = "StripeFinancialConnectionsTests"
                ReferencedContainer = "container:StripeFinancialConnections/StripeFinancialConnections.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F60015A1B2C3D4"
+               BuildableName = "StripeFinancialConnectionsLiteTests.xctest"
+               BlueprintName = "StripeFinancialConnectionsLiteTests"
+               ReferencedContainer = "container:StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference

--- a/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworks-NoMocks.xcscheme
+++ b/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworks-NoMocks.xcscheme
@@ -168,6 +168,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F60009A1B2C3D4"
+               BuildableName = "StripeFinancialConnectionsLite.framework"
+               BlueprintName = "StripeFinancialConnectionsLite"
+               ReferencedContainer = "container:StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "57AEC53510AE0DC0539730F3"
                BuildableName = "Stripe3DS2.framework"
                BlueprintName = "Stripe3DS2"
@@ -325,6 +339,16 @@
                BuildableName = "StripeFinancialConnectionsTests.xctest"
                BlueprintName = "StripeFinancialConnectionsTests"
                ReferencedContainer = "container:StripeFinancialConnections/StripeFinancialConnections.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F60015A1B2C3D4"
+               BuildableName = "StripeFinancialConnectionsLiteTests.xctest"
+               BlueprintName = "StripeFinancialConnectionsLiteTests"
+               ReferencedContainer = "container:StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference

--- a/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworks-iOS26.xcscheme
+++ b/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworks-iOS26.xcscheme
@@ -168,6 +168,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F60009A1B2C3D4"
+               BuildableName = "StripeFinancialConnectionsLite.framework"
+               BlueprintName = "StripeFinancialConnectionsLite"
+               ReferencedContainer = "container:StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "57AEC53510AE0DC0539730F3"
                BuildableName = "Stripe3DS2.framework"
                BlueprintName = "Stripe3DS2"

--- a/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworks.xcscheme
+++ b/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworks.xcscheme
@@ -168,6 +168,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F60009A1B2C3D4"
+               BuildableName = "StripeFinancialConnectionsLite.framework"
+               BlueprintName = "StripeFinancialConnectionsLite"
+               ReferencedContainer = "container:StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "57AEC53510AE0DC0539730F3"
                BuildableName = "Stripe3DS2.framework"
                BlueprintName = "Stripe3DS2"
@@ -362,6 +376,16 @@
                BuildableName = "StripeFinancialConnectionsTests.xctest"
                BlueprintName = "StripeFinancialConnectionsTests"
                ReferencedContainer = "container:StripeFinancialConnections/StripeFinancialConnections.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F60015A1B2C3D4"
+               BuildableName = "StripeFinancialConnectionsLiteTests.xctest"
+               BlueprintName = "StripeFinancialConnectionsLiteTests"
+               ReferencedContainer = "container:StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj">
             </BuildableReference>
          </TestableReference>
          <TestableReference

--- a/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworksCatalyst.xcscheme
+++ b/Stripe.xcworkspace/xcshareddata/xcschemes/AllStripeFrameworksCatalyst.xcscheme
@@ -98,6 +98,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F60009A1B2C3D4"
+               BuildableName = "StripeFinancialConnectionsLite.framework"
+               BlueprintName = "StripeFinancialConnectionsLite"
+               ReferencedContainer = "container:StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "DE3C3F3D3BB67DD660A44B1E"
                BuildableName = "StripeUICore.framework"
                BlueprintName = "StripeUICore"

--- a/StripeCore/StripeCore/Source/Connections Bindings/DeviceCanUseNativeLink.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/DeviceCanUseNativeLink.swift
@@ -1,0 +1,26 @@
+//
+//  DeviceCanUseNativeLink.swift
+//  StripeCore
+//
+//  Created by Mat Schmid on 2025-03-19.
+//
+
+import Foundation
+
+/// Check if native Link is available on this device
+@_spi(STP) public func deviceCanUseNativeLink(
+    useAttestationEndpoints: Bool?,
+    apiClient: STPAPIClient
+) -> Bool {
+    let useAttestationEndpoints = useAttestationEndpoints ?? false
+    guard useAttestationEndpoints else {
+        return false
+    }
+
+    // If we're in testmode, we don't need to attest for native Link
+    if apiClient.isTestmode {
+        return true
+    }
+
+    return apiClient.stripeAttest.isSupported
+}

--- a/StripeFinancialConnectionsLite.podspec
+++ b/StripeFinancialConnectionsLite.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
 
   # Do not update s.version directly.
   # Instead, update the VERSION file and run ./ci_scripts/update_version.sh
-  s.version                        = '25.15.0'
+  s.version                        = '26.1.0'
 
   s.summary                        = 'StripeFinancialConnectionsLite is a lightweight SDK for connecting financial '\
                                      'accounts to Stripe via a hosted web flow.'

--- a/StripeFinancialConnectionsLite.podspec
+++ b/StripeFinancialConnectionsLite.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
   s.frameworks                     = 'Foundation', 'UIKit', 'WebKit', 'AuthenticationServices'
   s.requires_arc                   = true
   s.platform                       = :ios
-  s.ios.deployment_target          = '13.0'
+  s.ios.deployment_target          = '15.0'
   s.swift_version                  = '5.0'
   s.source_files                   = 'StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/**/*.swift'
   s.dependency                       'StripeCore', "#{s.version}"

--- a/StripeFinancialConnectionsLite.podspec
+++ b/StripeFinancialConnectionsLite.podspec
@@ -1,0 +1,21 @@
+Pod::Spec.new do |s|
+  s.name                           = 'StripeFinancialConnectionsLite'
+
+  # Do not update s.version directly.
+  # Instead, update the VERSION file and run ./ci_scripts/update_version.sh
+  s.version                        = '25.15.0'
+
+  s.summary                        = 'StripeFinancialConnectionsLite is a lightweight SDK for connecting financial '\
+                                     'accounts to Stripe via a hosted web flow.'
+  s.license                        = { :type => 'MIT', :file => 'LICENSE' }
+  s.homepage                       = 'https://stripe.com/docs/financial-connections'
+  s.authors                        = { 'Stripe' => 'support+github@stripe.com' }
+  s.source                         = { :git => 'https://github.com/stripe/stripe-ios.git', :tag => "#{s.version}" }
+  s.frameworks                     = 'Foundation', 'UIKit', 'WebKit', 'AuthenticationServices'
+  s.requires_arc                   = true
+  s.platform                       = :ios
+  s.ios.deployment_target          = '13.0'
+  s.swift_version                  = '5.0'
+  s.source_files                   = 'StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/**/*.swift'
+  s.dependency                       'StripeCore', "#{s.version}"
+end

--- a/StripeFinancialConnectionsLite.podspec
+++ b/StripeFinancialConnectionsLite.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
 
   # Do not update s.version directly.
   # Instead, update the VERSION file and run ./ci_scripts/update_version.sh
-  s.version                        = '26.5.0'
+  s.version                        = '26.6.0'
 
   s.summary                        = 'StripeFinancialConnectionsLite is a lightweight SDK for connecting financial '\
                                      'accounts to Stripe via a hosted web flow.'

--- a/StripeFinancialConnectionsLite.podspec
+++ b/StripeFinancialConnectionsLite.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
 
   # Do not update s.version directly.
   # Instead, update the VERSION file and run ./ci_scripts/update_version.sh
-  s.version                        = '26.1.0'
+  s.version                        = '26.4.1'
 
   s.summary                        = 'StripeFinancialConnectionsLite is a lightweight SDK for connecting financial '\
                                      'accounts to Stripe via a hosted web flow.'

--- a/StripeFinancialConnectionsLite.podspec
+++ b/StripeFinancialConnectionsLite.podspec
@@ -3,7 +3,7 @@ Pod::Spec.new do |s|
 
   # Do not update s.version directly.
   # Instead, update the VERSION file and run ./ci_scripts/update_version.sh
-  s.version                        = '26.4.1'
+  s.version                        = '26.5.0'
 
   s.summary                        = 'StripeFinancialConnectionsLite is a lightweight SDK for connecting financial '\
                                      'accounts to Stripe via a hosted web flow.'

--- a/StripeFinancialConnectionsLite/README.md
+++ b/StripeFinancialConnectionsLite/README.md
@@ -1,0 +1,14 @@
+```
+  ______    _____   _       _  _          
+ |  ____|  / ____| | |     (_)| |         
+ | |__    | |      | |      _ | |_   ___  
+ |  __|   | |      | |     | || __| / _ \ 
+ | |      | |____  | |____ | || |_ |  __/ 
+ |_|       \_____| |______||_| \__| \___| 
+```
+
+## StripeFinancialConnectionsLite
+
+`StripeFinancialConnectionsLite` is a lightweight version of the `StripeFinancialConnections` SDK. It is a simple web wrapper that allows users to go through the Stripe pay-by-bank flow without requiring an additional dependency on the `StripeFinancialConnections` SDK. It is intended to be used in scenarios where the full SDK is not available.
+
+When a `returnUrl` is provided, `StripeFinancialConnectionsLite` supports app-to-app authentication with compatible banks (such as Chase) when their app is installed on the user's device. Otherwise, the bank's authentication flow will open in a secure browser window. [Learn more](https://docs.stripe.com/financial-connections/other-data-powered-products?platform=ios#ios-set-up-return-url) about setting up a return URL.

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj/project.pbxproj
@@ -1,0 +1,390 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 70;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		A1B2C3D4E5F60001A1B2C3D4 /* StripeFinancialConnectionsLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60002A1B2C3D4 /* StripeFinancialConnectionsLite.framework */; };
+		A1B2C3D4E5F60003A1B2C3D4 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60004A1B2C3D4 /* StripeCore.framework */; };
+		A1B2C3D4E5F60005A1B2C3D4 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60006A1B2C3D4 /* XCTest.framework */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		A1B2C3D4E5F60007A1B2C3D4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = A1B2C3D4E5F60008A1B2C3D4 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A1B2C3D4E5F60009A1B2C3D4;
+			remoteInfo = StripeFinancialConnectionsLite;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		A1B2C3D4E5F6000AA1B2C3D4 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1B2C3D4E5F6000BA1B2C3D4 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		A1B2C3D4E5F6000CA1B2C3D4 /* StripeFinancialConnectionsLiteTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = StripeFinancialConnectionsLiteTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1B2C3D4E5F60002A1B2C3D4 /* StripeFinancialConnectionsLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnectionsLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1B2C3D4E5F6000DA1B2C3D4 /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
+		A1B2C3D4E5F6000EA1B2C3D4 /* StripeiOS Tests-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS Tests-Debug.xcconfig"; sourceTree = "<group>"; };
+		A1B2C3D4E5F6000FA1B2C3D4 /* StripeiOS-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS-Debug.xcconfig"; sourceTree = "<group>"; };
+		A1B2C3D4E5F60010A1B2C3D4 /* StripeiOS-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS-Release.xcconfig"; sourceTree = "<group>"; };
+		A1B2C3D4E5F60004A1B2C3D4 /* StripeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A1B2C3D4E5F60006A1B2C3D4 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		A1B2C3D4E5F60011A1B2C3D4 /* StripeiOS Tests-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS Tests-Release.xcconfig"; sourceTree = "<group>"; };
+		A1B2C3D4E5F60012A1B2C3D4 /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		A1B2C3D4E5F60013A1B2C3D4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			publicHeaders = (
+				StripeFinancialConnectionsLite.h,
+			);
+			target = A1B2C3D4E5F60009A1B2C3D4 /* StripeFinancialConnectionsLite */;
+		};
+		A1B2C3D4E5F60014A1B2C3D4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = A1B2C3D4E5F60015A1B2C3D4 /* StripeFinancialConnectionsLiteTests */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		A1B2C3D4E5F60016A1B2C3D4 /* StripeFinancialConnectionsLite */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A1B2C3D4E5F60013A1B2C3D4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = StripeFinancialConnectionsLite; sourceTree = "<group>"; };
+		A1B2C3D4E5F60017A1B2C3D4 /* StripeFinancialConnectionsLiteTests */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (A1B2C3D4E5F60014A1B2C3D4 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = StripeFinancialConnectionsLiteTests; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		A1B2C3D4E5F60018A1B2C3D4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1B2C3D4E5F60003A1B2C3D4 /* StripeCore.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1B2C3D4E5F60019A1B2C3D4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A1B2C3D4E5F60005A1B2C3D4 /* XCTest.framework in Frameworks */,
+				A1B2C3D4E5F60001A1B2C3D4 /* StripeFinancialConnectionsLite.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		A1B2C3D4E5F6001AA1B2C3D4 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3D4E5F60006A1B2C3D4 /* XCTest.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		A1B2C3D4E5F6001BA1B2C3D4 /* BuildConfigurations */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3D4E5F6000DA1B2C3D4 /* Project-Debug.xcconfig */,
+				A1B2C3D4E5F60012A1B2C3D4 /* Project-Release.xcconfig */,
+				A1B2C3D4E5F6000EA1B2C3D4 /* StripeiOS Tests-Debug.xcconfig */,
+				A1B2C3D4E5F60011A1B2C3D4 /* StripeiOS Tests-Release.xcconfig */,
+				A1B2C3D4E5F6000FA1B2C3D4 /* StripeiOS-Debug.xcconfig */,
+				A1B2C3D4E5F60010A1B2C3D4 /* StripeiOS-Release.xcconfig */,
+			);
+			name = BuildConfigurations;
+			path = ../BuildConfigurations;
+			sourceTree = "<group>";
+		};
+		A1B2C3D4E5F6001CA1B2C3D4 = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3D4E5F6001DA1B2C3D4 /* Project */,
+				A1B2C3D4E5F6001AA1B2C3D4 /* Frameworks */,
+				A1B2C3D4E5F6001EA1B2C3D4 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		A1B2C3D4E5F6001EA1B2C3D4 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3D4E5F60002A1B2C3D4 /* StripeFinancialConnectionsLite.framework */,
+				A1B2C3D4E5F6000CA1B2C3D4 /* StripeFinancialConnectionsLiteTests.xctest */,
+				A1B2C3D4E5F60004A1B2C3D4 /* StripeCore.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		A1B2C3D4E5F6001DA1B2C3D4 /* Project */ = {
+			isa = PBXGroup;
+			children = (
+				A1B2C3D4E5F6001BA1B2C3D4 /* BuildConfigurations */,
+				A1B2C3D4E5F60016A1B2C3D4 /* StripeFinancialConnectionsLite */,
+				A1B2C3D4E5F60017A1B2C3D4 /* StripeFinancialConnectionsLiteTests */,
+			);
+			name = Project;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		A1B2C3D4E5F6001FA1B2C3D4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		A1B2C3D4E5F60009A1B2C3D4 /* StripeFinancialConnectionsLite */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1B2C3D4E5F60020A1B2C3D4 /* Build configuration list for PBXNativeTarget "StripeFinancialConnectionsLite" */;
+			buildPhases = (
+				A1B2C3D4E5F6001FA1B2C3D4 /* Headers */,
+				A1B2C3D4E5F60021A1B2C3D4 /* Sources */,
+				A1B2C3D4E5F60022A1B2C3D4 /* Resources */,
+				A1B2C3D4E5F6000BA1B2C3D4 /* Embed Frameworks */,
+				A1B2C3D4E5F60018A1B2C3D4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				A1B2C3D4E5F60016A1B2C3D4 /* StripeFinancialConnectionsLite */,
+			);
+			name = StripeFinancialConnectionsLite;
+			productName = StripeFinancialConnectionsLite;
+			productReference = A1B2C3D4E5F60002A1B2C3D4 /* StripeFinancialConnectionsLite.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		A1B2C3D4E5F60015A1B2C3D4 /* StripeFinancialConnectionsLiteTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A1B2C3D4E5F60023A1B2C3D4 /* Build configuration list for PBXNativeTarget "StripeFinancialConnectionsLiteTests" */;
+			buildPhases = (
+				A1B2C3D4E5F60024A1B2C3D4 /* Sources */,
+				A1B2C3D4E5F60025A1B2C3D4 /* Resources */,
+				A1B2C3D4E5F6000AA1B2C3D4 /* Embed Frameworks */,
+				A1B2C3D4E5F60019A1B2C3D4 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A1B2C3D4E5F60026A1B2C3D4 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				A1B2C3D4E5F60017A1B2C3D4 /* StripeFinancialConnectionsLiteTests */,
+			);
+			name = StripeFinancialConnectionsLiteTests;
+			productName = StripeFinancialConnectionsLiteTests;
+			productReference = A1B2C3D4E5F6000CA1B2C3D4 /* StripeFinancialConnectionsLiteTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		A1B2C3D4E5F60008A1B2C3D4 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+			};
+			buildConfigurationList = A1B2C3D4E5F60027A1B2C3D4 /* Build configuration list for PBXProject "StripeFinancialConnectionsLite" */;
+			compatibilityVersion = "Xcode 13.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				Base,
+				en,
+			);
+			mainGroup = A1B2C3D4E5F6001CA1B2C3D4;
+			productRefGroup = A1B2C3D4E5F6001EA1B2C3D4 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				A1B2C3D4E5F60009A1B2C3D4 /* StripeFinancialConnectionsLite */,
+				A1B2C3D4E5F60015A1B2C3D4 /* StripeFinancialConnectionsLiteTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		A1B2C3D4E5F60025A1B2C3D4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1B2C3D4E5F60022A1B2C3D4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		A1B2C3D4E5F60021A1B2C3D4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A1B2C3D4E5F60024A1B2C3D4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		A1B2C3D4E5F60026A1B2C3D4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = StripeFinancialConnectionsLite;
+			target = A1B2C3D4E5F60009A1B2C3D4 /* StripeFinancialConnectionsLite */;
+			targetProxy = A1B2C3D4E5F60007A1B2C3D4 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		A1B2C3D4E5F60028A1B2C3D4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1B2C3D4E5F60011A1B2C3D4 /* StripeiOS Tests-Release.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = StripeFinancialConnectionsLiteTests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.StripeFinancialConnectionsLiteTests;
+				PRODUCT_NAME = StripeFinancialConnectionsLiteTests;
+				SDKROOT = iphoneos;
+			};
+			name = Release;
+		};
+		A1B2C3D4E5F60029A1B2C3D4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1B2C3D4E5F60010A1B2C3D4 /* StripeiOS-Release.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = StripeFinancialConnectionsLite/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.stripe-financial-connections-lite";
+				PRODUCT_NAME = StripeFinancialConnectionsLite;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+			};
+			name = Release;
+		};
+		A1B2C3D4E5F6002AA1B2C3D4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1B2C3D4E5F6000FA1B2C3D4 /* StripeiOS-Debug.xcconfig */;
+			buildSettings = {
+				INFOPLIST_FILE = StripeFinancialConnectionsLite/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.stripe-financial-connections-lite";
+				PRODUCT_NAME = StripeFinancialConnectionsLite;
+				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
+				SUPPORTS_MACCATALYST = YES;
+				TARGETED_DEVICE_FAMILY = "1,2,7";
+			};
+			name = Debug;
+		};
+		A1B2C3D4E5F6002BA1B2C3D4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1B2C3D4E5F60012A1B2C3D4 /* Project-Release.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
+		A1B2C3D4E5F6002CA1B2C3D4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1B2C3D4E5F6000DA1B2C3D4 /* Project-Debug.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		A1B2C3D4E5F6002DA1B2C3D4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A1B2C3D4E5F6000EA1B2C3D4 /* StripeiOS Tests-Debug.xcconfig */;
+			buildSettings = {
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PLATFORM_DIR)/Developer/Library/Frameworks",
+				);
+				INFOPLIST_FILE = StripeFinancialConnectionsLiteTests/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stripe.StripeFinancialConnectionsLiteTests;
+				PRODUCT_NAME = StripeFinancialConnectionsLiteTests;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		A1B2C3D4E5F60027A1B2C3D4 /* Build configuration list for PBXProject "StripeFinancialConnectionsLite" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1B2C3D4E5F6002CA1B2C3D4 /* Debug */,
+				A1B2C3D4E5F6002BA1B2C3D4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A1B2C3D4E5F60023A1B2C3D4 /* Build configuration list for PBXNativeTarget "StripeFinancialConnectionsLiteTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1B2C3D4E5F6002DA1B2C3D4 /* Debug */,
+				A1B2C3D4E5F60028A1B2C3D4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		A1B2C3D4E5F60020A1B2C3D4 /* Build configuration list for PBXNativeTarget "StripeFinancialConnectionsLite" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A1B2C3D4E5F6002AA1B2C3D4 /* Debug */,
+				A1B2C3D4E5F60029A1B2C3D4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = A1B2C3D4E5F60008A1B2C3D4 /* Project object */;
+}

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj/xcshareddata/xcschemes/StripeFinancialConnectionsLite.xcscheme
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.xcodeproj/xcshareddata/xcschemes/StripeFinancialConnectionsLite.xcscheme
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1010"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F60009A1B2C3D4"
+               BuildableName = "StripeFinancialConnectionsLite.framework"
+               BlueprintName = "StripeFinancialConnectionsLite"
+               ReferencedContainer = "container:StripeFinancialConnectionsLite.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1B2C3D4E5F60009A1B2C3D4"
+            BuildableName = "StripeFinancialConnectionsLite.framework"
+            BlueprintName = "StripeFinancialConnectionsLite"
+            ReferencedContainer = "container:StripeFinancialConnectionsLite.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A1B2C3D4E5F60015A1B2C3D4"
+               BuildableName = "StripeFinancialConnectionsLiteTests.xctest"
+               BlueprintName = "StripeFinancialConnectionsLiteTests"
+               ReferencedContainer = "container:StripeFinancialConnectionsLite.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1B2C3D4E5F60009A1B2C3D4"
+            BuildableName = "StripeFinancialConnectionsLite.framework"
+            BlueprintName = "StripeFinancialConnectionsLite"
+            ReferencedContainer = "container:StripeFinancialConnectionsLite.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A1B2C3D4E5F60009A1B2C3D4"
+            BuildableName = "StripeFinancialConnectionsLite.framework"
+            BlueprintName = "StripeFinancialConnectionsLite"
+            ReferencedContainer = "container:StripeFinancialConnectionsLite.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Docs.docc/StripeFinancialConnectionsLite.md
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Docs.docc/StripeFinancialConnectionsLite.md
@@ -1,0 +1,3 @@
+# ``StripeFinancialConnectionsLite``
+
+A lightweight SDK for connecting financial accounts to Stripe via a hosted web flow.

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Info.plist
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/API Client/FCLiteApiClient.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/API Client/FCLiteApiClient.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteApiClient.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-03-19.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteAuthFlowViewController.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteAuthFlowViewController.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteAuthFlowViewController.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-03-19.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteContainerViewController.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteContainerViewController.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteContainerViewController.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-03-19.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteSecureAuthFlowViewController.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteSecureAuthFlowViewController.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteSecureAuthFlowViewController.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-11-20.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/FCLiteImplementation.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/FCLiteImplementation.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteImplementation.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-03-25.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/FinancialConnectionsLite.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/FinancialConnectionsLite.swift
@@ -1,6 +1,6 @@
 //
 //  FinancialConnectionsLite.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-03-19.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/FCLiteColor.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/FCLiteColor.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteColor.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-03-19.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/FCLiteError.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/FCLiteError.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteError.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-03-19.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/FCLiteErrorView.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/FCLiteErrorView.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteErrorView.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-03-19.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/FCLiteModalPresentationWrapper.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/FCLiteModalPresentationWrapper.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteModalPresentationWrapper.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-03-19.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/FCLiteWebFlowResult.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/FCLiteWebFlowResult.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteWebFlowResult.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-11-20.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/STPVisionSupport.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/STPVisionSupport.swift
@@ -1,0 +1,24 @@
+//
+//  STPVisionSupport.swift
+//  StripeFinancialConnectionsLite
+//
+//  Created for visionOS compatibility.
+//
+
+import AuthenticationServices
+import UIKit
+
+/// Creates a fallback ASPresentationAnchor when no window is available.
+/// On visionOS, UIWindow() without a scene is deprecated, so we find a scene first.
+func stp_makeFallbackPresentationAnchor() -> ASPresentationAnchor {
+    #if !os(visionOS)
+    return ASPresentationAnchor()
+    #else
+    if let windowScene = UIApplication.shared.connectedScenes
+        .compactMap({ $0 as? UIWindowScene })
+        .first {
+        return UIWindow(windowScene: windowScene)
+    }
+    fatalError()
+    #endif
+}

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/URL+MatchesSchemeHostAndPath.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Helpers/URL+MatchesSchemeHostAndPath.swift
@@ -1,0 +1,18 @@
+//
+//  URL+MatchesSchemeHostAndPath.swift
+//  StripeFinancialConnectionsLite
+//
+//  Created by Mat Schmid on 2025-03-19.
+//
+
+import Foundation
+
+extension URL {
+    func matchesSchemeHostAndPath(of otherURL: URL) -> Bool {
+        return (
+            self.scheme == otherURL.scheme &&
+            self.host == otherURL.host &&
+            self.path == otherURL.path
+        )
+    }
+}

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Models/FCLiteManifest.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Models/FCLiteManifest.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteManifest.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-03-19.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Models/FCLiteSession.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Models/FCLiteSession.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteSession.swift
-//  StripePaymentSheet
+//  StripeFinancialConnectionsLite
 //
 //  Created by Mat Schmid on 2025-03-19.
 //

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.h
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite.h
@@ -1,0 +1,12 @@
+//
+//  StripeFinancialConnectionsLite.h
+//  StripeFinancialConnectionsLite
+//
+
+#import <Foundation/Foundation.h>
+
+//! Project version number for StripeFinancialConnectionsLite.
+FOUNDATION_EXPORT double StripeFinancialConnectionsLiteVersionNumber;
+
+//! Project version string for StripeFinancialConnectionsLite.
+FOUNDATION_EXPORT const unsigned char StripeFinancialConnectionsLiteVersionString[];

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLiteTests/FCLiteImplementationTests.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLiteTests/FCLiteImplementationTests.swift
@@ -1,6 +1,6 @@
 //
 //  FCLiteImplementationTests.swift
-//  StripePaymentSheetTests
+//  StripeFinancialConnectionsLiteTests
 //
 //  Created by Mat Schmid on 2025-03-28.
 //
@@ -11,7 +11,7 @@ import XCTest
 class FCLiteImplementationTests: XCTestCase {
     func testFCLiteImplementationAvailable() {
         let FinancialConnectionsLiteImplementation: FinancialConnectionsSDKInterface.Type? =
-            NSClassFromString("StripePaymentSheet.FCLiteImplementation")
+            NSClassFromString("StripeFinancialConnectionsLite.FCLiteImplementation")
             as? FinancialConnectionsSDKInterface.Type
         XCTAssertNotNil(FinancialConnectionsLiteImplementation)
     }

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLiteTests/Info.plist
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLiteTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+</dict>
+</plist>

--- a/StripePaymentSheet.podspec
+++ b/StripePaymentSheet.podspec
@@ -23,4 +23,5 @@ Pod::Spec.new do |s|
   s.dependency                       'StripePayments', s.version.to_s
   s.dependency                       'StripePaymentsUI', s.version.to_s
   s.dependency                       'StripeApplePay', s.version.to_s
+  s.dependency                       'StripeFinancialConnectionsLite', s.version.to_s
 end

--- a/StripePaymentSheet/README.md
+++ b/StripePaymentSheet/README.md
@@ -38,4 +38,5 @@ If you link this library manually, use a version from our [releases](https://git
 - `StripePayments.xcframework`
 - `StripePaymentsUI.xcframework`
 - `StripeApplePay.xcframework`
+- `StripeFinancialConnectionsLite.xcframework`
 - `StripePaymentSheet.xcframework`

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -36,6 +36,8 @@
 		E792B9597C67C5E6EA70E81A /* StripePaymentsTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 15854DCE06F859BB426E9C9A /* StripePaymentsTestUtils.framework */; };
 		EAE876E2E023C88D2EFCE3CD /* StripePaymentsUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F22354BD25171B8DC2B922D2 /* StripePaymentsUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FAB721318163CB8DF4EA2286 /* Stripe3DS2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9300105117D75EDBB229C14F /* Stripe3DS2.framework */; };
+		FCL00200000000000000001A /* StripeFinancialConnectionsLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = FCL00100000000000000001A /* StripeFinancialConnectionsLite.framework */; };
+		FCL00300000000000000001A /* StripeFinancialConnectionsLite.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = FCL00100000000000000001A /* StripeFinancialConnectionsLite.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -86,6 +88,7 @@
 				23FBF09FDCE5C94F9E407458 /* StripeApplePay.framework in Embed Frameworks */,
 				B4679C9095BCD53CCC2C7D25 /* StripeCore.framework in Embed Frameworks */,
 				E6D9F6C7D768F76B7A84BC91 /* StripeCoreTestUtils.framework in Embed Frameworks */,
+				FCL00300000000000000001A /* StripeFinancialConnectionsLite.framework in Embed Frameworks */,
 				395CFB782E1F93789A260434 /* StripePaymentSheet.framework in Embed Frameworks */,
 				98F1E3C5FA699C0C14938125 /* StripePayments.framework in Embed Frameworks */,
 				99B9F22868B1FAF2CA834995 /* StripePaymentsObjcTestUtils.framework in Embed Frameworks */,
@@ -123,6 +126,7 @@
 		E41AA4E90E5BB28D588FDE51 /* StripeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB98DA1D622DC572F0894A28 /* StripeiOS Tests-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS Tests-Release.xcconfig"; sourceTree = "<group>"; };
 		F22354BD25171B8DC2B922D2 /* StripePaymentsUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripePaymentsUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		FCL00100000000000000001A /* StripeFinancialConnectionsLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnectionsLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8A3A76BD737F195578558CA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -174,6 +178,7 @@
 				FAB721318163CB8DF4EA2286 /* Stripe3DS2.framework in Frameworks */,
 				999D46841AFC73E411A91037 /* StripeApplePay.framework in Frameworks */,
 				3D4497A6A1CB151C4B75A68F /* StripeCore.framework in Frameworks */,
+				FCL00200000000000000001A /* StripeFinancialConnectionsLite.framework in Frameworks */,
 				61C0D3B8C63EB4558AB74A7E /* StripePayments.framework in Frameworks */,
 				4A8C7B2AFB290567C961DAB0 /* StripePaymentsUI.framework in Frameworks */,
 				96B1DCBDA1923BF5E7F990B8 /* StripeUICore.framework in Frameworks */,
@@ -198,6 +203,7 @@
 				E41AA4E90E5BB28D588FDE51 /* StripeCore.framework */,
 				169C7CCB7A003FEDEA598095 /* StripeCoreTestUtils.framework */,
 				5A1C7CFA5C9C1A8A73CFA1C0 /* StripePayments.framework */,
+				FCL00100000000000000001A /* StripeFinancialConnectionsLite.framework */,
 				2E42F31D392C0AED757D6239 /* StripePaymentSheet.framework */,
 				B829BC7EEE9576F724F7A9B3 /* StripePaymentSheetTestHostApp.app */,
 				4C6AA41454A6757B3E26AE67 /* StripePaymentSheetTests.xctest */,

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -126,8 +126,8 @@
 		E41AA4E90E5BB28D588FDE51 /* StripeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB98DA1D622DC572F0894A28 /* StripeiOS Tests-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "StripeiOS Tests-Release.xcconfig"; sourceTree = "<group>"; };
 		F22354BD25171B8DC2B922D2 /* StripePaymentsUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripePaymentsUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		FCL00100000000000000001A /* StripeFinancialConnectionsLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnectionsLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8A3A76BD737F195578558CA /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		FCL00100000000000000001A /* StripeFinancialConnectionsLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnectionsLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -102,24 +102,6 @@ extension PaymentSheet {
 // MARK: - Native Link helpers
 
 /// Check if native Link is available on this device
-func deviceCanUseNativeLink(
-    useAttestationEndpoints: Bool?,
-    apiClient: STPAPIClient
-) -> Bool {
-    let useAttestationEndpoints = useAttestationEndpoints ?? false
-    guard useAttestationEndpoints else {
-        return false
-    }
-
-    // If we're in testmode, we don't need to attest for native Link
-    if apiClient.isTestmode {
-        return true
-    }
-
-    return apiClient.stripeAttest.isSupported
-}
-
-/// Check if native Link is available on this device
 func deviceCanUseNativeLink(elementsSession: STPElementsSession, configuration: PaymentElementConfiguration) -> Bool {
     return deviceCanUseNativeLink(
         useAttestationEndpoints: elementsSession.linkSettings?.useAttestationEndpoints,

--- a/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
+++ b/StripePayments/StripePayments/Source/Internal/Helpers/ConnectionsSDKAvailability.swift
@@ -16,7 +16,7 @@ import UIKit
         as? FinancialConnectionsSDKInterface.Type
 
     static let FinancialConnectionsLiteImplementation: FinancialConnectionsSDKInterface.Type? =
-        NSClassFromString("StripePaymentSheet.FCLiteImplementation")
+        NSClassFromString("StripeFinancialConnectionsLite.FCLiteImplementation")
         as? FinancialConnectionsSDKInterface.Type
 
     @_spi(STP) public static var fcLiteKillswitchEnabled: Bool = false

--- a/Tests/installation_tests/cocoapods/with_frameworks_objc/Podfile
+++ b/Tests/installation_tests/cocoapods/with_frameworks_objc/Podfile
@@ -10,6 +10,7 @@ target 'CocoapodsTest' do
 	pod 'StripeCardScan', path: '../../../..'
 	pod 'StripePayments', path: '../../../..'
 	pod 'StripePaymentsUI', path: '../../../..'
+	pod 'StripeFinancialConnectionsLite', path: '../../../..'
 	pod 'StripePaymentSheet', path: '../../../..'
     pod 'StripeIssuing', path: '../../../..'
 

--- a/Tests/installation_tests/cocoapods/with_frameworks_swift/Podfile
+++ b/Tests/installation_tests/cocoapods/with_frameworks_swift/Podfile
@@ -14,6 +14,7 @@ target 'CocoapodsTest' do
   pod 'StripeUICore', path: '../../../..'
   pod 'StripePayments', path: '../../../..'
   pod 'StripePaymentsUI', path: '../../../..'
+  pod 'StripeFinancialConnectionsLite', path: '../../../..'
   pod 'StripePaymentSheet', path: '../../../..'
   pod 'StripeIssuing', path: '../../../..'
   

--- a/Tests/installation_tests/cocoapods/without_frameworks_objc/Podfile
+++ b/Tests/installation_tests/cocoapods/without_frameworks_objc/Podfile
@@ -7,6 +7,7 @@ target 'CocoapodsTest' do
   pod 'StripeCardScan', path: '../../../..'
   pod 'StripePayments', path: '../../../..'
   pod 'StripePaymentsUI', path: '../../../..'
+  pod 'StripeFinancialConnectionsLite', path: '../../../..'
   pod 'StripePaymentSheet', path: '../../../..'
   pod 'StripeIssuing', path: '../../../..'
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -381,6 +381,13 @@ workflows:
         - destination: $DEFAULT_TEST_DEVICE
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "2"
+        - scheme: StripeFinancialConnectionsLite
+        is_always_run: true
+    - xcode-test@6:
+        inputs:
+        - destination: $DEFAULT_TEST_DEVICE
+        - test_repetition_mode: retry_on_failure
+        - maximum_test_repetitions: "2"
         - scheme: StripeCardScan
         is_always_run: true
     - xcode-test@6:

--- a/ci_scripts/api_diff/diff_public_interface.rb
+++ b/ci_scripts/api_diff/diff_public_interface.rb
@@ -17,8 +17,8 @@ def normalize_line(line)
 end
 
 def sorted_diff_lines(old_path, new_path)
-  old_lines = File.readlines(old_path).map { |l| normalize_line(l) }.sort
-  new_lines = File.readlines(new_path).map { |l| normalize_line(l) }.sort
+  old_lines = File.exist?(old_path) ? File.readlines(old_path).map { |l| normalize_line(l) }.sort : []
+  new_lines = File.exist?(new_path) ? File.readlines(new_path).map { |l| normalize_line(l) }.sort : []
 
   old_temp = Tempfile.new(['sorted_old', File.extname(old_path)])
   new_temp = Tempfile.new(['sorted_new', File.extname(new_path)])

--- a/modules.yaml
+++ b/modules.yaml
@@ -184,6 +184,11 @@ modules:
     readme: StripeCardScan/README.md
   localization_dir: StripeCardScan/StripeCardScan
 
+- podspec: StripeFinancialConnectionsLite.podspec
+  scheme: StripeFinancialConnectionsLite
+  framework_name: StripeFinancialConnectionsLite
+  supports_catalyst: true
+
 - podspec: StripeFinancialConnections.podspec
   scheme: StripeFinancialConnections
   framework_name: StripeFinancialConnections
@@ -235,6 +240,7 @@ modules:
 pod_push_order:
 - StripeCore.podspec
 - StripeUICore.podspec
+- StripeFinancialConnectionsLite.podspec
 - StripeCameraCore.podspec
 - StripeApplePay.podspec
 - StripePayments.podspec


### PR DESCRIPTION
## Summary

Extracts FC Lite out of `StripePaymentSheet` and into its own standalone module: `StripeFinancialConnectionsLite`. `StripePaymentSheet` has a hard dependency on the new module, so there is no behavior or integration change for merchants.

## Motivation

Doc: https://docs.google.com/document/d/1GGBXm_B9tflE-C3sKvWKX3ZdvNh3_NrRNXaw6O6Vmt0/edit?tab=t.ioeujvw7u91q

Decoupling FC Lite from MPE will allow us to remove the web-based FC implementation in the `StripeFinancialConnections` module by reusing FC Lite ([draft PR](https://github.com/stripe/stripe-ios/pull/6795)), and in turn allow us to provide direct integrations with FC Lite and allowing React Native users access FC Lite.

## Testing

- Existing `FCLiteImplementationTests` moved to `StripeFinancialConnectionsLiteTests`.
- Built and ran StripePaymentSheet tests to confirm no regressions.

## Changelog

N/a? Not sure if this change should be mentioned, as there should be no behavior changes.
