### PR TITLE
Rename LinkPaymentController to InstantBankPaymentsController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ MINOR
 
 ## X.Y.Z - changes pending release
 
+### PaymentSheet
+* [Changed] Renamed `LinkPaymentController` to `InstantBankPaymentsController`.
+
 ### CryptoOnramp (Alpha)
 * [Changed] Updated EU compliance identifier APIs to match the latest backend contract, including CRS/CARF TIN requirements and `SubmitIdentifiersResult.completed`.
 * [Added] Added known compliance identifier types for Spain NIF (`es_nif`) and France NIR (`fr_nir`).

--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard2.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard2.xctestplan
@@ -35,7 +35,7 @@
         "CustomerSheetUITest",
         "EmbeddedUITests",
         "EmbeddedUITests\/testUpdate()",
-        "LinkPaymentControllerUITest",
+        "InstantBankPaymentsControllerUITest",
         "PaymentSheetBillingCollectionBankTests",
         "PaymentSheetBillingCollectionLPMUITests",
         "PaymentSheetBillingCollectionUICardTests",

--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard3.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard3.xctestplan
@@ -37,7 +37,7 @@
         "EmbeddedUITests\/testUpdate()",
         "FCLiteUITests",
         "FCLiteUITests\/testFCLiteInitialPaneAndDismiss()",
-        "LinkPaymentControllerUITest",
+        "InstantBankPaymentsControllerUITest",
         "PaymentSheetBillingCollectionBankTests",
         "PaymentSheetCVCRecollectionUITests",
         "PaymentSheetCardBrandFilteringUITests",

--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard4.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard4.xctestplan
@@ -35,7 +35,7 @@
         "CustomerSheetUITest",
         "FCLiteUITests",
         "FCLiteUITests\/testFCLiteInitialPaneAndDismiss()",
-        "LinkPaymentControllerUITest",
+        "InstantBankPaymentsControllerUITest",
         "PaymentSheetBillingCollectionBankTests",
         "PaymentSheetBillingCollectionLPMUITests",
         "PaymentSheetBillingCollectionUICardTests",

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
@@ -14,7 +14,7 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
     @IBOutlet weak var paymentMethodButton: UIButton!
     @IBOutlet weak var paymentMethodImage: UIImageView!
     @IBOutlet weak var deferredSwitch: UISwitch!
-    var linkPaymentController: InstantBankPaymentsController!
+    var instantBankPaymentsController: InstantBankPaymentsController!
     static let baseEndpoint = "https://stp-mobile-playground-backend-v7.stripedemos.com"
     var backendCheckoutUrl: String {
         "\(ExampleLinkPaymentCheckoutViewController.baseEndpoint)/checkout"
@@ -66,9 +66,9 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
                                 }
                             }
 
-                    self.linkPaymentController = InstantBankPaymentsController(intentConfiguration: intentConfiguration, returnURL: returnURL, billingDetails: self.billingDetails)
+                    self.instantBankPaymentsController = InstantBankPaymentsController(intentConfiguration: intentConfiguration, returnURL: returnURL, billingDetails: self.billingDetails)
                 } else {
-                    self.linkPaymentController = InstantBankPaymentsController(paymentIntentClientSecret: paymentIntentClientSecret, returnURL: returnURL, billingDetails: self.billingDetails)
+                    self.instantBankPaymentsController = InstantBankPaymentsController(paymentIntentClientSecret: paymentIntentClientSecret, returnURL: returnURL, billingDetails: self.billingDetails)
                 }
 
                 self.updateButtons()
