### PR TITLE
PMM Experiment — Rework Embedded+PS payment method list delegation; fix immediateAction + mandate edge case

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
@@ -74,10 +74,6 @@ class EmbeddedFormViewController: UIViewController {
         return paymentMethodFormViewController.form
     }
 
-    var collectsUserInput: Bool {
-        return form.collectsUserInput
-    }
-
     enum Error: Swift.Error {
         case noPaymentOptionOnBuyButtonTap
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -134,6 +134,7 @@ extension EmbeddedPaymentElement {
 // MARK: - EmbeddedPaymentMethodsViewDelegate
 
 extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
+
     func embeddedPaymentMethodsViewDidUpdateHeight() {
         delegate?.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: self)
     }
@@ -218,22 +219,20 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         presentingViewController?.presentAsBottomSheet(bottomSheetVC, appearance: configuration.appearance)
     }
 
-    func shouldAnimateOnPress(_ paymentMethodType: PaymentSheet.PaymentMethodType) -> Bool {
-        let formViewController = EmbeddedFormViewController(
+    func willDisplayForm(for rowButtonType: RowButtonType?) -> Bool {
+        // Attempt to create a form and return whether one is created
+        return Self.makeFormViewControllerIfNecessary(
+            selection: rowButtonType,
+            previousPaymentOption: nil, // This is just to check if there's a form, so this data isn't necessary
             configuration: configuration,
             intent: intent,
             elementsSession: elementsSession,
-            shouldUseNewCardNewCardHeader: savedPaymentMethods.first?.type == .card,
-            paymentMethodType: paymentMethodType,
-            previousPaymentOption: nil,
+            savedPaymentMethods: savedPaymentMethods,
             analyticsHelper: analyticsHelper,
-            paymentMethodMessagingPromotionsHelper: loadResult.paymentMethodMessagingPromotionsHelper,
+            paymentMethodMessagingPromotionsHelper: nil, // This is just to check if there's a form, so this data isn't necessary
             formCache: .init(),  // Use a fresh form cache to ensure forms aren't re-added to a different view controller's hierarchy
             delegate: self
-        )
-
-        // Show an animation on the label if the payment method shows a form
-        return formViewController.collectsUserInput
+        ) != nil
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -22,10 +22,10 @@ protocol EmbeddedPaymentMethodsViewDelegate: AnyObject {
 
     func embeddedPaymentMethodsViewDidTapViewMoreSavedPaymentMethods(selectedSavedPaymentMethod: STPPaymentMethod?)
 
-    /// Determines if the button for a given `PaymentSheet.PaymentMethodType` should animate when tapped
-    /// - Parameter paymentMethodType: A `PaymentSheet.PaymentMethodType`
-    /// - Returns: True if the button for this payment method type should animate when tapped
-    func shouldAnimateOnPress(_ paymentMethodType: PaymentSheet.PaymentMethodType) -> Bool
+    /// Determines if selecting the given row button type will cause a form to be displayed.
+    /// - Parameter rowButtonType: The type of row button being evaluated.
+    /// - Returns: True if selecting this row button type will display a form.
+    func willDisplayForm(for rowButtonType: RowButtonType?) -> Bool
 }
 
 /// The view for an embedded payment element
@@ -46,7 +46,7 @@ class EmbeddedPaymentMethodsView: UIView {
             guard let previousSelectedRowButton, selectedRowButton?.type != previousSelectedRowButton.type else {
                 return
             }
-            previousSelectedRowButton.isSelected = false
+            previousSelectedRowButton.updateSelectedState(false, willDisplayForm: delegate?.willDisplayForm(for: selectedRowButton?.type) == true)
             // Clear out the 'Change >' button and any sublabel (eg 4242) we set for new PM rows
             switch previousSelectedRowButton.type {
             case .new(paymentMethodType: let paymentMethodType):
@@ -67,7 +67,7 @@ class EmbeddedPaymentMethodsView: UIView {
                 delegate?.embeddedPaymentMethodsViewDidUpdateSelection()
             }
             if let selectedRowButton {
-                selectedRowButton.isSelected = true
+                selectedRowButton.updateSelectedState(true, willDisplayForm: delegate?.willDisplayForm(for: selectedRowButton.type) == true)
             }
         }
     }
@@ -203,7 +203,7 @@ class EmbeddedPaymentMethodsView: UIView {
 
         // If we have a row button that matches the initial selection, make it selected
         if let initialSelectedRowType, let rowButtonMatchingInitialSelection = rowButtons.filter({ $0.type == initialSelectedRowType }).first {
-            rowButtonMatchingInitialSelection.isSelected = true
+            rowButtonMatchingInitialSelection.updateSelectedState(true, willDisplayForm: delegate?.willDisplayForm(for: rowButtonMatchingInitialSelection.type) == true)
             if let initialSelectedRowChangeButtonState {
                 selectedRowChangeButtonState = initialSelectedRowChangeButtonState
                 if initialSelectedRowChangeButtonState.shouldShowChangeButton {
@@ -357,9 +357,11 @@ class EmbeddedPaymentMethodsView: UIView {
                                                                                savedPaymentMethodAccessoryType: accessoryType)
             if isSelected {
                 self.stackView.arrangedSubviews.forEach { view in
-                    (view as? RowButton)?.isSelected = false
+                    if let rowButton = view as? RowButton {
+                        rowButton.updateSelectedState(false, willDisplayForm: delegate?.willDisplayForm(for: rowButton.type) == true)
+                    }
                 }
-                updatedSavedPaymentMethodButton.isSelected = true
+                updatedSavedPaymentMethodButton.updateSelectedState(true, willDisplayForm: delegate?.willDisplayForm(for: updatedSavedPaymentMethodButton.type) == true)
                 self.selectedRowButton = updatedSavedPaymentMethodButton
             }
             // Remove old button & insert new button
@@ -528,7 +530,7 @@ class EmbeddedPaymentMethodsView: UIView {
             promoText: incentive?.takeIfAppliesTo(paymentMethodType)?.displayText,
             appearance: appearance,
             originalCornerRadius: appearance.cornerRadius,
-            shouldAnimateOnPress: delegate?.shouldAnimateOnPress(paymentMethodType) == true,
+            shouldAnimateOnPress: delegate?.willDisplayForm(for: .new(paymentMethodType: paymentMethodType)) == true,
             isEmbedded: true,
             didTap: { [weak self] rowButton in
                 self?.didTap(rowButton: rowButton)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -866,15 +866,15 @@ extension PaymentSheetVerticalViewController: VerticalSavedPaymentMethodsViewCon
 
 extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewControllerDelegate {
 
-    func shouldSelectPaymentMethod(_ selection: RowButtonType) -> Bool {
+    func willDisplayForm(_ selection: RowButtonType) -> Bool {
         switch selection {
         case .applePay, .link:
-            return true
+            return false
         case let .new(paymentMethodType: paymentMethodType):
             // Only make payment methods appear selected in the list if they don't push to a form
-            return !shouldDisplayForm(for: paymentMethodType)
+            return shouldDisplayForm(for: paymentMethodType)
         case .saved:
-            return true
+            return false
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton+Sublabel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton+Sublabel.swift
@@ -21,7 +21,7 @@ extension RowButton {
         /// Updates the displayed text, optionally animating the visibility transition.
         func setSublabel(text: String?, animated: Bool)
         /// Notifies the sublabel that the parent row's selection state changed.
-        func updateSelectedState(_ isRowSelected: Bool)
+        func updateSelectedState(_ isRowSelected: Bool, willDisplayForm: Bool)
     }
 }
 
@@ -118,7 +118,7 @@ extension RowButton {
             }
         }
 
-        func updateSelectedState(_ isRowSelected: Bool) {
+        func updateSelectedState(_ isRowSelected: Bool, willDisplayForm: Bool) {
             // Plain sublabel has no selection-dependent behavior
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -35,11 +35,8 @@ class RowButton: UIView, EventHandler {
 
     // MARK: State
 
-    var isSelected: Bool = false {
-        didSet {
-            updateSelectedState()
-        }
-    }
+    private(set) var isSelected: Bool = false
+
     /// When enabled the `didTap` closure will be called when the button is tapped. When false the `didTap` closure will not be called on taps
     var isEnabled: Bool = true {
         didSet {
@@ -191,11 +188,14 @@ class RowButton: UIView, EventHandler {
         }
     }
 
-    func updateSelectedState() {
+    func updateSelectedState(_ isSelected: Bool, willDisplayForm: Bool) {
+        self.isSelected = isSelected
+
         // Default badge font is heavier when the row is selected
         defaultBadgeLabel?.font = isSelected ? appearance.selectedDefaultBadgeFont : appearance.defaultBadgeFont
         updateAccessibilityTraits()
-        sublabel.updateSelectedState(isSelected)
+
+        sublabel.updateSelectedState(isSelected, willDisplayForm: willDisplayForm)
     }
 
     // MARK: EventHandler

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFlatWithCheckmark.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFlatWithCheckmark.swift
@@ -21,8 +21,8 @@ final class RowButtonFlatWithCheckmark: RowButton {
         return checkmarkImageView
     }()
 
-    override func updateSelectedState() {
-        super.updateSelectedState()
+    override func updateSelectedState(_ isSelected: Bool, willDisplayForm: Bool) {
+        super.updateSelectedState(isSelected, willDisplayForm: willDisplayForm)
         checkmarkImageView.isHidden = !isSelected
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFlatWithRadioView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFlatWithRadioView.swift
@@ -20,8 +20,8 @@ final class RowButtonFlatWithRadioView: RowButton {
         return radioButton
     }()
 
-    override func updateSelectedState() {
-        super.updateSelectedState()
+    override func updateSelectedState(_ isSelected: Bool, willDisplayForm: Bool) {
+        super.updateSelectedState(isSelected, willDisplayForm: willDisplayForm)
         radioButton.isOn = isSelected
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFloating.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButtonFloating.swift
@@ -43,8 +43,8 @@ final class RowButtonFloating: RowButton {
         return 16
     }
 
-    override func updateSelectedState() {
-        super.updateSelectedState()
+    override func updateSelectedState(_ isSelected: Bool, willDisplayForm: Bool) {
+        super.updateSelectedState(isSelected, willDisplayForm: willDisplayForm)
         selectableRectangle.isSelected = isSelected
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/VerticalPaymentMethodListViewController.swift
@@ -124,7 +124,7 @@ class VerticalPaymentMethodListViewController: UIViewController {
                 self?.didTap(rowButton: $0, selection: selection)
             }
             if initialSelection == selection {
-                savedPaymentMethodButton.isSelected = true
+                savedPaymentMethodButton.updateSelectedState(true, willDisplayForm: delegate?.willDisplayForm(savedPaymentMethodButton.type) == true)
                 currentSelection = selection
             }
             views += [
@@ -143,7 +143,7 @@ class VerticalPaymentMethodListViewController: UIViewController {
                 self?.didTap(rowButton: $0, selection: .applePay)
             }
             if initialSelection == selection {
-                rowButton.isSelected = true
+                rowButton.updateSelectedState(true, willDisplayForm: delegate?.willDisplayForm(rowButton.type) == true)
                 currentSelection = selection
             }
             return rowButton
@@ -155,7 +155,7 @@ class VerticalPaymentMethodListViewController: UIViewController {
                 self?.didTap(rowButton: $0, selection: .link)
             }
             if initialSelection == selection {
-                rowButton.isSelected = true
+                rowButton.updateSelectedState(true, willDisplayForm: delegate?.willDisplayForm(rowButton.type) == true)
                 currentSelection = selection
             }
             return rowButton
@@ -173,7 +173,7 @@ class VerticalPaymentMethodListViewController: UIViewController {
                 promoText: incentive?.takeIfAppliesTo(paymentMethodType)?.displayText,
                 appearance: appearance,
                 // Enable press animation if tapping this transitions the screen to a form instead of becoming selected
-                shouldAnimateOnPress: delegate?.shouldSelectPaymentMethod(selection) == false
+                shouldAnimateOnPress: delegate?.willDisplayForm(selection) == true
             ) { [weak self] in
                 self?.didTap(rowButton: $0, selection: selection)
             }
@@ -182,7 +182,7 @@ class VerticalPaymentMethodListViewController: UIViewController {
                 indexAfterCards = index + 1
             }
             if initialSelection == selection {
-                rowButton.isSelected = true
+                rowButton.updateSelectedState(true, willDisplayForm: delegate?.willDisplayForm(rowButton.type) == true)
                 currentSelection = selection
             }
         }
@@ -249,14 +249,14 @@ class VerticalPaymentMethodListViewController: UIViewController {
 
     func didTap(rowButton: RowButton, selection: RowButtonType) {
         guard let delegate else { return }
-        let shouldSelect = delegate.shouldSelectPaymentMethod(selection)
+        let shouldSelect = !delegate.willDisplayForm(rowButton.type)
         if shouldSelect {
             // Deselect previous row
             rowButtons.forEach {
-                $0.isSelected = false
+                $0.updateSelectedState(false, willDisplayForm: delegate.willDisplayForm($0.type))
             }
             // Select new row
-            rowButton.isSelected = shouldSelect
+            rowButton.updateSelectedState(shouldSelect, willDisplayForm: delegate.willDisplayForm(rowButton.type))
             currentSelection = selection
         }
         delegate.didTapPaymentMethod(selection)
@@ -288,8 +288,8 @@ class VerticalPaymentMethodListViewController: UIViewController {
 // MARK: - VerticalPaymentMethodListViewControllerDelegate
 protocol VerticalPaymentMethodListViewControllerDelegate: AnyObject {
     /// Called when a row is tapped, before `didTapPaymentMethod` is called.
-    /// - Returns: Whether or not the payment method row button should appear selected.
-    func shouldSelectPaymentMethod(_ selection: RowButtonType) -> Bool
+    /// - Returns: Whether or not selecting the RowButtonType will cause a form to be displayed.
+    func willDisplayForm(_ rowButtonType: RowButtonType) -> Bool
 
     /// Called after a row is tapped and after `shouldSelectPaymentMethod` is called
     func didTapPaymentMethod(_ selection: RowButtonType)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/SavedPaymentMethodRowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/SavedPaymentMethodRowButton.swift
@@ -36,7 +36,8 @@ final class SavedPaymentMethodRowButton: UIView {
                 previousSelectedState = oldValue
             }
 
-            rowButton.isSelected = isSelected
+            // saved payment methods never show a form
+            rowButton.updateSelectedState(isSelected, willDisplayForm: false)
             chevronButton.isHidden = !isEditing
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
@@ -180,7 +180,7 @@ private class MockEmbeddedPaymentMethodsViewDelegate: EmbeddedPaymentMethodsView
     func embeddedPaymentMethodsViewDidTapViewMoreSavedPaymentMethods(selectedSavedPaymentMethod: STPPaymentMethod?) {
     }
 
-    func shouldAnimateOnPress(_ paymentMethodType: PaymentSheet.PaymentMethodType) -> Bool {
+    func willDisplayForm(for rowButtonType: RowButtonType?) -> Bool {
         return false
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodRowButtonSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodRowButtonSnapshotTests.swift
@@ -138,7 +138,7 @@ class PaymentMethodRowButtonSnapshotTests: STPSnapshotTestCase {
                 isEmbedded: true,
                 didTap: { _ in }
             )
-            rowButton.isSelected = true
+            rowButton.updateSelectedState(true, willDisplayForm: false)
             // ...the row button icon should have 0 left padding and 30 right padding
             verify(rowButton, identifier: "\(style)_0_left_padding_30_right_padding")
         }
@@ -174,7 +174,7 @@ class PaymentMethodRowButtonSnapshotTests: STPSnapshotTestCase {
                 isEmbedded: true,
                 didTap: { _ in }
             )
-            rowButton.isSelected = true
+            rowButton.updateSelectedState(true, willDisplayForm: false)
             // ...the row button label should have the custom italic font
             verify(rowButton, identifier: "\(style)_custom_italic_font")
         }
@@ -205,7 +205,7 @@ class PaymentMethodRowButtonSnapshotTests: STPSnapshotTestCase {
                 isEmbedded: true,
                 didTap: { _ in }
             )
-            rowButton.isSelected = true
+            rowButton.updateSelectedState(true, willDisplayForm: false)
             verify(rowButton, identifier: "\(style)")
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewControllerSnapshotTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewControllerSnapshotTest.swift
@@ -15,8 +15,8 @@ import XCTest
 // ☠️ WARNING: These snapshots are missing selected borders at the corners on iOS 26 - this is a snapshot-test-only-bug and does not repro on simulator/device.
 // @iOS26
 final class VerticalPaymentMethodListViewControllerSnapshotTest: STPSnapshotTestCase, VerticalPaymentMethodListViewControllerDelegate {
-    func shouldSelectPaymentMethod(_ selection: StripePaymentSheet.RowButtonType) -> Bool {
-        return true
+    func willDisplayForm(_ rowButtonType: StripePaymentSheet.RowButtonType) -> Bool {
+        return false
     }
 
     func didTapPaymentMethod(_ selection: StripePaymentSheet.RowButtonType) {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalPaymentMethodListViewControllerTest.swift
@@ -11,7 +11,7 @@ import StripeCoreTestUtils
 import XCTest
 
 final class VerticalPaymentMethodListViewControllerTest: XCTestCase {
-    var shouldSelectPaymentMethodReturnValue: Bool = false
+    var willDisplayFormReturnValue: Bool = true
 
     func testCurrentSelection() {
         let savedPaymentMethod = STPPaymentMethod._testCard()
@@ -38,7 +38,7 @@ final class VerticalPaymentMethodListViewControllerTest: XCTestCase {
         XCTAssertTrue(savedPMButton.isSelected)
 
         // Selecting Apple Pay...
-        shouldSelectPaymentMethodReturnValue = true // (and mocking `didTapPaymentMethod` to return true)
+        willDisplayFormReturnValue = false // (and mocking `willDisplayForm` to return false, meaning it should select)
         let applePayRowButton = sut.getRowButton(accessibilityIdentifier: "Apple Pay")
         sut.didTap(rowButton: applePayRowButton, selection: .applePay)
         // ...should change the current selection from the saved PM...
@@ -48,7 +48,7 @@ final class VerticalPaymentMethodListViewControllerTest: XCTestCase {
         XCTAssertTrue(applePayRowButton.isSelected)
 
         // Selecting card...
-        shouldSelectPaymentMethodReturnValue = false // (and mocking `didTapPaymentMethod` to return false)
+        willDisplayFormReturnValue = true // (and mocking `willDisplayForm` to return true, meaning it will show a form)
         let cardButton = sut.getRowButton(accessibilityIdentifier: "New card")
         sut.didTap(rowButton: cardButton, selection: .new(paymentMethodType: .stripe(.card)))
         // ...should not change the current selection...
@@ -170,8 +170,8 @@ extension VerticalPaymentMethodListViewControllerTest: VerticalPaymentMethodList
         // no-op
     }
 
-    func shouldSelectPaymentMethod(_ selection: StripePaymentSheet.RowButtonType) -> Bool {
-        return shouldSelectPaymentMethodReturnValue
+    func willDisplayForm(_ rowButtonType: StripePaymentSheet.RowButtonType) -> Bool {
+        return willDisplayFormReturnValue
     }
 
     func didTapPaymentMethod(_ selection: StripePaymentSheet.RowButtonType) {


### PR DESCRIPTION
## Summary
- Use `willDisplayForm` in `EmbeddedPaymentMethodsViewDelegate` and `VerticalPaymentMethodListViewControllerDelegate` instead of `shouldAnimateOnPress` and `shouldSelectPaymentMethod`. This more expansive semantic will also cover the Payment Method Messaging in PS/Embedded use case that will be added in a subsequent PR. `willDisplayForm` is functionally the same with the key difference in the edge case described below:
- Fix the edge case in the selection of a payment method in Embedded using `rowSelectionBehavior = .immediateAction` and has a mandate but collects no user input. `shouldAnimateOnPress`, which drove whether or not there would be an animation upon selecting the button, re-implemented most of the logic from `EmbeddedPaymentElement. makeFormViewControllerIfNecessary`, but not all. In particular, it omitted the `rowSelectionBehavior = .immediateAction` edge case logic, and so it incorrectly gave a value of `false` in this case. The new `willDisplayForm` delegate method implementation reuses `makeFormViewControllerIfNecessary` and thus corrects this issue. Before/after video below.
- Change `RowButton` to have its selection state updated via `updateSelectedState` instead of directly setting the property. This allows a `willDisplayForm` value to be passed, which will be used for the Payment Method Messaging in PS/Embedded added in a subsequent PR

## Motivation
- Prepare for Payment Method Messaging in PS/Embedded (https://docs.google.com/document/d/1pi9vehSvFpT80lgEYwBmE_NCcDE5nPTnRrhBrYqlzUQ/edit?tab=t.0)
- Fix bug described above

before:

https://github.com/user-attachments/assets/cf16e6a9-4746-4e2f-961b-391c63bc5859

after:

https://github.com/user-attachments/assets/23fe615a-e727-4995-8659-a0902c4e4821



## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
