### PR TITLE
Don't use card art for Link passthrough SPMs

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/ElementsCustomer.swift
@@ -79,12 +79,18 @@ struct ElementsCustomer: Equatable, Hashable {
                     } else {
                         paymentMethod.isLinkOrigin = paymentMethodWithLinkDetails.isLinkOrigin
                     }
-                    paymentMethod.card?.cardArt = cardArtByPaymentMethodId[paymentMethod.stripeId]
+                    if !paymentMethod.isLinkPassthroughMode {
+                        // Preserve the Link branding
+                        paymentMethod.card?.cardArt = cardArtByPaymentMethodId[paymentMethod.stripeId]
+                    }
                     paymentMethods.append(paymentMethod)
                 }
             } else {
                 if let paymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: json) {
-                    paymentMethod.card?.cardArt = cardArtByPaymentMethodId[paymentMethod.stripeId]
+                    if !paymentMethod.isLinkPassthroughMode {
+                        // Preserve the Link branding
+                        paymentMethod.card?.cardArt = cardArtByPaymentMethodId[paymentMethod.stripeId]
+                    }
                     paymentMethods.append(paymentMethod)
                 }
             }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -900,6 +900,30 @@ class STPElementsSessionTest: XCTestCase {
         ]
     }
 
+    func testMergeCardArt_flatFormat_linkWalletSkipsCardArt() throws {
+        var linkWalletCardJSON = testCardJSON
+        linkWalletCardJSON[jsonDict: "card"]?["wallet"] = [
+            "type": "link",
+        ]
+
+        let response: [AnyHashable: Any] = [
+            "payment_methods": [linkWalletCardJSON],
+            "card_art": [
+                ["payment_method": "pm_123card",
+                 "art_image": ["url": "https://b.stripecdn.com/cardart/assets/abc123"],
+                 "program_name": "Test Program",
+                ],
+            ],
+            "customer_session": customerSessionJSON,
+        ]
+
+        let customer = try XCTUnwrap(ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: false))
+        let paymentMethod = try XCTUnwrap(customer.paymentMethods.first)
+
+        XCTAssertTrue(paymentMethod.isLinkPassthroughMode)
+        XCTAssertNil(paymentMethod.card?.cardArt)
+    }
+
     private func linkWrappedUnknownPM(_ pmJSON: [AnyHashable: Any]) -> [AnyHashable: Any] {
         return [
             "payment_method": pmJSON,
@@ -963,6 +987,26 @@ class STPElementsSessionTest: XCTestCase {
         let customer = ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true)
         XCTAssertNotNil(customer)
         XCTAssertNil(customer?.paymentMethods.first?.card?.cardArt)
+    }
+
+    func testMergeCardArt_linkFormat_linkOriginSkipsCardArt() throws {
+        let response: [AnyHashable: Any] = [
+            "payment_methods_with_link_details": [linkWrappedPM(testCardJSON, isLinkOrigin: true)],
+            "card_art": [
+                ["payment_method": "pm_123card",
+                 "art_image": ["url": "https://b.stripecdn.com/cardart/assets/abc123"],
+                 "program_name": "Test Program",
+                ],
+            ],
+            "customer_session": customerSessionJSON,
+        ]
+
+        let customer = try XCTUnwrap(ElementsCustomer.decoded(fromAPIResponse: response, enableLinkInSPM: true))
+        let paymentMethod = try XCTUnwrap(customer.paymentMethods.first)
+
+        XCTAssertTrue(paymentMethod.isLinkOrigin)
+        XCTAssertTrue(paymentMethod.isLinkPassthroughMode)
+        XCTAssertNil(paymentMethod.card?.cardArt)
     }
 
     func testMergeCardArt_linkFormat_multiplePaymentMethods() {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request prevents card-art usage for Link passthrough mode SPMs.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[RUN_LINK_MOBILE-192](https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-192)

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

Unit tests.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

N/A
