### PR TITLE
CryptoOnramp SDK: Adds Debug Print for Errors

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -907,6 +907,11 @@ private extension CryptoOnrampCoordinator {
         )
         let errorMessage = (mappedError as? StripeCryptoOnrampError)?.developerMessage ?? mappedError.localizedDescription
         analyticsClient.log(.errorOccurred(during: operation, errorMessage: errorMessage))
+
+        #if DEBUG
+        print("[Stripe SDK] CryptoOnrampCoordinator error: \(errorMessage)")
+        #endif
+
         throw mappedError
     }
 


### PR DESCRIPTION
## Summary
Adds a `#if DEBUG` / `#endif` print statement to log error messages originating from Crypto Onramp calls to the console.

## Motivation
The analytics logs currently flatten the formatting with escaped `\n`s, making the nicely formatted console messages harder to read at a quick glance.
<img width="400" alt="CleanShot 2026-06-10 at 13 56 49" src="https://github.com/user-attachments/assets/edce6e00-6334-496b-99cd-d0302ae85bce" />


## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Tested manually by changing the app id parameter before making a request to look up a consumer:
```swift
mutableParameters["app_id"] = "intentionally_invalid_app_id_for_testing"
```
then tried logging in using the Crypto Onramp example app.

Console output:
<img width="400" alt="CleanShot 2026-06-10 at 13 57 00" src="https://github.com/user-attachments/assets/feca063b-9081-4d94-a97e-aea927304a0c" />


## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
