### PR TITLE
CryptoOnramp SDK: Makes LinkAppearance.PrimaryButtonConfiguration Optionality Match Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ PATCH
 
 ## X.Y.Z - changes pending release
 ### PaymentSheet
+* [Fixed] Fixed `LinkAppearance.PrimaryButtonConfiguration` styling so unspecified custom height and corner radius values use Link defaults.
 * [Fixed] Fixed Japan address form missing the city field. ([#6506](https://github.com/stripe/stripe-ios/issues/6506))
 
 ### Address Element

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 The next release's version bump will so far be:
-PATCH
+MINOR
 
 ## X.Y.Z - changes pending release
 ### PaymentSheet

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/ConfirmButton+Link.swift
@@ -32,12 +32,13 @@ extension ConfirmButton {
                 appearance.primaryButton.textColor = contentOnPrimaryColor
             }
 
-            if let buttonConfiguration = linkAppearance.primaryButton {
-                appearance.primaryButton.cornerRadius = buttonConfiguration.cornerRadius
+            if let cornerRadius = linkAppearance.primaryButton.cornerRadius {
+                appearance.primaryButton.cornerRadius = cornerRadius
+            }
 
-                // Adjust the margins to back solve for the `LinkAppearance` customized height.
-                let desiredHeight = buttonConfiguration.height
-                let verticalMargin = LinkUI.verticalMarginForPrimaryButton(withDesiredHeight: desiredHeight)
+            // Adjust the margins to back solve for the `LinkAppearance` customized height.
+            if let height = linkAppearance.primaryButton.height {
+                let verticalMargin = LinkUI.verticalMarginForPrimaryButton(withDesiredHeight: height)
                 directionalLayoutMargins.top = verticalMargin
                 directionalLayoutMargins.bottom = verticalMargin
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkAppearance.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkAppearance.swift
@@ -14,17 +14,17 @@ public struct LinkAppearance {
     /// Configuration values for the primary button.
     public struct PrimaryButtonConfiguration {
 
-        /// The corner radius of of the primary button. Defaults to 0.
-        public var cornerRadius: CGFloat = .zero
+        /// The corner radius of of the primary button. Defaults to Link's primary button corner radius.
+        public var cornerRadius: CGFloat?
 
-        /// The height of the primary button. Defaults to 0.
-        public var height: CGFloat = .zero
+        /// The height of the primary button. Defaults to Link's primary button height.
+        public var height: CGFloat?
 
         /// Creates a new instance of `PrimaryButtonConfiguration`.
         /// - Parameters:
-        ///   - cornerRadius: The corner radius of of the primary button. Defaults to 0.
-        ///   - height: The height of the primary button. Defaults to 0.
-        public init(cornerRadius: CGFloat = .zero, height: CGFloat = .zero) {
+        ///   - cornerRadius: The corner radius of of the primary button. Defaults to Link's primary button corner radius.
+        ///   - height: The height of the primary button. Defaults to Link's primary button height.
+        public init(cornerRadius: CGFloat? = nil, height: CGFloat? = nil) {
             self.cornerRadius = cornerRadius
             self.height = height
         }
@@ -56,8 +56,8 @@ public struct LinkAppearance {
     /// Custom colors used throughout the Link UI. Defaults to Link colors.
     public var colors: Colors?
 
-    /// Configuration values for the primary button. Uses reasonable defaults if nothing is provided.
-    public var primaryButton: PrimaryButtonConfiguration?
+    /// Configuration values for the primary button. Uses Link defaults when individual values are not provided.
+    public var primaryButton: PrimaryButtonConfiguration
 
     /// Style options for colors in the Link UI. Defaults to automatic.
     public var style: PaymentSheet.UserInterfaceStyle = .automatic
@@ -80,7 +80,7 @@ public struct LinkAppearance {
         reduceLinkBranding: Bool = false
     ) {
         self.colors = colors
-        self.primaryButton = primaryButton
+        self.primaryButton = primaryButton ?? PrimaryButtonConfiguration()
         self.style = style
         self.reduceLinkBranding = reduceLinkBranding
     }


### PR DESCRIPTION
## Summary
Previously, unspecified values on `init` made `PrimaryButtonConfiguration`'s properties default to `.zero`. This led to a mismatch in mapping behavior since the properties couldn’t be `nil`, and individually apply corner radius or height, falling back to Link  defaults for the other.

## Motivation
This comment: https://github.com/stripe/stripe-react-native/pull/2404#discussion_r3134337573

## Testing
Ensured that when applied to the react native repo (https://github.com/stripe/stripe-react-native/pull/2475), we were able to set each value independently while relying on a default for the other. I used intentionally obvious values to ensure they were being applied, and differed from sensible defaults.

| Corner radius set only | Height set only | Both set | Neither set (both defaults) |
| --- | --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/95c22e7f-96d2-42b0-a0e5-c18ea8a2a167" width="300" /> | <img src="https://github.com/user-attachments/assets/436a1b55-9fca-4f19-a12d-ade5c6b4e501" width="300" /> | <img src="https://github.com/user-attachments/assets/f5aede24-d793-4700-935d-42e1c09095fa" width="300" /> | <img src="https://github.com/user-attachments/assets/368e5970-79bf-4763-8e68-639c1011bcf0" width="300" /> |

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
✅ 
