### PR TITLE
Remove PaymentSheet.init(Checkout)

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
@@ -42,7 +42,7 @@ struct CheckoutCartContentView: View {
                 promotionCodeSection
                 orderSummarySection
 
-                Spacer().frame(height: 100)
+                Spacer().frame(height: 160)
             }
             .padding(.top, 20)
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -16,89 +16,174 @@ struct CheckoutCartPaymentButton: View {
 
     private var session: Checkout.Session { checkout.state.session }
 
+    @State private var flowController: PaymentSheet.FlowController?
+    @State private var isLoadingFlowController = false
+    @State private var loadError: Error?
     @State private var paymentResult: PaymentSheetResult?
+    @State private var isShowingPaymentOptions = false
+    @State private var isConfirming = false
 
     var body: some View {
         VStack {
             if let result = paymentResult {
-                switch result {
-                case .completed:
-                    VStack(spacing: 12) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .font(.system(size: 48))
-                            .foregroundColor(.green)
-                        Text("Payment Successful!")
-                            .font(.headline)
-                            .foregroundColor(.primary)
-                    }
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 24)
-                    .background(
-                        Color(UIColor.systemBackground)
-                            .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: -5)
-                    )
-                    .onAppear {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
-                            onDismiss()
-                        }
-                    }
-                case .canceled:
-                    Color.clear
-                        .onAppear { paymentResult = nil }
-                case .failed(let error):
-                    VStack(spacing: 8) {
-                        Image(systemName: "xmark.circle.fill")
-                            .font(.system(size: 36))
-                            .foregroundColor(.red)
-                        Text(error.localizedDescription)
-                            .font(.subheadline)
-                            .foregroundColor(.secondary)
-                            .multilineTextAlignment(.center)
-                    }
-                    .frame(maxWidth: .infinity)
+                paymentResultView(result: result)
+            } else if let flowController {
+                flowControllerView(flowController: flowController)
+            } else if isLoadingFlowController {
+                ProgressView()
                     .padding()
-                    .background(
-                        Color(UIColor.systemBackground)
-                            .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: -5)
-                    )
-                }
+            } else if let loadError {
+                errorView(error: loadError)
             } else {
-                let paymentSheet = makePaymentSheet()
-                PaymentSheet.PaymentButton(
-                    paymentSheet: paymentSheet,
-                    onCompletion: { result in
-                        paymentResult = result
-                    }
-                ) {
-                    HStack {
-                        Text("Checkout")
-                        Spacer()
-                        if let total = session.total, let currency = session.currency {
-                            Text(formatCartCurrency(amount: total.total.minorUnitsAmount, currency: currency))
-                        }
-                    }
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .padding()
-                    .background(Color.blue)
-                    .cornerRadius(14)
-                }
-                .padding(.horizontal)
-                .padding(.bottom, 16)
-                .padding(.top, 16)
-                .background(
-                    Color(UIColor.systemBackground)
-                        .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: -5)
-                )
+                Color.clear
+                    .onAppear { loadFlowController() }
             }
         }
     }
 
