### PR TITLE
Fix crash in AutoCompleteViewController highlightSearchString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ MINOR
 ## X.Y.Z - changes pending release
 
 ### PaymentSheet
+* [Fixed] Fixed an NSRangeException crash in address autocomplete search results.
 * [Changed] Renamed `LinkPaymentController` to `InstantBankPaymentsController`.
 * [Changed] Link bank account display strings now include the last 4 digits in `LinkController.PaymentMethodPreview.sublabel` and `PaymentSheet.FlowController.PaymentOptionDisplayData.labels.sublabel`, matching the existing card behavior.
 * [Fixed] The Link verification flow no longer shows an indefinite loading state when encountering rate limit errors.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/String+AutoComplete.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/String+AutoComplete.swift
@@ -23,11 +23,21 @@ extension String {
             value: isSubtitle ? appearance.colors.textSecondary : appearance.colors.text,
             range: (self as NSString).range(of: self))
 
+        let fullRange = NSRange(location: 0, length: (self as NSString).length)
         for highlightRange in highlightRanges {
+            let range = highlightRange.rangeValue
+            // Validate range is within bounds to prevent NSRangeException crashes
+            // See https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5400
+            guard range.location != NSNotFound,
+                  NSIntersectionRange(fullRange, range).length > 0
+            else {
+                continue
+            }
+            let clampedRange = NSIntersectionRange(fullRange, range)
             attributedString.addAttribute(
                 NSAttributedString.Key.font,
                 value: appearance.scaledFont(for: appearance.font.base.bold, style: textStyle, maximumPointSize: 25),
-                range: highlightRange.rangeValue)
+                range: clampedRange)
         }
 
         return attributedString

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AutoCompleteViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AutoCompleteViewControllerSnapshotTests.swift
@@ -187,6 +187,27 @@ class AutoCompleteViewControllerSnapshotTests: STPSnapshotTestCase {
         verify(vc.view)
     }
 
+    func testAutoCompleteViewController_outOfBoundsHighlightRanges_doesNotCrash() {
+        let testWindow = UIWindow(frame: CGRect(x: 0, y: 0, width: 428, height: 500))
+        testWindow.isHidden = false
+        let vc = AutoCompleteViewController(
+            configuration: configuration,
+            initialLine1Text: nil,
+            selectedCountry: nil,
+            addressSpecProvider: addressSpecProvider
+        )
+        vc.results = [
+            MockAddressSearchResult(
+                title: "Hello",
+                subtitle: "World",
+                titleHighlightRanges: [NSValue(range: NSRange(location: 3, length: 10))],
+                subtitleHighlightRanges: [NSValue(range: NSRange(location: 100, length: 5))]
+            ),
+        ]
+        testWindow.rootViewController = vc
+        vc.view.layoutIfNeeded()
+    }
+
     func verify(
         _ view: UIView,
         identifier: String? = nil,


### PR DESCRIPTION
The highlightSearchString method in String+AutoComplete.swift was crashing with an NSRangeException. 
```
OS Version: iOS 26.5 (23F77)
Report Version: 104

Exception Type: EXC_CRASH (SIGABRT)
Crashed Thread: 0

Application Specific Information:
NSMutableRLEArray objectAtIndex:effectiveRange:: Out of bounds

Thread 0 Crashed:
0   CoreFoundation                  0x32540323c         <redacted>
1   libobjc.A.dylib                 0x31ea85224         objc_exception_throw
2   Foundation                      0x31f857bc8         <redacted>
3   Foundation                      0x31f8ed6a4         <redacted>
4   Link                            0x202d69560         String.highlightSearchString (String+AutoComplete.swift:27)
5   Link                            0x202d682c8         AutoCompleteViewController.tableView (AutoCompleteViewController.swift:285)
6   Link                            0x202d684f0         AutoCompleteViewController.tableView```
```

The fix validates each highlight range against the string's actual length, clamping out-of-bounds ranges to the valid portion of the string and skipping ranges that don't intersect at all.

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5400

## Testing
See test. Fails before fix, passes after.

## Changelog
See CHANGELOG