### PR TITLE
PMM Experiment — Disable double tap selection behavior

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEPromotionTextView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEPromotionTextView.swift
@@ -27,4 +27,18 @@ class PMMEPromotionTextView: LinkOpeningTextView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    // To avoid double-tap selection behavior we block double tap gestures. These double taps will instead open the link
+    public override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        // Intercept tap gesture recognizers
+        if let tapGesture = gestureRecognizer as? UITapGestureRecognizer {
+            // Block the gesture if it requires a double-tap
+            if tapGesture.numberOfTapsRequired == 2 {
+                return false
+            }
+        }
+
+        // Allow all other system gestures (scrolling, link clicks, etc.)
+        return super.gestureRecognizerShouldBegin(gestureRecognizer)
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEPromotionTextView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEPromotionTextView.swift
@@ -15,6 +15,14 @@ class PMMEPromotionTextView: LinkOpeningTextView {
         super.init(frame: .zero, textContainer: nil)
         isScrollEnabled = false
         isEditable = false
+        /*
+         `LinkOpeningTextView` keeps the underlying actual `isSelectable` property set to `true`,
+         which is required for links to work. However, setting it `false` will disable events to
+         any point other than the link text. We still need to handle double tap selection on the
+         link, which we do below.
+         This is a workaround for UIKit not allowing links to work if the `UITextView` does not
+         have `isSelectable = true`.
+         */
         isSelectable = false
         backgroundColor = .clear
         textContainerInset = .zero


### PR DESCRIPTION
## Summary
Previously, double tapping the PMM link in either the standalone PMME or the PMM in MPE would result in the double-tapped link text being selected, which it should not be. This prevents it by intercepting double tap gestures.

## Motivation
https://docs.google.com/document/d/1E-EQ4hEIvIkQFQF9doshXYKiKh1_3Y-tIecjgapSkdY/edit?tab=t.0
https://jira.corp.stripe.com/browse/MOBILESDK-4566

## Testing
Manual testing of standalone PMME and PMM in MPE

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
