### PR TITLE
Reduce network calls when updating a CheckoutSession

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+CurrencySelectorView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+CurrencySelectorView.swift
@@ -238,7 +238,8 @@ extension Checkout.CurrencySelectorView: TwoOptionSelectorViewDelegate {
         // Disable interaction during the API call
         selectorView?.setEnabled(false)
 
-        Task {
+        Task { [weak self] in
+            guard let self else { return }
             do {
                 try await checkout.selectCurrency(id)
                 STPAnalyticsClient.sharedClient.log(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -70,28 +70,25 @@ extension Checkout {
         try await operation.value
     }
 
-    /// Sends a mutation to the Stripe API and refreshes the session.
-    ///
-    /// The update endpoint returns partial data, so we always re-fetch the full session
-    /// afterward to keep ``state`` as the single source of truth.
+    /// Sends a mutation to the Stripe API and updates the session from the response.
     ///
     /// - Parameter applyOverrides: Forwarded to ``updateSession(_:applyOverrides:)``.
     ///   Runs only after a successful API call — use this to set client-side overrides
-    ///   on the refreshed session so local state stays in sync with the backend.
+    ///   on the updated session so local state stays in sync with the backend.
     func performAPIUpdate(
         _ update: SessionUpdate,
         applyOverrides: ((STPCheckoutSession) -> Void)? = nil
     ) async throws {
         do {
             let sessionId = Self.extractSessionId(from: clientSecret)
-            _ = try await apiClient.updateCheckoutSession(
+            let updatedSession = try await apiClient.updateCheckoutSession(
                 checkoutSessionId: sessionId,
                 parameters: update.parameters
             )
+            updateSession(updatedSession, applyOverrides: applyOverrides)
         } catch {
             throw CheckoutError.apiError(message: error.nonGenericDescription)
         }
-        try await refreshSession(applyOverrides: applyOverrides)
     }
 
     /// Fetches the latest Checkout Session from Stripe and publishes it to observers.


### PR DESCRIPTION
## Summary
- Reduces a extra network call to get the latest session as the update call gives it back to us

## Motivation
- Latency

## Testing
- Existing tests

## Changelog
N/A
