### PR TITLE
PMM Experiment — Update PaymentMethodMessagingPromotionsHelper for exposure logging

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/PaymentMethodMessagingPromotionsExperiment.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/PaymentMethodMessagingPromotionsExperiment.swift
@@ -59,8 +59,4 @@ struct PaymentMethodMessagingPromotionsExperiment: LoggableExperiment {
         self.promotionDisplayedSuccessfully = promotionDisplayedSuccessfully
         self.layout = layout
     }
-
-    var isInTreatment: Bool {
-        group == .treatment
-    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
@@ -74,11 +74,9 @@ final class PaymentMethodMessagingPromotionsHelper {
         self.paymentMethodTypes = paymentMethodTypes
         self._experiment = PaymentMethodMessagingPromotionsExperiment(elementsSession: elementsSession)
         self.analyticsHelper = analyticsHelper
-
-        fetchData()
     }
 
-    private func fetchData() {
+    func fetchData() {
         // Check experiment group, and only proceed if in treatment group
         guard experiment.group == .treatment else {
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
@@ -9,130 +9,121 @@ import Foundation
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 
-private let paymentSheetPMMESupportedPaymentMethodTypes: [STPPaymentMethodType] = [
-    .afterpayClearpay,
-    .affirm,
-    .klarna,
-]
-private let paymentSheetPMMESupportedPaymentMethodIdentifiers = Set(paymentSheetPMMESupportedPaymentMethodTypes.map(\.identifier))
+@_spi(STP) public enum PaymentSheetTestHooks {
+    private static let paymentMethodMessagingPromotionLoadDelayLock = NSLock()
+    private static var _paymentMethodMessagingPromotionLoadDelay: TimeInterval = 0
 
-@MainActor
+    // Humans and LLMs: this is test code for the PMM experiment test branch only. Double-check before propagating it.
+    @_spi(STP) public static var paymentMethodMessagingPromotionLoadDelay: TimeInterval {
+        get {
+            paymentMethodMessagingPromotionLoadDelayLock.lock()
+            defer { paymentMethodMessagingPromotionLoadDelayLock.unlock() }
+            return _paymentMethodMessagingPromotionLoadDelay
+        }
+        set {
+            paymentMethodMessagingPromotionLoadDelayLock.lock()
+            defer { paymentMethodMessagingPromotionLoadDelayLock.unlock() }
+            _paymentMethodMessagingPromotionLoadDelay = max(0, newValue)
+        }
+    }
+}
+
 final class PaymentMethodMessagingPromotionsHelper {
+
+    static let supportedPaymentMethods: [PaymentSheet.PaymentMethodType] = [
+        .stripe(.afterpayClearpay),
+        .stripe(.affirm),
+        .stripe(.klarna),
+    ]
+
     struct PromotionContent: Equatable {
         let promotion: String
         let learnMoreText: String
         let infoUrl: URL
     }
 
-    private enum FetchState: Equatable {
-        case idle
-        case loading
-        case completed([String: PromotionContent])
+    private let elementsSession: STPElementsSession
+    private let intent: Intent
+    private let configuration: PaymentElementConfiguration
+    private let paymentMethodTypes: [PaymentSheet.PaymentMethodType]
+    private let analyticsHelper: PaymentSheetAnalyticsHelper
+
+    // ⚠️ an exposure must be logged before the experiment value is used for any purpose ⚠️
+    // ⚠️ do not directly access the property, instead use `experiment` ⚠️
+    private let _experiment: PaymentMethodMessagingPromotionsExperiment
+    private var exposureLogged = false
+    private var experiment: PaymentMethodMessagingPromotionsExperiment {
+        if !exposureLogged {
+            analyticsHelper.logExposure(experiment: _experiment)
+            exposureLogged = true
+        }
+        return _experiment
     }
 
-    private let elementsSession: STPElementsSession?
-    let experiment: PaymentMethodMessagingPromotionsExperiment
+    private let promotionsLock = NSLock()
+    // null until set by loading
+    private var _promotions: [String: PromotionContent]?
+    private var promotions: [String: PromotionContent]? {
+        get {
+            promotionsLock.lock()
+            defer { promotionsLock.unlock() }
+            return _promotions
+        }
+        set {
+            promotionsLock.lock()
+            defer { promotionsLock.unlock() }
+            _promotions = newValue
+        }
+    }
 
-    private var fetchState: FetchState
-    private var fetchTask: Task<Void, Never>?
-
-    init(elementsSession: STPElementsSession) {
-        self.elementsSession = elementsSession
-        self.experiment = PaymentMethodMessagingPromotionsExperiment(elementsSession: elementsSession)
-        self.fetchState = experiment.isInTreatment ? .idle : .completed([:])
+    var isInTreatmentGroup: Bool {
+        experiment.group == .treatment
     }
 
     init(
-        experiment: PaymentMethodMessagingPromotionsExperiment,
-        prefetchedPromotionContents: [String: PromotionContent]
-    ) {
-        self.elementsSession = nil
-        self.experiment = experiment
-        self.fetchState = .completed(prefetchedPromotionContents)
-    }
-
-    func prefetchIfNeeded(
-        intent: Intent,
-        configuration: PaymentElementConfiguration,
-        paymentMethodTypes: [PaymentSheet.PaymentMethodType]
-    ) {
-        guard experiment.isInTreatment else {
-            fetchState = .completed([:])
-            return
-        }
-        guard beginLoadingIfIdle() else {
-            return
-        }
-        guard let elementsSession else {
-            fetchState = .completed([:])
-            return
-        }
-        guard let requestConfiguration = Self.makeConfiguration(
-            intent: intent,
-            elementsSession: elementsSession,
-            configuration: configuration,
-            paymentMethodTypes: paymentMethodTypes
-        ) else {
-            fetchState = .completed([:])
-            return
-        }
-
-        fetchTask = Task { [weak self] in
-            let contents = await Self.fetchPromotionContents(
-                configuration: requestConfiguration,
-                apiClient: configuration.apiClient
-            )
-            await MainActor.run {
-                self?.fetchState = .completed(contents)
-            }
-        }
-    }
-
-    func promotion(for paymentMethodType: PaymentSheet.PaymentMethodType) -> PromotionContent? {
-        guard experiment.isInTreatment else {
-            return nil
-        }
-        guard let identifier = Self.paymentMethodIdentifier(for: paymentMethodType) else {
-            return nil
-        }
-        guard case .completed(let contentsByPaymentMethodType) = fetchState else {
-            return nil
-        }
-        return contentsByPaymentMethodType[identifier]
-    }
-
-    private func beginLoadingIfIdle() -> Bool {
-        guard case .idle = fetchState else {
-            return false
-        }
-        fetchState = .loading
-        return true
-    }
-
-    private static func makeConfiguration(
-        intent: Intent,
         elementsSession: STPElementsSession,
+        intent: Intent,
         configuration: PaymentElementConfiguration,
-        paymentMethodTypes: [PaymentSheet.PaymentMethodType]
-    ) -> PaymentMethodMessagingElement.Configuration? {
-        guard let amount = intent.amount, let currency = intent.currency else {
-            return nil
+        paymentMethodTypes: [PaymentSheet.PaymentMethodType],
+        analyticsHelper: PaymentSheetAnalyticsHelper
+    ) {
+        self.elementsSession = elementsSession
+        self.intent = intent
+        self.configuration = configuration
+        self.paymentMethodTypes = paymentMethodTypes
+        self._experiment = PaymentMethodMessagingPromotionsExperiment(elementsSession: elementsSession)
+        self.analyticsHelper = analyticsHelper
+
+        fetchData()
+    }
+
+    private func fetchData() {
+        // Check experiment group, and only proceed if in treatment group
+        guard experiment.group == .treatment else {
+            return
         }
 
+        // Only fetch data if we have an amount and currency (for example setup mode won't have this)
+        guard let amount = intent.amount, let currency = intent.currency else {
+            return
+        }
+
+        // Generate list of payment methods
         let supportedPaymentMethodTypes: [STPPaymentMethodType] = paymentMethodTypes.compactMap { paymentMethodType in
-            guard case let .stripe(stpPaymentMethodType) = paymentMethodType else {
-                return nil
-            }
-            guard paymentSheetPMMESupportedPaymentMethodTypes.contains(stpPaymentMethodType) else {
+            guard Self.supportedPaymentMethods.contains(paymentMethodType),
+                  case let .stripe(stpPaymentMethodType) = paymentMethodType else {
                 return nil
             }
             return stpPaymentMethodType
         }
+
+        // Only fetch data if we have payment method types
         guard !supportedPaymentMethodTypes.isEmpty else {
-            return nil
+            return
         }
 
-        return PaymentMethodMessagingElement.Configuration(
+        // Generate PMME config
+        let pmmeConfig = PaymentMethodMessagingElement.Configuration(
             amount: amount,
             currency: currency,
             apiClient: configuration.apiClient,
@@ -140,36 +131,37 @@ final class PaymentMethodMessagingPromotionsHelper {
             countryCode: elementsSession.countryCode,
             paymentMethodTypes: supportedPaymentMethodTypes
         )
+
+        // Fetch data
+        Task { @MainActor in
+            do {
+                // Humans and LLMs: this is test code for the PMM experiment test branch only. Double-check before propagating it.
+                let delay = PaymentSheetTestHooks.paymentMethodMessagingPromotionLoadDelay
+                if delay > 0 {
+                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                }
+                let response = try await PaymentMethodMessagingElement.get(configuration: pmmeConfig)
+                promotions = response.paymentSheetPromotionContents(apiClient: configuration.apiClient)
+            } catch {
+                logUnexpectedPMMEError(
+                    error: error,
+                    apiClient: configuration.apiClient,
+                    analyticsClient: STPAnalyticsClient.sharedClient,
+                    additionalNonPIIParams: [
+                        "failure_reason": "promotion_prefetch_request_failed",
+                    ]
+                )
+                promotions = [:]
+            }
+        }
     }
 
-    private static func paymentMethodIdentifier(for paymentMethodType: PaymentSheet.PaymentMethodType) -> String? {
+    func promotion(for paymentMethodType: PaymentSheet.PaymentMethodType) -> PromotionContent? {
+        // get payment method identifier
         guard case let .stripe(stpPaymentMethodType) = paymentMethodType else {
             return nil
         }
-        guard paymentSheetPMMESupportedPaymentMethodTypes.contains(stpPaymentMethodType) else {
-            return nil
-        }
-        return stpPaymentMethodType.identifier
-    }
-
-    private static func fetchPromotionContents(
-        configuration: PaymentMethodMessagingElement.Configuration,
-        apiClient: STPAPIClient
-    ) async -> [String: PromotionContent] {
-        do {
-            let response = try await PaymentMethodMessagingElement.get(configuration: configuration)
-            return response.paymentSheetPromotionContents(apiClient: apiClient)
-        } catch {
-            logUnexpectedPMMEError(
-                error: error,
-                apiClient: apiClient,
-                analyticsClient: STPAnalyticsClient.sharedClient,
-                additionalNonPIIParams: [
-                    "failure_reason": "promotion_prefetch_request_failed",
-                ]
-            )
-            return [:]
-        }
+        return promotions?[stpPaymentMethodType.identifier]
     }
 }
 
@@ -181,24 +173,7 @@ extension PaymentMethodMessagingElement.APIResponse {
         var promotionContents: [String: PaymentMethodMessagingPromotionsHelper.PromotionContent] = [:]
 
         for paymentPlanGroup in paymentPlanGroups {
-            let rawType = paymentPlanGroup.type
-            let normalizedType = rawType.lowercased()
-
-            guard paymentSheetPMMESupportedPaymentMethodIdentifiers.contains(normalizedType) else {
-                logUnexpectedPMMEError(
-                    error: PaymentMethodMessagingElementError.unexpectedResponseFromStripeAPI,
-                    apiClient: apiClient,
-                    analyticsClient: analyticsClient,
-                    additionalNonPIIParams: [
-                        "failure_reason": "unsupported_payment_plan_group_type",
-                        "payment_method_type": normalizedType,
-                    ]
-                )
-                stpAssertionFailure(
-                    "Received unsupported payment_plan_groups.type '\(rawType)' while building PaymentSheet PMME promotions."
-                )
-                continue
-            }
+            let paymentMethodType = paymentPlanGroup.type.lowercased()
 
             guard let promotionContent = paymentPlanGroup.makePaymentSheetPromotionContent() else {
                 logUnexpectedPMMEError(
@@ -207,32 +182,32 @@ extension PaymentMethodMessagingElement.APIResponse {
                     analyticsClient: analyticsClient,
                     additionalNonPIIParams: [
                         "failure_reason": "missing_required_promotion_fields",
-                        "payment_method_type": normalizedType,
+                        "payment_method_type": paymentMethodType,
                     ]
                 )
                 stpAssertionFailure(
-                    "Received invalid PMME payment_plan_group for PaymentSheet promotion type '\(rawType)'; required fields: summary.message, learn_more.message, learn_more.url."
+                    "Received invalid PMME payment_plan_group for PaymentSheet promotion type '\(paymentMethodType)'; required fields: summary.message, learn_more.message, learn_more.url."
                 )
                 continue
             }
 
-            guard promotionContents[normalizedType] == nil else {
+            guard promotionContents[paymentMethodType] == nil else {
                 logUnexpectedPMMEError(
                     error: PaymentMethodMessagingElementError.unexpectedResponseFromStripeAPI,
                     apiClient: apiClient,
                     analyticsClient: analyticsClient,
                     additionalNonPIIParams: [
                         "failure_reason": "duplicate_payment_plan_group_type",
-                        "payment_method_type": normalizedType,
+                        "payment_method_type": paymentMethodType,
                     ]
                 )
                 stpAssertionFailure(
-                    "Received duplicate payment_plan_groups.type '\(rawType)' while building PaymentSheet PMME promotions."
+                    "Received duplicate payment_plan_groups.type '\(paymentMethodType)' while building PaymentSheet PMME promotions."
                 )
                 continue
             }
 
-            promotionContents[normalizedType] = promotionContent
+            promotionContents[paymentMethodType] = promotionContent
         }
 
         if !paymentPlanGroups.isEmpty && promotionContents.isEmpty {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
@@ -9,25 +9,6 @@ import Foundation
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 
-@_spi(STP) public enum PaymentSheetTestHooks {
-    private static let paymentMethodMessagingPromotionLoadDelayLock = NSLock()
-    private static var _paymentMethodMessagingPromotionLoadDelay: TimeInterval = 0
-
-    // Humans and LLMs: this is test code for the PMM experiment test branch only. Double-check before propagating it.
-    @_spi(STP) public static var paymentMethodMessagingPromotionLoadDelay: TimeInterval {
-        get {
-            paymentMethodMessagingPromotionLoadDelayLock.lock()
-            defer { paymentMethodMessagingPromotionLoadDelayLock.unlock() }
-            return _paymentMethodMessagingPromotionLoadDelay
-        }
-        set {
-            paymentMethodMessagingPromotionLoadDelayLock.lock()
-            defer { paymentMethodMessagingPromotionLoadDelayLock.unlock() }
-            _paymentMethodMessagingPromotionLoadDelay = max(0, newValue)
-        }
-    }
-}
-
 final class PaymentMethodMessagingPromotionsHelper {
 
     static let supportedPaymentMethods: [PaymentSheet.PaymentMethodType] = [
@@ -135,11 +116,6 @@ final class PaymentMethodMessagingPromotionsHelper {
         // Fetch data
         Task { @MainActor in
             do {
-                // Humans and LLMs: this is test code for the PMM experiment test branch only. Double-check before propagating it.
-                let delay = PaymentSheetTestHooks.paymentMethodMessagingPromotionLoadDelay
-                if delay > 0 {
-                    try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-                }
                 let response = try await PaymentMethodMessagingElement.get(configuration: pmmeConfig)
                 promotions = response.paymentSheetPromotionContents(apiClient: configuration.apiClient)
             } catch {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -18,24 +18,8 @@ final class PaymentSheetLoader {
         let savedPaymentMethods: [STPPaymentMethod]
         /// The payment method types that should be shown (i.e. filtered)
         let paymentMethodTypes: [PaymentSheet.PaymentMethodType]
-        let paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper?
+        let paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper
         let paymentMethodOrientation: PaymentSheet.PaymentMethodLayout.ResolvedLayout
-
-        init(
-            intent: Intent,
-            elementsSession: STPElementsSession,
-            savedPaymentMethods: [STPPaymentMethod],
-            paymentMethodTypes: [PaymentSheet.PaymentMethodType],
-            paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper? = nil,
-            paymentMethodOrientation: PaymentSheet.PaymentMethodLayout.ResolvedLayout
-        ) {
-            self.intent = intent
-            self.elementsSession = elementsSession
-            self.savedPaymentMethods = savedPaymentMethods
-            self.paymentMethodTypes = paymentMethodTypes
-            self.paymentMethodMessagingPromotionsHelper = paymentMethodMessagingPromotionsHelper
-            self.paymentMethodOrientation = paymentMethodOrientation
-        }
     }
 
     enum IntegrationShape {
@@ -215,11 +199,13 @@ final class PaymentSheetLoader {
             let prefetchedSavedPaymentMethods = try await prefetchedSavedPaymentMethodsTask.value
             let filteredSavedPaymentMethods = filterSavedPaymentMethods(intent: intent, elementsSession: elementsSession, configuration: configuration, prefetchedSPMs: prefetchedSavedPaymentMethods, loadTimings: loadTimings)
 
-            let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession)
-            paymentMethodMessagingPromotionsHelper.prefetchIfNeeded(
+            // Initializing PaymentMethodMessagingPromotionsHelper kick off loading the PMM/BNPL info
+            let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(
+                elementsSession: elementsSession,
                 intent: intent,
                 configuration: configuration,
-                paymentMethodTypes: paymentMethodTypes
+                paymentMethodTypes: paymentMethodTypes,
+                analyticsHelper: analyticsHelper
             )
 
             let paymentMethodOrientation = configuration.resolveLayout(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -199,7 +199,6 @@ final class PaymentSheetLoader {
             let prefetchedSavedPaymentMethods = try await prefetchedSavedPaymentMethodsTask.value
             let filteredSavedPaymentMethods = filterSavedPaymentMethods(intent: intent, elementsSession: elementsSession, configuration: configuration, prefetchedSPMs: prefetchedSavedPaymentMethods, loadTimings: loadTimings)
 
-            // Initializing PaymentMethodMessagingPromotionsHelper kick off loading the PMM/BNPL info
             let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(
                 elementsSession: elementsSession,
                 intent: intent,
@@ -207,6 +206,7 @@ final class PaymentSheetLoader {
                 paymentMethodTypes: paymentMethodTypes,
                 analyticsHelper: analyticsHelper
             )
+            paymentMethodMessagingPromotionsHelper.fetchData()
 
             let paymentMethodOrientation = configuration.resolveLayout(
                 elementsSession: elementsSession,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -254,8 +254,9 @@ fileprivate extension PaymentSheet.FlowController {
         let elementsSession = STPElementsSession(allResponseFields: [:], sessionID: "", configID: "", orderedPaymentMethodTypes: [], orderedPaymentMethodTypesAndWallets: ["card", "link", "apple_pay"], unactivatedPaymentMethodTypes: [], countryCode: nil, merchantCountryCode: nil, merchantLogoUrl: nil, linkSettings: nil, experimentsData: nil, flags: [:], paymentMethodSpecs: nil, cardBrandChoice: nil, isApplePayEnabled: true, externalPaymentMethods: [], customPaymentMethods: [], passiveCaptchaData: nil, customer: nil)
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 10, currency: "USD", setupFutureUsage: nil, captureMethod: .automatic, paymentMethodOptions: nil)) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodOrientation: .vertical)
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
+        let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession, intent: intent, configuration: psConfig, paymentMethodTypes: [], analyticsHelper: analyticsHelper)
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper, paymentMethodOrientation: .vertical)
         return PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEIntegrationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEIntegrationTests.swift
@@ -75,7 +75,7 @@ class ECEIntegrationTests: XCTestCase {
             elementsSession: elementsSession,
             savedPaymentMethods: [],
             paymentMethodTypes: [],
-            paymentMethodOrientation: .vertical
+            paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
         )
         analyticsHelper = PaymentSheetAnalyticsHelper(
             integrationShape: .flowController,
@@ -574,7 +574,7 @@ class ECEIntegrationTests: XCTestCase {
                 elementsSession: loadResult.elementsSession,
                 savedPaymentMethods: [],
                 paymentMethodTypes: [],
-                paymentMethodOrientation: .vertical
+                paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
             ),
             analyticsHelper: PaymentSheetAnalyticsHelper(
                 integrationShape: .flowController,
@@ -611,7 +611,7 @@ class ECEIntegrationTests: XCTestCase {
                 elementsSession: loadResult.elementsSession,
                 savedPaymentMethods: [],
                 paymentMethodTypes: [],
-                paymentMethodOrientation: .vertical
+                paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
             ),
             analyticsHelper: PaymentSheetAnalyticsHelper(
                 integrationShape: .flowController,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEIntegrationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ECEIntegrationTests.swift
@@ -75,7 +75,8 @@ class ECEIntegrationTests: XCTestCase {
             elementsSession: elementsSession,
             savedPaymentMethods: [],
             paymentMethodTypes: [],
-            paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
         )
         analyticsHelper = PaymentSheetAnalyticsHelper(
             integrationShape: .flowController,
@@ -574,7 +575,8 @@ class ECEIntegrationTests: XCTestCase {
                 elementsSession: loadResult.elementsSession,
                 savedPaymentMethods: [],
                 paymentMethodTypes: [],
-                paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
+                paymentMethodMessagingPromotionsHelper: ._testValue(),
+                paymentMethodOrientation: .vertical
             ),
             analyticsHelper: PaymentSheetAnalyticsHelper(
                 integrationShape: .flowController,
@@ -611,7 +613,8 @@ class ECEIntegrationTests: XCTestCase {
                 elementsSession: loadResult.elementsSession,
                 savedPaymentMethods: [],
                 paymentMethodTypes: [],
-                paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
+                paymentMethodMessagingPromotionsHelper: ._testValue(),
+                paymentMethodOrientation: .vertical
             ),
             analyticsHelper: PaymentSheetAnalyticsHelper(
                 integrationShape: .flowController,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ShopPayECEPresenterTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ShopPayECEPresenterTests.swift
@@ -80,7 +80,7 @@ class ShopPayECEPresenterTests: XCTestCase {
             elementsSession: elementsSession,
             savedPaymentMethods: [],
             paymentMethodTypes: [],
-            paymentMethodOrientation: .vertical
+            paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
         )
         analyticsHelper = PaymentSheetAnalyticsHelper(
             integrationShape: .flowController,
@@ -647,7 +647,7 @@ class ShopPayECEPresenterTests: XCTestCase {
             elementsSession: elementsSession,
             savedPaymentMethods: [],
             paymentMethodTypes: [],
-            paymentMethodOrientation: .vertical
+            paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
         )
         let successfulFlowController = PaymentSheet.FlowController(
             configuration: mockConfiguration,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ShopPayECEPresenterTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ECE/ShopPayECEPresenterTests.swift
@@ -80,7 +80,8 @@ class ShopPayECEPresenterTests: XCTestCase {
             elementsSession: elementsSession,
             savedPaymentMethods: [],
             paymentMethodTypes: [],
-            paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
         )
         analyticsHelper = PaymentSheetAnalyticsHelper(
             integrationShape: .flowController,
@@ -647,7 +648,8 @@ class ShopPayECEPresenterTests: XCTestCase {
             elementsSession: elementsSession,
             savedPaymentMethods: [],
             paymentMethodTypes: [],
-            paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
         )
         let successfulFlowController = PaymentSheet.FlowController(
             configuration: mockConfiguration,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedFormViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedFormViewControllerSnapshotTests.swift
@@ -31,6 +31,7 @@ final class EmbeddedFormViewControllerSnapshotTests: STPSnapshotTestCase {
             elementsSession: ._testValue(paymentMethodTypes: [paymentMethodType.identifier]),
             savedPaymentMethods: savedPaymentMethods,
             paymentMethodTypes: [.stripe(paymentMethodType)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementSnapshotTests.swift
@@ -111,6 +111,7 @@ class EmbeddedPaymentElementSnapshotTests: STPSnapshotTestCase, EmbeddedPaymentE
             elementsSession: ._testValue(paymentMethodTypes: ["card", "us_bank_account", "afterpay_clearpay"]),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card), .stripe(.USBankAccount), .stripe(.afterpayClearpay)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         let sut = EmbeddedPaymentElement(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -724,6 +724,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
             paymentMethodTypes: [.stripe(.card)],
             analyticsHelper: analyticsHelper
         )
+        promotionsHelper.fetchData()
         let loadResult = PaymentSheetLoader.LoadResult(
             intent: intent,
             elementsSession: elementsSession,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -6,7 +6,7 @@
 //
 
 @testable@_spi(STP) import StripeCore
-import StripeCoreTestUtils
+@_spi(STP) import StripeCoreTestUtils
 @_spi(AppearanceAPIAdditionsPreview) @_spi(STP) @testable import StripePaymentSheet
 @testable@_spi(STP) import StripePaymentsTestUtils
 @testable@_spi(STP) import StripeUICore
@@ -696,6 +696,61 @@ class EmbeddedPaymentElementTest: XCTestCase {
         // ...the label should read "Cartes Bancaire ****1001"
         sut.updateChangeButtonAndSublabelState(for: .new(paymentMethodType: .stripe(.card)))
         XCTAssertEqual(sut.embeddedPaymentMethodsView.selectedRowChangeButtonState?.sublabel, "Cartes Bancaires •••• 1001")
+    }
+
+    func testPMMExperimentExposureLogged() async throws {
+        let analyticsClientV2 = MockAnalyticsClientV2()
+        let arbId = "arb_pmm_embedded_789"
+        let experimentsData = ExperimentsData(
+            arbId: arbId,
+            experimentAssignments: [
+                PaymentMethodMessagingPromotionsExperiment.experimentName: .treatment,
+            ],
+            allResponseFields: [:]
+        )
+        let analyticsHelper = PaymentSheetAnalyticsHelper(
+            integrationShape: .embedded,
+            configuration: EmbeddedPaymentElement.Configuration(),
+            analyticsClient: STPTestingAnalyticsClient(),
+            analyticsClientV2: analyticsClientV2
+        )
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
+        let elementsSession = STPElementsSession._testValue(experimentsData: experimentsData)
+        let intent = Intent.deferredIntent(intentConfig: intentConfig)
+        let promotionsHelper = PaymentMethodMessagingPromotionsHelper(
+            elementsSession: elementsSession,
+            intent: intent,
+            configuration: configuration,
+            paymentMethodTypes: [.stripe(.card)],
+            analyticsHelper: analyticsHelper
+        )
+        let loadResult = PaymentSheetLoader.LoadResult(
+            intent: intent,
+            elementsSession: elementsSession,
+            savedPaymentMethods: [],
+            paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: promotionsHelper,
+            paymentMethodOrientation: .vertical
+        )
+        await AddressSpecProvider.shared.loadAddressSpecs()
+        await FormSpecProvider.shared.load()
+        let sut = EmbeddedPaymentElement(
+            configuration: configuration,
+            loadResult: loadResult,
+            analyticsHelper: analyticsHelper
+        )
+        sut.delegate = self
+        sut.presentingViewController = UIViewController()
+        sut.view.autosizeHeight(width: 320)
+
+        // Verify PMM experiment exposure was logged exactly once with correct params
+        let exposurePayloads = analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName)
+        XCTAssertEqual(exposurePayloads.count, 1)
+        if let payload = exposurePayloads.first {
+            XCTAssertEqual(payload["arb_id"] as? String, arbId)
+            XCTAssertEqual(payload["experiment_retrieved"] as? String, PaymentMethodMessagingPromotionsExperiment.experimentName)
+            XCTAssertEqual(payload["assignment_group"] as? String, ExperimentGroup.treatment.rawValue)
+        }
     }
 
     func testDelegatePaymentOptionUpdate() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -662,6 +662,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
             elementsSession: elementsSession,
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         let sut = EmbeddedPaymentElement(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
@@ -1,0 +1,115 @@
+//
+//  PaymentMethodMessagingPromotionsHelperTests.swift
+//  StripePaymentSheetTests
+//
+
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeCoreTestUtils
+@_spi(STP) import StripePayments
+@_spi(STP) @testable import StripePaymentSheet
+import XCTest
+
+final class PaymentMethodMessagingPromotionsHelperTests: XCTestCase {
+    func testIsInTreatmentGroup_treatmentAssignment() {
+        let analyticsClientV2 = MockAnalyticsClientV2()
+        let arbId = "arb_123"
+        let experimentsData = ExperimentsData(
+            arbId: arbId,
+            experimentAssignments: [
+                PaymentMethodMessagingPromotionsExperiment.experimentName: .treatment,
+            ],
+            allResponseFields: [:]
+        )
+        let elementsSession = STPElementsSession._testValue(experimentsData: experimentsData)
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
+        let intent = Intent.deferredIntent(intentConfig: intentConfig)
+        let analyticsHelper = PaymentSheetAnalyticsHelper(
+            integrationShape: .complete,
+            configuration: PaymentSheet.Configuration(),
+            analyticsClient: STPTestingAnalyticsClient(),
+            analyticsClientV2: analyticsClientV2
+        )
+        let helper = PaymentMethodMessagingPromotionsHelper(
+            elementsSession: elementsSession,
+            intent: intent,
+            configuration: PaymentSheet.Configuration(),
+            paymentMethodTypes: [.stripe(.affirm)],
+            analyticsHelper: analyticsHelper
+        )
+
+        XCTAssertTrue(helper.isInTreatmentGroup)
+
+        // Verify exposure was logged exactly once with correct parameters
+        let payloads = analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName)
+        XCTAssertEqual(payloads.count, 1)
+        guard let payload = payloads.first else {
+            return XCTFail("Expected exposure event to be logged")
+        }
+        XCTAssertEqual(payload["arb_id"] as? String, arbId)
+        XCTAssertEqual(payload["experiment_retrieved"] as? String, PaymentMethodMessagingPromotionsExperiment.experimentName)
+        XCTAssertEqual(payload["assignment_group"] as? String, ExperimentGroup.treatment.rawValue)
+
+        // Second access should not log again
+        _ = helper.isInTreatmentGroup
+        XCTAssertEqual(analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName).count, 1)
+    }
+
+    func testIsInTreatmentGroup_controlAssignment() {
+        let analyticsClientV2 = MockAnalyticsClientV2()
+        let arbId = "arb_123"
+        let experimentsData = ExperimentsData(
+            arbId: arbId,
+            experimentAssignments: [
+                PaymentMethodMessagingPromotionsExperiment.experimentName: .control,
+            ],
+            allResponseFields: [:]
+        )
+        let elementsSession = STPElementsSession._testValue(experimentsData: experimentsData)
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
+        let intent = Intent.deferredIntent(intentConfig: intentConfig)
+        let analyticsHelper = PaymentSheetAnalyticsHelper(
+            integrationShape: .complete,
+            configuration: PaymentSheet.Configuration(),
+            analyticsClient: STPTestingAnalyticsClient(),
+            analyticsClientV2: analyticsClientV2
+        )
+        let helper = PaymentMethodMessagingPromotionsHelper(
+            elementsSession: elementsSession,
+            intent: intent,
+            configuration: PaymentSheet.Configuration(),
+            paymentMethodTypes: [.stripe(.affirm)],
+            analyticsHelper: analyticsHelper
+        )
+
+        XCTAssertFalse(helper.isInTreatmentGroup)
+
+        // Verify exposure was logged exactly once with correct parameters
+        let payloads = analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName)
+        XCTAssertEqual(payloads.count, 1)
+        guard let payload = payloads.first else {
+            return XCTFail("Expected exposure event to be logged")
+        }
+        XCTAssertEqual(payload["arb_id"] as? String, arbId)
+        XCTAssertEqual(payload["experiment_retrieved"] as? String, PaymentMethodMessagingPromotionsExperiment.experimentName)
+        XCTAssertEqual(payload["assignment_group"] as? String, ExperimentGroup.control.rawValue)
+
+        // Second access should not log again
+        _ = helper.isInTreatmentGroup
+        XCTAssertEqual(analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName).count, 1)
+    }
+
+    func testPromotion_returnsNilForUnsupportedType() {
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"])
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
+        let intent = Intent.deferredIntent(intentConfig: intentConfig)
+        let helper = PaymentMethodMessagingPromotionsHelper(
+            elementsSession: elementsSession,
+            intent: intent,
+            configuration: PaymentSheet.Configuration(),
+            paymentMethodTypes: [],
+            analyticsHelper: PaymentSheetAnalyticsHelper._testValue()
+        )
+
+        XCTAssertNil(helper.promotion(for: .stripe(.cashApp)))
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
@@ -156,7 +156,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         }
 
         stub { urlRequest in
-            guard let pathComponents = urlRequest.url?.pathComponents else { return false }
+            guard let pathComponents = urlRequest.url?.pathComponents, pathComponents.count >= 3 else { return false }
             return pathComponents[2] == "setup_intents" && pathComponents.last != "confirm"
         } response: { request in
             var json = MockJson.setupIntent

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -401,7 +401,8 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         let configuration = PaymentSheet.Configuration()
         let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
         let elementsSession = STPElementsSession._testCardValue()
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [.stripe(.card)], paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical)
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [.stripe(.card)], paymentMethodMessagingPromotionsHelper: ._testValue(),
+ paymentMethodOrientation: .vertical)
 
         let flowController = PaymentSheet.FlowController(
             configuration: configuration,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -401,7 +401,7 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         let configuration = PaymentSheet.Configuration()
         let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
         let elementsSession = STPElementsSession._testCardValue()
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [.stripe(.card)], paymentMethodOrientation: .vertical)
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [.stripe(.card)], paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical)
 
         let flowController = PaymentSheet.FlowController(
             configuration: configuration,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
@@ -20,6 +20,7 @@ final class PaymentSheetFlowControllerViewControllerSnapshotTests: STPSnapshotTe
             elementsSession: ._testValue(paymentMethodTypes: ["card"], isLinkPassthroughModeEnabled: false),
             savedPaymentMethods: savedPaymentMethods,
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .horizontal
         )
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerViewControllerSnapshotTests.swift
@@ -121,6 +121,7 @@ final class PaymentSheetFlowControllerViewControllerSnapshotTests: STPSnapshotTe
             ),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .horizontal
         )
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -869,9 +869,9 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
 
         // Verify the 3 exposure events
         let exposures = mockAnalyticsClientV2.loggedAnalyticPayloads(withEventName: "elements.experiment_exposure")
-        XCTAssertEqual(exposures.count, 3)
+        XCTAssertEqual(exposures.count, 4)
         let experimentNames = Set(exposures.compactMap { $0["experiment_retrieved"] as? String })
-        XCTAssertEqual(experimentNames, ["link_global_holdback", "link_global_holdback_aa", "link_ab_test"])
+        XCTAssertEqual(experimentNames, ["link_global_holdback", "link_global_holdback_aa", "link_ab_test", "ocs_mobile_payment_method_messaging_promotions"])
         for exposure in exposures {
             XCTAssertEqual(exposure["arb_id"] as? String, "test_arb_123")
             XCTAssertNotNil(exposure["assignment_group"], "Expected assignment_group in exposure: \(exposure)")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerSnapshotTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerSnapshotTest.swift
@@ -305,6 +305,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["us_bank_account", "cashapp"], isLinkPassthroughModeEnabled: false),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.USBankAccount), .stripe(.cashApp)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         let sut = PaymentSheetVerticalViewController(configuration: ._testValue_MostPermissive(isApplePayEnabled: false), loadResult: loadResult, isFlowController: true, analyticsHelper: ._testValue(), previousPaymentOption: nil)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerSnapshotTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerSnapshotTest.swift
@@ -53,6 +53,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testCardValue(),
             savedPaymentMethods: [._testCard()],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         verify(makeSUT(loadResult: loadResult1, isApplePayEnabled: false, isFlowController: false), identifier: "saved_pms")
@@ -63,6 +64,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["sepa_debit"]),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.SEPADebit)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         verify(makeSUT(loadResult: loadResult2, isApplePayEnabled: false, isFlowController: false), identifier: "one_non_card_pm")
@@ -73,6 +75,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["sepa_debit"]),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.SEPADebit)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         verify(makeSUT(loadResult: loadResult3, isApplePayEnabled: true, isFlowController: false), identifier: "one_non_card_pm_apple_pay_enabled")
@@ -83,6 +86,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["cashapp"]),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.cashApp)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         verify(makeSUT(loadResult: loadResult4, isApplePayEnabled: false, isFlowController: false), identifier: "one_non_card_pm_no_input")
@@ -93,6 +97,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["cashapp"]),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.cashApp)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         verify(makeSUT(loadResult: loadResult5, isApplePayEnabled: true, isFlowController: false), identifier: "one_non_card_pm_no_input_apple_pay_enabled")
@@ -103,6 +108,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["cashapp"]),
             savedPaymentMethods: [._testCard()],
             paymentMethodTypes: [.stripe(.cashApp)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         verify(makeSUT(loadResult: loadResult6, isApplePayEnabled: true, isFlowController: false), identifier: "one_non_card_pm_no_input_saved_pm")
@@ -113,6 +119,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["klarna"]),
             savedPaymentMethods: [._testCard()],
             paymentMethodTypes: [.stripe(.klarna)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         verify(makeSUT(loadResult: loadResult7, isApplePayEnabled: true, isFlowController: false), identifier: "one_non_card_pm_saved_pm")
@@ -123,6 +130,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["card", "sepa_debit"]),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card), .stripe(.SEPADebit)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         verify(makeSUT(loadResult: loadResult8, isApplePayEnabled: false, isFlowController: false), identifier: "multiple_pms")
@@ -133,6 +141,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["card"], isLinkPassthroughModeEnabled: true),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         verify(makeSUT(loadResult: loadResult9, isApplePayEnabled: true, isFlowController: true), identifier: "card_link_applepay_flowcontroller")
@@ -143,6 +152,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testCardValue(),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         verify(makeSUT(loadResult: loadResult10, isApplePayEnabled: true, isFlowController: true), identifier: "card_applepay_flowcontroller")
@@ -162,6 +172,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
                 elementsSession: elementsSession,
                 savedPaymentMethods: [],
                 paymentMethodTypes: [.stripe(.card)],
+                paymentMethodMessagingPromotionsHelper: ._testValue(),
                 paymentMethodOrientation: .vertical
             )
             return PaymentSheetVerticalViewController(configuration: config, loadResult: loadResult, isFlowController: isFlowController, analyticsHelper: ._testValue(), previousPaymentOption: nil)
@@ -189,6 +200,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["card", "cashapp"]),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         // ...and previous customer input is card...
@@ -206,6 +218,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["card"], isLinkPassthroughModeEnabled: false),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         // ...and previous customer input is card...
@@ -222,6 +235,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["card", "cashapp"], isLinkPassthroughModeEnabled: false),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         // ...and previous customer input is cash app - a PM without a form
@@ -240,6 +254,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["card", "cashapp"]),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         // ...and previous customer input is SEPA - a PM that is not in the list
@@ -256,6 +271,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["card", "cashapp"], isLinkPassthroughModeEnabled: false),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card), .stripe(.cashApp)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         // ...and previous customer input is cash app - a PM without a form...
@@ -272,6 +288,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["card", "sepa_debit"], isLinkPassthroughModeEnabled: false),
             savedPaymentMethods: [._testSEPA()],
             paymentMethodTypes: [.stripe(.card), .stripe(.SEPADebit)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         let sut = PaymentSheetVerticalViewController(configuration: ._testValue_MostPermissive(isApplePayEnabled: false), loadResult: loadResult, isFlowController: true, analyticsHelper: ._testValue(), previousPaymentOption: nil)
@@ -286,6 +303,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["card", "us_bank_account"], isLinkPassthroughModeEnabled: false),
             savedPaymentMethods: [._testUSBankAccount()],
             paymentMethodTypes: [.stripe(.card), .stripe(.USBankAccount)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         let sut = PaymentSheetVerticalViewController(configuration: ._testValue_MostPermissive(isApplePayEnabled: false), loadResult: loadResult, isFlowController: true, analyticsHelper: ._testValue(), previousPaymentOption: nil)
@@ -333,6 +351,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testCardValue(),
             savedPaymentMethods: [._testCard()],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         let sut = PaymentSheetVerticalViewController(configuration: ._testValue_MostPermissive(), loadResult: loadResult, isFlowController: false, analyticsHelper: ._testValue(), previousPaymentOption: nil)
@@ -352,6 +371,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: elementsSession,
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card), .linkCardBrand],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         let sut = PaymentSheetVerticalViewController(configuration: ._testValue_MostPermissive(), loadResult: loadResult, isFlowController: false, analyticsHelper: ._testValue(), previousPaymentOption: nil)
@@ -371,6 +391,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: elementsSession,
             savedPaymentMethods: [savedCard],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         let sut = PaymentSheetVerticalViewController(configuration: ._testValue_MostPermissive(isApplePayEnabled: false), loadResult: loadResult, isFlowController: false, analyticsHelper: ._testValue(), previousPaymentOption: nil)
@@ -416,6 +437,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["card", "cashapp", "afterpay_clearpay"]),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card), .stripe(.cashApp), .stripe(.afterpayClearpay)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
 
@@ -437,6 +459,7 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
             elementsSession: ._testValue(paymentMethodTypes: ["card", "cashapp", "afterpay_clearpay"]),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card), .stripe(.cashApp), .stripe(.afterpayClearpay)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
@@ -61,6 +61,7 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
             paymentMethodTypes: [.stripe(.card)],
             analyticsHelper: analyticsHelper
         )
+        promotionsHelper.fetchData()
         let savedPMsLoadResult = PaymentSheetLoader.LoadResult(
             intent: intent,
             elementsSession: elementsSession,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
@@ -39,6 +39,7 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
             elementsSession: ._testCardValue(),
             savedPaymentMethods: [._testCard()],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         XCTAssertTrue(makeViewController(loadResult: savedPMsLoadResult).children.first is VerticalPaymentMethodListViewController)
@@ -49,6 +50,7 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
             elementsSession: ._testCardValue(),
             savedPaymentMethods: [],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         XCTAssertTrue(makeViewController(loadResult: formDirectlyResult).children.first is PaymentMethodFormViewController)
@@ -59,6 +61,7 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
             elementsSession: ._testCardValue(),
             savedPaymentMethods: [._testCard()],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         XCTAssertTrue(makeViewController(loadResult: onlyOnePM).children.first is VerticalPaymentMethodListViewController)
@@ -69,6 +72,7 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
             elementsSession: ._testCardValue(),
             savedPaymentMethods: [._testCard()],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         XCTAssertTrue(makeViewController(loadResult: multiplePMs).children.first is VerticalPaymentMethodListViewController)
@@ -79,6 +83,7 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
             elementsSession: ._testCardValue(),
             savedPaymentMethods: [._testCard()],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         XCTAssertTrue(makeViewController(loadResult: onePMAndLink).children.first is VerticalPaymentMethodListViewController)
@@ -89,6 +94,7 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
             elementsSession: ._testCardValue(),
             savedPaymentMethods: [._testCard()],
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .vertical
         )
         XCTAssertTrue(makeViewController(loadResult: onePMAndApplePay).children.first is VerticalPaymentMethodListViewController)
@@ -102,6 +108,7 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
                 elementsSession: ._testValue(paymentMethodTypes: ["card"], isLinkPassthroughModeEnabled: true),
                 savedPaymentMethods: hasSavedPM ? [._testCard()] : [],
                 paymentMethodTypes: [.stripe(.card)],
+                paymentMethodMessagingPromotionsHelper: ._testValue(),
                 paymentMethodOrientation: .vertical
             )
             return PaymentSheetVerticalViewController(
@@ -155,6 +162,7 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
                 elementsSession: ._testValue(paymentMethodTypes: ["card"], isLinkPassthroughModeEnabled: true),
                 savedPaymentMethods: hasSavedPM ? [savedPM] : [],
                 paymentMethodTypes: [.stripe(.card)],
+                paymentMethodMessagingPromotionsHelper: ._testValue(),
                 paymentMethodOrientation: .vertical
             )
             return PaymentSheetVerticalViewController(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
@@ -5,7 +5,9 @@
 //  Created by Yuki Tokuhiro on 6/4/24.
 //
 
-import StripeCoreTestUtils
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeCoreTestUtils
+@_spi(STP) import StripePayments
 @_spi(STP) @testable import StripePaymentSheet
 @_spi(STP) import StripeUICore
 import XCTest
@@ -23,26 +25,60 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
     }
 
     func testInitialScreen() {
+        let analyticsClientV2 = MockAnalyticsClientV2()
+        let arbId = "arb_pmm_123"
+        let experimentsData = ExperimentsData(
+            arbId: arbId,
+            experimentAssignments: [
+                PaymentMethodMessagingPromotionsExperiment.experimentName: .treatment,
+            ],
+            allResponseFields: [:]
+        )
+        let analyticsHelper = PaymentSheetAnalyticsHelper(
+            integrationShape: .complete,
+            configuration: PaymentSheet.Configuration(),
+            analyticsClient: STPTestingAnalyticsClient(),
+            analyticsClientV2: analyticsClientV2
+        )
+
         func makeViewController(loadResult: PaymentSheetLoader.LoadResult) -> PaymentSheetVerticalViewController {
             return PaymentSheetVerticalViewController(
                 configuration: ._testValue_MostPermissive(),
                 loadResult: loadResult,
                 isFlowController: false,
-                analyticsHelper: ._testValue(),
+                analyticsHelper: analyticsHelper,
                 previousPaymentOption: nil
             )
         }
         // TODO: Test other things like `selectedPaymentOption`
         // If there are saved PMs, always show the list, even if there's only one other PM
+        let elementsSession = STPElementsSession._testValue(experimentsData: experimentsData)
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
+        let promotionsHelper = PaymentMethodMessagingPromotionsHelper(
+            elementsSession: elementsSession,
+            intent: intent,
+            configuration: PaymentSheet.Configuration(),
+            paymentMethodTypes: [.stripe(.card)],
+            analyticsHelper: analyticsHelper
+        )
         let savedPMsLoadResult = PaymentSheetLoader.LoadResult(
-            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
-            elementsSession: ._testCardValue(),
+            intent: intent,
+            elementsSession: elementsSession,
             savedPaymentMethods: [._testCard()],
             paymentMethodTypes: [.stripe(.card)],
-            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodMessagingPromotionsHelper: promotionsHelper,
             paymentMethodOrientation: .vertical
         )
         XCTAssertTrue(makeViewController(loadResult: savedPMsLoadResult).children.first is VerticalPaymentMethodListViewController)
+
+        // Verify PMM experiment exposure was logged exactly once with correct params
+        let exposurePayloads = analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName)
+        XCTAssertEqual(exposurePayloads.count, 1)
+        if let payload = exposurePayloads.first {
+            XCTAssertEqual(payload["arb_id"] as? String, arbId)
+            XCTAssertEqual(payload["experiment_retrieved"] as? String, PaymentMethodMessagingPromotionsExperiment.experimentName)
+            XCTAssertEqual(payload["assignment_group"] as? String, ExperimentGroup.treatment.rawValue)
+        }
 
         // If there are no saved payment methods and we have only one payment method and it collects user input, display the form directly
         let formDirectlyResult = PaymentSheetLoader.LoadResult(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetViewControllerSnapshotTests.swift
@@ -18,6 +18,7 @@ final class PaymentSheetViewControllerSnapshotTests: STPSnapshotTestCase {
             elementsSession: ._testValue(paymentMethodTypes: ["card"], isLinkPassthroughModeEnabled: false),
             savedPaymentMethods: savedPaymentMethods,
             paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
             paymentMethodOrientation: .horizontal
         )
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -443,12 +443,37 @@ extension PaymentSheetLoader.LoadResult {
             paymentMethodTypes: paymentMethodTypes
         )
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
+        let analyticsHelper = PaymentSheetAnalyticsHelper._testValue()
+        let pmTypes = paymentMethodTypes.map { PaymentSheet.PaymentMethodType.stripe(STPPaymentMethod.type(from: $0)) }
+        let promotionsHelper = PaymentMethodMessagingPromotionsHelper(
+            elementsSession: elementsSession,
+            intent: intent,
+            configuration: PaymentSheet.Configuration(),
+            paymentMethodTypes: pmTypes,
+            analyticsHelper: analyticsHelper
+        )
         return PaymentSheetLoader.LoadResult(
             intent: intent,
             elementsSession: elementsSession,
             savedPaymentMethods: savedPaymentMethods,
-            paymentMethodTypes: paymentMethodTypes.map { .stripe(STPPaymentMethod.type(from: $0)) },
-            paymentMethodOrientation: .vertical
+            paymentMethodTypes: pmTypes,
+            paymentMethodMessagingPromotionsHelper: promotionsHelper,
+            paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
+        )
+    }
+}
+
+extension PaymentMethodMessagingPromotionsHelper {
+    static func _testValue() -> PaymentMethodMessagingPromotionsHelper {
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
+        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"])
+        let intent = Intent.deferredIntent(intentConfig: intentConfig)
+        return PaymentMethodMessagingPromotionsHelper(
+            elementsSession: elementsSession,
+            intent: intent,
+            configuration: PaymentSheet.Configuration(),
+            paymentMethodTypes: [],
+            analyticsHelper: PaymentSheetAnalyticsHelper._testValue()
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -458,7 +458,7 @@ extension PaymentSheetLoader.LoadResult {
             savedPaymentMethods: savedPaymentMethods,
             paymentMethodTypes: pmTypes,
             paymentMethodMessagingPromotionsHelper: promotionsHelper,
-            paymentMethodMessagingPromotionsHelper: ._testValue(), paymentMethodOrientation: .vertical
+            paymentMethodOrientation: .vertical
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/WalletButtonsViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/WalletButtonsViewTests.swift
@@ -40,7 +40,8 @@ class WalletButtonsViewTests: XCTestCase {
         psConfig.applePay = .init(merchantId: "test_merchant_id", merchantCountryCode: "US")
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "usd", setupFutureUsage: nil, captureMethod: .automatic, paymentMethodOptions: nil)) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodOrientation: .vertical)
+        let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession, intent: intent, configuration: psConfig, paymentMethodTypes: [], analyticsHelper: PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig))
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper, paymentMethodOrientation: .vertical)
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
         let flowController = PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
 
