### PR TITLE
PMM Experiment — Add support for not being in an experiment

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/PaymentMethodMessagingPromotionsExperiment.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/Experiments/PaymentMethodMessagingPromotionsExperiment.swift
@@ -20,13 +20,15 @@ struct PaymentMethodMessagingPromotionsExperiment: LoggableExperiment {
         ["in_app_elements_layout": layout]
     }
 
-    init(
+    init?(
         elementsSession: STPElementsSession,
         layout: String
     ) {
-        let assignment = elementsSession.experimentsData?.experimentAssignments[Self.experimentName]
+        guard let assignment = elementsSession.experimentsData?.experimentAssignments[Self.experimentName] else {
+            return nil
+        }
         self.arbId = elementsSession.experimentsData?.arbId ?? ""
-        self.group = assignment ?? .control
+        self.group = assignment
         self.layout = layout
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
@@ -64,19 +64,22 @@ class PaymentMethodMessagingPromotionsHelper {
         experiment.group == .treatment
     }
 
-    init(
+    init?(
         elementsSession: STPElementsSession,
         intent: Intent,
         configuration: PaymentElementConfiguration,
         paymentMethodTypes: [PaymentSheet.PaymentMethodType],
         analyticsHelper: PaymentSheetAnalyticsHelper
     ) {
+        let layout = configuration.resolveLayout(elementsSession: elementsSession, paymentMethodTypes: paymentMethodTypes)
+        guard let experiment = PaymentMethodMessagingPromotionsExperiment(elementsSession: elementsSession, layout: layout.rawValue) else {
+            return nil
+        }
         self.elementsSession = elementsSession
         self.intent = intent
         self.configuration = configuration
         self.paymentMethodTypes = paymentMethodTypes
-        let layout = configuration.resolveLayout(elementsSession: elementsSession, paymentMethodTypes: paymentMethodTypes)
-        self._experiment = PaymentMethodMessagingPromotionsExperiment(elementsSession: elementsSession, layout: layout.rawValue)
+        self._experiment = experiment
         self.analyticsHelper = analyticsHelper
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -18,7 +18,7 @@ final class PaymentSheetLoader {
         let savedPaymentMethods: [STPPaymentMethod]
         /// The payment method types that should be shown (i.e. filtered)
         let paymentMethodTypes: [PaymentSheet.PaymentMethodType]
-        let paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper
+        let paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper?
         let paymentMethodOrientation: PaymentSheet.PaymentMethodLayout.ResolvedLayout
     }
 
@@ -206,7 +206,7 @@ final class PaymentSheetLoader {
                 paymentMethodTypes: paymentMethodTypes,
                 analyticsHelper: analyticsHelper
             )
-            paymentMethodMessagingPromotionsHelper.fetchData()
+            paymentMethodMessagingPromotionsHelper?.fetchData()
 
             let paymentMethodOrientation = configuration.resolveLayout(
                 elementsSession: elementsSession,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -717,13 +717,13 @@ class EmbeddedPaymentElementTest: XCTestCase {
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
         let elementsSession = STPElementsSession._testValue(experimentsData: experimentsData)
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
-        let promotionsHelper = PaymentMethodMessagingPromotionsHelper(
+        let promotionsHelper = try XCTUnwrap(PaymentMethodMessagingPromotionsHelper(
             elementsSession: elementsSession,
             intent: intent,
             configuration: configuration,
             paymentMethodTypes: [.stripe(.card)],
             analyticsHelper: analyticsHelper
-        )
+        ))
         promotionsHelper.fetchData()
         let loadResult = PaymentSheetLoader.LoadResult(
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
@@ -83,6 +83,22 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
         XCTAssertEqual(analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName).count, 1)
     }
 
+    func testInit_noAssignment_returnsNil() {
+        let elementsSession = STPElementsSession._testValue(experimentsData: nil)
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
+        let intent = Intent.deferredIntent(intentConfig: intentConfig)
+        let configuration = stubbedConfiguration()
+        let helper = PaymentMethodMessagingPromotionsHelper(
+            elementsSession: elementsSession,
+            intent: intent,
+            configuration: configuration,
+            paymentMethodTypes: [.stripe(.affirm)],
+            analyticsHelper: PaymentSheetAnalyticsHelper._testValue()
+        )
+
+        XCTAssertNil(helper)
+    }
+
     func testIsInTreatmentGroup_controlAssignment() throws {
         let analyticsClientV2 = MockAnalyticsClientV2()
         let arbId = "arb_123"

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
@@ -38,7 +38,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
         return config
     }
 
-    func testIsInTreatmentGroup_treatmentAssignment() {
+    func testIsInTreatmentGroup_treatmentAssignment() throws {
         let analyticsClientV2 = MockAnalyticsClientV2()
         let arbId = "arb_123"
         let experimentsData = ExperimentsData(
@@ -58,13 +58,13 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             analyticsClient: STPTestingAnalyticsClient(),
             analyticsClientV2: analyticsClientV2
         )
-        let helper = PaymentMethodMessagingPromotionsHelper(
+        let helper = try XCTUnwrap(PaymentMethodMessagingPromotionsHelper(
             elementsSession: elementsSession,
             intent: intent,
             configuration: configuration,
             paymentMethodTypes: [.stripe(.affirm)],
             analyticsHelper: analyticsHelper
-        )
+        ))
 
         XCTAssertTrue(helper.isInTreatmentGroup)
 
@@ -83,7 +83,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
         XCTAssertEqual(analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName).count, 1)
     }
 
-    func testIsInTreatmentGroup_controlAssignment() {
+    func testIsInTreatmentGroup_controlAssignment() throws {
         let analyticsClientV2 = MockAnalyticsClientV2()
         let arbId = "arb_123"
         let experimentsData = ExperimentsData(
@@ -103,13 +103,13 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             analyticsClient: STPTestingAnalyticsClient(),
             analyticsClientV2: analyticsClientV2
         )
-        let helper = PaymentMethodMessagingPromotionsHelper(
+        let helper = try XCTUnwrap(PaymentMethodMessagingPromotionsHelper(
             elementsSession: elementsSession,
             intent: intent,
             configuration: configuration,
             paymentMethodTypes: [.stripe(.affirm)],
             analyticsHelper: analyticsHelper
-        )
+        ))
 
         XCTAssertFalse(helper.isInTreatmentGroup)
 
@@ -128,18 +128,23 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
         XCTAssertEqual(analyticsClientV2.loggedAnalyticPayloads(withEventName: PaymentSheetAnalyticsHelper.eventName).count, 1)
     }
 
-    func testPromotion_returnsNilForUnsupportedType() async {
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"])
+    func testPromotion_returnsNilForUnsupportedType() async throws {
+        let experimentsData = ExperimentsData(
+            arbId: "arb_123",
+            experimentAssignments: [PaymentMethodMessagingPromotionsExperiment.experimentName: .treatment],
+            allResponseFields: [:]
+        )
+        let elementsSession = STPElementsSession._testValue(orderedPaymentMethodTypes: [.card], experimentsData: experimentsData)
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
         let configuration = stubbedConfiguration()
-        let helper = PaymentMethodMessagingPromotionsHelper(
+        let helper = try XCTUnwrap(PaymentMethodMessagingPromotionsHelper(
             elementsSession: elementsSession,
             intent: intent,
             configuration: configuration,
             paymentMethodTypes: [],
             analyticsHelper: PaymentSheetAnalyticsHelper._testValue()
-        )
+        ))
 
         helper.fetchData()
         await helper.fetchTask?.value
@@ -149,7 +154,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
 
     // MARK: - Analytics
 
-    func testFetchData_logsFetchBeginEvent() async {
+    func testFetchData_logsFetchBeginEvent() async throws {
         let analyticsClient = STPTestingAnalyticsClient()
         let experimentsData = ExperimentsData(
             arbId: "arb_123",
@@ -165,13 +170,13 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             configuration: configuration,
             analyticsClient: analyticsClient
         )
-        let helper = PaymentMethodMessagingPromotionsHelper(
+        let helper = try XCTUnwrap(PaymentMethodMessagingPromotionsHelper(
             elementsSession: elementsSession,
             intent: intent,
             configuration: configuration,
             paymentMethodTypes: [.stripe(.affirm)],
             analyticsHelper: analyticsHelper
-        )
+        ))
 
         helper.fetchData()
         await helper.fetchTask?.value
@@ -180,7 +185,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
         XCTAssertEqual(fetchBeginEvents.count, 1)
     }
 
-    func testFetchData_controlGroup_doesNotLogFetchBegin() async {
+    func testFetchData_controlGroup_doesNotLogFetchBegin() async throws {
         let analyticsClient = STPTestingAnalyticsClient()
         let experimentsData = ExperimentsData(
             arbId: "arb_123",
@@ -196,13 +201,13 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             configuration: configuration,
             analyticsClient: analyticsClient
         )
-        let helper = PaymentMethodMessagingPromotionsHelper(
+        let helper = try XCTUnwrap(PaymentMethodMessagingPromotionsHelper(
             elementsSession: elementsSession,
             intent: intent,
             configuration: configuration,
             paymentMethodTypes: [.stripe(.affirm)],
             analyticsHelper: analyticsHelper
-        )
+        ))
 
         helper.fetchData()
         await helper.fetchTask?.value
@@ -211,7 +216,7 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
         XCTAssertEqual(fetchBeginEvents.count, 0)
     }
 
-    func testLogDisplayedAnalytic_afterFetch_logsDurationAndSuccess() async {
+    func testLogDisplayedAnalytic_afterFetch_logsDurationAndSuccess() async throws {
         let analyticsClient = STPTestingAnalyticsClient()
         let experimentsData = ExperimentsData(
             arbId: "arb_123",
@@ -227,13 +232,13 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             configuration: configuration,
             analyticsClient: analyticsClient
         )
-        let helper = PaymentMethodMessagingPromotionsHelper(
+        let helper = try XCTUnwrap(PaymentMethodMessagingPromotionsHelper(
             elementsSession: elementsSession,
             intent: intent,
             configuration: configuration,
             paymentMethodTypes: [.stripe(.affirm)],
             analyticsHelper: analyticsHelper
-        )
+        ))
 
         helper.fetchData()
         await helper.fetchTask?.value
@@ -246,9 +251,14 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
         XCTAssertGreaterThanOrEqual(event["duration"] as? Double ?? -1, 0)
     }
 
-    func testLogDisplayedAnalytic_withoutFetch_logsDurationZero() {
+    func testLogDisplayedAnalytic_withoutFetch_logsDurationZero() throws {
         let analyticsClient = STPTestingAnalyticsClient()
-        let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"])
+        let experimentsData = ExperimentsData(
+            arbId: "arb_123",
+            experimentAssignments: [PaymentMethodMessagingPromotionsExperiment.experimentName: .treatment],
+            allResponseFields: [:]
+        )
+        let elementsSession = STPElementsSession._testValue(orderedPaymentMethodTypes: [.card], experimentsData: experimentsData)
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
         let configuration = stubbedConfiguration()
@@ -257,13 +267,13 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
             configuration: configuration,
             analyticsClient: analyticsClient
         )
-        let helper = PaymentMethodMessagingPromotionsHelper(
+        let helper = try XCTUnwrap(PaymentMethodMessagingPromotionsHelper(
             elementsSession: elementsSession,
             intent: intent,
             configuration: configuration,
             paymentMethodTypes: [],
             analyticsHelper: analyticsHelper
-        )
+        ))
 
         helper.logDisplayedAnalytic(displayedSuccessfully: false)
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
@@ -213,6 +213,41 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
         XCTAssertEqual(payload["dimensions-integration_shape"] as? String, "flowcontroller")
         XCTAssertEqual(payload["dimensions-has_spms"] as? String, "false")
     }
+    func testPaymentMethodMessagingPromotionsExperiment_noAssignment_returnsNil() {
+        let elementsSession = STPElementsSession._testValue(
+            experimentsData: nil,
+            customer: nil
+        )
+
+        let experiment = PaymentMethodMessagingPromotionsExperiment(
+            elementsSession: elementsSession,
+            layout: "vertical"
+        )
+
+        XCTAssertNil(experiment)
+    }
+
+    func testPaymentMethodMessagingPromotionsExperiment_unrelatedAssignment_returnsNil() {
+        let experimentsData = ExperimentsData(
+            arbId: "arb_id_123",
+            experimentAssignments: [
+                "some_other_experiment": .treatment,
+            ],
+            allResponseFields: [:]
+        )
+        let elementsSession = STPElementsSession._testValue(
+            experimentsData: experimentsData,
+            customer: nil
+        )
+
+        let experiment = PaymentMethodMessagingPromotionsExperiment(
+            elementsSession: elementsSession,
+            layout: "vertical"
+        )
+
+        XCTAssertNil(experiment)
+    }
+
     func testPaymentMethodMessagingPromotionsExperiment() throws {
         let experimentsData = ExperimentsData(
             arbId: "arb_id_123",

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetAnalyticsExperimentsTests.swift
@@ -213,7 +213,7 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
         XCTAssertEqual(payload["dimensions-integration_shape"] as? String, "flowcontroller")
         XCTAssertEqual(payload["dimensions-has_spms"] as? String, "false")
     }
-    func testPaymentMethodMessagingPromotionsExperiment() {
+    func testPaymentMethodMessagingPromotionsExperiment() throws {
         let experimentsData = ExperimentsData(
             arbId: "arb_id_123",
             experimentAssignments: [
@@ -226,10 +226,10 @@ final class PaymentSheetAnalyticsExperimentsTests: XCTestCase {
             customer: nil
         )
 
-        let experiment = PaymentMethodMessagingPromotionsExperiment(
+        let experiment = try XCTUnwrap(PaymentMethodMessagingPromotionsExperiment(
             elementsSession: elementsSession,
             layout: "vertical"
-        )
+        ))
 
         XCTAssertEqual(experiment.name, PaymentMethodMessagingPromotionsExperiment.experimentName)
         XCTAssertEqual(experiment.arbId, "arb_id_123")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -863,14 +863,14 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
 
         // Experiment exposures are logged asynchronously after the lookup completes
         let predicate = NSPredicate { _, _ in
-            mockAnalyticsClientV2.loggedAnalyticPayloads(withEventName: "elements.experiment_exposure").count >= 6
+            mockAnalyticsClientV2.loggedAnalyticPayloads(withEventName: "elements.experiment_exposure").count >= 5
         }
         wait(for: [XCTNSPredicateExpectation(predicate: predicate, object: nil)], timeout: 5)
 
         let exposures = mockAnalyticsClientV2.loggedAnalyticPayloads(withEventName: "elements.experiment_exposure")
-        XCTAssertEqual(exposures.count, 6)
+        XCTAssertEqual(exposures.count, 5)
         let experimentNames = Set(exposures.compactMap { $0["experiment_retrieved"] as? String })
-        XCTAssertEqual(experimentNames, ["link_global_holdback", "link_global_holdback_aa", "link_ab_test", "ocs_mobile_payment_method_messaging_promotions", "connections_fc_lite_vs_native", "connections_fc_lite_vs_native_aa"])
+        XCTAssertEqual(experimentNames, ["link_global_holdback", "link_global_holdback_aa", "link_ab_test", "connections_fc_lite_vs_native", "connections_fc_lite_vs_native_aa"])
         for exposure in exposures {
             XCTAssertEqual(exposure["arb_id"] as? String, "test_arb_123")
             XCTAssertNotNil(exposure["assignment_group"], "Expected assignment_group in exposure: \(exposure)")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerTest.swift
@@ -24,7 +24,7 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
         waitForExpectations(timeout: 1)
     }
 
-    func testInitialScreen() {
+    func testInitialScreen() throws {
         let analyticsClientV2 = MockAnalyticsClientV2()
         let arbId = "arb_pmm_123"
         let experimentsData = ExperimentsData(
@@ -54,13 +54,13 @@ final class PaymentSheetVerticalViewControllerTest: XCTestCase {
         // If there are saved PMs, always show the list, even if there's only one other PM
         let elementsSession = STPElementsSession._testValue(experimentsData: experimentsData)
         let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
-        let promotionsHelper = PaymentMethodMessagingPromotionsHelper(
+        let promotionsHelper = try XCTUnwrap(PaymentMethodMessagingPromotionsHelper(
             elementsSession: elementsSession,
             intent: intent,
             configuration: PaymentSheet.Configuration(),
             paymentMethodTypes: [.stripe(.card)],
             analyticsHelper: analyticsHelper
-        )
+        ))
         promotionsHelper.fetchData()
         let savedPMsLoadResult = PaymentSheetLoader.LoadResult(
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -465,7 +465,7 @@ extension PaymentSheetLoader.LoadResult {
 }
 
 extension PaymentMethodMessagingPromotionsHelper {
-    static func _testValue() -> PaymentMethodMessagingPromotionsHelper {
+    static func _testValue() -> PaymentMethodMessagingPromotionsHelper? {
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"])
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
@@ -493,7 +493,7 @@ extension PaymentMethodMessagingPromotionsHelper {
             configuration: PaymentSheet.Configuration(),
             paymentMethodTypes: [],
             analyticsHelper: PaymentSheetAnalyticsHelper._testValue()
-        )
+        )!
     }
 }
 


### PR DESCRIPTION
## Summary
Sometimes we are not in the experiment at all, such as when in setup mode or without any BNPLs. In this case we should not create the experiment object or the promotions helper rather than defaulting to the control group.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
Added tests that verify new failable initializers in non-experiment cases

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
