### PR TITLE
Simplify Checkout session update internals

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -90,19 +90,6 @@ extension Checkout {
 
     // MARK: - Validation
 
-    /// Validates that the session is open and no sheet is presented.
-    @discardableResult
-    func requireOpenSession() throws -> STPCheckoutSession {
-        guard let currentSession = stpSession else {
-            stpAssertionFailure("Expected STPCheckoutSession, got \(type(of: state.session))")
-            throw CheckoutError.apiError(message: "Unexpected session type: expected STPCheckoutSession")
-        }
-        guard currentSession.status?.type == .open else {
-            throw CheckoutError.sessionNotOpen
-        }
-        return currentSession
-    }
-
     func requireSheetNotPresented() throws {
         guard integrationDelegate?.isSheetPresented != true else {
             throw CheckoutError.sheetCurrentlyPresented

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -22,21 +22,6 @@ extension Checkout {
 
     // MARK: - Session Updates
 
-    /// Replaces the current session, preserves client-side overrides, and notifies delegates.
-    ///
-    /// Client-side address overrides are copied from the current session to `newSession`
-    /// automatically. To update an address, set it on `stpSession` before calling this method.
-    func commitSession(_ newSession: STPCheckoutSession) async throws {
-        // Preserve client-side address overrides on the new session.
-        newSession.billingAddress = stpSession?.billingAddress
-        newSession.shippingAddress = stpSession?.shippingAddress
-        stpSession = newSession
-        let publicSession = newSession.makePublicSession()
-        state = pendingOperations.isEmpty ? .loaded(publicSession) : .loading(publicSession)
-        try await integrationDelegate?.checkoutDidUpdate(self)
-        delegate?.checkout(self, didChangeState: state)
-    }
-
     /// Runs `body` as a tracked session update, serialized behind any in-flight ops.
     ///
     /// Operations execute in strict FIFO order: each task waits for the previous

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -18,9 +18,7 @@ extension Checkout {
     /// - Throws: ``CheckoutError`` if the update fails.
     func selectCurrency(_ currency: String) async throws {
         try requireOpenSessionForInSheetUpdate()
-        try await enqueueSessionUpdate {
-            try await self.performAPIUpdate(.setCurrency(currency))
-        }
+        try await performUpdate(.setCurrency(currency))
     }
 
     // MARK: - Session Updates
@@ -63,19 +61,53 @@ extension Checkout {
         try await operation.value
     }
 
-    /// Sends a mutation to the Stripe API and updates the session from the response.
-    func performAPIUpdate(_ update: SessionUpdate) async throws {
-        let sessionId = Self.extractSessionId(from: clientSecret)
-        let updatedSession: STPCheckoutSession
-        do {
-            updatedSession = try await apiClient.updateCheckoutSession(
-                checkoutSessionId: sessionId,
-                parameters: update.parameters
-            )
-        } catch {
-            throw CheckoutError.apiError(message: error.nonGenericDescription)
+    /// Enqueues a serialized API mutation and updates the session from the response.
+    func performUpdate(_ update: SessionUpdate) async throws {
+        try await enqueueSessionUpdate {
+            let sessionId = Self.extractSessionId(from: self.clientSecret)
+            let updatedSession: STPCheckoutSession
+            do {
+                updatedSession = try await self.apiClient.updateCheckoutSession(
+                    checkoutSessionId: sessionId,
+                    parameters: update.parameters
+                )
+            } catch {
+                throw CheckoutError.apiError(message: error.nonGenericDescription)
+            }
+            try await self.updateSession(updatedSession)
         }
-        try await updateSession(updatedSession)
+    }
+
+    /// Enqueues a serialized API mutation with a local state change applied before the API call.
+    func performUpdate(
+        _ update: SessionUpdate,
+        applying sideEffect: @MainActor @Sendable @escaping () -> Void
+    ) async throws {
+        try await enqueueSessionUpdate {
+            sideEffect()
+            let sessionId = Self.extractSessionId(from: self.clientSecret)
+            let updatedSession: STPCheckoutSession
+            do {
+                updatedSession = try await self.apiClient.updateCheckoutSession(
+                    checkoutSessionId: sessionId,
+                    parameters: update.parameters
+                )
+            } catch {
+                throw CheckoutError.apiError(message: error.nonGenericDescription)
+            }
+            try await self.updateSession(updatedSession)
+        }
+    }
+
+    /// Enqueues a local-only session update (no API call) and notifies delegates.
+    func performUpdate(
+        applying sideEffect: @MainActor @Sendable @escaping () -> Void
+    ) async throws {
+        try await enqueueSessionUpdate {
+            sideEffect()
+            guard let session = self.stpSession else { return }
+            try await self.updateSession(session)
+        }
     }
 
     /// Fetches the latest Checkout Session from Stripe and publishes it to observers.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -61,52 +61,38 @@ extension Checkout {
         try await operation.value
     }
 
-    /// Enqueues a serialized API mutation and updates the session from the response.
-    func performUpdate(_ update: SessionUpdate) async throws {
-        try await enqueueSessionUpdate {
-            let sessionId = Self.extractSessionId(from: self.clientSecret)
-            let updatedSession: STPCheckoutSession
-            do {
-                updatedSession = try await self.apiClient.updateCheckoutSession(
-                    checkoutSessionId: sessionId,
-                    parameters: update.parameters
-                )
-            } catch {
-                throw CheckoutError.apiError(message: error.nonGenericDescription)
-            }
-            try await self.updateSession(updatedSession)
-        }
-    }
-
-    /// Enqueues a serialized API mutation with a local state change applied before the API call.
+    /// Enqueues a serialized session update.
+    ///
+    /// - If `update` is non-nil, the side effect (if any) is applied first, then the
+    ///   API mutation is performed and the session is updated from the response.
+    /// - If `update` is nil, the side effect is applied locally and delegates are
+    ///   notified without making a network request.
+    ///
+    /// - Parameters:
+    ///   - update: The API mutation to perform, or nil for a local-only update.
+    ///   - localMutation: A local state change to apply before the API call (or on its own).
     func performUpdate(
-        _ update: SessionUpdate,
-        applying sideEffect: @MainActor @Sendable @escaping () -> Void
+        _ update: SessionUpdate? = nil,
+        applying localMutation: (@MainActor @Sendable () -> Void)? = nil
     ) async throws {
         try await enqueueSessionUpdate {
-            sideEffect()
-            let sessionId = Self.extractSessionId(from: self.clientSecret)
-            let updatedSession: STPCheckoutSession
-            do {
-                updatedSession = try await self.apiClient.updateCheckoutSession(
-                    checkoutSessionId: sessionId,
-                    parameters: update.parameters
-                )
-            } catch {
-                throw CheckoutError.apiError(message: error.nonGenericDescription)
+            localMutation?()
+            if let update {
+                let sessionId = Self.extractSessionId(from: self.clientSecret)
+                let updatedSession: STPCheckoutSession
+                do {
+                    updatedSession = try await self.apiClient.updateCheckoutSession(
+                        checkoutSessionId: sessionId,
+                        parameters: update.parameters
+                    )
+                } catch {
+                    throw CheckoutError.apiError(message: error.nonGenericDescription)
+                }
+                try await self.updateSession(updatedSession)
+            } else {
+                guard let session = self.stpSession else { return }
+                try await self.updateSession(session)
             }
-            try await self.updateSession(updatedSession)
-        }
-    }
-
-    /// Enqueues a local-only session update (no API call) and notifies delegates.
-    func performUpdate(
-        applying sideEffect: @MainActor @Sendable @escaping () -> Void
-    ) async throws {
-        try await enqueueSessionUpdate {
-            sideEffect()
-            guard let session = self.stpSession else { return }
-            try await self.updateSession(session)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -27,11 +27,13 @@ extension Checkout {
     ///
     /// Client-side address overrides are copied from the current session to `newSession`
     /// automatically. To update an address, set it on `stpSession` before calling this method.
-    func updateSession(_ newSession: STPCheckoutSession) async throws {
+    func commitSession(_ newSession: STPCheckoutSession) async throws {
         // Preserve client-side address overrides on the new session.
         newSession.billingAddress = stpSession?.billingAddress
         newSession.shippingAddress = stpSession?.shippingAddress
-        setSession(newSession)
+        stpSession = newSession
+        let publicSession = newSession.makePublicSession()
+        state = pendingOperations.isEmpty ? .loaded(publicSession) : .loading(publicSession)
         try await integrationDelegate?.checkoutDidUpdate(self)
         delegate?.checkout(self, didChangeState: state)
     }
@@ -52,12 +54,11 @@ extension Checkout {
         }
 
         pendingOperations.append(operation)
-        if let session = stpSession { setSession(session) }
 
         defer {
             pendingOperations.removeAll { $0 == operation }
-            if let session = stpSession { setSession(session) }
         }
+        
         try await operation.value
     }
 
@@ -70,30 +71,32 @@ extension Checkout {
     ///
     /// - Parameters:
     ///   - update: The API mutation to perform, or nil for a local-only update.
-    ///   - localMutation: A local state change to apply before the API call (or on its own).
+    ///   - localMutation: A local state change to apply prior to the API call (or on its own).
     func performUpdate(
         _ update: SessionUpdate? = nil,
         applying localMutation: (@MainActor @Sendable () -> Void)? = nil
     ) async throws {
         try await enqueueSessionUpdate {
-            localMutation?()
-            if let update {
-                let sessionId = Self.extractSessionId(from: self.clientSecret)
-                let updatedSession: STPCheckoutSession
-                do {
-                    updatedSession = try await self.apiClient.updateCheckoutSession(
-                        checkoutSessionId: sessionId,
-                        parameters: update.parameters
-                    )
-                } catch {
-                    throw CheckoutError.apiError(message: error.nonGenericDescription)
+            let updatedSession: STPCheckoutSession? = try await {
+                // Apply the update on the server if required
+                if let update {
+                    let sessionId = Checkout.extractSessionId(from: self.clientSecret)
+                    do {
+                        return try await self.apiClient.updateCheckoutSession(
+                            checkoutSessionId: sessionId,
+                            parameters: update.parameters
+                        )
+                    } catch {
+                        throw CheckoutError.apiError(message: error.nonGenericDescription)
+                    }
+                } else {
+                    return self.stpSession
                 }
-                try await self.updateSession(updatedSession)
-            } else {
-                guard let session = self.stpSession else { return }
-                try await self.updateSession(session)
-            }
-        }
+            }()
+            
+            // Apply local mutations after running the API update
+            localMutation?()
+            try await self.commitSession(updatedSession)
     }
 
     /// Fetches the latest Checkout Session from Stripe and publishes it to observers.
@@ -108,7 +111,7 @@ extension Checkout {
         } catch {
             throw CheckoutError.apiError(message: error.nonGenericDescription)
         }
-        try await updateSession(refreshedCheckoutSession)
+        try await commitSession(refreshedCheckoutSession)
     }
 
     // MARK: - Validation

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -58,7 +58,7 @@ extension Checkout {
         defer {
             pendingOperations.removeAll { $0 == operation }
         }
-        
+
         try await operation.value
     }
 
@@ -77,26 +77,30 @@ extension Checkout {
         applying localMutation: (@MainActor @Sendable () -> Void)? = nil
     ) async throws {
         try await enqueueSessionUpdate {
-            let updatedSession: STPCheckoutSession? = try await {
-                // Apply the update on the server if required
+            // Transition to loading before the async work begins so observers show a loading state.
+            self.state = .loading(self.state.session)
+
+            do {
+                let updatedSession: STPCheckoutSession
                 if let update {
                     let sessionId = Checkout.extractSessionId(from: self.clientSecret)
-                    do {
-                        return try await self.apiClient.updateCheckoutSession(
-                            checkoutSessionId: sessionId,
-                            parameters: update.parameters
-                        )
-                    } catch {
-                        throw CheckoutError.apiError(message: error.nonGenericDescription)
-                    }
+                    updatedSession = try await self.apiClient.updateCheckoutSession(
+                        checkoutSessionId: sessionId,
+                        parameters: update.parameters
+                    )
                 } else {
-                    return self.stpSession
+                    guard let session = self.stpSession else { return }
+                    updatedSession = session
                 }
-            }()
-            
-            // Apply local mutations after running the API update
-            localMutation?()
-            try await self.commitSession(updatedSession)
+
+                localMutation?()
+                try await self.commitSession(updatedSession)
+            } catch {
+                // Restore loaded state on failure so the UI doesn't stay stuck in loading.
+                self.state = .loaded(self.state.session)
+                throw CheckoutError.apiError(message: error.nonGenericDescription)
+            }
+        }
     }
 
     /// Fetches the latest Checkout Session from Stripe and publishes it to observers.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -77,6 +77,7 @@ extension Checkout {
         applying localMutation: (@MainActor @Sendable () -> Void)? = nil
     ) async throws {
         try await enqueueSessionUpdate {
+            try self.requireSheetNotPresented()
             // Transition to loading before the async work begins so observers show a loading state.
             self.state = .loading(self.state.session)
 
@@ -134,20 +135,11 @@ extension Checkout {
         return currentSession
     }
 
-    /// Validates that the session is open and no sheet is presented.
-    @discardableResult
-    func requireOpenSession() throws -> STPCheckoutSession {
-        guard let currentSession = stpSession else {
-            stpAssertionFailure("Expected STPCheckoutSession, got \(type(of: state.session))")
-            throw CheckoutError.apiError(message: "Unexpected session type: expected STPCheckoutSession")
-        }
-        guard currentSession.status?.type == .open else {
-            throw CheckoutError.sessionNotOpen
-        }
+    /// Validates that no payment sheet is currently presented.
+    func requireSheetNotPresented() throws {
         guard integrationDelegate?.isSheetPresented != true else {
             throw CheckoutError.sheetCurrentlyPresented
         }
-        return currentSession
     }
 
     // MARK: - Client Secrets

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -103,21 +103,6 @@ extension Checkout {
         }
     }
 
-    /// Fetches the latest Checkout Session from Stripe and publishes it to observers.
-    func refreshSession() async throws {
-        let sessionId = Self.extractSessionId(from: clientSecret)
-        let refreshedCheckoutSession: STPCheckoutSession
-        do {
-            refreshedCheckoutSession = try await apiClient.initCheckoutSession(
-                checkoutSessionId: sessionId,
-                adaptivePricingAllowed: configuration.adaptivePricing.allowed
-            )
-        } catch {
-            throw CheckoutError.apiError(message: error.nonGenericDescription)
-        }
-        try await commitSession(refreshedCheckoutSession)
-    }
-
     // MARK: - Validation
 
     /// Validates that the session is open and no sheet is presented.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -174,14 +174,12 @@ public final class Checkout: ObservableObject {
     /// - Parameter code: The promotion code to apply.
     /// - Throws: ``CheckoutError`` if applying the promotion code fails.
     public func applyPromotionCode(_ code: String) async throws {
-        try requireOpenSession()
         try await performUpdate(.setPromotionCode(code))
     }
 
     /// Removes the currently applied promotion code.
     /// - Throws: ``CheckoutError`` if removing the promotion code fails.
     public func removePromotionCode() async throws {
-        try requireOpenSession()
         try await performUpdate(.setPromotionCode(""))
     }
 
@@ -193,7 +191,6 @@ public final class Checkout: ObservableObject {
     ///   - quantity: The new quantity to set.
     /// - Throws: ``CheckoutError`` if the update fails.
     public func updateQuantity(lineItemId: String, quantity: Int) async throws {
-        try requireOpenSession()
         try await performUpdate(.setLineItemQuantity(lineItemId: lineItemId, quantity: quantity))
     }
 
@@ -203,7 +200,6 @@ public final class Checkout: ObservableObject {
     /// - Parameter optionId: The ID of the shipping rate to select.
     /// - Throws: ``CheckoutError`` if the update fails.
     public func selectShippingOption(_ optionId: String) async throws {
-        try requireOpenSession()
         try await performUpdate(.setShippingRate(optionId))
     }
 
@@ -228,7 +224,7 @@ public final class Checkout: ObservableObject {
         phone: String? = nil,
         address: Address
     ) async throws {
-        let currentSession = try requireOpenSession()
+        guard let currentSession = stpSession else { return }
         let contactAddress = ContactAddress(name: name, phone: phone, address: address)
         guard currentSession.billingAddress != contactAddress else { return }
         if currentSession.shouldSendTaxRegion(for: "billing") {
@@ -261,7 +257,7 @@ public final class Checkout: ObservableObject {
         phone: String? = nil,
         address: Address
     ) async throws {
-        let currentSession = try requireOpenSession()
+        guard let currentSession = stpSession else { return }
         let contactAddress = ContactAddress(name: name, phone: phone, address: address)
         guard currentSession.shippingAddress != contactAddress else { return }
         if currentSession.shouldSendTaxRegion(for: "shipping") {
@@ -290,8 +286,8 @@ public final class Checkout: ObservableObject {
     public func runServerUpdate(
         _ updateFunction: @escaping () async throws -> Void
     ) async throws {
-        try requireOpenSession()
         try await enqueueSessionUpdate {
+            try self.requireSheetNotPresented()
             let result = await withTimeout(Self.serverUpdateTimeout) {
                 try await updateFunction()
             }
@@ -301,7 +297,6 @@ public final class Checkout: ObservableObject {
                 }
                 throw CheckoutError.apiError(message: error.localizedDescription)
             }
-            try self.requireOpenSession()
             try await self.refreshSession()
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -33,7 +33,7 @@ public final class Checkout: ObservableObject {
     ///
     /// After initialization this is always ``State.loaded(_:)``. It transitions to
     /// ``State.loading(_:)`` while a mutation is in flight.
-    @Published public private(set) var state: State
+    @Published public internal(set) var state: State
 
     /// The configuration supplied at initialization.
     public let configuration: Configuration
@@ -51,7 +51,7 @@ public final class Checkout: ObservableObject {
     /// because they go through `Checkout`'s MainActor-isolated mutation methods.
     /// Requiring full MainActor isolation would propagate `@MainActor` through nearly all of
     /// PaymentSheet's internal types, which is not warranted by the actual concurrency risk.
-    nonisolated(unsafe) private(set) var stpSession: STPCheckoutSession!
+    nonisolated(unsafe) internal(set) var stpSession: STPCheckoutSession!
 
     weak var integrationDelegate: CheckoutIntegrationDelegate?
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -51,7 +51,7 @@ public final class Checkout: ObservableObject {
     /// because they go through `Checkout`'s MainActor-isolated mutation methods.
     /// Requiring full MainActor isolation would propagate `@MainActor` through nearly all of
     /// PaymentSheet's internal types, which is not warranted by the actual concurrency risk.
-    nonisolated(unsafe) var stpSession: STPCheckoutSession!
+    nonisolated(unsafe) private(set) var stpSession: STPCheckoutSession!
 
     weak var integrationDelegate: CheckoutIntegrationDelegate?
 
@@ -309,6 +309,23 @@ public final class Checkout: ObservableObject {
             }
             try await self.commitSession(refreshedCheckoutSession)
         }
+    }
+
+    // MARK: - State updates
+
+    /// Replaces the current session, preserves client-side overrides, and notifies delegates.
+    ///
+    /// Client-side address overrides are copied from the current session to `newSession`
+    /// automatically. To update an address, set it on `stpSession` before calling this method.
+    func commitSession(_ newSession: STPCheckoutSession) async throws {
+        // Preserve client-side address overrides on the new session.
+        newSession.billingAddress = stpSession?.billingAddress
+        newSession.shippingAddress = stpSession?.shippingAddress
+        stpSession = newSession
+        let publicSession = newSession.makePublicSession()
+        state = pendingOperations.isEmpty ? .loaded(publicSession) : .loading(publicSession)
+        try await integrationDelegate?.checkoutDidUpdate(self)
+        delegate?.checkout(self, didChangeState: state)
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -297,7 +297,17 @@ public final class Checkout: ObservableObject {
                 }
                 throw CheckoutError.apiError(message: error.localizedDescription)
             }
-            try await self.refreshSession()
+            let sessionId = Self.extractSessionId(from: self.clientSecret)
+            let refreshedCheckoutSession: STPCheckoutSession
+            do {
+                refreshedCheckoutSession = try await self.apiClient.initCheckoutSession(
+                    checkoutSessionId: sessionId,
+                    adaptivePricingAllowed: self.configuration.adaptivePricing.allowed
+                )
+            } catch {
+                throw CheckoutError.apiError(message: error.nonGenericDescription)
+            }
+            try await self.commitSession(refreshedCheckoutSession)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -182,18 +182,14 @@ public final class Checkout: ObservableObject {
     /// - Throws: ``CheckoutError`` if applying the promotion code fails.
     public func applyPromotionCode(_ code: String) async throws {
         try requireOpenSession()
-        try await enqueueSessionUpdate {
-            try await self.performAPIUpdate(.setPromotionCode(code))
-        }
+        try await performUpdate(.setPromotionCode(code))
     }
 
     /// Removes the currently applied promotion code.
     /// - Throws: ``CheckoutError`` if removing the promotion code fails.
     public func removePromotionCode() async throws {
         try requireOpenSession()
-        try await enqueueSessionUpdate {
-            try await self.performAPIUpdate(.setPromotionCode(""))
-        }
+        try await performUpdate(.setPromotionCode(""))
     }
 
     // MARK: - Line Items
@@ -205,9 +201,7 @@ public final class Checkout: ObservableObject {
     /// - Throws: ``CheckoutError`` if the update fails.
     public func updateQuantity(lineItemId: String, quantity: Int) async throws {
         try requireOpenSession()
-        try await enqueueSessionUpdate {
-            try await self.performAPIUpdate(.setLineItemQuantity(lineItemId: lineItemId, quantity: quantity))
-        }
+        try await performUpdate(.setLineItemQuantity(lineItemId: lineItemId, quantity: quantity))
     }
 
     // MARK: - Shipping
@@ -217,9 +211,7 @@ public final class Checkout: ObservableObject {
     /// - Throws: ``CheckoutError`` if the update fails.
     public func selectShippingOption(_ optionId: String) async throws {
         try requireOpenSession()
-        try await enqueueSessionUpdate {
-            try await self.performAPIUpdate(.setShippingRate(optionId))
-        }
+        try await performUpdate(.setShippingRate(optionId))
     }
 
     // MARK: - Addresses
@@ -247,16 +239,13 @@ public final class Checkout: ObservableObject {
         let contactAddress = ContactAddress(name: name, phone: phone, address: address)
         guard currentSession.billingAddress != contactAddress else { return }
         if currentSession.shouldSendTaxRegion(for: "billing") {
-            try await enqueueSessionUpdate {
+            try await performUpdate(.setTaxRegion(address), applying: {
                 self.stpSession?.billingAddress = contactAddress
-                try await self.performAPIUpdate(.setTaxRegion(address))
-            }
+            })
         } else {
-            try await enqueueSessionUpdate {
+            try await performUpdate(applying: {
                 self.stpSession?.billingAddress = contactAddress
-                guard let session = self.stpSession else { return }
-                try await self.updateSession(session)
-            }
+            })
         }
     }
 
@@ -283,16 +272,13 @@ public final class Checkout: ObservableObject {
         let contactAddress = ContactAddress(name: name, phone: phone, address: address)
         guard currentSession.shippingAddress != contactAddress else { return }
         if currentSession.shouldSendTaxRegion(for: "shipping") {
-            try await enqueueSessionUpdate {
+            try await performUpdate(.setTaxRegion(address), applying: {
                 self.stpSession?.shippingAddress = contactAddress
-                try await self.performAPIUpdate(.setTaxRegion(address))
-            }
+            })
         } else {
-            try await enqueueSessionUpdate {
+            try await performUpdate(applying: {
                 self.stpSession?.shippingAddress = contactAddress
-                guard let session = self.stpSession else { return }
-                try await self.updateSession(session)
-            }
+            })
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -68,13 +68,6 @@ public final class Checkout: ObservableObject {
     /// Timeout enforced on the merchant's closure in ``runServerUpdate(_:)``.
     nonisolated static let serverUpdateTimeout: TimeInterval = 20
 
-    /// The single state writer. Stores the STPCheckoutSession, publishes the public session.
-    func setSession(_ session: STPCheckoutSession) {
-        stpSession = session
-        let publicSession = session.makePublicSession()
-        state = pendingOperations.isEmpty ? .loaded(publicSession) : .loading(publicSession)
-    }
-
     // MARK: - Initialization
 
     /// Loads a Checkout Session from Stripe and returns a ready-to-use instance.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -51,7 +51,7 @@ public final class Checkout: ObservableObject {
     /// because they go through `Checkout`'s MainActor-isolated mutation methods.
     /// Requiring full MainActor isolation would propagate `@MainActor` through nearly all of
     /// PaymentSheet's internal types, which is not warranted by the actual concurrency risk.
-    nonisolated(unsafe) internal(set) var stpSession: STPCheckoutSession!
+    nonisolated(unsafe) var stpSession: STPCheckoutSession!
 
     weak var integrationDelegate: CheckoutIntegrationDelegate?
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
@@ -84,7 +84,7 @@ extension PaymentSheet {
             )
 
             // Update the Checkout instance with the confirmed session response
-            try await checkout.updateSession(response)
+            try await checkout.commitSession(response)
 
             // 4. Handle response based on checkout session mode
             return try await handleCheckoutSessionConfirmResponse(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -201,7 +201,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         )
 
         // 5. Update the Checkout instance with the confirmed session response
-        try await checkout.updateSession(response)
+        try await checkout.commitSession(response)
 
         // 6. Return client secret based on checkout session mode
         return try response.clientSecret(for: checkoutSession.mode)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorViewTests.swift
@@ -25,7 +25,7 @@ final class CheckoutCurrencySelectorViewTests: XCTestCase {
     func testHiddenWhenAdaptivePricingNotActive() async throws {
         let checkout = await Checkout(clientSecret: "cs_test_123_secret_abc", session: CheckoutTestHelpers.makeOpenSession())
         let session = makeSession(adaptivePricingActive: false)
-        try await checkout.updateSession(session)
+        try await checkout.commitSession(session)
 
         let view = Checkout.CurrencySelectorView(checkout: checkout)
 
@@ -41,7 +41,7 @@ final class CheckoutCurrencySelectorViewTests: XCTestCase {
     func testHiddenWhenLocalizedPricesEmpty() async throws {
         let checkout = await Checkout(clientSecret: "cs_test_123_secret_abc", session: CheckoutTestHelpers.makeOpenSession())
         let session = makeSession(includeLocalizedPrices: false)
-        try await checkout.updateSession(session)
+        try await checkout.commitSession(session)
 
         let view = Checkout.CurrencySelectorView(checkout: checkout)
 
@@ -56,7 +56,7 @@ final class CheckoutCurrencySelectorViewTests: XCTestCase {
     func testHiddenWhenExchangeRateMetaNil() async throws {
         let checkout = await Checkout(clientSecret: "cs_test_123_secret_abc", session: CheckoutTestHelpers.makeOpenSession())
         let session = makeSession(includeExchangeRateFields: false)
-        try await checkout.updateSession(session)
+        try await checkout.commitSession(session)
 
         let view = Checkout.CurrencySelectorView(checkout: checkout)
 
@@ -71,7 +71,7 @@ final class CheckoutCurrencySelectorViewTests: XCTestCase {
     func testVisibleWhenAdaptivePricingActive() async throws {
         let checkout = await Checkout(clientSecret: "cs_test_123_secret_abc", session: CheckoutTestHelpers.makeOpenSession())
         let session = makeSession()
-        try await checkout.updateSession(session)
+        try await checkout.commitSession(session)
 
         let view = Checkout.CurrencySelectorView(checkout: checkout)
 
@@ -92,7 +92,7 @@ final class CheckoutCurrencySelectorViewTests: XCTestCase {
 
         // Update with AP session
         let session = makeSession()
-        try await checkout.updateSession(session)
+        try await checkout.commitSession(session)
 
         let expectation = expectation(description: "View becomes visible")
         DispatchQueue.main.async {
@@ -107,7 +107,7 @@ final class CheckoutCurrencySelectorViewTests: XCTestCase {
     func testLabelsUpdateWhenSessionAmountChanges() async throws {
         let checkout = await Checkout(clientSecret: "cs_test_123_secret_abc", session: CheckoutTestHelpers.makeOpenSession())
         let session = makeSession(integrationAmount: 1200, localAmount: 1000)
-        try await checkout.updateSession(session)
+        try await checkout.commitSession(session)
 
         var appearance = Checkout.CurrencySelectorView.Appearance()
         appearance.labelContent = .amount
@@ -127,7 +127,7 @@ final class CheckoutCurrencySelectorViewTests: XCTestCase {
 
         // Update session with new amounts
         let updatedSession = makeSession(integrationAmount: 2400, localAmount: 2000)
-        try await checkout.updateSession(updatedSession)
+        try await checkout.commitSession(updatedSession)
 
         let updated = expectation(description: "Labels updated")
         DispatchQueue.main.async {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
@@ -14,7 +14,7 @@ import XCTest
 @MainActor
 final class CheckoutPendingOperationsTests: XCTestCase {
 
-    func testEnqueueSessionUpdateSerializesOperationsAndKeepsLoadingUntilDrained() async throws {
+    func testEnqueueSessionUpdateSerializesOperations() async throws {
         let checkout = await makeCheckoutWithOpenSession()
         let firstGate = CheckoutPendingOperationsTestGate()
         var events: [String] = []
@@ -42,7 +42,6 @@ final class CheckoutPendingOperationsTests: XCTestCase {
             checkout.pendingOperations.count == 2
         }
         XCTAssertEqual(events, ["first started"])
-        XCTAssertTrue(checkout.state.isLoading)
 
         firstGate.open()
         try await firstTask.value
@@ -50,7 +49,6 @@ final class CheckoutPendingOperationsTests: XCTestCase {
 
         XCTAssertEqual(events, ["first started", "first finished", "second ran"])
         XCTAssertTrue(checkout.pendingOperations.isEmpty)
-        XCTAssertFalse(checkout.state.isLoading)
     }
 
     func testAwaitPendingOperationsWaitsForQueuedWork() async throws {
@@ -87,7 +85,6 @@ final class CheckoutPendingOperationsTests: XCTestCase {
 
         XCTAssertTrue(waiterCompleted)
         XCTAssertTrue(checkout.pendingOperations.isEmpty)
-        XCTAssertFalse(checkout.state.isLoading)
     }
 
     func testAwaitPendingOperationsTimesOutWithoutCancelingQueuedWork() async throws {
@@ -116,14 +113,12 @@ final class CheckoutPendingOperationsTests: XCTestCase {
         }
 
         XCTAssertEqual(checkout.pendingOperations.count, 1)
-        XCTAssertTrue(checkout.state.isLoading)
 
         gate.open()
         try await operationTask.value
         try await checkout.awaitPendingOperations(timeout: 1)
 
         XCTAssertTrue(checkout.pendingOperations.isEmpty)
-        XCTAssertFalse(checkout.state.isLoading)
     }
 
     // MARK: - Helpers

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -40,98 +40,6 @@ final class CheckoutUnitTests: XCTestCase {
         XCTAssertFalse(checkout.state.isLoading)
     }
 
-    // MARK: - Requires Open Session Tests
-
-    func testApplyPromotionCodeRequiresOpenSession() async throws {
-        let checkout = await makeCheckoutWithClosedSession()
-
-        do {
-            try await checkout.applyPromotionCode("SAVE25")
-            XCTFail("Expected CheckoutError.sessionNotOpen")
-        } catch let error as CheckoutError {
-            guard case .sessionNotOpen = error else {
-                XCTFail("Expected .sessionNotOpen, got \(error)")
-                return
-            }
-        }
-    }
-
-    func testRemovePromotionCodeRequiresOpenSession() async throws {
-        let checkout = await makeCheckoutWithClosedSession()
-
-        do {
-            try await checkout.removePromotionCode()
-            XCTFail("Expected CheckoutError.sessionNotOpen")
-        } catch let error as CheckoutError {
-            guard case .sessionNotOpen = error else {
-                XCTFail("Expected .sessionNotOpen, got \(error)")
-                return
-            }
-        }
-    }
-
-    func testUpdateQuantityRequiresOpenSession() async throws {
-        let checkout = await makeCheckoutWithClosedSession()
-
-        do {
-            try await checkout.updateQuantity(lineItemId: "li_123", quantity: 2)
-            XCTFail("Expected CheckoutError.sessionNotOpen")
-        } catch let error as CheckoutError {
-            guard case .sessionNotOpen = error else {
-                XCTFail("Expected .sessionNotOpen, got \(error)")
-                return
-            }
-        }
-    }
-
-    func testSelectShippingOptionRequiresOpenSession() async throws {
-        let checkout = await makeCheckoutWithClosedSession()
-
-        do {
-            try await checkout.selectShippingOption("shr_123")
-            XCTFail("Expected CheckoutError.sessionNotOpen")
-        } catch let error as CheckoutError {
-            guard case .sessionNotOpen = error else {
-                XCTFail("Expected .sessionNotOpen, got \(error)")
-                return
-            }
-        }
-    }
-
-    func testUpdateBillingAddressRequiresOpenSession() async throws {
-        let checkout = await makeCheckoutWithClosedSession()
-
-        do {
-            try await checkout.updateBillingAddress(
-                name: "Jane Doe",
-                address: .init(country: "US")
-            )
-            XCTFail("Expected CheckoutError.sessionNotOpen")
-        } catch let error as CheckoutError {
-            guard case .sessionNotOpen = error else {
-                XCTFail("Expected .sessionNotOpen, got \(error)")
-                return
-            }
-        }
-    }
-
-    func testUpdateShippingAddressRequiresOpenSession() async throws {
-        let checkout = await makeCheckoutWithClosedSession()
-
-        do {
-            try await checkout.updateShippingAddress(
-                name: "Jane Doe",
-                address: .init(country: "US")
-            )
-            XCTFail("Expected CheckoutError.sessionNotOpen")
-        } catch let error as CheckoutError {
-            guard case .sessionNotOpen = error else {
-                XCTFail("Expected .sessionNotOpen, got \(error)")
-                return
-            }
-        }
-    }
-
     // MARK: - runServerUpdate Tests
 
     func testRunServerUpdateWrapsClosureError() async {
@@ -575,10 +483,6 @@ final class CheckoutUnitTests: XCTestCase {
         return await Checkout(clientSecret: "cs_test_123_secret_abc", session: session)
     }
 
-    private func makeCheckoutWithClosedSession() async -> Checkout {
-        let session = CheckoutTestHelpers.makeClosedSession()
-        return await Checkout(clientSecret: "cs_test_123_secret_abc", session: session)
-    }
 }
 
 // MARK: - Mock Delegate

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -406,7 +406,7 @@ final class CheckoutUnitTests: XCTestCase {
         XCTAssertEqual(session.total?.taxExclusive.minorUnitsAmount, 1000)
     }
 
-    // MARK: - updateSession Tests
+    // MARK: - commitSession Tests
 
     func testUpdateSessionNotifiesDelegate() async throws {
         let checkout = await makeCheckoutWithOpenSession()
@@ -419,7 +419,7 @@ final class CheckoutUnitTests: XCTestCase {
         updatedJSON["payment_status"] = "paid"
         let confirmResponse = STPCheckoutSession.decodedObject(fromAPIResponse: updatedJSON)!
 
-        try await checkout.updateSession(confirmResponse)
+        try await checkout.commitSession(confirmResponse)
 
         // Verify session was updated with the confirm response data
         XCTAssertEqual(checkout.state.session.status?.type, .complete)
@@ -443,7 +443,7 @@ final class CheckoutUnitTests: XCTestCase {
         updatedJSON["payment_status"] = "paid"
         let confirmResponse = STPCheckoutSession.decodedObject(fromAPIResponse: updatedJSON)!
 
-        try await checkout.updateSession(confirmResponse)
+        try await checkout.commitSession(confirmResponse)
 
         // Address overrides should be carried over to the new session
         XCTAssertEqual(checkout.state.session.billingAddress?.name, "Jane Doe")
@@ -467,7 +467,7 @@ final class CheckoutUnitTests: XCTestCase {
         firstResponse["payment_status"] = "paid"
         let firstConfirm = STPCheckoutSession.decodedObject(fromAPIResponse: firstResponse)!
 
-        try await checkout.updateSession(firstConfirm)
+        try await checkout.commitSession(firstConfirm)
         XCTAssertEqual(checkout.state.session.status?.type, .complete)
         XCTAssertEqual(checkout.state.session.billingAddress?.name, "Jane Doe")
 
@@ -476,7 +476,7 @@ final class CheckoutUnitTests: XCTestCase {
         secondResponse["status"] = "open"
         let secondSession = STPCheckoutSession.decodedObject(fromAPIResponse: secondResponse)!
 
-        try await checkout.updateSession(secondSession)
+        try await checkout.commitSession(secondSession)
         XCTAssertEqual(checkout.state.session.status?.type, .open)
         XCTAssertEqual(checkout.state.session.billingAddress?.name, "Jane Doe")
         XCTAssertEqual(delegate.changeStateCallCount, 2)
@@ -507,7 +507,7 @@ final class CheckoutUnitTests: XCTestCase {
         updatedJSON["payment_status"] = "paid"
         let updatedSession = STPCheckoutSession.decodedObject(fromAPIResponse: updatedJSON)!
 
-        try await checkout.updateSession(updatedSession)
+        try await checkout.commitSession(updatedSession)
 
         XCTAssertEqual(integrationDelegate.checkoutDidUpdateCallCount, 1)
         XCTAssertTrue(integrationDelegate.lastCheckout === checkout)
@@ -521,7 +521,7 @@ final class CheckoutUnitTests: XCTestCase {
         // Update with same session data — delegates still fire because the caller
         // decided an update occurred (e.g. after an API call).
         let sameSession = STPCheckoutSession.decodedObject(fromAPIResponse: CheckoutTestHelpers.makeOpenSessionJSON())!
-        try await checkout.updateSession(sameSession)
+        try await checkout.commitSession(sameSession)
 
         XCTAssertEqual(integrationDelegate.checkoutDidUpdateCallCount, 1)
     }
@@ -543,7 +543,7 @@ final class CheckoutUnitTests: XCTestCase {
         updatedJSON["payment_status"] = "paid"
         let updatedSession = STPCheckoutSession.decodedObject(fromAPIResponse: updatedJSON)!
 
-        try await checkout.updateSession(updatedSession)
+        try await checkout.commitSession(updatedSession)
 
         XCTAssertEqual(callOrder, ["integration", "regular"])
     }
@@ -561,7 +561,7 @@ final class CheckoutUnitTests: XCTestCase {
         let updatedSession = STPCheckoutSession.decodedObject(fromAPIResponse: updatedJSON)!
 
         do {
-            try await checkout.updateSession(updatedSession)
+            try await checkout.commitSession(updatedSession)
             XCTFail("Expected error to propagate")
         } catch {
             XCTAssertEqual((error as NSError).code, 42)


### PR DESCRIPTION
## Summary

Simplifies the Checkout session update internals by consolidating duplicated patterns into a single performUpdate function. Also updates the confirm flow to use runServerUpdate instead of directly calling commitSession.

Before
```swift
  func applyPromotionCode(_ code: String) async throws {
      try requireOpenSession()
      try await enqueueSessionUpdate {
          try await self.performAPIUpdate(.setPromotionCode(code))
      }
  }

  // performAPIUpdate called updateSession, which called setSession
  // setSession stored the session and published state
  // updateSession also notified delegates
  // Two separate functions for one logical operation
```
  After

```swift
  func applyPromotionCode(_ code: String) async throws {
      try await performUpdate(.setPromotionCode(code))
  }

  // performUpdate handles everything:
  // 1. Enqueues on the serial queue
  // 2. Sets .loading state
  // 3. Calls the API
  // 4. Applies local mutations (e.g. address overrides)
  // 5. Calls commitSession (stores session, publishes state, notifies delegates)
  // 6. On error, restores .loaded state
```

Confirm flow change

The confirm flow previously called updateSession directly after getting a confirm response. This is now handled through runServerUpdate, which refreshes the session from our server. This means the confirm update goes through the same serialized queue as everything else.

  What changed

  - setSession + updateSession merged into commitSession: one function that stores, publishes, and notifies
  - performAPIUpdate removed: its logic lives inside performUpdate
  - Loading/error state management lives in one place instead of scattered in enqueueSessionUpdate
  - enqueueSessionUpdate is now a pure serialization primitive with no state side effects

## Motivation
- The old pattern required each caller to manually compose queue enrollment, API calls, and session updates. The new shape makes the happy path and error path explicit in one place.

## Testing
- Existing tests

## Changelog
N/A
