### PR TITLE
Await updates before presenting FC sheet

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -27,7 +27,6 @@ struct CheckoutCartPaymentButton: View {
             } else if let flowController {
                 CheckoutFlowControllerView(
                     flowController: flowController,
-                    checkout: checkout,
                     session: session,
                     paymentResult: $paymentResult
                 )
@@ -124,7 +123,6 @@ struct CheckoutCartPaymentButton: View {
 @available(iOS 15.0, *)
 private struct CheckoutFlowControllerView: View {
     @ObservedObject var flowController: PaymentSheet.FlowController
-    let checkout: Checkout
     let session: Checkout.Session
     @Binding var paymentResult: PaymentSheetResult?
 
@@ -134,17 +132,7 @@ private struct CheckoutFlowControllerView: View {
     var body: some View {
         VStack(spacing: 12) {
             Button {
-                // Kick off mutations to test "present while mutations in-flight" behavior.
-                Task {
-                    Task {
-                        try? await checkout.runServerUpdate {
-                            try? await Task.sleep(nanoseconds: 2_000_000_000)
-                        }
-                    }
-                    // Yield to let the mutation enqueue before presenting.
-                    await Task.yield()
-                    isShowingPaymentOptions = true
-                }
+                isShowingPaymentOptions = true
             } label: {
                 HStack {
                     if let paymentOption = flowController.paymentOption {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -27,6 +27,7 @@ struct CheckoutCartPaymentButton: View {
             } else if let flowController {
                 CheckoutFlowControllerView(
                     flowController: flowController,
+                    checkout: checkout,
                     session: session,
                     paymentResult: $paymentResult
                 )
@@ -123,6 +124,7 @@ struct CheckoutCartPaymentButton: View {
 @available(iOS 15.0, *)
 private struct CheckoutFlowControllerView: View {
     @ObservedObject var flowController: PaymentSheet.FlowController
+    let checkout: Checkout
     let session: Checkout.Session
     @Binding var paymentResult: PaymentSheetResult?
 
@@ -132,7 +134,17 @@ private struct CheckoutFlowControllerView: View {
     var body: some View {
         VStack(spacing: 12) {
             Button {
-                isShowingPaymentOptions = true
+                // Kick off mutations to test "present while mutations in-flight" behavior.
+                Task {
+                    Task {
+                        try? await checkout.runServerUpdate {
+                            try? await Task.sleep(nanoseconds: 2_000_000_000)
+                        }
+                    }
+                    // Yield to let the mutation enqueue before presenting.
+                    await Task.yield()
+                    isShowingPaymentOptions = true
+                }
             } label: {
                 HStack {
                     if let paymentOption = flowController.paymentOption {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -511,7 +511,7 @@ extension PaymentSheet {
             }
             presentPaymentOptionsCompletionWithResult = wrappedCompletion
 
-            // If Checkout mutations are in-flight, present a loading sheet and await them.
+            // Mutations in-flight: show loading, await them, then present payment options internally.
             // TODO(porter): Remove assumeIsolated once presentPaymentOptions is @MainActor (blocked on new FC API designs)
             if let checkout, MainActor.assumeIsolated({ !checkout.pendingOperations.isEmpty }) {
                 presentPaymentOptionsAwaitingMutations(
@@ -519,6 +519,7 @@ extension PaymentSheet {
                     checkout: checkout,
                     completion: wrappedCompletion
                 )
+                // Early exit, presentPaymentOptionsAwaitingMutations will present after awaiting mutations
                 return
             }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -304,6 +304,7 @@ extension PaymentSheet {
 
         private weak var checkout: Checkout?
         private var isPresented = false
+        private var pendingPresentTask: Task<Void, Never>?
         private(set) var didPresentAndContinue: Bool = false
         private var confirmationChallenge: ConfirmationChallenge?
         let analyticsHelper: PaymentSheetAnalyticsHelper
@@ -512,47 +513,11 @@ extension PaymentSheet {
 
             // If Checkout mutations are in-flight, present a loading sheet and await them.
             if let checkout, MainActor.assumeIsolated({ !checkout.pendingOperations.isEmpty }) {
-                let loadingVC = LoadingViewController(
-                    delegate: self,
-                    appearance: configuration.appearance,
-                    isTestMode: configuration.apiClient.isTestmode
+                presentPaymentOptionsAwaitingMutations(
+                    from: presentingViewController,
+                    checkout: checkout,
+                    completion: wrappedCompletion
                 )
-                let bottomSheetVC = Self.makeBottomSheetViewController(
-                    loadingVC,
-                    configuration: configuration,
-                    didCancelNative3DS2: { [weak self] in
-                        self?.paymentHandler.cancel3DS2ChallengeFlow()
-                    }
-                )
-                presentingViewController.presentAsBottomSheet(bottomSheetVC, appearance: configuration.appearance)
-
-                Task { @MainActor [weak self] in
-                    guard let self else { return }
-                    do {
-                        try await checkout.awaitPendingOperations()
-                    } catch {
-                        bottomSheetVC.dismiss(animated: true) {
-                            wrappedCompletion(true)
-                        }
-                        return
-                    }
-                    self.isPresented = true
-                    // Refresh the view controller with the updated session data.
-                    checkout.stpSession.applyAddressOverrides(to: &self.configuration)
-                    let updateID = UUID()
-                    self.performUpdate(mode: .checkout(checkout), updateID: updateID) { [weak self] error in
-                        guard let self else { return }
-                        if error != nil {
-                            self.isPresented = false
-                            bottomSheetVC.dismiss(animated: true) {
-                                wrappedCompletion(true)
-                            }
-                        } else {
-                            self.viewController.flowControllerDelegate = self
-                            bottomSheetVC.setViewControllers([self.viewController])
-                        }
-                    }
-                }
                 return
             }
 
@@ -583,6 +548,57 @@ extension PaymentSheet {
             }
 
             showPaymentOptions()
+        }
+
+        /// Presents a loading sheet while awaiting in-flight Checkout mutations,
+        /// then swaps to the payment options view controller on success or dismisses on failure.
+        private func presentPaymentOptionsAwaitingMutations(
+            from presentingViewController: UIViewController,
+            checkout: Checkout,
+            completion: @escaping (Bool) -> Void
+        ) {
+            let loadingVC = LoadingViewController(
+                delegate: self,
+                appearance: configuration.appearance,
+                isTestMode: configuration.apiClient.isTestmode
+            )
+            let bottomSheetVC = Self.makeBottomSheetViewController(
+                loadingVC,
+                configuration: configuration,
+                didCancelNative3DS2: { [weak self] in
+                    self?.paymentHandler.cancel3DS2ChallengeFlow()
+                }
+            )
+            presentingViewController.presentAsBottomSheet(bottomSheetVC, appearance: configuration.appearance)
+
+            pendingPresentTask = Task { @MainActor [weak self] in
+                guard let self else { return }
+                do {
+                    try await checkout.awaitPendingOperations()
+                } catch {
+                    guard !Task.isCancelled else { return }
+                    bottomSheetVC.dismiss(animated: true) {
+                        completion(true)
+                    }
+                    return
+                }
+                guard !Task.isCancelled else { return }
+                self.isPresented = true
+                checkout.stpSession.applyAddressOverrides(to: &self.configuration)
+                let updateID = UUID()
+                self.performUpdate(mode: .checkout(checkout), updateID: updateID) { [weak self] error in
+                    guard let self else { return }
+                    if error != nil {
+                        self.isPresented = false
+                        bottomSheetVC.dismiss(animated: true) {
+                            completion(true)
+                        }
+                    } else {
+                        self.viewController.flowControllerDelegate = self
+                        bottomSheetVC.setViewControllers([self.viewController])
+                    }
+                }
+            }
         }
 
         private func presentNativeLinkInPlaceOfFlowController(
@@ -964,10 +980,11 @@ extension PaymentSheet.FlowController: CheckoutIntegrationDelegate {
 
 extension PaymentSheet.FlowController: LoadingViewControllerDelegate {
     func shouldDismiss(_ loadingViewController: LoadingViewController) {
+        pendingPresentTask?.cancel()
+        pendingPresentTask = nil
         loadingViewController.dismiss(animated: true) {
             self.presentPaymentOptionsCompletionWithResult?(true)
             self.updatePaymentOption()
-            self.isPresented = false
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -510,6 +510,52 @@ extension PaymentSheet {
             }
             presentPaymentOptionsCompletionWithResult = wrappedCompletion
 
+            // If Checkout mutations are in-flight, present a loading sheet and await them.
+            if let checkout, MainActor.assumeIsolated({ !checkout.pendingOperations.isEmpty }) {
+                let loadingVC = LoadingViewController(
+                    delegate: self,
+                    appearance: configuration.appearance,
+                    isTestMode: configuration.apiClient.isTestmode
+                )
+                let bottomSheetVC = Self.makeBottomSheetViewController(
+                    loadingVC,
+                    configuration: configuration,
+                    didCancelNative3DS2: { [weak self] in
+                        self?.paymentHandler.cancel3DS2ChallengeFlow()
+                    }
+                )
+                presentingViewController.presentAsBottomSheet(bottomSheetVC, appearance: configuration.appearance)
+
+                Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    do {
+                        try await checkout.awaitPendingOperations()
+                    } catch {
+                        bottomSheetVC.dismiss(animated: true) {
+                            wrappedCompletion(true)
+                        }
+                        return
+                    }
+                    self.isPresented = true
+                    // Refresh the view controller with the updated session data.
+                    checkout.stpSession.applyAddressOverrides(to: &self.configuration)
+                    let updateID = UUID()
+                    self.performUpdate(mode: .checkout(checkout), updateID: updateID) { [weak self] error in
+                        guard let self else { return }
+                        if error != nil {
+                            self.isPresented = false
+                            bottomSheetVC.dismiss(animated: true) {
+                                wrappedCompletion(true)
+                            }
+                        } else {
+                            self.viewController.flowControllerDelegate = self
+                            bottomSheetVC.setViewControllers([self.viewController])
+                        }
+                    }
+                }
+                return
+            }
+
             let showPaymentOptions: () -> Void = { [weak self] in
                 guard let self = self else { return }
 
@@ -911,6 +957,18 @@ extension PaymentSheet {
 extension PaymentSheet.FlowController: CheckoutIntegrationDelegate {
     var isSheetPresented: Bool {
         isPresented
+    }
+}
+
+// MARK: - LoadingViewControllerDelegate
+
+extension PaymentSheet.FlowController: LoadingViewControllerDelegate {
+    func shouldDismiss(_ loadingViewController: LoadingViewController) {
+        loadingViewController.dismiss(animated: true) {
+            self.presentPaymentOptionsCompletionWithResult?(true)
+            self.updatePaymentOption()
+            self.isPresented = false
+        }
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -512,6 +512,7 @@ extension PaymentSheet {
             presentPaymentOptionsCompletionWithResult = wrappedCompletion
 
             // If Checkout mutations are in-flight, present a loading sheet and await them.
+            // TODO(porter): Remove assumeIsolated once presentPaymentOptions is @MainActor (blocked on new FC API designs)
             if let checkout, MainActor.assumeIsolated({ !checkout.pendingOperations.isEmpty }) {
                 presentPaymentOptionsAwaitingMutations(
                     from: presentingViewController,
@@ -649,7 +650,7 @@ extension PaymentSheet {
         ) {
             assert(Thread.isMainThread, "PaymentSheet.FlowController.confirm must be called from the main thread.")
 
-            // assumeIsolated needed because FlowController isn't @MainActor but we assert main thread above.
+            // TODO(porter): Remove assumeIsolated once confirm is @MainActor (blocked on new FC API designs)
             if let checkout, MainActor.assumeIsolated({ !checkout.pendingOperations.isEmpty }) {
                 assertionFailure("`confirm` should not be called while the Checkout session is loading.")
                 let error = PaymentSheetError.flowControllerConfirmFailed(


### PR DESCRIPTION
## Summary
- If there are updates pending when the user calls presentPaymentOptions on flow controller, we will show a sheet with a loading indicator and await those tasks to finish presenting the sheet.
- If one of the updates fails, the sheet presentation will silently fail and the loading sheet will dismiss. 

#### Demo (using runServerUpdate to run a simulated a 2 second update)

https://github.com/user-attachments/assets/2738bdb5-307d-4d25-8487-7d36e67356e7



## Motivation
- https://docs.google.com/document/d/1CWglcOHR6I8cOWKjztPfnhnVG8axucpv-j5cWIoey7E/edit?tab=t.uzy1hgt1h5jt#bookmark=id.7lu47ty3ex39

## Testing
- Manual, difficult to write unit tests for

## Changelog
N/A
