### PR TITLE
LinkController tweaks based on API review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ MINOR
 * [Added] Added rich Crypto Onramp API error mapping types: `WalletOwnershipChallengeExpiredError`, `InvalidWalletOwnershipChallengeError`, `InvalidWalletOwnershipSignatureError`, `WalletNotFoundError`, and `UnsupportedNetworkError`.
 * [Changed] Renamed `AppAttestationAPIError` to `AppAttestationError` and `UncategorizedAPIError` to `UncategorizedError`.
 
+### PaymentSheet
+* [Added] Added standalone Link wallet APIs in private preview via `LinkController`.
+
 ### StripeConnect
 * [Changed] `PaymentsViewController`, `PaymentsViewControllerDelegate`, `PayoutsViewController`, `PayoutsViewControllerDelegate`, and `EmbeddedComponentManager.PaymentsListDefaultFiltersOptions` are now part of the public API and no longer require `@_spi(PreviewConnect)` to access.
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
@@ -61,7 +61,9 @@ struct ExampleLinkControllerPreviewView: View {
                     VStack(alignment: .leading, spacing: 16) {
                         ForEach(LinkPaymentMethodType.allCases, id: \.self) { paymentMethodType in
                             Button {
-                                togglePaymentMethodType(paymentMethodType)
+                                Task { @MainActor in
+                                    await togglePaymentMethodType(paymentMethodType)
+                                }
                             } label: {
                                 HStack(spacing: 12) {
                                     Image(systemName: selectedPaymentMethodTypes.contains(paymentMethodType) ? "checkmark.square.fill" : "square")
@@ -72,6 +74,7 @@ struct ExampleLinkControllerPreviewView: View {
                                 }
                             }
                             .buttonStyle(.plain)
+                            .disabled(isLoading)
                         }
                     }
                 }
@@ -141,12 +144,16 @@ struct ExampleLinkControllerPreviewView: View {
     private func initializeLinkController() async {
         STPAPIClient.shared.publishableKey = Self.publishableKey
 
+        linkController = nil
         isLoading = true
         errorMessage = nil
         statusMessage = "Initializing LinkController..."
 
         do {
-            linkController = try await LinkController.create(mode: .setup)
+            linkController = try await LinkController.create(
+                mode: .setup,
+                configuration: .init(supportedPaymentMethodTypes: supportedPaymentMethodTypes)
+            )
             isLoading = false
             statusMessage = "LinkController initialized successfully"
         } catch {
@@ -182,7 +189,6 @@ struct ExampleLinkControllerPreviewView: View {
             let result = try await linkController.present(
                 email: email,
                 phoneNumber: phone.isEmpty ? nil : phone,
-                supportedPaymentMethodTypes: supportedPaymentMethodTypes,
                 from: rootViewController
             )
 
@@ -213,12 +219,15 @@ struct ExampleLinkControllerPreviewView: View {
         await initializeLinkController()
     }
 
-    private func togglePaymentMethodType(_ paymentMethodType: LinkPaymentMethodType) {
+    @MainActor
+    private func togglePaymentMethodType(_ paymentMethodType: LinkPaymentMethodType) async {
         if selectedPaymentMethodTypes.contains(paymentMethodType) {
             selectedPaymentMethodTypes.remove(paymentMethodType)
         } else {
             selectedPaymentMethodTypes.insert(paymentMethodType)
         }
+
+        await initializeLinkController()
     }
 
     private func paymentMethodTypeTitle(_ paymentMethodType: LinkPaymentMethodType) -> String {

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
@@ -86,7 +86,7 @@ struct ExampleLinkControllerPreviewView: View {
                         }
                     }
                     .buttonStyle(PreviewPrimaryButtonStyle())
-                    .disabled(isLoading || email.isEmpty || linkController == nil || supportedPaymentMethodTypes.isEmpty)
+                    .disabled(isLoading || linkController == nil)
 
                     Button("Reset LinkController") {
                         Task { @MainActor in
@@ -166,11 +166,6 @@ struct ExampleLinkControllerPreviewView: View {
     private func presentLinkFlow() async {
         guard let linkController else {
             errorMessage = "LinkController not initialized"
-            return
-        }
-
-        guard !email.isEmpty else {
-            errorMessage = "Please enter an email address"
             return
         }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
@@ -151,7 +151,6 @@ struct ExampleLinkControllerPreviewView: View {
 
         do {
             linkController = try await LinkController.create(
-                mode: .setup,
                 configuration: .init(supportedPaymentMethodTypes: supportedPaymentMethodTypes)
             )
             isLoading = false

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import UIKit
 
-@_spi(STP) import StripePaymentSheet
+@_spi(STP) @_spi(LinkControllerPreview) import StripePaymentSheet
 
 @available(iOS 16.0, *)
 struct ExampleLinkControllerView: View {
@@ -24,6 +24,10 @@ struct ExampleLinkControllerView: View {
     @State private var userExists: Bool?
     @State private var selectedPaymentMethodTypes: Set<LinkPaymentMethodType> = Set(LinkPaymentMethodType.allCases)
     @FocusState private var isEmailFieldFocused: Bool
+
+    private var supportedPaymentMethodTypes: [LinkPaymentMethodType] {
+        LinkPaymentMethodType.allCases.filter(selectedPaymentMethodTypes.contains)
+    }
 
     var body: some View {
         NavigationView {
@@ -112,6 +116,7 @@ struct ExampleLinkControllerView: View {
                                         }
                                     }
                                     .buttonStyle(PlainButtonStyle())
+                                    .disabled(isLoading)
                                 }
                             }
                         }
@@ -315,13 +320,19 @@ struct ExampleLinkControllerView: View {
     private func initializeLinkController() {
         STPAPIClient.shared.publishableKey = "pk_test_51K9W3OHMaDsveWq0oLP0ZjldetyfHIqyJcz27k2BpMGHxu9v9Cei2tofzoHncPyk3A49jMkFEgTOBQyAMTUffRLa00xzzARtZO"
 
+        linkController = nil
+        authenticationResult = nil
+        userExists = nil
         isLoading = true
         errorMessage = nil
         statusMessage = "Initializing LinkController..."
 
         Task {
             do {
-                let controller = try await LinkController.create(mode: .setup)
+                let controller = try await LinkController.create(
+                    mode: .setup,
+                    linkConfiguration: .init(supportedPaymentMethodTypes: supportedPaymentMethodTypes)
+                )
                 await MainActor.run {
                     self.linkController = controller
                     self.isLoading = false
@@ -494,7 +505,7 @@ struct ExampleLinkControllerView: View {
         let paymentMethodPreview = await linkController.collectPaymentMethod(
             from: rootViewController,
             with: email,
-            supportedPaymentMethodTypes: Array(selectedPaymentMethodTypes)
+            supportedPaymentMethodTypes: supportedPaymentMethodTypes
         )
 
         await MainActor.run {
@@ -535,7 +546,6 @@ struct ExampleLinkControllerView: View {
             let result = try await linkController.present(
                 email: email,
                 phoneNumber: phone.isEmpty ? nil : phone,
-                supportedPaymentMethodTypes: Array(selectedPaymentMethodTypes),
                 from: rootViewController
             )
             await MainActor.run {
@@ -607,6 +617,8 @@ struct ExampleLinkControllerView: View {
         } else {
             selectedPaymentMethodTypes.insert(paymentMethodType)
         }
+
+        initializeLinkController()
     }
 
     private func findViewController() -> UIViewController? {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -117,7 +117,8 @@ final class PayWithLinkViewController: BottomSheetViewController {
         func getSupportedPaymentDetailsTypes(linkAccount: PaymentSheetLinkAccount) -> Set<ParsedEnum<ConsumerPaymentDetails.DetailsType>> {
             var allSupportedPaymentDetailsTypes = linkAccount.supportedPaymentDetailsTypes(for: elementsSession)
 
-            if let supportedPaymentDetailsTypes = supportedPaymentMethodTypes?.detailsTypes {
+            if let supportedPaymentDetailsTypes = supportedPaymentMethodTypes?.detailsTypes,
+               !supportedPaymentDetailsTypes.isEmpty {
                 allSupportedPaymentDetailsTypes = allSupportedPaymentDetailsTypes.intersection(supportedPaymentDetailsTypes)
             }
 
@@ -140,7 +141,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         ///   - launchedFromFlowController: Whether the flow was opened from `FlowController`.
         ///   - initiallySelectedPaymentDetailsID: The ID of an initially selected payment method. This is set when opened instead of FlowController.
         ///   - callToAction: A custom CTA to display on the confirm button. If `nil`, will display `intent`'s default CTA.
-        ///   - supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil`, all available types are supported.
+        ///   - supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil` or empty, all available types are supported.
         ///   - analyticsHelper: An instance of `AnalyticsHelper` to use for logging.
         ///   - linkAppearance: Optional appearance overrides for Link UI.
         ///   - linkConfiguration: Configuration for Link behavior and content.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
@@ -8,21 +8,38 @@
 import Foundation
 
 /// Injectible configuration for Link behavior and content.
-@_spi(STP)
+@_spi(STP) @_spi(LinkControllerPreview)
 public struct LinkConfiguration {
 
     /// Custom hint message to display in the wallet view. If `nil`, no hint will be shown.
-    public let hintMessage: String?
+    @_spi(STP) public let hintMessage: String?
 
     /// Whether to allow the user to log out. When `false`, the logout menu button will be hidden.
-    public let allowLogout: Bool
+    @_spi(STP) public let allowLogout: Bool
+
+    /// The payment method types to support in the Link sheet. If `nil`, all available types are shown.
+    @_spi(LinkControllerPreview) public let supportedPaymentMethodTypes: [LinkPaymentMethodType]?
 
     /// Creates a new instance of `LinkConfiguration`.
     /// - Parameters:
     ///   - hintMessage: Custom hint message to display in the wallet view. If `nil`, no hint will be shown.
     ///   - allowLogout: Whether to allow the user to log out. When `false`, the logout menu button will be hidden. Defaults to `true`.
-    public init(hintMessage: String? = nil, allowLogout: Bool = true) {
+    @_spi(STP) public init(
+        hintMessage: String? = nil,
+        allowLogout: Bool = true
+    ) {
         self.hintMessage = hintMessage
         self.allowLogout = allowLogout
+        self.supportedPaymentMethodTypes = nil
+    }
+
+    /// Creates a new instance of `LinkConfiguration`.
+    /// - Parameter supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil`, all available types are shown.
+    @_spi(LinkControllerPreview) public init(
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil
+    ) {
+        self.hintMessage = nil
+        self.allowLogout = true
+        self.supportedPaymentMethodTypes = supportedPaymentMethodTypes
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
@@ -17,7 +17,7 @@ public struct LinkConfiguration {
     /// Whether to allow the user to log out. When `false`, the logout menu button will be hidden.
     @_spi(STP) @_spi(LinkControllerPreview) public let allowLogout: Bool
 
-    /// The payment method types to support in the Link sheet. If `nil`, all available types are shown.
+    /// The payment method types to support in the Link sheet. If `nil` or empty, all available types are shown.
     @_spi(LinkControllerPreview) public let supportedPaymentMethodTypes: [LinkPaymentMethodType]?
 
     /// Creates a new instance of `LinkConfiguration`.
@@ -35,7 +35,7 @@ public struct LinkConfiguration {
 
     /// Creates a new instance of `LinkConfiguration`.
     /// - Parameters:
-    ///   - supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil`, all available types are shown.
+    ///   - supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil` or empty, all available types are shown.
     ///   - allowLogout: Whether to allow the user to log out. When `false`, the logout menu button will be hidden. Defaults to `true`.
     @_spi(LinkControllerPreview) public init(
         supportedPaymentMethodTypes: [LinkPaymentMethodType]?,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
@@ -15,7 +15,7 @@ public struct LinkConfiguration {
     @_spi(STP) public let hintMessage: String?
 
     /// Whether to allow the user to log out. When `false`, the logout menu button will be hidden.
-    @_spi(STP) public let allowLogout: Bool
+    @_spi(STP) @_spi(LinkControllerPreview) public let allowLogout: Bool
 
     /// The payment method types to support in the Link sheet. If `nil`, all available types are shown.
     @_spi(LinkControllerPreview) public let supportedPaymentMethodTypes: [LinkPaymentMethodType]?
@@ -34,12 +34,15 @@ public struct LinkConfiguration {
     }
 
     /// Creates a new instance of `LinkConfiguration`.
-    /// - Parameter supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil`, all available types are shown.
+    /// - Parameters:
+    ///   - supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil`, all available types are shown.
+    ///   - allowLogout: Whether to allow the user to log out. When `false`, the logout menu button will be hidden. Defaults to `true`.
     @_spi(LinkControllerPreview) public init(
-        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]?,
+        allowLogout: Bool = true
     ) {
         self.hintMessage = nil
-        self.allowLogout = true
+        self.allowLogout = allowLogout
         self.supportedPaymentMethodTypes = supportedPaymentMethodTypes
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -20,7 +20,7 @@ import UIKit
     @_spi(STP) @_spi(LinkControllerPreview) public struct PaymentMethodPreview {
 
         /// Represents the type of selected payment method.
-        @_spi(STP) @_spi(LinkControllerPreview) public enum PaymentMethodType {
+        @_spi(STP) public enum PaymentMethodType {
 
             /// The user chose a card-based payment method, such as a debit or credit card.
             case card
@@ -30,7 +30,7 @@ import UIKit
         }
 
         /// The type of the selected payment method.
-        @_spi(STP) @_spi(LinkControllerPreview) public let paymentMethodType: PaymentMethodType
+        @_spi(STP) public let paymentMethodType: PaymentMethodType
 
         /// The Link icon to render in your screen.
         @_spi(STP) @_spi(LinkControllerPreview) public let icon: UIImage

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -92,7 +92,7 @@ import UIKit
     }
 
     /// The intent for which the `LinkController` collects a payment method.
-    @_spi(STP) @_spi(LinkControllerPreview) public enum Mode {
+    @_spi(STP) public enum Mode {
         case payment
         case paymentAndSetupFutureUse
         case setup
@@ -286,21 +286,19 @@ import UIKit
         }
     }
 
-    /// Creates a `LinkController` for the specified `mode`.
+    /// Creates a `LinkController` with the specified preview `configuration`.
     ///
     /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
-    /// - Parameter mode: The mode in which the Link payment method controller should operate, either `payment` or `setup`.
     /// - Parameter configuration: Configuration for Link behavior and content. If not specified, default behavior is used.
     /// - Parameter completion: A closure that is called with the result of the creation. It returns a `LinkController` if successful, or an error if the creation failed.
     @_spi(LinkControllerPreview) public static func create(
         apiClient: STPAPIClient = .shared,
-        mode: LinkController.Mode,
         configuration: LinkConfiguration = .init(),
         completion: @escaping (Result<LinkController, Error>) -> Void
     ) {
         self.create(
             apiClient: apiClient,
-            mode: mode,
+            mode: .setup,
             linkConfiguration: configuration,
             completion: completion
         )
@@ -1304,19 +1302,17 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
 
 @_spi(LinkControllerPreview) public extension LinkController {
 
-    /// Creates a `LinkController` for the specified `mode`.
+    /// Creates a `LinkController` with the specified preview `configuration`.
     ///
     /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
-    /// - Parameter mode: The mode in which the Link payment method controller should operate, either `payment` or `setup`.
     /// - Parameter configuration: Configuration for Link behavior and content. If not specified, default behavior is used.
     /// - Returns: A `LinkController` if successful, or throws an error if the creation failed.
     static func create(
         apiClient: STPAPIClient = .shared,
-        mode: LinkController.Mode,
         configuration: LinkConfiguration = .init()
     ) async throws -> LinkController {
         return try await withCheckedThrowingContinuation { continuation in
-            create(apiClient: apiClient, mode: mode, configuration: configuration) { result in
+            create(apiClient: apiClient, configuration: configuration) { result in
                 switch result {
                 case .success(let controller):
                     continuation.resume(returning: controller)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -102,10 +102,10 @@ import UIKit
     private let mode: Mode
     private let elementsSession: STPElementsSession
     private let intent: Intent
-    private let configuration: PaymentElementConfiguration
+    private let paymentElementConfiguration: PaymentElementConfiguration
     private let initialLinkBrand: LinkBrand
     private let appearance: LinkAppearance?
-    private let linkConfiguration: LinkConfiguration?
+    private let configuration: LinkConfiguration?
     private let analyticsHelper: PaymentSheetAnalyticsHelper
     private let requestSurface: LinkRequestSurface
 
@@ -151,10 +151,10 @@ import UIKit
         mode: Mode,
         elementsSession: STPElementsSession,
         intent: Intent,
-        configuration: PaymentElementConfiguration,
+        paymentElementConfiguration: PaymentElementConfiguration,
         linkBrand: LinkBrand,
         appearance: LinkAppearance?,
-        linkConfiguration: LinkConfiguration?,
+        configuration: LinkConfiguration?,
         analyticsHelper: PaymentSheetAnalyticsHelper,
         requestSurface: LinkRequestSurface
     ) {
@@ -162,10 +162,10 @@ import UIKit
         self.mode = mode
         self.elementsSession = elementsSession
         self.intent = intent
-        self.configuration = configuration
+        self.paymentElementConfiguration = paymentElementConfiguration
         self.initialLinkBrand = linkBrand
         self.appearance = appearance
-        self.linkConfiguration = linkConfiguration
+        self.configuration = configuration
         self.analyticsHelper = analyticsHelper
         self.requestSurface = requestSurface
 
@@ -193,6 +193,12 @@ import UIKit
         case .unparsable:
             return Self.linkIcon
         }
+    }
+
+    private func resolvedSupportedPaymentMethodTypes(
+        override supportedPaymentMethodTypes: [LinkPaymentMethodType]?
+    ) -> [LinkPaymentMethodType]? {
+        supportedPaymentMethodTypes ?? configuration?.supportedPaymentMethodTypes
     }
 
     private func updatePaymentMethodPreview() {
@@ -228,26 +234,32 @@ import UIKit
         apiClient: STPAPIClient = .shared,
         mode: LinkController.Mode,
         appearance: LinkAppearance? = nil,
-        linkConfiguration: LinkConfiguration? = nil,
+        linkConfiguration configuration: LinkConfiguration? = nil,
         requestSurface: LinkRequestSurface = .default,
         completion: @escaping (Result<LinkController, Error>) -> Void
     ) {
         Task {
             do {
-                var configuration = PaymentSheet.Configuration()
-                configuration.apiClient = apiClient
+                var paymentElementConfiguration = PaymentSheet.Configuration()
+                paymentElementConfiguration.apiClient = apiClient
                 if let appearance = appearance {
-                    configuration.style = appearance.style
+                    paymentElementConfiguration.style = appearance.style
                 }
 
-                let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .linkController, configuration: configuration)
+                let analyticsHelper = PaymentSheetAnalyticsHelper(
+                    integrationShape: .linkController,
+                    configuration: paymentElementConfiguration
+                )
 
                 let loadResult = try await Self.loadElementsSession(
-                    configuration: configuration,
+                    paymentElementConfiguration: paymentElementConfiguration,
                     analyticsHelper: analyticsHelper
                 )
 
-                guard deviceCanUseNativeLink(elementsSession: loadResult.elementsSession, configuration: configuration) else {
+                guard deviceCanUseNativeLink(
+                    elementsSession: loadResult.elementsSession,
+                    configuration: paymentElementConfiguration
+                ) else {
                     completion(.failure(IntegrationError.missingAppAttestation))
                     return
                 }
@@ -257,10 +269,13 @@ import UIKit
                     mode: mode,
                     elementsSession: loadResult.elementsSession,
                     intent: loadResult.intent,
-                    configuration: configuration,
-                    linkBrand: configuration.resolvedLinkBrand(elementsSession: loadResult.elementsSession, linkAccount: LinkAccountContext.shared.account),
+                    paymentElementConfiguration: paymentElementConfiguration,
+                    linkBrand: paymentElementConfiguration.resolvedLinkBrand(
+                        elementsSession: loadResult.elementsSession,
+                        linkAccount: LinkAccountContext.shared.account
+                    ),
                     appearance: appearance,
-                    linkConfiguration: linkConfiguration,
+                    configuration: configuration,
                     analyticsHelper: analyticsHelper,
                     requestSurface: requestSurface
                 )
@@ -275,16 +290,18 @@ import UIKit
     ///
     /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
     /// - Parameter mode: The mode in which the Link payment method controller should operate, either `payment` or `setup`.
+    /// - Parameter configuration: Configuration for Link behavior and content. If not specified, default behavior is used.
     /// - Parameter completion: A closure that is called with the result of the creation. It returns a `LinkController` if successful, or an error if the creation failed.
     @_spi(LinkControllerPreview) public static func create(
         apiClient: STPAPIClient = .shared,
         mode: LinkController.Mode,
+        configuration: LinkConfiguration = .init(),
         completion: @escaping (Result<LinkController, Error>) -> Void
     ) {
         self.create(
             apiClient: apiClient,
             mode: mode,
-            linkConfiguration: nil,
+            linkConfiguration: configuration,
             completion: completion
         )
     }
@@ -387,7 +404,7 @@ import UIKit
             mode: .inlineLogin,
             linkAccount: linkAccount,
             brand: resolvedLinkBrand,
-            configuration: configuration,
+            configuration: paymentElementConfiguration,
             appearance: appearance
         )
 
@@ -417,11 +434,11 @@ import UIKit
         collectName: Bool = false,
         completion: @escaping (_ didSelectPaymentMethod: Bool) -> Void
     ) {
-        var configuration = self.configuration
-        configuration.defaultBillingDetails.email = email
+        var paymentElementConfiguration = self.paymentElementConfiguration
+        paymentElementConfiguration.defaultBillingDetails.email = email
 
         if collectName {
-            configuration.billingDetailsCollectionConfiguration.name = .always
+            paymentElementConfiguration.billingDetailsCollectionConfiguration.name = .always
         }
 
         // TODO: We need a way to override Link's default primary button label, since we don't want to show "Pay $xx.xx" even for payment mode.
@@ -429,13 +446,15 @@ import UIKit
 
         presentingViewController.presentNativeLink(
             selectedPaymentDetailsID: selectedPaymentDetails?.stripeID,
-            configuration: configuration,
+            configuration: paymentElementConfiguration,
             intent: intent,
             elementsSession: elementsSession,
             analyticsHelper: analyticsHelper,
-            supportedPaymentMethodTypes: supportedPaymentMethodTypes,
+            supportedPaymentMethodTypes: resolvedSupportedPaymentMethodTypes(
+                override: supportedPaymentMethodTypes
+            ),
             linkAppearance: appearance,
-            linkConfiguration: linkConfiguration,
+            linkConfiguration: configuration,
             shouldShowSecondaryCta: false
         ) { [weak self] confirmOption, shouldClearSelection in
             guard let confirmOption else {
@@ -462,14 +481,12 @@ import UIKit
     ///
     /// - Parameter email: The email address to look up and associate with the Link account.
     /// - Parameter phoneNumber: Optional phone number in E.164 format to prefill during signup.
-    /// - Parameter supportedPaymentMethodTypes: The payment method types to support. If `nil`, all available types are shown.
     /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
     /// - Parameter completion: A closure called with `.success(.completed(paymentMethod))` on selection,
     ///   `.success(.canceled)` if the user dismisses the flow, or `.failure(error)` on API or network errors.
     @_spi(STP) @_spi(LinkControllerPreview) public func present(
         email: String,
         phoneNumber: String? = nil,
-        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         from presentingViewController: UIViewController,
         completion: @escaping (Result<PaymentMethodResult, Error>) -> Void
     ) {
@@ -478,21 +495,21 @@ import UIKit
 
         let presentWallet = { [weak self] in
             guard let self else { return }
-            var configuration = self.configuration
-            configuration.defaultBillingDetails.email = email
+            var paymentElementConfiguration = self.paymentElementConfiguration
+            paymentElementConfiguration.defaultBillingDetails.email = email
             if let phoneNumber {
-                configuration.defaultBillingDetails.phone = phoneNumber
+                paymentElementConfiguration.defaultBillingDetails.phone = phoneNumber
             }
 
             presentingViewController.presentNativeLink(
                 selectedPaymentDetailsID: nil,
-                configuration: configuration,
+                configuration: paymentElementConfiguration,
                 intent: self.intent,
                 elementsSession: self.elementsSession,
                 analyticsHelper: self.analyticsHelper,
-                supportedPaymentMethodTypes: supportedPaymentMethodTypes,
+                supportedPaymentMethodTypes: self.resolvedSupportedPaymentMethodTypes(override: nil),
                 linkAppearance: self.appearance,
-                linkConfiguration: self.linkConfiguration,
+                linkConfiguration: self.configuration,
                 shouldShowSecondaryCta: false
             ) { [weak self] confirmOption, _ in
                 guard let self else { return }
@@ -846,7 +863,7 @@ import UIKit
             mode: .inlineLogin,
             linkAccount: linkAccount,
             brand: resolvedLinkBrand,
-            configuration: configuration,
+            configuration: paymentElementConfiguration,
             appearance: appearance,
             consentViewModel: consentViewModel
         )
@@ -919,7 +936,7 @@ import UIKit
     }
 
     private static func loadElementsSession(
-        configuration: PaymentElementConfiguration,
+        paymentElementConfiguration: PaymentElementConfiguration,
         analyticsHelper: PaymentSheetAnalyticsHelper
     ) async throws -> PaymentSheetLoader.LoadResult {
         // Always load as setup mode, even if the merchant specifies another mode.
@@ -936,7 +953,7 @@ import UIKit
 
         let (result, _) = try await PaymentSheetLoader.load(
             mode: .deferredIntent(intentConfiguration),
-            configuration: configuration,
+            configuration: paymentElementConfiguration,
             analyticsHelper: analyticsHelper,
             // TODO: Add a non-logging integration shape or something
             integrationShape: .paymentSheet
@@ -1024,7 +1041,7 @@ import UIKit
 
         let bottomSheetViewController = BottomSheetViewController(
             contentViewController: fullConsentViewController,
-            appearance: configuration.appearance,
+            appearance: paymentElementConfiguration.appearance,
             isTestMode: false,
             didCancelNative3DS2: {}
         )
@@ -1032,7 +1049,10 @@ import UIKit
         // Store completion handler for use in delegate method
         self.fullConsentCompletion = completion
 
-        viewController.presentAsBottomSheet(bottomSheetViewController, appearance: configuration.appearance)
+        viewController.presentAsBottomSheet(
+            bottomSheetViewController,
+            appearance: paymentElementConfiguration.appearance
+        )
     }
 }
 
@@ -1073,11 +1093,17 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
         apiClient: STPAPIClient = .shared,
         mode: LinkController.Mode,
         appearance: LinkAppearance? = nil,
-        linkConfiguration: LinkConfiguration? = nil,
+        linkConfiguration configuration: LinkConfiguration? = nil,
         requestSurface: LinkRequestSurface = .default
     ) async throws -> LinkController {
         return try await withCheckedThrowingContinuation { continuation in
-            create(apiClient: apiClient, mode: mode, appearance: appearance, linkConfiguration: linkConfiguration, requestSurface: requestSurface) { result in
+            create(
+                apiClient: apiClient,
+                mode: mode,
+                appearance: appearance,
+                linkConfiguration: configuration,
+                requestSurface: requestSurface
+            ) { result in
                 switch result {
                 case .success(let controller):
                     continuation.resume(returning: controller)
@@ -1282,13 +1308,15 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
     ///
     /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
     /// - Parameter mode: The mode in which the Link payment method controller should operate, either `payment` or `setup`.
+    /// - Parameter configuration: Configuration for Link behavior and content. If not specified, default behavior is used.
     /// - Returns: A `LinkController` if successful, or throws an error if the creation failed.
     static func create(
         apiClient: STPAPIClient = .shared,
-        mode: LinkController.Mode
+        mode: LinkController.Mode,
+        configuration: LinkConfiguration = .init()
     ) async throws -> LinkController {
         return try await withCheckedThrowingContinuation { continuation in
-            create(apiClient: apiClient, mode: mode) { result in
+            create(apiClient: apiClient, mode: mode, configuration: configuration) { result in
                 switch result {
                 case .success(let controller):
                     continuation.resume(returning: controller)
@@ -1298,6 +1326,7 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
             }
         }
     }
+
 }
 
 @_spi(STP) @_spi(LinkControllerPreview) public extension LinkController {
@@ -1313,21 +1342,18 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
     ///
     /// - Parameter email: The email address to look up and associate with the Link account.
     /// - Parameter phoneNumber: Optional phone number in E.164 format to prefill during signup.
-    /// - Parameter supportedPaymentMethodTypes: The payment method types to support. If `nil`, all available types are shown.
     /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
     /// - Returns: `.completed(paymentMethod)` on selection, or `.canceled` if the user dismisses the flow.
     /// - Throws: An error if the lookup fails or payment method creation fails.
     func present(
         email: String,
         phoneNumber: String? = nil,
-        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         from presentingViewController: UIViewController
     ) async throws -> PaymentMethodResult {
         try await withCheckedThrowingContinuation { continuation in
             present(
                 email: email,
                 phoneNumber: phoneNumber,
-                supportedPaymentMethodTypes: supportedPaymentMethodTypes,
                 from: presentingViewController
             ) { result in
                 switch result {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -198,7 +198,17 @@ import UIKit
     private func resolvedSupportedPaymentMethodTypes(
         override supportedPaymentMethodTypes: [LinkPaymentMethodType]?
     ) -> [LinkPaymentMethodType]? {
-        supportedPaymentMethodTypes ?? configuration?.supportedPaymentMethodTypes
+        Self.nonEmptySupportedPaymentMethodTypes(supportedPaymentMethodTypes)
+            ?? Self.nonEmptySupportedPaymentMethodTypes(configuration?.supportedPaymentMethodTypes)
+    }
+
+    private static func nonEmptySupportedPaymentMethodTypes(
+        _ supportedPaymentMethodTypes: [LinkPaymentMethodType]?
+    ) -> [LinkPaymentMethodType]? {
+        guard let supportedPaymentMethodTypes, !supportedPaymentMethodTypes.isEmpty else {
+            return nil
+        }
+        return supportedPaymentMethodTypes
     }
 
     private func updatePaymentMethodPreview() {
@@ -422,7 +432,7 @@ import UIKit
     ///
     /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
     /// - Parameter email: The email address to pre-fill in the Link sheet. If `nil`, the email field will be empty.
-    /// - Parameter supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil`, all available types are supported.
+    /// - Parameter supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil` or empty, all available types are supported.
     /// - Parameter collectName: Whether or not we should collect the user's name and attach it to the billing details.
     /// - Parameter completion: A closure that is called when the user has selected a payment method or canceled the sheet. If the user selects a payment method, the `paymentMethodPreview` will be updated accordingly.
     @_spi(STP) public func collectPaymentMethod(
@@ -1223,7 +1233,7 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
     ///
     /// - Parameter presentingViewController: The view controller from which to present the Link sheet.
     /// - Parameter email: The email address to pre-fill in the Link sheet. If `nil`, the email field will be empty.
-    /// - Parameter supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil`, all available types are supported.
+    /// - Parameter supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil` or empty, all available types are supported.
     /// - Parameter collectName: Whether or not we should collect the user's name and attach it to the billing details.
     /// - Returns: A `PaymentMethodDisplayData` if the user selected a payment method, or `nil` otherwise.
     func collectPaymentMethod(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -296,7 +296,7 @@ import UIKit
         }
     }
 
-    /// Creates a `LinkController` with the specified preview `configuration`.
+    /// Creates a `LinkController` with the specified `configuration`.
     ///
     /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
     /// - Parameter configuration: Configuration for Link behavior and content. If not specified, default behavior is used.
@@ -1312,7 +1312,7 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
 
 @_spi(LinkControllerPreview) public extension LinkController {
 
-    /// Creates a `LinkController` with the specified preview `configuration`.
+    /// Creates a `LinkController` with the specified `configuration`.
     ///
     /// - Parameter apiClient: The `STPAPIClient` instance for this controller. Defaults to `.shared`.
     /// - Parameter configuration: Configuration for Link behavior and content. If not specified, default behavior is used.

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
@@ -11,6 +11,7 @@ final class LinkControllerPreviewAPITests: XCTestCase {
     func testPreviewSPISurfaceCompiles() {
         _ = LinkPaymentMethodType.card
         _ = LinkConfiguration(supportedPaymentMethodTypes: [.card])
+        _ = LinkConfiguration(supportedPaymentMethodTypes: [.card], allowLogout: false).allowLogout
 
         let result: LinkController.PaymentMethodResult = .canceled
         _ = result

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
@@ -17,7 +17,6 @@ final class LinkControllerPreviewAPITests: XCTestCase {
 
         if false {
             LinkController.create(
-                mode: .payment,
                 configuration: .init(supportedPaymentMethodTypes: [.card])
             ) { result in
                 _ = result
@@ -25,7 +24,6 @@ final class LinkControllerPreviewAPITests: XCTestCase {
 
             Task { @MainActor in
                 let controller = try await LinkController.create(
-                    mode: .payment,
                     configuration: .init(supportedPaymentMethodTypes: [.card])
                 )
                 _ = controller.paymentMethodPreview

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
@@ -10,23 +10,29 @@ final class LinkControllerPreviewAPITests: XCTestCase {
     @MainActor
     func testPreviewSPISurfaceCompiles() {
         _ = LinkPaymentMethodType.card
+        _ = LinkConfiguration(supportedPaymentMethodTypes: [.card])
 
         let result: LinkController.PaymentMethodResult = .canceled
         _ = result
 
         if false {
-            LinkController.create(mode: .payment) { result in
+            LinkController.create(
+                mode: .payment,
+                configuration: .init(supportedPaymentMethodTypes: [.card])
+            ) { result in
                 _ = result
             }
 
             Task { @MainActor in
-                let controller = try await LinkController.create(mode: .payment)
+                let controller = try await LinkController.create(
+                    mode: .payment,
+                    configuration: .init(supportedPaymentMethodTypes: [.card])
+                )
                 _ = controller.paymentMethodPreview
 
                 controller.present(
                     email: "jenny.rosen@example.com",
                     phoneNumber: "+14155551234",
-                    supportedPaymentMethodTypes: [.card],
                     from: UIViewController()
                 ) { result in
                     _ = result
@@ -35,7 +41,6 @@ final class LinkControllerPreviewAPITests: XCTestCase {
                 _ = try await controller.present(
                     email: "jenny.rosen@example.com",
                     phoneNumber: "+14155551234",
-                    supportedPaymentMethodTypes: [.card],
                     from: UIViewController()
                 )
             }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
@@ -190,6 +190,26 @@ class PayWithLinkViewController_WalletViewModelTests: XCTestCase {
         XCTAssertEqual(sut.supportedPaymentMethodTypes, [ParsedEnum(.bankAccount)])
     }
 
+    func test_supportedPaymentMethodTypes_whenFilterIsEmpty_usesAllCasesAtIntersection() throws {
+        let sut = try makeSUT(
+            supportedPaymentDetailsTypes: [ParsedEnum(.bankAccount)],
+            supportedPaymentMethodTypes: [],
+            linkFundingSources: ["BANK_ACCOUNT"]
+        )
+
+        XCTAssertEqual(sut.supportedPaymentMethodTypes, [ParsedEnum(.bankAccount)])
+    }
+
+    func test_supportedPaymentMethodTypes_whenFilterIsCard_returnsCardOnly() throws {
+        let sut = try makeSUT(
+            supportedPaymentDetailsTypes: [ParsedEnum(.card), ParsedEnum(.bankAccount)],
+            supportedPaymentMethodTypes: [.card],
+            linkFundingSources: ["CARD", "BANK_ACCOUNT"]
+        )
+
+        XCTAssertEqual(sut.supportedPaymentMethodTypes, [ParsedEnum(.card)])
+    }
+
     func test_cardBrandFiltering_passThroughEnabled() throws {
         let sut = try makeSUT(supportedPaymentDetailsTypes: [ParsedEnum(.card)],
                               linkFundingSources: ["CARD"],


### PR DESCRIPTION
## Summary

Makes the following tweaks to the LinkController APIs exposed via `@_spi(LinkControllerPreview)`:

- [Move supportedPaymentMethods to LinkConfiguration](https://github.com/stripe/stripe-ios/pull/6561/commits/bba5e3435bf30e3bf6c8fa1809bc483321f00616)
- [Remove paymentMethodType from LinkControllerPreview](https://github.com/stripe/stripe-ios/pull/6561/commits/6ae8e0e77549534d3bbdf2fd9624c1d2d10d6e3d)
- [Remove mode from create](https://github.com/stripe/stripe-ios/pull/6561/commits/36c91dd5cd15f60bd50f81133fa70ffacb21c5b8)
- [Add allowLogout field to LinkControllerPreview API](https://github.com/stripe/stripe-ios/pull/6561/commits/8452913f5af2c945026cdeec1f316459b6046d81)
- [Treat empty supportedPaymentMethodTypes array the same as nil](https://github.com/stripe/stripe-ios/pull/6561/commits/36c0b91a63fe1b5853482f19c035a8b184f2d360)

## Motivation

https://docs.google.com/document/d/1VoMxNhXmKix5kiFzWO3eJc2YzE3dpEO63rKp_Kb9F6E/edit?usp=sharing

## Testing

Manually tested using the `LinkControllerPreview Demo`

## Changelog

```
### PaymentSheet
* [Added] Added standalone Link wallet APIs in private preview via `LinkController`.
```
