### PR TITLE
Refactor intent to hold a Checkout instance

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPClientAttributionMetadata+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPClientAttributionMetadata+PaymentSheet.swift
@@ -35,6 +35,8 @@ extension STPClientAttributionMetadata {
                          paymentIntentCreationFlow: .deferred,
                          paymentMethodSelectionFlow: isAutomaticPaymentMethodsEnabled ? .automatic : .merchantSpecified)
         case .checkout(let checkout):
+            // CheckoutSession: Stripe owns the intent lifecycle, so omit `paymentIntentCreationFlow`
+            // to match web's hosted Checkout behavior.
             return .init(elementsSessionConfigId: elementsSessionConfigId,
                          checkoutSessionId: checkout.stpSession.id,
                          paymentIntentCreationFlow: nil,

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPClientAttributionMetadata+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPClientAttributionMetadata+PaymentSheet.swift
@@ -34,11 +34,9 @@ extension STPClientAttributionMetadata {
             return .init(elementsSessionConfigId: elementsSessionConfigId,
                          paymentIntentCreationFlow: .deferred,
                          paymentMethodSelectionFlow: isAutomaticPaymentMethodsEnabled ? .automatic : .merchantSpecified)
-        case .checkoutSession(let session):
-            // CheckoutSession: Stripe owns the intent lifecycle, so omit `paymentIntentCreationFlow`
-            // to match web's hosted Checkout behavior.
+        case .checkout(let checkout):
             return .init(elementsSessionConfigId: elementsSessionConfigId,
-                         checkoutSessionId: session.id,
+                         checkoutSessionId: checkout.stpSession.id,
                          paymentIntentCreationFlow: nil,
                          paymentMethodSelectionFlow: .automatic)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/SavedPaymentMethodManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/SavedPaymentMethodManager.swift
@@ -51,11 +51,11 @@ final class SavedPaymentMethodManager {
 
     func detach(paymentMethod: STPPaymentMethod) {
         switch intent {
-        case .checkoutSession(let checkoutSession):
+        case .checkout(let checkout):
             Task {
                 try? await configuration.apiClient.detachPaymentMethod(
                     paymentMethod.stripeId,
-                    fromCheckoutSession: checkoutSession.id
+                    fromCheckoutSession: checkout.stpSession.id
                 )
             }
         case .paymentIntent, .setupIntent, .deferredIntent:

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -98,7 +98,7 @@ extension STPAPIClient {
             parameters["type"] = "setup_intent"
             parameters["client_secret"] = clientSecret
             parameters["expand"] = ["payment_method_preference.setup_intent.payment_method"]
-        case .checkoutSession:
+        case .checkout:
             assertionFailure("CheckoutSession mode should not use makeElementsSessionsParams")
         }
         return parameters

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/STPCheckoutSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/STPCheckoutSession.swift
@@ -156,9 +156,6 @@ class STPCheckoutSession: NSObject {
     /// Client-side shipping address override.
     var shippingAddress: Checkout.ContactAddress?
 
-    /// Called by confirm handlers with the updated session after a successful confirm.
-    var onConfirmed: ((STPCheckoutSession) -> Void)?
-
     // MARK: - Convenience
 
     /// Returns `true` when the server needs a `tax_region` update for the given address type.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -35,9 +35,6 @@ extension Checkout {
         newSession.billingAddress = stpSession?.billingAddress
         newSession.shippingAddress = stpSession?.shippingAddress
         applyOverrides?(newSession)
-        newSession.onConfirmed = { [weak self] response in
-            self?.updateSession(response)
-        }
         let changed = stpSession?.allResponseFields as NSDictionary? != newSession.allResponseFields as NSDictionary
         setSession(newSession)
         if changed {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -45,9 +45,12 @@ public final class Checkout: ObservableObject {
 
     /// The underlying `STPCheckoutSession` backing the current public ``state``.
     ///
-    /// Internal callers that need `STPCheckoutSession`-specific data (e.g.
-    /// `allResponseFields`, address overrides, the expanded intent objects)
-    /// should read this rather than casting from `state.session`.
+    /// Marked `nonisolated(unsafe)` because PaymentSheet internals read this from non-MainActor
+    /// contexts. This is safe: reads only occur after the session is loaded and while the payment
+    /// UI is presented, a window during which no mutations occur. Writes are always on MainActor
+    /// because they go through `Checkout`'s MainActor-isolated mutation methods.
+    /// Requiring full MainActor isolation would propagate `@MainActor` through nearly all of
+    /// PaymentSheet's internal types, which is not warranted by the actual concurrency risk.
     nonisolated(unsafe) private(set) var stpSession: STPCheckoutSession!
 
     weak var integrationDelegate: CheckoutIntegrationDelegate?

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -110,6 +110,7 @@ public final class Checkout: ObservableObject {
         }
     }
 
+#if DEBUG
     /// Internal initializer for unit tests that injects a pre-loaded session.
     init(
         clientSecret: String,
@@ -125,7 +126,6 @@ public final class Checkout: ObservableObject {
         self.state = .loaded(session.makePublicSession())
     }
 
-    #if ENABLE_STPASSERTIONFAILURE
     /// Synchronous test-only initializer that wraps a pre-loaded session without async work.
     init(session: STPCheckoutSession) {
         self.clientSecret = ""
@@ -134,7 +134,7 @@ public final class Checkout: ObservableObject {
         self.stpSession = session
         self.state = .loaded(session.makePublicSession())
     }
-    #endif
+#endif
 
     // MARK: - Pending Operations
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -48,7 +48,7 @@ public final class Checkout: ObservableObject {
     /// Internal callers that need `STPCheckoutSession`-specific data (e.g.
     /// `allResponseFields`, address overrides, the expanded intent objects)
     /// should read this rather than casting from `state.session`.
-    private(set) var stpSession: STPCheckoutSession?
+    nonisolated(unsafe) private(set) var stpSession: STPCheckoutSession!
 
     weak var integrationDelegate: CheckoutIntegrationDelegate?
 
@@ -127,6 +127,17 @@ public final class Checkout: ObservableObject {
             self?.updateSession(response)
         }
     }
+
+    #if ENABLE_STPASSERTIONFAILURE
+    /// Synchronous test-only initializer that wraps a pre-loaded session without async work.
+    nonisolated init(session: STPCheckoutSession) {
+        self.clientSecret = ""
+        self.configuration = Configuration()
+        self.apiClient = .shared
+        self.stpSession = session
+        self._state = Published(wrappedValue: .loaded(session.makePublicSession()))
+    }
+    #endif
 
     // MARK: - Pending Operations
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -130,12 +130,12 @@ public final class Checkout: ObservableObject {
 
     #if ENABLE_STPASSERTIONFAILURE
     /// Synchronous test-only initializer that wraps a pre-loaded session without async work.
-    nonisolated init(session: STPCheckoutSession) {
+    init(session: STPCheckoutSession) {
         self.clientSecret = ""
         self.configuration = Configuration()
         self.apiClient = .shared
         self.stpSession = session
-        self._state = Published(wrappedValue: .loaded(session.makePublicSession()))
+        self.state = .loaded(session.makePublicSession())
     }
     #endif
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -105,9 +105,6 @@ public final class Checkout: ObservableObject {
             await flagImageManager.prefetchFlagImages(for: checkoutSession)
             self.stpSession = checkoutSession
             self.state = .loaded(checkoutSession.makePublicSession())
-            checkoutSession.onConfirmed = { [weak self] response in
-                self?.updateSession(response)
-            }
         } catch {
             throw CheckoutError.apiError(message: error.nonGenericDescription)
         }
@@ -126,9 +123,6 @@ public final class Checkout: ObservableObject {
         await flagImageManager.prefetchFlagImages(for: session)
         self.stpSession = session
         self.state = .loaded(session.makePublicSession())
-        session.onConfirmed = { [weak self] response in
-            self?.updateSession(response)
-        }
     }
 
     #if ENABLE_STPASSERTIONFAILURE

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -112,12 +112,8 @@ public final class EmbeddedPaymentElement {
         configuration: Configuration
     ) async throws -> EmbeddedPaymentElement {
         try await checkout.awaitPendingOperations()
-        guard let stpSession = checkout.stpSession else {
-            stpAssertionFailure("Expected STPCheckoutSession, got \(type(of: checkout.state.session))")
-            throw PaymentSheetError.unknown(debugDescription: "Invalid checkout session type")
-        }
         var config = configuration
-        stpSession.applyAddressOverrides(to: &config)
+        checkout.stpSession.applyAddressOverrides(to: &config)
 
         try validateRowSelectionConfiguration(configuration: config)
 
@@ -126,7 +122,7 @@ public final class EmbeddedPaymentElement {
         let analyticsHelper = PaymentSheetAnalyticsHelper(integrationShape: .embedded, configuration: config)
 
         let (loadResult, confirmationChallenge) = try await PaymentSheetLoader.load(
-            mode: .checkoutSession(stpSession),
+            mode: .checkout(checkout),
             configuration: config,
             analyticsHelper: analyticsHelper,
             integrationShape: .embedded
@@ -180,12 +176,8 @@ public final class EmbeddedPaymentElement {
         } catch {
             return .failed(error: error)
         }
-        guard let stpSession = checkout.stpSession else {
-            stpAssertionFailure("Expected STPCheckoutSession, got \(type(of: checkout.state.session))")
-            return .failed(error: PaymentSheetError.unknown(debugDescription: "Invalid checkout session type"))
-        }
-        stpSession.applyAddressOverrides(to: &configuration)
-        return await performUpdate(mode: .checkoutSession(stpSession))
+        checkout.stpSession.applyAddressOverrides(to: &configuration)
+        return await performUpdate(mode: .checkout(checkout))
     }
 
     private func performUpdate(mode: PaymentSheet.InitializationMode) async -> UpdateResult {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
@@ -16,19 +16,19 @@ import UIKit
 
 // MARK: - Intent
 
-/// An internal type representing either a PaymentIntent, SetupIntent, a "deferred Intent", or a CheckoutSession
+/// An internal type representing either a PaymentIntent, SetupIntent, a "deferred Intent", or a Checkout
 enum Intent {
     case paymentIntent(STPPaymentIntent)
     case setupIntent(STPSetupIntent)
     case deferredIntent(intentConfig: PaymentSheet.IntentConfiguration)
-    case checkoutSession(STPCheckoutSession)
+    case checkout(Checkout)
 
     var stripeId: String? {
         switch self {
         case .paymentIntent(let intent): intent.stripeId
         case .setupIntent(let intent): intent.stripeID
         case .deferredIntent: nil
-        case .checkoutSession(let session): session.id
+        case .checkout(let checkout): checkout.stpSession.id
         }
     }
 
@@ -45,8 +45,8 @@ enum Intent {
             case .setup:
                 return false
             }
-        case .checkoutSession(let session):
-            return session.mode == .payment || session.mode == .subscription
+        case .checkout(let checkout):
+            return checkout.stpSession.mode == .payment || checkout.stpSession.mode == .subscription
         }
     }
 
@@ -58,7 +58,7 @@ enum Intent {
             return false
         case .deferredIntent:
             return true
-        case .checkoutSession:
+        case .checkout:
             return false
         }
     }
@@ -67,7 +67,7 @@ enum Intent {
         switch self {
         case .deferredIntent(let intentConfig):
             return intentConfig
-        case .paymentIntent, .setupIntent, .checkoutSession:
+        case .paymentIntent, .setupIntent, .checkout:
             return nil
         }
     }
@@ -78,8 +78,7 @@ enum Intent {
             return intentConfig.requireCVCRecollection
         case .paymentIntent(let paymentIntent):
             return paymentIntent.paymentMethodOptions?.card?.requireCvcRecollection ?? false
-        case .setupIntent, .checkoutSession:
-            // CheckoutSession does not yet support CVC recollection
+        case .setupIntent, .checkout:
             return false
         }
     }
@@ -97,8 +96,8 @@ enum Intent {
             case .setup(let currency, _):
                 return currency
             }
-        case .checkoutSession(let session):
-            return session.currency
+        case .checkout(let checkout):
+            return checkout.stpSession.currency
         }
     }
 
@@ -115,8 +114,8 @@ enum Intent {
             case .setup:
                 return nil
             }
-        case .checkoutSession(let session):
-            return session.expectedAmount()
+        case .checkout(let checkout):
+            return checkout.stpSession.expectedAmount()
         }
     }
 
@@ -129,10 +128,10 @@ enum Intent {
                 return setupFutureUsage?.rawValue
             }
             return nil
-        case .checkoutSession(let checkoutSession):
-            switch checkoutSession.mode {
+        case .checkout(let checkout):
+            switch checkout.stpSession.mode {
             case .payment:
-                return checkoutSession.setupFutureUsage
+                return checkout.stpSession.setupFutureUsage
             case .setup:
                 return nil
             case .subscription, .unknown:
@@ -156,8 +155,8 @@ enum Intent {
                 return !setupFutureUsageValues.isEmpty
             }
             return nil
-        case .checkoutSession(let checkoutSession):
-            return checkoutSession.isPaymentMethodOptionsSetupFutureUsageSet
+        case .checkout(let checkout):
+            return checkout.stpSession.isPaymentMethodOptionsSetupFutureUsageSet
         case .setupIntent:
             return nil
         }
@@ -181,10 +180,10 @@ enum Intent {
             case .setup:
                 return true
             }
-        case .checkoutSession(let checkoutSession):
-            switch checkoutSession.mode {
+        case .checkout(let checkout):
+            switch checkout.stpSession.mode {
             case .payment:
-                guard let setupFutureUsage = checkoutSession.setupFutureUsage(for: paymentMethodType) else {
+                guard let setupFutureUsage = checkout.stpSession.setupFutureUsage(for: paymentMethodType) else {
                     return false
                 }
                 return setupFutureUsage != "none"
@@ -199,8 +198,8 @@ enum Intent {
 
     func allowsPaymentMethodRemoval(elementsSession: STPElementsSession) -> Bool {
         switch self {
-        case .checkoutSession(let checkoutSession):
-            return checkoutSession.customer?.canDetachPaymentMethod ?? false
+        case .checkout(let checkout):
+            return checkout.stpSession.customer?.canDetachPaymentMethod ?? false
         case .paymentIntent, .setupIntent, .deferredIntent:
             return elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
@@ -79,6 +79,7 @@ enum Intent {
         case .paymentIntent(let paymentIntent):
             return paymentIntent.paymentMethodOptions?.card?.requireCvcRecollection ?? false
         case .setupIntent, .checkout:
+            // CheckoutSession does not yet support CVC recollection
             return false
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkPaymentController.swift
@@ -213,7 +213,7 @@ import UIKit
                     ) { [weak self] linkAccountSession, error in
                         self?.generateManifest(continuation: continuation, error: error, emailAddress: self?.configuration.defaultBillingDetails.email, linkAccountSession: linkAccountSession)
                     }
-            case .checkoutSession:
+            case .checkout:
                 continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Link payment controller is not yet supported by CheckoutSession"))
             }
         }
@@ -306,7 +306,7 @@ import UIKit
                 intentType: .deferred,
                 financialConnectionsCompletion: completionHandler
             )
-        case .checkoutSession:
+        case .checkout:
             completionHandler(nil, nil, PaymentSheetError.unknown(debugDescription: "Link payment controller is not yet supported by CheckoutSession") as NSError)
         }
     }
@@ -433,7 +433,7 @@ import UIKit
                     configuration: configuration
                 )
                 linkBrand = elementsSession.linkBrand
-            case .checkoutSession:
+            case .checkout:
                 linkBrand = nil
             }
 
@@ -561,7 +561,7 @@ import UIKit
                         continuation.resume()
                     }
                 }
-            case .checkoutSession:
+            case .checkout:
                 continuation.resume(throwing: PaymentSheetError.unknown(debugDescription: "Link payment controller is not yet supported by CheckoutSession"))
             }
         }
@@ -611,7 +611,7 @@ private extension PaymentSheet.InitializationMode {
             case .setup:
                 return nil
             }
-        case .checkoutSession:
+        case .checkout:
             return nil
         }
     }
@@ -629,7 +629,7 @@ private extension PaymentSheet.InitializationMode {
             case .setup(let currency, _):
                 return currency
             }
-        case .checkoutSession:
+        case .checkout:
             return nil
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -170,9 +170,9 @@ extension PaymentSheet {
             intent.isSetupFutureUsageSet(for: paymentMethodType) || elementsSession.forceSaveFutureUseBehaviorAndNewMandateText
         }
         let setAllowRedisplay: (IntentConfirmParams, STPPaymentMethodType) -> Void = { confirmParams, paymentMethodType in
-            if case .checkoutSession(let checkoutSession) = intent {
+            if case .checkout(let checkout) = intent {
                 confirmParams.setAllowRedisplayForCheckoutSession(
-                    merchantWillSavePaymentMethod: checkoutSession.merchantWillSavePaymentMethod(paymentMethodType)
+                    merchantWillSavePaymentMethod: checkout.stpSession.merchantWillSavePaymentMethod(paymentMethodType)
                 )
             } else {
                 confirmParams.setAllowRedisplay(
@@ -284,11 +284,11 @@ extension PaymentSheet {
                         await confirmationChallenge?.complete()
                         completion(result.result, result.deferredIntentConfirmationType)
                     }
-                    // MARK: ↪ CheckoutSession
-                case .checkoutSession(let checkoutSession):
+                    // MARK: ↪ Checkout
+                case .checkout(let checkout):
                     Task { @MainActor in
                         let result = await handleCheckoutSessionConfirmation(
-                            checkoutSession: checkoutSession,
+                            checkout: checkout,
                             confirmType: .new(
                                 params: confirmParams.paymentMethodParams,
                                 paymentOptions: confirmParams.confirmPaymentMethodOptions,
@@ -359,8 +359,8 @@ extension PaymentSheet {
                     )
                     completion(result.result, result.deferredIntentConfirmationType)
                 }
-                // MARK: ↪ CheckoutSession
-            case .checkoutSession(let checkoutSession):
+                // MARK: ↪ Checkout
+            case .checkout(let checkout):
                 Task { @MainActor in
                     let paymentOptions = intentConfirmParamsForDeferredIntent?.confirmPaymentMethodOptions != nil
                     // Flow controller and embedded collects CVC using interstitial:
@@ -368,7 +368,7 @@ extension PaymentSheet {
                     // PaymentSheet collects CVC in sheet:
                     : intentConfirmParamsFromSavedPaymentMethod?.confirmPaymentMethodOptions
                     let result = await handleCheckoutSessionConfirmation(
-                        checkoutSession: checkoutSession,
+                        checkout: checkout,
                         confirmType: .saved(paymentMethod,
                                             paymentOptions: paymentOptions,
                                             clientAttributionMetadata: clientAttributionMetadata,
@@ -452,9 +452,9 @@ extension PaymentSheet {
                             await confirmationChallenge?.complete()
                             completion(result.result, result.deferredIntentConfirmationType)
                         }
-                    case .checkoutSession(let checkoutSession):
+                    case .checkout(let checkout):
                         let result = await handleCheckoutSessionConfirmation(
-                            checkoutSession: checkoutSession,
+                            checkout: checkout,
                             confirmType: .new(
                                 params: paymentMethodParams,
                                 paymentOptions: STPConfirmPaymentMethodOptions(),
@@ -544,9 +544,9 @@ extension PaymentSheet {
                             await confirmationChallenge?.complete()
                             completion(result.result, result.deferredIntentConfirmationType)
                         }
-                    case .checkoutSession(let checkoutSession):
+                    case .checkout(let checkout):
                         let result = await handleCheckoutSessionConfirmation(
-                            checkoutSession: checkoutSession,
+                            checkout: checkout,
                             confirmType: .saved(paymentMethod, paymentOptions: nil, clientAttributionMetadata: clientAttributionMetadata, radarOptions: radarOptions),
                             configuration: configuration,
                             authenticationContext: authenticationContext,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
@@ -44,6 +44,7 @@ extension PaymentSheet {
                 paymentMethodType = params.type
                 paymentMethodOptions = paymentOptions
                 params.clientAttributionMetadata = clientAttributionMetadata
+                // Ensure email is set on the payment method — fall back to the checkout session's customer email
                 if params.billingDetails?.email == nil, let customerEmail = checkoutSession.email {
                     params.nonnil_billingDetails.email = customerEmail
                 }
@@ -59,6 +60,7 @@ extension PaymentSheet {
             let savePaymentMethod: Bool? = {
                 switch checkoutSession.mode {
                 case .setup:
+                    // setup mode does not send the save_payment_method param
                     return nil
                 case .payment:
                     return confirmType.savePaymentMethodForCheckoutSession
@@ -81,6 +83,7 @@ extension PaymentSheet {
                 clientAttributionMetadata: clientAttributionMetadata
             )
 
+            // Update the Checkout session with the latest response
             checkoutSession.onConfirmed?(response)
 
             // 4. Handle response based on checkout session mode

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
@@ -14,16 +14,17 @@ extension PaymentSheet {
     /// Confirms a checkout session with a new payment method
     @MainActor
     static func handleCheckoutSessionConfirmation(
-        checkoutSession: STPCheckoutSession,
+        checkout: Checkout,
         confirmType: ConfirmPaymentMethodType,
         configuration: PaymentElementConfiguration,
         authenticationContext: STPAuthenticationContext,
         paymentHandler: STPPaymentHandler,
         elementsSession: STPElementsSession
     ) async -> PaymentSheetResult {
+        let checkoutSession = checkout.stpSession!
         do {
             let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(
-                intent: .checkoutSession(checkoutSession),
+                intent: .checkout(checkout),
                 elementsSession: elementsSession
             )
 
@@ -43,7 +44,6 @@ extension PaymentSheet {
                 paymentMethodType = params.type
                 paymentMethodOptions = paymentOptions
                 params.clientAttributionMetadata = clientAttributionMetadata
-                // Ensure email is set on the payment method — fall back to the checkout session's customer email
                 if params.billingDetails?.email == nil, let customerEmail = checkoutSession.email {
                     params.nonnil_billingDetails.email = customerEmail
                 }
@@ -59,7 +59,6 @@ extension PaymentSheet {
             let savePaymentMethod: Bool? = {
                 switch checkoutSession.mode {
                 case .setup:
-                    // setup mode does not send the save_payment_method param
                     return nil
                 case .payment:
                     return confirmType.savePaymentMethodForCheckoutSession
@@ -82,7 +81,6 @@ extension PaymentSheet {
                 clientAttributionMetadata: clientAttributionMetadata
             )
 
-            // Update the Checkout session with the latest response
             checkoutSession.onConfirmed?(response)
 
             // 4. Handle response based on checkout session mode

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
@@ -21,7 +21,7 @@ extension PaymentSheet {
         paymentHandler: STPPaymentHandler,
         elementsSession: STPElementsSession
     ) async -> PaymentSheetResult {
-        let checkoutSession = checkout.stpSession!
+        let checkoutSession: STPCheckoutSession = checkout.stpSession
         do {
             let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(
                 intent: .checkout(checkout),
@@ -83,8 +83,8 @@ extension PaymentSheet {
                 clientAttributionMetadata: clientAttributionMetadata
             )
 
-            // Update the Checkout session with the latest response
-            checkoutSession.onConfirmed?(response)
+            // Update the Checkout instance with the confirmed session response
+            checkout.updateSession(response)
 
             // 4. Handle response based on checkout session mode
             return try await handleCheckoutSessionConfirmResponse(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -208,6 +208,8 @@ extension Intent: PaymentMethodRequirementProvider {
         case let .checkout(checkout):
             var reqs = [PaymentMethodTypeRequirement]()
 
+            // The session is configured to collect a shipping address, so payment methods
+            // that require one can be offered.
             if checkout.stpSession.requiresShippingAddress {
                 reqs.append(.shippingAddress)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -214,6 +214,7 @@ extension Intent: PaymentMethodRequirementProvider {
                 reqs.append(.shippingAddress)
             }
 
+            // Mirror PaymentIntent/SetupIntent: valid us bank verification method
             if let usBankOptions = checkout.stpSession.paymentMethodOptions?.usBankAccount,
                 usBankOptions.verificationMethod.isValidForPaymentSheet
             {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -205,17 +205,14 @@ extension Intent: PaymentMethodRequirementProvider {
         case .deferredIntent:
             // Verification method is always 'automatic'
             return [.validUSBankVerificationMethod]
-        case let .checkoutSession(checkoutSession):
+        case let .checkout(checkout):
             var reqs = [PaymentMethodTypeRequirement]()
 
-            // The session is configured to collect a shipping address, so payment methods
-            // that require one can be offered.
-            if checkoutSession.requiresShippingAddress {
+            if checkout.stpSession.requiresShippingAddress {
                 reqs.append(.shippingAddress)
             }
 
-            // Mirror PaymentIntent/SetupIntent: valid us bank verification method
-            if let usBankOptions = checkoutSession.paymentMethodOptions?.usBankAccount,
+            if let usBankOptions = checkout.stpSession.paymentMethodOptions?.usBankAccount,
                 usBankOptions.verificationMethod.isValidForPaymentSheet
             {
                 reqs.append(.validUSBankVerificationMethod)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -170,10 +170,8 @@ public class PaymentSheet {
                     completion(.failed(error: error))
                     return
                 }
-                if checkout.stpSession != nil {
-                    loadMode = .checkout(checkout)
-                    checkout.stpSession.applyAddressOverrides(to: &self.configuration)
-                }
+                loadMode = .checkout(checkout)
+                checkout.stpSession.applyAddressOverrides(to: &self.configuration)
             }
 
             // Configure the Payment Sheet VC after loading the PI/SI, Customer, etc.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -48,13 +48,13 @@ public class PaymentSheet {
         case paymentIntentClientSecret(String)
         case setupIntentClientSecret(String)
         case deferredIntent(PaymentSheet.IntentConfiguration)
-        case checkoutSession(STPCheckoutSession)
+        case checkout(Checkout)
 
         var intentConfig: PaymentSheet.IntentConfiguration? {
             switch self {
             case .deferredIntent(let intentConfig):
                 return intentConfig
-            case .paymentIntentClientSecret, .setupIntentClientSecret, .checkoutSession:
+            case .paymentIntentClientSecret, .setupIntentClientSecret, .checkout:
                 return nil
             }
         }
@@ -111,13 +111,10 @@ public class PaymentSheet {
     @_spi(ReactNativeSDK)
     @MainActor
     public convenience init(checkout: Checkout, configuration: Configuration) {
-        guard let stpSession = checkout.stpSession else {
-            fatalError("Expected STPCheckoutSession, got \(type(of: checkout.state.session))")
-        }
         var config = configuration
-        stpSession.applyAddressOverrides(to: &config)
+        checkout.stpSession.applyAddressOverrides(to: &config)
         self.init(
-            mode: .checkoutSession(stpSession),
+            mode: .checkout(checkout),
             configuration: config
         )
         self.checkout = checkout
@@ -173,9 +170,9 @@ public class PaymentSheet {
                     completion(.failed(error: error))
                     return
                 }
-                if let stpSession = checkout.stpSession {
-                    loadMode = .checkoutSession(stpSession)
-                    stpSession.applyAddressOverrides(to: &self.configuration)
+                if checkout.stpSession != nil {
+                    loadMode = .checkout(checkout)
+                    checkout.stpSession.applyAddressOverrides(to: &self.configuration)
                 }
             }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -412,14 +412,9 @@ extension PaymentSheet {
                     completion(.failure(error))
                     return
                 }
-                guard let stpSession = checkout.stpSession else {
-                    stpAssertionFailure("Expected STPCheckoutSession, got \(type(of: checkout.state.session))")
-                    completion(.failure(PaymentSheetError.unknown(debugDescription: "Invalid checkout session type")))
-                    return
-                }
                 var config = configuration
-                stpSession.applyAddressOverrides(to: &config)
-                create(mode: .checkoutSession(stpSession),
+                checkout.stpSession.applyAddressOverrides(to: &config)
+                create(mode: .checkout(checkout),
                        configuration: config
                 ) { result in
                     if case .success(let flowController) = result {
@@ -704,14 +699,8 @@ extension PaymentSheet {
                     completion(error)
                     return
                 }
-                guard let stpSession = checkout.stpSession else {
-                    stpAssertionFailure("Expected STPCheckoutSession, got \(type(of: checkout.state.session))")
-                    self.failUpdate(updateID)
-                    completion(PaymentSheetError.unknown(debugDescription: "Invalid checkout session type"))
-                    return
-                }
-                stpSession.applyAddressOverrides(to: &configuration)
-                performUpdate(mode: .checkoutSession(stpSession), updateID: updateID, completion: completion)
+                checkout.stpSession.applyAddressOverrides(to: &configuration)
+                performUpdate(mode: .checkout(checkout), updateID: updateID, completion: completion)
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -1100,12 +1100,12 @@ extension PaymentSheetFormFactory {
         intent: Intent,
         elementsSession: STPElementsSession
     ) -> SavePaymentMethodConsentBehavior {
-        guard case .checkoutSession(let checkoutSession) = intent else {
+        guard case .checkout(let checkout) = intent else {
             return elementsSession.savePaymentMethodConsentBehavior
         }
 
-        guard checkoutSession.customerId != nil,
-              let offerSave = checkoutSession.savedPaymentMethodsOfferSave,
+        guard checkout.stpSession.customerId != nil,
+              let offerSave = checkout.stpSession.savedPaymentMethodsOfferSave,
               offerSave.enabled
         else {
             return .paymentSheetWithCheckoutSessionPaymentMethodSaveDisabled

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -84,6 +84,7 @@ final class PaymentSheetLoader {
                 stpAssertionFailure("Configuration.customer must not be set when using a CheckoutSession. The CheckoutSession manages its own customer.")
                 throw PaymentSheetError.integrationError(nonPIIDebugDescription: "PaymentSheet.Configuration.customer must not be set when using a CheckoutSession.")
             }
+            // defaultBillingDetails.email is populated from the CheckoutSession's customerEmail (if not already set) by applyAddressOverrides, which runs before the loader.
             if case .checkout = mode, configuration.defaultBillingDetails.email == nil {
                 stpAssertionFailure("An email address is required when using a CheckoutSession. Set configuration.defaultBillingDetails.email or ensure the CheckoutSession has a customer_email.")
                 throw PaymentSheetError.integrationError(nonPIIDebugDescription: "An email address is required when using a CheckoutSession. Set PaymentSheet.Configuration.defaultBillingDetails.email or ensure the CheckoutSession has a customer_email.")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -80,12 +80,11 @@ final class PaymentSheetLoader {
                let error = intentConfiguration.validate() {
                 throw error
             }
-            if case .checkoutSession = mode, configuration.customer != nil {
+            if case .checkout = mode, configuration.customer != nil {
                 stpAssertionFailure("Configuration.customer must not be set when using a CheckoutSession. The CheckoutSession manages its own customer.")
                 throw PaymentSheetError.integrationError(nonPIIDebugDescription: "PaymentSheet.Configuration.customer must not be set when using a CheckoutSession.")
             }
-            // defaultBillingDetails.email is populated from the CheckoutSession's customerEmail (if not already set) by applyAddressOverrides, which runs before the loader.
-            if case .checkoutSession = mode, configuration.defaultBillingDetails.email == nil {
+            if case .checkout = mode, configuration.defaultBillingDetails.email == nil {
                 stpAssertionFailure("An email address is required when using a CheckoutSession. Set configuration.defaultBillingDetails.email or ensure the CheckoutSession has a customer_email.")
                 throw PaymentSheetError.integrationError(nonPIIDebugDescription: "An email address is required when using a CheckoutSession. Set PaymentSheet.Configuration.defaultBillingDetails.email or ensure the CheckoutSession has a customer_email.")
             }
@@ -116,7 +115,7 @@ final class PaymentSheetLoader {
             // Overwrite the form specs that were already loaded from disk
             loadTimings.logStart("loadFormSpecs")
             switch intent {
-            case .paymentIntent, .deferredIntent, .checkoutSession:
+            case .paymentIntent, .deferredIntent, .checkout:
                 if !elementsSession.isBackupInstance {
                     _ = FormSpecProvider.shared.loadFrom(elementsSession.paymentMethodSpecs as Any)
                 }
@@ -488,13 +487,13 @@ final class PaymentSheetLoader {
                 elementsSession = .makeBackupElementsSession(allResponseFields: [:], paymentMethodTypes: paymentMethodTypes)
                 intent = .deferredIntent(intentConfig: intentConfig)
             }
-        case .checkoutSession(let checkoutSession):
-            guard let elementsSessionJSON = checkoutSession.allResponseFields["elements_session"] as? [AnyHashable: Any],
+        case .checkout(let checkout):
+            guard let elementsSessionJSON = checkout.stpSession.allResponseFields["elements_session"] as? [AnyHashable: Any],
                   let decodedElementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJSON) else {
                 throw PaymentSheetError.unknown(debugDescription: "Failed to decode elements session from provided checkout session object")
             }
             elementsSession = decodedElementsSession
-            intent = .checkoutSession(checkoutSession)
+            intent = .checkout(checkout)
         }
 
         // Warn the merchant if we see unactivated payment method types in the Intent
@@ -546,8 +545,8 @@ final class PaymentSheetLoader {
         if let elementsSessionPaymentMethods = elementsSession.customer?.paymentMethods {
             // A. SPMs are on ElementSessions object when using CustomerSession.
             savedPaymentMethods = elementsSessionPaymentMethods
-        } else if case let .checkoutSession(checkoutSession) = intent,
-                  let customerPaymentMethods = checkoutSession.customer?.paymentMethods {
+        } else if case let .checkout(checkout) = intent,
+                  let customerPaymentMethods = checkout.stpSession.customer?.paymentMethods {
             // B. SPMs are on CheckoutSession object
             savedPaymentMethods = customerPaymentMethods
         } else if let prefetchedSPMs {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPAnalyticsClient+PaymentSheet.swift
@@ -148,7 +148,7 @@ extension Intent {
             case .setup:
                 return "deferred_setup_intent"
             }
-        case .checkoutSession:
+        case .checkout:
             return "checkout_session"
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -62,7 +62,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
             return setupIntent.clientSecret
         case .checkout(let checkout):
             return try await handleCheckoutSessionApplePay(
-                checkoutSession: checkout.stpSession,
+                checkout: checkout,
                 paymentMethod: paymentMethod,
                 paymentInformation: paymentInformation,
                 context: context
@@ -169,11 +169,13 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
 
     /// Handles Apple Pay confirmation for CheckoutSession by calling the confirm API with the payment method.
     private func handleCheckoutSessionApplePay(
-        checkoutSession: STPCheckoutSession,
+        checkout: Checkout,
         paymentMethod: StripeAPI.PaymentMethod,
         paymentInformation: PKPayment,
         context: STPApplePayContext
     ) async throws -> String {
+        let checkoutSession: STPCheckoutSession = checkout.stpSession
+
         // 1. Build client attribution metadata
         let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(
             intent: intent,
@@ -198,8 +200,8 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
             clientAttributionMetadata: clientAttributionMetadata
         )
 
-        // 5. Update the Checkout session with the latest response
-        checkoutSession.onConfirmed?(response)
+        // 5. Update the Checkout instance with the confirmed session response
+        await checkout.updateSession(response)
 
         // 6. Return client secret based on checkout session mode
         return try response.clientSecret(for: checkoutSession.mode)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -60,9 +60,9 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
             return paymentIntent.clientSecret
         case .setupIntent(let setupIntent):
             return setupIntent.clientSecret
-        case .checkoutSession(let checkoutSession):
+        case .checkout(let checkout):
             return try await handleCheckoutSessionApplePay(
-                checkoutSession: checkoutSession,
+                checkoutSession: checkout.stpSession,
                 paymentMethod: paymentMethod,
                 paymentInformation: paymentInformation,
                 context: context
@@ -365,11 +365,11 @@ extension STPApplePayContext {
         if let paymentSummaryItems = applePay.paymentSummaryItems {
             // Use the merchant supplied paymentSummaryItems
             paymentRequest.paymentSummaryItems = paymentSummaryItems
-        } else if case .checkoutSession(let session) = intent,
-                  !session.lineItems.isEmpty,
-                  let total = session.total {
+        } else if case .checkout(let checkout) = intent,
+                  !checkout.stpSession.lineItems.isEmpty,
+                  let total = checkout.stpSession.total {
             paymentRequest.paymentSummaryItems = STPApplePayContext.makeApplePayPaymentSummaryItems(
-                lineItems: session.lineItems,
+                lineItems: checkout.stpSession.lineItems,
                 total: total,
                 totalLabel: label,
                 currency: intent.currency

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -363,10 +363,8 @@ extension PaymentMethodFormViewController {
                 return .setup(setupIntent.stripeID)
             case .deferredIntent:
                 return .deferred(elementsSession.sessionID)
-            case .checkoutSession(let checkoutSession):
-                // This ID is used for financial incentive eligibility. Ideally we'd use the underlying
-                // paymentIntentId or setupIntentId, but those are not yet populated on CheckoutSession.
-                return .deferred(checkoutSession.id)
+            case .checkout(let checkout):
+                return .deferred(checkout.stpSession.id)
             }
         }()
 
@@ -556,13 +554,13 @@ extension PaymentMethodFormViewController {
                 intentType: .deferred,
                 financialConnectionsCompletion: financialConnectionsCompletion
             )
-        case .checkoutSession(let checkoutSession):
+        case .checkout(let checkout):
             client.collectBankAccountForDeferredIntentOrCheckoutSession(
                 sessionId: elementsSession.sessionID,
                 returnURL: configuration.returnURL,
                 onEvent: nil,
-                amount: checkoutSession.expectedAmount(),
-                currency: checkoutSession.currency,
+                amount: checkout.stpSession.expectedAmount(),
+                currency: checkout.stpSession.currency,
                 onBehalfOf: nil,
                 additionalParameters: additionalParameters,
                 elementsSessionContext: elementsSessionContext,
@@ -621,7 +619,7 @@ extension PaymentMethodFormViewController {
         switch intent {
         case .paymentIntent, .setupIntent:
             additionalParameters["attach_required"] = true
-        case .deferredIntent, .checkoutSession:
+        case .deferredIntent, .checkout:
             break
         }
 
@@ -672,13 +670,13 @@ extension PaymentMethodFormViewController {
                 intentType: .deferred,
                 financialConnectionsCompletion: financialConnectionsCompletion
             )
-        case .checkoutSession(let checkoutSession):
+        case .checkout(let checkout):
             client.collectBankAccountForDeferredIntentOrCheckoutSession(
                 sessionId: elementsSession.sessionID,
                 returnURL: configuration.returnURL,
                 onEvent: nil,
-                amount: checkoutSession.expectedAmount(),
-                currency: checkoutSession.currency,
+                amount: checkout.stpSession.expectedAmount(),
+                currency: checkout.stpSession.currency,
                 onBehalfOf: nil,
                 additionalParameters: additionalParameters,
                 elementsSessionContext: elementsSessionContext,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -364,6 +364,8 @@ extension PaymentMethodFormViewController {
             case .deferredIntent:
                 return .deferred(elementsSession.sessionID)
             case .checkout(let checkout):
+                // This ID is used for financial incentive eligibility. Ideally we'd use the underlying
+                // paymentIntentId or setupIntentId, but those are not yet populated on CheckoutSession.
                 return .deferred(checkout.stpSession.id)
             }
         }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
@@ -46,11 +46,11 @@ class ConfirmButton: UIControl {
                 case .setup:
                     return .setup
                 }
-            case .checkoutSession(let checkoutSession):
-                switch checkoutSession.mode {
+            case .checkout(let checkout):
+                switch checkout.stpSession.mode {
                 case .payment:
-                    if let amount = checkoutSession.expectedAmount(),
-                       let currency = checkoutSession.currency {
+                    if let amount = checkout.stpSession.expectedAmount(),
+                       let currency = checkout.stpSession.currency {
                         return .pay(amount: amount, currency: currency, withLock: withLock)
                     }
                     stpAssertionFailure("Missing amount and currency in checkout session for .payment mode")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -406,9 +406,9 @@ final class CheckoutUnitTests: XCTestCase {
         XCTAssertEqual(session.total?.taxExclusive.minorUnitsAmount, 1000)
     }
 
-    // MARK: - onConfirmed Tests
+    // MARK: - updateSession Tests
 
-    func testOnConfirmedUpdatesSessionAndNotifiesDelegate() async {
+    func testUpdateSessionNotifiesDelegate() async {
         let checkout = await makeCheckoutWithOpenSession()
         let delegate = MockCheckoutDelegate()
         checkout.delegate = delegate
@@ -419,9 +419,7 @@ final class CheckoutUnitTests: XCTestCase {
         updatedJSON["payment_status"] = "paid"
         let confirmResponse = STPCheckoutSession.decodedObject(fromAPIResponse: updatedJSON)!
 
-        // Invoke the onConfirmed closure as the confirm call sites do
-        let stpSession = checkout.stpSession!
-        stpSession.onConfirmed?(confirmResponse)
+        checkout.updateSession(confirmResponse)
 
         // Verify session was updated with the confirm response data
         XCTAssertEqual(checkout.state.session.status?.type, .complete)
@@ -429,7 +427,7 @@ final class CheckoutUnitTests: XCTestCase {
         XCTAssertTrue(delegate.didChangeStateCalled)
     }
 
-    func testOnConfirmedCarriesOverAddressOverrides() async {
+    func testUpdateSessionCarriesOverAddressOverrides() async {
         let checkout = await makeCheckoutWithOpenSession()
 
         // Set address overrides on the initial session
@@ -437,7 +435,7 @@ final class CheckoutUnitTests: XCTestCase {
             name: "Jane Doe",
             address: .init(country: "US")
         )
-        checkout.stpSession!.billingAddress = billingUpdate
+        checkout.stpSession.billingAddress = billingUpdate
 
         // Simulate a confirm response
         var updatedJSON = CheckoutTestHelpers.makeOpenSessionJSON()
@@ -445,32 +443,35 @@ final class CheckoutUnitTests: XCTestCase {
         updatedJSON["payment_status"] = "paid"
         let confirmResponse = STPCheckoutSession.decodedObject(fromAPIResponse: updatedJSON)!
 
-        let stpSession = checkout.stpSession!
-        stpSession.onConfirmed?(confirmResponse)
+        checkout.updateSession(confirmResponse)
 
         // Address overrides should be carried over to the new session
         XCTAssertEqual(checkout.state.session.billingAddress?.name, "Jane Doe")
         XCTAssertEqual(checkout.state.session.billingAddress?.address.country, "US")
     }
 
-    func testOnConfirmedSetsNewClosureOnUpdatedSession() async {
+    func testUpdateSessionCanBeCalledMultipleTimes() async {
         let checkout = await makeCheckoutWithOpenSession()
         let delegate = MockCheckoutDelegate()
         checkout.delegate = delegate
 
-        // First confirm
+        // First update
         var firstResponse = CheckoutTestHelpers.makeOpenSessionJSON()
         firstResponse["status"] = "complete"
         firstResponse["payment_status"] = "paid"
         let firstConfirm = STPCheckoutSession.decodedObject(fromAPIResponse: firstResponse)!
 
-        checkout.stpSession!.onConfirmed?(firstConfirm)
+        checkout.updateSession(firstConfirm)
         XCTAssertEqual(checkout.state.session.status?.type, .complete)
 
-        // The new session should also have onConfirmed set,
-        // so a second invocation still works
-        let secondSession = checkout.stpSession!
-        XCTAssertNotNil(secondSession.onConfirmed)
+        // Second update still works on the same Checkout instance
+        var secondResponse = CheckoutTestHelpers.makeOpenSessionJSON()
+        secondResponse["status"] = "complete"
+        secondResponse["payment_status"] = "paid"
+        let secondConfirm = STPCheckoutSession.decodedObject(fromAPIResponse: secondResponse)!
+
+        checkout.updateSession(secondConfirm)
+        XCTAssertEqual(checkout.state.session.status?.type, .complete)
     }
 
     // MARK: - State Convenience Tests

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/STPCheckoutSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/STPCheckoutSessionTest.swift
@@ -462,7 +462,7 @@ class STPCheckoutSessionTest: XCTestCase {
             "setup_future_usage": "off_session",
         ])
 
-        XCTAssertEqual(Intent.checkoutSession(session).setupFutureUsageString, "off_session")
+        XCTAssertEqual(Intent.checkout(Checkout(session: session)).setupFutureUsageString, "off_session")
     }
 
     func testCheckoutSessionIntent_isPaymentMethodOptionsSetupFutureUsageSet() {
@@ -473,7 +473,7 @@ class STPCheckoutSessionTest: XCTestCase {
             "payment_method_types": ["paypal"],
         ])
 
-        XCTAssertEqual(Intent.checkoutSession(session).isPaymentMethodOptionsSetupFutureUsageSet, true)
+        XCTAssertEqual(Intent.checkout(Checkout(session: session)).isPaymentMethodOptionsSetupFutureUsageSet, true)
     }
 
     func testCheckoutSessionIntent_isSetupFutureUsageSet_topLevel() {
@@ -482,7 +482,7 @@ class STPCheckoutSessionTest: XCTestCase {
             "payment_method_types": ["paypal"],
         ])
 
-        XCTAssertTrue(Intent.checkoutSession(session).isSetupFutureUsageSet(for: .payPal))
+        XCTAssertTrue(Intent.checkout(Checkout(session: session)).isSetupFutureUsageSet(for: .payPal))
     }
 
     func testCheckoutSessionIntent_isSetupFutureUsageSet_topLevelNone() {
@@ -491,8 +491,8 @@ class STPCheckoutSessionTest: XCTestCase {
             "payment_method_types": ["paypal"],
         ])
 
-        XCTAssertEqual(Intent.checkoutSession(session).setupFutureUsageString, "none")
-        XCTAssertFalse(Intent.checkoutSession(session).isSetupFutureUsageSet(for: .payPal))
+        XCTAssertEqual(Intent.checkout(Checkout(session: session)).setupFutureUsageString, "none")
+        XCTAssertFalse(Intent.checkout(Checkout(session: session)).isSetupFutureUsageSet(for: .payPal))
     }
 
     func testCheckoutSessionIntent_isSetupFutureUsageSet_perPaymentMethod() {
@@ -503,7 +503,7 @@ class STPCheckoutSessionTest: XCTestCase {
             "payment_method_types": ["paypal"],
         ])
 
-        XCTAssertTrue(Intent.checkoutSession(session).isSetupFutureUsageSet(for: .payPal))
+        XCTAssertTrue(Intent.checkout(Checkout(session: session)).isSetupFutureUsageSet(for: .payPal))
     }
 
     func testCheckoutSessionIntent_isSetupFutureUsageSet_perPaymentMethodNoneOverridesTopLevel() {
@@ -515,7 +515,7 @@ class STPCheckoutSessionTest: XCTestCase {
             "payment_method_types": ["paypal"],
         ])
 
-        XCTAssertFalse(Intent.checkoutSession(session).isSetupFutureUsageSet(for: .payPal))
+        XCTAssertFalse(Intent.checkout(Checkout(session: session)).isSetupFutureUsageSet(for: .payPal))
     }
 
     // MARK: - TaxStatus Tests

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/STPCheckoutSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/STPCheckoutSessionTest.swift
@@ -12,6 +12,7 @@
 import StripePaymentsObjcTestUtils
 import XCTest
 
+@MainActor
 class STPCheckoutSessionTest: XCTestCase {
     private func makeCheckoutSession(_ overrides: [String: Any]) -> STPCheckoutSession {
         var json: [String: Any] = [

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
@@ -356,7 +356,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkoutSession(checkoutSession),
+            intent: .checkout(Checkout(session: checkoutSession)),
             elementsSession: elementsSession,
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
@@ -389,7 +389,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkoutSession(checkoutSession),
+            intent: .checkout(Checkout(session: checkoutSession)),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
@@ -422,7 +422,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkoutSession(checkoutSession),
+            intent: .checkout(Checkout(session: checkoutSession)),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
@@ -454,7 +454,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkoutSession(checkoutSession),
+            intent: .checkout(Checkout(session: checkoutSession)),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
@@ -489,7 +489,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkoutSession(checkoutSession),
+            intent: .checkout(Checkout(session: checkoutSession)),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
@@ -528,7 +528,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkoutSession(checkoutSession),
+            intent: .checkout(Checkout(session: checkoutSession)),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
@@ -563,7 +563,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkoutSession(checkoutSession),
+            intent: .checkout(Checkout(session: checkoutSession)),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
@@ -15,6 +15,7 @@ import XCTest
 import OHHTTPStubs
 import OHHTTPStubsSwift
 
+@MainActor
 final class PaymentSheetAPIMockTest: APIStubbedTestCase {
     enum MockJson {
         static let cardPaymentMethod = STPTestUtils.jsonNamed("CardPaymentMethod")!

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -84,7 +84,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             json["customer_managed_saved_payment_methods_offer_save"] = offerSave
         }
         let checkoutSession = STPCheckoutSession.decodedObject(fromAPIResponse: json)!
-        return .checkoutSession(checkoutSession)
+        return .checkout(Checkout(session: checkoutSession))
     }
 
     func testUpdatesParams() {
@@ -2877,7 +2877,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             }
             let checkoutSession = STPCheckoutSession.decodedObject(fromAPIResponse: json)!
             return PaymentSheetFormFactory(
-                intent: .checkoutSession(checkoutSession),
+                intent: .checkout(Checkout(session: checkoutSession)),
                 elementsSession: ._testValue(paymentMethodTypes: ["paypal"]),
                 configuration: .paymentElement(PaymentSheet.Configuration._testValue_MostPermissive()),
                 paymentMethod: .stripe(.payPal),

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -34,6 +34,7 @@ class MockElement: Element {
     lazy var view: UIView = { UIView() }()
 }
 
+@MainActor
 class PaymentSheetFormFactoryTest: XCTestCase {
     private func extractBNPLHeaderView(from subtitle: SubtitleElement) -> BNPLFormHeaderView? {
         if let headerView = subtitle.view as? BNPLFormHeaderView {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -462,7 +462,7 @@ final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
                         clientDefaultPaymentMethod: nil,
                         configuration: configuration
                     )
-                case .checkoutSession:
+                case .checkout:
                     elementsSession = ._testValue(intent: intent)
                 }
 
@@ -1018,7 +1018,7 @@ extension PaymentSheetLPMConfirmFlowTests {
             XCTAssertEqual(regeneratedIntentConfirmParams, intentConfirmParams)
 
             // Checkout sessions require a billing email on the payment method
-            if case .checkoutSession = intent {
+            if case .checkout = intent {
                 intentConfirmParams.paymentMethodParams.nonnil_billingDetails.email = "test@example.com"
             }
 
@@ -1137,7 +1137,7 @@ extension PaymentSheetLPMConfirmFlowTests {
             intents = [
                 ("PaymentIntent", .paymentIntent(paymentIntent)),
                 ("Deferred PaymentIntent - client side confirmation", makeDeferredIntent(deferredCSC)),
-                ("CheckoutSession", .checkoutSession(checkoutSession)),
+                ("CheckoutSession", .checkout(Checkout(session: checkoutSession))),
             ]
             guard paymentMethod != .blik else {
                 // Blik doesn't support server-side confirmation
@@ -1278,7 +1278,7 @@ extension PaymentSheetLPMConfirmFlowTests {
                     checkoutSessionId: checkoutSessionResponse.id,
                     adaptivePricingAllowed: true
                 )
-                intents.append(("CheckoutSession w/ setup_future_usage", .checkoutSession(checkoutSession)))
+                intents.append(("CheckoutSession w/ setup_future_usage", .checkout(Checkout(session: checkoutSession))))
             }
 
             return intents
@@ -1390,7 +1390,7 @@ extension PaymentSheetLPMConfirmFlowTests {
                     checkoutSessionId: checkoutSessionResponse.id,
                     adaptivePricingAllowed: true
                 )
-                intents.append(("CheckoutSession w/ PMO setup_future_usage", .checkoutSession(checkoutSession)))
+                intents.append(("CheckoutSession w/ PMO setup_future_usage", .checkout(Checkout(session: checkoutSession))))
             }
 
             return intents
@@ -1430,7 +1430,7 @@ extension PaymentSheetLPMConfirmFlowTests {
                 ("Deferred SetupIntent - server side confirmation", makeDeferredIntent(deferredSSC)),
                 ("Deferred SetupIntent - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
                 ("Deferred SetupIntent - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
-                ("CheckoutSession", .checkoutSession(checkoutSession)),
+                ("CheckoutSession", .checkout(Checkout(session: checkoutSession))),
             ]
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -509,7 +509,7 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         let loaded = expectation(description: "Loaded")
         STPAssertTestUtil.shouldSuppressNextSTPAlert = true
         PaymentSheetLoader.load(
-            mode: .checkoutSession(checkoutSession),
+            mode: .checkout(Checkout(session: checkoutSession)),
             configuration: configuration,
             analyticsHelper: ._testValue(integrationShape: .complete),
             integrationShape: .paymentSheet
@@ -539,7 +539,7 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         let loaded = expectation(description: "Loaded")
         STPAssertTestUtil.shouldSuppressNextSTPAlert = true
         PaymentSheetLoader.load(
-            mode: .checkoutSession(checkoutSession),
+            mode: .checkout(Checkout(session: checkoutSession)),
             configuration: configuration,
             analyticsHelper: ._testValue(integrationShape: .complete),
             integrationShape: .paymentSheet

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -12,6 +12,7 @@ import OHHTTPStubsSwift
 import StripePaymentsObjcTestUtils
 import XCTest
 
+@MainActor
 class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
     private func configuration(apiClient: STPAPIClient) -> PaymentSheet.Configuration {
         var config = PaymentSheet.Configuration()

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -783,8 +783,9 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
         // Fetch the full STPCheckoutSession object (with allResponseFields containing elements_session)
         let checkoutSession = try await customApiClient.initCheckoutSession(checkoutSessionId: checkoutSessionId, adaptivePricingAllowed: true)
 
+        let checkout = Checkout(session: checkoutSession)
         PaymentSheetLoader.load(
-            mode: .checkoutSession(checkoutSession),
+            mode: .checkout(checkout),
             configuration: configuration,
             analyticsHelper: .init(integrationShape: .complete, configuration: configuration),
             integrationShape: .paymentSheet
@@ -792,16 +793,12 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
             expectation.fulfill()
             switch result {
             case .success(let (loadResult, _)):
-                // Verify the intent is a checkoutSession
-                guard case let .checkoutSession(loadedSession) = loadResult.intent else {
-                    XCTFail("Expected checkoutSession intent type")
+                guard case let .checkout(loadedCheckout) = loadResult.intent else {
+                    XCTFail("Expected checkout intent type")
                     return
                 }
-                // Verify CheckoutSession properties
-                XCTAssertEqual(loadedSession.id, checkoutSessionId)
-                // Verify elements session is loaded
+                XCTAssertEqual(loadedCheckout.stpSession.id, checkoutSessionId)
                 XCTAssertTrue(loadResult.elementsSession.sessionID.hasPrefix("elements_session_"))
-                // Verify payment methods are loaded
                 XCTAssertTrue(loadResult.elementsSession.orderedPaymentMethodTypes.contains(.card))
             case .failure(let error):
                 XCTFail(error.nonGenericDescription)
@@ -813,7 +810,6 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
     @MainActor
     func testPaymentSheetLoadWithCheckoutSessionSetup() async throws {
         let expectation = XCTestExpectation(description: "Load w/ CheckoutSession setup mode")
-        // Fetch a fresh checkout session in setup mode from the test backend
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionSetupMode()
         let checkoutSessionId = checkoutSessionResponse.id
         let customApiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
@@ -821,11 +817,11 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
         configuration.apiClient = customApiClient
         configuration.defaultBillingDetails.email = "test@example.com"
 
-        // Fetch the full STPCheckoutSession object (with allResponseFields containing elements_session)
         let checkoutSession = try await customApiClient.initCheckoutSession(checkoutSessionId: checkoutSessionId, adaptivePricingAllowed: true)
+        let checkout = Checkout(session: checkoutSession)
 
         PaymentSheetLoader.load(
-            mode: .checkoutSession(checkoutSession),
+            mode: .checkout(checkout),
             configuration: configuration,
             analyticsHelper: .init(integrationShape: .complete, configuration: configuration),
             integrationShape: .paymentSheet
@@ -833,19 +829,15 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
             expectation.fulfill()
             switch result {
             case .success(let (loadResult, _)):
-                // Verify the intent is a checkoutSession
-                guard case let .checkoutSession(checkoutSession) = loadResult.intent else {
-                    XCTFail("Expected checkoutSession intent type")
+                guard case let .checkout(loadedCheckout) = loadResult.intent else {
+                    XCTFail("Expected checkout intent type")
                     return
                 }
-                // Verify CheckoutSession properties
-                XCTAssertEqual(checkoutSession.id, checkoutSessionId)
-                XCTAssertEqual(checkoutSession.mode, .setup)
-                XCTAssertEqual(checkoutSession.status?.type, .open)
-                XCTAssertEqual(checkoutSession.status?.paymentStatus, .noPaymentRequired)
-                // Verify elements session is loaded
+                XCTAssertEqual(loadedCheckout.stpSession.id, checkoutSessionId)
+                XCTAssertEqual(loadedCheckout.stpSession.mode, .setup)
+                XCTAssertEqual(loadedCheckout.stpSession.status?.type, .open)
+                XCTAssertEqual(loadedCheckout.stpSession.status?.paymentStatus, .noPaymentRequired)
                 XCTAssertTrue(loadResult.elementsSession.sessionID.hasPrefix("elements_session_"))
-                // Verify payment methods are loaded
                 XCTAssertTrue(loadResult.elementsSession.orderedPaymentMethodTypes.contains(.card))
             case .failure(let error):
                 XCTFail(error.nonGenericDescription)
@@ -857,7 +849,6 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
     @MainActor
     func testPaymentSheetLoadWithDirectCheckoutSessionMissingElementsSession() async throws {
         let expectation = XCTestExpectation(description: "Load w/ direct CheckoutSession missing elements_session")
-        // Create a minimal STPCheckoutSession without elements_session in allResponseFields
         let mockJSON: [AnyHashable: Any] = [
             "session_id": "cs_test_fake",
             "livemode": false,
@@ -869,12 +860,13 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
             XCTFail("Failed to create mock STPCheckoutSession")
             return
         }
+        let checkout = Checkout(session: checkoutSession)
         var configuration = PaymentSheet.Configuration()
         configuration.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
         configuration.defaultBillingDetails.email = "test@example.com"
 
         PaymentSheetLoader.load(
-            mode: .checkoutSession(checkoutSession),
+            mode: .checkout(checkout),
             configuration: configuration,
             analyticsHelper: .init(integrationShape: .complete, configuration: configuration),
             integrationShape: .paymentSheet

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -12,6 +12,7 @@
 @testable import StripePaymentsTestUtils
 import XCTest
 
+@MainActor
 final class STPApplePayContext_PaymentSheetTest: XCTestCase {
     let dummyDeferredConfirmHandler: PaymentSheet.IntentConfiguration.ConfirmHandler = { _, _ in return "" /* no-op */ }
     let dummyConfirmationTokenConfirmHandler: PaymentSheet.IntentConfiguration.ConfirmationTokenConfirmHandler = { _ in return "" }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -233,8 +233,8 @@ extension STPElementsSession {
                 return setupIntent.paymentMethodTypes.map { STPPaymentMethod.string(from: $0) ?? "unknown" }
             case .deferredIntent(let intentConfig):
                 return intentConfig.paymentMethodTypes ?? []
-            case .checkoutSession(let checkoutSession):
-                return checkoutSession.paymentMethodTypes.map { STPPaymentMethod.string(from: $0) ?? "unknown" }
+            case .checkout(let checkout):
+                return checkout.stpSession.paymentMethodTypes.map { STPPaymentMethod.string(from: $0) ?? "unknown" }
             }
         }()
         var customerSessionData: [String: Any]?
@@ -379,7 +379,7 @@ extension Intent {
         }
 
         let checkoutSession = STPCheckoutSession.decodedObject(fromAPIResponse: json)!
-        return .checkoutSession(checkoutSession)
+        return .checkout(Checkout(session: checkoutSession))
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -297,7 +297,7 @@ extension Intent {
         return .deferredIntent(intentConfig: .init(mode: .payment(amount: 1010, currency: "USD", setupFutureUsage: setupFutureUsage, paymentMethodOptions: PaymentSheet.IntentConfiguration.Mode.PaymentMethodOptions(setupFutureUsageValues: paymentMethodOptionsSetupFutureUsage)), confirmHandler: { _, _ in return "" }))
     }
 
-    static func _testCheckoutSession(
+    @MainActor static func _testCheckoutSession(
         mode: Checkout.Mode = .payment,
         amount: Int? = 2345,
         currency: String = "USD",

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTests.swift
@@ -131,7 +131,7 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
         let sut = SavedPaymentMethodManager(
             configuration: configuration,
             elementsSession: ._testValue(paymentMethodTypes: ["card"]),
-            intent: .checkoutSession(checkoutSession)
+            intent: .checkout(Checkout(session: checkoutSession))
         )
         sut.detach(paymentMethod: paymentMethod)
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTests.swift
@@ -12,6 +12,7 @@ import StripeCoreTestUtils
 @_spi(STP)@testable import StripePaymentSheet
 import XCTest
 
+@MainActor
 final class SavedPaymentMethodManagerTests: XCTestCase {
 
     let ephemeralKey = "test-eph-key"

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
@@ -232,7 +232,7 @@ class VerticalSavedPaymentMethodsViewControllerTests: XCTestCase {
         guard let checkoutSession = STPCheckoutSession.decodedObject(fromAPIResponse: json) else {
             fatalError("Failed to create checkout session test fixture")
         }
-        return .checkoutSession(checkoutSession)
+        return .checkout(Checkout(session: checkoutSession))
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
@@ -10,6 +10,7 @@ import StripeCoreTestUtils
 @testable @_spi(STP) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) import StripePaymentSheet
 import XCTest
 
+@MainActor
 class VerticalSavedPaymentMethodsViewControllerTests: XCTestCase {
 
     var paymentMethods: [STPPaymentMethod]!


### PR DESCRIPTION
## Summary
  - Refactors Intent.checkoutSession(STPCheckoutSession) to Intent.checkout(Checkout), passing the SDK's lifecycle manager instead of the raw API model
  - Removes the onConfirmed closure indirection on STPCheckoutSession; PaymentSheet now calls checkout.updateSession(_:) directly

## Motivation
- This will make it easier for future users to make updates to Checkout from MPE, like updating the billing address or other. Now we can just call `checkout.updateX(...)` within MPE easily.

## Testing
- Existing tests

## Changelog
N/A