### PR TITLE
CryptoOnramp SDK: Updates EU Declaration Acceptance Screen to Use HTML

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -429,7 +429,7 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
             let linkAccountInfo = try await self.linkAccountInfo
             let declaration = try await apiClient.retrieveCRSCARFDeclaration(linkAccountInfo: linkAccountInfo)
             let result = try await linkController.presentCRSCARFDeclaration(
-                text: declaration.text,
+                html: declaration.html,
                 appearance: appearance,
                 from: viewController,
                 onConfirm: { [apiClient] in

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/CRSCARFDeclaration.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/CRSCARFDeclaration.swift
@@ -10,9 +10,14 @@ import Foundation
 /// Decodable model representing the declaration returned by `/v1/crypto/internal/crs_carf_declaration`.
 struct CRSCARFDeclaration: Decodable, Equatable {
 
-    /// The declaration text to present to the customer.
-    let text: String
+    /// The declaration HTML to present to the customer.
+    let html: String
 
     /// The declaration version.
     let version: String
+
+    private enum CodingKeys: String, CodingKey {
+        case html = "text"
+        case version
+    }
 }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -157,10 +157,10 @@ extension STPAPIClient {
         return try await post(resource: endpoint, object: requestObject)
     }
 
-    /// Retrieves the CRS/CARF declaration text for the current Link user.
+    /// Retrieves the CRS/CARF declaration HTML for the current Link user.
     /// - Parameters:
     ///   - linkAccountInfo: Information associated with the link account including the client secret and whether the account has been verified.
-    /// - Returns: An instance of `CRSCARFDeclaration` containing the declaration text and version.
+    /// - Returns: An instance of `CRSCARFDeclaration` containing the declaration HTML and version.
     /// Throws if the `linkAccountSessionState` is not verified, a client secret doesn’t exist, or if an API error occurs.
     func retrieveCRSCARFDeclaration(linkAccountInfo: PaymentSheetLinkAccountInfoProtocol) async throws -> CRSCARFDeclaration {
         guard let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret else {

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Mock Data/JSON/RetrieveCRSCARFDeclarationResponse_200.json
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Mock Data/JSON/RetrieveCRSCARFDeclarationResponse_200.json
@@ -1,4 +1,4 @@
 {
-  "text": "test",
+  "text": "<p>test</p>",
   "version": "0"
 }

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
@@ -584,7 +584,7 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         let apiClient = stubbedAPIClient()
         let response = try await apiClient.retrieveCRSCARFDeclaration(linkAccountInfo: Constant.validLinkAccountInfo)
 
-        XCTAssertEqual(response.text, "test")
+        XCTAssertEqual(response.html, "<p>test</p>")
         XCTAssertEqual(response.version, "0")
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/bg-BG.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/bg-BG.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Добавете своята информация за плащането";
 
-"Agree and accept" = "Съгласявам се и приемам";
-
 "Approve payment" = "Одобряване на плащането";
 
 "Back" = "Назад";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ca-ES.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ca-ES.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Afegir la teva informació de pagament";
 
-"Agree and accept" = "Permet i accepta";
-
 "Approve payment" = "Aprova el pagament";
 
 "Back" = "Tornar";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/cs-CZ.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/cs-CZ.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Přidejte své platební údaje";
 
-"Agree and accept" = "Souhlasím a přijímám";
-
 "Approve payment" = "Schválit platbu";
 
 "Back" = "Zpět";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/da.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/da.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Tilføj dine betalingsoplysninger";
 
-"Agree and accept" = "Acceptér";
-
 "Approve payment" = "Godkend betaling";
 
 "Back" = "Tilbage";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/de.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/de.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Zahlungsinformationen hinzufügen";
 
-"Agree and accept" = "Zustimmen und akzeptieren";
-
 "Approve payment" = "Zahlung genehmigen";
 
 "Back" = "Zurück";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/el-GR.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/el-GR.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Προσθέστε τα στοιχεία πληρωμής σας";
 
-"Agree and accept" = "Συμφωνία και αποδοχή";
-
 "Approve payment" = "Έγκριση πληρωμής";
 
 "Back" = "Πίσω";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en-GB.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en-GB.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Add your payment information";
 
-"Agree and accept" = "Agree and accept";
-
 "Approve payment" = "Approve payment";
 
 "Back" = "Back";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/en.lproj/Localizable.strings
@@ -13,6 +13,9 @@
 /* Exchange rate caption, e.g. '1 GBP = 1.2871 USD' */
 "1 %@ = %@ %@" = "1 %1$@ = %2$@ %3$@";
 
+/* Label for a button that confirms the user accepts a declaration */
+"Accept" = "Accept";
+
 /* Title shown above a card entry form */
 "Add a card" = "Add a card";
 
@@ -36,9 +39,6 @@
 
 /* Title shown above a form where the customer can enter payment information like credit card details, email, billing address, etc. */
 "Add your payment information" = "Add your payment information";
-
-/* Label for a button that confirms the user agrees to and accepts a declaration */
-"Agree and accept" = "Agree and accept";
 
 /* Text on a screen asking the user to approve a payment */
 "Approve payment" = "Approve payment";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/es-419.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/es-419.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Agrega la información de pago";
 
-"Agree and accept" = "Aceptar";
-
 "Approve payment" = "Aprobar pago";
 
 "Back" = "Atrás";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/es.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/es.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Añadir información de pago";
 
-"Agree and accept" = "Aceptar";
-
 "Approve payment" = "Aprobar pago";
 
 "Back" = "Atrás";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/et-EE.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/et-EE.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Lisage makseteave";
 
-"Agree and accept" = "Nõustu ja aktsepteeri";
-
 "Approve payment" = "Kinnitage makse";
 
 "Back" = "Tagasi";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fi.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fi.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Lisää maksutiedot";
 
-"Agree and accept" = "Hyväksy";
-
 "Approve payment" = "Hyväksy maksu";
 
 "Back" = "Takaisin";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fil.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fil.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Magdagdag ng iyong impormasyon sa pagbabayad";
 
-"Agree and accept" = "Sumang-ayon at tanggapin";
-
 "Approve payment" = "Aprubahan ang pagbabayad";
 
 "Back" = "Bumalik";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fr-CA.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fr-CA.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Ajoutez vos informations de paiement";
 
-"Agree and accept" = "Accepter et consentir";
-
 "Approve payment" = "Autoriser le paiement";
 
 "Back" = "Retour";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fr.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/fr.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Ajoutez vos informations de paiement";
 
-"Agree and accept" = "Accepter";
-
 "Approve payment" = "Autoriser le paiement";
 
 "Back" = "Retour";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/hr.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/hr.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Dodavanje informacija o plaćanju";
 
-"Agree and accept" = "Slažem se i prihvaćam";
-
 "Approve payment" = "Odobri plaćanje";
 
 "Back" = "Natrag";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/hu.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/hu.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Fizetési adatok megadása";
 
-"Agree and accept" = "Beleegyezés és elfogadás";
-
 "Approve payment" = "Fizetés jóváhagyása";
 
 "Back" = "Vissza";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/id.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/id.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Tambahkan informasi pembayaran Anda";
 
-"Agree and accept" = "Setuju dan terima";
-
 "Approve payment" = "Setujui pembayaran";
 
 "Back" = "Kembali";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/it.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/it.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Aggiungi dati di pagamento";
 
-"Agree and accept" = "Accetta";
-
 "Approve payment" = "Approva pagamento";
 
 "Back" = "Indietro";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ja.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ja.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "支払い情報を追加";
 
-"Agree and accept" = "同意して承認";
-
 "Approve payment" = "支払いを承認する";
 
 "Back" = "戻る";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ko.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ko.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "결제 정보를 추가하세요.";
 
-"Agree and accept" = "동의 및 수락";
-
 "Approve payment" = "결제 승인";
 
 "Back" = "뒤로";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/lt-LT.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/lt-LT.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Pridėkite mokėjimo informaciją";
 
-"Agree and accept" = "Sutinku ir priimu";
-
 "Approve payment" = "Patvirtinti mokėjimą";
 
 "Back" = "Atgal";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/lv-LV.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/lv-LV.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Pievienot maksājuma informāciju";
 
-"Agree and accept" = "Piekrītu un pieņemu";
-
 "Approve payment" = "Apstiprināt maksājumu";
 
 "Back" = "Atpakaļ";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ms-MY.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ms-MY.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Tambah maklumat pembayaran anda";
 
-"Agree and accept" = "Setuju dan terima";
-
 "Approve payment" = "Luluskan pembayaran";
 
 "Back" = "Undur";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/mt.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/mt.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Żid l-informazzjoni dwar il-pagament tiegħek";
 
-"Agree and accept" = "Aqbel u aċċetta";
-
 "Approve payment" = "Approva l-pagament";
 
 "Back" = "Lura";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/nb.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/nb.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Legg til betalingsinformasjon";
 
-"Agree and accept" = "Godta og fortsett";
-
 "Approve payment" = "Godkjenn betaling";
 
 "Back" = "Tilbake";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/nl.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/nl.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Je betaalgegevens toevoegen";
 
-"Agree and accept" = "Akkoord en accepteren";
-
 "Approve payment" = "Betaling goedkeuren";
 
 "Back" = "Terug";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pl-PL.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pl-PL.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Dodaj informacje o płatności";
 
-"Agree and accept" = "Wyraź zgodę i zaakceptuj";
-
 "Approve payment" = "Zatwierdź płatność";
 
 "Back" = "Wstecz";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pt-BR.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pt-BR.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Adicione seus dados de pagamento";
 
-"Agree and accept" = "Concordar e aceitar";
-
 "Approve payment" = "Aprovar pagamento";
 
 "Back" = "Voltar";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pt-PT.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/pt-PT.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Adicione as suas informações de pagamento";
 
-"Agree and accept" = "Concordar e aceitar";
-
 "Approve payment" = "Aprovar pagamento";
 
 "Back" = "Voltar";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ro-RO.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ro-RO.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Adăuga informațiile privind plata";
 
-"Agree and accept" = "Sunt de acord și accept";
-
 "Approve payment" = "Aprobare plată";
 
 "Back" = "Înapoi";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ru.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/ru.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Укажите платежные данные";
 
-"Agree and accept" = "Согласиться и принять";
-
 "Approve payment" = "Подтвердить платеж";
 
 "Back" = "Назад";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sk-SK.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sk-SK.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Pridajte svoje informácie o platbe";
 
-"Agree and accept" = "Súhlasím a prijímam";
-
 "Approve payment" = "Schváliť platbu";
 
 "Back" = "Späť";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sl-SI.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sl-SI.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Dodajte podatke o plačilu";
 
-"Agree and accept" = "Strinjam se in sprejemam";
-
 "Approve payment" = "Odobrite plačilo";
 
 "Back" = "Nazaj";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sv.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/sv.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Lägg till betalningsinformation";
 
-"Agree and accept" = "Godkänn och acceptera";
-
 "Approve payment" = "Godkänn betalning";
 
 "Back" = "Tillbaka";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/th.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/th.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "เพิ่มข้อมูลการชำระเงิน";
 
-"Agree and accept" = "ตกลงและยอมรับ";
-
 "Approve payment" = "อนุมัติการชำระเงิน";
 
 "Back" = "ย้อนกลับ";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/tr.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/tr.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Ödeme bilgilerinizi ekleyin";
 
-"Agree and accept" = "Kabul et ve onayla";
-
 "Approve payment" = "Ödemeyi onaylayın";
 
 "Back" = "Geri";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/vi.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/vi.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "Thêm thông tin thanh toán của bạn";
 
-"Agree and accept" = "Đồng ý và chấp nhận";
-
 "Approve payment" = "Chấp nhận thanh toán";
 
 "Back" = "Quay lại";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/zh-HK.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/zh-HK.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "添加您的支付資訊";
 
-"Agree and accept" = "同意並接受";
-
 "Approve payment" = "批准付款";
 
 "Back" = "上一步";

--- a/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/zh-Hans.lproj/Localizable.strings
+++ b/StripePaymentSheet/StripePaymentSheet/Resources/Localizations/zh-Hans.lproj/Localizable.strings
@@ -24,8 +24,6 @@
 
 "Add your payment information" = "添加您的支付信息";
 
-"Agree and accept" = "同意并接受";
-
 "Approve payment" = "批准付款";
 
 "Back" = "返回";

--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/String+Localized.swift
@@ -779,8 +779,8 @@ extension String.Localized {
         STPLocalizedString("Declarations", "Title label for a screen showing CRS/CARF tax declarations")
     }
 
-    static var agree_and_accept: String {
-        STPLocalizedString("Agree and accept", "Label for a button that confirms the user agrees to and accepts a declaration")
+    static var accept: String {
+        STPLocalizedString("Accept", "Label for a button that confirms the user accepts a declaration")
     }
 
     static var last_4_digits_of_ssn: String {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
@@ -9,7 +9,6 @@ import SafariServices
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
 import UIKit
-import WebKit
 
 /// The content view of `CRSCARFDeclarationViewController`, which displays CRS/CARF declaration HTML with a confirmation button.
 final class CRSCARFDeclarationContentViewController: UIViewController, BottomSheetContentViewController {
@@ -64,45 +63,46 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         return label
     }()
 
-    private lazy var declarationWebView: WKWebView = {
-        let configuration = WKWebViewConfiguration()
-        configuration.dataDetectorTypes = [.link]
-        if #unavailable(iOS 14.0) {
-            configuration.preferences.javaScriptEnabled = false
-        }
-
-        let webView = WKWebView(frame: .zero, configuration: configuration)
-        webView.translatesAutoresizingMaskIntoConstraints = false
-        webView.backgroundColor = .clear
-        webView.isOpaque = false
-        webView.navigationDelegate = self
-        webView.scrollView.alwaysBounceVertical = true
-        webView.scrollView.contentInsetAdjustmentBehavior = .never
-        return webView
+    private lazy var declarationTextView: UITextView = {
+        let textView = UITextView()
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        textView.backgroundColor = .clear
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.delegate = self
+        textView.attributedText = attributedDeclarationHTML
+        textView.linkTextAttributes = [
+            .foregroundColor: linkPrimaryButtonColor,
+        ]
+        return textView
     }()
 
-    private var declarationHTML: String {
-        """
-        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
-        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
-        <style>
-        body {
-            margin: 0;
-            color: \(cssColor(for: .linkTextPrimary));
-            font-family: -apple-system, sans-serif;
-            font-size: \(LinkUI.font(forTextStyle: .body).pointSize)px;
-            line-height: \(declarationLineHeight);
-            -webkit-text-size-adjust: 100%;
+    private var attributedDeclarationHTML: NSAttributedString {
+        guard let importedString = try? NSMutableAttributedString(
+            data: Data(html.utf8),
+            options: [
+                .documentType: NSAttributedString.DocumentType.html,
+                .characterEncoding: String.Encoding.utf8.rawValue,
+            ],
+            documentAttributes: nil
+        ) else {
+            return NSAttributedString(string: html, attributes: declarationHTMLAttributes(isLink: false))
         }
-        p {
-            margin: 0;
+
+        var rangesToUpdate: [(range: NSRange, isLink: Bool)] = []
+        let fullRange = NSRange(location: 0, length: importedString.length)
+        importedString.enumerateAttributes(in: fullRange) { attributes, range, _ in
+            rangesToUpdate.append((range, attributes[.link] != nil))
         }
-        a {
-            color: \(cssColor(for: linkPrimaryButtonColor));
+        rangesToUpdate.forEach { range, isLink in
+            importedString.addAttributes(
+                declarationHTMLAttributes(isLink: isLink),
+                range: range
+            )
         }
-        </style>
-        \(html)
-        """
+        return importedString
     }
 
     private lazy var bottomButtonContainer: UIView = {
@@ -113,7 +113,7 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
     }()
 
     private lazy var confirmButton = ConfirmButton.makeLinkButton(
-        callToAction: .custom(title: String.Localized.agree_and_accept),
+        callToAction: .custom(title: String.Localized.accept),
         showProcessingLabel: false,
         linkAppearance: appearance
     ) { [weak self] in
@@ -124,7 +124,7 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         super.viewDidLoad()
 
         view.addSubview(headingLabel)
-        view.addSubview(declarationWebView)
+        view.addSubview(declarationTextView)
         view.addSubview(bottomButtonContainer)
 
         NSLayoutConstraint.activate([
@@ -132,27 +132,15 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
             headingLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: LinkUI.contentSpacing),
             headingLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -LinkUI.contentSpacing),
 
-            declarationWebView.topAnchor.constraint(equalTo: headingLabel.bottomAnchor, constant: LinkUI.contentSpacing),
-            declarationWebView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: LinkUI.contentSpacing),
-            declarationWebView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -LinkUI.contentSpacing),
-            declarationWebView.heightAnchor.constraint(equalToConstant: 200),
-            declarationWebView.bottomAnchor.constraint(equalTo: bottomButtonContainer.topAnchor),
+            declarationTextView.topAnchor.constraint(equalTo: headingLabel.bottomAnchor, constant: LinkUI.contentSpacing),
+            declarationTextView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: LinkUI.contentSpacing),
+            declarationTextView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -LinkUI.contentSpacing),
+            declarationTextView.bottomAnchor.constraint(equalTo: bottomButtonContainer.topAnchor),
 
             bottomButtonContainer.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             bottomButtonContainer.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             bottomButtonContainer.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
         ])
-
-        declarationWebView.loadHTMLString(declarationHTML, baseURL: nil)
-    }
-
-    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
-        super.traitCollectionDidChange(previousTraitCollection)
-
-        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) else {
-            return
-        }
-        declarationWebView.loadHTMLString(declarationHTML, baseURL: nil)
     }
 
     private func confirmButtonTapped() {
@@ -169,10 +157,15 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         20 / LinkUI.font(forTextStyle: .body).pointSize
     }
 
