### PR TITLE
Fail confirm if mutations are in flight

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -514,7 +514,7 @@ extension EmbeddedPaymentElement {
         }
 
         if let checkout, !checkout.pendingOperations.isEmpty {
-            let errorMessage = "confirm was called while a Checkout mutation (e.g. applyPromotionCode) is still in progress. Wait for it to finish before calling confirm."
+            let errorMessage = "confirm was called while the Checkout session is still loading. Wait until the Checkout state is .loaded before calling confirm."
             let error = PaymentSheetError.integrationError(nonPIIDebugDescription: errorMessage)
             return (.failed(error: error), nil)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -513,6 +513,12 @@ extension EmbeddedPaymentElement {
             return (.failed(error: PaymentSheetError.embeddedPaymentElementAlreadyConfirmedIntent), nil)
         }
 
+        if let checkout, !checkout.pendingOperations.isEmpty {
+            let errorMessage = "confirm was called while a Checkout mutation (e.g. applyPromotionCode) is still in progress. Wait for it to finish before calling confirm."
+            let error = PaymentSheetError.integrationError(nonPIIDebugDescription: errorMessage)
+            return (.failed(error: error), nil)
+        }
+
         if let latestUpdateContext {
             switch latestUpdateContext.status {
             case .inProgress:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -134,6 +134,7 @@ public final class EmbeddedPaymentElement {
             analyticsHelper: analyticsHelper
         )
         embeddedPaymentElement.clearPaymentOptionIfNeeded()
+        embeddedPaymentElement.checkout = checkout
         checkout.integrationDelegate = embeddedPaymentElement
         return embeddedPaymentElement
     }
@@ -386,6 +387,7 @@ public final class EmbeddedPaymentElement {
     internal var hasConfirmedIntent = false
     /// Tracks info about the currently in-flight or most recent update attempt.
     internal var latestUpdateContext: EmbeddedUpdateContext?
+    internal weak var checkout: Checkout?
 #if DEBUG
     internal var _test_paymentOption: PaymentOption? // for testing only
 #endif

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -302,6 +302,7 @@ extension PaymentSheet {
             }
         }
 
+        private weak var checkout: Checkout?
         private var isPresented = false
         private(set) var didPresentAndContinue: Bool = false
         private var confirmationChallenge: ConfirmationChallenge?
@@ -418,6 +419,7 @@ extension PaymentSheet {
                        configuration: config
                 ) { result in
                     if case .success(let flowController) = result {
+                        flowController.checkout = checkout
                         checkout.integrationDelegate = flowController
                     }
                     completion(result)
@@ -584,6 +586,16 @@ extension PaymentSheet {
             completion: @escaping (PaymentSheetResult) -> Void
         ) {
             assert(Thread.isMainThread, "PaymentSheet.FlowController.confirm must be called from the main thread.")
+
+            // assumeIsolated needed because FlowController isn't @MainActor but we assert main thread above.
+            if let checkout, MainActor.assumeIsolated({ !checkout.pendingOperations.isEmpty }) {
+                assertionFailure("`confirm` should not be called while a Checkout mutation is in progress.")
+                let error = PaymentSheetError.flowControllerConfirmFailed(
+                    message: "confirmPayment was called while a Checkout mutation (e.g. applyPromotionCode) is still in progress."
+                )
+                completion(.failed(error: error))
+                return
+            }
 
             switch latestUpdateContext?.status {
             case .inProgress:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -589,9 +589,9 @@ extension PaymentSheet {
 
             // assumeIsolated needed because FlowController isn't @MainActor but we assert main thread above.
             if let checkout, MainActor.assumeIsolated({ !checkout.pendingOperations.isEmpty }) {
-                assertionFailure("`confirm` should not be called while a Checkout mutation is in progress.")
+                assertionFailure("`confirm` should not be called while the Checkout session is loading.")
                 let error = PaymentSheetError.flowControllerConfirmFailed(
-                    message: "confirmPayment was called while a Checkout mutation (e.g. applyPromotionCode) is still in progress."
+                    message: "confirmPayment was called while the Checkout session is still loading. Wait until the Checkout state is .loaded before calling confirm."
                 )
                 completion(.failed(error: error))
                 return


### PR DESCRIPTION
## Summary
-  Fail EPE/FlowController confirm() if the backing Checkout has in-flight mutations.
- When a Checkout mutation (e.g. applyPromotionCode) is in progress, the session state is stale. Confirming against it could charge the wrong amount. This adds a guard so confirm() fails immediately if checkout.pendingOperations is non-empty.

## Motivation
- https://jira.corp.stripe.com/browse/MOBILESDK-4583

## Testing
- Manual
- Quite difficult to unit test, this is just a safe guard.

## Changelog
N/A
