### PR TITLE
Send to r instead of q behind static flag

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticsClient.swift
@@ -25,6 +25,16 @@ import UIKit
 
 @_spi(STP) public class STPAnalyticsClient: NSObject, STPAnalyticsClientProtocol {
     @objc public static let sharedClient = STPAnalyticsClient()
+
+    /// When `true`, sends analytics directly to r.stripe.com via POST.
+    /// When `false`, sends to q.stripe.com via GET (legacy path).
+    @_spi(STP) public static var sendAnalyticsToRStripe: Bool = false
+
+    private static let rStripeUrl = URL(string: "https://r.stripe.com/0")!
+    private static let qStripeUrl = URL(string: "https://q.stripe.com")!
+    private static let rStripeClientId = "stripe-mobile-payments-sdk"
+    private static let rStripeOrigin = "stripe-mobile-payments-sdk-ios"
+
     /// When this class logs a payload in an XCTestCase, it's added to `_testLogHistory` instead of being sent over the network.
     /// This is a hack - ideally, we inject a different analytics client in our tests. This is an escape hatch until we can make that (significant) refactor
     private var _testLogHistoryStorage: [[String: Any]] = []
@@ -45,7 +55,6 @@ import UIKit
     @objc public var productUsage: Set<String> = Set()
     private var additionalInfoSet: Set<String> = Set()
     let urlSession: URLSession
-    let url = URL(string: "https://q.stripe.com")!
     private let analyticsEventTranslator = STPAnalyticsEventTranslator()
 
     public init(
@@ -110,6 +119,9 @@ import UIKit
         var payload = commonPayload(apiClient)
 
         payload["event"] = analytic.event.rawValue
+        if STPAnalyticsClient.sendAnalyticsToRStripe {
+            payload["event_name"] = analytic.event.rawValue
+        }
 
         payload.mergeAssertingOnOverwrites(analytic.params)
         return payload
@@ -153,10 +165,19 @@ import UIKit
             return
         }
 
-        var request = URLRequest(url: url)
-        request.stp_addParameters(toURL: payload)
-        let task: URLSessionDataTask = urlSession.dataTask(with: request as URLRequest)
-        task.resume()
+        if STPAnalyticsClient.sendAnalyticsToRStripe {
+            var request = URLRequest(url: STPAnalyticsClient.rStripeUrl)
+            request.httpMethod = "POST"
+            request.stp_setFormPayload(payload)
+            request.setValue(STPAnalyticsClient.rStripeOrigin, forHTTPHeaderField: "Origin")
+            let task: URLSessionDataTask = urlSession.dataTask(with: request as URLRequest)
+            task.resume()
+        } else {
+            var request = URLRequest(url: STPAnalyticsClient.qStripeUrl)
+            request.stp_addParameters(toURL: payload)
+            let task: URLSessionDataTask = urlSession.dataTask(with: request as URLRequest)
+            task.resume()
+        }
     }
 
     /// Whether to send the analytic  or not. If `false`, appends payload to `self._testLogHistory` instead.
