### PR TITLE
StripeConnect: GA Payments and Payouts components 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 The next release's version bump will so far be:
-PATCH
+MINOR
 
 ## X.Y.Z - changes pending release
+
+### StripeConnect
+* [Changed] `PaymentsViewController`, `PaymentsViewControllerDelegate`, `PayoutsViewController`, `PayoutsViewControllerDelegate`, and `EmbeddedComponentManager.PaymentsListDefaultFiltersOptions` are now part of the public API and no longer require `@_spi(PreviewConnect)` to access.
 
 ## 26.2.0 2026-07-06
 ### CryptoOnramp (Alpha)

--- a/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
@@ -54,12 +54,8 @@ class MainViewController: UITableViewController {
 
         var stageQualifier: String? {
             switch self {
-            case .onboarding:
-                return nil  // GA
-            case .payouts:
-                return "Beta"
-            case .payments:
-                return "Beta"
+            case .onboarding, .payouts, .payments:
+                return nil
             case .checkScanning:
                 return "Private Preview"
             }

--- a/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/MainViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Mel Ludowise on 4/30/24.
 //
 
-@_spi(PrivatePreviewConnect) @_spi(PreviewConnect) import StripeConnect
+@_spi(PrivatePreviewConnect) import StripeConnect
 import SwiftUI
 import UIKit
 

--- a/Example/StripeConnectExample/StripeConnectExample/Settings/Components/Payments/PaymentsSettings.swift
+++ b/Example/StripeConnectExample/StripeConnectExample/Settings/Components/Payments/PaymentsSettings.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@_spi(PreviewConnect) import StripeConnect
+import StripeConnect
 
 struct PaymentsSettings: Equatable {
 

--- a/StripeConnect/StripeConnect/Source/Components/PaymentsViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/PaymentsViewController.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-@_spi(PreviewConnect)
 public class PaymentsViewController: UIViewController {
 
     struct Props: Encodable {
@@ -48,7 +47,6 @@ public class PaymentsViewController: UIViewController {
 }
 
 /// Delegate of an `PaymentsViewController`
-@_spi(PreviewConnect)
 public protocol PaymentsViewControllerDelegate: AnyObject {
 
     /**

--- a/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
+++ b/StripeConnect/StripeConnect/Source/Components/PayoutsViewController.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 
-@_spi(PreviewConnect)
 public class PayoutsViewController: UIViewController {
     private(set) var webVC: ConnectComponentWebViewController!
 
@@ -36,7 +35,6 @@ public class PayoutsViewController: UIViewController {
 }
 
 /// Delegate of an `PayoutsViewController`
-@_spi(PreviewConnect)
 public protocol PayoutsViewControllerDelegate: AnyObject {
 
     /**

--- a/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
+++ b/StripeConnect/StripeConnect/Source/EmbeddedComponentManager.swift
@@ -148,7 +148,6 @@ public final class EmbeddedComponentManager {
 
     /// Creates a `PayoutsViewController`
     /// - Seealso: [Payouts component documentation](https://docs.stripe.com/connect/supported-embedded-components/payouts?platform=ios)
-    @_spi(PreviewConnect)
     @_documentation(visibility: public)
     public func createPayoutsViewController() -> PayoutsViewController {
         .init(componentManager: self,
@@ -160,7 +159,6 @@ public final class EmbeddedComponentManager {
     /// - Seealso: [Payments component documentation](https://docs.stripe.com/connect/supported-embedded-components/payments?platform=ios)
     /// - Parameters:
     ///   - defaultFilters: The default filters to apply to the payments list
-    @_spi(PreviewConnect)
     @_documentation(visibility: public)
     public func createPaymentsViewController(
         defaultFilters: EmbeddedComponentManager.PaymentsListDefaultFiltersOptions = .init()

--- a/StripeConnect/StripeConnect/Source/Models/PaymentsListDefaultFiltersOptions.swift
+++ b/StripeConnect/StripeConnect/Source/Models/PaymentsListDefaultFiltersOptions.swift
@@ -20,7 +20,6 @@ private extension String {
     }
 }
 
-@_spi(PreviewConnect)
 @_documentation(visibility: public)
 extension EmbeddedComponentManager {
     @_documentation(visibility: public)

--- a/StripeConnect/StripeConnectTests/Components/PaymentsViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/PaymentsViewControllerTests.swift
@@ -6,7 +6,7 @@
 //
 
 import SafariServices
-@_spi(PreviewConnect) @testable import StripeConnect
+@testable import StripeConnect
 @_spi(STP) import StripeCore
 import WebKit
 import XCTest

--- a/StripeConnect/StripeConnectTests/Components/PayoutsViewControllerTests.swift
+++ b/StripeConnect/StripeConnectTests/Components/PayoutsViewControllerTests.swift
@@ -6,7 +6,7 @@
 //
 
 import SafariServices
-@_spi(PreviewConnect) @testable import StripeConnect
+@testable import StripeConnect
 @_spi(STP) import StripeCore
 import WebKit
 import XCTest


### PR DESCRIPTION
## Summary

Removes `@_spi(PreviewConnect)` annotations from the Payments and Payouts embedded components, promoting them to the fully public API surface. Also updates consumer import sites in tests and the example app accordingly. 

[API Review](https://docs.google.com/document/d/1DLyInRUCd1kPNf42z2N5edLqGSrm2aMjgR69K2S2U-g/edit?tab=t.0#heading=h.wy37pln22zhb)

## Motivation

The Payments and Payouts components are ready for general availability. By removing the `@_spi(PreviewConnect)` gate, consumers no longer need to opt in via a special SPI import to use `PaymentsViewController`, `PayoutsViewController`, or the associated types — they are now accessible via a standard `import StripeConnect`.

`@_spi(PrivatePreviewConnect)` (used for CheckScanning) is intentionally left unchanged.

## Testing

- Existing unit tests for `PaymentsViewController` and `PayoutsViewController` pass without the `@_spi(PreviewConnect)` import attribute.
- The example app compiles with the updated import in `MainViewController.swift` (retaining `@_spi(PrivatePreviewConnect)` for CheckScanning) and `PaymentsSettings.swift`.

## Changelog

```
### StripeConnect
* [Changed] `PaymentsViewController`, `PaymentsViewControllerDelegate`, `PayoutsViewController`, `PayoutsViewControllerDelegate`, and `EmbeddedComponentManager.PaymentsListDefaultFiltersOptions` are now part of the public API and no longer require `@_spi(PreviewConnect)` to access.
```