-    private func cssColor(for color: UIColor) -> String {
-        let resolvedColor = color.resolvedColor(with: traitCollection)
-        let rgba = resolvedColor.rgba
-        return "rgba(\(Int(rgba.red * 255)), \(Int(rgba.green * 255)), \(Int(rgba.blue * 255)), \(rgba.alpha))"
+    private func declarationHTMLAttributes(isLink: Bool) -> [NSAttributedString.Key: Any] {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = declarationLineHeight
+
+        return [
+            .font: LinkUI.font(forTextStyle: .body),
+            .foregroundColor: isLink ? linkPrimaryButtonColor : UIColor.linkTextPrimary,
+            .paragraphStyle: paragraphStyle,
+        ]
     }
 
     // MARK: - BottomSheetContentViewController
@@ -182,47 +175,27 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
     }
 }
 
-extension CRSCARFDeclarationContentViewController: WKNavigationDelegate {
-    func webView(
-        _ webView: WKWebView,
-        decidePolicyFor navigationAction: WKNavigationAction,
-        preferences: WKWebpagePreferences,
-        decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void
-    ) {
-        if #available(iOS 14.0, *) {
-            preferences.allowsContentJavaScript = false
+extension CRSCARFDeclarationContentViewController: UITextViewDelegate {
+
+#if !os(visionOS)
+    func textView(
+        _ textView: UITextView,
+        shouldInteractWith URL: URL,
+        in characterRange: NSRange,
+        interaction: UITextItemInteraction
+    ) -> Bool {
+        guard interaction == .invokeDefaultAction else {
+            return false
         }
-        decisionHandler(policy(for: navigationAction), preferences)
+
+        if ["http", "https"].contains(URL.scheme?.lowercased()) {
+            let safariViewController = SFSafariViewController(url: URL)
+            safariViewController.dismissButtonStyle = .close
+            safariViewController.modalPresentationStyle = .overFullScreen
+            present(safariViewController, animated: true)
+        }
+
+        return false
     }
-
-    func webView(
-        _ webView: WKWebView,
-        decidePolicyFor navigationAction: WKNavigationAction,
-        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
-    ) {
-        decisionHandler(policy(for: navigationAction))
-    }
-
-    private func policy(for navigationAction: WKNavigationAction) -> WKNavigationActionPolicy {
-        if navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url {
-            if ["http", "https"].contains(url.scheme?.lowercased()) {
-                let safariViewController = SFSafariViewController(url: url)
-                #if !os(visionOS)
-                safariViewController.dismissButtonStyle = .close
-                #endif
-                safariViewController.modalPresentationStyle = .overFullScreen
-                present(safariViewController, animated: true)
-            }
-            return .cancel
-        }
-
-        guard navigationAction.navigationType == .other else {
-            return .cancel
-        }
-
-        if navigationAction.request.url?.scheme == "about" {
-            return .allow
-        }
-        return .cancel
-    }
+#endif
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
@@ -5,11 +5,13 @@
 //  Created by Michael Liberatore on 4/23/26.
 //
 
+import SafariServices
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
 import UIKit
+import WebKit
 
-/// The content view of `CRSCARFDeclarationViewController`, which displays CRS/CARF declaration text with a confirmation button.
+/// The content view of `CRSCARFDeclarationViewController`, which displays CRS/CARF declaration HTML with a confirmation button.
 final class CRSCARFDeclarationContentViewController: UIViewController, BottomSheetContentViewController {
 
     // MARK: - BottomSheetContentViewController
@@ -26,11 +28,11 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         return navigationBar
     }()
 
-    let requiresFullScreen: Bool = true
+    let requiresFullScreen: Bool = false
 
     // MARK: - CRSCARFDeclarationContentViewController
 
-    private let text: String
+    private let html: String
     private let appearance: LinkAppearance
     private let brand: LinkBrand
 
@@ -39,10 +41,10 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
 
     /// Creates a new instance of `CRSCARFDeclarationContentViewController`.
     /// - Parameters:
-    ///   - text: The declaration text to display.
+    ///   - html: The declaration HTML to display.
     ///   - appearance: Determines the colors, corner radius, and height of the confirmation button.
-    init(text: String, appearance: LinkAppearance, brand: LinkBrand) {
-        self.text = text
+    init(html: String, appearance: LinkAppearance, brand: LinkBrand) {
+        self.html = html
         self.appearance = appearance
         self.brand = brand
         super.init(nibName: nil, bundle: nil)
@@ -51,41 +53,6 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-
-    private lazy var scrollView: UIScrollView = {
-        let scrollView = UIScrollView()
-        scrollView.alwaysBounceVertical = true
-        scrollView.translatesAutoresizingMaskIntoConstraints = false
-
-        scrollView.addSubview(containerStackView)
-        NSLayoutConstraint.activate([
-            containerStackView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
-            containerStackView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
-            containerStackView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
-            containerStackView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
-            containerStackView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
-        ])
-
-        return scrollView
-    }()
-
-    private lazy var containerStackView: UIStackView = {
-        let stackView = UIStackView(arrangedSubviews: [
-            headingLabel,
-            declarationLabel,
-        ])
-        stackView.axis = .vertical
-        stackView.spacing = LinkUI.contentSpacing
-        stackView.isLayoutMarginsRelativeArrangement = true
-        stackView.directionalLayoutMargins = NSDirectionalEdgeInsets(
-            top: LinkUI.smallContentSpacing,
-            leading: LinkUI.contentSpacing,
-            bottom: LinkUI.contentSpacing,
-            trailing: LinkUI.contentSpacing
-        )
-        stackView.translatesAutoresizingMaskIntoConstraints = false
-        return stackView
-    }()
 
     private lazy var headingLabel: UILabel = {
         let label = UILabel()
@@ -97,25 +64,45 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         return label
     }()
 
-    private lazy var declarationLabel: UILabel = {
-        let label = UILabel()
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.font = LinkUI.font(forTextStyle: .detail)
-        label.textColor = .linkTextPrimary
-        label.numberOfLines = 0
-        label.attributedText = attributedDeclarationText
-        return label
+    private lazy var declarationWebView: WKWebView = {
+        let configuration = WKWebViewConfiguration()
+        configuration.dataDetectorTypes = [.link]
+        if #unavailable(iOS 14.0) {
+            configuration.preferences.javaScriptEnabled = false
+        }
+
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.backgroundColor = .clear
+        webView.isOpaque = false
+        webView.navigationDelegate = self
+        webView.scrollView.alwaysBounceVertical = true
+        webView.scrollView.contentInsetAdjustmentBehavior = .never
+        return webView
     }()
 
-    private var attributedDeclarationText: NSAttributedString {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineSpacing = LinkUI.tinyContentSpacing
-        return NSAttributedString(
-            string: text,
-            attributes: [
-                .paragraphStyle: paragraphStyle,
-            ]
-        )
+    private var declarationHTML: String {
+        """
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no">
+        <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';">
+        <style>
+        body {
+            margin: 0;
+            color: \(cssColor(for: .linkTextPrimary));
+            font-family: -apple-system, sans-serif;
+            font-size: \(LinkUI.font(forTextStyle: .body).pointSize)px;
+            line-height: \(declarationLineHeight);
+            -webkit-text-size-adjust: 100%;
+        }
+        p {
+            margin: 0;
+        }
+        a {
+            color: \(cssColor(for: linkPrimaryButtonColor));
+        }
+        </style>
+        \(html)
+        """
     }
 
     private lazy var bottomButtonContainer: UIView = {
@@ -136,19 +123,36 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.addSubview(scrollView)
+        view.addSubview(headingLabel)
+        view.addSubview(declarationWebView)
         view.addSubview(bottomButtonContainer)
 
         NSLayoutConstraint.activate([
+            headingLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: LinkUI.smallContentSpacing),
+            headingLabel.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: LinkUI.contentSpacing),
+            headingLabel.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -LinkUI.contentSpacing),
+
+            declarationWebView.topAnchor.constraint(equalTo: headingLabel.bottomAnchor, constant: LinkUI.contentSpacing),
+            declarationWebView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor, constant: LinkUI.contentSpacing),
+            declarationWebView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor, constant: -LinkUI.contentSpacing),
+            declarationWebView.heightAnchor.constraint(equalToConstant: 200),
+            declarationWebView.bottomAnchor.constraint(equalTo: bottomButtonContainer.topAnchor),
+
             bottomButtonContainer.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
             bottomButtonContainer.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
             bottomButtonContainer.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-
-            scrollView.topAnchor.constraint(equalTo: view.topAnchor),
-            scrollView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
-            scrollView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
-            scrollView.bottomAnchor.constraint(equalTo: bottomButtonContainer.topAnchor),
         ])
+
+        declarationWebView.loadHTMLString(declarationHTML, baseURL: nil)
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        guard traitCollection.hasDifferentColorAppearance(comparedTo: previousTraitCollection) else {
+            return
+        }
+        declarationWebView.loadHTMLString(declarationHTML, baseURL: nil)
     }
 
     private func confirmButtonTapped() {
@@ -156,9 +160,69 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         onResult?(.confirmed)
     }
 
+    private var linkPrimaryButtonColor: UIColor {
+        appearance.colors?.primary ?? LinkUI.appearance.primaryButton.backgroundColor ?? LinkUI.appearance.colors.primary
+    }
+
+    private var declarationLineHeight: CGFloat {
+        // based on the "20px" value in Figma
+        20 / LinkUI.font(forTextStyle: .body).pointSize
+    }
+
+    private func cssColor(for color: UIColor) -> String {
+        let resolvedColor = color.resolvedColor(with: traitCollection)
+        let rgba = resolvedColor.rgba
+        return "rgba(\(Int(rgba.red * 255)), \(Int(rgba.green * 255)), \(Int(rgba.blue * 255)), \(rgba.alpha))"
+    }
+
     // MARK: - BottomSheetContentViewController
 
     func didTapOrSwipeToDismiss() {
         onResult?(.canceled)
+    }
+}
+
+extension CRSCARFDeclarationContentViewController: WKNavigationDelegate {
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        preferences: WKWebpagePreferences,
+        decisionHandler: @escaping (WKNavigationActionPolicy, WKWebpagePreferences) -> Void
+    ) {
+        if #available(iOS 14.0, *) {
+            preferences.allowsContentJavaScript = false
+        }
+        decisionHandler(policy(for: navigationAction), preferences)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        decisionHandler(policy(for: navigationAction))
+    }
+
+    private func policy(for navigationAction: WKNavigationAction) -> WKNavigationActionPolicy {
+        if navigationAction.navigationType == .linkActivated, let url = navigationAction.request.url {
+            if ["http", "https"].contains(url.scheme?.lowercased()) {
+                let safariViewController = SFSafariViewController(url: url)
+                #if !os(visionOS)
+                safariViewController.dismissButtonStyle = .close
+                #endif
+                safariViewController.modalPresentationStyle = .overFullScreen
+                present(safariViewController, animated: true)
+            }
+            return .cancel
+        }
+
+        guard navigationAction.navigationType == .other else {
+            return .cancel
+        }
+
+        if navigationAction.request.url?.scheme == "about" {
+            return .allow
+        }
+        return .cancel
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
@@ -152,14 +152,9 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         appearance.colors?.primary ?? LinkUI.appearance.primaryButton.backgroundColor ?? LinkUI.appearance.colors.primary
     }
 
