### PR TITLE
Avoid hardcoded SDK version in Crypto Onramp test

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/CryptoOnrampCoordinatorErrorMappingTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/CryptoOnrampCoordinatorErrorMappingTests.swift
@@ -129,7 +129,7 @@ final class CryptoOnrampCoordinatorErrorMappingTests: XCTestCase {
 
         Next step: Fix the integration.
         Docs: https://stripe.com/docs/test
-        SDK: stripe-ios@25.16.0
+        SDK: stripe-ios@\(STPAPIClient.STPSDKVersion)
         """)
     }
 


### PR DESCRIPTION
## Summary
- Replace the hardcoded Crypto Onramp SDK version expectation with STPAPIClient.STPSDKVersion.
- Keep the full rendered developer message assertion intact.

## Testing
- Passes CI