### PR TITLE
Update the AP selector on session updates

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+CheckoutSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+CheckoutSession.swift
@@ -59,10 +59,14 @@ extension STPAPIClient {
         checkoutSessionId: String,
         parameters: [String: Any]
     ) async throws -> STPCheckoutSession {
+        var params = parameters
+        params["elements_session_client"] = [
+            "is_aggregation_expected": true,
+        ]
         return try await APIRequest<STPCheckoutSession>.post(
             with: self,
             endpoint: "payment_pages/\(checkoutSessionId)",
-            parameters: parameters
+            parameters: params
         )
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+CurrencySelectorView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+CurrencySelectorView.swift
@@ -129,8 +129,8 @@ extension Checkout {
         }
 
         /// Called when the session changes. Builds the selector on the first
-        /// session that has adaptive pricing data, then updates the caption
-        /// on subsequent changes. Hides the view if AP data is unavailable.
+        /// session that has adaptive pricing data, then updates labels and
+        /// caption on subsequent changes. Hides the view if AP data is unavailable.
         private func handleSessionUpdate() {
             guard let (session, exchangeRateMeta, rawCurrency) =
                     CurrencySelectorUtilities.adaptivePricingData(from: checkout.stpSession)
@@ -143,28 +143,29 @@ extension Checkout {
 
             clearError()
 
-            // Build the selector after initial session load; subsequent updates only change the caption
             if selectorView == nil {
                 buildSelectorView(session: session, exchangeRateMeta: exchangeRateMeta, currency: currency)
+            } else {
+                updateSelectorItems(session: session, exchangeRateMeta: exchangeRateMeta)
             }
 
             updateCaption(currency: currency, exchangeRateMeta: exchangeRateMeta)
         }
 
-        private func buildSelectorView(
-            session: STPCheckoutSession,
-            exchangeRateMeta: STPCheckoutSessionExchangeRateMeta,
-            currency: CurrencySelectorUtilities.CurrencyCode
-        ) {
-            let resolvedLabelContent: Appearance.LabelContent = {
-                guard case .automatic = appearance.labelContent else {
-                    return appearance.labelContent
-                }
-                return session.mode == .subscription ? .currencyCode : .amount
-            }()
+        private func resolveLabelContent(session: STPCheckoutSession) -> Appearance.LabelContent {
+            guard case .automatic = appearance.labelContent else {
+                return appearance.labelContent
+            }
+            return session.mode == .subscription ? .currencyCode : .amount
+        }
 
+        private func buildSelectorItems(
+            session: STPCheckoutSession,
+            exchangeRateMeta: STPCheckoutSessionExchangeRateMeta
+        ) -> (left: TwoOptionSelectorItem, right: TwoOptionSelectorItem) {
+            let resolvedLabelContent = resolveLabelContent(session: session)
             let flagFont = appearance.scaledFont(for: appearance.font, style: .footnote)
-            let (left, right) = CurrencySelectorUtilities.buildSelectorItems(
+            return CurrencySelectorUtilities.buildSelectorItems(
                 exchangeRateMeta: exchangeRateMeta,
                 localizedPricesMetas: session.localizedPricesMetas,
                 labelContent: resolvedLabelContent,
@@ -172,6 +173,22 @@ extension Checkout {
                     checkout?.flagImageManager.flagIcon(for: currency, font: flagFont) ?? NSAttributedString()
                 }
             )
+        }
+
+        private func updateSelectorItems(
+            session: STPCheckoutSession,
+            exchangeRateMeta: STPCheckoutSessionExchangeRateMeta
+        ) {
+            let (left, right) = buildSelectorItems(session: session, exchangeRateMeta: exchangeRateMeta)
+            selectorView?.updateItems(left: left, right: right)
+        }
+
+        private func buildSelectorView(
+            session: STPCheckoutSession,
+            exchangeRateMeta: STPCheckoutSessionExchangeRateMeta,
+            currency: CurrencySelectorUtilities.CurrencyCode
+        ) {
+            let (left, right) = buildSelectorItems(session: session, exchangeRateMeta: exchangeRateMeta)
 
             let newSelector = TwoOptionSelectorView(
                 leftItem: left,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TwoOptionSelectorView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TwoOptionSelectorView.swift
@@ -59,8 +59,8 @@ final class TwoOptionSelectorView: UIView {
 
     private let appearance: TwoOptionSelectorViewAppearance
 
-    private let leftItem: TwoOptionSelectorItem
-    private let rightItem: TwoOptionSelectorItem
+    private(set) var leftItem: TwoOptionSelectorItem
+    private(set) var rightItem: TwoOptionSelectorItem
     private(set) var selectedItemId: String
 
     private let mainStackView = UIStackView()
@@ -246,6 +246,22 @@ final class TwoOptionSelectorView: UIView {
             range: NSRange(location: 0, length: styled.length)
         )
         button.setAttributedTitle(styled, for: .normal)
+    }
+
+    // MARK: - Update Items
+
+    func updateItems(left: TwoOptionSelectorItem, right: TwoOptionSelectorItem) {
+        leftItem = left
+        rightItem = right
+        updateButton(leftButton, item: leftItem)
+        updateButton(rightButton, item: rightItem)
+        updateButtonStyles(animated: false)
+    }
+
+    private func updateButton(_ button: UIButton, item: TwoOptionSelectorItem) {
+        button.setAttributedTitle(item.displayText, for: .normal)
+        button.accessibilityLabel = item.accessibilityLabel
+        button.accessibilityIdentifier = item.accessibilityIdentifier
     }
 
     // MARK: - Caption

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorViewTests.swift
@@ -102,17 +102,58 @@ final class CheckoutCurrencySelectorViewTests: XCTestCase {
         await fulfillment(of: [expectation], timeout: 1.0)
     }
 
+    // MARK: - Label update tests
+
+    func testLabelsUpdateWhenSessionAmountChanges() async {
+        let checkout = await Checkout(clientSecret: "cs_test_123_secret_abc", session: CheckoutTestHelpers.makeOpenSession())
+        let session = makeSession(integrationAmount: 1200, localAmount: 1000)
+        checkout.updateSession(session)
+
+        var appearance = Checkout.CurrencySelectorView.Appearance()
+        appearance.labelContent = .amount
+        let view = Checkout.CurrencySelectorView(checkout: checkout, appearance: appearance)
+
+        // Wait for initial build
+        let built = expectation(description: "Initial build")
+        DispatchQueue.main.async {
+            built.fulfill()
+        }
+        await fulfillment(of: [built], timeout: 1.0)
+
+        let selectorView = view.subviews.compactMap { ($0 as? UIStackView)?.arrangedSubviews.compactMap { $0 as? TwoOptionSelectorView }.first }.first
+        XCTAssertNotNil(selectorView)
+        XCTAssertTrue(selectorView!.leftItem.displayText.string.contains("10"))
+        XCTAssertTrue(selectorView!.rightItem.displayText.string.contains("12"))
+
+        // Update session with new amounts
+        let updatedSession = makeSession(integrationAmount: 2400, localAmount: 2000)
+        checkout.updateSession(updatedSession)
+
+        let updated = expectation(description: "Labels updated")
+        DispatchQueue.main.async {
+            updated.fulfill()
+        }
+        await fulfillment(of: [updated], timeout: 1.0)
+
+        XCTAssertTrue(selectorView!.leftItem.displayText.string.contains("20"))
+        XCTAssertTrue(selectorView!.rightItem.displayText.string.contains("24"))
+    }
+
     // MARK: - Helpers
 
     private func makeSession(
         adaptivePricingActive: Bool = true,
         includeLocalizedPrices: Bool = true,
-        includeExchangeRateFields: Bool = true
+        includeExchangeRateFields: Bool = true,
+        integrationAmount: Int = 1200,
+        localAmount: Int = 1000
     ) -> STPCheckoutSession {
         CheckoutTestHelpers.makeAdaptivePricingSession(
             adaptivePricingActive: adaptivePricingActive,
             includeLocalizedPrices: includeLocalizedPrices,
-            includeExchangeRateFields: includeExchangeRateFields
+            includeExchangeRateFields: includeExchangeRateFields,
+            integrationAmount: integrationAmount,
+            localAmount: localAmount
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -47,7 +47,9 @@ enum CheckoutTestHelpers {
         currency: String = "usd",
         adaptivePricingActive: Bool = true,
         includeLocalizedPrices: Bool = true,
-        includeExchangeRateFields: Bool = true
+        includeExchangeRateFields: Bool = true,
+        integrationAmount: Int = 1200,
+        localAmount: Int = 1000
     ) -> STPCheckoutSession {
         var json: [AnyHashable: Any] = [
             "session_id": "cs_test_123",
@@ -59,9 +61,9 @@ enum CheckoutTestHelpers {
             "payment_method_types": ["card"],
             "currency": currency,
             "total_summary": [
-                "subtotal": 1200,
-                "total": 1200,
-                "due": 1200,
+                "subtotal": integrationAmount,
+                "total": integrationAmount,
+                "due": integrationAmount,
             ],
             "developer_tool_context": [
                 "adaptive_pricing": [
@@ -73,7 +75,7 @@ enum CheckoutTestHelpers {
         if includeLocalizedPrices {
             var localCurrencyOption: [AnyHashable: Any] = [
                 "currency": "gbp",
-                "amount": 1000,
+                "amount": localAmount,
             ]
             if includeExchangeRateFields {
                 localCurrencyOption["presentment_exchange_rate"] = "0.776917"
@@ -81,7 +83,7 @@ enum CheckoutTestHelpers {
             }
             json["adaptive_pricing_info"] = [
                 "integration_currency": "usd",
-                "integration_amount": 1200,
+                "integration_amount": integrationAmount,
                 "active_presentment_currency": currency,
                 "local_currency_options": [localCurrencyOption],
             ]


### PR DESCRIPTION
## Summary
- Fixes a bug where the AP selector would not respond to changes in amount that are displayed in the selector. After adding a new style to the selector this became obvious.
- Fixed an issue where elements_session instances were not attached to the update responses.

## Motivation
- Bug fixes

## Testing
- New tests
- Manual

## Changelog
- N/A
