### PR TITLE
PMM Experiment — Link out to external browser if non-stripe link is hit

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEInfoModal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEInfoModal.swift
@@ -115,6 +115,17 @@ final class PMMEInfoModal: UIViewController {
 
 extension PMMEInfoModal: WKNavigationDelegate {
 
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        // Non-Stripe links (e.g. partner sites) should open in the external browser
+        // rather than navigating within the modal webview.
+        if let host = navigationAction.request.url?.host, !host.contains("stripe") {
+            UIApplication.shared.open(navigationAction.request.url!)
+            decisionHandler(.cancel)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         activityIndicator.stopAnimating()
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEInfoModal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEInfoModal.swift
@@ -15,6 +15,8 @@ final class PMMEInfoModal: UIViewController {
     private let infoUrl: URL
     private let style: PaymentMethodMessagingElement.Appearance.UserInterfaceStyle
     private let activityIndicator: UIActivityIndicatorView
+    private var webView: WKWebView?
+    private var themedUrl: URL?
 
     init(infoUrl: URL, style: PaymentMethodMessagingElement.Appearance.UserInterfaceStyle) {
         self.infoUrl = infoUrl
@@ -67,10 +69,16 @@ final class PMMEInfoModal: UIViewController {
 
         // setup webview
         let webView = WKWebView(frame: CGRect.zero)
+        self.webView = webView
+        self.themedUrl = themedUrl
         webView.navigationDelegate = self
         webView.isOpaque = false
         webView.translatesAutoresizingMaskIntoConstraints = false
         view.addAndPinSubview(webView)
+
+        // Reload original page when returning from external browser
+        // This is needed to reset the state of the page in case there was a loading animation or anything from the link-out
+        NotificationCenter.default.addObserver(self, selector: #selector(appWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
 
         // setup activity indicator
         activityIndicator.center = self.view.center
@@ -110,6 +118,12 @@ final class PMMEInfoModal: UIViewController {
     @objc
     private func didTapCloseButton() {
         dismiss(animated: true)
+    }
+
+    @objc
+    private func appWillEnterForeground() {
+        guard let themedUrl else { return }
+        webView?.load(URLRequest(url: themedUrl))
     }
 }
 


### PR DESCRIPTION
## Summary
- if a non-stripe-host navigation is attempted, link out to external browser
- when returning from the external browser, refresh the page to get rid of any transition/loading state

## Motivation
3rd party UI such as Affirm's prequalification flow has UX issues when embedded into the PMMEInfoModal. Thus, we link out to the external browser if a non-stripe navigation happens
https://docs.google.com/document/d/1E-EQ4hEIvIkQFQF9doshXYKiKh1_3Y-tIecjgapSkdY/edit?tab=t.0#heading=h.cz1xkpga7giy

## Testing
https://github.com/user-attachments/assets/af5f1aa7-f9e2-4537-9bc3-1a7a73a55970

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
