### PR TITLE
Respect FC Lite experiment assignment

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -173,7 +173,7 @@ final class PaymentSheetLoader {
             let isFcLiteKillswitchEnabled = elementsSession.flags["elements_disable_fc_lite"] == true
             FinancialConnectionsSDKAvailability.fcLiteKillswitchEnabled = isFcLiteKillswitchEnabled
 
-            let remoteFcLiteOverrideEnabled = elementsSession.flags["elements_prefer_fc_lite"] == true
+            let remoteFcLiteOverrideEnabled = shouldPreferFCLite(elementsSession: elementsSession)
             FinancialConnectionsSDKAvailability.remoteFcLiteOverride = remoteFcLiteOverrideEnabled
 
             let paymentMethodTypes = PaymentSheet.PaymentMethodType.filteredPaymentMethodTypes(from: intent, elementsSession: elementsSession, configuration: configuration, logAvailability: true)
@@ -674,6 +674,13 @@ final class PaymentSheetLoader {
         }
 
         return allowedCountries.contains(billingCountry)
+    }
+
+    static func shouldPreferFCLite(elementsSession: STPElementsSession) -> Bool {
+        let flagPrefersFCLite = elementsSession.flags["elements_prefer_fc_lite"] == true
+        let experimentPrefersFCLite =
+            elementsSession.experimentsData?.experimentAssignments[ConnectionsFCLiteVsNative.experimentName] == .treatment
+        return flagPrefersFCLite || experimentPrefersFCLite
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderFCLiteTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderFCLiteTests.swift
@@ -1,0 +1,43 @@
+//
+//  PaymentSheetLoaderFCLiteTests.swift
+//  StripePaymentSheetTests
+//
+
+@testable @_spi(STP) import StripePaymentSheet
+import XCTest
+
+final class PaymentSheetLoaderFCLiteTests: XCTestCase {
+    func testShouldPreferFCLiteWhenElementsSessionFlagEnabled() {
+        let elementsSession = STPElementsSession._testValue(
+            flags: ["elements_prefer_fc_lite": true]
+        )
+
+        XCTAssertTrue(PaymentSheetLoader.shouldPreferFCLite(elementsSession: elementsSession))
+    }
+
+    func testShouldPreferFCLiteWhenExperimentAssignmentIsTreatment() {
+        let experimentsData = ExperimentsData(
+            arbId: "test_arb",
+            experimentAssignments: [ConnectionsFCLiteVsNative.experimentName: .treatment],
+            allResponseFields: [:]
+        )
+        let elementsSession = STPElementsSession._testValue(
+            experimentsData: experimentsData
+        )
+
+        XCTAssertTrue(PaymentSheetLoader.shouldPreferFCLite(elementsSession: elementsSession))
+    }
+
+    func testShouldNotPreferFCLiteWhenFlagDisabledAndExperimentNotInTreatment() {
+        let experimentsData = ExperimentsData(
+            arbId: "test_arb",
+            experimentAssignments: [ConnectionsFCLiteVsNative.experimentName: .control],
+            allResponseFields: [:]
+        )
+        let elementsSession = STPElementsSession._testValue(
+            experimentsData: experimentsData
+        )
+
+        XCTAssertFalse(PaymentSheetLoader.shouldPreferFCLite(elementsSession: elementsSession))
+    }
+}


### PR DESCRIPTION
## Summary

Updates our SDKs to prefer FC Lite over the FC SDK when the `connections_fc_lite_vs_native` experiment assignment is `treatment`.

## Motivation

https://docs.google.com/document/d/1op-_3Wzg1oKxb4DN7NXmLjbjM6DmQ3jii_9naKSQUcM/edit?usp=sharing

## Testing

Tests added

## Changelog

N/a
