### PR TITLE
[Xcode 27] Fix UIApplication shared windows deprecation warnings

### DIFF
--- a/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
+++ b/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
@@ -574,7 +574,15 @@ class PlaygroundViewController: UIViewController {
 
     func applyUIAppearance() {
         // Changes to UIAppearance are only applied when the view is added to the window hierarchy
-        UIApplication.shared.windows.forEach { window in
+        let windows: [UIWindow]
+        if #available(iOS 15.0, *) {
+            windows = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+        } else {
+            windows = UIApplication.shared.windows
+        }
+        windows.forEach { window in
             window.subviews.forEach { view in
                 view.removeFromSuperview()
                 window.addSubview(view)

--- a/Example/PaymentSheet Example/PaymentSheet Example/AppDelegate+BrokenConstraints.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/AppDelegate+BrokenConstraints.swift
@@ -32,7 +32,7 @@ extension AppDelegate {
         guard let constraint = notification.object as? NSLayoutConstraint else {
             return
         }
-        let window = UIApplication.shared.windows.first(where: { $0.isKeyWindow })
+        let window = UIApplication.shared.stripe_keyWindow
         // Ignore broken constraints that existed at the time of writing this - please try to fix newly introduced ones instead of ignoring!
         // Sometimes the broken constraint references something that is unique, in which case we can ignore it easily
         let ignoredBrokenConstraints = [

--- a/Example/PaymentSheet Example/PaymentSheet Example/AppDelegate.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/AppDelegate.swift
@@ -28,7 +28,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             PlaygroundController.resetCustomer()
 
             // Speed up animations for quicker CI times
-            UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.layer.speed = 100
+            UIApplication.shared.stripe_keyWindow?.layer.speed = 100
         }
 #endif
         catchBrokenConstraints()
@@ -54,5 +54,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the user discards a scene session.
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+}
+
+extension UIApplication {
+    var stripe_allWindows: [UIWindow] {
+        if #available(iOS 15.0, *) {
+            return connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+        } else {
+            return windows
+        }
+    }
+
+    var stripe_keyWindow: UIWindow? {
+        stripe_allWindows.first { $0.isKeyWindow }
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/CustomerSheetTestPlaygroundController.swift
@@ -58,7 +58,7 @@ class CustomerSheetTestPlaygroundController: ObservableObject {
 
     var rootViewController: UIViewController {
         // Hack, should do this in SwiftUI
-        return UIApplication.shared.windows.first!.rootViewController!
+        return UIApplication.shared.stripe_keyWindow!.rootViewController!
     }
 
     func makeAlertController() -> UIAlertController {

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
@@ -610,7 +610,7 @@ struct ExampleLinkControllerView: View {
     }
 
     private func findViewController() -> UIViewController? {
-        let keyWindow = UIApplication.shared.windows.filter { $0.isKeyWindow }.first
+        let keyWindow = UIApplication.shared.stripe_keyWindow
         var topController = keyWindow?.rootViewController
         while let presentedViewController = topController?.presentedViewController {
             topController = presentedViewController

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkStandaloneComponent.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkStandaloneComponent.swift
@@ -661,7 +661,7 @@ enum CarType: CaseIterable {
 }
 
 private func findViewController() -> UIViewController? {
-    let keyWindow = UIApplication.shared.windows.filter { $0.isKeyWindow }.first
+    let keyWindow = UIApplication.shared.stripe_keyWindow
     var topController = keyWindow?.rootViewController
     while let presentedViewController = topController?.presentedViewController {
         topController = presentedViewController

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -616,7 +616,7 @@ import UIKit
 
     var rootViewController: UIViewController {
         // Hack, should do this in SwiftUI
-        return UIApplication.shared.windows.first!.rootViewController!
+        return UIApplication.shared.stripe_keyWindow!.rootViewController!
     }
 
     private var subscribers: Set<AnyCancellable> = []

--- a/Example/PaymentSheet Example/PaymentSheet Example/ViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ViewController.swift
@@ -70,14 +70,7 @@ extension UIViewController {
 
     static func topMostViewController() -> UIViewController? {
         let window: UIWindow?
-        #if os(visionOS)
-        window = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap { $0.windows }
-            .first { $0.isKeyWindow }
-        #else
-        window = UIApplication.shared.keyWindow
-        #endif
+        window = UIApplication.shared.stripe_keyWindow
         guard let window else {
             return nil
         }

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -230,7 +230,15 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
             .sorted { firstWindow, _ in firstWindow.isKeyWindow }
         let window = windows.first
         #else
-        let window = UIApplication.shared.windows.first { $0.isKeyWindow }
+        let window: UIWindow?
+        if #available(iOS 15.0, *) {
+            window = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+                .first { $0.isKeyWindow }
+        } else {
+            window = UIApplication.shared.windows.first { $0.isKeyWindow }
+        }
         #endif
         self.presentApplePay(from: window, completion: completion)
     }

--- a/StripeCardScan/StripeCardScan/Source/CardScan/UI/InterfaceOrientation.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardScan/UI/InterfaceOrientation.swift
@@ -9,11 +9,17 @@ import UIKit
 
 extension UIWindow {
     static var interfaceOrientation: UIInterfaceOrientation {
-        return
-            UIApplication.shared.windows
-            .first?
-            .windowScene?
-            .interfaceOrientation ?? .unknown
+        if #available(iOS 15.0, *) {
+            return UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .first?
+                .interfaceOrientation ?? .unknown
+        } else {
+            return UIApplication.shared.windows
+                .first?
+                .windowScene?
+                .interfaceOrientation ?? .unknown
+        }
     }
 
     static var interfaceOrientationToString: String {

--- a/StripeCardScan/StripeCardScan/Source/CardVerify/Helpers/EndToEndTestDataSource.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardVerify/Helpers/EndToEndTestDataSource.swift
@@ -23,7 +23,15 @@
         }()
 
         func nextSquareAndFullImage() -> CGImage? {
-            guard let targetSize = UIApplication.shared.windows.first?.frame.size else {
+            let windows: [UIWindow]
+            if #available(iOS 15.0, *) {
+                windows = UIApplication.shared.connectedScenes
+                    .compactMap { $0 as? UIWindowScene }
+                    .flatMap { $0.windows }
+            } else {
+                windows = UIApplication.shared.windows
+            }
+            guard let targetSize = windows.first?.frame.size else {
                 return nil
             }
 

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/PaneLayoutView/PaneLayoutView.swift
@@ -29,7 +29,15 @@ final class PaneLayoutView {
     /// Whether or not the sheet is currently presented as a form sheet (which only happens on iPad).
     /// Unfortunately, the best way to know this is to check if the sheet's width is not equal to the window's width.
     private var isPresentedAsFormSheet: Bool {
-        guard let window = UIApplication.shared.windows.filter({ $0.isKeyWindow }).first else { return false }
+        let windows: [UIWindow]
+        if #available(iOS 15.0, *) {
+            windows = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+        } else {
+            windows = UIApplication.shared.windows
+        }
+        guard let window = windows.first(where: { $0.isKeyWindow }) else { return false }
         guard let presentingView else { return false }
         return window.frame.width != presentingView.frame.width
     }

--- a/StripePayments/StripePayments/Source/Captcha/HCaptchaWebViewManager.swift
+++ b/StripePayments/StripePayments/Source/Captcha/HCaptchaWebViewManager.swift
@@ -295,7 +295,15 @@ fileprivate extension HCaptchaWebViewManager {
             .sorted { firstWindow, _ in firstWindow.isKeyWindow }
         let window = windows.first
         #else
-        let window = UIApplication.shared.windows.first { $0.isKeyWindow }
+        let window: UIWindow?
+        if #available(iOS 15.0, *) {
+            window = UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+                .first { $0.isKeyWindow }
+        } else {
+            window = UIApplication.shared.windows.first { $0.isKeyWindow }
+        }
         #endif
         if let window {
             setupWebview(on: window, html: html, url: url)

--- a/StripePayments/StripePaymentsTests/Captcha/HCaptchaWebViewManager__Tests.swift
+++ b/StripePayments/StripePaymentsTests/Captcha/HCaptchaWebViewManager__Tests.swift
@@ -11,6 +11,18 @@
 import WebKit
 import XCTest
 
+private extension UIApplication {
+    var stp_testWindows: [UIWindow] {
+        if #available(iOS 15.0, *) {
+            return connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+        } else {
+            return windows
+        }
+    }
+}
+
 class HCaptchaWebViewManager__Tests: XCTestCase {
 
     fileprivate var apiKey: String!
@@ -19,7 +31,7 @@ class HCaptchaWebViewManager__Tests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        presenterView = UIApplication.shared.windows.first(where: { $0.isKeyWindow })?.rootViewController?.view
+        presenterView = UIApplication.shared.stp_testWindows.first(where: { $0.isKeyWindow })?.rootViewController?.view
         apiKey = UUID().uuidString
     }
 

--- a/StripePayments/StripePaymentsTests/Captcha/HCaptcha__Tests.swift
+++ b/StripePayments/StripePaymentsTests/Captcha/HCaptcha__Tests.swift
@@ -9,6 +9,18 @@
 @_spi(STP) @testable import StripePayments
 import XCTest
 
+private extension UIApplication {
+    var stp_testWindows: [UIWindow] {
+        if #available(iOS 15.0, *) {
+            return connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap { $0.windows }
+        } else {
+            return windows
+        }
+    }
+}
+
 class HCaptcha__Tests: XCTestCase {
     fileprivate struct Constants {
         struct InfoDictKeys {
@@ -82,7 +94,7 @@ class HCaptcha__Tests: XCTestCase {
         let exp = expectation(description: "execute js function must be called only once")
         let hcaptcha = HCaptcha(manager: HCaptchaWebViewManager(messageBody: "{action: \"showHCaptcha\"}"))
         hcaptcha.didFinishLoading {
-            let view = UIApplication.shared.windows.first?.rootViewController?.view
+            let view = UIApplication.shared.stp_testWindows.first?.rootViewController?.view
             hcaptcha.onEvent { e, _ in
                 if e == .open {
                     exp.fulfill()
@@ -106,7 +118,7 @@ class HCaptcha__Tests: XCTestCase {
             }
         }
         hcaptcha.didFinishLoading {
-            let view = UIApplication.shared.windows.first?.rootViewController?.view
+            let view = UIApplication.shared.stp_testWindows.first?.rootViewController?.view
             hcaptcha.onEvent { e, _ in
                 if e == .open {
                     hcaptcha.redrawView()
@@ -130,7 +142,7 @@ class HCaptcha__Tests: XCTestCase {
         hcaptcha.didFinishLoading {
             loaded.fulfill()
         }
-        let view = UIApplication.shared.windows.first!.rootViewController!.view!
+        let view = UIApplication.shared.stp_testWindows.first!.rootViewController!.view!
         hcaptcha.validate(on: view) { result in
             XCTAssertEqual("some_token", result.token)
             tokenRecieved.fulfill()


### PR DESCRIPTION
## Summary
Uses scene-based window lookup on iOS 15 and later. We'll remove the legacy path when removing iOS 13-14 support.