### PR TITLE
Expose bank account last 4 in `linkPaymentDetailsFormattedString`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ MINOR
 
 ### PaymentSheet
 * [Changed] Renamed `LinkPaymentController` to `InstantBankPaymentsController`.
+* [Changed] Link bank account display strings now include the last 4 digits in `LinkController.PaymentMethodPreview.sublabel` and `PaymentSheet.FlowController.PaymentOptionDisplayData.labels.sublabel`, matching the existing card behavior.
 
 ### CryptoOnramp (Alpha)
 * [Changed] Updated EU compliance identifier APIs to match the latest backend contract, including CRS/CARF TIN requirements and `SubmitIdentifiersResult.completed`.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
@@ -390,7 +390,7 @@ extension ConsumerPaymentDetails {
             return components.joined(separator: " ")
         case .bankAccount(let bankAccount):
             let label = bankAccount.displayName(with: nickname)
-            let sublabel = "••••\(bankAccount.last4)"
+            let sublabel = "•••• \(bankAccount.last4)"
             return [label, sublabel].joined(separator: " ")
         case .unparsable:
             guard let display else { return nil }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/Link/PaymentDetails.swift
@@ -389,7 +389,9 @@ extension ConsumerPaymentDetails {
             let components = [label, sublabel].compactMap { $0 }
             return components.joined(separator: " ")
         case .bankAccount(let bankAccount):
-            return bankAccount.displayName(with: nickname)
+            let label = bankAccount.displayName(with: nickname)
+            let sublabel = "••••\(bankAccount.last4)"
+            return [label, sublabel].joined(separator: " ")
         case .unparsable:
             guard let display else { return nil }
             let components = [display.label, display.sublabel].compactMap { $0 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -391,7 +391,7 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         // Test labels for Link with bank account payment details - should show "Link" as label and formatted details as sublabel
         XCTAssertEqual(displayData.labels.label, "Link")
         // The sublabel should show the bank account details
-        XCTAssertEqual(displayData.labels.sublabel, "My Checking")
+        XCTAssertEqual(displayData.labels.sublabel, "My Checking ••••6789")
     }
 
     // MARK: - Enhanced Completion Block Tests

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -391,7 +391,7 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         // Test labels for Link with bank account payment details - should show "Link" as label and formatted details as sublabel
         XCTAssertEqual(displayData.labels.label, "Link")
         // The sublabel should show the bank account details
-        XCTAssertEqual(displayData.labels.sublabel, "My Checking ••••6789")
+        XCTAssertEqual(displayData.labels.sublabel, "My Checking •••• 6789")
     }
 
     // MARK: - Enhanced Completion Block Tests


### PR DESCRIPTION
## Summary

Exposes the bank account last 4 in `linkPaymentDetailsFormattedString`. Cards were already showing this, but bank accounts just showed the account name. 

The places this field is currently used:

- LinkController.PaymentMethodPreview.sublabel
- In the Link wallet, the delete payment method confirmation dialog
- PaymentSheet.FlowController.PaymentOptionDisplayData.labels.sublabel for native Link .withPaymentDetails
  - This might be displayed in user's apps, so I added a note in the changelog.

## Motivation

Parity between cards and bank account display labels.

## Testing

| Before | After |
|--------|--------|
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-05 at 11 00 00" src="https://github.com/user-attachments/assets/fac4fdb7-c533-40a5-8eb6-411afcbdc826" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-06-04 at 21 44 34" src="https://github.com/user-attachments/assets/930fe3ed-6855-46ab-9300-017e212c6dd8" /> |

The other surface impacted is the delete payment method confirmation dialog: 

<img width=40% src="https://github.com/user-attachments/assets/1d03dfbf-dde7-437a-9eff-99796426389e" />


## Changelog

```md
* [Changed] Link bank account display strings now include the last 4 digits in `LinkController.PaymentMethodPreview.sublabel` and `PaymentSheet.FlowController.PaymentOptionDisplayData.labels.sublabel`, matching the existing card behavior.
```

