### PR TITLE
Fix behavior on spm's with no address w/ default payment method on update screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ The next release's version bump will so far be:
 MINOR
 
 ## X.Y.Z - changes pending release
+### PaymentSheet
+* [Fixed] Fixed defaultBillingDetails not being applied when editing a saved payment method that has no billing address.
+
+### CustomerSheet
+* [Fixed] Fixed defaultBillingDetails not being applied when editing a saved payment method that has no billing address.
 
 ### CryptoOnramp (Alpha)
 * [Changed] Renamed `CryptoOnrampCoordinator.presentCRSCARFDeclaration(from:)` to `presentUserAttestation(from:)`, and renamed `CRSCARFDeclarationResult` to `UserAttestationResult`.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerSavedPaymentMethodsCollectionViewController.swift
@@ -452,7 +452,8 @@ extension CustomerSavedPaymentMethodsCollectionViewController: PaymentOptionCell
                                                                            cardBrandFilter: savedPaymentMethodsConfiguration.cardBrandFilter,
                                                                            canRemove: configuration.paymentMethodRemove && (savedPaymentMethods.count > 1 || configuration.allowsRemovalOfLastSavedPaymentMethod),
                                                                            canUpdate: configuration.paymentMethodUpdate,
-                                                                           isCBCEligible: paymentMethod.isCoBrandedCard && cbcEligible)
+                                                                           isCBCEligible: paymentMethod.isCoBrandedCard && cbcEligible,
+                                                                           defaultBillingDetails: savedPaymentMethodsConfiguration.defaultBillingDetails)
         let removeSavedPaymentMethodMessage = UpdatePaymentMethodViewController.resolveRemoveMessage(
             removeSavedPaymentMethodMessage: savedPaymentMethodsConfiguration.removeSavedPaymentMethodMessage,
             paymentMethodRemoveIsPartial: configuration.paymentMethodRemoveIsPartial,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -191,7 +191,8 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
                                                                                canUpdate: elementsSession.paymentMethodUpdateForPaymentSheet,
                                                                                isCBCEligible: paymentMethod.isCoBrandedCard && elementsSession.isCardBrandChoiceEligible,
                                                                                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
-                                                                               isDefault: paymentMethod == defaultPaymentMethod)
+                                                                               isDefault: paymentMethod == defaultPaymentMethod,
+                                                                               defaultBillingDetails: configuration.defaultBillingDetails)
             let removeSavedPaymentMethodMessage = UpdatePaymentMethodViewController.resolveRemoveMessage(
                 removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                 paymentMethodRemoveIsPartial: elementsSession.paymentMethodRemoveIsPartialForPaymentSheet(),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -635,7 +635,8 @@ extension SavedPaymentOptionsViewController: PaymentOptionCellDelegate {
                                                                            canUpdate: elementsSession.paymentMethodUpdateForPaymentSheet,
                                                                            isCBCEligible: paymentMethod.isCoBrandedCard && cbcEligible,
                                                                            allowsSetAsDefaultPM: configuration.allowsSetAsDefaultPM,
-                                                                           isDefault: isDefaultPaymentMethod(savedPaymentMethodId: paymentMethod.stripeId))
+                                                                           isDefault: isDefaultPaymentMethod(savedPaymentMethodId: paymentMethod.stripeId),
+                                                                           defaultBillingDetails: paymentSheetConfiguration.defaultBillingDetails)
         let removeSavedPaymentMethodMessage = UpdatePaymentMethodViewController.resolveRemoveMessage(
             removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
             paymentMethodRemoveIsPartial: elementsSession.paymentMethodRemoveIsPartialForPaymentSheet(),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethodFormFactory/SavedPaymentMethodFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethodFormFactory/SavedPaymentMethodFormFactory+Card.swift
@@ -111,7 +111,8 @@ extension SavedPaymentMethodFormFactory {
             let section = AddressSectionElement(
                 title: String.Localized.billing_address_lowercase,
                 countries: countries,
-                defaults: currentBillingDetails(paymentMethod: configuration.paymentMethod),
+                defaults: currentBillingDetails(paymentMethod: configuration.paymentMethod,
+                                               defaultBillingDetails: configuration.defaultBillingDetails),
                 collectionMode: collectionMode,
                 additionalFields: .init(
                     billingSameAsShippingCheckbox: .disabled
@@ -121,13 +122,28 @@ extension SavedPaymentMethodFormFactory {
             return PaymentSheetFormFactory.makeBillingAddressPaymentMethodWrapper(section: section, countryAPIPath: nil)
     }
 
-    func currentBillingDetails(paymentMethod: STPPaymentMethod) -> AddressSectionElement.AddressDetails {
-        let address = AddressSectionElement.AddressDetails.Address(city: paymentMethod.billingDetails?.address?.city,
-                                                                   country: paymentMethod.billingDetails?.address?.country,
-                                                                   line1: paymentMethod.billingDetails?.address?.line1,
-                                                                   line2: paymentMethod.billingDetails?.address?.line2,
-                                                                   postalCode: paymentMethod.billingDetails?.address?.postalCode,
-                                                                   state: paymentMethod.billingDetails?.address?.state)
+    func currentBillingDetails(paymentMethod: STPPaymentMethod,
+                               defaultBillingDetails: PaymentSheet.BillingDetails) -> AddressSectionElement.AddressDetails {
+        let currentPMHasBillingDetails = paymentMethod.billingDetails?.address?.city != nil
+        || paymentMethod.billingDetails?.address?.country != nil
+        || paymentMethod.billingDetails?.address?.line1 != nil
+        || paymentMethod.billingDetails?.address?.line2 != nil
+        || paymentMethod.billingDetails?.address?.postalCode != nil
+        || paymentMethod.billingDetails?.address?.state != nil
+
+        let address = currentPMHasBillingDetails
+        ? AddressSectionElement.AddressDetails.Address(city: paymentMethod.billingDetails?.address?.city,
+                                                       country: paymentMethod.billingDetails?.address?.country,
+                                                       line1: paymentMethod.billingDetails?.address?.line1,
+                                                       line2: paymentMethod.billingDetails?.address?.line2,
+                                                       postalCode: paymentMethod.billingDetails?.address?.postalCode,
+                                                       state: paymentMethod.billingDetails?.address?.state)
+        : AddressSectionElement.AddressDetails.Address(city: defaultBillingDetails.address.city,
+                                                       country: defaultBillingDetails.address.country,
+                                                       line1: defaultBillingDetails.address.line1,
+                                                       line2: defaultBillingDetails.address.line2,
+                                                       postalCode: defaultBillingDetails.address.postalCode,
+                                                       state: defaultBillingDetails.address.state)
         return AddressSectionElement.AddressDetails(name: nil, phone: nil, address: address)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -787,7 +787,8 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                                                                                canUpdate: elementsSession.paymentMethodUpdateForPaymentSheet,
                                                                                isCBCEligible: paymentMethod.isCoBrandedCard && elementsSession.isCardBrandChoiceEligible,
                                                                                allowsSetAsDefaultPM: elementsSession.paymentMethodSetAsDefaultForPaymentSheet,
-                                                                               isDefault: paymentMethod == defaultPaymentMethod)
+                                                                               isDefault: paymentMethod == defaultPaymentMethod,
+                                                                               defaultBillingDetails: configuration.defaultBillingDetails)
             let removeSavedPaymentMethodMessage = UpdatePaymentMethodViewController.resolveRemoveMessage(
                 removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
                 paymentMethodRemoveIsPartial: elementsSession.paymentMethodRemoveIsPartialForPaymentSheet(),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -372,7 +372,8 @@ extension VerticalSavedPaymentMethodsViewController: SavedPaymentMethodRowButton
                                                                            canUpdate: paymentMethodUpdate,
                                                                            isCBCEligible: paymentMethod.isCoBrandedCard && isCBCEligible,
                                                                            allowsSetAsDefaultPM: paymentMethodSetAsDefault,
-                                                                           isDefault: isDefaultPaymentMethod(paymentMethodId: paymentMethod.stripeId))
+                                                                           isDefault: isDefaultPaymentMethod(paymentMethodId: paymentMethod.stripeId),
+                                                                           defaultBillingDetails: configuration.defaultBillingDetails)
         let removeSavedPaymentMethodMessage = UpdatePaymentMethodViewController.resolveRemoveMessage(
             removeSavedPaymentMethodMessage: configuration.removeSavedPaymentMethodMessage,
             paymentMethodRemoveIsPartial: elementsSession.paymentMethodRemoveIsPartialForPaymentSheet(),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/UpdatePaymentMethodViewController+Configuration.swift
@@ -22,6 +22,7 @@ extension UpdatePaymentMethodViewController {
         let isCBCEligible: Bool
         let isSetAsDefaultPMEnabled: Bool
         let isDefault: Bool
+        let defaultBillingDetails: PaymentSheet.BillingDetails
 
         var shouldShowSaveButton: Bool {
             guard !paymentMethod.isLinkPaymentMethod else {
@@ -91,7 +92,7 @@ extension UpdatePaymentMethodViewController {
             }
         }
 
-        init(paymentMethod: STPPaymentMethod, appearance: PaymentSheet.Appearance, billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration, hostedSurface: HostedSurface, cardBrandFilter: CardBrandFilter = .default, canRemove: Bool, canUpdate: Bool, isCBCEligible: Bool, allowsSetAsDefaultPM: Bool = false, isDefault: Bool = false) {
+        init(paymentMethod: STPPaymentMethod, appearance: PaymentSheet.Appearance, billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration, hostedSurface: HostedSurface, cardBrandFilter: CardBrandFilter = .default, canRemove: Bool, canUpdate: Bool, isCBCEligible: Bool, allowsSetAsDefaultPM: Bool = false, isDefault: Bool = false, defaultBillingDetails: PaymentSheet.BillingDetails = .init()) {
             if !PaymentSheet.supportedSavedPaymentMethods.contains(paymentMethod.type) {
                 assertionFailure("Unsupported payment type \(paymentMethod.type) in UpdatePaymentMethodViewModel")
             }
@@ -105,6 +106,7 @@ extension UpdatePaymentMethodViewController {
             self.isCBCEligible = isCBCEligible
             self.isSetAsDefaultPMEnabled = allowsSetAsDefaultPM
             self.isDefault = isDefault
+            self.defaultBillingDetails = defaultBillingDetails
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodFormFactoryTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodFormFactoryTests.swift
@@ -1,0 +1,92 @@
+//
+//  SavedPaymentMethodFormFactoryTests.swift
+//  StripePaymentSheetTests
+//
+
+@_spi(STP) @testable import StripePaymentSheet
+@testable import StripePaymentsTestUtils
+@_spi(STP) import StripeUICore
+import XCTest
+
+final class SavedPaymentMethodFormFactoryTests: XCTestCase {
+
+    let factory = SavedPaymentMethodFormFactory()
+
+    // MARK: - currentBillingDetails
+
+    func test_currentBillingDetails_pmHasBillingDetails_usesPaymentMethodValues() {
+        let paymentMethod = STPPaymentMethod._testCard(
+            line1: "123 Main St",
+            city: "London",
+            state: nil,
+            postalCode: "SW1A 1AA",
+            countryCode: "GB"
+        )
+
+        var defaultBillingDetails = PaymentSheet.BillingDetails()
+        defaultBillingDetails.address.country = "US"
+        defaultBillingDetails.address.city = "San Francisco"
+        defaultBillingDetails.address.postalCode = "94102"
+
+        let result = factory.currentBillingDetails(paymentMethod: paymentMethod,
+                                                   defaultBillingDetails: defaultBillingDetails)
+
+        XCTAssertEqual(result.address.country, "GB")
+        XCTAssertEqual(result.address.city, "London")
+        XCTAssertEqual(result.address.postalCode, "SW1A 1AA")
+        XCTAssertEqual(result.address.line1, "123 Main St")
+    }
+
+    func test_currentBillingDetails_pmHasNoBillingDetails_usesDefaultBillingDetails() {
+        // PM with no billing address
+        let paymentMethod = STPPaymentMethod._testCard()
+
+        var defaultBillingDetails = PaymentSheet.BillingDetails()
+        defaultBillingDetails.address.country = "CA"
+        defaultBillingDetails.address.city = "Toronto"
+        defaultBillingDetails.address.line1 = "100 Queen St"
+        defaultBillingDetails.address.postalCode = "M5H 2N2"
+
+        let result = factory.currentBillingDetails(paymentMethod: paymentMethod,
+                                                   defaultBillingDetails: defaultBillingDetails)
+
+        XCTAssertEqual(result.address.country, "CA")
+        XCTAssertEqual(result.address.city, "Toronto")
+        XCTAssertEqual(result.address.line1, "100 Queen St")
+        XCTAssertEqual(result.address.postalCode, "M5H 2N2")
+    }
+
+    func test_currentBillingDetails_pmHasNoBillingDetails_noDefaults_returnsNilFields() {
+        let paymentMethod = STPPaymentMethod._testCard()
+        let defaultBillingDetails = PaymentSheet.BillingDetails()
+
+        let result = factory.currentBillingDetails(paymentMethod: paymentMethod,
+                                                   defaultBillingDetails: defaultBillingDetails)
+
+        XCTAssertNil(result.address.country)
+        XCTAssertNil(result.address.city)
+        XCTAssertNil(result.address.line1)
+        XCTAssertNil(result.address.line2)
+        XCTAssertNil(result.address.postalCode)
+        XCTAssertNil(result.address.state)
+    }
+
+    func test_currentBillingDetails_pmHasPartialBillingDetails_doesNotFallbackToDefaults() {
+        // PM has only postalCode set — city is nil on PM
+        let paymentMethod = STPPaymentMethod._testCard(postalCode: "90210",
+                                                       countryCode: "US")
+
+        var defaultBillingDetails = PaymentSheet.BillingDetails()
+        defaultBillingDetails.address.country = "DE"
+        defaultBillingDetails.address.city = "Berlin"
+        defaultBillingDetails.address.postalCode = "10115"
+
+        let result = factory.currentBillingDetails(paymentMethod: paymentMethod,
+                                                   defaultBillingDetails: defaultBillingDetails)
+
+        // Should use PM values, not mix in defaults
+        XCTAssertEqual(result.address.postalCode, "90210")
+        XCTAssertEqual(result.address.country, "US")
+        XCTAssertNil(result.address.city)
+    }
+}


### PR DESCRIPTION
## Summary
Previously, when a user edited a saved payment method that had no billing details stored, we ignored the merchant-provided defaultBillingDetails from the configuration and instead defaulted the country to the device's locale. This change ensures we respect the merchant's configured defaults before falling back to the device locale.

To reproduce (within payment sheet example)
1. Attach a payment method without any billing address information.
2. Switch device region to United Kingdom (Settings app → General → Language & Region → Region → United Kingdom)
3. Open payment sheet w/ "Default Billing Address" set to off
4. Notice that when adding a new payment method, card form defaults to "United kingdom"
5. Notice that when updating a new payment method, card form defaults to "United kingdom".
6. Close payment sheet.
7.  Open payment sheet w/ "Default billing address" set to `on` (so that default billing address is now set 510 Townsend, SF, 94102, CA, US)
8. Notice that when adding a new payment method, card form defaults to "US"
9. Notice that when updating a new payment method, card form defaults to "UK"

Ultimately, there is an inconsistency between the add screen and the update screen in how we use the default billing address. Note this also impacts CustomerSheet, which was initially reported here:
https://github.com/stripe/stripe-react-native/issues/2493

## Motivation
Updated intended behavior for defaultBillingDetails on the updatePage to be consistent with the add payment method page.

## Testing
Manually tested & added unit tests

## Changelog
Updated