### PR TITLE
API function to update CheckoutSession payment methods

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+CheckoutSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+CheckoutSession.swift
@@ -9,6 +9,45 @@ import Foundation
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 
+// MARK: - Payment Method Update Types
+
+struct CheckoutPaymentMethodBillingDetails {
+    let name: String?
+    let email: String?
+    let phone: String?
+    let address: CheckoutPaymentMethodBillingAddress?
+
+    init(name: String? = nil, email: String? = nil, phone: String? = nil, address: CheckoutPaymentMethodBillingAddress? = nil) {
+        self.name = name
+        self.email = email
+        self.phone = phone
+        self.address = address
+    }
+}
+
+struct CheckoutPaymentMethodBillingAddress {
+    let line1: String?
+    let line2: String?
+    let city: String?
+    let state: String?
+    let postalCode: String?
+    let country: String?
+
+    init(line1: String? = nil, line2: String? = nil, city: String? = nil, state: String? = nil, postalCode: String? = nil, country: String? = nil) {
+        self.line1 = line1
+        self.line2 = line2
+        self.city = city
+        self.state = state
+        self.postalCode = postalCode
+        self.country = country
+    }
+}
+
+struct CheckoutPaymentMethodExpiryDetails {
+    let expMonth: Int
+    let expYear: Int
+}
+
 extension STPAPIClient {
 
     /// Initializes a CheckoutSession, fetching payment configuration data.
@@ -79,6 +118,63 @@ extension STPAPIClient {
             endpoint: "payment_pages/\(checkoutSessionId)",
             parameters: ["payment_method_to_detach": paymentMethodId]
         )
+    }
+
+    /// Updates a saved payment method's billing details and/or card expiry on a Checkout Session.
+    /// - Parameters:
+    ///   - paymentMethodId: The ID of the payment method to update (e.g., "pm_xxx").
+    ///   - checkoutSessionId: The ID of the checkout session (e.g., "cs_test_xxx").
+    ///   - billingDetails: Optional billing details to update (name, email, phone, address).
+    ///   - expiryDetails: Optional card expiry to update (month and year).
+    /// - Returns: The updated STPCheckoutSession.
+    func updatePaymentMethod(
+        _ paymentMethodId: String,
+        inCheckoutSession checkoutSessionId: String,
+        billingDetails: CheckoutPaymentMethodBillingDetails? = nil,
+        expiryDetails: CheckoutPaymentMethodExpiryDetails? = nil
+    ) async throws -> STPCheckoutSession {
+        var params = Self.updatePaymentMethodParameters(
+            paymentMethodId: paymentMethodId,
+            billingDetails: billingDetails,
+            expiryDetails: expiryDetails
+        )
+        params["elements_session_client"] = ["is_aggregation_expected": true]
+        return try await APIRequest<STPCheckoutSession>.post(
+            with: self,
+            endpoint: "payment_pages/\(checkoutSessionId)",
+            parameters: params
+        )
+    }
+
+    static func updatePaymentMethodParameters(
+        paymentMethodId: String,
+        billingDetails: CheckoutPaymentMethodBillingDetails?,
+        expiryDetails: CheckoutPaymentMethodExpiryDetails?
+    ) -> [String: Any] {
+        var params: [String: Any] = [
+            "payment_method_to_update[payment_method_id]": paymentMethodId,
+        ]
+        if let billing = billingDetails {
+            let p = "payment_method_to_update[billing_details]"
+            if let name = billing.name { params["\(p)[name]"] = name }
+            if let email = billing.email { params["\(p)[email]"] = email }
+            if let phone = billing.phone { params["\(p)[phone]"] = phone }
+            if let address = billing.address {
+                let a = "\(p)[address]"
+                if let v = address.line1 { params["\(a)[line1]"] = v }
+                if let v = address.line2 { params["\(a)[line2]"] = v }
+                if let v = address.city { params["\(a)[city]"] = v }
+                if let v = address.state { params["\(a)[state]"] = v }
+                if let v = address.postalCode { params["\(a)[postal_code]"] = v }
+                if let v = address.country { params["\(a)[country]"] = v }
+            }
+        }
+        if let expiry = expiryDetails {
+            let p = "payment_method_to_update[expiry_details]"
+            params["\(p)[exp_month]"] = expiry.expMonth
+            params["\(p)[exp_year]"] = expiry.expYear
+        }
+        return params
     }
 
     /// Confirms a CheckoutSession with the provided payment method and parameters.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+CheckoutSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+CheckoutSession.swift
@@ -155,24 +155,24 @@ extension STPAPIClient {
             "payment_method_to_update[payment_method_id]": paymentMethodId,
         ]
         if let billing = billingDetails {
-            let p = "payment_method_to_update[billing_details]"
-            if let name = billing.name { params["\(p)[name]"] = name }
-            if let email = billing.email { params["\(p)[email]"] = email }
-            if let phone = billing.phone { params["\(p)[phone]"] = phone }
+            let billingPrefix = "payment_method_to_update[billing_details]"
+            if let name = billing.name { params["\(billingPrefix)[name]"] = name }
+            if let email = billing.email { params["\(billingPrefix)[email]"] = email }
+            if let phone = billing.phone { params["\(billingPrefix)[phone]"] = phone }
             if let address = billing.address {
-                let a = "\(p)[address]"
-                if let v = address.line1 { params["\(a)[line1]"] = v }
-                if let v = address.line2 { params["\(a)[line2]"] = v }
-                if let v = address.city { params["\(a)[city]"] = v }
-                if let v = address.state { params["\(a)[state]"] = v }
-                if let v = address.postalCode { params["\(a)[postal_code]"] = v }
-                if let v = address.country { params["\(a)[country]"] = v }
+                let addressPrefix = "\(billingPrefix)[address]"
+                if let line1 = address.line1 { params["\(addressPrefix)[line1]"] = line1 }
+                if let line2 = address.line2 { params["\(addressPrefix)[line2]"] = line2 }
+                if let city = address.city { params["\(addressPrefix)[city]"] = city }
+                if let state = address.state { params["\(addressPrefix)[state]"] = state }
+                if let postalCode = address.postalCode { params["\(addressPrefix)[postal_code]"] = postalCode }
+                if let country = address.country { params["\(addressPrefix)[country]"] = country }
             }
         }
         if let expiry = expiryDetails {
-            let p = "payment_method_to_update[expiry_details]"
-            params["\(p)[exp_month]"] = expiry.expMonth
-            params["\(p)[exp_year]"] = expiry.expYear
+            let expiryPrefix = "payment_method_to_update[expiry_details]"
+            params["\(expiryPrefix)[exp_month]"] = expiry.expMonth
+            params["\(expiryPrefix)[exp_year]"] = expiry.expYear
         }
         return params
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -476,6 +476,99 @@ final class CheckoutUnitTests: XCTestCase {
         }
     }
 
