### PR TITLE
Derive `isLinkPassthroughMode` from wallet type

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
@@ -77,14 +77,13 @@ struct ElementsCustomer: Equatable, Hashable {
                     if let linkDetails = paymentMethodWithLinkDetails.linkDetails {
                         paymentMethod.setLinkPaymentDetails(from: linkDetails)
                     } else {
-                        paymentMethod.isLinkPassthroughMode = paymentMethodWithLinkDetails.isLinkOrigin
+                        paymentMethod.isLinkOrigin = paymentMethodWithLinkDetails.isLinkOrigin
                     }
                     paymentMethod.card?.cardArt = cardArtByPaymentMethodId[paymentMethod.stripeId]
                     paymentMethods.append(paymentMethod)
                 }
             } else {
                 if let paymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: json) {
-                    paymentMethod.isLinkPassthroughMode = paymentMethod.card?.wallet?.type == .link
                     paymentMethod.card?.cardArt = cardArtByPaymentMethodId[paymentMethod.stripeId]
                     paymentMethods.append(paymentMethod)
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -515,7 +515,7 @@ private extension STPPaymentMethod {
     func updateLocalFields(from original: STPPaymentMethod) {
         // We don't receive the following fields as part of the update response, so we need to copy them over
         linkPaymentDetails = original.linkPaymentDetails
-        isLinkPassthroughMode = original.isLinkPassthroughMode
+        isLinkOrigin = original.isLinkOrigin
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -325,7 +325,7 @@ class PaymentSheetFlowControllerTests: XCTestCase {
 
     func testPaymentOptionDisplayData_SavedLinkPassthroughUsesOnelinkLabel() {
         let paymentMethod = STPPaymentMethod._testCard()
-        paymentMethod.isLinkPassthroughMode = true
+        paymentMethod.isLinkOrigin = true
 
         let paymentOption = PaymentSheet.PaymentOption.saved(paymentMethod: paymentMethod, confirmParams: nil)
         let displayData = PaymentSheet.FlowController.PaymentOptionDisplayData(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -713,6 +713,22 @@ class STPElementsSessionTest: XCTestCase {
             "exp_year": "2040",
         ],
     ] as [AnyHashable: Any]
+    private let testCardWithLinkWalletJSON = [
+        "id": "pm_123card_link_wallet",
+        "type": "card",
+        "created": "12345",
+        "card": [
+            "last4": "4242",
+            "brand": "visa",
+            "fingerprint": "B8XXs2y2JsVBtB9f",
+            "networks": ["available": ["visa"]],
+            "exp_month": "01",
+            "exp_year": "2040",
+            "wallet": [
+                "type": "link",
+            ],
+        ],
+    ] as [AnyHashable: Any]
     private let testCardAmexJSON = [
         "id": "pm_123amexcard",
         "type": "card",
@@ -877,8 +893,11 @@ class STPElementsSessionTest: XCTestCase {
 
     // MARK: Link-wrapped format (enableLinkInSPM: true)
 
-    private func linkWrappedPM(_ pmJSON: [AnyHashable: Any]) -> [AnyHashable: Any] {
-        return ["payment_method": pmJSON]
+    private func linkWrappedPM(_ pmJSON: [AnyHashable: Any], isLinkOrigin: Bool = false) -> [AnyHashable: Any] {
+        return [
+            "payment_method": pmJSON,
+            "is_link_origin": isLinkOrigin,
+        ]
     }
 
     private func linkWrappedUnknownPM(_ pmJSON: [AnyHashable: Any]) -> [AnyHashable: Any] {
@@ -913,6 +932,21 @@ class STPElementsSessionTest: XCTestCase {
         let pm = customer?.paymentMethods.first
         XCTAssertNotNil(pm?.card?.cardArt)
         XCTAssertEqual(pm?.card?.cardArt?.artImage?.url?.absoluteString, "https://b.stripecdn.com/cardart/assets/abc123")
+    }
+
+    func testDecodeLinkWrappedPaymentMethod_setsLinkOriginWithoutLinkPaymentDetails() {
+        let response: [AnyHashable: Any] = [
+            "payment_methods_with_link_details": [linkWrappedPM(testCardJSON, isLinkOrigin: true)],
+            "customer_session": customerSessionJSON,
+        ]
+
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true)
+        let paymentMethod = customer?.paymentMethods.first
+
+        XCTAssertEqual(customer?.paymentMethods.count, 1)
+        XCTAssertTrue(paymentMethod?.isLinkOrigin ?? false)
+        XCTAssertTrue(paymentMethod?.isLinkPassthroughMode ?? false)
+        XCTAssertFalse(paymentMethod?.isLinkPaymentMethod ?? true)
     }
 
     func testMergeCardArt_linkFormat_nonMatchingId() {
@@ -974,10 +1008,26 @@ class STPElementsSessionTest: XCTestCase {
         let paymentMethod = try XCTUnwrap(customer?.paymentMethods.first)
         XCTAssertEqual(paymentMethod.type, .link)
         XCTAssertTrue(paymentMethod.isLinkPaymentMethod)
+        XCTAssertFalse(paymentMethod.isLinkPassthroughMode)
         guard case .generic(let genericDetails) = paymentMethod.linkPaymentDetails else {
             return XCTFail("Expected generic Link payment details")
         }
         XCTAssertEqual(genericDetails.label, "Pix")
         XCTAssertEqual(genericDetails.sublabel, "000••••••••")
+    }
+
+    func testDecodeFlatPaymentMethod_derivesLinkPassthroughFromWallet() throws {
+        let response: [AnyHashable: Any] = [
+            "payment_methods": [testCardWithLinkWalletJSON],
+            "customer_session": customerSessionJSON,
+        ]
+
+        let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false)
+        let paymentMethod = try XCTUnwrap(customer?.paymentMethods.first)
+
+        XCTAssertEqual(customer?.paymentMethods.count, 1)
+        XCTAssertFalse(paymentMethod.isLinkOrigin)
+        XCTAssertTrue(paymentMethod.isLinkPassthroughMode)
+        XCTAssertFalse(paymentMethod.isLinkPaymentMethod)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPPaymentMethod+PaymentSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPPaymentMethod+PaymentSheetTests.swift
@@ -26,6 +26,24 @@ class STPPPaymentMethodPaymentSheetTests: XCTestCase {
         XCTAssertEqual(paymentMethod.linkPaymentDetailsFormattedString, "Pix 000••••••••")
     }
 
+    func testIsLinkPassthroughMode() {
+        let plainCard = STPPaymentMethod._testCard()
+        XCTAssertFalse(plainCard.isLinkPassthroughMode)
+
+        let linkOriginCard = STPPaymentMethod._testCard()
+        linkOriginCard.isLinkOrigin = true
+        XCTAssertTrue(linkOriginCard.isLinkPassthroughMode)
+
+        let linkWalletCard = makeLinkWalletCardPaymentMethod()
+        XCTAssertTrue(linkWalletCard.isLinkPassthroughMode)
+        XCTAssertFalse(linkWalletCard.isLinkOrigin)
+        XCTAssertFalse(linkWalletCard.isLinkPaymentMethod)
+
+        let linkPaymentMethod = STPPaymentMethod._testLink()
+        XCTAssertTrue(linkPaymentMethod.isLinkPaymentMethod)
+        XCTAssertFalse(linkPaymentMethod.isLinkPassthroughMode)
+    }
+
     func testHasUpdatedCardParams() {
         XCTAssertFalse(_testHasUpdatedCardParams(STPPaymentMethod._testCard(), expMonth: 01, expYear: 40))
         XCTAssertTrue(_testHasUpdatedCardParams(STPPaymentMethod._testCard(), expMonth: 01, expYear: 41))
@@ -152,5 +170,23 @@ class STPPPaymentMethodPaymentSheetTests: XCTestCase {
         updatedParams.nonnil_address.country = "US"
 
         XCTAssertTrue(_testHasUpdatedFullBillingDetailsParams(paymentMethod: cardWithFullAddr, line1: "123 main", line2: "apt 2", city: "San Francisco", state: "CA", postalCode: "94016", country: "US"))
+    }
+
+    private func makeLinkWalletCardPaymentMethod() -> STPPaymentMethod {
+        return STPPaymentMethod.decodedObject(fromAPIResponse: [
+            "id": "pm_link_wallet_card",
+            "object": "payment_method",
+            "created": "12345",
+            "type": "card",
+            "card": [
+                "brand": "visa",
+                "last4": "4242",
+                "exp_month": 12,
+                "exp_year": 2025,
+                "wallet": [
+                    "type": "link",
+                ],
+            ],
+        ])!
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodRowButtonTests.swift
@@ -145,7 +145,7 @@ final class SavedPaymentMethodRowButtonTests: XCTestCase {
     func testLinkPassthroughUsesConfiguredBrandForSublabel() {
         let paymentMethod = STPPaymentMethod._testLink()
         paymentMethod.linkPaymentDetails = nil
-        paymentMethod.isLinkPassthroughMode = true
+        paymentMethod.isLinkOrigin = true
 
         let sut = SavedPaymentMethodRowButton(
             paymentMethod: paymentMethod,
@@ -160,7 +160,7 @@ final class SavedPaymentMethodRowButtonTests: XCTestCase {
 
     func testLinkPassthroughPreservesFundingDetailsInAccessibilityLabel() {
         let paymentMethod = STPPaymentMethod._testCard()
-        paymentMethod.isLinkPassthroughMode = true
+        paymentMethod.isLinkOrigin = true
 
         let sut = SavedPaymentMethodRowButton(
             paymentMethod: paymentMethod,

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
@@ -110,11 +110,17 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
     /// The payment details of a PaymentMethod that was created using Link.
     @_spi(STP) public var linkPaymentDetails: LinkPaymentDetails?
 
-    /// Whether this payment method is coming from Link.
-    @_spi(STP) public var isLinkPassthroughMode: Bool = false
+    /// Whether this payment method originated from Link.
+    @_spi(STP) public var isLinkOrigin: Bool = false
 
+    /// Whether this payment method is coming from Link in payment method mode.
     @_spi(STP) public var isLinkPaymentMethod: Bool {
         linkPaymentDetails != nil
+    }
+
+    /// Whether this payment method is coming from Link in passthrough mode.
+    @_spi(STP) public var isLinkPassthroughMode: Bool {
+        isLinkOrigin || card?.wallet?.type == .link
     }
 
     /// :nodoc:
@@ -369,7 +375,6 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
         paymentMethod.payByBank = STPPaymentMethodPayByBank.decodedObject(
             fromAPIResponse: dict.stp_dictionary(forKey: "pay_by_bank")
         )
-        paymentMethod.isLinkPassthroughMode = paymentMethod.card?.wallet?.type == .link
         return paymentMethod
     }
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
@@ -109,6 +109,7 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
 
     /// The payment details of a PaymentMethod that was created using Link.
     @_spi(STP) public var linkPaymentDetails: LinkPaymentDetails?
+
     /// Whether this payment method is coming from Link.
     @_spi(STP) public var isLinkPassthroughMode: Bool = false
 
@@ -368,6 +369,7 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
         paymentMethod.payByBank = STPPaymentMethodPayByBank.decodedObject(
             fromAPIResponse: dict.stp_dictionary(forKey: "pay_by_bank")
         )
+        paymentMethod.isLinkPassthroughMode = paymentMethod.card?.wallet?.type == .link
         return paymentMethod
     }
 }


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request updates how `isLinkPassthroughMode` is computed.

Previously, we relied on `isLinkOrigin` to be provided as part of the Elements session response. However, other calls such as `/payment_details/share` don't return this information. Therefore, we now update the logic as follows:

```
isLinkPassthroughMode = isLinkOrigin || card?.wallet.type == .link
```

With this change, we continue to take `isLinkOrigin` from the Elements sessions response while also correctly labeling newly created payment methods as originating from Link.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_LINK_MOBILE-87](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-87)

## Recording

`isLinkPassthroughMode` is `true` for card and bank payments in passthrough mode. For payments in payment method mode, the method isn't called and the log line is therefore not executed.

https://github.com/user-attachments/assets/658e41c1-a774-490f-8fb3-d686e0297e82

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

N/A