@@ -80,7 +81,8 @@ class WalletButtonsViewTests: XCTestCase {
         // Don't set up Apple Pay
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "usd", setupFutureUsage: nil, captureMethod: .automatic, paymentMethodOptions: nil)) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodOrientation: .vertical)
+        let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession, intent: intent, configuration: psConfig, paymentMethodTypes: [], analyticsHelper: PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig))
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper, paymentMethodOrientation: .vertical)
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
         let flowController = PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
 
@@ -120,7 +122,8 @@ class WalletButtonsViewTests: XCTestCase {
         // Don't set up Apple Pay
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "usd", setupFutureUsage: nil, captureMethod: .automatic, paymentMethodOptions: nil)) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodOrientation: .vertical)
+        let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession, intent: intent, configuration: psConfig, paymentMethodTypes: [], analyticsHelper: PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig))
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper, paymentMethodOrientation: .vertical)
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
         let flowController = PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
 
@@ -169,7 +172,8 @@ class WalletButtonsViewTests: XCTestCase {
         )
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "usd", setupFutureUsage: nil, captureMethod: .automatic, paymentMethodOptions: nil)) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodOrientation: .vertical)
+        let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession, intent: intent, configuration: psConfig, paymentMethodTypes: [], analyticsHelper: PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig))
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper, paymentMethodOrientation: .vertical)
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
         let flowController = PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
 