@@ -93,7 +93,7 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
     @objc
     func didTapPaymentMethodButton() {
         buyButton.isEnabled = false
-        linkPaymentController.present(from: self) { [weak self] result in
+        instantBankPaymentsController.present(from: self) { [weak self] result in
             switch result {
             case .success:
                 self?.updateButtons()
@@ -106,7 +106,7 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
 
     @objc
     func didTapCheckoutButton() {
-        linkPaymentController.confirm(from: self) { paymentResult in
+        instantBankPaymentsController.confirm(from: self) { paymentResult in
             switch paymentResult {
             case .completed:
                 self.displayAlert("Your order is confirmed!")
@@ -127,7 +127,7 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
 
     func updateButtons() {
         // MARK: Update the payment method and buy buttons
-        if let paymentOption = linkPaymentController.paymentOption {
+        if let paymentOption = instantBankPaymentsController.paymentOption {
             paymentMethodButton.setTitle(paymentOption.label, for: .normal)
             paymentMethodButton.setTitleColor(.label, for: .normal)
             paymentMethodImage.image = paymentOption.image

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkPaymentCheckoutViewController.swift
@@ -14,7 +14,7 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
     @IBOutlet weak var paymentMethodButton: UIButton!
     @IBOutlet weak var paymentMethodImage: UIImageView!
     @IBOutlet weak var deferredSwitch: UISwitch!
-    var linkPaymentController: LinkPaymentController!
+    var linkPaymentController: InstantBankPaymentsController!
     static let baseEndpoint = "https://stp-mobile-playground-backend-v7.stripedemos.com"
     var backendCheckoutUrl: String {
         "\(ExampleLinkPaymentCheckoutViewController.baseEndpoint)/checkout"
@@ -66,9 +66,9 @@ class ExampleLinkPaymentCheckoutViewController: UIViewController {
                                 }
                             }
 
-                    self.linkPaymentController = LinkPaymentController(intentConfiguration: intentConfiguration, returnURL: returnURL, billingDetails: self.billingDetails)
+                    self.linkPaymentController = InstantBankPaymentsController(intentConfiguration: intentConfiguration, returnURL: returnURL, billingDetails: self.billingDetails)
                 } else {
-                    self.linkPaymentController = LinkPaymentController(paymentIntentClientSecret: paymentIntentClientSecret, returnURL: returnURL, billingDetails: self.billingDetails)
+                    self.linkPaymentController = InstantBankPaymentsController(paymentIntentClientSecret: paymentIntentClientSecret, returnURL: returnURL, billingDetails: self.billingDetails)
                 }
 
                 self.updateButtons()

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
@@ -153,7 +153,7 @@ struct PaymentSheetExampleAppRootView: View {
             case .customerSheet_swiftUI:
                 return "CustomerSheet (SwiftUI)"
             case .linkPaymentController:
-                return "LinkPaymentController"
+                return "InstantBankPaymentsController"
             case .linkController:
                 return "LinkController (SwiftUI)"
             case .linkStandaloneDemo:

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetExampleAppRootView.swift
@@ -84,7 +84,7 @@ struct PaymentSheetExampleAppRootView: View {
         case paymentSheet_flowController_swiftUI
 
         case customerSheet_swiftUI
-        case linkPaymentController
+        case instantBankPaymentsController
         case linkController
         case linkStandaloneDemo
         case linkPayoutsDemo
@@ -115,7 +115,7 @@ struct PaymentSheetExampleAppRootView: View {
                      .paymentSheet_swiftUI,
                      .paymentSheet_flowController_swiftUI,
                      .customerSheet_swiftUI,
-                     .linkPaymentController,
+                     .instantBankPaymentsController,
                      .linkController,
                      .linkStandaloneDemo,
                      .linkPayoutsDemo,
@@ -152,7 +152,7 @@ struct PaymentSheetExampleAppRootView: View {
 
             case .customerSheet_swiftUI:
                 return "CustomerSheet (SwiftUI)"
-            case .linkPaymentController:
+            case .instantBankPaymentsController:
                 return "InstantBankPaymentsController"
             case .linkController:
                 return "LinkController (SwiftUI)"
@@ -226,7 +226,7 @@ struct PaymentSheetExampleAppRootView: View {
         case .customerSheet_swiftUI:
             ExampleSwiftUICustomerSheet()
 
-        case .linkPaymentController:
+        case .instantBankPaymentsController:
             StoryboardSceneView<ExampleLinkPaymentCheckoutViewController>(sceneIdentifier: "ExampleLinkPaymentCheckoutViewController")
         case .linkController:
             if #available(iOS 16.0, *) {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Resources/Base.lproj/Main.storyboard
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Resources/Base.lproj/Main.storyboard
@@ -85,7 +85,7 @@
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" id="Ysb-4K-dUG">
                                         <rect key="frame" x="121" y="96" width="156" height="0.0"/>
                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                        <state key="normal" title="LinkPaymentController"/>
+                                        <state key="normal" title="InstantBankPaymentsController"/>
                                         <connections>
                                             <segue destination="jqF-43-4W3" kind="show" id="I4Q-i5-Ogf"/>
                                         </connections>

--- a/Example/PaymentSheet Example/PaymentSheet Example/Resources/th.lproj/Main.strings
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Resources/th.lproj/Main.strings
@@ -245,8 +245,8 @@
 /* Class = "UILabel"; text = "€8.99"; ObjectID = "Xxx-yh-jB6"; */
 "Xxx-yh-jB6.text" = "€8.99";
 
-/* Class = "UIButton"; normalTitle = "LinkPaymentController"; ObjectID = "Ysb-4K-dUG"; */
-"Ysb-4K-dUG.normalTitle" = "LinkPaymentController";
+/* Class = "UIButton"; normalTitle = "InstantBankPaymentsController"; ObjectID = "Ysb-4K-dUG"; */
+"Ysb-4K-dUG.normalTitle" = "InstantBankPaymentsController";
 
 /* Class = "UIButton"; normalTitle = "EmbeddedPaymentElement"; ObjectID = "ZXq-dE-S2O"; */
 "ZXq-dE-S2O.normalTitle" = "EmbeddedPaymentElement";

--- a/Example/PaymentSheet Example/PaymentSheetUITest/InstantBankPaymentsControllerUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/InstantBankPaymentsControllerUITest.swift
@@ -52,7 +52,7 @@ class InstantBankPaymentsControllerUITest: XCTestCase {
             .matching(NSPredicate(format: "label CONTAINS 'Email address'"))
             .firstMatch
             .waitForExistenceAndTap(timeout: 10)
-        let email = "linkpaymentcontrolleruitest-\(UUID().uuidString)@example.com"
+        let email = "instantbankpaymentscontrolleruitest-\(UUID().uuidString)@example.com"
         app.typeText(email + XCUIKeyboardKey.return.rawValue)
         app.textFields["Phone number"].tap()
         // the `XCUIKeyboardKey.return.rawValue` will automatically

--- a/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/LinkPaymentControllerUITest.swift
@@ -1,5 +1,5 @@
 //
-//  LinkPaymentControllerUITest.swift
+//  InstantBankPaymentsControllerUITest.swift
 //  PaymentSheetUITest
 //
 //  Created by Krisjanis Gaidis on 6/3/24.
@@ -7,7 +7,7 @@
 
 import XCTest
 
-class LinkPaymentControllerUITest: XCTestCase {
+class InstantBankPaymentsControllerUITest: XCTestCase {
     fileprivate var app: XCUIApplication!
     fileprivate let timeout: TimeInterval = 10
 
@@ -25,14 +25,14 @@ class LinkPaymentControllerUITest: XCTestCase {
         app.launchEnvironment = [:]
     }
 
-    func testWebInstantDebitsOnlyLinkPaymentController() {
+    func testWebInstantDebitsOnlyInstantBankPaymentsController() {
         app.launchEnvironment["FinancialConnectionsSDKAvailable"] = "false"
         app.launch()
 
         // PaymentSheet Example
-        app.staticTexts["LinkPaymentController"].tap()
+        app.staticTexts["InstantBankPaymentsController"].tap()
 
-        // LinkPaymentController
+        // InstantBankPaymentsController
         let paymentMethodButton = app.buttons["SelectPaymentMethodButton"]
         let paymentMethodButtonEnabledExpectation = expectation(
             for: NSPredicate(format: "enabled == true"),
@@ -78,20 +78,20 @@ class LinkPaymentControllerUITest: XCTestCase {
 
         sleep(3) // wait for modal to disappear before pressing Buy
 
-        // Back to "LinkPaymentController"
+        // Back to "InstantBankPaymentsController"
         app.buttons["Buy"].waitForExistenceAndTap(timeout: timeout)
         XCTAssert(app.alerts.staticTexts["Your order is confirmed!"].waitForExistence(timeout: timeout))
     }
 
-    func testNativeInstantDebitsOnlyLinkPaymentController() {
+    func testNativeInstantDebitsOnlyInstantBankPaymentsController() {
         app.launchArguments += ["-FINANCIAL_CONNECTIONS_EXAMPLE_APP_ENABLE_NATIVE", "YES"]
         app.launchEnvironment["FinancialConnectionsSDKAvailable"] = "true"
         app.launch()
 
         // PaymentSheet Example
-        app.staticTexts["LinkPaymentController"].tap()
+        app.staticTexts["InstantBankPaymentsController"].tap()
 
-        // LinkPaymentController
+        // InstantBankPaymentsController
         let paymentMethodButton = app.buttons["SelectPaymentMethodButton"]
         let paymentMethodButtonEnabledExpectation = expectation(
             for: NSPredicate(format: "enabled == true"),
@@ -104,7 +104,7 @@ class LinkPaymentControllerUITest: XCTestCase {
 
         sleep(3) // wait for modal to disappear before pressing Buy
 
-        // Back to "LinkPaymentController"
+        // Back to "InstantBankPaymentsController"
         app.buttons["Buy"].waitForExistenceAndTap(timeout: timeout)
         XCTAssert(app.alerts.staticTexts["Your order is confirmed!"].waitForExistence(timeout: timeout))
     }

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITestCase+Helpers.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetUITestCase+Helpers.swift
@@ -315,7 +315,7 @@ extension PaymentSheetUITestCase {
                 .matching(NSPredicate(format: "label CONTAINS 'Email address'"))
                 .firstMatch
                 .waitForExistenceAndTap(timeout: 10)
-            let email = "linkpaymentcontrolleruitest-\(UUID().uuidString)@example.com"
+            let email = "instantbankpaymentscontrolleruitest-\(UUID().uuidString)@example.com"
             app.typeText(email + XCUIKeyboardKey.return.rawValue)
         }
 

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -352,6 +352,9 @@ import Foundation
     // MARK: - Synthetic latency tests
     case mpeSyntheticLatency = "mpe.synthetic_latency"
 
+    // MARK: - InstantBankPaymentsController
+    case instantBankPaymentsControllerInit = "mc_instant_bank_payments_controller_init"
+
     // MARK: - Adaptive Pricing
     case adaptivePricingCurrencySelectorInit = "elements.adaptive_pricing.currency_selector_init"
     case adaptivePricingCurrencyToggled = "elements.adaptive_pricing.currency_toggled"

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/InstantBankPaymentsController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/InstantBankPaymentsController.swift
@@ -1,5 +1,5 @@
 //
-//  LinkPaymentController.swift
+//  InstantBankPaymentsController.swift
 //  StripePaymentSheet
 //
 //  Created by Bill Meltsner on 12/9/22.
@@ -12,9 +12,9 @@ import AuthenticationServices
 @_spi(STP) import StripeUICore
 import UIKit
 
-/// `LinkPaymentController` encapsulates the Link payment flow, allowing you to let your customers pay with their Link account.
+/// `InstantBankPaymentsController` encapsulates the Link payment flow, allowing you to let your customers pay with their Link account.
 /// This feature is currently invite-only. To accept payments, [use the Mobile Payment Element.](https://stripe.com/docs/payments/accept-a-payment?platform=ios&ui=payment-sheet)
-@_spi(LinkOnly) public class LinkPaymentController: NSObject {
+@_spi(LinkOnly) public class InstantBankPaymentsController: NSObject {
     private let mode: PaymentSheet.InitializationMode
     private let configuration: PaymentSheet.Configuration
 
@@ -69,7 +69,7 @@ import UIKit
         return vc
     }()
 
-    /// Initializes a new `LinkPaymentController` instance.
+    /// Initializes a new `InstantBankPaymentsController` instance.
     /// - Parameter paymentIntentClientSecret: The [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret) of a Stripe PaymentIntent object
     /// - Note: This can be used to complete a payment - don't log it, store it, or expose it to anyone other than the customer.
     /// - Parameter returnURL: A URL that redirects back to your app for flows that complete authentication in another app (such as a bank app).
@@ -78,7 +78,7 @@ import UIKit
         self.init(intentSecret: .paymentIntentClientSecret(paymentIntentClientSecret), returnURL: returnURL, billingDetails: billingDetails)
     }
 
-    /// Initializes a new `LinkPaymentController` instance.
+    /// Initializes a new `InstantBankPaymentsController` instance.
     /// - Parameter setupIntentClientSecret: The [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret) of a Stripe SetupIntent object
     /// - Parameter returnURL: A URL that redirects back to your app for flows that complete authentication in another app (such as a bank app).
     /// - Parameter billingDetails: Any information about the customer you've already collected.
@@ -86,9 +86,8 @@ import UIKit
         self.init(intentSecret: .setupIntentClientSecret(setupIntentClientSecret), returnURL: returnURL, billingDetails: billingDetails)
     }
 
-    /// Initializes a new `LinkPaymentController` instance.
-    /// - Parameter paymentIntentClientSecret: The [client secret](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-client_secret) of a Stripe PaymentIntent object
-    /// - Note: This can be used to complete a payment - don't log it, store it, or expose it to anyone other than the customer.
+    /// Initializes a new `InstantBankPaymentsController` instance.
+    /// - Parameter intentConfiguration: The `IntentConfiguration` for the payment
     /// - Parameter returnURL: A URL that redirects back to your app for flows that complete authentication in another app (such as a bank app).
     /// - Parameter billingDetails: Any information about the customer you've already collected.
     @_spi(LinkOnly) public convenience init(intentConfiguration: PaymentSheet.IntentConfiguration, returnURL: String? = nil, billingDetails: PaymentSheet.BillingDetails? = nil) {
@@ -103,13 +102,17 @@ import UIKit
             configuration.defaultBillingDetails = billingDetails
         }
         self.configuration = configuration
+        super.init()
+        STPAnalyticsClient.sharedClient.log(
+            analytic: GenericAnalytic(event: .instantBankPaymentsControllerInit, params: [:])
+        )
     }
 
     /// Presents the Link payment flow, allowing your customer to pay with Link.
     /// The flow lets your customer log into or create a Link account, select a valid source of funds, and approve the usage of those funds to complete the purchase. The actual purchase will not occur until you call `confirm(from:completion:)`.
     /// - Note: Once `confirm(from:completion:)` completes successfully (i.e. when `result` is `.success`), calling this method is an error, as payment/setup intents should not be reused. Until then, you may call this method as many times as is necessary.
     /// - Parameter presentingViewController: The view controller to present the payment flow from.
-    /// - Parameter completion: Called when the payment flow is dismissed. If the flow was completed successfully, the result will be `.success`, and you can call `confirm(from:completion:)` when you're ready to complete the payment. If it was not, the result will be `.failure` with an `Error` describing what happened; this will be `LinkPaymentController.Error.canceled` if the customer canceled the flow.
+    /// - Parameter completion: Called when the payment flow is dismissed. If the flow was completed successfully, the result will be `.success`, and you can call `confirm(from:completion:)` when you're ready to complete the payment. If it was not, the result will be `.failure` with an `Error` describing what happened; this will be `InstantBankPaymentsController.Error.canceled` if the customer canceled the flow.
     @_spi(LinkOnly) public func present(from presentingViewController: UIViewController, completion: @escaping (Result<Void, Swift.Error>) -> Void) {
         Task {
             do {
@@ -130,7 +133,7 @@ import UIKit
     /// If this method returns successfully, you can call `confirm(from:)` when you're ready to complete the payment.
     /// - Note: Once `confirm(from:)` returns successfully, calling this method is an error, as payment/setup intents should not be reused. Until then, you may call this method as many times as is necessary.
     /// - Parameter presentingViewController: The view controller to present the payment flow from.
-    /// - Throws: Either `LinkPaymentController.Error.canceled`, meaning the customer canceled the flow, or an error describing what went wrong.
+    /// - Throws: Either `InstantBankPaymentsController.Error.canceled`, meaning the customer canceled the flow, or an error describing what went wrong.
     @MainActor
     @_spi(LinkOnly) public func present(from presentingViewController: UIViewController) async throws {
         guard FinancialConnectionsSDKAvailability.isFinancialConnectionsSDKAvailable else {
@@ -214,7 +217,7 @@ import UIKit
                         self?.generateManifest(continuation: continuation, error: error, emailAddress: self?.configuration.defaultBillingDetails.email, linkAccountSession: linkAccountSession)
                     }
             case .checkoutSession:
-                continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Link payment controller is not yet supported by CheckoutSession"))
+                continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "InstantBankPaymentsController is not yet supported by CheckoutSession"))
             }
         }
 
@@ -307,7 +310,7 @@ import UIKit
                 financialConnectionsCompletion: completionHandler
             )
         case .checkoutSession:
-            completionHandler(nil, nil, PaymentSheetError.unknown(debugDescription: "Link payment controller is not yet supported by CheckoutSession") as NSError)
+            completionHandler(nil, nil, PaymentSheetError.unknown(debugDescription: "InstantBankPaymentsController is not yet supported by CheckoutSession") as NSError)
         }
     }
 
@@ -468,7 +471,7 @@ import UIKit
     }
 
     /// Completes the Link payment or setup.
-    /// - Note: Once `completion` is called with a `.completed` result, this `LinkPaymentController` instance should no longer be used, as payment/setup intents should not be reused. Other results indicate cancellation or failure, and do not invalidate the instance.
+    /// - Note: Once `completion` is called with a `.completed` result, this `InstantBankPaymentsController` instance should no longer be used, as payment/setup intents should not be reused. Other results indicate cancellation or failure, and do not invalidate the instance.
     /// - Parameter presentingViewController: The view controller used to present any view controllers required e.g. to authenticate the customer
     /// - Parameter completion: Called with the result of the payment after any presented view controllers are dismissed
     @_spi(LinkOnly) public func confirm(from presentingViewController: UIViewController, completion: @escaping (PaymentSheetResult) -> Void) {
@@ -491,9 +494,9 @@ import UIKit
     }
 
     /// Completes the Link payment or setup.
-    /// - Note: Once this method returns successfully, this `LinkPaymentController` instance should no longer be used, as payment/setup intents should not be reused. Thrown errors indicate cancellation or failure, and do not invalidate the instance.
+    /// - Note: Once this method returns successfully, this `InstantBankPaymentsController` instance should no longer be used, as payment/setup intents should not be reused. Thrown errors indicate cancellation or failure, and do not invalidate the instance.
     /// - Parameter presentingViewController: The view controller used to present any view controllers required e.g. to authenticate the customer
-    /// - Throws: Either `LinkPaymentController.Error.canceled`, meaning the customer canceled the flow, or an error describing what went wrong.
+    /// - Throws: Either `InstantBankPaymentsController.Error.canceled`, meaning the customer canceled the flow, or an error describing what went wrong.
     @MainActor
     @_spi(LinkOnly) public func confirm(from presentingViewController: UIViewController) async throws {
         guard let paymentMethodId = paymentMethodId else {
@@ -544,7 +547,7 @@ import UIKit
                 Task { @MainActor in
                     let result = await PaymentSheet
                         .routeDeferredIntentConfirmation(
-                            confirmType: .saved(paymentMethod, paymentOptions: nil, clientAttributionMetadata: nil, radarOptions: nil), // LinkPaymentController is standalone and isn't a part of MPE, so it doesn't generate a client_session_id and doesn't have an elements session object so we don't want to send CAM here
+                            confirmType: .saved(paymentMethod, paymentOptions: nil, clientAttributionMetadata: nil, radarOptions: nil), // InstantBankPaymentsController is standalone and isn't a part of MPE, so it doesn't generate a client_session_id and doesn't have an elements session object so we don't want to send CAM here
                             configuration: configuration,
                             intentConfig: intentConfiguration,
                             authenticationContext: authenticationContext,
@@ -562,7 +565,7 @@ import UIKit
                     }
                 }
             case .checkoutSession:
-                continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Link payment controller is not yet supported by CheckoutSession"))
+                continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "InstantBankPaymentsController is not yet supported by CheckoutSession"))
             }
         }
     }
@@ -575,9 +578,9 @@ import UIKit
         PaymentSheet.resetCustomer()
     }
 
-    /// Errors related to the Link payment flow
+    /// Errors related to the InstantBankPaymentsController payment flow
     ///
-    /// Most errors do not originate from LinkPaymentController itself; instead, they come from the Stripe API or other SDK components
+    /// Most errors do not originate from InstantBankPaymentsController itself; instead, they come from the Stripe API or other SDK components
     @frozen @_spi(LinkOnly) public enum Error: Swift.Error {
         /// The customer canceled the flow they were in.
         case canceled
@@ -587,7 +590,7 @@ import UIKit
 }
 
 @_spi(LinkOnly)
-extension LinkPaymentController: LoadingViewControllerDelegate {
+extension InstantBankPaymentsController: LoadingViewControllerDelegate {
     func shouldDismiss(_ loadingViewController: LoadingViewController) {
         instantDebitsOnlyAuthenticationSessionManager = nil
         paymentMethodId = nil


### PR DESCRIPTION
## Summary

Renames the `LinkPaymentController` to `InstantBankPaymentsController` in anticipation of the `LinkController`. Also adds a simple analytic event when the class is initialized.

## Motivation

https://docs.google.com/document/d/1VoMxNhXmKix5kiFzWO3eJc2YzE3dpEO63rKp_Kb9F6E/edit?disco=AAAB8E45KpU

## Testing

Ensure tests still pass 

## Changelog

```
* [Changed] Renamed `LinkPaymentController` to `InstantBankPaymentsController`.
```