### PR TITLE
Fix Link Inline Signup GB Test Case

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLinkUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLinkUITests.swift
@@ -479,7 +479,7 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
 
         try fillCardData(app)
 
-        app.switches["Save my info for faster checkout with Link"].tap()
+        app.switches["Save my info for faster checkout with One-link"].tap()
 
         let emailField = app.textFields["Email"]
         emailField.tap()


### PR DESCRIPTION
## Summary
Use the accessibility brand label for Link in GB instead of the US brand name.

## Motivation
Fix `testLinkInlineSignup_gb` UI test.