@@ -218,7 +222,8 @@ class WalletButtonsViewTests: XCTestCase {
         )
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "usd", setupFutureUsage: nil, captureMethod: .automatic, paymentMethodOptions: nil)) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodOrientation: .vertical)
+        let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession, intent: intent, configuration: psConfig, paymentMethodTypes: [], analyticsHelper: PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig))
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper, paymentMethodOrientation: .vertical)
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
         let flowController = PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
 
@@ -267,7 +272,8 @@ class WalletButtonsViewTests: XCTestCase {
         )
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "usd", setupFutureUsage: nil, captureMethod: .automatic, paymentMethodOptions: nil)) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodOrientation: .vertical)
+        let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession, intent: intent, configuration: psConfig, paymentMethodTypes: [], analyticsHelper: PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig))
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper, paymentMethodOrientation: .vertical)
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
         let flowController = PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
 
@@ -307,7 +313,8 @@ class WalletButtonsViewTests: XCTestCase {
         psConfig.applePay = .init(merchantId: "test_merchant_id", merchantCountryCode: "US")
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "usd", setupFutureUsage: nil, captureMethod: .automatic, paymentMethodOptions: nil)) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodOrientation: .vertical)
+        let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession, intent: intent, configuration: psConfig, paymentMethodTypes: [], analyticsHelper: PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig))
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper, paymentMethodOrientation: .vertical)
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
         let flowController = PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
 
