### PR TITLE
CryptoOnramp SDK: EU Declaration: Fixes `<ul>` Rendering

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/CRSCARF Declaration/CRSCARFDeclarationContentViewController.swift
@@ -40,13 +40,9 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
     }
 
     private var declarationBaseAttributes: [NSAttributedString.Key: Any] {
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineHeightMultiple = 1.2
-
-        return [
+        [
             .font: LinkUI.font(forTextStyle: .body),
             .foregroundColor: UIColor.linkTextPrimary,
-            .paragraphStyle: paragraphStyle,
         ]
     }
 
@@ -121,9 +117,24 @@ final class CRSCARFDeclarationContentViewController: UIViewController, BottomShe
         }
 
         attributedString.addAttributes(declarationBaseAttributes, range: fullRange)
+
+        // Processing the HTML via NSAttributedString applies paragraph style properties. We need to apply our line height multiple to each of these
+        // paragraph styles individually, as setting the paragraph style for the entire range will overwrite other formatting aspects from the HTML,
+        // such as lists/bullet points and indentation.
+        var paragraphStyles: [(style: NSMutableParagraphStyle, range: NSRange)] = []
+        attributedString.enumerateAttribute(.paragraphStyle, in: fullRange) { value, range, _ in
+            let paragraphStyle = (value as? NSParagraphStyle)?.mutableCopy() as? NSMutableParagraphStyle ?? NSMutableParagraphStyle()
+            paragraphStyle.lineHeightMultiple = 1.2
+            paragraphStyles.append((paragraphStyle, range))
+        }
+
+        paragraphStyles.forEach { style, range in
+            attributedString.addAttribute(.paragraphStyle, value: style, range: range)
+        }
         linkRanges.forEach { range in
             attributedString.addAttributes(declarationLinkAttributes, range: range)
         }
+
         return attributedString
     }
 


### PR DESCRIPTION
## Summary
Applying a `paragraphStyle` wholesale to the declarations HTML string overwrites any `paragraphStyle` attributes specified by `NSAttributedString.DocumentType.html`. This was causing the new `<ul>` to render incorrectly without bullets and indentation. I’ve fixed the issue by modifying the existing paragraph style for each range to include the desired `lineHeightMultiple` instead of applying it wholesale.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
To fix the rendering of the HTML string from the backend.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Tested by comparing the existing behavior to the latest in the example app when registering a new EU user.
| Before | After (Light Mode) | After (Dark Mode) |
| --- | --- | --- |
| <img src="https://github.com/user-attachments/assets/6623dd06-3c20-4282-a3c6-53d454a9a5e3" width="300" /> | <img src="https://github.com/user-attachments/assets/2228405f-91f4-41f0-90e1-3e49c7d649f2" width="300" /> | <img src="https://github.com/user-attachments/assets/64ffa17f-0d42-4b86-afa8-f411612ca8af" width="300" /> |

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
