### PR TITLE
[Xcode 27] Fix javaScriptEnabled deprecation warning

### DIFF
--- a/Stripe3DS2/Stripe3DS2/STDSWebView.m
+++ b/Stripe3DS2/Stripe3DS2/STDSWebView.m
@@ -15,7 +15,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init {
     WKWebViewConfiguration *configuration = [[WKWebViewConfiguration alloc] init];
 #if !TARGET_OS_VISION
-    configuration.preferences.javaScriptEnabled = NO;
+    if (@available(iOS 15.0, *)) {
+        WKWebpagePreferences *pagePreferences = [[WKWebpagePreferences alloc] init];
+        pagePreferences.allowsContentJavaScript = NO;
+        configuration.defaultWebpagePreferences = pagePreferences;
+    } else {
+        configuration.preferences.javaScriptEnabled = NO;
+    }
 #endif
     return [super initWithFrame:CGRectZero configuration:configuration];
 }


### PR DESCRIPTION
## Summary
- Uses WKWebpagePreferences.allowsContentJavaScript on iOS 15 and later
- Keeps WKPreferences.javaScriptEnabled for older OS versions, will remove shortly