### PR TITLE
Analytics for Payment Details Type Names Sent/Received

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -173,6 +173,7 @@ import Foundation
     case linkAccountLookupComplete = "link.account_lookup.complete"
     case linkAccountLookupFailure = "link.account_lookup.failure"
     case linkEmailSuggestionAccepted = "link.email_suggestion.accepted"
+    case linkPaymentDetailsListRequest = "link.payment_details.list.request"
 
     // MARK: - LUXE
     case luxeSerializeFailure = "luxe_serialize_failure"

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewController.swift
@@ -293,6 +293,11 @@ extension PayWithLinkViewController {
                 shouldRetryOnAuthError: true
             ) { [weak self] result in
                 if case .success(let paymentDetails) = result {
+                    let receivedTypes = paymentDetails.map { $0.type }
+                    self?.context.analyticsHelper.analyticsClient.logLinkPaymentDetailsListRequest(
+                        sentTypes: supportedPaymentDetailsTypes,
+                        receivedTypes: receivedTypes
+                    )
                     self?.viewModel.updatePaymentMethods(paymentDetails)
                 }
                 completion?()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -431,6 +431,12 @@ private extension PayWithLinkViewController {
             do {
                 let paymentDetails = try await paymentDetailsTask.value
 
+                let receivedTypes = paymentDetails.map { $0.type }
+                context.analyticsHelper.analyticsClient.logLinkPaymentDetailsListRequest(
+                    sentTypes: supportedPaymentDetailsTypes,
+                    receivedTypes: receivedTypes
+                )
+
                 // Ignore any errors that might happen here.
                 shippingAddressResponse = await shippingAddressTask.value
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/STPAnalyticsClient+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Extensions/STPAnalyticsClient+Link.swift
@@ -158,6 +158,19 @@ extension STPAnalyticsClient {
                                  linkSessionType: sessionType,
                                  params: params)
         }
+
+    // MARK: - Payment Details
+
+    func logLinkPaymentDetailsListRequest(
+        sentTypes: [ParsedEnum<ConsumerPaymentDetails.DetailsType>],
+        receivedTypes: [ParsedEnum<ConsumerPaymentDetails.DetailsType>]
+    ) {
+        let params: [String: Any] = [
+            "sent_types": sentTypes.map(\.rawValue).sorted().joined(separator: ","),
+            "received_types": receivedTypes.map(\.rawValue).sorted().joined(separator: ","),
+        ]
+        self.logPaymentSheetEvent(event: .linkPaymentDetailsListRequest, params: params)
+    }
 }
 
 extension LinkInlineSignupViewModel.Mode {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/STPAnalyticsClientLinkPaymentDetailsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/STPAnalyticsClientLinkPaymentDetailsTests.swift
@@ -1,0 +1,162 @@
+//  STPAnalyticsClientLinkPaymentDetailsTests.swift
+//  StripePaymentSheetTests
+//
+
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import XCTest
+
+@testable @_spi(STP) import StripeCore
+@testable @_spi(STP) import StripeCoreTestUtils
+@testable @_spi(STP) import StripePayments
+@testable @_spi(STP) import StripePaymentSheet
+@testable @_spi(STP) import StripePaymentsTestUtils
+
+final class STPAnalyticsClientLinkPaymentDetailsTests: APIStubbedTestCase {
+
+    // Tests that `logLinkPaymentDetailsListRequest` fires an event with the correct
+    // `sent_types` and `received_types` params when the backend returns a mix of
+    // known and unknown payment detail types.
+    func testListPaymentDetails_firesAnalyticsEvent() {
+        let analyticsClient = STPTestingAnalyticsClient()
+
+        // Stub the consumers/payment_details/list endpoint to return one CARD and one PIX entry.
+        stub { request in
+            request.url?.absoluteString.contains("consumers/payment_details/list") ?? false
+        } response: { _ in
+            let cardEntry: [String: Any] = [
+                "id": "pd_card",
+                "type": "CARD",
+                "cardDetails": [
+                    "expYear": 30,
+                    "expMonth": 12,
+                    "brand": "visa",
+                    "networks": ["visa"],
+                    "last4": "4242",
+                    "funding": "CREDIT",
+                ],
+                "isDefault": true,
+            ]
+            let pixEntry: [String: Any] = [
+                "id": "pd_pix",
+                "type": "PIX",
+                "isDefault": false,
+            ]
+            let body: [String: Any] = ["redacted_payment_details": [cardEntry, pixEntry]]
+            return HTTPStubsResponse(jsonObject: body, statusCode: 200, headers: nil)
+        }
+
+        let account = PaymentSheetLinkAccount(
+            email: "user@example.com",
+            session: LinkStubs.consumerSession(),
+            publishableKey: nil,
+            displayablePaymentDetails: nil,
+            apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey),
+            useMobileEndpoints: false,
+            canSyncAttestationState: false
+        )
+
+        let sentTypes: [ParsedEnum<ConsumerPaymentDetails.DetailsType>] = [
+            ParsedEnum(.card),
+            ParsedEnum(rawValue: "PIX"),
+        ]
+
+        let expectation = expectation(description: "listPaymentDetails completes")
+
+        account.listPaymentDetails(
+            supportedTypes: sentTypes,
+            shouldRetryOnAuthError: false
+        ) { result in
+            guard case .success(let paymentDetails) = result else {
+                XCTFail("Expected success, got \(result)")
+                expectation.fulfill()
+                return
+            }
+
+            let receivedTypes = paymentDetails.map { $0.type }
+            analyticsClient.logLinkPaymentDetailsListRequest(
+                sentTypes: sentTypes,
+                receivedTypes: receivedTypes
+            )
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+
+        // Verify the event was logged.
+        let loggedEvent = analyticsClient._testLogHistory.last
+        XCTAssertEqual(loggedEvent?["event"] as? String, "link.payment_details.list.request")
+        XCTAssertEqual(loggedEvent?["sent_types"] as? String, "CARD,PIX")
+        XCTAssertEqual(loggedEvent?["received_types"] as? String, "CARD,PIX")
+    }
+
+    // Tests that `logLinkPaymentDetailsListRequest` correctly reflects when
+    // the backend strips a type that was sent (simulating LPM kill switch behavior).
+    func testListPaymentDetails_detectsStrippedType() {
+        let analyticsClient = STPTestingAnalyticsClient()
+
+        // Backend only returns CARD, not PIX (simulating kill switch removing PIX).
+        stub { request in
+            request.url?.absoluteString.contains("consumers/payment_details/list") ?? false
+        } response: { _ in
+            let cardEntry: [String: Any] = [
+                "id": "pd_card",
+                "type": "CARD",
+                "cardDetails": [
+                    "expYear": 30,
+                    "expMonth": 12,
+                    "brand": "visa",
+                    "networks": ["visa"],
+                    "last4": "4242",
+                    "funding": "CREDIT",
+                ],
+                "isDefault": true,
+            ]
+            let body: [String: Any] = ["redacted_payment_details": [cardEntry]]
+            return HTTPStubsResponse(jsonObject: body, statusCode: 200, headers: nil)
+        }
+
+        let account = PaymentSheetLinkAccount(
+            email: "user@example.com",
+            session: LinkStubs.consumerSession(),
+            publishableKey: nil,
+            displayablePaymentDetails: nil,
+            apiClient: STPAPIClient(publishableKey: STPTestingDefaultPublishableKey),
+            useMobileEndpoints: false,
+            canSyncAttestationState: false
+        )
+
+        let sentTypes: [ParsedEnum<ConsumerPaymentDetails.DetailsType>] = [
+            ParsedEnum(.card),
+            ParsedEnum(rawValue: "PIX"),
+        ]
+
+        let expectation = expectation(description: "listPaymentDetails completes")
+
+        account.listPaymentDetails(
+            supportedTypes: sentTypes,
+            shouldRetryOnAuthError: false
+        ) { result in
+            guard case .success(let paymentDetails) = result else {
+                XCTFail("Expected success, got \(result)")
+                expectation.fulfill()
+                return
+            }
+
+            let receivedTypes = paymentDetails.map { $0.type }
+            analyticsClient.logLinkPaymentDetailsListRequest(
+                sentTypes: sentTypes,
+                receivedTypes: receivedTypes
+            )
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5)
+
+        // Verify sent_types includes PIX but received_types does not.
+        let loggedEvent = analyticsClient._testLogHistory.last
+        XCTAssertEqual(loggedEvent?["event"] as? String, "link.payment_details.list.request")
+        XCTAssertEqual(loggedEvent?["sent_types"] as? String, "CARD,PIX")
+        XCTAssertEqual(loggedEvent?["received_types"] as? String, "CARD")
+    }
+}


### PR DESCRIPTION
## Summary
Adds analytic events tracking which PD type names were sent to and received from `payment_details/list` 

## Motivation
Observability for LPM surfacing in native Link.

## Testing
Added tests for each and tracked the analytic event firing manually.