-    private func makePaymentSheet() -> PaymentSheet {
+    // MARK: - Subviews
+
+    @ViewBuilder
+    private func paymentResultView(result: PaymentSheetResult) -> some View {
+        switch result {
+        case .completed:
+            VStack(spacing: 12) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundColor(.green)
+                Text("Payment Successful!")
+                    .font(.headline)
+                    .foregroundColor(.primary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 24)
+            .background(
+                Color(UIColor.systemBackground)
+                    .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: -5)
+            )
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                    onDismiss()
+                }
+            }
+        case .canceled:
+            Color.clear
+                .onAppear { paymentResult = nil }
+        case .failed(let error):
+            errorView(error: error)
+        }
+    }
+
+    @ViewBuilder
+    private func flowControllerView(flowController: PaymentSheet.FlowController) -> some View {
+        VStack(spacing: 12) {
+            // Payment method selector button
+            Button {
+                isShowingPaymentOptions = true
+            } label: {
+                HStack {
+                    if let paymentOption = flowController.paymentOption {
+                        Image(uiImage: paymentOption.image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 30, height: 20)
+                        Text(paymentOption.label)
+                            .font(.subheadline)
+                            .foregroundColor(.primary)
+                    } else {
+                        Text("Select payment method")
+                            .font(.subheadline)
+                            .foregroundColor(.primary)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                )
+            }
+            .padding(.horizontal)
+            .paymentOptionsSheet(
+                isPresented: $isShowingPaymentOptions,
+                paymentSheetFlowController: flowController,
+                onSheetDismissed: {}
+            )
+
+            // Confirm / checkout button
+            Button {
+                isConfirming = true
+            } label: {
+                HStack {
+                    Text("Checkout")
+                    Spacer()
+                    if let total = session.total, let currency = session.currency {
+                        Text(formatCartCurrency(amount: total.total.minorUnitsAmount, currency: currency))
+                    }
+                }
+                .font(.headline)
+                .foregroundColor(.white)
+                .padding()
+                .background(flowController.paymentOption != nil ? Color.blue : Color.gray)
+                .cornerRadius(14)
+            }
+            .disabled(flowController.paymentOption == nil)
+            .padding(.horizontal)
+            .paymentConfirmationSheet(
+                isConfirming: $isConfirming,
+                paymentSheetFlowController: flowController,
+                onCompletion: { result in
+                    paymentResult = result
+                }
+            )
+        }
+        .padding(.bottom, 16)
+        .padding(.top, 16)
+        .background(
+            Color(UIColor.systemBackground)
+                .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: -5)
+        )
+    }
+
+    @ViewBuilder
+    private func errorView(error: Error) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 36))
+                .foregroundColor(.red)
+            Text(error.localizedDescription)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(
+            Color(UIColor.systemBackground)
+                .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: -5)
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func loadFlowController() {
+        isLoadingFlowController = true
         var configuration = PaymentSheet.Configuration()
         configuration.returnURL = "payments-example://stripe-redirect"
-        // PaymentSheet no longer supports direct checkout initialization.
-        // Use FlowController or EmbeddedPaymentElement for checkout session integrations.
-        fatalError("PaymentSheet does not support checkout session initialization.")
+        PaymentSheet.FlowController.create(
+            checkout: checkout,
+            configuration: configuration
+        ) { result in
+            isLoadingFlowController = false
+            switch result {
+            case .success(let fc):
+                flowController = fc
+            case .failure(let error):
+                loadError = error
+            }
+        }
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -20,15 +20,18 @@ struct CheckoutCartPaymentButton: View {
     @State private var isLoadingFlowController = false
     @State private var loadError: Error?
     @State private var paymentResult: PaymentSheetResult?
-    @State private var isShowingPaymentOptions = false
-    @State private var isConfirming = false
 
     var body: some View {
         VStack {
             if let result = paymentResult {
                 paymentResultView(result: result)
             } else if let flowController {
-                flowControllerView(flowController: flowController)
+                CheckoutFlowControllerView(
+                    flowController: flowController,
+                    session: session,
+                    paymentResult: $paymentResult,
+                    onDismiss: onDismiss
+                )
             } else if isLoadingFlowController {
                 ProgressView()
                     .padding()
@@ -71,81 +74,12 @@ struct CheckoutCartPaymentButton: View {
                 .onAppear { paymentResult = nil }
         case .failed(let error):
             errorView(error: error)
-        }
-    }
-
-    @ViewBuilder
-    private func flowControllerView(flowController: PaymentSheet.FlowController) -> some View {
-        VStack(spacing: 12) {
-            // Payment method selector button
-            Button {
-                isShowingPaymentOptions = true
-            } label: {
-                HStack {
-                    if let paymentOption = flowController.paymentOption {
-                        Image(uiImage: paymentOption.image)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 30, height: 20)
-                        Text(paymentOption.label)
-                            .font(.subheadline)
-                            .foregroundColor(.primary)
-                    } else {
-                        Text("Select payment method")
-                            .font(.subheadline)
-                            .foregroundColor(.primary)
-                    }
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
-                .padding()
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
-                )
-            }
-            .padding(.horizontal)
-            .paymentOptionsSheet(
-                isPresented: $isShowingPaymentOptions,
-                paymentSheetFlowController: flowController,
-                onSheetDismissed: {}
-            )
-
-            // Confirm / checkout button
-            Button {
-                isConfirming = true
-            } label: {
-                HStack {
-                    Text("Checkout")
-                    Spacer()
-                    if let total = session.total, let currency = session.currency {
-                        Text(formatCartCurrency(amount: total.total.minorUnitsAmount, currency: currency))
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                        paymentResult = nil
                     }
                 }
-                .font(.headline)
-                .foregroundColor(.white)
-                .padding()
-                .background(flowController.paymentOption != nil ? Color.blue : Color.gray)
-                .cornerRadius(14)
-            }
-            .disabled(flowController.paymentOption == nil)
-            .padding(.horizontal)
-            .paymentConfirmationSheet(
-                isConfirming: $isConfirming,
-                paymentSheetFlowController: flowController,
-                onCompletion: { result in
-                    paymentResult = result
-                }
-            )
         }
-        .padding(.bottom, 16)
-        .padding(.top, 16)
-        .background(
-            Color(UIColor.systemBackground)
-                .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: -5)
-        )
     }
 
     @ViewBuilder
@@ -185,5 +119,87 @@ struct CheckoutCartPaymentButton: View {
                 loadError = error
             }
         }
+    }
+}
+
+@available(iOS 15.0, *)
+private struct CheckoutFlowControllerView: View {
+    @ObservedObject var flowController: PaymentSheet.FlowController
+    let session: Checkout.Session
+    @Binding var paymentResult: PaymentSheetResult?
+    let onDismiss: () -> Void
+
+    @State private var isShowingPaymentOptions = false
+    @State private var isConfirming = false
+
+    var body: some View {
+        VStack(spacing: 12) {
+            Button {
+                isShowingPaymentOptions = true
+            } label: {
+                HStack {
+                    if let paymentOption = flowController.paymentOption {
+                        Image(uiImage: paymentOption.image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 30, height: 20)
+                        Text(paymentOption.label)
+                            .font(.subheadline)
+                            .foregroundColor(.primary)
+                    } else {
+                        Text("Select payment method")
+                            .font(.subheadline)
+                            .foregroundColor(.primary)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                )
+            }
+            .padding(.horizontal)
+            .paymentOptionsSheet(
+                isPresented: $isShowingPaymentOptions,
+                paymentSheetFlowController: flowController,
+                onSheetDismissed: {}
+            )
+
+            Button {
+                isConfirming = true
+            } label: {
+                HStack {
+                    Text("Checkout")
+                    Spacer()
+                    if let total = session.total, let currency = session.currency {
+                        Text(formatCartCurrency(amount: total.total.minorUnitsAmount, currency: currency))
+                    }
+                }
+                .font(.headline)
+                .foregroundColor(.white)
+                .padding()
+                .background(flowController.paymentOption != nil ? Color.blue : Color.gray)
+                .cornerRadius(14)
+            }
+            .disabled(flowController.paymentOption == nil)
+            .padding(.horizontal)
+            .paymentConfirmationSheet(
+                isConfirming: $isConfirming,
+                paymentSheetFlowController: flowController,
+                onCompletion: { result in
+                    paymentResult = result
+                }
+            )
+        }
+        .padding(.bottom, 16)
+        .padding(.top, 16)
+        .background(
+            Color(UIColor.systemBackground)
+                .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: -5)
+        )
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -97,6 +97,8 @@ struct CheckoutCartPaymentButton: View {
     private func makePaymentSheet() -> PaymentSheet {
         var configuration = PaymentSheet.Configuration()
         configuration.returnURL = "payments-example://stripe-redirect"
-        return PaymentSheet(checkout: checkout, configuration: configuration)
+        // PaymentSheet no longer supports direct checkout initialization.
+        // Use FlowController or EmbeddedPaymentElement for checkout session integrations.
+        fatalError("PaymentSheet does not support checkout session initialization.")
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -29,8 +29,7 @@ struct CheckoutCartPaymentButton: View {
                 CheckoutFlowControllerView(
                     flowController: flowController,
                     session: session,
-                    paymentResult: $paymentResult,
-                    onDismiss: onDismiss
+                    paymentResult: $paymentResult
                 )
             } else if isLoadingFlowController {
                 ProgressView()
@@ -127,7 +126,6 @@ private struct CheckoutFlowControllerView: View {
     @ObservedObject var flowController: PaymentSheet.FlowController
     let session: Checkout.Session
     @Binding var paymentResult: PaymentSheetResult?
-    let onDismiss: () -> Void
 
     @State private var isShowingPaymentOptions = false
     @State private var isConfirming = false

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetSearchViews.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetSearchViews.swift
@@ -83,6 +83,7 @@ private func pickerEnumMatchesSearch<S: PickerEnum>(_ enumType: S.Type, searchTe
 struct SearchableSettingView<S: PickerEnum>: View {
     var setting: Binding<S>
     var title: String?
+    var disabledSettings: [S] = []
     @Binding var searchText: String
 
     private var isVisible: Bool {
@@ -95,7 +96,7 @@ struct SearchableSettingView<S: PickerEnum>: View {
     var body: some View {
         Group {
             if isVisible {
-                SettingView(setting: setting, title: title)
+                SettingView(setting: setting, title: title, disabledSettings: disabledSettings)
             }
         }
         .preference(key: VisibleSettingsCountKey.self, value: isVisible ? 1 : 0)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -28,7 +28,7 @@ struct PaymentSheetTestPlayground: View {
 
     @ViewBuilder
     func clientSettings(searchText: Binding<String>) -> some View {
-        SearchableSettingPickerView(
+        SearchableSettingView(
             setting: uiStyleBinding,
             disabledSettings: playgroundController.settings.integrationType == .checkoutSession ? [.paymentSheet] : [],
             searchText: searchText
@@ -809,12 +809,13 @@ struct AttestationResetButtonView: View {
 struct SettingView<S: PickerEnum>: View {
     var setting: Binding<S>
     var title: String?
+    var disabledSettings: [S] = []
 
     var body: some View {
         HStack {
             Text(title ?? S.enumName).font(.subheadline)
             Picker(title ?? S.enumName, selection: setting) {
-                ForEach(S.allCases, id: \.self) { t in
+                ForEach(S.allCases.filter({ !disabledSettings.contains($0) }), id: \.self) { t in
                     Text(t.displayName)
                 }
             }.pickerStyle(.segmented)

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlayground.swift
@@ -28,7 +28,11 @@ struct PaymentSheetTestPlayground: View {
 
     @ViewBuilder
     func clientSettings(searchText: Binding<String>) -> some View {
-        SearchableSettingView(setting: uiStyleBinding, searchText: searchText)
+        SearchableSettingPickerView(
+            setting: uiStyleBinding,
+            disabledSettings: playgroundController.settings.integrationType == .checkoutSession ? [.paymentSheet] : [],
+            searchText: searchText
+        )
         if playgroundController.settings.uiStyle != .embedded {
             SearchableSettingView(setting: $playgroundController.settings.layout, searchText: searchText)
         }
@@ -447,6 +451,10 @@ struct PaymentSheetTestPlayground: View {
             // If switching to CSC and embedded is selected, reset to PaymentSheet
             if newIntegrationType == .normal && playgroundController.settings.uiStyle == .embedded {
                 playgroundController.settings.uiStyle = .paymentSheet
+            }
+            // PaymentSheet does not support checkout session; switch to flow controller
+            if newIntegrationType == .checkoutSession && playgroundController.settings.uiStyle == .paymentSheet {
+                playgroundController.settings.uiStyle = .flowController
             }
             playgroundController.settings.integrationType = newIntegrationType
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -654,6 +654,14 @@ import UIKit
         updateForcedConsumerLinkBrand(settings)
 
         $settings.removeDuplicates().sink { [weak self] newValue in
+            // PaymentSheet does not support checkout session; auto-correct to flow controller
+            if newValue.integrationType == .checkoutSession && newValue.uiStyle == .paymentSheet {
+                DispatchQueue.main.async {
+                    self?.settings.uiStyle = .flowController
+                }
+                return
+            }
+
             if newValue.autoreload == .on {
                 // This closure is called *before* `settings` is updated! Wait until the next run loop before calling `load`
                 DispatchQueue.main.async {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -709,7 +709,7 @@ import UIKit
         case .deferred_csc, .deferred_ssc, .deferred_mp, .deferred_mc:
             mc = PaymentSheet(intentConfiguration: intentConfig, configuration: configuration)
         case .checkoutSession:
-            mc = PaymentSheet(checkout: self.checkout!, configuration: configuration)
+            fatalError("PaymentSheet does not support checkout session initialization. Use FlowController or EmbeddedPaymentElement instead.")
         }
 
         self.paymentSheet = mc

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -104,23 +104,6 @@ public class PaymentSheet {
         )
     }
 
-    /// Initializes PaymentSheet with a Checkout object
-    /// - Parameter checkout: A loaded Checkout instance.
-    /// - Parameter configuration: Configuration for the PaymentSheet. e.g. your business name, Customer details, etc.
-    @_spi(STP)
-    @_spi(ReactNativeSDK)
-    @MainActor
-    public convenience init(checkout: Checkout, configuration: Configuration) {
-        var config = configuration
-        checkout.stpSession.applyAddressOverrides(to: &config)
-        self.init(
-            mode: .checkout(checkout),
-            configuration: config
-        )
-        self.checkout = checkout
-        checkout.integrationDelegate = self
-    }
-
     required init(mode: InitializationMode, configuration: Configuration) {
         AnalyticsHelper.shared.generateSessionID()
         STPAnalyticsClient.sharedClient.addClass(toProductUsageIfNecessary: PaymentSheet.self)
@@ -162,21 +145,9 @@ public class PaymentSheet {
                 completion(.failed(error: error))
                 return
             }
-            var loadMode = mode
-            if let checkout {
-                do {
-                    try await checkout.awaitPendingOperations()
-                } catch {
-                    completion(.failed(error: error))
-                    return
-                }
-                loadMode = .checkout(checkout)
-                checkout.stpSession.applyAddressOverrides(to: &self.configuration)
-            }
-
             // Configure the Payment Sheet VC after loading the PI/SI, Customer, etc.
             PaymentSheetLoader.load(
-                mode: loadMode,
+                mode: mode,
                 configuration: configuration,
                 analyticsHelper: analyticsHelper,
                 integrationShape: .paymentSheet
@@ -256,9 +227,6 @@ public class PaymentSheet {
 
     /// The initialization mode this instance was initialized with
     let mode: InitializationMode
-
-    /// The Checkout that backs checkout-session mode integrations, if any.
-    private weak var checkout: Checkout?
 
     /// A user-supplied completion block. Nil until `present` is called.
     var completion: ((PaymentSheetResult) -> Void)?
@@ -411,14 +379,6 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
         }
     }
 
-}
-
-// MARK: - CheckoutIntegrationDelegate
-
-extension PaymentSheet: CheckoutIntegrationDelegate {
-    var isSheetPresented: Bool {
-        bottomSheetViewController.presentingViewController != nil
-    }
 }
 
 extension PaymentSheet: LoadingViewControllerDelegate {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -84,11 +84,6 @@ final class PaymentSheetLoader {
                 stpAssertionFailure("Configuration.customer must not be set when using a CheckoutSession. The CheckoutSession manages its own customer.")
                 throw PaymentSheetError.integrationError(nonPIIDebugDescription: "PaymentSheet.Configuration.customer must not be set when using a CheckoutSession.")
             }
-            // defaultBillingDetails.email is populated from the CheckoutSession's customerEmail (if not already set) by applyAddressOverrides, which runs before the loader.
-            if case .checkout = mode, configuration.defaultBillingDetails.email == nil {
-                stpAssertionFailure("An email address is required when using a CheckoutSession. Set configuration.defaultBillingDetails.email or ensure the CheckoutSession has a customer_email.")
-                throw PaymentSheetError.integrationError(nonPIIDebugDescription: "An email address is required when using a CheckoutSession. Set PaymentSheet.Configuration.defaultBillingDetails.email or ensure the CheckoutSession has a customer_email.")
-            }
 
             // Fetch ElementsSession
             // ⚠️ Note using `async let` instead of Tasks here triggered a crash when compiling with Xcode 26.4 / Swift 6.3

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -529,36 +529,6 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         wait(for: [loaded], timeout: 2)
     }
 
-    func testCheckoutSessionWithoutEmailThrowsError() {
-        var json = STPTestUtils.jsonNamed("CheckoutSession")!
-        json["customer_email"] = NSNull()
-        let checkoutSession = STPCheckoutSession.decodedObject(fromAPIResponse: json)!
-
-        var configuration = PaymentSheet.Configuration()
-        configuration.apiClient = stubbedAPIClient()
-
-        let loaded = expectation(description: "Loaded")
-        STPAssertTestUtil.shouldSuppressNextSTPAlert = true
-        PaymentSheetLoader.load(
-            mode: .checkout(Checkout(session: checkoutSession)),
-            configuration: configuration,
-            analyticsHelper: ._testValue(integrationShape: .complete),
-            integrationShape: .paymentSheet
-        ) { result in
-            switch result {
-            case .success:
-                XCTFail("Expected failure when email is not set with CheckoutSession mode")
-            case .failure(let error):
-                guard case PaymentSheetError.integrationError = error else {
-                    XCTFail("Expected PaymentSheetError.integrationError, got \(error)")
-                    return
-                }
-            }
-            loaded.fulfill()
-        }
-        wait(for: [loaded], timeout: 2)
-    }
-
     func testSendsErrorAnalytic() {
         // If v1/elements/session and the fallback fail to load...
         let analyticsClient = STPAnalyticsClient()


### PR DESCRIPTION
## Summary
- Removes PaymentSheet.init(Checkout), replaced by PS.FC and EPE
- Replaces/removes PaymentSheet as an option in the playground when CheckoutSessions is selected

## Motivation
- Product brief

## Testing
- Manual
- CI

## Changelog
N/A
