### PR TITLE
Fix blank screen in specific Financial Connections scenario

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -150,6 +150,11 @@ final class AccountPickerViewController: UIViewController {
             .pollAuthSessionAccounts()
             .observe(on: .main) { [weak self] result in
                 guard let self = self else { return }
+
+                // There are scenarios where we want to keep the "Retrieving accounts…" view on the screen
+                // even though retrieval is done, as we otherwise would just render a blank screen.
+                var keepShowingLoadingView = false
+
                 switch result {
                 case .success(let accountsPayload):
                     self.dataSource
@@ -184,6 +189,7 @@ final class AccountPickerViewController: UIViewController {
                     //  `accountsPayload.skipAccountSelection` is true, OR `accountsPayload.skipAccountSelection` nil
                     // AND `authSession.skipAccountSelection` is true
                     let skipAccountSelection = (accountsPayload.skipAccountSelection ?? self.dataSource.authSession.skipAccountSelection ?? false)
+
                     if skipAccountSelection {
                         let selectableAccounts = accounts.filter(\.allowSelectionNonOptional)
                         if self.dataSource.manifest.singleAccount {
@@ -201,6 +207,7 @@ final class AccountPickerViewController: UIViewController {
                             self.dataSource.updateSelectedAccounts(selectableAccounts)
                         }
                         self.didSelectLinkAccounts(isSkipAccountSelection: true)
+                        keepShowingLoadingView = true
                     } else if
                         self.dataSource.manifest.singleAccount,
                         self.dataSource.authSession.institutionSkipAccountSelection ?? false,
@@ -211,6 +218,7 @@ final class AccountPickerViewController: UIViewController {
                         // we had done account selection, and submit.
                         self.dataSource.updateSelectedAccounts(accounts)
                         self.didSelectLinkAccounts(isSkipAccountSelection: true)
+                        keepShowingLoadingView = true
                     } else {
                         let (enabledAccounts, disabledAccounts) =
                             accounts
@@ -252,7 +260,10 @@ final class AccountPickerViewController: UIViewController {
                         self.showAccountLoadErrorView(error: error)
                     }
                 }
-                retreivingAccountsLoadingView.removeFromSuperview()
+
+                if !keepShowingLoadingView {
+                    retreivingAccountsLoadingView.removeFromSuperview()
+                }
             }
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue in the Financial Connections flow where we'd temporarily show a blank screen when connecting a single account. As a fix, we keep the `Retrieving accounts…` placeholder on screen until the next screen is pushed on top.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[LINK_MOBILE-969](https://jira.corp.stripe.com/browse/LINK_MOBILE-969)

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

### Before

https://github.com/user-attachments/assets/0990726a-6c0e-4a61-98d8-e5a1ed419468

### After

https://github.com/user-attachments/assets/084f26ad-f9ff-4077-ba31-bb589ff08032

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

N/A