@@ -206,7 +227,13 @@ extension STPAnalyticsClient {
         payload["install"] = InstallMethod.current.rawValue
         payload["publishable_key"] = apiClient.sanitizedPublishableKey ?? "unknown"
         payload["session_id"] = AnalyticsHelper.shared.sessionID
-        payload["timestamp"] = Date().timeIntervalSince1970
+        let timestamp = Date().timeIntervalSince1970
+        payload["timestamp"] = timestamp
+        if STPAnalyticsClient.sendAnalyticsToRStripe {
+            payload["client_id"] = STPAnalyticsClient.rStripeClientId
+            payload["event_id"] = UUID().uuidString
+            payload["created"] = timestamp
+        }
         if STPAnalyticsClient.isSimulatorOrTest {
             payload["is_development"] = true
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -396,6 +396,11 @@ extension STPElementsSession {
     var shouldUseAutocompleteProxyEndpoints: Bool {
         flags["ocs_mobile_should_use_autocomplete_proxy_endpoints"] == true
     }
+
+    /// Whether legacy analytics (`STPAnalyticsClient`) should be sent to r.stripe.com instead of q.stripe.com.
+    var isAnalyticsToRStripeEnabled: Bool {
+        flags["ocs_mobile_enable_analytics_to_r"] == true
+    }
 }
 
 extension STPElementsSession {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -120,6 +120,9 @@ final class PaymentSheetLoader {
             let isFcLiteKillswitchEnabled = elementsSession.flags["elements_disable_fc_lite"] == true
             FinancialConnectionsSDKAvailability.fcLiteKillswitchEnabled = isFcLiteKillswitchEnabled
 
+            // Send legacy analytics to r.stripe.com instead of q.stripe.com if enabled
+            STPAnalyticsClient.sendAnalyticsToRStripe = elementsSession.isAnalyticsToRStripeEnabled
+
             let remoteFcLiteOverrideEnabled = shouldPreferFCLite(elementsSession: elementsSession)
             FinancialConnectionsSDKAvailability.remoteFcLiteOverride = remoteFcLiteOverrideEnabled
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderStubbedTest.swift
@@ -538,6 +538,89 @@ class PaymentSheetLoaderStubbedTest: APIStubbedTestCase {
         wait(for: [loadExpectation], timeout: STPTestingNetworkRequestTimeout)
     }
 
+    // MARK: - Analytics destination flag
+
+    func testLoad_setsSendAnalyticsToRStripe_whenFlagEnabled() throws {
+        StubbedBackend.stubSessions(
+            fileMock: .elementsSessionsPaymentMethod_200,
+            responseCallback: { data in
+                var mutated = StubbedBackend.updatePaymentMethodDetail(
+                    data: data,
+                    variables: ["<paymentMethods>": "\"card\"", "<currency>": "\"usd\""]
+                )
+                var json = try! JSONSerialization.jsonObject(with: mutated) as! [String: Any]
+                json["flags"] = ["ocs_mobile_enable_analytics_to_r": true]
+                mutated = try! JSONSerialization.data(withJSONObject: json)
+                return mutated
+            }
+        )
+        StubbedBackend.stubPaymentMethods(paymentMethodTypes: [])
+        StubbedBackend.stubCustomers()
+        StubbedBackend.stubLookup()
+
+        STPAnalyticsClient.sendAnalyticsToRStripe = false
+        defer { STPAnalyticsClient.sendAnalyticsToRStripe = false }
+
+        let loaded = expectation(description: "Loaded")
+        let configuration = self.configuration(apiClient: stubbedAPIClient())
+        PaymentSheetLoader.load(
+            mode: .paymentIntentClientSecret("pi_12345_secret_54321"),
+            configuration: configuration,
+            analyticsHelper: ._testValue(integrationShape: .flowController, configuration: configuration),
+            integrationShape: .flowController
+        ) { result in
+            switch result {
+            case .success:
+                XCTAssertTrue(STPAnalyticsClient.sendAnalyticsToRStripe)
+                loaded.fulfill()
+            case .failure(let error):
+                XCTFail(error.nonGenericDescription)
+            }
+        }
+        wait(for: [loaded], timeout: 2)
+    }
+
+    func testLoad_doesNotSetSendAnalyticsToRStripe_whenFlagDisabled() throws {
+        StubbedBackend.stubSessions(
+            fileMock: .elementsSessionsPaymentMethod_200,
+            responseCallback: { data in
+                var mutated = StubbedBackend.updatePaymentMethodDetail(
+                    data: data,
+                    variables: ["<paymentMethods>": "\"card\"", "<currency>": "\"usd\""]
+                )
+                var json = try! JSONSerialization.jsonObject(with: mutated) as! [String: Any]
+                json["flags"] = ["ocs_mobile_enable_analytics_to_r": false]
+                mutated = try! JSONSerialization.data(withJSONObject: json)
+                return mutated
+            }
+        )
+        StubbedBackend.stubPaymentMethods(paymentMethodTypes: [])
+        StubbedBackend.stubCustomers()
+        StubbedBackend.stubLookup()
+
+        // Simulate a prior load having turned the flag on, to verify a subsequent load without the flag turns it back off.
+        STPAnalyticsClient.sendAnalyticsToRStripe = false
+        defer { STPAnalyticsClient.sendAnalyticsToRStripe = false }
+
+        let loaded = expectation(description: "Loaded")
+        let configuration = self.configuration(apiClient: stubbedAPIClient())
+        PaymentSheetLoader.load(
+            mode: .paymentIntentClientSecret("pi_12345_secret_54321"),
+            configuration: configuration,
+            analyticsHelper: ._testValue(integrationShape: .flowController, configuration: configuration),
+            integrationShape: .flowController
+        ) { result in
+            switch result {
+            case .success:
+                XCTAssertFalse(STPAnalyticsClient.sendAnalyticsToRStripe)
+                loaded.fulfill()
+            case .failure(let error):
+                XCTFail(error.nonGenericDescription)
+            }
+        }
+        wait(for: [loaded], timeout: 2)
+    }
+
     // MARK: - Link Lookup Session Preservation
 
     @MainActor

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPElementsSessionTest.swift
@@ -68,6 +68,22 @@ class STPElementsSessionTest: XCTestCase {
         XCTAssertFalse(elementsSession.shouldAttestOnConfirmation)
     }
 
+    func testDecodedObjectFromAPIResponseMapping_analyticsToR() {
+        var elementsSessionJson = STPTestUtils.jsonNamed("ElementsSession")!
+        elementsSessionJson["flags"] = ["ocs_mobile_enable_analytics_to_r": true]
+
+        var elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
+        XCTAssertTrue(elementsSession.isAnalyticsToRStripeEnabled)
+
+        elementsSessionJson["flags"] = ["ocs_mobile_enable_analytics_to_r": false]
+        elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
+        XCTAssertFalse(elementsSession.isAnalyticsToRStripeEnabled)
+
+        elementsSessionJson["flags"] = [:]
+        elementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJson)!
+        XCTAssertFalse(elementsSession.isAnalyticsToRStripeEnabled)
+    }
+
     func testDecodedObjectFromAPIResponseMapping_linkBrandLink() {
         var elementsSessionJson = STPTestUtils.jsonNamed("ElementsSession")!
         elementsSessionJson[jsonDict: "link_settings"]?["link_brand"] = "link"


### PR DESCRIPTION
## Summary
Updates analytics client to talk directly to R instead of Q

## Motivation
Data migration

## Testing
Blocked -- awaiting deployments in backend.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
