### PR TITLE
Add analytics for payments cancelled due to polling budget exhaustion

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -40,6 +40,7 @@ import Foundation
     case paymentHandlerConfirmFinished = "stripeios.paymenthandler.confirm.finished"
     case paymentHandlerHandleNextActionStarted = "stripeios.paymenthandler.handle_next_action.started"
     case paymentHandlerHandleNextActionFinished = "stripeios.paymenthandler.handle_next_action.finished"
+    case paymentHandlerCanceledPollingDurationExceeded = "stripeios.paymenthandler.canceled.polling_duration_exceeded"
 
     // MARK: - Card Metadata
     case cardMetadataLoadedTooSlow = "stripeios.card_metadata_loaded_too_slow"

--- a/StripePayments/StripePayments/Source/PaymentHandler/PollingBudget.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/PollingBudget.swift
@@ -12,7 +12,7 @@ import Foundation
 final class PollingBudget {
     /// The timestamp when polling started
     private var startDate: Date
-    /// The polling duration in seconds
+    /// The maximum polling duration in seconds
     private let duration: TimeInterval
     /// Whether polling is currently allowed
     private(set) var canPoll: Bool = true
@@ -20,7 +20,7 @@ final class PollingBudget {
     private var lastPollAttempt: Date?
 
     /// The elapsed time since polling started
-    private var elapsedTime: TimeInterval {
+    var elapsedTime: TimeInterval {
         return Date().timeIntervalSince(startDate)
     }
 

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPAnalyticsClient+STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPAnalyticsClient+STPPaymentHandler.swift
@@ -165,6 +165,24 @@ extension STPPaymentHandler {
         case appForegrounded = "app_foregrounded"
     }
 
+    // MARK: - Polling duration exceeded -> canceled
+
+    func logPollingDurationExceededCancellation(intentID: String?, paymentMethodType: String?, duration: TimeInterval) {
+        let analytic = Analytic(
+            event: .paymentHandlerCanceledPollingDurationExceeded,
+            intentID: intentID,
+            actionID: actionID,
+            status: nil,
+            paymentMethodType: paymentMethodType,
+            paymentMethodID: nil,
+            duration: duration,
+            error: nil
+        )
+        analyticsClient.log(analytic: analytic, apiClient: apiClient)
+    }
+
+    // MARK: - URL Redirect next action
+
     func logURLRedirectNextActionStarted(redirectType: URLRedirectNextActionRedirectType) {
         let analytic = GenericAnalytic(event: .urlRedirectNextAction, params: [
             "redirect_type": redirectType.rawValue,

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1645,6 +1645,14 @@ public class STPPaymentHandler: NSObject {
                                     } else if paymentMethodType != .paynow && paymentMethodType != .promptPay {
                                         // For PayNow, we don't want to mark as canceled when the web view dismisses
                                         // Instead we rely on the presented PollingViewController to complete the currentAction
+                                        if let pollingBudget, !pollingBudget.canPoll {
+                                            // Log if we are canceling because we finished polling and the status is not terminal
+                                            self.logPollingDurationExceededCancellation(
+                                                intentID: paymentIntent.stripeId,
+                                                paymentMethodType: paymentMethodType.identifier,
+                                                duration: pollingBudget.elapsedTime
+                                            )
+                                        }
                                         self._markChallengeCanceled(currentAction: currentAction) { _, _ in
                                             // We don't forward cancelation errors
                                             currentAction.complete(with: .canceled, error: nil)
@@ -1723,6 +1731,14 @@ public class STPPaymentHandler: NSObject {
                             } else {
                                 // If the status is still RequiresAction, the user exited from the redirect before the
                                 // setup intent was updated. Consider it a cancel
+                                if let pollingBudget, !pollingBudget.canPoll {
+                                    // Log if we are canceling because we finished polling and the status is not terminal
+                                    self.logPollingDurationExceededCancellation(
+                                        intentID: setupIntent.stripeID,
+                                        paymentMethodType: paymentMethod.type.identifier,
+                                        duration: pollingBudget.elapsedTime
+                                    )
+                                }
                                 self._markChallengeCanceled(currentAction: currentAction) { _, _ in
                                     // We don't forward cancelation errors
                                     currentAction.complete(with: .canceled, error: nil)


### PR DESCRIPTION
When the SDK cancels a payment because the polling budget has been exhausted (i.e., the intent is still in requires_action after the polling duration elapses), we now fire a
'paymenthandler.canceled.polling_budget_exhausted' analytic event.

This analytic includes the intent ID, payment method type, and duration, providing visibility into how often polling timeouts cause cancellations.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5404

## Testing
Manually tested
-  canceling revolut pay sends the analytic
- succesfully paying, failing to pay w/ revolut pay does not send analytic

## Changelog
Not user facing