### PR TITLE
PMM Experiment — update exposure logging dimensions

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/PaymentMethodMessagingPromotionsExperiment.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/PaymentMethodMessagingPromotionsExperiment.swift
@@ -29,14 +29,4 @@ struct PaymentMethodMessagingPromotionsExperiment: LoggableExperiment {
         self.group = assignment ?? .control
         self.layout = layout
     }
-
-    init(
-        arbId: String,
-        group: ExperimentGroup,
-        layout: String
-    ) {
-        self.arbId = arbId
-        self.group = group
-        self.layout = layout
-    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/PaymentMethodMessagingPromotionsExperiment.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/PaymentMethodMessagingPromotionsExperiment.swift
@@ -14,49 +14,29 @@ struct PaymentMethodMessagingPromotionsExperiment: LoggableExperiment {
     let arbId: String
     let group: ExperimentGroup
 
-    let selectedPaymentMethodType: String?
-    let promotionDisplayedSuccessfully: Bool?
-    let layout: String?
+    let layout: String
 
     var dimensions: [String: String] {
-        var dimensions: [String: String] = [:]
-        if let selectedPaymentMethodType {
-            dimensions["selected_payment_method_type"] = selectedPaymentMethodType
-        }
-        if let promotionDisplayedSuccessfully {
-            dimensions["promotion_displayed_successfully"] = promotionDisplayedSuccessfully.description
-        }
-        if let layout {
-            dimensions["in_app_elements_layout"] = layout
-        }
-        return dimensions
+        ["in_app_elements_layout": layout]
     }
 
     init(
         elementsSession: STPElementsSession,
-        selectedPaymentMethodType: String? = nil,
-        promotionDisplayedSuccessfully: Bool? = nil,
-        layout: String? = nil
+        layout: String
     ) {
         let assignment = elementsSession.experimentsData?.experimentAssignments[Self.experimentName]
         self.arbId = elementsSession.experimentsData?.arbId ?? ""
         self.group = assignment ?? .control
-        self.selectedPaymentMethodType = selectedPaymentMethodType
-        self.promotionDisplayedSuccessfully = promotionDisplayedSuccessfully
         self.layout = layout
     }
 
     init(
         arbId: String,
         group: ExperimentGroup,
-        selectedPaymentMethodType: String? = nil,
-        promotionDisplayedSuccessfully: Bool? = nil,
-        layout: String? = nil
+        layout: String
     ) {
         self.arbId = arbId
         self.group = group
-        self.selectedPaymentMethodType = selectedPaymentMethodType
-        self.promotionDisplayedSuccessfully = promotionDisplayedSuccessfully
         self.layout = layout
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
@@ -72,7 +72,8 @@ class PaymentMethodMessagingPromotionsHelper {
         self.intent = intent
         self.configuration = configuration
         self.paymentMethodTypes = paymentMethodTypes
-        self._experiment = PaymentMethodMessagingPromotionsExperiment(elementsSession: elementsSession)
+        let layout = configuration.resolveLayout(elementsSession: elementsSession, paymentMethodTypes: paymentMethodTypes)
+        self._experiment = PaymentMethodMessagingPromotionsExperiment(elementsSession: elementsSession, layout: layout.rawValue)
         self.analyticsHelper = analyticsHelper
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
@@ -228,8 +228,6 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
 
         let experiment = PaymentMethodMessagingPromotionsExperiment(
             elementsSession: elementsSession,
-            selectedPaymentMethodType: "klarna",
-            promotionDisplayedSuccessfully: true,
             layout: "vertical"
         )
 
@@ -239,8 +237,6 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
         XCTAssertEqual(
             experiment.dimensions,
             [
-                "selected_payment_method_type": "klarna",
-                "promotion_displayed_successfully": "true",
                 "in_app_elements_layout": "vertical",
             ]
         )


### PR DESCRIPTION
## Summary
Remove selected PM and displayed_successfully dimensions. Hook up data source to layout

## Motivation
After discussing with data scientists we decided that dynamic dimensions should be avoided. displayed_successfully is still logged via normal analytics.
See android PR: https://github.com/stripe/stripe-android/pull/13199

## Testing
Updated PaymentSheetAnalyticsExperimentsTests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
