### PR TITLE
[Xcode 27] Fix strong capture compiler warnings

### DIFF
--- a/StripeCameraCore/StripeCameraCore/Source/Views/CameraPreviewView.swift
+++ b/StripeCameraCore/StripeCameraCore/Source/Views/CameraPreviewView.swift
@@ -64,10 +64,9 @@ import UIKit
         // Get reference to videoPreviewLayer on main queue then dispatch to
         // worker queue to set session so it doesn't block main.
 
-        let mainWorkItem = DispatchWorkItem { [weak self] in
+        let mainWorkItem = DispatchWorkItem { [weak self, weak captureSession] in
             guard let self = self else { return }
-            cameraSessionQueue.async {
-                [weak captureSession, weak videoPreviewLayer = self.videoPreviewLayer] in
+            cameraSessionQueue.async { [weak videoPreviewLayer = self.videoPreviewLayer] in
                 videoPreviewLayer?.session = captureSession
             }
         }

--- a/StripeCardScan/StripeCardScan/Source/CardVerify/VerifyCardViewController.swift
+++ b/StripeCardScan/StripeCardScan/Source/CardVerify/VerifyCardViewController.swift
@@ -269,8 +269,7 @@ class VerifyCardViewController: SimpleScanViewController {
 
             self.roiView.layer.borderColor = UIColor.red.cgColor
             self.lastWrongCard = Date()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-                guard let self = self else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
                 guard let lastWrongCard = self.lastWrongCard else { return }
                 if -lastWrongCard.timeIntervalSinceNow >= 0.5 {
                     self.showNoCard()

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -337,7 +337,8 @@ final class PartnerAuthViewController: SheetViewController {
         UIApplication.shared.open(
             url,
             options: [.universalLinksOnly: true]
-        ) { (didOpenBankingApp) in
+        ) { [weak self] (didOpenBankingApp) in
+            guard let self = self else { return }
             guard !didOpenBankingApp else {
                 // we pass control to the bank app
                 return

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/ImageScanningConcurrencyManager.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/ImageScanner/ImageScanningConcurrencyManager.swift
@@ -163,9 +163,9 @@ final class ImageScanningConcurrencyManager: ImageScanningConcurrencyManagerProt
             let scanEndTime = Date()
 
             // Update stateful properties on perfQueue
-            self.perfQueue.async { [weak self] in
-                self?.perfLastScanEndTime = scanEndTime
-                self?.perfNumFramesScanned += 1
+            self.perfQueue.async {
+                self.perfLastScanEndTime = scanEndTime
+                self.perfNumFramesScanned += 1
             }
 
             self.futureQueue.sync {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ConfirmationChallenge/PassiveCaptchaChallenge.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ConfirmationChallenge/PassiveCaptchaChallenge.swift
@@ -72,7 +72,7 @@ actor PassiveCaptchaChallenge {
     init(passiveCaptchaData: PassiveCaptchaData, hcaptchaFactory: HCaptchaFactory) {
         self.passiveCaptchaData = passiveCaptchaData
         self.hcaptchaFactory = hcaptchaFactory
-        Task { try await fetchToken() } // Intentionally not blocking loading/initialization!
+        _ = Task { try await fetchToken() } // Intentionally not blocking loading/initialization!
     }
 
     public func fetchToken() async throws -> String {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -1189,7 +1189,11 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
         collectName: Bool = false
     ) async -> LinkController.PaymentMethodPreview? {
         return await withCheckedContinuation { continuation in
-            DispatchQueue.main.async {
+            DispatchQueue.main.async { [weak self] in
+                guard let self else {
+                    continuation.resume(returning: nil)
+                    return
+                }
                 self.collectPaymentMethod(
                     from: presentingViewController,
                     with: email,

--- a/StripePayments/StripePayments/Source/Captcha/HCaptchaWebViewManager.swift
+++ b/StripePayments/StripePayments/Source/Captcha/HCaptchaWebViewManager.swift
@@ -117,7 +117,8 @@ internal class HCaptchaWebViewManager: NSObject {
         self.decoder = HCaptchaDecoder { [weak self] result in
             self?.handle(result: result)
         }
-        DispatchQueue.global(qos: .userInitiated).async {
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            guard let self = self else { return }
             let arguments = ["apiKey": config.apiKey,
                              "endpoint": config.actualEndpoint.absoluteString,
                              "size": config.size.rawValue,


### PR DESCRIPTION
## Summary
- Remove unnecessary weak/strong self dance in a few places to avoid compiler warnings
- Marks an intentionally unawaited Task as discarded