### PR TITLE
Added merchant display name parameter to LinkConfiguration

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
@@ -151,7 +151,7 @@ struct ExampleLinkControllerPreviewView: View {
 
         do {
             linkController = try await LinkController.create(
-                configuration: .init(supportedPaymentMethodTypes: supportedPaymentMethodTypes)
+                configuration: .init(supportedPaymentMethodTypes: supportedPaymentMethodTypes, merchantDisplayName: "Example, Inc.")
             )
             isLoading = false
             statusMessage = "LinkController initialized successfully"

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerView.swift
@@ -331,7 +331,7 @@ struct ExampleLinkControllerView: View {
             do {
                 let controller = try await LinkController.create(
                     mode: .setup,
-                    linkConfiguration: .init(supportedPaymentMethodTypes: supportedPaymentMethodTypes)
+                    linkConfiguration: .init(supportedPaymentMethodTypes: supportedPaymentMethodTypes, merchantDisplayName: "Example, Inc.")
                 )
                 await MainActor.run {
                     self.linkController = controller

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
@@ -20,7 +20,7 @@ public struct LinkConfiguration {
     /// The payment method types to support in the Link sheet. If `nil` or empty, all available types are shown.
     @_spi(LinkControllerPreview) public let supportedPaymentMethodTypes: [LinkPaymentMethodType]?
 
-    /// The merchant name displayed in Link UI (e.g. consent text, wallet header).
+    /// The merchant name displayed in Link UI (e.g. consent text).
     /// If `nil`, defaults to the host app's `CFBundleDisplayName` / `CFBundleName`.
     @_spi(LinkControllerPreview) public let merchantDisplayName: String?
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
@@ -20,6 +20,10 @@ public struct LinkConfiguration {
     /// The payment method types to support in the Link sheet. If `nil` or empty, all available types are shown.
     @_spi(LinkControllerPreview) public let supportedPaymentMethodTypes: [LinkPaymentMethodType]?
 
+    /// The merchant name displayed in Link UI (e.g. consent text, wallet header).
+    /// If `nil`, defaults to the host app's `CFBundleDisplayName` / `CFBundleName`.
+    @_spi(LinkControllerPreview) public let merchantDisplayName: String?
+
     /// Creates a new instance of `LinkConfiguration`.
     /// - Parameters:
     ///   - hintMessage: Custom hint message to display in the wallet view. If `nil`, no hint will be shown.
@@ -31,18 +35,22 @@ public struct LinkConfiguration {
         self.hintMessage = hintMessage
         self.allowLogout = allowLogout
         self.supportedPaymentMethodTypes = nil
+        self.merchantDisplayName = nil
     }
 
     /// Creates a new instance of `LinkConfiguration`.
     /// - Parameters:
     ///   - supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil` or empty, all available types are shown.
     ///   - allowLogout: Whether to allow the user to log out. When `false`, the logout menu button will be hidden. Defaults to `true`.
+    ///   - merchantDisplayName: The merchant name displayed in Link UI. If `nil`, defaults to the app's `CFBundleDisplayName`.
     @_spi(LinkControllerPreview) public init(
-        supportedPaymentMethodTypes: [LinkPaymentMethodType]?,
-        allowLogout: Bool = true
+        supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
+        allowLogout: Bool = true,
+        merchantDisplayName: String? = nil
     ) {
         self.hintMessage = nil
         self.allowLogout = allowLogout
         self.supportedPaymentMethodTypes = supportedPaymentMethodTypes
+        self.merchantDisplayName = merchantDisplayName
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -255,6 +255,9 @@ import UIKit
                 if let appearance = appearance {
                     paymentElementConfiguration.style = appearance.style
                 }
+                if let merchantDisplayName = configuration?.merchantDisplayName {
+                    paymentElementConfiguration.merchantDisplayName = merchantDisplayName
+                }
 
                 let analyticsHelper = PaymentSheetAnalyticsHelper(
                     integrationShape: .linkController,
@@ -303,7 +306,7 @@ import UIKit
     /// - Parameter completion: A closure that is called with the result of the creation. It returns a `LinkController` if successful, or an error if the creation failed.
     @_spi(LinkControllerPreview) public static func create(
         apiClient: STPAPIClient = .shared,
-        configuration: LinkConfiguration = .init(),
+        configuration: LinkConfiguration = .init(supportedPaymentMethodTypes: nil),
         completion: @escaping (Result<LinkController, Error>) -> Void
     ) {
         self.create(
@@ -1319,7 +1322,7 @@ extension LinkController: LinkFullConsentViewControllerDelegate {
     /// - Returns: A `LinkController` if successful, or throws an error if the creation failed.
     static func create(
         apiClient: STPAPIClient = .shared,
-        configuration: LinkConfiguration = .init()
+        configuration: LinkConfiguration = .init(supportedPaymentMethodTypes: nil)
     ) async throws -> LinkController {
         return try await withCheckedThrowingContinuation { continuation in
             create(apiClient: apiClient, configuration: configuration) { result in

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
@@ -12,6 +12,7 @@ final class LinkControllerPreviewAPITests: XCTestCase {
         _ = LinkPaymentMethodType.card
         _ = LinkConfiguration(supportedPaymentMethodTypes: [.card])
         _ = LinkConfiguration(supportedPaymentMethodTypes: [.card], allowLogout: false).allowLogout
+        _ = LinkConfiguration(supportedPaymentMethodTypes: [.card], merchantDisplayName: "Example Merchant")
 
         let result: LinkController.PaymentMethodResult = .canceled
         _ = result


### PR DESCRIPTION
## Summary
Added display name parameter to LinkConfiguration to let the merchant explicitly set their display name.

## Motivation
https://docs.google.com/document/d/1VoMxNhXmKix5kiFzWO3eJc2YzE3dpEO63rKp_Kb9F6E/edit?usp=sharing

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
n/a
