### PR TITLE
Remove updateTaxId from Checkout.swift and related tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 The next release's version bump will so far be:
-PATCH
+MINOR
 
 ## X.Y.Z - changes pending release
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -320,4 +320,3 @@ public final class Checkout: ObservableObject {
     }
 
 }
-

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -319,18 +319,5 @@ public final class Checkout: ObservableObject {
         }
     }
 
-    // MARK: - Tax ID
-
-    /// Sets the customer's tax ID on the session.
-    /// - Parameters:
-    ///   - type: The type of tax ID to set (for example, `"eu_vat"`).
-    ///   - value: The tax ID value to set.
-    /// - Throws: ``CheckoutError`` if the update fails.
-    public func updateTaxId(type: String, value: String) async throws {
-        try requireOpenSession()
-        try await enqueueSessionUpdate {
-            try await self.performAPIUpdate(.setTaxId(type: type, value: value))
-        }
-    }
-
 }
+

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutSessionUpdate.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutSessionUpdate.swift
@@ -15,7 +15,6 @@ extension Checkout {
         case setLineItemQuantity(lineItemId: String, quantity: Int)
         case setShippingRate(String)
         case setTaxRegion(Address)
-        case setTaxId(type: String, value: String)
         case setCurrency(String)
 
         var parameters: [String: Any] {
@@ -38,11 +37,6 @@ extension Checkout {
                     "tax_region[state]": address.state,
                     "tax_region[postal_code]": address.postalCode,
                 ] as [String: Any?]).compactMapValues { $0 }
-            case .setTaxId(let type, let value):
-                return [
-                    "tax_id_collection[tax_id][type]": type,
-                    "tax_id_collection[tax_id][value]": value,
-                ]
             case .setCurrency(let currency):
                 return ["updated_currency": currency]
             }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
@@ -251,22 +251,6 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         XCTAssertEqual(checkout.state.session.total?.total.minorUnitsAmount, 5542)
     }
 
-    func testUpdateTaxId() async throws {
-        let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
-            enableTaxIdCollection: true
-        )
-        let checkout = try await Checkout(
-            clientSecret: checkoutSessionResponse.clientSecret,
-            apiClient: STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        )
-
-        try await checkout.updateTaxId(type: "eu_vat", value: "DE123456789")
-
-        // Updating the tax ID does not change any properties on the payment page init response
-        // Nothing to assert on other than it did not fail/throw
-        XCTAssertEqual(checkout.state.session.status?.type, .open)
-    }
-
     func testSelectCurrency() async throws {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             adaptivePricingEnabled: true,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -132,20 +132,6 @@ final class CheckoutUnitTests: XCTestCase {
         }
     }
 
-    func testUpdateTaxIdRequiresOpenSession() async throws {
-        let checkout = await makeCheckoutWithClosedSession()
-
-        do {
-            try await checkout.updateTaxId(type: "eu_vat", value: "DE123456789")
-            XCTFail("Expected CheckoutError.sessionNotOpen")
-        } catch let error as CheckoutError {
-            guard case .sessionNotOpen = error else {
-                XCTFail("Expected .sessionNotOpen, got \(error)")
-                return
-            }
-        }
-    }
-
     // MARK: - runServerUpdate Tests
 
     func testRunServerUpdateWrapsClosureError() async {


### PR DESCRIPTION
## Summary
- Remove updateTaxId(type:value:) public method from Checkout
- Remove setTaxId case from SessionUpdate enum
- Remove testUpdateTaxId integration test
- Remove testUpdateTaxIdRequiresOpenSession unit test

## Motivation
- Not in scope for private preview or possibly GA

## Testing
- CI

## Changelog
N/A
