### PR TITLE
PMM Experiment — Use correct UserInterfaceStyle when showing PaymentMethodMessaging modal in sublabel view

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -860,14 +860,6 @@ extension PaymentSheetFormFactory {
         return country
     }
 
-    private var bnplHeaderStyle: PaymentSheet.UserInterfaceStyle {
-        guard case .paymentElement(let configuration, _) = configuration else {
-            stpAssertionFailure("BNPL headers are only supported for PaymentSheet/FlowController/EmbeddedPaymentElement and not CustomerSheet.")
-            return .automatic
-        }
-        return configuration.style
-    }
-
     func makeKlarnaHeader() -> SubtitleElement {
         if let header = makeBNPLHeader() {
             // Use the shared BNPL header when header content is available.
@@ -896,7 +888,6 @@ extension PaymentSheetFormFactory {
         return nil
 //        let headerView = BNPLFormHeaderView(
 //            appearance: configuration.appearance,
-//            style: bnplHeaderStyle,
 //            promotion: "TODO: fill in with real promotion content",
 //            learnMoreText: "TODO: fill in with real learn more text",
 //            infoUrl: URL(string: "https://stripe.com")!

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton+PaymentMethodMessagingSublabelView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton+PaymentMethodMessagingSublabelView.swift
@@ -134,7 +134,7 @@ extension RowButton {
                 return
             }
 
-            PMMEInfoModal.present(infoUrl: infoUrl, style: .automatic, from: self)
+            PMMEInfoModal.present(infoUrl: infoUrl, style: traitCollection.isDarkMode ? .alwaysDark : .alwaysLight, from: self)
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/BNPLFormHeaderView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/BNPLFormHeaderView.swift
@@ -8,7 +8,6 @@ import UIKit
 
 final class BNPLFormHeaderView: UIView {
     private let appearance: PaymentSheet.Appearance
-    let style: PaymentSheet.UserInterfaceStyle
     let promotion: String
     let learnMoreText: String
     let infoUrl: URL
@@ -37,26 +36,15 @@ final class BNPLFormHeaderView: UIView {
 
     init(
         appearance: PaymentSheet.Appearance,
-        style: PaymentSheet.UserInterfaceStyle,
         promotion: String,
         learnMoreText: String,
         infoUrl: URL
     ) {
         self.appearance = appearance
-        self.style = style
         self.promotion = promotion
         self.learnMoreText = learnMoreText
         self.infoUrl = infoUrl
         super.init(frame: .zero)
-
-        switch style {
-        case .automatic:
-            break
-        case .alwaysLight:
-            overrideUserInterfaceStyle = .light
-        case .alwaysDark:
-            overrideUserInterfaceStyle = .dark
-        }
 
         addAndPinSubview(textView)
         isAccessibilityElement = false
@@ -68,18 +56,7 @@ final class BNPLFormHeaderView: UIView {
     }
 
     private func openInfoModal() {
-        PMMEInfoModal.present(infoUrl: infoUrl, style: pmmeStyle, from: self)
-    }
-
-    private var pmmeStyle: PaymentMethodMessagingElement.Appearance.UserInterfaceStyle {
-        switch style {
-        case .automatic:
-            return .automatic
-        case .alwaysLight:
-            return .alwaysLight
-        case .alwaysDark:
-            return .alwaysDark
-        }
+        PMMEInfoModal.present(infoUrl: infoUrl, style: traitCollection.isDarkMode ? .alwaysDark : .alwaysLight, from: self)
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/BNPLFormHeaderViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/BNPLFormHeaderViewSnapshotTests.swift
@@ -18,7 +18,7 @@ final class BNPLFormHeaderViewSnapshotTests: STPSnapshotTestCase {
     }
 
     func testAlwaysDarkStyleSnapshot() {
-        let (headerView, _, _) = makeHeaderView(style: .alwaysDark)
+        let (headerView, _, _) = makeHeaderView(interfaceStyle: .dark)
 
         verify(headerView)
     }
@@ -36,16 +36,16 @@ final class BNPLFormHeaderViewSnapshotTests: STPSnapshotTestCase {
 
     private func makeHeaderView(
         appearance: PaymentSheet.Appearance = .default,
-        style: PaymentSheet.UserInterfaceStyle = .automatic
+        interfaceStyle: UIUserInterfaceStyle = .unspecified
     ) -> (BNPLFormHeaderView, UIViewController, UIWindow) {
         let headerView = BNPLFormHeaderView(
             appearance: appearance,
-            style: style,
             promotion: "Split your purchase into monthly payments",
             learnMoreText: "Learn more",
             infoUrl: URL(string: "https://example.com/affirm")!
         )
         let rootViewController = UIViewController()
+        rootViewController.overrideUserInterfaceStyle = interfaceStyle
         headerView.backgroundColor = appearance.colors.background
         rootViewController.view.backgroundColor = appearance.colors.background
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 200))

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/BNPLFormHeaderViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/BNPLFormHeaderViewTests.swift
@@ -10,10 +10,8 @@ import XCTest
 
 @MainActor
 final class BNPLFormHeaderViewTests: XCTestCase {
-    func testAlwaysDarkStyle_AppliesToHeaderAndInfoModal() throws {
-        let (headerView, rootViewController, _) = makeHeaderView(style: .alwaysDark)
-
-        XCTAssertEqual(headerView.overrideUserInterfaceStyle, .dark)
+    func testDarkMode_AppliesToInfoModal() throws {
+        let (headerView, rootViewController, _) = makeHeaderView(interfaceStyle: .dark)
 
         let didHandleTap = headerView.textView(
             UITextView(),
@@ -29,10 +27,8 @@ final class BNPLFormHeaderViewTests: XCTestCase {
         XCTAssertEqual(infoModal.overrideUserInterfaceStyle, .dark)
     }
 
-    func testAlwaysLightStyle_AppliesToHeaderAndInfoModal() throws {
-        let (headerView, rootViewController, _) = makeHeaderView(style: .alwaysLight)
-
-        XCTAssertEqual(headerView.overrideUserInterfaceStyle, .light)
+    func testLightMode_AppliesToInfoModal() throws {
+        let (headerView, rootViewController, _) = makeHeaderView(interfaceStyle: .light)
 
         let didHandleTap = headerView.textView(
             UITextView(),
@@ -50,16 +46,16 @@ final class BNPLFormHeaderViewTests: XCTestCase {
 
     private func makeHeaderView(
         appearance: PaymentSheet.Appearance = .default,
-        style: PaymentSheet.UserInterfaceStyle = .automatic
+        interfaceStyle: UIUserInterfaceStyle = .unspecified
     ) -> (BNPLFormHeaderView, UIViewController, UIWindow) {
         let headerView = BNPLFormHeaderView(
             appearance: appearance,
-            style: style,
             promotion: "Split your purchase into monthly payments",
             learnMoreText: "Learn more",
             infoUrl: URL(string: "https://example.com/affirm")!
         )
         let rootViewController = UIViewController()
+        rootViewController.overrideUserInterfaceStyle = interfaceStyle
         headerView.backgroundColor = appearance.colors.background
         rootViewController.view.backgroundColor = appearance.colors.background
         let window = UIWindow(frame: CGRect(x: 0, y: 0, width: 320, height: 200))


### PR DESCRIPTION
## Summary
- Use correct UserInterfaceStyle when showing PaymentMethodMessaging modal in sublabel view
- Simplify derivation of UserInterfaceStyle for BNPLFormHeaderView by just checking the style in the view (which is already set according to the config)

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
- existing unit and snapshot tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