@@ -356,7 +363,8 @@ class WalletButtonsViewTests: XCTestCase {
         psConfig.applePay = .init(merchantId: "test_merchant_id", merchantCountryCode: "US")
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "usd", setupFutureUsage: nil, captureMethod: .automatic, paymentMethodOptions: nil)) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodOrientation: .vertical)
+        let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession, intent: intent, configuration: psConfig, paymentMethodTypes: [], analyticsHelper: PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig))
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper, paymentMethodOrientation: .vertical)
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
         let flowController = PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
 
@@ -410,7 +418,8 @@ class WalletButtonsViewTests: XCTestCase {
         psConfig.applePay = .init(merchantId: "test_merchant_id", merchantCountryCode: "US")
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "usd", setupFutureUsage: nil, captureMethod: .automatic, paymentMethodOptions: nil)) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodOrientation: .vertical)
+        let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession, intent: intent, configuration: psConfig, paymentMethodTypes: [], analyticsHelper: PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig))
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper, paymentMethodOrientation: .vertical)
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
         let flowController = PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
 
@@ -465,7 +474,8 @@ class WalletButtonsViewTests: XCTestCase {
         psConfig.applePay = .init(merchantId: "test_merchant_id", merchantCountryCode: "US")
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "usd", setupFutureUsage: nil, captureMethod: .automatic, paymentMethodOptions: nil)) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodOrientation: .vertical)
+        let paymentMethodMessagingPromotionsHelper = PaymentMethodMessagingPromotionsHelper(elementsSession: elementsSession, intent: intent, configuration: psConfig, paymentMethodTypes: [], analyticsHelper: PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig))
+        let loadResult = PaymentSheetLoader.LoadResult(intent: intent, elementsSession: elementsSession, savedPaymentMethods: [], paymentMethodTypes: [], paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper, paymentMethodOrientation: .vertical)
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .complete, configuration: psConfig)
         let flowController = PaymentSheet.FlowController(configuration: psConfig, loadResult: loadResult, analyticsHelper: analyticsHelper)
 


### PR DESCRIPTION
## Summary
- Simplify code to be better suited for new exposure logging strategy
- Add exposure logging when getting experiment data. We wait until the experiment data is actually used to log an exposure. This is because we want to minimize the number of sessions that log an exposure but where the experiment data doesn't actually impact the customer experience. If we logged an exposure when we first fetch the experiment data (upon payment sheet loading), we could potentially gather extraneous exposures.
- Make the PaymentMethodMessagingPromotionsHelper not `@MainActor` isolated and instead enforce thread safety with a lock. `PaymentMethodMessagingPromotionsHelper` will be used from non-`@MainActor` contexts that cannot easily be made `@MainActor` and so it is easiest to just protect the read/write to the one piece of async fetched code this way.

## Motivation
https://docs.google.com/document/d/1pi9vehSvFpT80lgEYwBmE_NCcDE5nPTnRrhBrYqlzUQ/edit?tab=t.0

## Testing
- added unit tests for PaymentMethodMessagingPromotionsHelper
- added integration tests that verify that PMM experiment logging is completed for both PS and embedded

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
