### PR TITLE
Fix shimmering on cells for horizontal mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ MINOR
 * [Fixed] Fixed Japan address form missing the city field. ([#6506](https://github.com/stripe/stripe-ios/issues/6506))
 * [Added] Added support for Card Art for saved payment methods when using CustomerSessions
 * [Added] `PaymentSheet.FlowController.PaymentOptionDisplayData.image` and `EmbeddedPaymentElement.PaymentOptionDisplayData` may now return card art for saved card. Integrators displaying this image in very compact layouts may wish to revisit sizing to best accommodate richer payment method visuals.
+* [Fixed] Fixed removal of shimmering effect for horizontal view cells
 
 ### Address Element
 * [Fixed] Fixed Japan address form missing the city field. ([#6506](https://github.com/stripe/stripe-ios/issues/6506))

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentMethodCollectionView.swift
@@ -382,6 +382,7 @@ extension SavedPaymentMethodCollectionView {
                                 }
                             }
                         } else {
+                            paymentMethodLogo.removeShimmer()
                             paymentMethodLogo.image = paymentMethodCellImage
                             paymentMethodLogoHeightConstraint.constant = paymentMethodLogoSize.height
                         }
@@ -392,6 +393,7 @@ extension SavedPaymentMethodCollectionView {
                         selectableRectangle.accessibilityIdentifier = label.text
                         selectableRectangle.accessibilityLabel = label.text
                         let paymentMethodLogoImage = PaymentOption.applePay.makeSavedPaymentMethodCellImage(overrideUserInterfaceStyle: overrideUserInterfaceStyle)
+                        paymentMethodLogo.removeShimmer()
                         paymentMethodLogo.image = paymentMethodLogoImage
                         paymentMethodLogo.tag = paymentMethodLogoImage.hashValue
                         paymentMethodLogoHeightConstraint.constant = paymentMethodLogoSize.height
@@ -401,6 +403,7 @@ extension SavedPaymentMethodCollectionView {
                         selectableRectangle.accessibilityIdentifier = label.text
                         selectableRectangle.accessibilityLabel = linkBrand.accessibilityText(from: linkBrand.displayName)
                         let paymentMethodLogoImage = Image.paymentSheetLinkLogoImage
+                        paymentMethodLogo.removeShimmer()
                         paymentMethodLogo.image = paymentMethodLogoImage
                         paymentMethodLogo.tag = paymentMethodLogoImage.hashValue
                         paymentMethodLogoHeightConstraint.constant = paymentMethodLogoSize.height
@@ -414,6 +417,7 @@ extension SavedPaymentMethodCollectionView {
                         )
                         selectableRectangle.accessibilityLabel = String.Localized.add_new_payment_method
                         selectableRectangle.accessibilityIdentifier = "+ Add"
+                        paymentMethodLogo.removeShimmer()
                         paymentMethodLogo.isHidden = true
                         paymentMethodLogo.tag = 0
                         plus.isHidden = false


### PR DESCRIPTION
## Summary
Properly removes shimmering effect.

Repro:
Start in light mode w/ a couple of saved payment methods
Clear cache to ensure assets will load in w/ shimmer
Open CustomerSheet/FlowController to see card art load in
Switch from light mode to dark mode


Exhibited behavior:
There is potentially a shimmer on the apple pay logo (see attached)

Expected behavior:
No visual shimmer

## Motivation
Visual bug

https://github.com/user-attachments/assets/6f9f96b6-bfc5-467b-984b-c146e71101da


## Testing
Manually tested

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