+    // MARK: - updatePaymentMethod Parameter Encoding Tests
+
+    func testUpdatePaymentMethodParameters_expiryOnly() {
+        let params = STPAPIClient.updatePaymentMethodParameters(
+            paymentMethodId: "pm_123",
+            billingDetails: nil,
+            expiryDetails: CheckoutPaymentMethodExpiryDetails(expMonth: 12, expYear: 2028)
+        )
+
+        XCTAssertEqual(params["payment_method_to_update[payment_method_id]"] as? String, "pm_123")
+        XCTAssertEqual(params["payment_method_to_update[expiry_details][exp_month]"] as? Int, 12)
+        XCTAssertEqual(params["payment_method_to_update[expiry_details][exp_year]"] as? Int, 2028)
+        XCTAssertNil(params["payment_method_to_update[billing_details][name]"])
+        XCTAssertEqual(params.count, 3)
+    }
+
+    func testUpdatePaymentMethodParameters_billingDetailsOnly() {
+        let billing = CheckoutPaymentMethodBillingDetails(
+            name: "Jane Doe",
+            email: "jane@example.com",
+            phone: "+15551234567",
+            address: CheckoutPaymentMethodBillingAddress(
+                line1: "123 Main St",
+                line2: "Apt 4",
+                city: "San Francisco",
+                state: "CA",
+                postalCode: "94105",
+                country: "US"
+            )
+        )
+        let params = STPAPIClient.updatePaymentMethodParameters(
+            paymentMethodId: "pm_456",
+            billingDetails: billing,
+            expiryDetails: nil
+        )
+
+        XCTAssertEqual(params["payment_method_to_update[payment_method_id]"] as? String, "pm_456")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][name]"] as? String, "Jane Doe")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][email]"] as? String, "jane@example.com")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][phone]"] as? String, "+15551234567")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][address][line1]"] as? String, "123 Main St")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][address][line2]"] as? String, "Apt 4")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][address][city]"] as? String, "San Francisco")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][address][state]"] as? String, "CA")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][address][postal_code]"] as? String, "94105")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][address][country]"] as? String, "US")
+        XCTAssertNil(params["payment_method_to_update[expiry_details][exp_month]"])
+        XCTAssertEqual(params.count, 10)
+    }
+
+    func testUpdatePaymentMethodParameters_billingAndExpiry() {
+        let billing = CheckoutPaymentMethodBillingDetails(
+            name: "John Smith",
+            address: nil
+        )
+        let expiry = CheckoutPaymentMethodExpiryDetails(expMonth: 3, expYear: 2026)
+        let params = STPAPIClient.updatePaymentMethodParameters(
+            paymentMethodId: "pm_789",
+            billingDetails: billing,
+            expiryDetails: expiry
+        )
+
+        XCTAssertEqual(params["payment_method_to_update[payment_method_id]"] as? String, "pm_789")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][name]"] as? String, "John Smith")
+        XCTAssertEqual(params["payment_method_to_update[expiry_details][exp_month]"] as? Int, 3)
+        XCTAssertEqual(params["payment_method_to_update[expiry_details][exp_year]"] as? Int, 2026)
+        XCTAssertNil(params["payment_method_to_update[billing_details][email]"])
+        XCTAssertNil(params["payment_method_to_update[billing_details][address][line1]"])
+        XCTAssertEqual(params.count, 4)
+    }
+
+    func testUpdatePaymentMethodParameters_partialBillingAddress() {
+        let billing = CheckoutPaymentMethodBillingDetails(
+            address: CheckoutPaymentMethodBillingAddress(
+                postalCode: "94105",
+                country: "US"
+            )
+        )
+        let params = STPAPIClient.updatePaymentMethodParameters(
+            paymentMethodId: "pm_abc",
+            billingDetails: billing,
+            expiryDetails: nil
+        )
+
+        XCTAssertEqual(params["payment_method_to_update[payment_method_id]"] as? String, "pm_abc")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][address][postal_code]"] as? String, "94105")
+        XCTAssertEqual(params["payment_method_to_update[billing_details][address][country]"] as? String, "US")
+        XCTAssertNil(params["payment_method_to_update[billing_details][name]"])
+        XCTAssertNil(params["payment_method_to_update[billing_details][address][line1]"])
+        XCTAssertNil(params["payment_method_to_update[billing_details][address][city]"])
+        XCTAssertEqual(params.count, 3)
+    }
+
     // MARK: - Helpers
 
     private func makeCheckoutWithOpenSession() async -> Checkout {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+CheckoutSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+CheckoutSessionTest.swift
@@ -124,6 +124,111 @@ final class STPAPIClientCheckoutSessionTest: STPNetworkStubbingTestCase {
         XCTAssertTrue(checkoutSession.localizedPricesMetas.isEmpty)
     }
 
+    // MARK: - Update Payment Method
+
+    func testUpdatePaymentMethodExpiry() async throws {
+        // 1. Create a customer and attach a card PM to them
+        let customerResponse = try await STPTestingAPIClient.shared.fetchCustomerAndEphemeralKey()
+        let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.expMonth = 12
+        cardParams.expYear = 2030
+        cardParams.cvc = "123"
+        let billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.email = "test@example.com"
+        let paymentMethodParams = STPPaymentMethodParams(card: cardParams, billingDetails: billingDetails, metadata: nil)
+        let paymentMethod = try await apiClient.createPaymentMethod(with: paymentMethodParams)
+
+        try await apiClient.attachPaymentMethod(
+            paymentMethod.stripeId,
+            customerID: customerResponse.customer,
+            ephemeralKeySecret: customerResponse.ephemeralKeySecret
+        )
+
+        // 2. Create a checkout session for this customer
+        let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
+            customerID: customerResponse.customer,
+            setupFutureUsage: "on_session"
+        )
+        let sessionApiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+
+        // 3. Init the session
+        _ = try await sessionApiClient.initCheckoutSession(
+            checkoutSessionId: checkoutSessionResponse.id,
+            adaptivePricingAllowed: false
+        )
+
+        // 4. Update the attached PM's expiry via the checkout session
+        let updatedSession = try await sessionApiClient.updatePaymentMethod(
+            paymentMethod.stripeId,
+            inCheckoutSession: checkoutSessionResponse.id,
+            expiryDetails: CheckoutPaymentMethodExpiryDetails(expMonth: 6, expYear: 2029)
+        )
+
+        // 5. Verify the session was returned successfully (proves the API accepted our request)
+        XCTAssertEqual(updatedSession.id, checkoutSessionResponse.id)
+        XCTAssertEqual(updatedSession.status?.type, .open)
+    }
+
+    func testUpdatePaymentMethodBillingDetails() async throws {
+        // 1. Create a customer and attach a card PM to them
+        let customerResponse = try await STPTestingAPIClient.shared.fetchCustomerAndEphemeralKey()
+        let apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+
+        let cardParams = STPPaymentMethodCardParams()
+        cardParams.number = "4242424242424242"
+        cardParams.expMonth = 12
+        cardParams.expYear = 2030
+        cardParams.cvc = "123"
+        let billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.email = "test@example.com"
+        let paymentMethodParams = STPPaymentMethodParams(card: cardParams, billingDetails: billingDetails, metadata: nil)
+        let paymentMethod = try await apiClient.createPaymentMethod(with: paymentMethodParams)
+
+        try await apiClient.attachPaymentMethod(
+            paymentMethod.stripeId,
+            customerID: customerResponse.customer,
+            ephemeralKeySecret: customerResponse.ephemeralKeySecret
+        )
+
+        // 2. Create a checkout session for this customer
+        let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
+            customerID: customerResponse.customer,
+            setupFutureUsage: "on_session"
+        )
+        let sessionApiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+
+        // 3. Init the session
+        _ = try await sessionApiClient.initCheckoutSession(
+            checkoutSessionId: checkoutSessionResponse.id,
+            adaptivePricingAllowed: false
+        )
+
+        // 4. Update the attached PM's billing details via the checkout session
+        let updatedSession = try await sessionApiClient.updatePaymentMethod(
+            paymentMethod.stripeId,
+            inCheckoutSession: checkoutSessionResponse.id,
+            billingDetails: CheckoutPaymentMethodBillingDetails(
+                name: "Jane Doe",
+                email: "jane@example.com",
+                phone: "+15551234567",
+                address: CheckoutPaymentMethodBillingAddress(
+                    line1: "123 Main St",
+                    city: "San Francisco",
+                    state: "CA",
+                    postalCode: "94105",
+                    country: "US"
+                )
+            )
+        )
+
+        // 5. Verify the session was returned successfully (proves the API accepted our request)
+        XCTAssertEqual(updatedSession.id, checkoutSessionResponse.id)
+        XCTAssertEqual(updatedSession.status?.type, .open)
+    }
+
     // MARK: - Setup Mode
 
     func testInitCheckoutSessionSetup() async throws {

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0000_post_create_ephemeral_key.tail
@@ -1,0 +1,17 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_ephemeral_key$
+200
+text/html
+x-content-type-options: nosniff
+x-cloud-trace-context: 4eb1aa2c70eea94bdd93eeeb7b29bfaa;o=1
+Content-Type: text/html;charset=utf-8
+Set-Cookie: rack.session=hGENI0Aq%2F%2F%2Bis7Sh5K0nQ0tev3eaoaovz5N3CWbdAAGhZ%2FkurwobsUhRC00ztHh%2FxM%2FZU%2F11o06RlR4CukloFteTWCdEAC%2BPh%2BR23v9KZ25WZfYoXhIr%2FMLU2y96wD2FhJ9gsxt0t0ATgn49Xs2wUHdGx2g7MOOQypYSWFfzE%2Bbv6vUw%2BgHULCqqlDuot5Oq2GOWfsMUwBkhiHOqzXwEHUKSRZzHz47Y1tCAAxJQnGk%3D; path=/
+Server: Google Frontend
+Via: 1.1 google
+Date: Wed, 24 Jun 2026 17:18:08 GMT
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+Content-Length: 149
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+
+{"ephemeral_key_secret":"ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLEFjSkgwRnp5NXRuMXh4Q0xoZnROYUdwME5zRWc5U2s_00QuroWF0D","customer":"cus_UlRJaOllpNM6Zo"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0001_post_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0001_post_v1_payment_methods.tail
@@ -1,0 +1,81 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_methods$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=kIaf7PfF0bhSosbnkjvuo8FbvKainRI023knIyDlKJdGfSAephfuwLu3ufFe0bmubbIR7hajXd_sxiRt; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=kIaf7PfF0bhSosbnkjvuo8FbvKainRI023knIyDlKJdGfSAephfuwLu3ufFe0bmubbIR7hajXd_sxiRt&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=kIaf7PfF0bhSosbnkjvuo8FbvKainRI023knIyDlKJdGfSAephfuwLu3ufFe0bmubbIR7hajXd_sxiRt&t=1"}],"include_subdomains":true}
+request-id: req_MvY4zNXMaaEkj0
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 1073
+Vary: Origin
+Date: Wed, 24 Jun 2026 17:18:09 GMT
+original-request: req_MvY4zNXMaaEkj0
+stripe-version: 2020-08-27
+idempotency-key: 4e7a7f42-acc3-4e0a-9dda-3cf8850a6dfe
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: allow_redisplay=unspecified&billing_details\[email]=test%40example\.com&card\[cvc]=123&card\[exp_month]=12&card\[exp_year]=2030&card\[number]=4242424242424242&guid=.*&muid=.*&payment_user_agent=.*&sid=.*&type=card
+
+{
+  "object" : "payment_method",
+  "id" : "pm_1TluRBFY0qyl6XeWFce40M87",
+  "billing_details" : {
+    "email" : "test@example.com",
+    "phone" : null,
+    "tax_id" : null,
+    "name" : null,
+    "address" : {
+      "state" : null,
+      "country" : null,
+      "line2" : null,
+      "city" : null,
+      "line1" : null,
+      "postal_code" : null
+    }
+  },
+  "card" : {
+    "regulated_status" : "unregulated",
+    "last4" : "4242",
+    "funding" : "credit",
+    "generated_from" : null,
+    "networks" : {
+      "available" : [
+        "visa"
+      ],
+      "preferred" : null
+    },
+    "brand" : "visa",
+    "checks" : {
+      "address_postal_code_check" : null,
+      "cvc_check" : null,
+      "address_line1_check" : null
+    },
+    "three_d_secure_usage" : {
+      "supported" : true
+    },
+    "wallet" : null,
+    "display_brand" : "visa",
+    "exp_month" : 12,
+    "exp_year" : 2030,
+    "country" : "US"
+  },
+  "livemode" : false,
+  "created" : 1782321489,
+  "allow_redisplay" : "unspecified",
+  "shared_payment_granted_token" : null,
+  "customer" : null,
+  "type" : "card",
+  "customer_account" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0002_post_v1_payment_methods_pm_1TluRBFY0qyl6XeWFce40M87_attach.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0002_post_v1_payment_methods_pm_1TluRBFY0qyl6XeWFce40M87_attach.tail
@@ -1,0 +1,82 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_methods\/pm_1TluRBFY0qyl6XeWFce40M87\/attach$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=FWomRQQrTBrMxXTBgLeCJGXP6DO8A58SFaHrNOq4VjmQZkTEHK8XI67cON2PpBxOtsv0NdhsDkZY6YX5; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=FWomRQQrTBrMxXTBgLeCJGXP6DO8A58SFaHrNOq4VjmQZkTEHK8XI67cON2PpBxOtsv0NdhsDkZY6YX5&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=FWomRQQrTBrMxXTBgLeCJGXP6DO8A58SFaHrNOq4VjmQZkTEHK8XI67cON2PpBxOtsv0NdhsDkZY6YX5&t=1"}],"include_subdomains":true}
+request-id: req_I7fCAp7pm4cEO0
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 1128
+Vary: Origin
+Date: Wed, 24 Jun 2026 17:18:11 GMT
+original-request: req_I7fCAp7pm4cEO0
+stripe-version: 2020-08-27
+idempotency-key: 0f257d1f-5069-404f-88fc-e20c43cc39f8
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: customer=cus_UlRJaOllpNM6Zo
+
+{
+  "object" : "payment_method",
+  "id" : "pm_1TluRBFY0qyl6XeWFce40M87",
+  "billing_details" : {
+    "email" : "test@example.com",
+    "phone" : null,
+    "tax_id" : null,
+    "name" : null,
+    "address" : {
+      "state" : null,
+      "country" : null,
+      "line2" : null,
+      "city" : null,
+      "line1" : null,
+      "postal_code" : null
+    }
+  },
+  "card" : {
+    "regulated_status" : "unregulated",
+    "fingerprint" : "96sroMqLCHmUdUpL",
+    "last4" : "4242",
+    "funding" : "credit",
+    "generated_from" : null,
+    "networks" : {
+      "available" : [
+        "visa"
+      ],
+      "preferred" : null
+    },
+    "brand" : "visa",
+    "checks" : {
+      "address_postal_code_check" : null,
+      "cvc_check" : null,
+      "address_line1_check" : null
+    },
+    "three_d_secure_usage" : {
+      "supported" : true
+    },
+    "wallet" : null,
+    "display_brand" : "visa",
+    "exp_month" : 12,
+    "exp_year" : 2030,
+    "country" : "US"
+  },
+  "livemode" : false,
+  "created" : 1782321489,
+  "allow_redisplay" : "unspecified",
+  "shared_payment_granted_token" : null,
+  "customer" : "cus_UlRJaOllpNM6Zo",
+  "type" : "card",
+  "customer_account" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0003_post_create_checkout_session.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0003_post_create_checkout_session.tail
@@ -1,0 +1,17 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_checkout_session$
+200
+text/html
+x-content-type-options: nosniff
+x-cloud-trace-context: ea509d9b1d007856ad951d5d69d39cc2
+Content-Type: text/html;charset=utf-8
+Set-Cookie: rack.session=WbvIEv6mOBOgVAkOCfUFi5lurSW%2Fm1WFOIATyOwhKgOz32JisxBdKBkD7hPr9glPJtUwFGkJqvNvSLC5gkwifPKmklW93i5m525fLJXIDy3e9Qs7KT7O9MU8lNzwKQJc9g9wfkN9DJlNTdhQran2plgilB3pCdSdyTAlUkUSmEOoRb68ytnt4XEeOfMmgehnQMiOrKEgluQRiCYtz1mOHI%2FOyDxpWZms%2FwoqyJFhP9g%3D; path=/
+Server: Google Frontend
+Via: 1.1 google
+Date: Wed, 24 Jun 2026 17:18:11 GMT
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+Content-Length: 293
+Alt-Svc: h3=":443"; ma=2592000
+
+{"id":"cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB","client_secret":"cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB_secret_fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdwbEhqYWAnPydmcHZxamgneCUl","publishable_key":"pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0004_post_v1_payment_pages_cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB_init.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0004_post_v1_payment_pages_cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB_init.tail
@@ -1,0 +1,986 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_pages\/cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB\/init$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=em6bvCcASFCtBNFw2LSdRycsFlNhXmXcUp7T0qUXmeTSXpmPjNbtAJ68skWAMYYCn55vfhlF39V6KHc5; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=em6bvCcASFCtBNFw2LSdRycsFlNhXmXcUp7T0qUXmeTSXpmPjNbtAJ68skWAMYYCn55vfhlF39V6KHc5&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=em6bvCcASFCtBNFw2LSdRycsFlNhXmXcUp7T0qUXmeTSXpmPjNbtAJ68skWAMYYCn55vfhlF39V6KHc5&t=1"}],"include_subdomains":true}
+request-id: req_0vXUxEavIrXko4
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 33985
+Vary: Origin
+Date: Wed, 24 Jun 2026 17:18:12 GMT
+original-request: req_0vXUxEavIrXko4
+stripe-version: 2020-08-27
+idempotency-key: bc68ac67-9d1a-45c7-a75d-224ba4a0d478
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: adaptive_pricing\[allowed]=false&browser_locale=.*&browser_timezone=.*&eid=.*&elements_session_client\[is_aggregation_expected]=true&elements_session_client\[locale]=.*&elements_session_client\[mobile_app_id]=.*&redirect_type=embedded
+
+{
+  "lpm_settings" : null,
+  "sepa_debit_info" : null,
+  "automatic_payment_method_types" : false,
+  "is_unclaimed_anonymous_sandbox" : false,
+  "tax_context" : {
+    "automatic_tax_error" : null,
+    "automatic_tax_enabled" : false,
+    "automatic_tax_taxability_reason" : null,
+    "dynamic_tax_enabled" : false,
+    "tax_id_collection_enabled" : false,
+    "automatic_tax_exempt" : "none",
+    "customer_tax_country" : null,
+    "tax_id_collection_required" : "never",
+    "has_maximum_tax_ids" : false,
+    "automatic_tax_address_source" : null
+  },
+  "payment_method_types" : [
+    "card"
+  ],
+  "payment_method_options" : {
+    "card" : {
+      "request_three_d_secure" : "automatic"
+    }
+  },
+  "bnpl_in_link_ui_enabled" : false,
+  "consent_collection" : null,
+  "experiment_data" : [
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs_aa",
+      "event_id" : "2d1152df-f681-4ad8-a73e-124baaf06133",
+      "exposure_event_name" : ""
+    },
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs",
+      "event_id" : "1477f900-dc62-4e76-9001-4049d1c704db",
+      "exposure_event_name" : ""
+    }
+  ],
+  "origin_context" : null,
+  "enforcement_mode" : "open",
+  "blocked_billing_address_countries" : [
+
+  ],
+  "id" : "ppage_1TluRDFY0qyl6XeWjtA6LrcW",
+  "subscription_settings" : null,
+  "consent" : null,
+  "does_not_collect_postal_code_for_non_us_card_transactions" : false,
+  "use_payment_methods" : true,
+  "application" : null,
+  "payment_method_collection" : "if_required",
+  "setup_intent" : null,
+  "shipping_options" : [
+
+  ],
+  "setup_future_usage_for_payment_method_type" : {
+    "card" : "on_session"
+  },
+  "capture_method" : "automatic_async",
+  "statement_descriptor" : "mobile",
+  "session_id" : "cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB",
+  "shipping_address_collection" : null,
+  "konbini_confirmation_number" : null,
+  "setup_future_usage" : "on_session",
+  "invoice_creation" : {
+    "enabled" : false
+  },
+  "has_dynamic_tax_rates" : false,
+  "receipt_emails_enabled" : false,
+  "link_settings" : {
+    "link_consumer_incentive" : null,
+    "link_payment_session_context" : null,
+    "consumer_found" : null,
+    "hcaptcha_rqdata" : null,
+    "link_supported_payment_methods_onboarding_enabled" : [
+
+    ],
+    "enable_partner_lookup" : false,
+    "link_us_bank_account_funding_source_enabled" : false,
+    "link_funding_sources" : [
+
+    ],
+    "hcaptcha_site_key" : null,
+    "link_brand" : "link",
+    "link_mode" : null,
+    "link_supported_payment_methods" : [
+
+    ]
+  },
+  "object" : "checkout.session",
+  "customer" : {
+    "object" : "customer",
+    "phone" : null,
+    "tax_ids" : [
+
+    ],
+    "id" : "cus_UlRJaOllpNM6Zo",
+    "business_name" : null,
+    "payment_methods" : [
+
+    ],
+    "email" : null,
+    "has_fallback_payment_method" : false,
+    "individual_name" : null,
+    "customer_provided" : true,
+    "name" : null
+  },
+  "shipping_rate" : null,
+  "success_url" : null,
+  "utm_codes" : null,
+  "beta_versions" : null,
+  "has_async_attached_payment_method" : false,
+  "feature_flags" : {
+    "checkout_enable_pay_by_bank_remember_bank_selection" : true,
+    "checkout_link_phone_registration_treatment_1_enabled" : true,
+    "sandboxes_rebrand_testmode" : true,
+    "checkout_enable_new_google_places_api" : true,
+    "checkout_link_enable_mfa" : true,
+    "checkout_link_purchase_protections_rollout" : true,
+    "checkout_tide_remount_override_replay" : true,
+    "checkout_optional_items" : true,
+    "checkout_link_in_habanero_enabled" : true,
+    "enable_custom_checkout_name_collection" : true,
+    "ocs_payment_prompt_for_agents" : true,
+    "checkout_passive_captcha" : true,
+    "checkout_enable_link_api_passive_hcaptcha" : true,
+    "checkout_hcaptcha_redundancy_control_enabled" : true,
+    "checkout_address_autocomplete_enabled" : true,
+    "checkout_enable_link_api_hcaptcha_rqdata" : true,
+    "checkout_show_swish_factoring_notice" : true
+  },
+  "locale" : null,
+  "custom_text" : {
+    "shipping_address" : null,
+    "terms_of_service_acceptance" : null,
+    "submit" : null,
+    "after_submit" : null
+  },
+  "route_to_orchestration_interface" : false,
+  "customer_email" : null,
+  "custom_components" : [
+
+  ],
+  "ui_mode" : "custom",
+  "url" : null,
+  "developer_tool_context" : {
+    "disabled_third_party_wallets" : {
+      "LINK_BUTTON" : {
+        "disabled_reason" : "merchant_payment_methods_settings"
+      },
+      "KLARNA_EXPRESS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "PAYPAL_ECS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "AMAZON_PAY" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      }
+    },
+    "adaptive_pricing" : {
+      "reason" : "not_allowed_for_ui",
+      "active" : false
+    },
+    "payment_method_configuration_details" : null
+  },
+  "token_notification_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "init_checksum" : "U8AEreXQqLMiEVpCMFwYNZnB16vSVJeJ",
+  "tax_exclusion_from_total_is_allowed" : false,
+  "bnpl_link_experiment_payment_method_type" : null,
+  "tax_meta" : {
+    "status" : "complete",
+    "error_reason" : null,
+    "computation_type" : "manual",
+    "customer_tax_exempt" : "none"
+  },
+  "payment_status" : "unpaid",
+  "enabled_third_party_wallets" : [
+    {
+      "apple_pay" : {
+        "required_version" : 2
+      },
+      "id" : "APPLE_PAY",
+      "enabled" : true,
+      "carousel_enabled" : true
+    },
+    {
+      "id" : "GOOGLE_PAY",
+      "enabled" : true,
+      "google_pay" : {
+        "id" : "GOOGLE_PAY",
+        "version_minor" : 0,
+        "version_major" : 2
+      },
+      "carousel_enabled" : false
+    },
+    {
+      "id" : "AMAZON_PAY",
+      "carousel_enabled" : false,
+      "enabled" : false
+    },
+    {
+      "id" : "KLARNA_EXPRESS",
+      "carousel_enabled" : false,
+      "enabled" : false
+    }
+  ],
+  "klarna_info" : null,
+  "visible_custom_component_locations" : [
+    "checkout_form_before",
+    "checkout_form_after",
+    "submit_button_before",
+    "submit_button_after",
+    "contact_before",
+    "contact_after",
+    "express_checkout_before",
+    "express_checkout_after",
+    "payment_details_before",
+    "payment_details_after"
+  ],
+  "display_consent_collection_promotions" : false,
+  "policies" : {
+    "contacts" : {
+      "display_phone" : true,
+      "display_url" : true,
+      "enabled" : false,
+      "display_email" : true
+    },
+    "legal" : {
+      "agreement_required" : false,
+      "enabled" : false
+    },
+    "returns" : {
+      "custom_message" : null,
+      "exchanges_accepted" : false,
+      "returns_accepted" : null,
+      "fee_type" : null,
+      "fee_required" : null,
+      "policy_url" : null,
+      "window_start" : null,
+      "refunds_accepted" : null,
+      "window" : null,
+      "enabled" : false,
+      "exceptions_apply" : false,
+      "logistics" : [
+
+      ]
+    }
+  },
+  "card_brands" : {
+    "mastercard" : true,
+    "link" : true,
+    "carnet" : false,
+    "accel" : false,
+    "elo" : false,
+    "rupay" : false,
+    "maestro" : false,
+    "unionpay" : true,
+    "amex" : true,
+    "jaywan" : false,
+    "conecs" : false,
+    "jcb" : true,
+    "visa" : true,
+    "cartes_bancaires" : false,
+    "pulse" : false,
+    "discover" : true,
+    "star" : false,
+    "eftpos_au" : false,
+    "diners" : true,
+    "girocard" : false,
+    "nyce" : false
+  },
+  "geocoding" : {
+    "country_code" : "US",
+    "region_name" : "UT"
+  },
+  "account_settings" : {
+    "assets" : {
+      "use_logo" : false,
+      "icon" : null,
+      "logo" : null
+    },
+    "specified_commercial_transactions_act_url" : null,
+    "business_url" : "https:\/\/github.com\/stripe\/stripe-ios",
+    "privacy_policy_url" : null,
+    "branding" : {
+      "button_color" : "#0074d4",
+      "background_color" : "#ffffff",
+      "border_style" : "default",
+      "font_family" : "default"
+    },
+    "statement_descriptor" : "mobile",
+    "support_email" : null,
+    "display_name" : "CI Stuff",
+    "merchant_of_record_country" : "US",
+    "order_summary_display_name" : "CI Stuff",
+    "support_phone" : "+12105550123",
+    "merchant_of_record_display_name" : "CI Stuff",
+    "support_url" : null,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "country" : "US",
+    "terms_of_service_url" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "server_built_elements_session_params" : {
+    "client_betas" : [
+
+    ],
+    "expand" : [
+
+    ],
+    "checkout_session_id" : "cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB",
+    "locale" : "en-US",
+    "country_override" : "US",
+    "mobile_app_id" : "com.stripe.StripeiOSTestHostApp",
+    "type" : "deferred_intent",
+    "deferred_intent" : {
+      "amount" : 2000,
+      "capture_method" : "automatic_async",
+      "currency" : "usd",
+      "payment_method_types" : [
+        "card"
+      ],
+      "setup_future_usage" : "on_session",
+      "mode" : "payment"
+    }
+  },
+  "shipping_tax_amounts" : [
+
+  ],
+  "billing_address_collection" : null,
+  "elements_options" : {
+    "amount" : 2000,
+    "__checkout_session_id" : "cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB",
+    "setup_future_usage" : "on_session",
+    "payment_method_types" : [
+      "card"
+    ],
+    "__disable_link_in_session" : false,
+    "__checkout_country_override" : "US",
+    "__checkout_automatic_payment_method_types" : false,
+    "__link_consumer_data" : {
+
+    },
+    "capture_method" : "automatic_async",
+    "__checkout_config_id" : "196a1583-e9cc-4858-8d0f-09cf83502aaa",
+    "mode" : "payment",
+    "__payment_pages_experiments" : [
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs_aa",
+        "event_id" : "2d1152df-f681-4ad8-a73e-124baaf06133",
+        "exposure_event_name" : ""
+      },
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs",
+        "event_id" : "1477f900-dc62-4e76-9001-4049d1c704db",
+        "exposure_event_name" : ""
+      }
+    ],
+    "currency" : "usd"
+  },
+  "experiments_data" : {
+    "event_id" : "347a9fb4-2852-46a1-95c6-98b777e06a5c",
+    "experiment_metadata" : {
+      "ocs_buyer_xp_cpl_lpm_holdback" : {
+        "heldback_special_wallets" : [
+
+        ]
+      }
+    },
+    "experiment_assignments" : {
+      "ocs_buyer_xp_cpl_separate_wallet_accordion" : "control",
+      "emea_wallets_ideal_wero_rebranding" : "control",
+      "ocs_buyer_xp_cpl_apple_pay_in_non_safari" : "control",
+      "ocs_buyer_xp_cpl_embedded_pay_button" : "control",
+      "ff_checkout_cpl_lid_promo_badge_color_opt" : "control",
+      "cpl_spicy_guacamole" : "control",
+      "ff_checkout_optimized_image_eff" : "control",
+      "connections_checkout_us_bank_account_picker_icons" : "control",
+      "ocs_buyer_xp_cpl_progressive_ece" : "control",
+      "ocs_buyer_xp_cpl_single_column_checkout" : "control",
+      "checkout_li_larger_image_size" : "control",
+      "link_ab_test_aa" : "control",
+      "ocs_buyer_xp_cpl_terms_above_submit" : "control",
+      "ocs_buyer_xp_cpl_currency_symbol_optimization" : "control",
+      "smor_checkout_ui_iteration" : "control",
+      "checkout_link_instant_debits_accordion_logos" : "control",
+      "checkout_enable_real_time_tax_id_verification_experiment" : "control",
+      "ff_checkout_test_frontend_eff" : "control",
+      "ocs_buyer_xp_cpl_link_signup_in_form" : "control",
+      "ocs_buyer_xp_remove_name_field_guac_related_pms" : "control",
+      "link_risk_based_disable_auto_prompting_checkout" : "control",
+      "ocs_buyer_xp_cpl_apple_pay_button_type" : "control",
+      "cpl_guacamole" : "control",
+      "ocs_buyer_xp_cpl_ece_kakao_naver" : "control",
+      "ocs_buyer_xp_cpl_lpm_content_simplification" : "control"
+    }
+  },
+  "return_url" : "https:\/\/example.com\/return",
+  "mode" : "payment",
+  "cancel_url" : null,
+  "elements_session" : {
+    "payment_method_preference" : {
+      "country_code" : "US",
+      "object" : "payment_method_preference",
+      "type" : "deferred_intent",
+      "ordered_payment_method_types" : [
+        "card"
+      ]
+    },
+    "capability_enabled_card_networks" : [
+      "cartes_bancaires",
+      "jcb",
+      "diners",
+      "discover"
+    ],
+    "flags" : {
+      "enable_tax_id_suspicious_pattern_check" : false,
+      "elements_easel_enable_elements_inspector_for_advanced_integrations_backend" : true,
+      "link_enable_signup_in_summary_in_habanero" : true,
+      "financial_connections_enable_deferred_intent_flow" : true,
+      "elements_enable_remove_last_validation" : true,
+      "ocs_payment_prompt_for_agents" : true,
+      "apple_pay_prb_killswitch" : false,
+      "elements_enable_easel_for_pi" : true,
+      "elements_mobile_card_funding_filtering" : true,
+      "link_payment_element_minor_signup_ui_updates" : false,
+      "link_enable_ncdv_usage_id_selectors_l3" : true,
+      "elements_disable_express_checkout_button_amazon_pay" : false,
+      "elements_easel_disable_appearance_api" : false,
+      "link_auth_partner_enable_link_auth_token_login" : true,
+      "link_enable_ncdv_recall_id_selectors_l3" : true,
+      "elements_disable_link_email_otp" : false,
+      "restrict_taxid_selection_to_buyer_address" : false,
+      "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
+      "ocs_buyer_xp_elements_card_brand_choice_toggle" : false,
+      "paypal_billing_address_support_in_ece" : true,
+      "elements_enable_pay_by_bank_remember_bank_selection" : true,
+      "link_auth_partner_enable_ios_instagram" : true,
+      "link_user_action_attempt_login_using_stored_credentials" : true,
+      "elements_disable_sepa_debit_eea_address_requirement" : false,
+      "elements_enable_instant_debits_postal_code_collection" : false,
+      "elements_financial_connections_canada_enabled" : false,
+      "elements_easel_disable_feedback" : false,
+      "link_enable_link_session_key_financial_connections" : false,
+      "elements_extend_hcaptcha_refresh_time" : true,
+      "link_auth_partner_consume_link_auth_intent" : true,
+      "ocs_buyer_xp_elements_remove_cpm_redirect_text" : false,
+      "elements_enable_south_korea_market_underlying_pms" : false,
+      "link_payment_element_steerage_enabled" : true,
+      "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text" : false,
+      "link_enable_apple_pay_in_safari_returning_in_guacamole" : false,
+      "elements_disable_payment_element_card_country_zip_validations" : false,
+      "link_payment_element_default_value_auto_open_modal" : true,
+      "elements_enable_link_card_brand_in_saved_payment_methods" : true,
+      "elements_disable_link_global_holdback_lookup" : false,
+      "financial_connections_enable_ca_accounts" : false,
+      "elements_apple_pay_inner_use_pending_payment_overrides" : false,
+      "link_enable_link_session_key_klarna" : false,
+      "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : true,
+      "elements_easel_disable_address_fill" : false,
+      "ocs_buyer_xp_elements_remove_redirect_lpm_content" : false,
+      "adaptive_pricing_hip_currency_selector_change_event" : true,
+      "elements_enable_payment_method_options_setup_future_usage" : true,
+      "enable_custom_checkout_currency_selector_element" : false,
+      "elements_mobile_android_tap_to_add_enabled" : false,
+      "link_enable_address_country_restrictions" : false,
+      "link_auth_partner_enable_android_fb" : true,
+      "checkout_kr_lpm_no_billing_address_collection" : false,
+      "elements_easel_disable_health_check" : false,
+      "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
+      "elements_disable_paypal_express" : false,
+      "disable_confirmation_modal_bacs" : false,
+      "legacy_customer_session_payment_element_features" : false,
+      "elements_enable_terms_element" : false,
+      "link_auth_partner_enable_authentication_element" : true,
+      "elements_allow_manual_payment_method_creation_with_spm" : false,
+      "elements_easel_disable" : false,
+      "link_enable_auth_partner_communication" : true,
+      "elements_apply_amex_icon_sorting" : false,
+      "elements_hide_card_brand_icons" : false,
+      "link_auth_partner_enable_distinctly_link_ios_facebook" : true,
+      "elements_easel_disable_customer_location_mocking" : false,
+      "elements_easel_disable_position_customization" : false,
+      "elements_enable_appearance_recompute" : false,
+      "link_enable_link_session_key_confirm_and_start_verification" : false,
+      "enable_link_lpm_dual_enablement" : false,
+      "elements_enable_19_digit_pans" : false,
+      "always_show_ece_paypal_recurring_button" : false,
+      "elements_enable_interac_apple_pay" : true,
+      "enable_payment_method_api_shop_pay" : true,
+      "enable_elements_tax_id_type_filtering" : false,
+      "elements_human_security_enabled" : false,
+      "link_enable_white_ece_button_theme" : false,
+      "link_in_accordion_layout_available_in_stripejs" : false,
+      "link_payment_element_widget_view_enabled" : true,
+      "elements_easel_disable_magic_fill" : false,
+      "avoid_redundant_billing_details_for_klarna" : false,
+      "distinctly_link_payment_element_ramp" : true,
+      "link_enable_ewcs_customer_name_prefill" : false,
+      "link_auth_partner_bypass_bridge_check" : false,
+      "link_disable_cookie_login" : false,
+      "elements_disable_express_checkout_button_shop_pay" : false,
+      "payment_element_link_modal_preload_killswitch" : false,
+      "link_enable_pass_checkout_session_id_to_signup" : true,
+      "elements_enable_hcaptcha_async_token_logging" : false,
+      "elements_enable_jp_card_installments" : true,
+      "elements_show_expanded_spm" : false,
+      "disable_payment_element_if_required_billing_config" : false,
+      "elements_enable_link_otp_takeover_in_guacamole" : false,
+      "elements_enable_link_spm" : true,
+      "elements_enable_read_allow_redisplay" : false,
+      "elements_enable_save_for_future_payments_pre_check" : false,
+      "link_forest_enable_ece_bank_use_shipping_as_billing" : false,
+      "elements_disable_express_checkout_button_klarna" : false,
+      "distinctly_link_cbc_killswitch" : false,
+      "elements_prefer_fc_lite" : false,
+      "elements_disable_payment_element_custom_payment_methods_byof" : false,
+      "elements_mobile_cardscan_use_mlkit" : true,
+      "elements_enable_link_takeover_in_guacamole" : false,
+      "link_disable_auth_partner_ua_check" : false,
+      "link_enable_link_session_key_incentives_and_status" : false,
+      "elements_easel_disable_optimizations_check" : false,
+      "elements_enable_passive_captcha" : true,
+      "distinctly_link_payment_element_opt_out_merchant_blocklist" : false,
+      "link_enable_non_blocking_doi_signup" : false,
+      "elements_enable_new_google_places_api" : true,
+      "checkout_form_automatic_tax_address_collection_precision" : false,
+      "elements_enable_express_checkout_button_demo_pay" : false,
+      "disable_cbc_in_link_popup" : false,
+      "elements_enable_installments_on_deferred_intents" : true,
+      "elements_sepa_debit_instant_microdeposits" : false,
+      "ocs_buyer_xp_elements_remove_generic_footer" : false,
+      "elements_spm_set_as_default" : true,
+      "elements_does_not_collect_postal_code_for_non_us_card_transactions_killswitch" : false,
+      "link_disable_login_if_signed_up_outside_of_elements" : true,
+      "elements_enable_link_autofill_prompt_padding_fix" : false,
+      "elements_mobile_attest_on_intent_confirmation" : false,
+      "link_trusted_origin_skip_secure_click" : true,
+      "elements_stop_move_focus_to_first_errored_field" : true,
+      "ocs_buyer_xp_enable_payment_element_accordion_box_shadow" : false,
+      "elements_enable_customer_address" : false,
+      "elements_enable_card_metadata" : true,
+      "elements_mobile_allow_stripecardscan" : false,
+      "elements_use_checkout_app_id_for_human_security" : false,
+      "sandboxes_rebrand_testmode" : true,
+      "bancontact_name_optional_one_time" : false,
+      "link_enable_card_brand_choice" : true,
+      "link_payment_element_keep_optional_doi_open_rollout" : true,
+      "adaptive_pricing_for_elements_with_payment_intents" : false,
+      "elements_allow_custom_payment_method_creation" : false,
+      "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+      "elements_mobile_link_inline_signup_with_saved_pm_enabled" : false,
+      "link_purchase_protections_rollout" : true,
+      "show_swish_factoring_notice" : true,
+      "elements_disable_fc_lite" : false,
+      "link_auth_partner_delay_recognition" : true,
+      "elements_enable_payment_element_custom_payment_methods_byof" : false,
+      "ocs_mobile_should_use_autocomplete_proxy_endpoints" : true,
+      "elements_enable_nme_for_us_bank_account_skip_verification" : false,
+      "ocs_buyer_xp_elements_remove_wallets_redirect_text" : false,
+      "elements_easel_enable_elements_inspector" : true,
+      "elements_google_pay_mit_fields" : false,
+      "apple_pay_pe_killswitch" : false,
+      "paypal_phone_number_support_in_ece" : false,
+      "elements_enable_pay_by_bank_multi_country_bank_selector_rollout_countries" : false,
+      "elements_easel_disable_payment_fill" : false,
+      "elements_easel_disable_tax_id_fill" : false,
+      "elements_spm_max_visible_payment_methods" : false,
+      "id_bank_transfers_v1_integration" : false,
+      "elements_enable_mx_card_installments" : true,
+      "elements_easel_disable_appearance_api_per_element_options" : true,
+      "elements_enable_easel_for_pi_killswitch" : false,
+      "link_enable_link_session_key_shipping_addresses" : false,
+      "enable_pe_options_for_billing_details_collection" : false,
+      "elements_spm_messages" : false,
+      "elements_easel_disable_session_summary" : false,
+      "apple_pay_ece_killswitch" : false,
+      "distinctly_link_pe_purchase_protection" : true,
+      "link_enable_link_session_key_consumer_person_details" : false,
+      "link_auth_partner_enable_distinctly_link_android_fb" : true,
+      "link_auth_partner_delay_android_fb_cookie_login" : false,
+      "elements_ae_hide_name_field" : false,
+      "legacy_confirmation_tokens" : false,
+      "link_auth_partner_enable_distinctly_link_ios_instagram" : false,
+      "elements_easel_disable_elements_inspector_for_pi" : false,
+      "link_auth_partner_enable_ece" : true,
+      "link_enable_link_session_key_payment_details" : false,
+      "distinctly_link_pe_backup_payment_method" : true,
+      "link_dedupe_shipping_address_creation" : true,
+      "ece_apple_pay_payment_request_passthrough" : false,
+      "checkout_link_pay_token_enabled" : false,
+      "link_enable_link_session_key_link_onboarding_session" : false,
+      "elements_mobile_force_vertical_payment_method_layout" : false,
+      "payto_enable_modal_in_payment_element" : true,
+      "checkout_link_in_habanero_enabled" : true,
+      "elements_disable_progressive_cursor" : false,
+      "link_enable_auth_partner_sizing_logging" : true,
+      "enable_checkout_session_update_customer" : false
+    },
+    "merchant_logo_url" : null,
+    "session_id" : "elements_session_1uxVMxKadBC",
+    "card_installments_enabled" : false,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "config_id" : "56fabbf2-dd28-412e-b0ab-cbaf77a5d71e",
+    "merchant_currency" : "usd",
+    "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+    "card_brand_choice" : {
+      "eligible" : false,
+      "preferred_networks" : [
+        "cartes_bancaires"
+      ],
+      "supported_cobranded_networks" : {
+        "cartes_bancaires" : false
+      }
+    },
+    "shipping_address_settings" : {
+      "autocomplete_allowed" : false
+    },
+    "external_payment_method_data" : null,
+    "custom_payment_method_data" : null,
+    "meta_pay_signed_container_context" : null,
+    "apple_pay_preference" : "enabled",
+    "country_override" : "US",
+    "managed_payments_enabled" : false,
+    "google_pay_preference" : "enabled",
+    "merchant_country" : "US",
+    "experiments_data" : {
+      "arb_id" : "15bf3129-9faa-4b3b-aafe-8a6002838bd3",
+      "experiment_metadata" : {
+        "seed" : "1a9b1bb606a182c72328e7724107a9701e36ef6ea116c63bac0f7ca9684d0ba3",
+        "semi_dominant_payment_methods" : [
+
+        ],
+        "lpm_holdback_t1_payment_methods" : [
+
+        ],
+        "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false,
+        "lpm_holdback_t2_payment_methods" : [
+
+        ]
+      },
+      "experiment_assignments" : {
+        "link_spm_show_checkbox_signup_aa" : "control",
+        "link_optional_doi_signup_holdback" : "control",
+        "link_ab_test_aa" : "control",
+        "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : "control",
+        "ocs_mobile_horizontal_mode" : "control",
+        "link_sign_up_form_container_aa" : "control",
+        "ff_elements_apple_pay_inner_use_pending_payment_overrides_eff" : "control",
+        "link_spm_show_checkbox_signup" : "control",
+        "pbb_bank_credential_hint_elements" : "control",
+        "ocs_mobile_card_art" : "control",
+        "link_ece_unrecognized_button_text_aa" : "control",
+        "link_ulm_in_ece" : "control",
+        "ibp_bank_tab_name" : "control",
+        "paypal_payment_handler" : "control",
+        "link_pe_signup_copy_aa" : "control",
+        "ibp_bank_tab_name_aa" : "control",
+        "link_ce_conversion_cookie_aa" : "control",
+        "link_dl_pe_inline_entrypoint_aa" : "control",
+        "link_sign_up_form_container" : "control",
+        "link_ulm_in_ece_aa" : "control",
+        "link_ece_unrecognized_button_text" : "control",
+        "link_ce_conversion_unrecognized_aa" : "control",
+        "link_pe_signup_copy" : "control",
+        "ocs_mobile_horizontal_mode_aa" : "control",
+        "connections_elements_variable_incentives_for_ibp_recurring_payments" : "control",
+        "link_ce_conversion_ncdv_aa" : "control",
+        "link_ce_conversion_unrecognized_copy_change" : "control",
+        "link_ce_conversion_unrecognized_post_entry_aa" : "control",
+        "link_pe_signup_green_logo" : "control",
+        "link_dl_pe_inline_entrypoint" : "control",
+        "ff_elements_test_frontend_eff" : "control",
+        "link_pe_signup_green_logo_aa" : "control",
+        "link_optional_doi_signup_holdback_aa" : "control",
+        "link_ce_conversion_responsive_button" : "control",
+        "ibp_localized_featured_institutions_accordion" : "control",
+        "elements_hcaptcha_init_timeout" : "control",
+        "link_ce_conversion_recognized_loading_animation" : "control",
+        "link_signup_name_from_billing_ae" : "control",
+        "ocs_buyer_xp_elements_apple_pay_in_non_safari" : "control"
+      }
+    },
+    "legacy_customer" : null,
+    "link_settings" : {
+      "link_passthrough_mode_enabled" : false,
+      "link_payment_element_smart_defaults_enabled" : false,
+      "link_mobile_attestation_state_sync_enabled" : false,
+      "link_no_code_default_values_recall" : true,
+      "link_funding_sources" : [
+
+      ],
+      "link_crypto_onramp_force_cvc_reverification" : false,
+      "link_enable_signup_in_express_checkout_element" : false,
+      "link_wanderlust_in_elements_enabled" : false,
+      "link_consumer_incentive" : null,
+      "link_crypto_onramp_bank_upsell" : false,
+      "link_ece_browser_compatibility_override" : false,
+      "link_enable_email_otp_for_link_popup" : false,
+      "link_crypto_onramp_elements_logout_disabled" : false,
+      "link_popup_enable_new_google_places_api" : false,
+      "link_no_code_default_values_identification" : true,
+      "link_pay_button_element_enabled" : true,
+      "link_payment_element_enable_webauthn_login" : false,
+      "link_bank_onboarding_enabled" : false,
+      "link_enable_instant_debits_in_testmode" : false,
+      "link_payment_element_disabled_by_targeting" : false,
+      "link_sign_up_opt_in_feature_enabled" : false,
+      "link_only_for_payment_method_types_enabled" : false,
+      "link_disabled_reasons" : {
+        "payment_element_payment_method_mode" : [
+          "link_not_specified_in_payment_method_types"
+        ],
+        "payment_element_passthrough_mode" : [
+          "link_not_enabled_on_payment_config"
+        ]
+      },
+      "link_sign_up_opt_in_initial_value" : false,
+      "link_mobile_use_attestation_endpoints" : false,
+      "link_elements_pageload_sign_up_disabled" : false,
+      "link_disable_pe_signup_prompt" : false,
+      "link_elements_is_crypto_onramp" : false,
+      "link_no_code_default_values_usage" : true,
+      "link_enable_webauthn_for_link_popup" : false,
+      "link_email_verification_login_enabled" : false,
+      "link_popup_webview_option" : "shared",
+      "link_targeting_results" : {
+        "payment_element_passthrough_mode" : null
+      },
+      "link_trusted_merchant_check_enabled" : false,
+      "link_global_holdback_on" : false,
+      "link_show_prefer_debit_card_hint" : false,
+      "link_local_storage_login_enabled" : false,
+      "link_payment_session_context" : null,
+      "link_session_storage_login_enabled" : false,
+      "link_brand" : "link",
+      "link_disable_in_safari_private_browsing" : false,
+      "link_mobile_disable_rux_in_flow_controller" : false,
+      "link_authenticated_change_event_enabled" : false,
+      "link_pm_killswitch_on_in_elements" : false,
+      "link_supported_payment_methods_onboarding_enabled" : [
+
+      ],
+      "link_hcaptcha_site_key" : null,
+      "link_payment_element_disable_signup" : false,
+      "link_enable_displayable_default_values_in_ece" : false,
+      "link_disable_email_otp" : false,
+      "link_hcaptcha_rqdata" : null,
+      "link_default_opt_in" : "NONE",
+      "link_supported_payment_methods" : [
+
+      ],
+      "link_mobile_disable_default_opt_in" : false,
+      "link_mode" : null,
+      "link_mobile_disable_signup" : false,
+      "link_popup_smart_defaults_enabled" : false
+    },
+    "passive_captcha" : {
+      "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+      "token_timeout_seconds" : 1770,
+      "rqdata" : null
+    },
+    "payment_method_configuration_id" : null,
+    "payment_method_specs" : [
+      {
+        "async" : false,
+        "type" : "card",
+        "fields" : [
+
+        ]
+      }
+    ],
+    "paypal_express_config" : {
+      "client_id" : null,
+      "client_token" : null,
+      "paypal_merchant_id" : null
+    },
+    "prefill_selectors" : {
+      "default_values" : {
+        "email" : [
+
+        ],
+        "merchant_provides_default_values_on_update" : true
+      }
+    },
+    "unactivated_payment_method_types" : [
+
+    ],
+    "order" : null,
+    "unverified_payment_methods_on_domain" : [
+      "apple_pay"
+    ],
+    "link_purchase_protections_data" : {
+      "type" : null,
+      "is_eligible" : false
+    },
+    "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+    "customer" : null,
+    "klarna_express_config" : {
+      "klarna_mid" : null
+    },
+    "lpm_killswitches" : {
+      "express_checkout" : [
+
+      ],
+      "payment_element" : [
+
+      ]
+    },
+    "business_name" : "CI Stuff",
+    "ordered_payment_method_types_and_wallets" : [
+      "card",
+      "apple_pay",
+      "google_pay"
+    ],
+    "customer_error" : null
+  },
+  "stripe_hosted_url" : "https:\/\/checkout.stripe.com\/c\/pay\/cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWkB3dnxIQEpRcGFWb1RXPW1tNVN3VHcwXTU1PXZHXUJKcDMnKSdjd2poVmB3c2B3Jz9xd3BgKSdnZGZuYndqcGthRmppancnPycmY2NjY2NjJyknaWR8anBxUXx1YCc%2FJ3Zsa2JpYFpscWBoJyknYGtkZ2lgVWlkZmBtamlhYHd2Jz9xd3BgeCUl",
+  "prefilled" : null,
+  "redirect_on_completion" : null,
+  "blob" : null,
+  "client_reference_id" : null,
+  "status" : "open",
+  "submit_type" : null,
+  "email_collection" : "always",
+  "permissions" : null,
+  "custom_fields" : [
+
+  ],
+  "phone_number_collection" : {
+    "enabled" : false
+  },
+  "livemode" : false,
+  "ordered_payment_method_types" : [
+    "card",
+    "apple_pay",
+    "google_pay"
+  ],
+  "state" : "active",
+  "currency" : "usd",
+  "subscription_data" : null,
+  "customer_managed_saved_payment_methods_offer_save" : null,
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping" : null,
+  "crypto_in_link_ui_enabled" : false,
+  "rqdata" : "iuSDprquYcQ29QwCXjLLN1x2kqeSBkzF4zbLBYqCajMcfN9tE4qdpT72qzp2N8c1EUAJ7092\/5PHtKtNfa5Fy2r\/j\/DAkjEpA5DHRByrpJxkW1JzlAXQbi96HiOaYoCgcM2UBGGJPfIAQsAQn5imFqtMGakRnvsTnkRI8kNYqKpKB1ddeb3fEV9msJEjm+FIgCi\/B88UEf84QhOuUBXtSg2QVxbmhiDS+WXU1dQhbZOqT08Be639cLvyI3BucWV1eD\/\/bcPRvAiCi4SIQ02vBnBJVlbRdM39\/WtBYQPmGXPfdePDfc+FIQE+uw==nCu5tIwAIiOC\/o7Z",
+  "total_summary" : {
+    "due" : 2000,
+    "subtotal" : 2000,
+    "total" : 2000
+  },
+  "on_behalf_of" : null,
+  "cross_sell_group" : null,
+  "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+  "checkout_multistep_ui" : false,
+  "eid" : "5907F89B-F461-42CE-A6FE-A5371030AC68",
+  "line_item_group" : {
+    "total" : 2000,
+    "line_items" : [
+      {
+        "id" : "li_1TluRDFY0qyl6XeWqLqno6AJ",
+        "description" : null,
+        "discount_amounts" : [
+
+        ],
+        "quantity" : 1,
+        "is_removable" : false,
+        "total" : 2000,
+        "tax_amounts" : [
+
+        ],
+        "subtotal" : 2000,
+        "cross_sell_from" : null,
+        "object" : "item",
+        "price" : {
+          "id" : "price_1TluRDFY0qyl6XeWnQLcxZgp",
+          "livemode" : false,
+          "active" : false,
+          "product" : {
+            "object" : "product",
+            "active" : false,
+            "addons" : null,
+            "id" : "prod_TnUMNVDoRiDXJx",
+            "images" : [
+
+            ],
+            "livemode" : false,
+            "url" : null,
+            "attributes" : [
+
+            ],
+            "description" : null,
+            "name" : "Test",
+            "unit_label" : null
+          },
+          "tax_behavior" : "exclusive",
+          "custom_unit_amount" : null,
+          "transform_quantity" : null,
+          "type" : "one_time",
+          "unit_amount" : 2000,
+          "unit_amount_decimal" : "2000",
+          "object" : "price",
+          "billing_scheme" : "per_unit",
+          "recurring" : null,
+          "currency" : "usd",
+          "tiers_mode" : null
+        },
+        "adjustable_quantity" : null,
+        "images" : null,
+        "unit_amount_override" : null,
+        "name" : "Test"
+      }
+    ],
+    "shipping_rate" : null,
+    "applied_credits" : [
+
+    ],
+    "subtotal" : 2000,
+    "discount_amounts" : [
+
+    ],
+    "currency" : "usd",
+    "tax_amounts" : [
+
+    ],
+    "due" : 2000
+  },
+  "managed_payments" : {
+    "enabled" : false
+  },
+  "name_collection" : null,
+  "payment_intent" : null,
+  "config_id" : "196a1583-e9cc-4858-8d0f-09cf83502aaa",
+  "is_sandbox_merchant" : false
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0005_post_v1_payment_pages_cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodBillingDetails/0005_post_v1_payment_pages_cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB.tail
@@ -1,0 +1,977 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_pages\/cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=HgLxYLe3cvGgEXpsz25N7D-h568dkeBIY3GYSaPpwUzUA-9pGyeYBcfLiwqDQ78xWS_UJxqk5Gu9RdEJ; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=HgLxYLe3cvGgEXpsz25N7D-h568dkeBIY3GYSaPpwUzUA-9pGyeYBcfLiwqDQ78xWS_UJxqk5Gu9RdEJ&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=HgLxYLe3cvGgEXpsz25N7D-h568dkeBIY3GYSaPpwUzUA-9pGyeYBcfLiwqDQ78xWS_UJxqk5Gu9RdEJ&t=1"}],"include_subdomains":true}
+request-id: req_zE7o5Q7OqztKi0
+x-stripe-routing-context-priority-tier: api-testmode
+Vary: Origin
+Date: Wed, 24 Jun 2026 17:18:13 GMT
+original-request: req_zE7o5Q7OqztKi0
+stripe-version: 2020-08-27
+idempotency-key: 0daed439-6dd5-44c2-8615-cc2abfbcdf4f
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: elements_session_client\[is_aggregation_expected]=true&payment_method_to_update%5Bbilling_details%5D%5Baddress%5D%5Bcity%5D=San%20Francisco&payment_method_to_update%5Bbilling_details%5D%5Baddress%5D%5Bcountry%5D=US&payment_method_to_update%5Bbilling_details%5D%5Baddress%5D%5Bline1%5D=123%20Main%20St&payment_method_to_update%5Bbilling_details%5D%5Baddress%5D%5Bpostal_code%5D=94105&payment_method_to_update%5Bbilling_details%5D%5Baddress%5D%5Bstate%5D=CA&payment_method_to_update%5Bbilling_details%5D%5Bemail%5D=jane%40example\.com&payment_method_to_update%5Bbilling_details%5D%5Bname%5D=Jane%20Doe&payment_method_to_update%5Bbilling_details%5D%5Bphone%5D=%2B15551234567&payment_method_to_update%5Bpayment_method_id%5D=pm_1TluRBFY0qyl6XeWFce40M87
+
+{
+  "lpm_settings" : null,
+  "sepa_debit_info" : null,
+  "automatic_payment_method_types" : false,
+  "is_unclaimed_anonymous_sandbox" : false,
+  "tax_context" : {
+    "automatic_tax_error" : null,
+    "automatic_tax_enabled" : false,
+    "automatic_tax_taxability_reason" : null,
+    "dynamic_tax_enabled" : false,
+    "tax_id_collection_enabled" : false,
+    "automatic_tax_exempt" : "none",
+    "customer_tax_country" : null,
+    "tax_id_collection_required" : "never",
+    "has_maximum_tax_ids" : false,
+    "automatic_tax_address_source" : null
+  },
+  "payment_method_types" : [
+    "card"
+  ],
+  "payment_method_options" : {
+    "card" : {
+      "request_three_d_secure" : "automatic"
+    }
+  },
+  "bnpl_in_link_ui_enabled" : false,
+  "consent_collection" : null,
+  "experiment_data" : [
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs_aa",
+      "event_id" : "eb36b926-22e8-48c3-b0ff-900b93748281",
+      "exposure_event_name" : ""
+    },
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs",
+      "event_id" : "a9501b90-bde1-4e04-b253-2d0161f2e994",
+      "exposure_event_name" : ""
+    }
+  ],
+  "origin_context" : null,
+  "enforcement_mode" : "open",
+  "blocked_billing_address_countries" : [
+
+  ],
+  "id" : "ppage_1TluRDFY0qyl6XeWjtA6LrcW",
+  "subscription_settings" : null,
+  "consent" : null,
+  "does_not_collect_postal_code_for_non_us_card_transactions" : false,
+  "use_payment_methods" : true,
+  "application" : null,
+  "payment_method_collection" : "if_required",
+  "setup_intent" : null,
+  "shipping_options" : [
+
+  ],
+  "setup_future_usage_for_payment_method_type" : {
+    "card" : "on_session"
+  },
+  "capture_method" : "automatic_async",
+  "statement_descriptor" : "mobile",
+  "session_id" : "cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB",
+  "shipping_address_collection" : null,
+  "konbini_confirmation_number" : null,
+  "setup_future_usage" : "on_session",
+  "invoice_creation" : {
+    "enabled" : false
+  },
+  "has_dynamic_tax_rates" : false,
+  "receipt_emails_enabled" : false,
+  "link_settings" : {
+    "link_consumer_incentive" : null,
+    "link_payment_session_context" : null,
+    "consumer_found" : null,
+    "hcaptcha_rqdata" : null,
+    "link_supported_payment_methods_onboarding_enabled" : [
+
+    ],
+    "enable_partner_lookup" : false,
+    "link_us_bank_account_funding_source_enabled" : false,
+    "link_funding_sources" : [
+
+    ],
+    "hcaptcha_site_key" : null,
+    "link_brand" : "link",
+    "link_mode" : null,
+    "link_supported_payment_methods" : [
+
+    ]
+  },
+  "object" : "checkout.session",
+  "customer" : {
+    "object" : "customer",
+    "phone" : null,
+    "tax_ids" : [
+
+    ],
+    "id" : "cus_UlRJaOllpNM6Zo",
+    "business_name" : null,
+    "payment_methods" : [
+
+    ],
+    "email" : null,
+    "has_fallback_payment_method" : false,
+    "individual_name" : null,
+    "customer_provided" : true,
+    "name" : null
+  },
+  "shipping_rate" : null,
+  "success_url" : null,
+  "utm_codes" : null,
+  "beta_versions" : null,
+  "has_async_attached_payment_method" : false,
+  "feature_flags" : {
+    "checkout_enable_pay_by_bank_remember_bank_selection" : true,
+    "checkout_link_phone_registration_treatment_1_enabled" : true,
+    "sandboxes_rebrand_testmode" : true,
+    "checkout_enable_new_google_places_api" : true,
+    "checkout_link_enable_mfa" : true,
+    "checkout_link_purchase_protections_rollout" : true,
+    "checkout_tide_remount_override_replay" : true,
+    "checkout_optional_items" : true,
+    "checkout_link_in_habanero_enabled" : true,
+    "enable_custom_checkout_name_collection" : true,
+    "ocs_payment_prompt_for_agents" : true,
+    "checkout_passive_captcha" : true,
+    "checkout_enable_link_api_passive_hcaptcha" : true,
+    "checkout_hcaptcha_redundancy_control_enabled" : true,
+    "checkout_address_autocomplete_enabled" : true,
+    "checkout_enable_link_api_hcaptcha_rqdata" : true,
+    "checkout_show_swish_factoring_notice" : true
+  },
+  "locale" : null,
+  "custom_text" : {
+    "shipping_address" : null,
+    "terms_of_service_acceptance" : null,
+    "submit" : null,
+    "after_submit" : null
+  },
+  "route_to_orchestration_interface" : false,
+  "customer_email" : null,
+  "custom_components" : [
+
+  ],
+  "ui_mode" : "custom",
+  "url" : null,
+  "developer_tool_context" : {
+    "disabled_third_party_wallets" : {
+      "LINK_BUTTON" : {
+        "disabled_reason" : "merchant_payment_methods_settings"
+      },
+      "KLARNA_EXPRESS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "PAYPAL_ECS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "AMAZON_PAY" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      }
+    },
+    "adaptive_pricing" : {
+      "reason" : "not_allowed_for_ui",
+      "active" : false
+    },
+    "payment_method_configuration_details" : null
+  },
+  "token_notification_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "init_checksum" : "U8AEreXQqLMiEVpCMFwYNZnB16vSVJeJ",
+  "tax_exclusion_from_total_is_allowed" : false,
+  "bnpl_link_experiment_payment_method_type" : null,
+  "tax_meta" : {
+    "status" : "complete",
+    "error_reason" : null,
+    "computation_type" : "manual",
+    "customer_tax_exempt" : "none"
+  },
+  "payment_status" : "unpaid",
+  "enabled_third_party_wallets" : [
+    {
+      "apple_pay" : {
+        "required_version" : 2
+      },
+      "id" : "APPLE_PAY",
+      "enabled" : true,
+      "carousel_enabled" : true
+    },
+    {
+      "id" : "GOOGLE_PAY",
+      "enabled" : true,
+      "google_pay" : {
+        "id" : "GOOGLE_PAY",
+        "version_minor" : 0,
+        "version_major" : 2
+      },
+      "carousel_enabled" : false
+    },
+    {
+      "id" : "AMAZON_PAY",
+      "carousel_enabled" : false,
+      "enabled" : false
+    },
+    {
+      "id" : "KLARNA_EXPRESS",
+      "carousel_enabled" : false,
+      "enabled" : false
+    }
+  ],
+  "klarna_info" : null,
+  "visible_custom_component_locations" : [
+    "checkout_form_before",
+    "checkout_form_after",
+    "submit_button_before",
+    "submit_button_after",
+    "contact_before",
+    "contact_after",
+    "express_checkout_before",
+    "express_checkout_after",
+    "payment_details_before",
+    "payment_details_after"
+  ],
+  "display_consent_collection_promotions" : false,
+  "policies" : {
+    "contacts" : {
+      "display_phone" : true,
+      "display_url" : true,
+      "enabled" : false,
+      "display_email" : true
+    },
+    "legal" : {
+      "agreement_required" : false,
+      "enabled" : false
+    },
+    "returns" : {
+      "custom_message" : null,
+      "exchanges_accepted" : false,
+      "returns_accepted" : null,
+      "fee_type" : null,
+      "fee_required" : null,
+      "policy_url" : null,
+      "window_start" : null,
+      "refunds_accepted" : null,
+      "window" : null,
+      "enabled" : false,
+      "exceptions_apply" : false,
+      "logistics" : [
+
+      ]
+    }
+  },
+  "card_brands" : {
+    "mastercard" : true,
+    "link" : true,
+    "carnet" : false,
+    "accel" : false,
+    "elo" : false,
+    "rupay" : false,
+    "maestro" : false,
+    "unionpay" : true,
+    "amex" : true,
+    "jaywan" : false,
+    "conecs" : false,
+    "jcb" : true,
+    "visa" : true,
+    "cartes_bancaires" : false,
+    "pulse" : false,
+    "discover" : true,
+    "star" : false,
+    "eftpos_au" : false,
+    "diners" : true,
+    "girocard" : false,
+    "nyce" : false
+  },
+  "geocoding" : {
+    "country_code" : "US",
+    "region_name" : "UT"
+  },
+  "account_settings" : {
+    "assets" : {
+      "use_logo" : false,
+      "icon" : null,
+      "logo" : null
+    },
+    "specified_commercial_transactions_act_url" : null,
+    "business_url" : "https:\/\/github.com\/stripe\/stripe-ios",
+    "privacy_policy_url" : null,
+    "branding" : {
+      "button_color" : "#0074d4",
+      "background_color" : "#ffffff",
+      "border_style" : "default",
+      "font_family" : "default"
+    },
+    "statement_descriptor" : "mobile",
+    "support_email" : null,
+    "display_name" : "CI Stuff",
+    "merchant_of_record_country" : "US",
+    "order_summary_display_name" : "CI Stuff",
+    "support_phone" : "+12105550123",
+    "merchant_of_record_display_name" : "CI Stuff",
+    "support_url" : null,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "country" : "US",
+    "terms_of_service_url" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "server_built_elements_session_params" : {
+    "expand" : [
+
+    ],
+    "checkout_session_id" : "cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB",
+    "client_betas" : [
+
+    ],
+    "deferred_intent" : {
+      "amount" : 2000,
+      "capture_method" : "automatic_async",
+      "currency" : "usd",
+      "payment_method_types" : [
+        "card"
+      ],
+      "setup_future_usage" : "on_session",
+      "mode" : "payment"
+    },
+    "country_override" : "US",
+    "type" : "deferred_intent"
+  },
+  "shipping_tax_amounts" : [
+
+  ],
+  "billing_address_collection" : null,
+  "elements_options" : {
+    "amount" : 2000,
+    "mode" : "payment",
+    "__checkout_country_override" : "US",
+    "__checkout_session_id" : "cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB",
+    "__payment_pages_experiments" : [
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs_aa",
+        "event_id" : "eb36b926-22e8-48c3-b0ff-900b93748281",
+        "exposure_event_name" : ""
+      },
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs",
+        "event_id" : "a9501b90-bde1-4e04-b253-2d0161f2e994",
+        "exposure_event_name" : ""
+      }
+    ],
+    "capture_method" : "automatic_async",
+    "payment_method_types" : [
+      "card"
+    ],
+    "setup_future_usage" : "on_session",
+    "currency" : "usd"
+  },
+  "experiments_data" : {
+    "event_id" : "04f6be83-1589-4113-98cd-45309f65e952",
+    "experiment_metadata" : {
+      "ocs_buyer_xp_cpl_lpm_holdback" : {
+        "heldback_special_wallets" : [
+
+        ]
+      }
+    },
+    "experiment_assignments" : {
+      "ocs_buyer_xp_cpl_separate_wallet_accordion" : "control",
+      "emea_wallets_ideal_wero_rebranding" : "control",
+      "ocs_buyer_xp_cpl_apple_pay_in_non_safari" : "control",
+      "ocs_buyer_xp_cpl_embedded_pay_button" : "control",
+      "ff_checkout_cpl_lid_promo_badge_color_opt" : "control",
+      "cpl_spicy_guacamole" : "control",
+      "ff_checkout_optimized_image_eff" : "control",
+      "connections_checkout_us_bank_account_picker_icons" : "control",
+      "ocs_buyer_xp_cpl_progressive_ece" : "control",
+      "ocs_buyer_xp_cpl_single_column_checkout" : "control",
+      "checkout_li_larger_image_size" : "control",
+      "link_ab_test_aa" : "control",
+      "ocs_buyer_xp_cpl_terms_above_submit" : "control",
+      "ocs_buyer_xp_cpl_currency_symbol_optimization" : "control",
+      "smor_checkout_ui_iteration" : "control",
+      "checkout_link_instant_debits_accordion_logos" : "control",
+      "checkout_enable_real_time_tax_id_verification_experiment" : "control",
+      "ff_checkout_test_frontend_eff" : "control",
+      "ocs_buyer_xp_cpl_link_signup_in_form" : "control",
+      "ocs_buyer_xp_remove_name_field_guac_related_pms" : "control",
+      "link_risk_based_disable_auto_prompting_checkout" : "control",
+      "ocs_buyer_xp_cpl_apple_pay_button_type" : "control",
+      "cpl_guacamole" : "control",
+      "ocs_buyer_xp_cpl_ece_kakao_naver" : "control",
+      "ocs_buyer_xp_cpl_lpm_content_simplification" : "control"
+    }
+  },
+  "return_url" : "https:\/\/example.com\/return",
+  "mode" : "payment",
+  "cancel_url" : null,
+  "elements_session" : {
+    "payment_method_preference" : {
+      "country_code" : "US",
+      "object" : "payment_method_preference",
+      "type" : "deferred_intent",
+      "ordered_payment_method_types" : [
+        "card"
+      ]
+    },
+    "capability_enabled_card_networks" : [
+      "cartes_bancaires",
+      "jcb",
+      "diners",
+      "discover"
+    ],
+    "flags" : {
+      "enable_tax_id_suspicious_pattern_check" : false,
+      "elements_easel_enable_elements_inspector_for_advanced_integrations_backend" : true,
+      "link_enable_signup_in_summary_in_habanero" : true,
+      "financial_connections_enable_deferred_intent_flow" : true,
+      "elements_enable_remove_last_validation" : true,
+      "ocs_payment_prompt_for_agents" : true,
+      "apple_pay_prb_killswitch" : false,
+      "elements_enable_easel_for_pi" : true,
+      "elements_mobile_card_funding_filtering" : true,
+      "link_payment_element_minor_signup_ui_updates" : false,
+      "link_enable_ncdv_usage_id_selectors_l3" : true,
+      "elements_disable_express_checkout_button_amazon_pay" : false,
+      "elements_easel_disable_appearance_api" : false,
+      "link_auth_partner_enable_link_auth_token_login" : true,
+      "link_enable_ncdv_recall_id_selectors_l3" : true,
+      "elements_disable_link_email_otp" : false,
+      "restrict_taxid_selection_to_buyer_address" : false,
+      "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
+      "ocs_buyer_xp_elements_card_brand_choice_toggle" : false,
+      "paypal_billing_address_support_in_ece" : true,
+      "elements_enable_pay_by_bank_remember_bank_selection" : true,
+      "link_auth_partner_enable_ios_instagram" : true,
+      "link_user_action_attempt_login_using_stored_credentials" : true,
+      "elements_disable_sepa_debit_eea_address_requirement" : false,
+      "elements_enable_instant_debits_postal_code_collection" : false,
+      "elements_financial_connections_canada_enabled" : false,
+      "elements_easel_disable_feedback" : false,
+      "link_enable_link_session_key_financial_connections" : false,
+      "elements_extend_hcaptcha_refresh_time" : true,
+      "link_auth_partner_consume_link_auth_intent" : true,
+      "ocs_buyer_xp_elements_remove_cpm_redirect_text" : false,
+      "elements_enable_south_korea_market_underlying_pms" : false,
+      "link_payment_element_steerage_enabled" : true,
+      "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text" : false,
+      "link_enable_apple_pay_in_safari_returning_in_guacamole" : false,
+      "elements_disable_payment_element_card_country_zip_validations" : false,
+      "link_payment_element_default_value_auto_open_modal" : true,
+      "elements_enable_link_card_brand_in_saved_payment_methods" : true,
+      "elements_disable_link_global_holdback_lookup" : false,
+      "financial_connections_enable_ca_accounts" : false,
+      "elements_apple_pay_inner_use_pending_payment_overrides" : false,
+      "link_enable_link_session_key_klarna" : false,
+      "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : true,
+      "elements_easel_disable_address_fill" : false,
+      "ocs_buyer_xp_elements_remove_redirect_lpm_content" : false,
+      "adaptive_pricing_hip_currency_selector_change_event" : true,
+      "elements_enable_payment_method_options_setup_future_usage" : true,
+      "enable_custom_checkout_currency_selector_element" : false,
+      "elements_mobile_android_tap_to_add_enabled" : false,
+      "link_enable_address_country_restrictions" : false,
+      "link_auth_partner_enable_android_fb" : true,
+      "checkout_kr_lpm_no_billing_address_collection" : false,
+      "elements_easel_disable_health_check" : false,
+      "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
+      "elements_disable_paypal_express" : false,
+      "disable_confirmation_modal_bacs" : false,
+      "legacy_customer_session_payment_element_features" : false,
+      "elements_enable_terms_element" : false,
+      "link_auth_partner_enable_authentication_element" : true,
+      "elements_allow_manual_payment_method_creation_with_spm" : false,
+      "elements_easel_disable" : false,
+      "link_enable_auth_partner_communication" : true,
+      "elements_apply_amex_icon_sorting" : false,
+      "elements_hide_card_brand_icons" : false,
+      "link_auth_partner_enable_distinctly_link_ios_facebook" : true,
+      "elements_easel_disable_customer_location_mocking" : false,
+      "elements_easel_disable_position_customization" : false,
+      "elements_enable_appearance_recompute" : false,
+      "link_enable_link_session_key_confirm_and_start_verification" : false,
+      "enable_link_lpm_dual_enablement" : false,
+      "elements_enable_19_digit_pans" : false,
+      "always_show_ece_paypal_recurring_button" : false,
+      "elements_enable_interac_apple_pay" : true,
+      "enable_payment_method_api_shop_pay" : true,
+      "enable_elements_tax_id_type_filtering" : false,
+      "elements_human_security_enabled" : false,
+      "link_enable_white_ece_button_theme" : false,
+      "link_in_accordion_layout_available_in_stripejs" : false,
+      "link_payment_element_widget_view_enabled" : true,
+      "elements_easel_disable_magic_fill" : false,
+      "avoid_redundant_billing_details_for_klarna" : false,
+      "distinctly_link_payment_element_ramp" : true,
+      "link_enable_ewcs_customer_name_prefill" : false,
+      "link_auth_partner_bypass_bridge_check" : false,
+      "link_disable_cookie_login" : false,
+      "elements_disable_express_checkout_button_shop_pay" : false,
+      "payment_element_link_modal_preload_killswitch" : false,
+      "link_enable_pass_checkout_session_id_to_signup" : true,
+      "elements_enable_hcaptcha_async_token_logging" : false,
+      "elements_enable_jp_card_installments" : true,
+      "elements_show_expanded_spm" : false,
+      "disable_payment_element_if_required_billing_config" : false,
+      "elements_enable_link_otp_takeover_in_guacamole" : false,
+      "elements_enable_link_spm" : true,
+      "elements_enable_read_allow_redisplay" : false,
+      "elements_enable_save_for_future_payments_pre_check" : false,
+      "link_forest_enable_ece_bank_use_shipping_as_billing" : false,
+      "elements_disable_express_checkout_button_klarna" : false,
+      "distinctly_link_cbc_killswitch" : false,
+      "elements_prefer_fc_lite" : false,
+      "elements_disable_payment_element_custom_payment_methods_byof" : false,
+      "elements_mobile_cardscan_use_mlkit" : true,
+      "elements_enable_link_takeover_in_guacamole" : false,
+      "link_disable_auth_partner_ua_check" : false,
+      "link_enable_link_session_key_incentives_and_status" : false,
+      "elements_easel_disable_optimizations_check" : false,
+      "elements_enable_passive_captcha" : true,
+      "distinctly_link_payment_element_opt_out_merchant_blocklist" : false,
+      "link_enable_non_blocking_doi_signup" : false,
+      "elements_enable_new_google_places_api" : true,
+      "checkout_form_automatic_tax_address_collection_precision" : false,
+      "elements_enable_express_checkout_button_demo_pay" : false,
+      "disable_cbc_in_link_popup" : false,
+      "elements_enable_installments_on_deferred_intents" : true,
+      "elements_sepa_debit_instant_microdeposits" : false,
+      "ocs_buyer_xp_elements_remove_generic_footer" : false,
+      "elements_spm_set_as_default" : true,
+      "elements_does_not_collect_postal_code_for_non_us_card_transactions_killswitch" : false,
+      "link_disable_login_if_signed_up_outside_of_elements" : true,
+      "elements_enable_link_autofill_prompt_padding_fix" : false,
+      "elements_mobile_attest_on_intent_confirmation" : false,
+      "link_trusted_origin_skip_secure_click" : true,
+      "elements_stop_move_focus_to_first_errored_field" : true,
+      "ocs_buyer_xp_enable_payment_element_accordion_box_shadow" : false,
+      "elements_enable_customer_address" : false,
+      "elements_enable_card_metadata" : true,
+      "elements_mobile_allow_stripecardscan" : false,
+      "elements_use_checkout_app_id_for_human_security" : false,
+      "sandboxes_rebrand_testmode" : true,
+      "bancontact_name_optional_one_time" : false,
+      "link_enable_card_brand_choice" : true,
+      "link_payment_element_keep_optional_doi_open_rollout" : true,
+      "adaptive_pricing_for_elements_with_payment_intents" : false,
+      "elements_allow_custom_payment_method_creation" : false,
+      "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+      "elements_mobile_link_inline_signup_with_saved_pm_enabled" : false,
+      "link_purchase_protections_rollout" : true,
+      "show_swish_factoring_notice" : true,
+      "elements_disable_fc_lite" : false,
+      "link_auth_partner_delay_recognition" : true,
+      "elements_enable_payment_element_custom_payment_methods_byof" : false,
+      "ocs_mobile_should_use_autocomplete_proxy_endpoints" : true,
+      "elements_enable_nme_for_us_bank_account_skip_verification" : false,
+      "ocs_buyer_xp_elements_remove_wallets_redirect_text" : false,
+      "elements_easel_enable_elements_inspector" : true,
+      "elements_google_pay_mit_fields" : false,
+      "apple_pay_pe_killswitch" : false,
+      "paypal_phone_number_support_in_ece" : false,
+      "elements_enable_pay_by_bank_multi_country_bank_selector_rollout_countries" : false,
+      "elements_easel_disable_payment_fill" : false,
+      "elements_easel_disable_tax_id_fill" : false,
+      "elements_spm_max_visible_payment_methods" : false,
+      "id_bank_transfers_v1_integration" : false,
+      "elements_enable_mx_card_installments" : true,
+      "elements_easel_disable_appearance_api_per_element_options" : true,
+      "elements_enable_easel_for_pi_killswitch" : false,
+      "link_enable_link_session_key_shipping_addresses" : false,
+      "enable_pe_options_for_billing_details_collection" : false,
+      "elements_spm_messages" : false,
+      "elements_easel_disable_session_summary" : false,
+      "apple_pay_ece_killswitch" : false,
+      "distinctly_link_pe_purchase_protection" : true,
+      "link_enable_link_session_key_consumer_person_details" : false,
+      "link_auth_partner_enable_distinctly_link_android_fb" : true,
+      "link_auth_partner_delay_android_fb_cookie_login" : false,
+      "elements_ae_hide_name_field" : false,
+      "legacy_confirmation_tokens" : false,
+      "link_auth_partner_enable_distinctly_link_ios_instagram" : false,
+      "elements_easel_disable_elements_inspector_for_pi" : false,
+      "link_auth_partner_enable_ece" : true,
+      "link_enable_link_session_key_payment_details" : false,
+      "distinctly_link_pe_backup_payment_method" : true,
+      "link_dedupe_shipping_address_creation" : true,
+      "ece_apple_pay_payment_request_passthrough" : false,
+      "checkout_link_pay_token_enabled" : false,
+      "link_enable_link_session_key_link_onboarding_session" : false,
+      "elements_mobile_force_vertical_payment_method_layout" : false,
+      "payto_enable_modal_in_payment_element" : true,
+      "checkout_link_in_habanero_enabled" : true,
+      "elements_disable_progressive_cursor" : false,
+      "link_enable_auth_partner_sizing_logging" : true,
+      "enable_checkout_session_update_customer" : false
+    },
+    "merchant_logo_url" : null,
+    "session_id" : "elements_session_1KdaFHSD2gx",
+    "card_installments_enabled" : false,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "config_id" : "e6cd8264-b576-4d3d-b986-7c00a4eae356",
+    "merchant_currency" : "usd",
+    "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+    "card_brand_choice" : {
+      "eligible" : false,
+      "preferred_networks" : [
+        "cartes_bancaires"
+      ],
+      "supported_cobranded_networks" : {
+        "cartes_bancaires" : false
+      }
+    },
+    "shipping_address_settings" : {
+      "autocomplete_allowed" : false
+    },
+    "external_payment_method_data" : null,
+    "custom_payment_method_data" : null,
+    "meta_pay_signed_container_context" : null,
+    "apple_pay_preference" : "enabled",
+    "country_override" : "US",
+    "managed_payments_enabled" : false,
+    "google_pay_preference" : "enabled",
+    "merchant_country" : "US",
+    "experiments_data" : {
+      "arb_id" : "b4034baf-5ff1-4d14-bdd2-de31ae238b2c",
+      "experiment_metadata" : {
+        "seed" : "1a9b1bb606a182c72328e7724107a9701e36ef6ea116c63bac0f7ca9684d0ba3",
+        "semi_dominant_payment_methods" : [
+
+        ],
+        "lpm_holdback_t1_payment_methods" : [
+
+        ],
+        "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false,
+        "lpm_holdback_t2_payment_methods" : [
+
+        ]
+      },
+      "experiment_assignments" : {
+        "link_spm_show_checkbox_signup_aa" : "control",
+        "link_optional_doi_signup_holdback" : "control",
+        "link_ab_test_aa" : "control",
+        "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : "control",
+        "ocs_mobile_horizontal_mode" : "control",
+        "link_sign_up_form_container_aa" : "control",
+        "ff_elements_apple_pay_inner_use_pending_payment_overrides_eff" : "control",
+        "link_spm_show_checkbox_signup" : "control",
+        "pbb_bank_credential_hint_elements" : "control",
+        "ocs_mobile_card_art" : "control",
+        "link_ece_unrecognized_button_text_aa" : "control",
+        "link_ulm_in_ece" : "control",
+        "ibp_bank_tab_name" : "control",
+        "paypal_payment_handler" : "control",
+        "link_pe_signup_copy_aa" : "control",
+        "ibp_bank_tab_name_aa" : "control",
+        "link_ce_conversion_cookie_aa" : "control",
+        "link_dl_pe_inline_entrypoint_aa" : "control",
+        "link_sign_up_form_container" : "control",
+        "link_ulm_in_ece_aa" : "control",
+        "link_ece_unrecognized_button_text" : "control",
+        "link_ce_conversion_unrecognized_aa" : "control",
+        "link_pe_signup_copy" : "control",
+        "ocs_mobile_horizontal_mode_aa" : "control",
+        "connections_elements_variable_incentives_for_ibp_recurring_payments" : "control",
+        "link_ce_conversion_ncdv_aa" : "control",
+        "link_ce_conversion_unrecognized_copy_change" : "control",
+        "link_ce_conversion_unrecognized_post_entry_aa" : "control",
+        "link_pe_signup_green_logo" : "control",
+        "link_dl_pe_inline_entrypoint" : "control",
+        "ff_elements_test_frontend_eff" : "control",
+        "link_pe_signup_green_logo_aa" : "control",
+        "link_optional_doi_signup_holdback_aa" : "control",
+        "link_ce_conversion_responsive_button" : "control",
+        "ibp_localized_featured_institutions_accordion" : "control",
+        "elements_hcaptcha_init_timeout" : "control",
+        "link_ce_conversion_recognized_loading_animation" : "control",
+        "link_signup_name_from_billing_ae" : "control",
+        "ocs_buyer_xp_elements_apple_pay_in_non_safari" : "control"
+      }
+    },
+    "legacy_customer" : null,
+    "link_settings" : {
+      "link_passthrough_mode_enabled" : false,
+      "link_payment_element_smart_defaults_enabled" : false,
+      "link_mobile_attestation_state_sync_enabled" : false,
+      "link_no_code_default_values_recall" : true,
+      "link_funding_sources" : [
+
+      ],
+      "link_crypto_onramp_force_cvc_reverification" : false,
+      "link_enable_signup_in_express_checkout_element" : false,
+      "link_wanderlust_in_elements_enabled" : false,
+      "link_consumer_incentive" : null,
+      "link_crypto_onramp_bank_upsell" : false,
+      "link_ece_browser_compatibility_override" : false,
+      "link_enable_email_otp_for_link_popup" : false,
+      "link_crypto_onramp_elements_logout_disabled" : false,
+      "link_popup_enable_new_google_places_api" : false,
+      "link_no_code_default_values_identification" : true,
+      "link_pay_button_element_enabled" : true,
+      "link_payment_element_enable_webauthn_login" : false,
+      "link_bank_onboarding_enabled" : false,
+      "link_enable_instant_debits_in_testmode" : false,
+      "link_payment_element_disabled_by_targeting" : false,
+      "link_sign_up_opt_in_feature_enabled" : false,
+      "link_only_for_payment_method_types_enabled" : false,
+      "link_disabled_reasons" : {
+        "payment_element_payment_method_mode" : [
+          "link_not_specified_in_payment_method_types"
+        ],
+        "payment_element_passthrough_mode" : [
+          "link_not_enabled_on_payment_config"
+        ]
+      },
+      "link_sign_up_opt_in_initial_value" : false,
+      "link_mobile_use_attestation_endpoints" : false,
+      "link_elements_pageload_sign_up_disabled" : false,
+      "link_disable_pe_signup_prompt" : false,
+      "link_elements_is_crypto_onramp" : false,
+      "link_no_code_default_values_usage" : true,
+      "link_enable_webauthn_for_link_popup" : false,
+      "link_email_verification_login_enabled" : false,
+      "link_popup_webview_option" : "shared",
+      "link_targeting_results" : {
+        "payment_element_passthrough_mode" : null
+      },
+      "link_trusted_merchant_check_enabled" : false,
+      "link_global_holdback_on" : false,
+      "link_show_prefer_debit_card_hint" : false,
+      "link_local_storage_login_enabled" : false,
+      "link_payment_session_context" : null,
+      "link_session_storage_login_enabled" : false,
+      "link_brand" : "link",
+      "link_disable_in_safari_private_browsing" : false,
+      "link_mobile_disable_rux_in_flow_controller" : false,
+      "link_authenticated_change_event_enabled" : false,
+      "link_pm_killswitch_on_in_elements" : false,
+      "link_supported_payment_methods_onboarding_enabled" : [
+
+      ],
+      "link_hcaptcha_site_key" : null,
+      "link_payment_element_disable_signup" : false,
+      "link_enable_displayable_default_values_in_ece" : false,
+      "link_disable_email_otp" : false,
+      "link_hcaptcha_rqdata" : null,
+      "link_default_opt_in" : "NONE",
+      "link_supported_payment_methods" : [
+
+      ],
+      "link_mobile_disable_default_opt_in" : false,
+      "link_mode" : null,
+      "link_mobile_disable_signup" : false,
+      "link_popup_smart_defaults_enabled" : false
+    },
+    "passive_captcha" : {
+      "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+      "token_timeout_seconds" : 1770,
+      "rqdata" : null
+    },
+    "payment_method_configuration_id" : null,
+    "payment_method_specs" : [
+      {
+        "async" : false,
+        "type" : "card",
+        "fields" : [
+
+        ]
+      }
+    ],
+    "paypal_express_config" : {
+      "client_id" : null,
+      "client_token" : null,
+      "paypal_merchant_id" : null
+    },
+    "prefill_selectors" : {
+      "default_values" : {
+        "email" : [
+
+        ],
+        "merchant_provides_default_values_on_update" : true
+      }
+    },
+    "unactivated_payment_method_types" : [
+
+    ],
+    "order" : null,
+    "unverified_payment_methods_on_domain" : [
+      "apple_pay"
+    ],
+    "link_purchase_protections_data" : {
+      "type" : null,
+      "is_eligible" : false
+    },
+    "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+    "customer" : null,
+    "klarna_express_config" : {
+      "klarna_mid" : null
+    },
+    "lpm_killswitches" : {
+      "express_checkout" : [
+
+      ],
+      "payment_element" : [
+
+      ]
+    },
+    "business_name" : "CI Stuff",
+    "ordered_payment_method_types_and_wallets" : [
+      "card",
+      "apple_pay",
+      "google_pay"
+    ],
+    "customer_error" : null
+  },
+  "stripe_hosted_url" : "https:\/\/checkout.stripe.com\/c\/pay\/cs_test_a1l56oJZ92Yg9fbxfUP3v6Dluprvl4567rNjhysQNi81dVMnx4DwTqeGsB#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWkB3dnxIQEpRcGFWb1RXPW1tNVN3VHcwXTU1PXZHXUJKcDMnKSdjd2poVmB3c2B3Jz9xd3BgKSdnZGZuYndqcGthRmppancnPycmY2NjY2NjJyknaWR8anBxUXx1YCc%2FJ3Zsa2JpYFpscWBoJyknYGtkZ2lgVWlkZmBtamlhYHd2Jz9xd3BgeCUl",
+  "prefilled" : null,
+  "redirect_on_completion" : null,
+  "blob" : null,
+  "client_reference_id" : null,
+  "status" : "open",
+  "submit_type" : null,
+  "email_collection" : "always",
+  "permissions" : null,
+  "custom_fields" : [
+
+  ],
+  "phone_number_collection" : {
+    "enabled" : false
+  },
+  "livemode" : false,
+  "ordered_payment_method_types" : [
+    "card",
+    "apple_pay",
+    "google_pay"
+  ],
+  "state" : "active",
+  "currency" : "usd",
+  "subscription_data" : null,
+  "customer_managed_saved_payment_methods_offer_save" : null,
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping" : null,
+  "crypto_in_link_ui_enabled" : false,
+  "rqdata" : "keAMeAylJyhjZVYjrrYfs3jBJyE4Xze\/jFCFE\/pnf5Q3b92NBW4VBduf9zS0ve\/EB6YhsT3BtHpN+GjjKZ0R5U3vtZLtowzFKweTvgHyGBc+03Y9exN+5\/F23DNlXTWlm9C\/Zb2gh7eW71UhswJPzRyrqlcwf53QCzGUASvASOuU3E1ybmt+JiN\/gSQmJk2wmX7OnR7ix30Ej9upHyZrGOpnY4J0pN0nlv2t\/Sis6UKTIVA5hPlHMQTcIVnT1ep3srh+Tc12b26fX584gYw0JXu4ocq+Cw+SDna+WFwCTKVPB4Db0lZukTWhmQ==ObElDt+PjKy5pIuM",
+  "total_summary" : {
+    "due" : 2000,
+    "subtotal" : 2000,
+    "total" : 2000
+  },
+  "on_behalf_of" : null,
+  "cross_sell_group" : null,
+  "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+  "checkout_multistep_ui" : false,
+  "eid" : "56d42221-8ff7-4b11-920b-220e3d4d620e",
+  "line_item_group" : {
+    "total" : 2000,
+    "line_items" : [
+      {
+        "id" : "li_1TluRDFY0qyl6XeWqLqno6AJ",
+        "description" : null,
+        "discount_amounts" : [
+
+        ],
+        "quantity" : 1,
+        "is_removable" : false,
+        "total" : 2000,
+        "tax_amounts" : [
+
+        ],
+        "subtotal" : 2000,
+        "cross_sell_from" : null,
+        "object" : "item",
+        "price" : {
+          "id" : "price_1TluRDFY0qyl6XeWnQLcxZgp",
+          "livemode" : false,
+          "active" : false,
+          "product" : {
+            "object" : "product",
+            "active" : false,
+            "addons" : null,
+            "id" : "prod_TnUMNVDoRiDXJx",
+            "images" : [
+
+            ],
+            "livemode" : false,
+            "url" : null,
+            "attributes" : [
+
+            ],
+            "description" : null,
+            "name" : "Test",
+            "unit_label" : null
+          },
+          "tax_behavior" : "exclusive",
+          "custom_unit_amount" : null,
+          "transform_quantity" : null,
+          "type" : "one_time",
+          "unit_amount" : 2000,
+          "unit_amount_decimal" : "2000",
+          "object" : "price",
+          "billing_scheme" : "per_unit",
+          "recurring" : null,
+          "currency" : "usd",
+          "tiers_mode" : null
+        },
+        "adjustable_quantity" : null,
+        "images" : null,
+        "unit_amount_override" : null,
+        "name" : "Test"
+      }
+    ],
+    "shipping_rate" : null,
+    "applied_credits" : [
+
+    ],
+    "subtotal" : 2000,
+    "discount_amounts" : [
+
+    ],
+    "currency" : "usd",
+    "tax_amounts" : [
+
+    ],
+    "due" : 2000
+  },
+  "managed_payments" : {
+    "enabled" : false
+  },
+  "name_collection" : null,
+  "payment_intent" : null,
+  "config_id" : "0b15e043-8946-4fee-8165-83648534e8d0",
+  "is_sandbox_merchant" : false
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0000_post_create_ephemeral_key.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0000_post_create_ephemeral_key.tail
@@ -1,0 +1,17 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_ephemeral_key$
+200
+text/html
+x-content-type-options: nosniff
+x-cloud-trace-context: ad2f95db2e0c8aa9ea3d770c5cd9bd06;o=1
+Content-Type: text/html;charset=utf-8
+Set-Cookie: rack.session=BWyJLHKIzpgy7QUFgb50132FAwJ1JD6DT9QnF5fH3QRPLKIacpJJBXaMQcZvK8YeG6kRJnSa7cVOU76FoRlNn7mVvnh%2F7Ax6yARI0XTgIQE43ze%2BWG4gZZqNpdzfE5ydIz344A9jRbH%2Fq7%2BzFRO5iTjLNXmiN5C33OYzBIXYVMyhCv2TA9HgUjZg4yHRtOW5e6ReGrO6KOjwXfy4yPwVtvGlWDRILI6mk4%2BpWy3dNc8%3D; path=/
+Server: Google Frontend
+Via: 1.1 google
+Date: Wed, 24 Jun 2026 17:17:37 GMT
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+Content-Length: 149
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+
+{"ephemeral_key_secret":"ek_test_YWNjdF8xRzZtMXBGWTBxeWw2WGVXLGtMQ3c4TUNIQVNET2p1UVpBM0RPOXRtVFIzRW11WVQ_00lct5r8ZX","customer":"cus_UlRJ4Dd9utegB7"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0001_post_v1_payment_methods.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0001_post_v1_payment_methods.tail
@@ -1,0 +1,81 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_methods$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=3KuXl2XTRtrtNVFJC-nIvx6V9ydkqoZC-e3fE8_PGIBNo7ZQcQbZrPzsWNtYzPTuPiYG9k5bk4e-dpAe; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=3KuXl2XTRtrtNVFJC-nIvx6V9ydkqoZC-e3fE8_PGIBNo7ZQcQbZrPzsWNtYzPTuPiYG9k5bk4e-dpAe&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=3KuXl2XTRtrtNVFJC-nIvx6V9ydkqoZC-e3fE8_PGIBNo7ZQcQbZrPzsWNtYzPTuPiYG9k5bk4e-dpAe&t=1"}],"include_subdomains":true}
+request-id: req_ZjdhUSGv9qWQUY
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 1073
+Vary: Origin
+Date: Wed, 24 Jun 2026 17:17:37 GMT
+original-request: req_ZjdhUSGv9qWQUY
+stripe-version: 2020-08-27
+idempotency-key: 249efc63-f1af-450c-9796-6a71ea43db0c
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: allow_redisplay=unspecified&billing_details\[email]=test%40example\.com&card\[cvc]=123&card\[exp_month]=12&card\[exp_year]=2030&card\[number]=4242424242424242&guid=.*&muid=.*&payment_user_agent=.*&sid=.*&type=card
+
+{
+  "object" : "payment_method",
+  "id" : "pm_1TluQfFY0qyl6XeW96NVVHzU",
+  "billing_details" : {
+    "email" : "test@example.com",
+    "phone" : null,
+    "tax_id" : null,
+    "name" : null,
+    "address" : {
+      "state" : null,
+      "country" : null,
+      "line2" : null,
+      "city" : null,
+      "line1" : null,
+      "postal_code" : null
+    }
+  },
+  "card" : {
+    "regulated_status" : "unregulated",
+    "last4" : "4242",
+    "funding" : "credit",
+    "generated_from" : null,
+    "networks" : {
+      "available" : [
+        "visa"
+      ],
+      "preferred" : null
+    },
+    "brand" : "visa",
+    "checks" : {
+      "address_postal_code_check" : null,
+      "cvc_check" : null,
+      "address_line1_check" : null
+    },
+    "three_d_secure_usage" : {
+      "supported" : true
+    },
+    "wallet" : null,
+    "display_brand" : "visa",
+    "exp_month" : 12,
+    "exp_year" : 2030,
+    "country" : "US"
+  },
+  "livemode" : false,
+  "created" : 1782321457,
+  "allow_redisplay" : "unspecified",
+  "shared_payment_granted_token" : null,
+  "customer" : null,
+  "type" : "card",
+  "customer_account" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0002_post_v1_payment_methods_pm_1TluQfFY0qyl6XeW96NVVHzU_attach.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0002_post_v1_payment_methods_pm_1TluQfFY0qyl6XeW96NVVHzU_attach.tail
@@ -1,0 +1,82 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_methods\/pm_1TluQfFY0qyl6XeW96NVVHzU\/attach$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=i978cKZ0PLEmdR_9aZfnVFZacTU3vsp75Pvw0_DlbIAla2kwLjw5N9dj4OrG1_3LkiQ1Y5Wut1gr5rqa; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=i978cKZ0PLEmdR_9aZfnVFZacTU3vsp75Pvw0_DlbIAla2kwLjw5N9dj4OrG1_3LkiQ1Y5Wut1gr5rqa&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=i978cKZ0PLEmdR_9aZfnVFZacTU3vsp75Pvw0_DlbIAla2kwLjw5N9dj4OrG1_3LkiQ1Y5Wut1gr5rqa&t=1"}],"include_subdomains":true}
+request-id: req_5et55tckOYfgLl
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 1128
+Vary: Origin
+Date: Wed, 24 Jun 2026 17:17:38 GMT
+original-request: req_5et55tckOYfgLl
+stripe-version: 2020-08-27
+idempotency-key: 084c0bc8-e882-45ba-a70f-b66eb16a1e49
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: customer=cus_UlRJ4Dd9utegB7
+
+{
+  "object" : "payment_method",
+  "id" : "pm_1TluQfFY0qyl6XeW96NVVHzU",
+  "billing_details" : {
+    "email" : "test@example.com",
+    "phone" : null,
+    "tax_id" : null,
+    "name" : null,
+    "address" : {
+      "state" : null,
+      "country" : null,
+      "line2" : null,
+      "city" : null,
+      "line1" : null,
+      "postal_code" : null
+    }
+  },
+  "card" : {
+    "regulated_status" : "unregulated",
+    "fingerprint" : "96sroMqLCHmUdUpL",
+    "last4" : "4242",
+    "funding" : "credit",
+    "generated_from" : null,
+    "networks" : {
+      "available" : [
+        "visa"
+      ],
+      "preferred" : null
+    },
+    "brand" : "visa",
+    "checks" : {
+      "address_postal_code_check" : null,
+      "cvc_check" : null,
+      "address_line1_check" : null
+    },
+    "three_d_secure_usage" : {
+      "supported" : true
+    },
+    "wallet" : null,
+    "display_brand" : "visa",
+    "exp_month" : 12,
+    "exp_year" : 2030,
+    "country" : "US"
+  },
+  "livemode" : false,
+  "created" : 1782321457,
+  "allow_redisplay" : "unspecified",
+  "shared_payment_granted_token" : null,
+  "customer" : "cus_UlRJ4Dd9utegB7",
+  "type" : "card",
+  "customer_account" : null
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0003_post_create_checkout_session.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0003_post_create_checkout_session.tail
@@ -1,0 +1,17 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_checkout_session$
+200
+text/html
+x-content-type-options: nosniff
+x-cloud-trace-context: 5682388414a6c4aa58e2bd5d101fb46b
+Content-Type: text/html;charset=utf-8
+Set-Cookie: rack.session=4Q%2FZolbp%2Bn2NV1C1jhfNp2PQaO9TDyxcXXN0Wj0%2FoB9%2BtiC0Cf9r5lTGJQ8xwbespp4zYpIx8gVbfRHfUP5%2FMuNCptn1Mhnhlp775VI1pJOJ8AsmB35XAl0Lc0izZkxEdkfX%2FIYbRG8Xwq0GWeLU2a3GkQ2etM1i%2F8lan%2B5sNizH8s56jonYNy9r87V2JpKJ1IiSA0TTZCB1Xd9MVvc%2BufWTsXed%2FtpvLBy4rCkKIqE%3D; path=/
+Server: Google Frontend
+Via: 1.1 google
+Date: Wed, 24 Jun 2026 17:17:38 GMT
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+Content-Length: 293
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+
+{"id":"cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I","client_secret":"cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I_secret_fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdwbEhqYWAnPydmcHZxamgneCUl","publishable_key":"pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0004_post_v1_payment_pages_cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I_init.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0004_post_v1_payment_pages_cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I_init.tail
@@ -1,0 +1,986 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_pages\/cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I\/init$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=7Z3K10CMtBr3GZF2rFCLnhn4FwO5KLGdppy66-IUvZEwQRw2OxLJxQXt3u2p0LB7l-dFRrfkIOJlFZJf; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=7Z3K10CMtBr3GZF2rFCLnhn4FwO5KLGdppy66-IUvZEwQRw2OxLJxQXt3u2p0LB7l-dFRrfkIOJlFZJf&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=7Z3K10CMtBr3GZF2rFCLnhn4FwO5KLGdppy66-IUvZEwQRw2OxLJxQXt3u2p0LB7l-dFRrfkIOJlFZJf&t=1"}],"include_subdomains":true}
+request-id: req_meJJTlAGoBPzil
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 33987
+Vary: Origin
+Date: Wed, 24 Jun 2026 17:17:39 GMT
+original-request: req_meJJTlAGoBPzil
+stripe-version: 2020-08-27
+idempotency-key: 7def1657-0667-45ef-92c8-2d10ead4c740
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: adaptive_pricing\[allowed]=false&browser_locale=.*&browser_timezone=.*&eid=.*&elements_session_client\[is_aggregation_expected]=true&elements_session_client\[locale]=.*&elements_session_client\[mobile_app_id]=.*&redirect_type=embedded
+
+{
+  "lpm_settings" : null,
+  "sepa_debit_info" : null,
+  "automatic_payment_method_types" : false,
+  "is_unclaimed_anonymous_sandbox" : false,
+  "tax_context" : {
+    "automatic_tax_error" : null,
+    "automatic_tax_enabled" : false,
+    "automatic_tax_taxability_reason" : null,
+    "dynamic_tax_enabled" : false,
+    "tax_id_collection_enabled" : false,
+    "automatic_tax_exempt" : "none",
+    "customer_tax_country" : null,
+    "tax_id_collection_required" : "never",
+    "has_maximum_tax_ids" : false,
+    "automatic_tax_address_source" : null
+  },
+  "payment_method_types" : [
+    "card"
+  ],
+  "payment_method_options" : {
+    "card" : {
+      "request_three_d_secure" : "automatic"
+    }
+  },
+  "bnpl_in_link_ui_enabled" : false,
+  "consent_collection" : null,
+  "experiment_data" : [
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs_aa",
+      "event_id" : "6afe5653-dc5e-4be0-b9d9-4698aaf4776f",
+      "exposure_event_name" : ""
+    },
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs",
+      "event_id" : "b12f7b64-62ec-43b5-a427-7fd9567c1fa6",
+      "exposure_event_name" : ""
+    }
+  ],
+  "origin_context" : null,
+  "enforcement_mode" : "open",
+  "blocked_billing_address_countries" : [
+
+  ],
+  "id" : "ppage_1TluQgFY0qyl6XeW8CF9XrAf",
+  "subscription_settings" : null,
+  "consent" : null,
+  "does_not_collect_postal_code_for_non_us_card_transactions" : false,
+  "use_payment_methods" : true,
+  "application" : null,
+  "payment_method_collection" : "if_required",
+  "setup_intent" : null,
+  "shipping_options" : [
+
+  ],
+  "setup_future_usage_for_payment_method_type" : {
+    "card" : "on_session"
+  },
+  "capture_method" : "automatic_async",
+  "statement_descriptor" : "mobile",
+  "session_id" : "cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I",
+  "shipping_address_collection" : null,
+  "konbini_confirmation_number" : null,
+  "setup_future_usage" : "on_session",
+  "invoice_creation" : {
+    "enabled" : false
+  },
+  "has_dynamic_tax_rates" : false,
+  "receipt_emails_enabled" : false,
+  "link_settings" : {
+    "link_consumer_incentive" : null,
+    "link_payment_session_context" : null,
+    "consumer_found" : null,
+    "hcaptcha_rqdata" : null,
+    "link_supported_payment_methods_onboarding_enabled" : [
+
+    ],
+    "enable_partner_lookup" : false,
+    "link_us_bank_account_funding_source_enabled" : false,
+    "link_funding_sources" : [
+
+    ],
+    "hcaptcha_site_key" : null,
+    "link_brand" : "link",
+    "link_mode" : null,
+    "link_supported_payment_methods" : [
+
+    ]
+  },
+  "object" : "checkout.session",
+  "customer" : {
+    "object" : "customer",
+    "phone" : null,
+    "tax_ids" : [
+
+    ],
+    "id" : "cus_UlRJ4Dd9utegB7",
+    "business_name" : null,
+    "payment_methods" : [
+
+    ],
+    "email" : null,
+    "has_fallback_payment_method" : false,
+    "individual_name" : null,
+    "customer_provided" : true,
+    "name" : null
+  },
+  "shipping_rate" : null,
+  "success_url" : null,
+  "utm_codes" : null,
+  "beta_versions" : null,
+  "has_async_attached_payment_method" : false,
+  "feature_flags" : {
+    "checkout_enable_pay_by_bank_remember_bank_selection" : true,
+    "checkout_link_phone_registration_treatment_1_enabled" : true,
+    "sandboxes_rebrand_testmode" : true,
+    "checkout_enable_new_google_places_api" : true,
+    "checkout_link_enable_mfa" : true,
+    "checkout_link_purchase_protections_rollout" : true,
+    "checkout_tide_remount_override_replay" : true,
+    "checkout_optional_items" : true,
+    "checkout_link_in_habanero_enabled" : true,
+    "enable_custom_checkout_name_collection" : true,
+    "ocs_payment_prompt_for_agents" : true,
+    "checkout_passive_captcha" : true,
+    "checkout_enable_link_api_passive_hcaptcha" : true,
+    "checkout_hcaptcha_redundancy_control_enabled" : true,
+    "checkout_address_autocomplete_enabled" : true,
+    "checkout_enable_link_api_hcaptcha_rqdata" : true,
+    "checkout_show_swish_factoring_notice" : true
+  },
+  "locale" : null,
+  "custom_text" : {
+    "shipping_address" : null,
+    "terms_of_service_acceptance" : null,
+    "submit" : null,
+    "after_submit" : null
+  },
+  "route_to_orchestration_interface" : false,
+  "customer_email" : null,
+  "custom_components" : [
+
+  ],
+  "ui_mode" : "custom",
+  "url" : null,
+  "developer_tool_context" : {
+    "disabled_third_party_wallets" : {
+      "LINK_BUTTON" : {
+        "disabled_reason" : "merchant_payment_methods_settings"
+      },
+      "KLARNA_EXPRESS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "PAYPAL_ECS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "AMAZON_PAY" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      }
+    },
+    "adaptive_pricing" : {
+      "reason" : "not_allowed_for_ui",
+      "active" : false
+    },
+    "payment_method_configuration_details" : null
+  },
+  "token_notification_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "init_checksum" : "mSIMdDCefVTd23ebLFMLLDtPak7Iw7PV",
+  "tax_exclusion_from_total_is_allowed" : false,
+  "bnpl_link_experiment_payment_method_type" : null,
+  "tax_meta" : {
+    "status" : "complete",
+    "error_reason" : null,
+    "computation_type" : "manual",
+    "customer_tax_exempt" : "none"
+  },
+  "payment_status" : "unpaid",
+  "enabled_third_party_wallets" : [
+    {
+      "apple_pay" : {
+        "required_version" : 2
+      },
+      "id" : "APPLE_PAY",
+      "enabled" : true,
+      "carousel_enabled" : true
+    },
+    {
+      "id" : "GOOGLE_PAY",
+      "enabled" : true,
+      "google_pay" : {
+        "id" : "GOOGLE_PAY",
+        "version_minor" : 0,
+        "version_major" : 2
+      },
+      "carousel_enabled" : false
+    },
+    {
+      "id" : "AMAZON_PAY",
+      "carousel_enabled" : false,
+      "enabled" : false
+    },
+    {
+      "id" : "KLARNA_EXPRESS",
+      "carousel_enabled" : false,
+      "enabled" : false
+    }
+  ],
+  "klarna_info" : null,
+  "visible_custom_component_locations" : [
+    "checkout_form_before",
+    "checkout_form_after",
+    "submit_button_before",
+    "submit_button_after",
+    "contact_before",
+    "contact_after",
+    "express_checkout_before",
+    "express_checkout_after",
+    "payment_details_before",
+    "payment_details_after"
+  ],
+  "display_consent_collection_promotions" : false,
+  "policies" : {
+    "contacts" : {
+      "display_phone" : true,
+      "display_url" : true,
+      "enabled" : false,
+      "display_email" : true
+    },
+    "legal" : {
+      "agreement_required" : false,
+      "enabled" : false
+    },
+    "returns" : {
+      "custom_message" : null,
+      "exchanges_accepted" : false,
+      "returns_accepted" : null,
+      "fee_type" : null,
+      "fee_required" : null,
+      "policy_url" : null,
+      "window_start" : null,
+      "refunds_accepted" : null,
+      "window" : null,
+      "enabled" : false,
+      "exceptions_apply" : false,
+      "logistics" : [
+
+      ]
+    }
+  },
+  "card_brands" : {
+    "mastercard" : true,
+    "link" : true,
+    "carnet" : false,
+    "accel" : false,
+    "elo" : false,
+    "rupay" : false,
+    "maestro" : false,
+    "unionpay" : true,
+    "amex" : true,
+    "jaywan" : false,
+    "conecs" : false,
+    "jcb" : true,
+    "visa" : true,
+    "cartes_bancaires" : false,
+    "pulse" : false,
+    "discover" : true,
+    "star" : false,
+    "eftpos_au" : false,
+    "diners" : true,
+    "girocard" : false,
+    "nyce" : false
+  },
+  "geocoding" : {
+    "country_code" : "US",
+    "region_name" : "UT"
+  },
+  "account_settings" : {
+    "assets" : {
+      "use_logo" : false,
+      "icon" : null,
+      "logo" : null
+    },
+    "specified_commercial_transactions_act_url" : null,
+    "business_url" : "https:\/\/github.com\/stripe\/stripe-ios",
+    "privacy_policy_url" : null,
+    "branding" : {
+      "button_color" : "#0074d4",
+      "background_color" : "#ffffff",
+      "border_style" : "default",
+      "font_family" : "default"
+    },
+    "statement_descriptor" : "mobile",
+    "support_email" : null,
+    "display_name" : "CI Stuff",
+    "merchant_of_record_country" : "US",
+    "order_summary_display_name" : "CI Stuff",
+    "support_phone" : "+12105550123",
+    "merchant_of_record_display_name" : "CI Stuff",
+    "support_url" : null,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "country" : "US",
+    "terms_of_service_url" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "server_built_elements_session_params" : {
+    "client_betas" : [
+
+    ],
+    "expand" : [
+
+    ],
+    "checkout_session_id" : "cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I",
+    "locale" : "en-US",
+    "country_override" : "US",
+    "mobile_app_id" : "com.stripe.StripeiOSTestHostApp",
+    "type" : "deferred_intent",
+    "deferred_intent" : {
+      "amount" : 2000,
+      "capture_method" : "automatic_async",
+      "currency" : "usd",
+      "payment_method_types" : [
+        "card"
+      ],
+      "setup_future_usage" : "on_session",
+      "mode" : "payment"
+    }
+  },
+  "shipping_tax_amounts" : [
+
+  ],
+  "billing_address_collection" : null,
+  "elements_options" : {
+    "amount" : 2000,
+    "__checkout_session_id" : "cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I",
+    "setup_future_usage" : "on_session",
+    "payment_method_types" : [
+      "card"
+    ],
+    "__disable_link_in_session" : false,
+    "__checkout_country_override" : "US",
+    "__checkout_automatic_payment_method_types" : false,
+    "__link_consumer_data" : {
+
+    },
+    "capture_method" : "automatic_async",
+    "__checkout_config_id" : "d9ab2311-6cf8-4c80-b991-b5800ceb472e",
+    "mode" : "payment",
+    "__payment_pages_experiments" : [
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs_aa",
+        "event_id" : "6afe5653-dc5e-4be0-b9d9-4698aaf4776f",
+        "exposure_event_name" : ""
+      },
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs",
+        "event_id" : "b12f7b64-62ec-43b5-a427-7fd9567c1fa6",
+        "exposure_event_name" : ""
+      }
+    ],
+    "currency" : "usd"
+  },
+  "experiments_data" : {
+    "event_id" : "de3b35bb-847a-47ec-b85e-a24e0b3e0b89",
+    "experiment_metadata" : {
+      "ocs_buyer_xp_cpl_lpm_holdback" : {
+        "heldback_special_wallets" : [
+
+        ]
+      }
+    },
+    "experiment_assignments" : {
+      "ocs_buyer_xp_cpl_separate_wallet_accordion" : "control",
+      "emea_wallets_ideal_wero_rebranding" : "control",
+      "ocs_buyer_xp_cpl_apple_pay_in_non_safari" : "control",
+      "ocs_buyer_xp_cpl_embedded_pay_button" : "control",
+      "ff_checkout_cpl_lid_promo_badge_color_opt" : "treatment",
+      "cpl_spicy_guacamole" : "control",
+      "ff_checkout_optimized_image_eff" : "control",
+      "connections_checkout_us_bank_account_picker_icons" : "control",
+      "ocs_buyer_xp_cpl_progressive_ece" : "control",
+      "ocs_buyer_xp_cpl_single_column_checkout" : "control",
+      "checkout_li_larger_image_size" : "control",
+      "link_ab_test_aa" : "control",
+      "ocs_buyer_xp_cpl_terms_above_submit" : "control",
+      "ocs_buyer_xp_cpl_currency_symbol_optimization" : "control",
+      "smor_checkout_ui_iteration" : "control",
+      "checkout_link_instant_debits_accordion_logos" : "control",
+      "checkout_enable_real_time_tax_id_verification_experiment" : "control",
+      "ff_checkout_test_frontend_eff" : "control",
+      "ocs_buyer_xp_cpl_link_signup_in_form" : "control",
+      "ocs_buyer_xp_remove_name_field_guac_related_pms" : "control",
+      "link_risk_based_disable_auto_prompting_checkout" : "control",
+      "ocs_buyer_xp_cpl_apple_pay_button_type" : "control",
+      "cpl_guacamole" : "control",
+      "ocs_buyer_xp_cpl_ece_kakao_naver" : "control",
+      "ocs_buyer_xp_cpl_lpm_content_simplification" : "control"
+    }
+  },
+  "return_url" : "https:\/\/example.com\/return",
+  "mode" : "payment",
+  "cancel_url" : null,
+  "elements_session" : {
+    "payment_method_preference" : {
+      "country_code" : "US",
+      "object" : "payment_method_preference",
+      "type" : "deferred_intent",
+      "ordered_payment_method_types" : [
+        "card"
+      ]
+    },
+    "capability_enabled_card_networks" : [
+      "cartes_bancaires",
+      "jcb",
+      "diners",
+      "discover"
+    ],
+    "flags" : {
+      "enable_tax_id_suspicious_pattern_check" : false,
+      "elements_easel_enable_elements_inspector_for_advanced_integrations_backend" : true,
+      "link_enable_signup_in_summary_in_habanero" : true,
+      "financial_connections_enable_deferred_intent_flow" : true,
+      "elements_enable_remove_last_validation" : true,
+      "ocs_payment_prompt_for_agents" : true,
+      "apple_pay_prb_killswitch" : false,
+      "elements_enable_easel_for_pi" : true,
+      "elements_mobile_card_funding_filtering" : true,
+      "link_payment_element_minor_signup_ui_updates" : false,
+      "link_enable_ncdv_usage_id_selectors_l3" : true,
+      "elements_disable_express_checkout_button_amazon_pay" : false,
+      "elements_easel_disable_appearance_api" : false,
+      "link_auth_partner_enable_link_auth_token_login" : true,
+      "link_enable_ncdv_recall_id_selectors_l3" : true,
+      "elements_disable_link_email_otp" : false,
+      "restrict_taxid_selection_to_buyer_address" : false,
+      "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
+      "ocs_buyer_xp_elements_card_brand_choice_toggle" : false,
+      "paypal_billing_address_support_in_ece" : true,
+      "elements_enable_pay_by_bank_remember_bank_selection" : true,
+      "link_auth_partner_enable_ios_instagram" : true,
+      "link_user_action_attempt_login_using_stored_credentials" : true,
+      "elements_disable_sepa_debit_eea_address_requirement" : false,
+      "elements_enable_instant_debits_postal_code_collection" : false,
+      "elements_financial_connections_canada_enabled" : false,
+      "elements_easel_disable_feedback" : false,
+      "link_enable_link_session_key_financial_connections" : false,
+      "elements_extend_hcaptcha_refresh_time" : true,
+      "link_auth_partner_consume_link_auth_intent" : true,
+      "ocs_buyer_xp_elements_remove_cpm_redirect_text" : false,
+      "elements_enable_south_korea_market_underlying_pms" : false,
+      "link_payment_element_steerage_enabled" : true,
+      "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text" : false,
+      "link_enable_apple_pay_in_safari_returning_in_guacamole" : false,
+      "elements_disable_payment_element_card_country_zip_validations" : false,
+      "link_payment_element_default_value_auto_open_modal" : true,
+      "elements_enable_link_card_brand_in_saved_payment_methods" : true,
+      "elements_disable_link_global_holdback_lookup" : false,
+      "financial_connections_enable_ca_accounts" : false,
+      "elements_apple_pay_inner_use_pending_payment_overrides" : false,
+      "link_enable_link_session_key_klarna" : false,
+      "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : true,
+      "elements_easel_disable_address_fill" : false,
+      "ocs_buyer_xp_elements_remove_redirect_lpm_content" : false,
+      "adaptive_pricing_hip_currency_selector_change_event" : true,
+      "elements_enable_payment_method_options_setup_future_usage" : true,
+      "enable_custom_checkout_currency_selector_element" : false,
+      "elements_mobile_android_tap_to_add_enabled" : false,
+      "link_enable_address_country_restrictions" : false,
+      "link_auth_partner_enable_android_fb" : true,
+      "checkout_kr_lpm_no_billing_address_collection" : false,
+      "elements_easel_disable_health_check" : false,
+      "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
+      "elements_disable_paypal_express" : false,
+      "disable_confirmation_modal_bacs" : false,
+      "legacy_customer_session_payment_element_features" : false,
+      "elements_enable_terms_element" : false,
+      "link_auth_partner_enable_authentication_element" : true,
+      "elements_allow_manual_payment_method_creation_with_spm" : false,
+      "elements_easel_disable" : false,
+      "link_enable_auth_partner_communication" : true,
+      "elements_apply_amex_icon_sorting" : false,
+      "elements_hide_card_brand_icons" : false,
+      "link_auth_partner_enable_distinctly_link_ios_facebook" : true,
+      "elements_easel_disable_customer_location_mocking" : false,
+      "elements_easel_disable_position_customization" : false,
+      "elements_enable_appearance_recompute" : false,
+      "link_enable_link_session_key_confirm_and_start_verification" : false,
+      "enable_link_lpm_dual_enablement" : false,
+      "elements_enable_19_digit_pans" : false,
+      "always_show_ece_paypal_recurring_button" : false,
+      "elements_enable_interac_apple_pay" : true,
+      "enable_payment_method_api_shop_pay" : true,
+      "enable_elements_tax_id_type_filtering" : false,
+      "elements_human_security_enabled" : false,
+      "link_enable_white_ece_button_theme" : false,
+      "link_in_accordion_layout_available_in_stripejs" : false,
+      "link_payment_element_widget_view_enabled" : true,
+      "elements_easel_disable_magic_fill" : false,
+      "avoid_redundant_billing_details_for_klarna" : false,
+      "distinctly_link_payment_element_ramp" : true,
+      "link_enable_ewcs_customer_name_prefill" : false,
+      "link_auth_partner_bypass_bridge_check" : false,
+      "link_disable_cookie_login" : false,
+      "elements_disable_express_checkout_button_shop_pay" : false,
+      "payment_element_link_modal_preload_killswitch" : false,
+      "link_enable_pass_checkout_session_id_to_signup" : true,
+      "elements_enable_hcaptcha_async_token_logging" : false,
+      "elements_enable_jp_card_installments" : true,
+      "elements_show_expanded_spm" : false,
+      "disable_payment_element_if_required_billing_config" : false,
+      "elements_enable_link_otp_takeover_in_guacamole" : false,
+      "elements_enable_link_spm" : true,
+      "elements_enable_read_allow_redisplay" : false,
+      "elements_enable_save_for_future_payments_pre_check" : false,
+      "link_forest_enable_ece_bank_use_shipping_as_billing" : false,
+      "elements_disable_express_checkout_button_klarna" : false,
+      "distinctly_link_cbc_killswitch" : false,
+      "elements_prefer_fc_lite" : false,
+      "elements_disable_payment_element_custom_payment_methods_byof" : false,
+      "elements_mobile_cardscan_use_mlkit" : true,
+      "elements_enable_link_takeover_in_guacamole" : false,
+      "link_disable_auth_partner_ua_check" : false,
+      "link_enable_link_session_key_incentives_and_status" : false,
+      "elements_easel_disable_optimizations_check" : false,
+      "elements_enable_passive_captcha" : true,
+      "distinctly_link_payment_element_opt_out_merchant_blocklist" : false,
+      "link_enable_non_blocking_doi_signup" : false,
+      "elements_enable_new_google_places_api" : true,
+      "checkout_form_automatic_tax_address_collection_precision" : false,
+      "elements_enable_express_checkout_button_demo_pay" : false,
+      "disable_cbc_in_link_popup" : false,
+      "elements_enable_installments_on_deferred_intents" : true,
+      "elements_sepa_debit_instant_microdeposits" : false,
+      "ocs_buyer_xp_elements_remove_generic_footer" : false,
+      "elements_spm_set_as_default" : true,
+      "elements_does_not_collect_postal_code_for_non_us_card_transactions_killswitch" : false,
+      "link_disable_login_if_signed_up_outside_of_elements" : true,
+      "elements_enable_link_autofill_prompt_padding_fix" : false,
+      "elements_mobile_attest_on_intent_confirmation" : false,
+      "link_trusted_origin_skip_secure_click" : true,
+      "elements_stop_move_focus_to_first_errored_field" : true,
+      "ocs_buyer_xp_enable_payment_element_accordion_box_shadow" : false,
+      "elements_enable_customer_address" : false,
+      "elements_enable_card_metadata" : true,
+      "elements_mobile_allow_stripecardscan" : false,
+      "elements_use_checkout_app_id_for_human_security" : false,
+      "sandboxes_rebrand_testmode" : true,
+      "bancontact_name_optional_one_time" : false,
+      "link_enable_card_brand_choice" : true,
+      "link_payment_element_keep_optional_doi_open_rollout" : true,
+      "adaptive_pricing_for_elements_with_payment_intents" : false,
+      "elements_allow_custom_payment_method_creation" : false,
+      "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+      "elements_mobile_link_inline_signup_with_saved_pm_enabled" : false,
+      "link_purchase_protections_rollout" : true,
+      "show_swish_factoring_notice" : true,
+      "elements_disable_fc_lite" : false,
+      "link_auth_partner_delay_recognition" : true,
+      "elements_enable_payment_element_custom_payment_methods_byof" : false,
+      "ocs_mobile_should_use_autocomplete_proxy_endpoints" : true,
+      "elements_enable_nme_for_us_bank_account_skip_verification" : false,
+      "ocs_buyer_xp_elements_remove_wallets_redirect_text" : false,
+      "elements_easel_enable_elements_inspector" : true,
+      "elements_google_pay_mit_fields" : false,
+      "apple_pay_pe_killswitch" : false,
+      "paypal_phone_number_support_in_ece" : false,
+      "elements_enable_pay_by_bank_multi_country_bank_selector_rollout_countries" : false,
+      "elements_easel_disable_payment_fill" : false,
+      "elements_easel_disable_tax_id_fill" : false,
+      "elements_spm_max_visible_payment_methods" : false,
+      "id_bank_transfers_v1_integration" : false,
+      "elements_enable_mx_card_installments" : true,
+      "elements_easel_disable_appearance_api_per_element_options" : true,
+      "elements_enable_easel_for_pi_killswitch" : false,
+      "link_enable_link_session_key_shipping_addresses" : false,
+      "enable_pe_options_for_billing_details_collection" : false,
+      "elements_spm_messages" : false,
+      "elements_easel_disable_session_summary" : false,
+      "apple_pay_ece_killswitch" : false,
+      "distinctly_link_pe_purchase_protection" : true,
+      "link_enable_link_session_key_consumer_person_details" : false,
+      "link_auth_partner_enable_distinctly_link_android_fb" : true,
+      "link_auth_partner_delay_android_fb_cookie_login" : false,
+      "elements_ae_hide_name_field" : false,
+      "legacy_confirmation_tokens" : false,
+      "link_auth_partner_enable_distinctly_link_ios_instagram" : false,
+      "elements_easel_disable_elements_inspector_for_pi" : false,
+      "link_auth_partner_enable_ece" : true,
+      "link_enable_link_session_key_payment_details" : false,
+      "distinctly_link_pe_backup_payment_method" : true,
+      "link_dedupe_shipping_address_creation" : true,
+      "ece_apple_pay_payment_request_passthrough" : false,
+      "checkout_link_pay_token_enabled" : false,
+      "link_enable_link_session_key_link_onboarding_session" : false,
+      "elements_mobile_force_vertical_payment_method_layout" : false,
+      "payto_enable_modal_in_payment_element" : true,
+      "checkout_link_in_habanero_enabled" : true,
+      "elements_disable_progressive_cursor" : false,
+      "link_enable_auth_partner_sizing_logging" : true,
+      "enable_checkout_session_update_customer" : false
+    },
+    "merchant_logo_url" : null,
+    "session_id" : "elements_session_16OiUEfyi0c",
+    "card_installments_enabled" : false,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "config_id" : "73ca7d9f-f925-4cbe-9abe-ac8c3696bd59",
+    "merchant_currency" : "usd",
+    "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+    "card_brand_choice" : {
+      "eligible" : false,
+      "preferred_networks" : [
+        "cartes_bancaires"
+      ],
+      "supported_cobranded_networks" : {
+        "cartes_bancaires" : false
+      }
+    },
+    "shipping_address_settings" : {
+      "autocomplete_allowed" : false
+    },
+    "external_payment_method_data" : null,
+    "custom_payment_method_data" : null,
+    "meta_pay_signed_container_context" : null,
+    "apple_pay_preference" : "enabled",
+    "country_override" : "US",
+    "managed_payments_enabled" : false,
+    "google_pay_preference" : "enabled",
+    "merchant_country" : "US",
+    "experiments_data" : {
+      "arb_id" : "5c0ef323-3f31-49e5-8e9a-3e1b9dd5aa01",
+      "experiment_metadata" : {
+        "seed" : "1a9b1bb606a182c72328e7724107a9701e36ef6ea116c63bac0f7ca9684d0ba3",
+        "semi_dominant_payment_methods" : [
+
+        ],
+        "lpm_holdback_t1_payment_methods" : [
+
+        ],
+        "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false,
+        "lpm_holdback_t2_payment_methods" : [
+
+        ]
+      },
+      "experiment_assignments" : {
+        "link_spm_show_checkbox_signup_aa" : "control",
+        "link_optional_doi_signup_holdback" : "control",
+        "link_ab_test_aa" : "control",
+        "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : "control",
+        "ocs_mobile_horizontal_mode" : "control",
+        "link_sign_up_form_container_aa" : "control",
+        "ff_elements_apple_pay_inner_use_pending_payment_overrides_eff" : "control",
+        "link_spm_show_checkbox_signup" : "control",
+        "pbb_bank_credential_hint_elements" : "control",
+        "ocs_mobile_card_art" : "control",
+        "link_ece_unrecognized_button_text_aa" : "control",
+        "link_ulm_in_ece" : "control",
+        "ibp_bank_tab_name" : "control",
+        "paypal_payment_handler" : "control",
+        "link_pe_signup_copy_aa" : "control",
+        "ibp_bank_tab_name_aa" : "control",
+        "link_ce_conversion_cookie_aa" : "control",
+        "link_dl_pe_inline_entrypoint_aa" : "control",
+        "link_sign_up_form_container" : "control",
+        "link_ulm_in_ece_aa" : "control",
+        "link_ece_unrecognized_button_text" : "control",
+        "link_ce_conversion_unrecognized_aa" : "control",
+        "link_pe_signup_copy" : "control",
+        "ocs_mobile_horizontal_mode_aa" : "control",
+        "connections_elements_variable_incentives_for_ibp_recurring_payments" : "control",
+        "link_ce_conversion_ncdv_aa" : "control",
+        "link_ce_conversion_unrecognized_copy_change" : "control",
+        "link_ce_conversion_unrecognized_post_entry_aa" : "control",
+        "link_pe_signup_green_logo" : "control",
+        "link_dl_pe_inline_entrypoint" : "control",
+        "ff_elements_test_frontend_eff" : "control",
+        "link_pe_signup_green_logo_aa" : "control",
+        "link_optional_doi_signup_holdback_aa" : "control",
+        "link_ce_conversion_responsive_button" : "control",
+        "ibp_localized_featured_institutions_accordion" : "control",
+        "elements_hcaptcha_init_timeout" : "control",
+        "link_ce_conversion_recognized_loading_animation" : "control",
+        "link_signup_name_from_billing_ae" : "control",
+        "ocs_buyer_xp_elements_apple_pay_in_non_safari" : "control"
+      }
+    },
+    "legacy_customer" : null,
+    "link_settings" : {
+      "link_passthrough_mode_enabled" : false,
+      "link_payment_element_smart_defaults_enabled" : false,
+      "link_mobile_attestation_state_sync_enabled" : false,
+      "link_no_code_default_values_recall" : true,
+      "link_funding_sources" : [
+
+      ],
+      "link_crypto_onramp_force_cvc_reverification" : false,
+      "link_enable_signup_in_express_checkout_element" : false,
+      "link_wanderlust_in_elements_enabled" : false,
+      "link_consumer_incentive" : null,
+      "link_crypto_onramp_bank_upsell" : false,
+      "link_ece_browser_compatibility_override" : false,
+      "link_enable_email_otp_for_link_popup" : false,
+      "link_crypto_onramp_elements_logout_disabled" : false,
+      "link_popup_enable_new_google_places_api" : false,
+      "link_no_code_default_values_identification" : true,
+      "link_pay_button_element_enabled" : true,
+      "link_payment_element_enable_webauthn_login" : false,
+      "link_bank_onboarding_enabled" : false,
+      "link_enable_instant_debits_in_testmode" : false,
+      "link_payment_element_disabled_by_targeting" : false,
+      "link_sign_up_opt_in_feature_enabled" : false,
+      "link_only_for_payment_method_types_enabled" : false,
+      "link_disabled_reasons" : {
+        "payment_element_payment_method_mode" : [
+          "link_not_specified_in_payment_method_types"
+        ],
+        "payment_element_passthrough_mode" : [
+          "link_not_enabled_on_payment_config"
+        ]
+      },
+      "link_sign_up_opt_in_initial_value" : false,
+      "link_mobile_use_attestation_endpoints" : false,
+      "link_elements_pageload_sign_up_disabled" : false,
+      "link_disable_pe_signup_prompt" : false,
+      "link_elements_is_crypto_onramp" : false,
+      "link_no_code_default_values_usage" : true,
+      "link_enable_webauthn_for_link_popup" : false,
+      "link_email_verification_login_enabled" : false,
+      "link_popup_webview_option" : "shared",
+      "link_targeting_results" : {
+        "payment_element_passthrough_mode" : null
+      },
+      "link_trusted_merchant_check_enabled" : false,
+      "link_global_holdback_on" : false,
+      "link_show_prefer_debit_card_hint" : false,
+      "link_local_storage_login_enabled" : false,
+      "link_payment_session_context" : null,
+      "link_session_storage_login_enabled" : false,
+      "link_brand" : "link",
+      "link_disable_in_safari_private_browsing" : false,
+      "link_mobile_disable_rux_in_flow_controller" : false,
+      "link_authenticated_change_event_enabled" : false,
+      "link_pm_killswitch_on_in_elements" : false,
+      "link_supported_payment_methods_onboarding_enabled" : [
+
+      ],
+      "link_hcaptcha_site_key" : null,
+      "link_payment_element_disable_signup" : false,
+      "link_enable_displayable_default_values_in_ece" : false,
+      "link_disable_email_otp" : false,
+      "link_hcaptcha_rqdata" : null,
+      "link_default_opt_in" : "NONE",
+      "link_supported_payment_methods" : [
+
+      ],
+      "link_mobile_disable_default_opt_in" : false,
+      "link_mode" : null,
+      "link_mobile_disable_signup" : false,
+      "link_popup_smart_defaults_enabled" : false
+    },
+    "passive_captcha" : {
+      "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+      "token_timeout_seconds" : 1770,
+      "rqdata" : null
+    },
+    "payment_method_configuration_id" : null,
+    "payment_method_specs" : [
+      {
+        "async" : false,
+        "type" : "card",
+        "fields" : [
+
+        ]
+      }
+    ],
+    "paypal_express_config" : {
+      "client_id" : null,
+      "client_token" : null,
+      "paypal_merchant_id" : null
+    },
+    "prefill_selectors" : {
+      "default_values" : {
+        "email" : [
+
+        ],
+        "merchant_provides_default_values_on_update" : true
+      }
+    },
+    "unactivated_payment_method_types" : [
+
+    ],
+    "order" : null,
+    "unverified_payment_methods_on_domain" : [
+      "apple_pay"
+    ],
+    "link_purchase_protections_data" : {
+      "type" : null,
+      "is_eligible" : false
+    },
+    "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+    "customer" : null,
+    "klarna_express_config" : {
+      "klarna_mid" : null
+    },
+    "lpm_killswitches" : {
+      "express_checkout" : [
+
+      ],
+      "payment_element" : [
+
+      ]
+    },
+    "business_name" : "CI Stuff",
+    "ordered_payment_method_types_and_wallets" : [
+      "card",
+      "apple_pay",
+      "google_pay"
+    ],
+    "customer_error" : null
+  },
+  "stripe_hosted_url" : "https:\/\/checkout.stripe.com\/c\/pay\/cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWkB3dnxIQEpRcGFWb1RXPW1tNVN3VHcwXTU1PXZHXUJKcDMnKSdjd2poVmB3c2B3Jz9xd3BgKSdnZGZuYndqcGthRmppancnPycmY2NjY2NjJyknaWR8anBxUXx1YCc%2FJ3Zsa2JpYFpscWBoJyknYGtkZ2lgVWlkZmBtamlhYHd2Jz9xd3BgeCUl",
+  "prefilled" : null,
+  "redirect_on_completion" : null,
+  "blob" : null,
+  "client_reference_id" : null,
+  "status" : "open",
+  "submit_type" : null,
+  "email_collection" : "always",
+  "permissions" : null,
+  "custom_fields" : [
+
+  ],
+  "phone_number_collection" : {
+    "enabled" : false
+  },
+  "livemode" : false,
+  "ordered_payment_method_types" : [
+    "card",
+    "apple_pay",
+    "google_pay"
+  ],
+  "state" : "active",
+  "currency" : "usd",
+  "subscription_data" : null,
+  "customer_managed_saved_payment_methods_offer_save" : null,
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping" : null,
+  "crypto_in_link_ui_enabled" : false,
+  "rqdata" : "lWcRdxEIq5ZA1gSVWY9G9zt0Jmo6siku8OjrEvswvJFG2SqnTMipO8vb9t+H3tMxsp6oaIIBYWDbxa9\/ev+xNakOBX2xTZgBLj60t\/xQtplIR0Sojs8JEDpJF6wJuw4qTMJVIy3kXxmgA4UaCcRzw\/x7W7FfFiBWSQkKVMNRQuQltme+oT1+zqnlunBZi+Eu\/67JTVvdRhS2zJH9FDgdPd0X8vorRSHo7oXv6xj0wlYAS9dEQzFyIT1kdoWgyPvZyPPIiYbBbQOBgye9beaTbberQG5wM6WD3hn8OVWVvOGwSIpMtclfAH9ZHw==kVqsim\/Kn0ke4RlL",
+  "total_summary" : {
+    "due" : 2000,
+    "subtotal" : 2000,
+    "total" : 2000
+  },
+  "on_behalf_of" : null,
+  "cross_sell_group" : null,
+  "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+  "checkout_multistep_ui" : false,
+  "eid" : "7E775055-E80C-4805-A843-18D13E99D6DB",
+  "line_item_group" : {
+    "total" : 2000,
+    "line_items" : [
+      {
+        "id" : "li_1TluQgFY0qyl6XeWUgHmc79h",
+        "description" : null,
+        "discount_amounts" : [
+
+        ],
+        "quantity" : 1,
+        "is_removable" : false,
+        "total" : 2000,
+        "tax_amounts" : [
+
+        ],
+        "subtotal" : 2000,
+        "cross_sell_from" : null,
+        "object" : "item",
+        "price" : {
+          "id" : "price_1TluQgFY0qyl6XeW8830FxO3",
+          "livemode" : false,
+          "active" : false,
+          "product" : {
+            "object" : "product",
+            "active" : false,
+            "addons" : null,
+            "id" : "prod_TnUMNVDoRiDXJx",
+            "images" : [
+
+            ],
+            "livemode" : false,
+            "url" : null,
+            "attributes" : [
+
+            ],
+            "description" : null,
+            "name" : "Test",
+            "unit_label" : null
+          },
+          "tax_behavior" : "exclusive",
+          "custom_unit_amount" : null,
+          "transform_quantity" : null,
+          "type" : "one_time",
+          "unit_amount" : 2000,
+          "unit_amount_decimal" : "2000",
+          "object" : "price",
+          "billing_scheme" : "per_unit",
+          "recurring" : null,
+          "currency" : "usd",
+          "tiers_mode" : null
+        },
+        "adjustable_quantity" : null,
+        "images" : null,
+        "unit_amount_override" : null,
+        "name" : "Test"
+      }
+    ],
+    "shipping_rate" : null,
+    "applied_credits" : [
+
+    ],
+    "subtotal" : 2000,
+    "discount_amounts" : [
+
+    ],
+    "currency" : "usd",
+    "tax_amounts" : [
+
+    ],
+    "due" : 2000
+  },
+  "managed_payments" : {
+    "enabled" : false
+  },
+  "name_collection" : null,
+  "payment_intent" : null,
+  "config_id" : "d9ab2311-6cf8-4c80-b991-b5800ceb472e",
+  "is_sandbox_merchant" : false
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0005_post_v1_payment_pages_cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testUpdatePaymentMethodExpiry/0005_post_v1_payment_pages_cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I.tail
@@ -1,0 +1,978 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_pages\/cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=-nCK4Yv3TA7U0spIczH0HCqaHRm8ItG1fshWea-lKdQaJ97P38ZT8F2P1OaB5uadQ_7zMSFJMiTC04lH; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=-nCK4Yv3TA7U0spIczH0HCqaHRm8ItG1fshWea-lKdQaJ97P38ZT8F2P1OaB5uadQ_7zMSFJMiTC04lH&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-05-27.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=-nCK4Yv3TA7U0spIczH0HCqaHRm8ItG1fshWea-lKdQaJ97P38ZT8F2P1OaB5uadQ_7zMSFJMiTC04lH&t=1"}],"include_subdomains":true}
+request-id: req_xSLv7CM1NfsmtI
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 33712
+Vary: Origin
+Date: Wed, 24 Jun 2026 17:17:40 GMT
+original-request: req_xSLv7CM1NfsmtI
+stripe-version: 2020-08-27
+idempotency-key: d88237da-081a-4c19-b49e-ff56f003c42a
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: elements_session_client\[is_aggregation_expected]=true&payment_method_to_update%5Bexpiry_details%5D%5Bexp_month%5D=6&payment_method_to_update%5Bexpiry_details%5D%5Bexp_year%5D=2029&payment_method_to_update%5Bpayment_method_id%5D=pm_1TluQfFY0qyl6XeW96NVVHzU
+
+{
+  "lpm_settings" : null,
+  "sepa_debit_info" : null,
+  "automatic_payment_method_types" : false,
+  "is_unclaimed_anonymous_sandbox" : false,
+  "tax_context" : {
+    "automatic_tax_error" : null,
+    "automatic_tax_enabled" : false,
+    "automatic_tax_taxability_reason" : null,
+    "dynamic_tax_enabled" : false,
+    "tax_id_collection_enabled" : false,
+    "automatic_tax_exempt" : "none",
+    "customer_tax_country" : null,
+    "tax_id_collection_required" : "never",
+    "has_maximum_tax_ids" : false,
+    "automatic_tax_address_source" : null
+  },
+  "payment_method_types" : [
+    "card"
+  ],
+  "payment_method_options" : {
+    "card" : {
+      "request_three_d_secure" : "automatic"
+    }
+  },
+  "bnpl_in_link_ui_enabled" : false,
+  "consent_collection" : null,
+  "experiment_data" : [
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs_aa",
+      "event_id" : "a4cd0a2b-d0c6-4861-9f9a-d04e7ed928f7",
+      "exposure_event_name" : ""
+    },
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs",
+      "event_id" : "b29dd951-77db-4bbd-a5e1-1b3cc74fd199",
+      "exposure_event_name" : ""
+    }
+  ],
+  "origin_context" : null,
+  "enforcement_mode" : "open",
+  "blocked_billing_address_countries" : [
+
+  ],
+  "id" : "ppage_1TluQgFY0qyl6XeW8CF9XrAf",
+  "subscription_settings" : null,
+  "consent" : null,
+  "does_not_collect_postal_code_for_non_us_card_transactions" : false,
+  "use_payment_methods" : true,
+  "application" : null,
+  "payment_method_collection" : "if_required",
+  "setup_intent" : null,
+  "shipping_options" : [
+
+  ],
+  "setup_future_usage_for_payment_method_type" : {
+    "card" : "on_session"
+  },
+  "capture_method" : "automatic_async",
+  "statement_descriptor" : "mobile",
+  "session_id" : "cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I",
+  "shipping_address_collection" : null,
+  "konbini_confirmation_number" : null,
+  "setup_future_usage" : "on_session",
+  "invoice_creation" : {
+    "enabled" : false
+  },
+  "has_dynamic_tax_rates" : false,
+  "receipt_emails_enabled" : false,
+  "link_settings" : {
+    "link_consumer_incentive" : null,
+    "link_payment_session_context" : null,
+    "consumer_found" : null,
+    "hcaptcha_rqdata" : null,
+    "link_supported_payment_methods_onboarding_enabled" : [
+
+    ],
+    "enable_partner_lookup" : false,
+    "link_us_bank_account_funding_source_enabled" : false,
+    "link_funding_sources" : [
+
+    ],
+    "hcaptcha_site_key" : null,
+    "link_brand" : "link",
+    "link_mode" : null,
+    "link_supported_payment_methods" : [
+
+    ]
+  },
+  "object" : "checkout.session",
+  "customer" : {
+    "object" : "customer",
+    "phone" : null,
+    "tax_ids" : [
+
+    ],
+    "id" : "cus_UlRJ4Dd9utegB7",
+    "business_name" : null,
+    "payment_methods" : [
+
+    ],
+    "email" : null,
+    "has_fallback_payment_method" : false,
+    "individual_name" : null,
+    "customer_provided" : true,
+    "name" : null
+  },
+  "shipping_rate" : null,
+  "success_url" : null,
+  "utm_codes" : null,
+  "beta_versions" : null,
+  "has_async_attached_payment_method" : false,
+  "feature_flags" : {
+    "checkout_enable_pay_by_bank_remember_bank_selection" : true,
+    "checkout_link_phone_registration_treatment_1_enabled" : true,
+    "sandboxes_rebrand_testmode" : true,
+    "checkout_enable_new_google_places_api" : true,
+    "checkout_link_enable_mfa" : true,
+    "checkout_link_purchase_protections_rollout" : true,
+    "checkout_tide_remount_override_replay" : true,
+    "checkout_optional_items" : true,
+    "checkout_link_in_habanero_enabled" : true,
+    "enable_custom_checkout_name_collection" : true,
+    "ocs_payment_prompt_for_agents" : true,
+    "checkout_passive_captcha" : true,
+    "checkout_enable_link_api_passive_hcaptcha" : true,
+    "checkout_hcaptcha_redundancy_control_enabled" : true,
+    "checkout_address_autocomplete_enabled" : true,
+    "checkout_enable_link_api_hcaptcha_rqdata" : true,
+    "checkout_show_swish_factoring_notice" : true
+  },
+  "locale" : null,
+  "custom_text" : {
+    "shipping_address" : null,
+    "terms_of_service_acceptance" : null,
+    "submit" : null,
+    "after_submit" : null
+  },
+  "route_to_orchestration_interface" : false,
+  "customer_email" : null,
+  "custom_components" : [
+
+  ],
+  "ui_mode" : "custom",
+  "url" : null,
+  "developer_tool_context" : {
+    "disabled_third_party_wallets" : {
+      "LINK_BUTTON" : {
+        "disabled_reason" : "merchant_payment_methods_settings"
+      },
+      "KLARNA_EXPRESS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "PAYPAL_ECS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "AMAZON_PAY" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      }
+    },
+    "adaptive_pricing" : {
+      "reason" : "not_allowed_for_ui",
+      "active" : false
+    },
+    "payment_method_configuration_details" : null
+  },
+  "token_notification_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "init_checksum" : "mSIMdDCefVTd23ebLFMLLDtPak7Iw7PV",
+  "tax_exclusion_from_total_is_allowed" : false,
+  "bnpl_link_experiment_payment_method_type" : null,
+  "tax_meta" : {
+    "status" : "complete",
+    "error_reason" : null,
+    "computation_type" : "manual",
+    "customer_tax_exempt" : "none"
+  },
+  "payment_status" : "unpaid",
+  "enabled_third_party_wallets" : [
+    {
+      "apple_pay" : {
+        "required_version" : 2
+      },
+      "id" : "APPLE_PAY",
+      "enabled" : true,
+      "carousel_enabled" : true
+    },
+    {
+      "id" : "GOOGLE_PAY",
+      "enabled" : true,
+      "google_pay" : {
+        "id" : "GOOGLE_PAY",
+        "version_minor" : 0,
+        "version_major" : 2
+      },
+      "carousel_enabled" : false
+    },
+    {
+      "id" : "AMAZON_PAY",
+      "carousel_enabled" : false,
+      "enabled" : false
+    },
+    {
+      "id" : "KLARNA_EXPRESS",
+      "carousel_enabled" : false,
+      "enabled" : false
+    }
+  ],
+  "klarna_info" : null,
+  "visible_custom_component_locations" : [
+    "checkout_form_before",
+    "checkout_form_after",
+    "submit_button_before",
+    "submit_button_after",
+    "contact_before",
+    "contact_after",
+    "express_checkout_before",
+    "express_checkout_after",
+    "payment_details_before",
+    "payment_details_after"
+  ],
+  "display_consent_collection_promotions" : false,
+  "policies" : {
+    "contacts" : {
+      "display_phone" : true,
+      "display_url" : true,
+      "enabled" : false,
+      "display_email" : true
+    },
+    "legal" : {
+      "agreement_required" : false,
+      "enabled" : false
+    },
+    "returns" : {
+      "custom_message" : null,
+      "exchanges_accepted" : false,
+      "returns_accepted" : null,
+      "fee_type" : null,
+      "fee_required" : null,
+      "policy_url" : null,
+      "window_start" : null,
+      "refunds_accepted" : null,
+      "window" : null,
+      "enabled" : false,
+      "exceptions_apply" : false,
+      "logistics" : [
+
+      ]
+    }
+  },
+  "card_brands" : {
+    "mastercard" : true,
+    "link" : true,
+    "carnet" : false,
+    "accel" : false,
+    "elo" : false,
+    "rupay" : false,
+    "maestro" : false,
+    "unionpay" : true,
+    "amex" : true,
+    "jaywan" : false,
+    "conecs" : false,
+    "jcb" : true,
+    "visa" : true,
+    "cartes_bancaires" : false,
+    "pulse" : false,
+    "discover" : true,
+    "star" : false,
+    "eftpos_au" : false,
+    "diners" : true,
+    "girocard" : false,
+    "nyce" : false
+  },
+  "geocoding" : {
+    "country_code" : "US",
+    "region_name" : "UT"
+  },
+  "account_settings" : {
+    "assets" : {
+      "use_logo" : false,
+      "icon" : null,
+      "logo" : null
+    },
+    "specified_commercial_transactions_act_url" : null,
+    "business_url" : "https:\/\/github.com\/stripe\/stripe-ios",
+    "privacy_policy_url" : null,
+    "branding" : {
+      "button_color" : "#0074d4",
+      "background_color" : "#ffffff",
+      "border_style" : "default",
+      "font_family" : "default"
+    },
+    "statement_descriptor" : "mobile",
+    "support_email" : null,
+    "display_name" : "CI Stuff",
+    "merchant_of_record_country" : "US",
+    "order_summary_display_name" : "CI Stuff",
+    "support_phone" : "+12105550123",
+    "merchant_of_record_display_name" : "CI Stuff",
+    "support_url" : null,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "country" : "US",
+    "terms_of_service_url" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "server_built_elements_session_params" : {
+    "expand" : [
+
+    ],
+    "checkout_session_id" : "cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I",
+    "client_betas" : [
+
+    ],
+    "deferred_intent" : {
+      "amount" : 2000,
+      "capture_method" : "automatic_async",
+      "currency" : "usd",
+      "payment_method_types" : [
+        "card"
+      ],
+      "setup_future_usage" : "on_session",
+      "mode" : "payment"
+    },
+    "country_override" : "US",
+    "type" : "deferred_intent"
+  },
+  "shipping_tax_amounts" : [
+
+  ],
+  "billing_address_collection" : null,
+  "elements_options" : {
+    "amount" : 2000,
+    "mode" : "payment",
+    "__checkout_country_override" : "US",
+    "__checkout_session_id" : "cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I",
+    "__payment_pages_experiments" : [
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs_aa",
+        "event_id" : "a4cd0a2b-d0c6-4861-9f9a-d04e7ed928f7",
+        "exposure_event_name" : ""
+      },
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs",
+        "event_id" : "b29dd951-77db-4bbd-a5e1-1b3cc74fd199",
+        "exposure_event_name" : ""
+      }
+    ],
+    "capture_method" : "automatic_async",
+    "payment_method_types" : [
+      "card"
+    ],
+    "setup_future_usage" : "on_session",
+    "currency" : "usd"
+  },
+  "experiments_data" : {
+    "event_id" : "6f682214-4c5e-49a6-974f-66ec8a7c9552",
+    "experiment_metadata" : {
+      "ocs_buyer_xp_cpl_lpm_holdback" : {
+        "heldback_special_wallets" : [
+
+        ]
+      }
+    },
+    "experiment_assignments" : {
+      "ocs_buyer_xp_cpl_separate_wallet_accordion" : "control",
+      "emea_wallets_ideal_wero_rebranding" : "control",
+      "ocs_buyer_xp_cpl_apple_pay_in_non_safari" : "control",
+      "ocs_buyer_xp_cpl_embedded_pay_button" : "control",
+      "ff_checkout_cpl_lid_promo_badge_color_opt" : "treatment",
+      "cpl_spicy_guacamole" : "control",
+      "ff_checkout_optimized_image_eff" : "control",
+      "connections_checkout_us_bank_account_picker_icons" : "control",
+      "ocs_buyer_xp_cpl_progressive_ece" : "control",
+      "ocs_buyer_xp_cpl_single_column_checkout" : "control",
+      "checkout_li_larger_image_size" : "control",
+      "link_ab_test_aa" : "control",
+      "ocs_buyer_xp_cpl_terms_above_submit" : "control",
+      "ocs_buyer_xp_cpl_currency_symbol_optimization" : "control",
+      "smor_checkout_ui_iteration" : "control",
+      "checkout_link_instant_debits_accordion_logos" : "control",
+      "checkout_enable_real_time_tax_id_verification_experiment" : "control",
+      "ff_checkout_test_frontend_eff" : "control",
+      "ocs_buyer_xp_cpl_link_signup_in_form" : "control",
+      "ocs_buyer_xp_remove_name_field_guac_related_pms" : "control",
+      "link_risk_based_disable_auto_prompting_checkout" : "control",
+      "ocs_buyer_xp_cpl_apple_pay_button_type" : "control",
+      "cpl_guacamole" : "control",
+      "ocs_buyer_xp_cpl_ece_kakao_naver" : "control",
+      "ocs_buyer_xp_cpl_lpm_content_simplification" : "control"
+    }
+  },
+  "return_url" : "https:\/\/example.com\/return",
+  "mode" : "payment",
+  "cancel_url" : null,
+  "elements_session" : {
+    "payment_method_preference" : {
+      "country_code" : "US",
+      "object" : "payment_method_preference",
+      "type" : "deferred_intent",
+      "ordered_payment_method_types" : [
+        "card"
+      ]
+    },
+    "capability_enabled_card_networks" : [
+      "cartes_bancaires",
+      "jcb",
+      "diners",
+      "discover"
+    ],
+    "flags" : {
+      "enable_tax_id_suspicious_pattern_check" : false,
+      "elements_easel_enable_elements_inspector_for_advanced_integrations_backend" : true,
+      "link_enable_signup_in_summary_in_habanero" : true,
+      "financial_connections_enable_deferred_intent_flow" : true,
+      "elements_enable_remove_last_validation" : true,
+      "ocs_payment_prompt_for_agents" : true,
+      "apple_pay_prb_killswitch" : false,
+      "elements_enable_easel_for_pi" : true,
+      "elements_mobile_card_funding_filtering" : true,
+      "link_payment_element_minor_signup_ui_updates" : false,
+      "link_enable_ncdv_usage_id_selectors_l3" : true,
+      "elements_disable_express_checkout_button_amazon_pay" : false,
+      "elements_easel_disable_appearance_api" : false,
+      "link_auth_partner_enable_link_auth_token_login" : true,
+      "link_enable_ncdv_recall_id_selectors_l3" : true,
+      "elements_disable_link_email_otp" : false,
+      "restrict_taxid_selection_to_buyer_address" : false,
+      "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
+      "ocs_buyer_xp_elements_card_brand_choice_toggle" : false,
+      "paypal_billing_address_support_in_ece" : true,
+      "elements_enable_pay_by_bank_remember_bank_selection" : true,
+      "link_auth_partner_enable_ios_instagram" : true,
+      "link_user_action_attempt_login_using_stored_credentials" : true,
+      "elements_disable_sepa_debit_eea_address_requirement" : false,
+      "elements_enable_instant_debits_postal_code_collection" : false,
+      "elements_financial_connections_canada_enabled" : false,
+      "elements_easel_disable_feedback" : false,
+      "link_enable_link_session_key_financial_connections" : false,
+      "elements_extend_hcaptcha_refresh_time" : true,
+      "link_auth_partner_consume_link_auth_intent" : true,
+      "ocs_buyer_xp_elements_remove_cpm_redirect_text" : false,
+      "elements_enable_south_korea_market_underlying_pms" : false,
+      "link_payment_element_steerage_enabled" : true,
+      "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text" : false,
+      "link_enable_apple_pay_in_safari_returning_in_guacamole" : false,
+      "elements_disable_payment_element_card_country_zip_validations" : false,
+      "link_payment_element_default_value_auto_open_modal" : true,
+      "elements_enable_link_card_brand_in_saved_payment_methods" : true,
+      "elements_disable_link_global_holdback_lookup" : false,
+      "financial_connections_enable_ca_accounts" : false,
+      "elements_apple_pay_inner_use_pending_payment_overrides" : false,
+      "link_enable_link_session_key_klarna" : false,
+      "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : true,
+      "elements_easel_disable_address_fill" : false,
+      "ocs_buyer_xp_elements_remove_redirect_lpm_content" : false,
+      "adaptive_pricing_hip_currency_selector_change_event" : true,
+      "elements_enable_payment_method_options_setup_future_usage" : true,
+      "enable_custom_checkout_currency_selector_element" : false,
+      "elements_mobile_android_tap_to_add_enabled" : false,
+      "link_enable_address_country_restrictions" : false,
+      "link_auth_partner_enable_android_fb" : true,
+      "checkout_kr_lpm_no_billing_address_collection" : false,
+      "elements_easel_disable_health_check" : false,
+      "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
+      "elements_disable_paypal_express" : false,
+      "disable_confirmation_modal_bacs" : false,
+      "legacy_customer_session_payment_element_features" : false,
+      "elements_enable_terms_element" : false,
+      "link_auth_partner_enable_authentication_element" : true,
+      "elements_allow_manual_payment_method_creation_with_spm" : false,
+      "elements_easel_disable" : false,
+      "link_enable_auth_partner_communication" : true,
+      "elements_apply_amex_icon_sorting" : false,
+      "elements_hide_card_brand_icons" : false,
+      "link_auth_partner_enable_distinctly_link_ios_facebook" : true,
+      "elements_easel_disable_customer_location_mocking" : false,
+      "elements_easel_disable_position_customization" : false,
+      "elements_enable_appearance_recompute" : false,
+      "link_enable_link_session_key_confirm_and_start_verification" : false,
+      "enable_link_lpm_dual_enablement" : false,
+      "elements_enable_19_digit_pans" : false,
+      "always_show_ece_paypal_recurring_button" : false,
+      "elements_enable_interac_apple_pay" : true,
+      "enable_payment_method_api_shop_pay" : true,
+      "enable_elements_tax_id_type_filtering" : false,
+      "elements_human_security_enabled" : false,
+      "link_enable_white_ece_button_theme" : false,
+      "link_in_accordion_layout_available_in_stripejs" : false,
+      "link_payment_element_widget_view_enabled" : true,
+      "elements_easel_disable_magic_fill" : false,
+      "avoid_redundant_billing_details_for_klarna" : false,
+      "distinctly_link_payment_element_ramp" : true,
+      "link_enable_ewcs_customer_name_prefill" : false,
+      "link_auth_partner_bypass_bridge_check" : false,
+      "link_disable_cookie_login" : false,
+      "elements_disable_express_checkout_button_shop_pay" : false,
+      "payment_element_link_modal_preload_killswitch" : false,
+      "link_enable_pass_checkout_session_id_to_signup" : true,
+      "elements_enable_hcaptcha_async_token_logging" : false,
+      "elements_enable_jp_card_installments" : true,
+      "elements_show_expanded_spm" : false,
+      "disable_payment_element_if_required_billing_config" : false,
+      "elements_enable_link_otp_takeover_in_guacamole" : false,
+      "elements_enable_link_spm" : true,
+      "elements_enable_read_allow_redisplay" : false,
+      "elements_enable_save_for_future_payments_pre_check" : false,
+      "link_forest_enable_ece_bank_use_shipping_as_billing" : false,
+      "elements_disable_express_checkout_button_klarna" : false,
+      "distinctly_link_cbc_killswitch" : false,
+      "elements_prefer_fc_lite" : false,
+      "elements_disable_payment_element_custom_payment_methods_byof" : false,
+      "elements_mobile_cardscan_use_mlkit" : true,
+      "elements_enable_link_takeover_in_guacamole" : false,
+      "link_disable_auth_partner_ua_check" : false,
+      "link_enable_link_session_key_incentives_and_status" : false,
+      "elements_easel_disable_optimizations_check" : false,
+      "elements_enable_passive_captcha" : true,
+      "distinctly_link_payment_element_opt_out_merchant_blocklist" : false,
+      "link_enable_non_blocking_doi_signup" : false,
+      "elements_enable_new_google_places_api" : true,
+      "checkout_form_automatic_tax_address_collection_precision" : false,
+      "elements_enable_express_checkout_button_demo_pay" : false,
+      "disable_cbc_in_link_popup" : false,
+      "elements_enable_installments_on_deferred_intents" : true,
+      "elements_sepa_debit_instant_microdeposits" : false,
+      "ocs_buyer_xp_elements_remove_generic_footer" : false,
+      "elements_spm_set_as_default" : true,
+      "elements_does_not_collect_postal_code_for_non_us_card_transactions_killswitch" : false,
+      "link_disable_login_if_signed_up_outside_of_elements" : true,
+      "elements_enable_link_autofill_prompt_padding_fix" : false,
+      "elements_mobile_attest_on_intent_confirmation" : false,
+      "link_trusted_origin_skip_secure_click" : true,
+      "elements_stop_move_focus_to_first_errored_field" : true,
+      "ocs_buyer_xp_enable_payment_element_accordion_box_shadow" : false,
+      "elements_enable_customer_address" : false,
+      "elements_enable_card_metadata" : true,
+      "elements_mobile_allow_stripecardscan" : false,
+      "elements_use_checkout_app_id_for_human_security" : false,
+      "sandboxes_rebrand_testmode" : true,
+      "bancontact_name_optional_one_time" : false,
+      "link_enable_card_brand_choice" : true,
+      "link_payment_element_keep_optional_doi_open_rollout" : true,
+      "adaptive_pricing_for_elements_with_payment_intents" : false,
+      "elements_allow_custom_payment_method_creation" : false,
+      "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+      "elements_mobile_link_inline_signup_with_saved_pm_enabled" : false,
+      "link_purchase_protections_rollout" : true,
+      "show_swish_factoring_notice" : true,
+      "elements_disable_fc_lite" : false,
+      "link_auth_partner_delay_recognition" : true,
+      "elements_enable_payment_element_custom_payment_methods_byof" : false,
+      "ocs_mobile_should_use_autocomplete_proxy_endpoints" : true,
+      "elements_enable_nme_for_us_bank_account_skip_verification" : false,
+      "ocs_buyer_xp_elements_remove_wallets_redirect_text" : false,
+      "elements_easel_enable_elements_inspector" : true,
+      "elements_google_pay_mit_fields" : false,
+      "apple_pay_pe_killswitch" : false,
+      "paypal_phone_number_support_in_ece" : false,
+      "elements_enable_pay_by_bank_multi_country_bank_selector_rollout_countries" : false,
+      "elements_easel_disable_payment_fill" : false,
+      "elements_easel_disable_tax_id_fill" : false,
+      "elements_spm_max_visible_payment_methods" : false,
+      "id_bank_transfers_v1_integration" : false,
+      "elements_enable_mx_card_installments" : true,
+      "elements_easel_disable_appearance_api_per_element_options" : true,
+      "elements_enable_easel_for_pi_killswitch" : false,
+      "link_enable_link_session_key_shipping_addresses" : false,
+      "enable_pe_options_for_billing_details_collection" : false,
+      "elements_spm_messages" : false,
+      "elements_easel_disable_session_summary" : false,
+      "apple_pay_ece_killswitch" : false,
+      "distinctly_link_pe_purchase_protection" : true,
+      "link_enable_link_session_key_consumer_person_details" : false,
+      "link_auth_partner_enable_distinctly_link_android_fb" : true,
+      "link_auth_partner_delay_android_fb_cookie_login" : false,
+      "elements_ae_hide_name_field" : false,
+      "legacy_confirmation_tokens" : false,
+      "link_auth_partner_enable_distinctly_link_ios_instagram" : false,
+      "elements_easel_disable_elements_inspector_for_pi" : false,
+      "link_auth_partner_enable_ece" : true,
+      "link_enable_link_session_key_payment_details" : false,
+      "distinctly_link_pe_backup_payment_method" : true,
+      "link_dedupe_shipping_address_creation" : true,
+      "ece_apple_pay_payment_request_passthrough" : false,
+      "checkout_link_pay_token_enabled" : false,
+      "link_enable_link_session_key_link_onboarding_session" : false,
+      "elements_mobile_force_vertical_payment_method_layout" : false,
+      "payto_enable_modal_in_payment_element" : true,
+      "checkout_link_in_habanero_enabled" : true,
+      "elements_disable_progressive_cursor" : false,
+      "link_enable_auth_partner_sizing_logging" : true,
+      "enable_checkout_session_update_customer" : false
+    },
+    "merchant_logo_url" : null,
+    "session_id" : "elements_session_1eUzrqCb9zw",
+    "card_installments_enabled" : false,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "config_id" : "083903a4-a795-4086-8d36-42078660ddd9",
+    "merchant_currency" : "usd",
+    "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+    "card_brand_choice" : {
+      "eligible" : false,
+      "preferred_networks" : [
+        "cartes_bancaires"
+      ],
+      "supported_cobranded_networks" : {
+        "cartes_bancaires" : false
+      }
+    },
+    "shipping_address_settings" : {
+      "autocomplete_allowed" : false
+    },
+    "external_payment_method_data" : null,
+    "custom_payment_method_data" : null,
+    "meta_pay_signed_container_context" : null,
+    "apple_pay_preference" : "enabled",
+    "country_override" : "US",
+    "managed_payments_enabled" : false,
+    "google_pay_preference" : "enabled",
+    "merchant_country" : "US",
+    "experiments_data" : {
+      "arb_id" : "43178e1b-c367-48e6-8d17-d65b0c1eb2f7",
+      "experiment_metadata" : {
+        "seed" : "1a9b1bb606a182c72328e7724107a9701e36ef6ea116c63bac0f7ca9684d0ba3",
+        "semi_dominant_payment_methods" : [
+
+        ],
+        "lpm_holdback_t1_payment_methods" : [
+
+        ],
+        "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false,
+        "lpm_holdback_t2_payment_methods" : [
+
+        ]
+      },
+      "experiment_assignments" : {
+        "link_spm_show_checkbox_signup_aa" : "control",
+        "link_optional_doi_signup_holdback" : "control",
+        "link_ab_test_aa" : "control",
+        "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : "control",
+        "ocs_mobile_horizontal_mode" : "control",
+        "link_sign_up_form_container_aa" : "control",
+        "ff_elements_apple_pay_inner_use_pending_payment_overrides_eff" : "control",
+        "link_spm_show_checkbox_signup" : "control",
+        "pbb_bank_credential_hint_elements" : "control",
+        "ocs_mobile_card_art" : "control",
+        "link_ece_unrecognized_button_text_aa" : "control",
+        "link_ulm_in_ece" : "control",
+        "ibp_bank_tab_name" : "control",
+        "paypal_payment_handler" : "control",
+        "link_pe_signup_copy_aa" : "control",
+        "ibp_bank_tab_name_aa" : "control",
+        "link_ce_conversion_cookie_aa" : "control",
+        "link_dl_pe_inline_entrypoint_aa" : "control",
+        "link_sign_up_form_container" : "control",
+        "link_ulm_in_ece_aa" : "control",
+        "link_ece_unrecognized_button_text" : "control",
+        "link_ce_conversion_unrecognized_aa" : "control",
+        "link_pe_signup_copy" : "control",
+        "ocs_mobile_horizontal_mode_aa" : "control",
+        "connections_elements_variable_incentives_for_ibp_recurring_payments" : "control",
+        "link_ce_conversion_ncdv_aa" : "control",
+        "link_ce_conversion_unrecognized_copy_change" : "control",
+        "link_ce_conversion_unrecognized_post_entry_aa" : "control",
+        "link_pe_signup_green_logo" : "control",
+        "link_dl_pe_inline_entrypoint" : "control",
+        "ff_elements_test_frontend_eff" : "control",
+        "link_pe_signup_green_logo_aa" : "control",
+        "link_optional_doi_signup_holdback_aa" : "control",
+        "link_ce_conversion_responsive_button" : "control",
+        "ibp_localized_featured_institutions_accordion" : "control",
+        "elements_hcaptcha_init_timeout" : "control",
+        "link_ce_conversion_recognized_loading_animation" : "control",
+        "link_signup_name_from_billing_ae" : "control",
+        "ocs_buyer_xp_elements_apple_pay_in_non_safari" : "control"
+      }
+    },
+    "legacy_customer" : null,
+    "link_settings" : {
+      "link_passthrough_mode_enabled" : false,
+      "link_payment_element_smart_defaults_enabled" : false,
+      "link_mobile_attestation_state_sync_enabled" : false,
+      "link_no_code_default_values_recall" : true,
+      "link_funding_sources" : [
+
+      ],
+      "link_crypto_onramp_force_cvc_reverification" : false,
+      "link_enable_signup_in_express_checkout_element" : false,
+      "link_wanderlust_in_elements_enabled" : false,
+      "link_consumer_incentive" : null,
+      "link_crypto_onramp_bank_upsell" : false,
+      "link_ece_browser_compatibility_override" : false,
+      "link_enable_email_otp_for_link_popup" : false,
+      "link_crypto_onramp_elements_logout_disabled" : false,
+      "link_popup_enable_new_google_places_api" : false,
+      "link_no_code_default_values_identification" : true,
+      "link_pay_button_element_enabled" : true,
+      "link_payment_element_enable_webauthn_login" : false,
+      "link_bank_onboarding_enabled" : false,
+      "link_enable_instant_debits_in_testmode" : false,
+      "link_payment_element_disabled_by_targeting" : false,
+      "link_sign_up_opt_in_feature_enabled" : false,
+      "link_only_for_payment_method_types_enabled" : false,
+      "link_disabled_reasons" : {
+        "payment_element_payment_method_mode" : [
+          "link_not_specified_in_payment_method_types"
+        ],
+        "payment_element_passthrough_mode" : [
+          "link_not_enabled_on_payment_config"
+        ]
+      },
+      "link_sign_up_opt_in_initial_value" : false,
+      "link_mobile_use_attestation_endpoints" : false,
+      "link_elements_pageload_sign_up_disabled" : false,
+      "link_disable_pe_signup_prompt" : false,
+      "link_elements_is_crypto_onramp" : false,
+      "link_no_code_default_values_usage" : true,
+      "link_enable_webauthn_for_link_popup" : false,
+      "link_email_verification_login_enabled" : false,
+      "link_popup_webview_option" : "shared",
+      "link_targeting_results" : {
+        "payment_element_passthrough_mode" : null
+      },
+      "link_trusted_merchant_check_enabled" : false,
+      "link_global_holdback_on" : false,
+      "link_show_prefer_debit_card_hint" : false,
+      "link_local_storage_login_enabled" : false,
+      "link_payment_session_context" : null,
+      "link_session_storage_login_enabled" : false,
+      "link_brand" : "link",
+      "link_disable_in_safari_private_browsing" : false,
+      "link_mobile_disable_rux_in_flow_controller" : false,
+      "link_authenticated_change_event_enabled" : false,
+      "link_pm_killswitch_on_in_elements" : false,
+      "link_supported_payment_methods_onboarding_enabled" : [
+
+      ],
+      "link_hcaptcha_site_key" : null,
+      "link_payment_element_disable_signup" : false,
+      "link_enable_displayable_default_values_in_ece" : false,
+      "link_disable_email_otp" : false,
+      "link_hcaptcha_rqdata" : null,
+      "link_default_opt_in" : "NONE",
+      "link_supported_payment_methods" : [
+
+      ],
+      "link_mobile_disable_default_opt_in" : false,
+      "link_mode" : null,
+      "link_mobile_disable_signup" : false,
+      "link_popup_smart_defaults_enabled" : false
+    },
+    "passive_captcha" : {
+      "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+      "token_timeout_seconds" : 1770,
+      "rqdata" : null
+    },
+    "payment_method_configuration_id" : null,
+    "payment_method_specs" : [
+      {
+        "async" : false,
+        "type" : "card",
+        "fields" : [
+
+        ]
+      }
+    ],
+    "paypal_express_config" : {
+      "client_id" : null,
+      "client_token" : null,
+      "paypal_merchant_id" : null
+    },
+    "prefill_selectors" : {
+      "default_values" : {
+        "email" : [
+
+        ],
+        "merchant_provides_default_values_on_update" : true
+      }
+    },
+    "unactivated_payment_method_types" : [
+
+    ],
+    "order" : null,
+    "unverified_payment_methods_on_domain" : [
+      "apple_pay"
+    ],
+    "link_purchase_protections_data" : {
+      "type" : null,
+      "is_eligible" : false
+    },
+    "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+    "customer" : null,
+    "klarna_express_config" : {
+      "klarna_mid" : null
+    },
+    "lpm_killswitches" : {
+      "express_checkout" : [
+
+      ],
+      "payment_element" : [
+
+      ]
+    },
+    "business_name" : "CI Stuff",
+    "ordered_payment_method_types_and_wallets" : [
+      "card",
+      "apple_pay",
+      "google_pay"
+    ],
+    "customer_error" : null
+  },
+  "stripe_hosted_url" : "https:\/\/checkout.stripe.com\/c\/pay\/cs_test_a1Teybf223vKqWNpFWpx1PLIjGRgCdkxY8ZHscJMAXGCwoKYlZlP9uw04I#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWkB3dnxIQEpRcGFWb1RXPW1tNVN3VHcwXTU1PXZHXUJKcDMnKSdjd2poVmB3c2B3Jz9xd3BgKSdnZGZuYndqcGthRmppancnPycmY2NjY2NjJyknaWR8anBxUXx1YCc%2FJ3Zsa2JpYFpscWBoJyknYGtkZ2lgVWlkZmBtamlhYHd2Jz9xd3BgeCUl",
+  "prefilled" : null,
+  "redirect_on_completion" : null,
+  "blob" : null,
+  "client_reference_id" : null,
+  "status" : "open",
+  "submit_type" : null,
+  "email_collection" : "always",
+  "permissions" : null,
+  "custom_fields" : [
+
+  ],
+  "phone_number_collection" : {
+    "enabled" : false
+  },
+  "livemode" : false,
+  "ordered_payment_method_types" : [
+    "card",
+    "apple_pay",
+    "google_pay"
+  ],
+  "state" : "active",
+  "currency" : "usd",
+  "subscription_data" : null,
+  "customer_managed_saved_payment_methods_offer_save" : null,
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping" : null,
+  "crypto_in_link_ui_enabled" : false,
+  "rqdata" : "C4kR0o+6td59pmyoMYKrCYP2cuCwLQRDokef4gZLkSK8lALExRCe+GSxN9wFhuoXMSrfLYSF+MjLUm5ehV7mM5tJGOOpJaTppBXVbMyaf6jvzGFM+XO+mkmuLrdLKSNUHt+mGW2Zn9K7KXO0C+RG7GrIntHY\/F7wdMpdfE6vNRmMi7UqJNRqQzM8RyEYSSJs6Uc9SZyoi8EjL3kWL4OcQ28UBn0SsOpk0\/hPC\/MYaKyKQ5AbMiDPiOr5sAEKWGZkFEoVZs+GbThHBb8GnEHEPdFanibmps9GgEBhWP6b1sau5ThtVVNuEquvyQ==LyuHH9MXZ4VINrnK",
+  "total_summary" : {
+    "due" : 2000,
+    "subtotal" : 2000,
+    "total" : 2000
+  },
+  "on_behalf_of" : null,
+  "cross_sell_group" : null,
+  "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+  "checkout_multistep_ui" : false,
+  "eid" : "cf45e538-a53e-40bd-95a4-fe39c05144e6",
+  "line_item_group" : {
+    "total" : 2000,
+    "line_items" : [
+      {
+        "id" : "li_1TluQgFY0qyl6XeWUgHmc79h",
+        "description" : null,
+        "discount_amounts" : [
+
+        ],
+        "quantity" : 1,
+        "is_removable" : false,
+        "total" : 2000,
+        "tax_amounts" : [
+
+        ],
+        "subtotal" : 2000,
+        "cross_sell_from" : null,
+        "object" : "item",
+        "price" : {
+          "id" : "price_1TluQgFY0qyl6XeW8830FxO3",
+          "livemode" : false,
+          "active" : false,
+          "product" : {
+            "object" : "product",
+            "active" : false,
+            "addons" : null,
+            "id" : "prod_TnUMNVDoRiDXJx",
+            "images" : [
+
+            ],
+            "livemode" : false,
+            "url" : null,
+            "attributes" : [
+
+            ],
+            "description" : null,
+            "name" : "Test",
+            "unit_label" : null
+          },
+          "tax_behavior" : "exclusive",
+          "custom_unit_amount" : null,
+          "transform_quantity" : null,
+          "type" : "one_time",
+          "unit_amount" : 2000,
+          "unit_amount_decimal" : "2000",
+          "object" : "price",
+          "billing_scheme" : "per_unit",
+          "recurring" : null,
+          "currency" : "usd",
+          "tiers_mode" : null
+        },
+        "adjustable_quantity" : null,
+        "images" : null,
+        "unit_amount_override" : null,
+        "name" : "Test"
+      }
+    ],
+    "shipping_rate" : null,
+    "applied_credits" : [
+
+    ],
+    "subtotal" : 2000,
+    "discount_amounts" : [
+
+    ],
+    "currency" : "usd",
+    "tax_amounts" : [
+
+    ],
+    "due" : 2000
+  },
+  "managed_payments" : {
+    "enabled" : false
+  },
+  "name_collection" : null,
+  "payment_intent" : null,
+  "config_id" : "61bf9da2-7cd7-4e36-a4a5-d24c06759185",
+  "is_sandbox_merchant" : false
+}