-    private var declarationLineHeight: CGFloat {
-        // based on the "20px" value in Figma
-        20 / LinkUI.font(forTextStyle: .body).pointSize
-    }
-
     private func declarationHTMLAttributes(isLink: Bool) -> [NSAttributedString.Key: Any] {
         let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineHeightMultiple = declarationLineHeight
+        paragraphStyle.lineHeightMultiple = 1.2
 
         return [
             .font: LinkUI.font(forTextStyle: .body),

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
@@ -35,6 +35,10 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
     private let appearance: LinkAppearance
     private let brand: LinkBrand
 
+    private var linkPrimaryButtonColor: UIColor {
+        appearance.colors?.primary ?? LinkUI.appearance.primaryButton.backgroundColor ?? LinkUI.appearance.colors.primary
+    }
+
     /// Closure called when a user confirms or cancels the declaration.
     var onResult: ((LinkController.CRSCARFDeclarationResult) -> Void)?
 
@@ -146,10 +150,6 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
     private func confirmButtonTapped() {
         confirmButton.update(status: .spinnerWithInteractionDisabled)
         onResult?(.confirmed)
-    }
-
-    private var linkPrimaryButtonColor: UIColor {
-        appearance.colors?.primary ?? LinkUI.appearance.primaryButton.backgroundColor ?? LinkUI.appearance.colors.primary
     }
 
     private func declarationHTMLAttributes(isLink: Bool) -> [NSAttributedString.Key: Any] {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
@@ -27,7 +27,7 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         return navigationBar
     }()
 
-    let requiresFullScreen: Bool = false
+    let requiresFullScreen = false
 
     // MARK: - CRSCARFDeclarationContentViewController
 
@@ -177,7 +177,6 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
 
 extension CRSCARFDeclarationContentViewController: UITextViewDelegate {
 
-#if !os(visionOS)
     func textView(
         _ textView: UITextView,
         shouldInteractWith URL: URL,
@@ -190,12 +189,13 @@ extension CRSCARFDeclarationContentViewController: UITextViewDelegate {
 
         if ["http", "https"].contains(URL.scheme?.lowercased()) {
             let safariViewController = SFSafariViewController(url: URL)
+            #if !os(visionOS)
             safariViewController.dismissButtonStyle = .close
+            #endif
             safariViewController.modalPresentationStyle = .overFullScreen
             present(safariViewController, animated: true)
         }
 
         return false
     }
-#endif
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
@@ -39,6 +39,23 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         appearance.colors?.primary ?? LinkUI.appearance.primaryButton.backgroundColor ?? LinkUI.appearance.colors.primary
     }
 
+    private var declarationBaseAttributes: [NSAttributedString.Key: Any] {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineHeightMultiple = 1.2
+
+        return [
+            .font: LinkUI.font(forTextStyle: .body),
+            .foregroundColor: UIColor.linkTextPrimary,
+            .paragraphStyle: paragraphStyle,
+        ]
+    }
+
+    private var declarationLinkAttributes: [NSAttributedString.Key: Any] {
+        [
+            .foregroundColor: linkPrimaryButtonColor,
+        ]
+    }
+
     /// Closure called when a user confirms or cancels the declaration.
     var onResult: ((LinkController.CRSCARFDeclarationResult) -> Void)?
 
@@ -84,7 +101,7 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
     }()
 
     private var attributedDeclarationHTML: NSAttributedString {
-        guard let importedString = try? NSMutableAttributedString(
+        guard let attributedString = try? NSMutableAttributedString(
             data: Data(html.utf8),
             options: [
                 .documentType: NSAttributedString.DocumentType.html,
@@ -92,21 +109,22 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
             ],
             documentAttributes: nil
         ) else {
-            return NSAttributedString(string: html, attributes: declarationHTMLAttributes(isLink: false))
+            return NSAttributedString(string: html, attributes: declarationBaseAttributes)
         }
 
-        var rangesToUpdate: [(range: NSRange, isLink: Bool)] = []
-        let fullRange = NSRange(location: 0, length: importedString.length)
-        importedString.enumerateAttributes(in: fullRange) { attributes, range, _ in
-            rangesToUpdate.append((range, attributes[.link] != nil))
+        let fullRange = NSRange(location: 0, length: attributedString.length)
+        var linkRanges: [NSRange] = []
+        attributedString.enumerateAttribute(.link, in: fullRange) { value, range, _ in
+            if value != nil {
+                linkRanges.append(range)
+            }
         }
-        rangesToUpdate.forEach { range, isLink in
-            importedString.addAttributes(
-                declarationHTMLAttributes(isLink: isLink),
-                range: range
-            )
+
+        attributedString.addAttributes(declarationBaseAttributes, range: fullRange)
+        linkRanges.forEach { range in
+            attributedString.addAttributes(declarationLinkAttributes, range: range)
         }
-        return importedString
+        return attributedString
     }
 
     private lazy var bottomButtonContainer: UIView = {
@@ -152,17 +170,6 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         onResult?(.confirmed)
     }
 
-    private func declarationHTMLAttributes(isLink: Bool) -> [NSAttributedString.Key: Any] {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineHeightMultiple = 1.2
-
-        return [
-            .font: LinkUI.font(forTextStyle: .body),
-            .foregroundColor: isLink ? linkPrimaryButtonColor : UIColor.linkTextPrimary,
-            .paragraphStyle: paragraphStyle,
-        ]
-    }
-
     // MARK: - BottomSheetContentViewController
 
     func didTapOrSwipeToDismiss() {
@@ -171,6 +178,8 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
 }
 
 extension CRSCARFDeclarationContentViewController: UITextViewDelegate {
+
+    // MARK: - UITextViewDelegate
 
     func textView(
         _ textView: UITextView,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationViewController.swift
@@ -8,7 +8,7 @@
 @_spi(STP) import StripeCore
 import UIKit
 
-/// Container view controller that displays the CRS/CARF declaration in a Link-styled bottom sheet.
+/// Container view controller that displays the CRS/CARF declaration HTML in a Link-styled bottom sheet.
 final class CRSCARFDeclarationViewController: BottomSheetViewController {
     private weak var contentViewController: CRSCARFDeclarationContentViewController?
 
@@ -25,10 +25,10 @@ final class CRSCARFDeclarationViewController: BottomSheetViewController {
 
     /// Creates a new instance of `CRSCARFDeclarationViewController`.
     /// - Parameters:
-    ///   - text: The declaration text to display.
+    ///   - html: The declaration HTML to display.
     ///   - appearance: Determines the colors, corner radius, and height of the confirmation button and the user interface style.
-    init(text: String, appearance: LinkAppearance, brand: LinkBrand) {
-        let contentViewController = CRSCARFDeclarationContentViewController(text: text, appearance: appearance, brand: brand)
+    init(html: String, appearance: LinkAppearance, brand: LinkBrand) {
+        let contentViewController = CRSCARFDeclarationContentViewController(html: html, appearance: appearance, brand: brand)
         self.contentViewController = contentViewController
 
         super.init(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -715,18 +715,18 @@ import UIKit
 
     /// Presents the CRS/CARF declaration to the user.
     ///
-    /// This method presents a bottom sheet displaying the provided declaration text for user review.
+    /// This method presents a bottom sheet displaying the provided declaration HTML for user review.
     /// The user can confirm the declaration or cancel.
     ///
     /// - Parameters:
-    ///   - text: The declaration text to display to the user.
+    ///   - html: The declaration HTML to display to the user.
     ///   - appearance: Appearance configuration for the declaration UI.
     ///   - viewController: The view controller from which to present the declaration flow.
     ///   - onConfirm: An async closure called when the user confirms. This is called *before* dismissal, allowing the caller to complete any async operations before the sheet is dismissed.
     /// - Returns: A `CRSCARFDeclarationResult` indicating whether the user confirmed or canceled.
     /// Throws any error thrown by the `onConfirm` handler.
     @_spi(STP) public func presentCRSCARFDeclaration(
-        text: String,
+        html: String,
         appearance: LinkAppearance,
         from viewController: UIViewController,
         onConfirm: @escaping (() async throws -> Void)
@@ -734,7 +734,7 @@ import UIKit
         return try await withCheckedThrowingContinuation { continuation in
             Task { @MainActor in
                 let declarationViewController = CRSCARFDeclarationViewController(
-                    text: text,
+                    html: html,
                     appearance: appearance,
                     brand: resolvedLinkBrand
                 )


### PR DESCRIPTION
## Summary
- The backend is providing basic HTML for formatting+links. We now render this HTML using `NSAttributedString`.
- We adjust the sheet size to fit the content instead of using a full-screen presentation, as the declaration text is expected to stay relatively small.
- Updated the CTA to "Accept" to match the declaration text.

## Motivation
To properly render the contents sent by the backend as opposed to raw html.

## Testing
1. Created a new EU user account in the example app.
2. Once I reached the declaration screen, tested in both light and dark modes to ensure everything was legible.
3. Made sure that tapping the links opened SafariViewController properly.

| Dark | Light | Opened Link |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/21274150-f53d-4cdf-9d4d-72df7886326a" width="300" /> | <img src="https://github.com/user-attachments/assets/8b396b52-5e7b-45ad-b251-ef0b8453d6b6" width="300" /> | <img src="https://github.com/user-attachments/assets/f0dfd61e-3ca7-4046-a854-b1aa74a455f6" width="300" /> |


## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A