### PR TITLE
Add ui mode headless support to StripeCryptoOnramp

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/CreatePaymentTokenRequest.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/CreatePaymentTokenRequest.swift
@@ -9,9 +9,7 @@ import Foundation
 
 /// Encodable model passed to the `/v1/crypto/internal/payment_token` endpoint.
 struct CreatePaymentTokenRequest: Encodable {
-    /// The crypto wallet address to register.
     let paymentMethod: String
-
-    /// The crypto customer ID.
     let cryptoCustomerId: String
+    let uiMode: String = "headless"
 }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -281,7 +281,8 @@ extension STPAPIClient {
         let endpoint = "crypto/internal/platform_settings"
 
         let parameters: [String: Any] = [
-            "crypto_customer_id": cryptoCustomerId
+            "crypto_customer_id": cryptoCustomerId,
+            "ui_mode": "headless",
         ]
         return try await get(resource: endpoint, parameters: parameters)
     }

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
@@ -972,9 +972,10 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
 
             let parameters = String(data: httpBody, encoding: .utf8)?.parsedHTTPParametersDictionary ?? [:]
 
-            XCTAssertEqual(parameters.count, 2)
+            XCTAssertEqual(parameters.count, 3)
             XCTAssertEqual(parameters["payment_method"], Constant.validPaymentId)
             XCTAssertEqual(parameters["crypto_customer_id"], Constant.validCustomerId)
+            XCTAssertEqual(parameters["ui_mode"], "headless")
 
             return true
         } response: { _ in
@@ -1029,8 +1030,9 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
 
             let parameters = queryParametersString.parsedHTTPParametersDictionary
 
-            XCTAssertEqual(parameters.count, 1)
+            XCTAssertEqual(parameters.count, 2)
             XCTAssertEqual(parameters["crypto_customer_id"], Constant.validCustomerId)
+            XCTAssertEqual(parameters["ui_mode"], "headless")
 
             return true
         } response: { _ in


### PR DESCRIPTION
Always send ui_mode=headless since this is the headless-only SDK. This will enable integration against the correct flows for headless in EU, while remaining consistent behavior for headless US. 
This param needs to show up in getPlatformSettings and createPaymentToken

Committed-By-Agent: claude

## Summary
<!-- Simple summary of what was changed. -->

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
