### PR TITLE
PMM Experiment — Add support for not being in an experiment

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/PaymentMethodMessagingPromotionsExperiment.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/PaymentMethodMessagingPromotionsExperiment.swift
@@ -20,13 +20,15 @@ struct PaymentMethodMessagingPromotionsExperiment: LoggableExperiment {
         ["in_app_elements_layout": layout]
     }
 
-    init(
+    init?(
         elementsSession: STPElementsSession,
         layout: String
     ) {
-        let assignment = elementsSession.experimentsData?.experimentAssignments[Self.experimentName]
+        guard let assignment = elementsSession.experimentsData?.experimentAssignments[Self.experimentName] else {
+            return nil
+        }
         self.arbId = elementsSession.experimentsData?.arbId ?? ""
-        self.group = assignment ?? .control
+        self.group = assignment
         self.layout = layout
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
@@ -64,7 +64,7 @@ class PaymentMethodMessagingPromotionsHelper {
         experiment.group == .treatment
     }
 
-    init(
+    init?(
         elementsSession: STPElementsSession,
         intent: Intent,
         configuration: PaymentElementConfiguration,
@@ -76,7 +76,13 @@ class PaymentMethodMessagingPromotionsHelper {
         self.configuration = configuration
         self.paymentMethodTypes = paymentMethodTypes
         let layout = configuration.resolveLayout(elementsSession: elementsSession, paymentMethodTypes: paymentMethodTypes)
-        self._experiment = PaymentMethodMessagingPromotionsExperiment(elementsSession: elementsSession, layout: layout.rawValue)
+        guard let exp = PaymentMethodMessagingPromotionsExperiment(
+            elementsSession: elementsSession,
+            layout: layout.rawValue
+        ) else {
+            return nil
+        }
+        self._experiment = exp
         self.analyticsHelper = analyticsHelper
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -18,7 +18,7 @@ final class PaymentSheetLoader {
         let savedPaymentMethods: [STPPaymentMethod]
         /// The payment method types that should be shown (i.e. filtered)
         let paymentMethodTypes: [PaymentSheet.PaymentMethodType]
-        let paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper
+        let paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper?
         let paymentMethodOrientation: PaymentSheet.PaymentMethodLayout.ResolvedLayout
     }
 
@@ -206,7 +206,7 @@ final class PaymentSheetLoader {
                 paymentMethodTypes: paymentMethodTypes,
                 analyticsHelper: analyticsHelper
             )
-            paymentMethodMessagingPromotionsHelper.fetchData()
+            paymentMethodMessagingPromotionsHelper?.fetchData()
 
             let paymentMethodOrientation = configuration.resolveLayout(
                 elementsSession: elementsSession,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -723,7 +723,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
             configuration: configuration,
             paymentMethodTypes: [.stripe(.card)],
             analyticsHelper: analyticsHelper
-        )
+        )!
         promotionsHelper.fetchData()
         let loadResult = PaymentSheetLoader.LoadResult(
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
@@ -64,7 +64,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             configuration: configuration,
             paymentMethodTypes: [.stripe(.affirm)],
             analyticsHelper: analyticsHelper
-        )
+        )!
 
         XCTAssertTrue(helper.isInTreatmentGroup)
 
@@ -109,7 +109,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             configuration: configuration,
             paymentMethodTypes: [.stripe(.affirm)],
             analyticsHelper: analyticsHelper
-        )
+        )!
 
         XCTAssertFalse(helper.isInTreatmentGroup)
 
@@ -139,7 +139,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             configuration: configuration,
             paymentMethodTypes: [],
             analyticsHelper: PaymentSheetAnalyticsHelper._testValue()
-        )
+        )!
 
         helper.fetchData()
         await helper.fetchTask?.value
@@ -171,7 +171,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             configuration: configuration,
             paymentMethodTypes: [.stripe(.affirm)],
             analyticsHelper: analyticsHelper
-        )
+        )!
 
         helper.fetchData()
         await helper.fetchTask?.value
@@ -202,7 +202,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             configuration: configuration,
             paymentMethodTypes: [.stripe(.affirm)],
             analyticsHelper: analyticsHelper
-        )
+        )!
 
         helper.fetchData()
         await helper.fetchTask?.value
@@ -233,7 +233,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             configuration: configuration,
             paymentMethodTypes: [.stripe(.affirm)],
             analyticsHelper: analyticsHelper
-        )
+        )!
 
         helper.fetchData()
         await helper.fetchTask?.value
@@ -263,7 +263,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             configuration: configuration,
             paymentMethodTypes: [],
             analyticsHelper: analyticsHelper
-        )
+        )!
 
         helper.logDisplayedAnalytic(displayedSuccessfully: false)
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
@@ -229,7 +229,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
         let experiment = PaymentMethodMessagingPromotionsExperiment(
             elementsSession: elementsSession,
             layout: "vertical"
-        )
+        )!
 
         XCTAssertEqual(experiment.name, PaymentMethodMessagingPromotionsExperiment.experimentName)
         XCTAssertEqual(experiment.arbId, "arb_id_123")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
@@ -60,7 +60,7 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
             configuration: PaymentSheet.Configuration(),
             paymentMethodTypes: [.stripe(.card)],
             analyticsHelper: analyticsHelper
-        )
+        )!
         promotionsHelper.fetchData()
         let savedPMsLoadResult = PaymentSheetLoader.LoadResult(
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -475,7 +475,7 @@ extension PaymentMethodMessagingPromotionsHelper {
             configuration: PaymentSheet.Configuration(),
             paymentMethodTypes: [],
             analyticsHelper: PaymentSheetAnalyticsHelper._testValue()
-        )
+        )!
     }
 
     static func _testValueInTreatment() -> PaymentMethodMessagingPromotionsHelper {
@@ -493,7 +493,7 @@ extension PaymentMethodMessagingPromotionsHelper {
             configuration: PaymentSheet.Configuration(),
             paymentMethodTypes: [],
             analyticsHelper: PaymentSheetAnalyticsHelper._testValue()
-        )
+        )!
     }
 }
 


### PR DESCRIPTION
## Summary
Sometimes we are not in the experiment at all, such as when in setup mode or without any BNPLs. In this case we should not create the experiment object or the promotions helper rather than defaulting to the control group.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
