### PR TITLE
Preserve Link metadata on saved payment method update

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Categories/STPPaymentMethod+PaymentSheet.swift
@@ -77,6 +77,12 @@ extension STPPaymentMethod {
         return components.joined(separator: " ")
     }
 
+    func updateLocalFields(from original: STPPaymentMethod) {
+        // The update endpoint returns a plain PaymentMethod, so preserve Link presentation state.
+        linkPaymentDetails = original.linkPaymentDetails
+        isLinkOrigin = original.isLinkOrigin
+    }
+
     func hasUpdatedCardParams(_ updatedParams: STPPaymentMethodCardParams?) -> Bool {
         guard let currCard = self.card,
               let updatedParams = updatedParams else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/SavedPaymentMethodManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/SavedPaymentMethodManager.swift
@@ -44,9 +44,11 @@ final class SavedPaymentMethodManager {
             throw PaymentSheetError.unknown(debugDescription: "Failed to read ephemeral key while updating a payment method.")
         }
 
-        return try await configuration.apiClient.updatePaymentMethod(with: paymentMethod.stripeId,
-                                                                     paymentMethodUpdateParams: updateParams,
-                                                                     ephemeralKeySecret: ephemeralKey)
+        let updatedPaymentMethod = try await configuration.apiClient.updatePaymentMethod(with: paymentMethod.stripeId,
+                                                                                         paymentMethodUpdateParams: updateParams,
+                                                                                         ephemeralKeySecret: ephemeralKey)
+        updatedPaymentMethod.updateLocalFields(from: paymentMethod)
+        return updatedPaymentMethod
     }
 
     func detach(paymentMethod: STPPaymentMethod) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsViewController.swift
@@ -979,7 +979,9 @@ extension CustomerSavedPaymentMethodsViewController: CustomerSavedPaymentMethods
         else {
             throw CustomerSheetError.unknown(debugDescription: "Failed to read payment method")
         }
-        return try await customerSheetDataSource.updatePaymentMethod(paymentMethodId: paymentMethod.stripeId, paymentMethodUpdateParams: updateParams)
+        let updatedPaymentMethod = try await customerSheetDataSource.updatePaymentMethod(paymentMethodId: paymentMethod.stripeId, paymentMethodUpdateParams: updateParams)
+        updatedPaymentMethod.updateLocalFields(from: paymentMethod)
+        return updatedPaymentMethod
     }
 
     func shouldCloseSheet(viewController: CustomerSavedPaymentMethodsCollectionViewController) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -511,12 +511,6 @@ private extension STPPaymentMethod {
         }
         return linkPaymentDetails.isNotCard
     }
-
-    func updateLocalFields(from original: STPPaymentMethod) {
-        // We don't receive the following fields as part of the update response, so we need to copy them over
-        linkPaymentDetails = original.linkPaymentDetails
-        isLinkOrigin = original.isLinkOrigin
-    }
 }
 
 private extension LinkPaymentDetails {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPPaymentMethod+PaymentSheetTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPPaymentMethod+PaymentSheetTests.swift
@@ -44,6 +44,30 @@ class STPPPaymentMethodPaymentSheetTests: XCTestCase {
         XCTAssertFalse(linkPaymentMethod.isLinkPassthroughMode)
     }
 
+    func testUpdateLocalFields_preservesLinkPresentationState() {
+        let originalPaymentMethod = STPPaymentMethod._testCard()
+        originalPaymentMethod.linkPaymentDetails = .card(
+            LinkPaymentDetails.Card(
+                id: "csmrpd_123",
+                displayName: "Visa",
+                expMonth: 12,
+                expYear: 2030,
+                last4: "4242",
+                brand: .visa
+            )
+        )
+        originalPaymentMethod.isLinkOrigin = true
+
+        let updatedPaymentMethod = STPPaymentMethod.stubbedPaymentMethod()
+        XCTAssertNil(updatedPaymentMethod.linkPaymentDetails)
+        XCTAssertFalse(updatedPaymentMethod.isLinkOrigin)
+
+        updatedPaymentMethod.updateLocalFields(from: originalPaymentMethod)
+
+        XCTAssertEqual(updatedPaymentMethod.linkPaymentDetailsFormattedString, originalPaymentMethod.linkPaymentDetailsFormattedString)
+        XCTAssertTrue(updatedPaymentMethod.isLinkOrigin)
+    }
+
     func testHasUpdatedCardParams() {
         XCTAssertFalse(_testHasUpdatedCardParams(STPPaymentMethod._testCard(), expMonth: 01, expYear: 40))
         XCTAssertTrue(_testHasUpdatedCardParams(STPPaymentMethod._testCard(), expMonth: 01, expYear: 41))

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTests.swift
@@ -9,6 +9,7 @@ import Foundation
 import OHHTTPStubs
 import OHHTTPStubsSwift
 import StripeCoreTestUtils
+@_spi(STP) @testable import StripePayments
 @_spi(STP)@testable import StripePaymentSheet
 import XCTest
 
@@ -67,6 +68,34 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
 
         // Verify the response was valid
         XCTAssertEqual("pm_123card", updatedPaymentMethod.stripeId)
+        await fulfillment(of: [expectation], timeout: 5.0)
+    }
+
+    func testUpdatePaymentMethod_preservesLocalLinkFields() async throws {
+        let paymentMethod = STPPaymentMethod.stubbedPaymentMethod()
+        paymentMethod.linkPaymentDetails = .card(
+            LinkPaymentDetails.Card(
+                id: "csmrpd_123",
+                displayName: "Visa",
+                expMonth: 12,
+                expYear: 2030,
+                last4: "4242",
+                brand: .visa
+            )
+        )
+        paymentMethod.isLinkOrigin = true
+
+        let expectation = stubUpdatePaymentMethod(paymentMethod: paymentMethod,
+                                                  ephemeralKey: ephemeralKey)
+        var configuration = configuration
+        configuration.customer = .init(id: "cus_test123", ephemeralKeySecret: ephemeralKey)
+
+        let sut = SavedPaymentMethodManager(configuration: configuration, elementsSession: ._testCardValue(), intent: ._testValue())
+        let updatedPaymentMethod = try await sut.update(paymentMethod: paymentMethod,
+                                                        with: STPPaymentMethodUpdateParams())
+
+        XCTAssertTrue(updatedPaymentMethod.isLinkOrigin)
+        XCTAssertEqual(updatedPaymentMethod.linkPaymentDetailsFormattedString, paymentMethod.linkPaymentDetailsFormattedString)
         await fulfillment(of: [expectation], timeout: 5.0)
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue where updating a Link-branded saved payment method would remove the branding. We fix it by moving the preservation of local fields to `STPPaymentMethod` directly.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_LINK_MOBILE-168](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-168)

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

https://github.com/user-attachments/assets/81274969-a0c4-45df-ba86-43da61fb67c1

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

N/A
