### PR TITLE
FC Lite experiment exposure logging

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/BaseConnectionsFCLiteExperiment.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/BaseConnectionsFCLiteExperiment.swift
@@ -1,0 +1,40 @@
+//
+//  BaseConnectionsFCLiteExperiment.swift
+//  StripePaymentSheet
+//
+//  Created by Mat Schmid on 2026-06-02.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
+
+struct BaseConnectionsFCLiteExperiment {
+    let group: ExperimentGroup
+
+    private let elementsSessionId: String
+    private let mobileSessionId: String
+    private let sdkVersion: String
+    private let fcSdkAvailability: String
+    private let availableLPMs: String
+
+    var dimensionsDictionary: [String: String] {
+        [
+            "elements_session_id": elementsSessionId,
+            "mobile_session_id": mobileSessionId,
+            "mobile_sdk_version": sdkVersion,
+            "fc_sdk_availability": fcSdkAvailability,
+            "available_lpms": availableLPMs,
+        ]
+    }
+
+    init(experimentName: String, elementsSession: STPElementsSession) {
+        let assignment = elementsSession.experimentsData?.experimentAssignments[experimentName]
+        self.group = assignment ?? .control
+        self.elementsSessionId = elementsSession.sessionID
+        self.mobileSessionId = AnalyticsHelper.shared.sessionID ?? "N/a"
+        self.sdkVersion = StripeAPIConfiguration.STPSDKVersion
+        self.fcSdkAvailability = FinancialConnectionsSDKAvailability.analyticsValue
+        self.availableLPMs = elementsSession.orderedPaymentMethodTypesAndWallets.joined(separator: ",")
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/ConnectionsFCLiteVsNative.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/ConnectionsFCLiteVsNative.swift
@@ -1,0 +1,27 @@
+//
+//  ConnectionsFCLiteVsNative.swift
+//  StripePaymentSheet
+//
+//  Created by Mat Schmid on 2026-06-02.
+//
+
+import Foundation
+
+struct ConnectionsFCLiteVsNative: LoggableExperiment {
+    static let experimentName = "connections_fc_lite_vs_native"
+    private let baseExperiment: BaseConnectionsFCLiteExperiment
+
+    let name: String = experimentName
+    let arbId: String
+
+    var group: ExperimentGroup { baseExperiment.group }
+    var dimensions: [String: String] { baseExperiment.dimensionsDictionary }
+
+    init(arbId: String, session elementsSession: STPElementsSession) {
+        self.arbId = arbId
+        self.baseExperiment = BaseConnectionsFCLiteExperiment(
+            experimentName: Self.experimentName,
+            elementsSession: elementsSession
+        )
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/ConnectionsFCLiteVsNativeAA.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/ConnectionsFCLiteVsNativeAA.swift
@@ -1,0 +1,27 @@
+//
+//  ConnectionsFCLiteVsNativeAA.swift
+//  StripePaymentSheet
+//
+//  Created by Mat Schmid on 2026-06-02.
+//
+
+import Foundation
+
+struct ConnectionsFCLiteVsNativeAA: LoggableExperiment {
+    static let experimentName = "connections_fc_lite_vs_native_aa"
+    private let baseExperiment: BaseConnectionsFCLiteExperiment
+
+    let name: String = experimentName
+    let arbId: String
+
+    var group: ExperimentGroup { baseExperiment.group }
+    var dimensions: [String: String] { baseExperiment.dimensionsDictionary }
+
+    init(arbId: String, session elementsSession: STPElementsSession) {
+        self.arbId = arbId
+        self.baseExperiment = BaseConnectionsFCLiteExperiment(
+            experimentName: Self.experimentName,
+            elementsSession: elementsSession
+        )
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -141,7 +141,7 @@ final class PaymentSheetLoader {
                 if isLinkEnabled {
                     LinkAccountContext.shared.account = linkAccount
                 }
-                Self.logLinkExperimentExposures(
+                Self.logExperimentExposures(
                     elementsSession: elementsSession,
                     configuration: configuration,
                     linkAccount: linkAccount,
@@ -352,7 +352,7 @@ final class PaymentSheetLoader {
     }
 
     @MainActor
-    private static func logLinkExperimentExposures(
+    private static func logExperimentExposures(
         elementsSession: STPElementsSession,
         configuration: PaymentElementConfiguration,
         linkAccount: PaymentSheetLinkAccount?,
@@ -362,32 +362,35 @@ final class PaymentSheetLoader {
             guard let arbId = elementsSession.experimentsData?.arbId else {
                 return
             }
-            let linkGlobalHoldbackExperiment = LinkGlobalHoldback(
+            analyticsHelper.logExposure(experiment: LinkGlobalHoldback(
                 arbId: arbId,
                 session: elementsSession,
                 configuration: configuration,
                 linkAccount: linkAccount,
                 integrationShape: analyticsHelper.integrationShape
-            )
-            analyticsHelper.logExposure(experiment: linkGlobalHoldbackExperiment)
-
-            let linkGlobalHoldbackAAExperiment = LinkGlobalHoldbackAA(
+            ))
+            analyticsHelper.logExposure(experiment: LinkGlobalHoldbackAA(
                 arbId: arbId,
                 session: elementsSession,
                 configuration: configuration,
                 linkAccount: linkAccount,
                 integrationShape: analyticsHelper.integrationShape
-            )
-            analyticsHelper.logExposure(experiment: linkGlobalHoldbackAAExperiment)
-
-            let linkAbTestExperiment = LinkABTest(
+            ))
+            analyticsHelper.logExposure(experiment: LinkABTest(
                 arbId: arbId,
                 session: elementsSession,
                 configuration: configuration,
                 linkAccount: linkAccount,
                 integrationShape: analyticsHelper.integrationShape
-            )
-            analyticsHelper.logExposure(experiment: linkAbTestExperiment)
+            ))
+            analyticsHelper.logExposure(experiment: ConnectionsFCLiteVsNative(
+                arbId: arbId,
+                session: elementsSession
+            ))
+            analyticsHelper.logExposure(experiment: ConnectionsFCLiteVsNativeAA(
+                arbId: arbId,
+                session: elementsSession
+            ))
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
@@ -245,4 +245,41 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             ]
         )
     }
+
+    func testConnectionsFCLiteVsNative() {
+        let arbId = "arb_id"
+        let experimentsData = ExperimentsData(
+            arbId: arbId,
+            experimentAssignments: [
+                ConnectionsFCLiteVsNative.experimentName: .treatment,
+                ConnectionsFCLiteVsNativeAA.experimentName: .control,
+            ],
+            allResponseFields: [:]
+        )
+        let session = STPElementsSession._testValue(
+            orderedPaymentMethodTypesAndWallets: ["card", "us_bank_account", "apple_pay"],
+            experimentsData: experimentsData,
+            customer: nil
+        )
+
+        let experiment = ConnectionsFCLiteVsNative(arbId: arbId, session: session)
+        analyticsClient.logExposure(experiment: experiment)
+
+        guard let payload = analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName).first else {
+            return XCTFail("Expected event logged with name \(PaymentSheetAnalyticsHelper.eventName)")
+        }
+
+        XCTAssertEqual(payload["arb_id"] as? String, arbId)
+        XCTAssertEqual(payload["experiment_retrieved"] as? String, ConnectionsFCLiteVsNative.experimentName)
+        XCTAssertEqual(payload["assignment_group"] as? String, ExperimentGroup.treatment.rawValue)
+        XCTAssertEqual(payload["dimensions-elements_session_id"] as? String, "test_123")
+        XCTAssertNotNil(payload["dimensions-mobile_session_id"])
+        XCTAssertNotNil(payload["dimensions-mobile_sdk_version"] as? String)
+        XCTAssertNotNil(payload["dimensions-fc_sdk_availability"] as? String)
+        XCTAssertEqual(payload["dimensions-available_lpms"] as? String, "card,us_bank_account,apple_pay")
+
+        let aaExperiment = ConnectionsFCLiteVsNativeAA(arbId: arbId, session: session)
+        XCTAssertEqual(aaExperiment.name, ConnectionsFCLiteVsNativeAA.experimentName)
+        XCTAssertEqual(aaExperiment.group, .control)
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -863,15 +863,14 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
 
         // Experiment exposures are logged asynchronously after the lookup completes
         let predicate = NSPredicate { _, _ in
-            mockAnalyticsClientV2.loggedAnalyticPayloads(withEventName: "elements.experiment_exposure").count >= 3
+            mockAnalyticsClientV2.loggedAnalyticPayloads(withEventName: "elements.experiment_exposure").count >= 6
         }
         wait(for: [XCTNSPredicateExpectation(predicate: predicate, object: nil)], timeout: 5)
 
-        // Verify the 3 exposure events
         let exposures = mockAnalyticsClientV2.loggedAnalyticPayloads(withEventName: "elements.experiment_exposure")
-        XCTAssertEqual(exposures.count, 4)
+        XCTAssertEqual(exposures.count, 6)
         let experimentNames = Set(exposures.compactMap { $0["experiment_retrieved"] as? String })
-        XCTAssertEqual(experimentNames, ["link_global_holdback", "link_global_holdback_aa", "link_ab_test", "ocs_mobile_payment_method_messaging_promotions"])
+        XCTAssertEqual(experimentNames, ["link_global_holdback", "link_global_holdback_aa", "link_ab_test", "ocs_mobile_payment_method_messaging_promotions", "connections_fc_lite_vs_native", "connections_fc_lite_vs_native_aa"])
         for exposure in exposures {
             XCTAssertEqual(exposure["arb_id"] as? String, "test_arb_123")
             XCTAssertNotNil(exposure["assignment_group"], "Expected assignment_group in exposure: \(exposure)")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -68,6 +68,7 @@ public extension PaymentSheet.Appearance {
 extension STPElementsSession {
     static func _testValue(
         orderedPaymentMethodTypes: [STPPaymentMethodType] = [.card],
+        orderedPaymentMethodTypesAndWallets: [String] = [],
         unactivatedPaymentMethodTypes: [STPPaymentMethodType] = [],
         countryCode: String? = nil,
         merchantCountryCode: String? = nil,
@@ -89,7 +90,7 @@ extension STPElementsSession {
             sessionID: "test_123",
             configID: "test_config",
             orderedPaymentMethodTypes: orderedPaymentMethodTypes,
-            orderedPaymentMethodTypesAndWallets: [],
+            orderedPaymentMethodTypesAndWallets: orderedPaymentMethodTypesAndWallets,
             unactivatedPaymentMethodTypes: unactivatedPaymentMethodTypes,
             countryCode: countryCode,
             merchantCountryCode: merchantCountryCode,


### PR DESCRIPTION
## Summary

Adding experiment exposure logging for `connections_fc_lite_vs_native` and `connections_fc_lite_vs_native_aa` which are upcoming experiments we'll be running.

## Motivation

https://docs.google.com/document/d/1op-_3Wzg1oKxb4DN7NXmLjbjM6DmQ3jii_9naKSQUcM/edit?usp=sharing

## Testing

Unit tests added

## Changelog

N/a