--- a/StripePayments/StripePaymentsTestUtils/STPTestingAPIClient+Swift.swift
+++ b/StripePayments/StripePaymentsTestUtils/STPTestingAPIClient+Swift.swift
@@ -208,7 +208,8 @@ extension STPTestingAPIClient {
         automaticTax: Bool = false,
         enableTaxIdCollection: Bool = false,
         adaptivePricingEnabled: Bool = false,
-        customerEmailLocation: String? = nil
+        customerEmailLocation: String? = nil,
+        enablePaymentMethodSave: Bool = false
     ) -> [String: Any] {
         var additionalParameters: [String: Any] = [:]
         if allowPromotionCodes {
@@ -286,6 +287,11 @@ extension STPTestingAPIClient {
                 ]
             }
         }
+        if enablePaymentMethodSave {
+            additionalParameters["saved_payment_method_options"] = [
+                "payment_method_save": "enabled",
+            ]
+        }
         return additionalParameters
     }
 
@@ -305,7 +311,8 @@ extension STPTestingAPIClient {
         automaticTax: Bool = false,
         enableTaxIdCollection: Bool = false,
         adaptivePricingEnabled: Bool = false,
-        customerEmailLocation: String? = nil
+        customerEmailLocation: String? = nil,
+        enablePaymentMethodSave: Bool = false
     ) async throws -> CreateCheckoutSessionResponse {
         let additionalParameters = Self.checkoutSessionAdditionalParameters(
             currency: currency,
@@ -320,7 +327,8 @@ extension STPTestingAPIClient {
             automaticTax: automaticTax,
             enableTaxIdCollection: enableTaxIdCollection,
             adaptivePricingEnabled: adaptivePricingEnabled,
-            customerEmailLocation: customerEmailLocation
+            customerEmailLocation: customerEmailLocation,
+            enablePaymentMethodSave: enablePaymentMethodSave
         )
         let params: [String: Any?] = [
             "account": merchantCountry,


### PR DESCRIPTION
## Summary
Add support for updating a saved payment method's billing details and card expiry through the checkout session API. This calls the existing POST /v1/payment_pages/{session_id} endpoint with a payment_method_to_update parameter, following the same pattern as the existing detachPaymentMethod method.

A follow up PR will come to hook this up to the update PM VC.

## Motivation
- Updating a PM in CheckoutSession
- Design: https://docs.google.com/document/d/1CWglcOHR6I8cOWKjztPfnhnVG8axucpv-j5cWIoey7E/edit?tab=t.k2ogcb9623lq#heading=h.a2lhvmal87zq

## Testing
- New tests

## Changelog
N/A