### PR TITLE
PMM Experiment — Lazy load form header

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+AfterpayClearpay.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+AfterpayClearpay.swift
@@ -21,18 +21,13 @@ extension PaymentSheetFormFactory {
     }
 
     func makeAfterpayClearpayHeader() -> SubtitleElement {
-        if let header = makeBNPLHeader() {
-            // Use the shared BNPL header when header content is available.
-            return header
-        } else {
-            // Fall back to the legacy Afterpay/Clearpay-specific header UI.
-            return SubtitleElement(
-                view: AfterpayPriceBreakdownView(
-                    currency: currency,
-                    appearance: configuration.appearance
-                ),
-                isHorizontalMode: paymentMethodOrientation == .horizontal
-            )
-        }
+        let legacyAffirmHeader = SubtitleElement(
+            view: AfterpayPriceBreakdownView(
+                currency: currency,
+                appearance: configuration.appearance
+            ),
+            isHorizontalMode: paymentMethodOrientation == .horizontal
+        )
+        return makeBNPLHeader(fallback: legacyAffirmHeader)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -861,35 +861,34 @@ extension PaymentSheetFormFactory {
     }
 
     func makeKlarnaHeader() -> SubtitleElement {
-        if let header = makeBNPLHeader() {
-            // Use the shared BNPL header when header content is available.
-            return header
-        } else {
-            // Fall back to the legacy Klarna copy label.
-            return makeCopyLabel(text: .Localized.buy_now_or_pay_later_with_klarna)
-        }
+        let legacyAffirmHeader = makeCopyLabel(text: .Localized.buy_now_or_pay_later_with_klarna)
+        return makeBNPLHeader(fallback: legacyAffirmHeader)
     }
 
     func makeAffirmHeader() -> SubtitleElement {
-        if let header = makeBNPLHeader() {
-            // Use the shared BNPL header when header content is available.
-            return header
-        } else {
-            // Fall back to the legacy Affirm-specific header UI.
-            return SubtitleElement(
-                view: AffirmCopyLabel(theme: theme),
-                isHorizontalMode: paymentMethodOrientation == .horizontal
-            )
-        }
+        let legacyAffirmHeader = SubtitleElement(
+            view: AffirmCopyLabel(theme: theme),
+            isHorizontalMode: paymentMethodOrientation == .horizontal
+        )
+        return makeBNPLHeader(fallback: legacyAffirmHeader)
     }
 
-    func makeBNPLHeader() -> SubtitleElement? {
-        guard let paymentMethodMessagingPromotionsHelper, let headerView = BNPLFormHeaderView(
-            appearance: configuration.appearance,
-            paymentMethod: paymentMethod,
-            promotionsHelper: paymentMethodMessagingPromotionsHelper
-        ) else { return nil }
-        return SubtitleElement(view: headerView, isHorizontalMode: paymentMethodOrientation == .horizontal)
+    func makeBNPLHeader(fallback: SubtitleElement) -> SubtitleElement {
+        // If we have a promotions helper, use it to construct the BNPL header.
+        // If not (we are not the PMM in MPE experiment or an unsupported case) we use the fallback header.
+        // We still pass the fallback through in case promotion content is not available.
+        // In that case it is important to still use the BNPLFormHeaderView for the purpose of experiment analytics logging.
+        if let paymentMethodMessagingPromotionsHelper {
+            let headerView = BNPLFormHeaderView(
+                appearance: configuration.appearance,
+                paymentMethod: paymentMethod,
+                promotionsHelper: paymentMethodMessagingPromotionsHelper,
+                fallback: fallback
+            )
+            return SubtitleElement(view: headerView, isHorizontalMode: paymentMethodOrientation == .horizontal)
+        } else {
+            return fallback
+        }
     }
 
     func makeCopyLabel(text: String) -> SubtitleElement {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/BNPLFormHeaderView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/BNPLFormHeaderView.swift
@@ -3,71 +3,84 @@
 //  StripePaymentSheet
 //
 
+@_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
 import UIKit
 
 final class BNPLFormHeaderView: UIView {
     private let appearance: PaymentSheet.Appearance
-    let promotionsHelper: PaymentMethodMessagingPromotionsHelper
-    let promotion: String
-    let learnMoreText: String
-    let infoUrl: URL
+    private let paymentMethod: PaymentSheet.PaymentMethodType
+    private let promotionsHelper: PaymentMethodMessagingPromotionsHelper
+    private let fallbackView: UIView
+
+    private var view: UIView
 
     private var theme: ElementsAppearance {
         appearance.asElementsTheme
     }
 
-    private lazy var textView: PMMEPromotionTextView = {
-        let textView = PMMEPromotionTextView(foregroundColor: theme.colors.primary)
-        textView.delegate = self
-        textView.linkTextAttributes = [
-            .foregroundColor: theme.colors.primary,
-            .underlineStyle: 0,
-        ]
-        textView.attributedText = NSMutableAttributedString.pmmePromoString(
-            font: theme.fonts.subheadline,
-            textColor: theme.colors.bodyText,
-            template: promotion,
-            substitution: nil,
-            learnMoreText: learnMoreText,
-            learnMoreUrl: infoUrl
-        )
-        return textView
-    }()
-
-    init?(
+    /// Creates a BNPL header that can show payment method messaging promotion content when available.
+    ///
+    /// The view starts by displaying `fallback` so the form always has header content. When the view
+    /// moves on screen, it asks `promotionsHelper` for promotion content for `paymentMethod`. If content
+    /// is available, the fallback is replaced with the promotion text and the successful display is
+    /// logged. If content is unavailable, the fallback remains visible and the unsuccessful display is
+    /// logged.
+    init(
         appearance: PaymentSheet.Appearance,
         paymentMethod: PaymentSheet.PaymentMethodType,
-        promotionsHelper: PaymentMethodMessagingPromotionsHelper
+        promotionsHelper: PaymentMethodMessagingPromotionsHelper,
+        fallback: SubtitleElement
     ) {
         self.appearance = appearance
+        self.paymentMethod = paymentMethod
         self.promotionsHelper = promotionsHelper
-        guard let promotionContent = promotionsHelper.promotion(for: paymentMethod) else { return nil }
-        self.promotion = promotionContent.promotion
-        self.learnMoreText = promotionContent.learnMoreText
-        self.infoUrl = promotionContent.infoUrl
+        self.fallbackView = fallback.view
+        self.view = fallbackView
         super.init(frame: .zero)
 
-        addAndPinSubview(textView)
-        isAccessibilityElement = false
-        accessibilityElements = [textView]
+        // We initially set the view to the fallback, but we will update it to the promotion view if possible when we display
+        addAndPinSubview(fallbackView)
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
-    override func didMoveToWindow() {
-        super.didMoveToWindow()
+    override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
 
-        // If we are moved on screen we log that the promotion was displayed successfully.
+        // If we are moved on screen we try to get the promotion content, display it, and log the attempt.
+        // We check if promotion content is nil to know if we were successfully able to display it or not.
         // When the form is moved off screen didMoveToWindow() will be called with window == nil and we do nothing in this case.
-        guard window != nil else { return }
-        promotionsHelper.logDisplayedAnalytic(displayedSuccessfully: true)
-    }
+        guard newWindow != nil else { return }
 
-    private func openInfoModal() {
-        PMMEInfoModal.present(infoUrl: infoUrl, style: traitCollection.isDarkMode ? .alwaysDark : .alwaysLight, from: self)
+        view.removeFromSuperview()
+        if let promotionContent = promotionsHelper.promotion(for: paymentMethod) {
+            let textView = PMMEPromotionTextView(foregroundColor: theme.colors.primary)
+            textView.delegate = self
+            textView.linkTextAttributes = [
+                .foregroundColor: theme.colors.primary,
+                .underlineStyle: 0,
+            ]
+            textView.attributedText = NSMutableAttributedString.pmmePromoString(
+                font: theme.fonts.subheadline,
+                textColor: theme.colors.bodyText,
+                template: promotionContent.promotion,
+                substitution: nil,
+                learnMoreText: promotionContent.learnMoreText,
+                learnMoreUrl: promotionContent.infoUrl
+            )
+            addAndPinSubview(textView)
+            isAccessibilityElement = false
+            accessibilityElements = [textView]
+
+            promotionsHelper.logDisplayedAnalytic(displayedSuccessfully: true)
+        } else {
+            addAndPinSubview(fallbackView)
+
+            promotionsHelper.logDisplayedAnalytic(displayedSuccessfully: false)
+        }
     }
 }
 
@@ -85,7 +98,12 @@ extension BNPLFormHeaderView: UITextViewDelegate {
             return false
         }
 
-        openInfoModal()
+        guard let infoUrl = promotionsHelper.promotion(for: paymentMethod)?.infoUrl else {
+            stpAssertionFailure("Missing promotion content. This text view should never be shown while the promotion is not present.")
+            return false
+        }
+
+        PMMEInfoModal.present(infoUrl: infoUrl, style: traitCollection.isDarkMode ? .alwaysDark : .alwaysLight, from: self)
         return false
     }
 #endif

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/BNPLFormHeaderViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/BNPLFormHeaderViewSnapshotTests.swift
@@ -4,6 +4,7 @@
 //
 
 import StripeCoreTestUtils
+@_spi(STP) import StripeUICore
 import UIKit
 import XCTest
 
@@ -42,8 +43,9 @@ final class BNPLFormHeaderViewSnapshotTests: STPSnapshotTestCase {
         let headerView = BNPLFormHeaderView(
             appearance: appearance,
             paymentMethod: .stripe(.affirm),
-            promotionsHelper: promotionsHelper
-        )!
+            promotionsHelper: promotionsHelper,
+            fallback: SubtitleElement(view: UIView(), isHorizontalMode: false)
+        )
         let rootViewController = UIViewController()
         rootViewController.overrideUserInterfaceStyle = interfaceStyle
         headerView.backgroundColor = appearance.colors.background

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/BNPLFormHeaderViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/BNPLFormHeaderViewTests.swift
@@ -3,6 +3,7 @@
 //  StripePaymentSheetTests
 //
 
+@_spi(STP) import StripeUICore
 import UIKit
 import XCTest
 
@@ -15,7 +16,7 @@ final class BNPLFormHeaderViewTests: XCTestCase {
 
         let didHandleTap = headerView.textView(
             UITextView(),
-            shouldInteractWith: headerView.infoUrl,
+            shouldInteractWith: PaymentMethodMessagingPromotionsHelper.MockPromotionsHelper.infoUrl,
             in: NSRange(location: 0, length: 0),
             interaction: .invokeDefaultAction
         )
@@ -32,7 +33,7 @@ final class BNPLFormHeaderViewTests: XCTestCase {
 
         let didHandleTap = headerView.textView(
             UITextView(),
-            shouldInteractWith: headerView.infoUrl,
+            shouldInteractWith: PaymentMethodMessagingPromotionsHelper.MockPromotionsHelper.infoUrl,
             in: NSRange(location: 0, length: 0),
             interaction: .invokeDefaultAction
         )
@@ -52,8 +53,9 @@ final class BNPLFormHeaderViewTests: XCTestCase {
         let headerView = BNPLFormHeaderView(
             appearance: appearance,
             paymentMethod: .stripe(.affirm),
-            promotionsHelper: promotionsHelper
-        )!
+            promotionsHelper: promotionsHelper,
+            fallback: SubtitleElement(view: UIView(), isHorizontalMode: false)
+        )
         let rootViewController = UIViewController()
         rootViewController.overrideUserInterfaceStyle = interfaceStyle
         headerView.backgroundColor = appearance.colors.background

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -495,15 +495,17 @@ extension PaymentMethodMessagingPromotionsHelper {
             analyticsHelper: PaymentSheetAnalyticsHelper._testValue()
         )
     }
-}
 
-private class MockPromotionsHelper: PaymentMethodMessagingPromotionsHelper {
-    override func promotion(for paymentMethodType: PaymentSheet.PaymentMethodType) -> PromotionContent? {
-        return PromotionContent(
-            promotion: "Pay in 4 interest-free payments of $12.50.",
-            learnMoreText: "See if you qualify",
-            infoUrl: URL(string: "https://b.stripecdn.com/payment-method-messaging-statics-srv/assets/learn-more/index.html?amount=5000&country=US&currency=USD&key=pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFfB7cY9WG4a00ZnDtiC2C&locale=en&payment_methods%5B0%5D=affirm&title=See%20if%20you%20qualify")!
-        )
+    class MockPromotionsHelper: PaymentMethodMessagingPromotionsHelper {
+        override func promotion(for paymentMethodType: PaymentSheet.PaymentMethodType) -> PromotionContent? {
+            return PromotionContent(
+                promotion: "Pay in 4 interest-free payments of $12.50.",
+                learnMoreText: "See if you qualify",
+                infoUrl: Self.infoUrl
+            )
+        }
+
+        static let infoUrl = URL(string: "https://b.stripecdn.com/payment-method-messaging-statics-srv/assets/learn-more/index.html?amount=5000&country=US&currency=USD&key=pk_test_51HvTI7Lu5o3P18Zp6t5AgBSkMvWoTtA0nyA7pVYDqpfLkRtWun7qZTYCOHCReprfLM464yaBeF72UFfB7cY9WG4a00ZnDtiC2C&locale=en&payment_methods%5B0%5D=affirm&title=See%20if%20you%20qualify")!
     }
 }
 


### PR DESCRIPTION
## Summary
Have any form header eligible for payment method messaging use the BNPLFormHeaderView. Have this view populate its content dynamically at the last second before being shown.

## Motivation
Previously, there were two issues:
1. If the customer tapped on a BNPL PM with a form before the PMM content had loaded, unselected it, and then selected it again after the PMM content has loaded, they would still see the generic non-PMM form header because it was initially created as a non-PMM header
2. If the customer tapped on a BNPL PM with a form before the PMM content had loaded, there would be no payment_method_messaging_displayed(isDisplayed: false) logging done
https://docs.google.com/document/d/1E-EQ4hEIvIkQFQF9doshXYKiKh1_3Y-tIecjgapSkdY/edit?tab=t.0

## Testing
Manual verification as outlined in the bug bash doc: https://docs.google.com/document/d/1E-EQ4hEIvIkQFQF9doshXYKiKh1_3Y-tIecjgapSkdY/edit?tab=t.0

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
