### PR TITLE
Populate billingContact on Apple Pay request from CheckoutSession

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+CheckoutSessionLineItems.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+CheckoutSessionLineItems.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2026 Stripe, Inc. All rights reserved.
 //
 
+import Contacts
 import Foundation
 import PassKit
 @_spi(STP) import StripeApplePay
@@ -99,5 +100,44 @@ extension STPApplePayContext {
         )
 
         return summaryItems
+    }
+
+    /// Converts a `Checkout.ContactAddress` into a `PKContact` for pre-populating the Apple Pay sheet.
+    static func makeBillingContact(from contactAddress: Checkout.ContactAddress) -> PKContact {
+        let contact = PKContact()
+
+        if let name = contactAddress.name {
+            contact.name = PersonNameComponentsFormatter().personNameComponents(from: name)
+        }
+
+        if let phone = contactAddress.phone {
+            contact.phoneNumber = CNPhoneNumber(stringValue: phone)
+        }
+
+        let postalAddress = CNMutablePostalAddress()
+        let address = contactAddress.address
+        postalAddress.isoCountryCode = address.country
+
+        var streetComponents: [String] = []
+        if let line1 = address.line1 { streetComponents.append(line1) }
+        if let line2 = address.line2 { streetComponents.append(line2) }
+        if !streetComponents.isEmpty {
+            postalAddress.street = streetComponents.joined(separator: "\n")
+        }
+
+        if let city = address.city {
+            postalAddress.city = city
+        }
+
+        if let state = address.state {
+            postalAddress.state = state
+        }
+
+        if let postalCode = address.postalCode {
+            postalAddress.postalCode = postalCode
+        }
+
+        contact.postalAddress = postalAddress
+        return contact
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -6,7 +6,6 @@
 //  Copyright © 2020 Stripe, Inc. All rights reserved.
 //
 
-import Contacts
 import Foundation
 import PassKit
 @_spi(STP) import StripeApplePay
@@ -415,7 +414,7 @@ extension STPApplePayContext {
         // Pre-populate billingContact from the CheckoutSession's billing address if available
         if case .checkout(let checkout) = intent,
            let billingAddress = checkout.stpSession.billingAddress {
-            paymentRequest.billingContact = makeBillingContact(from: billingAddress)
+            paymentRequest.billingContact = Self.makeBillingContact(from: billingAddress)
         }
 
         return paymentRequest
@@ -439,46 +438,6 @@ private func makeShippingDetails(from configuration: PaymentElementConfiguration
         name: name,
         phone: shippingDetails.phone
     )
-}
-
-/// Converts a `Checkout.ContactAddress` into a `PKContact` for pre-populating the Apple Pay sheet.
-private func makeBillingContact(from contactAddress: Checkout.ContactAddress) -> PKContact {
-    let contact = PKContact()
-
-    if let name = contactAddress.name {
-        contact.name = PersonNameComponentsFormatter().personNameComponents(from: name)
-    }
-
-    if let phone = contactAddress.phone {
-        contact.phoneNumber = CNPhoneNumber(stringValue: phone)
-    }
-
-    let postalAddress = CNMutablePostalAddress()
-    let address = contactAddress.address
-    postalAddress.isoCountryCode = address.country
-
-    if let line1 = address.line1 {
-        if let line2 = address.line2 {
-            postalAddress.street = "\(line1)\n\(line2)"
-        } else {
-            postalAddress.street = line1
-        }
-    }
-
-    if let city = address.city {
-        postalAddress.city = city
-    }
-
-    if let state = address.state {
-        postalAddress.state = state
-    }
-
-    if let postalCode = address.postalCode {
-        postalAddress.postalCode = postalCode
-    }
-
-    contact.postalAddress = postalAddress
-    return contact
 }
 
 private func makeRequiredBillingDetails(from configuration: PaymentElementConfiguration) -> Set<PKContactField> {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Stripe, Inc. All rights reserved.
 //
 
+import Contacts
 import Foundation
 import PassKit
 @_spi(STP) import StripeApplePay
@@ -411,6 +412,12 @@ extension STPApplePayContext {
             paymentRequest.merchantCapabilities = merchantCapabilities
         }
 
+        // Pre-populate billingContact from the CheckoutSession's billing address if available
+        if case .checkout(let checkout) = intent,
+           let billingAddress = checkout.stpSession.billingAddress {
+            paymentRequest.billingContact = makeBillingContact(from: billingAddress)
+        }
+
         return paymentRequest
     }
 }
@@ -432,6 +439,46 @@ private func makeShippingDetails(from configuration: PaymentElementConfiguration
         name: name,
         phone: shippingDetails.phone
     )
+}
+
+/// Converts a `Checkout.ContactAddress` into a `PKContact` for pre-populating the Apple Pay sheet.
+private func makeBillingContact(from contactAddress: Checkout.ContactAddress) -> PKContact {
+    let contact = PKContact()
+
+    if let name = contactAddress.name {
+        contact.name = PersonNameComponentsFormatter().personNameComponents(from: name)
+    }
+
+    if let phone = contactAddress.phone {
+        contact.phoneNumber = CNPhoneNumber(stringValue: phone)
+    }
+
+    let postalAddress = CNMutablePostalAddress()
+    let address = contactAddress.address
+    postalAddress.isoCountryCode = address.country
+
+    if let line1 = address.line1 {
+        if let line2 = address.line2 {
+            postalAddress.street = "\(line1)\n\(line2)"
+        } else {
+            postalAddress.street = line1
+        }
+    }
+
+    if let city = address.city {
+        postalAddress.city = city
+    }
+
+    if let state = address.state {
+        postalAddress.state = state
+    }
+
+    if let postalCode = address.postalCode {
+        postalAddress.postalCode = postalCode
+    }
+
+    contact.postalAddress = postalAddress
+    return contact
 }
 
 private func makeRequiredBillingDetails(from configuration: PaymentElementConfiguration) -> Set<PKContactField> {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -606,6 +606,116 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
         XCTAssertEqual(sut.paymentSummaryItems[0].type, .final)
     }
 
+    // MARK: - CheckoutSession Billing Contact Tests
+
+    func testCreatePaymentRequest_CheckoutSession_PopulatesBillingContactFromFullAddress() {
+        let intent = Intent._testCheckoutSession(mode: .payment, amount: 2345, currency: "USD")
+        guard case .checkout(let checkout) = intent else {
+            XCTFail("Expected checkout intent")
+            return
+        }
+        checkout.stpSession.billingAddress = Checkout.ContactAddress(
+            name: "Jane Doe",
+            phone: "+14155551234",
+            address: Checkout.Address(
+                country: "US",
+                line1: "510 Townsend St",
+                line2: "Apt 2",
+                city: "San Francisco",
+                state: "CA",
+                postalCode: "94103"
+            )
+        )
+
+        let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
+
+        let billingContact = sut.billingContact
+        XCTAssertNotNil(billingContact)
+
+        let name = billingContact?.name
+        XCTAssertNotNil(name)
+        let formattedName = PersonNameComponentsFormatter.localizedString(from: name!, style: .default)
+        XCTAssertEqual(formattedName, "Jane Doe")
+
+        XCTAssertEqual(billingContact?.phoneNumber?.stringValue, "+14155551234")
+
+        let postalAddress = billingContact?.postalAddress
+        XCTAssertNotNil(postalAddress)
+        XCTAssertEqual(postalAddress?.isoCountryCode, "US")
+        XCTAssertEqual(postalAddress?.street, "510 Townsend St\nApt 2")
+        XCTAssertEqual(postalAddress?.city, "San Francisco")
+        XCTAssertEqual(postalAddress?.state, "CA")
+        XCTAssertEqual(postalAddress?.postalCode, "94103")
+    }
+
+    func testCreatePaymentRequest_CheckoutSession_PopulatesBillingContactWithCountryOnly() {
+        let intent = Intent._testCheckoutSession(mode: .payment, amount: 2345, currency: "USD")
+        guard case .checkout(let checkout) = intent else {
+            XCTFail("Expected checkout intent")
+            return
+        }
+        checkout.stpSession.billingAddress = Checkout.ContactAddress(
+            address: Checkout.Address(country: "GB")
+        )
+
+        let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
+
+        let billingContact = sut.billingContact
+        XCTAssertNotNil(billingContact)
+        XCTAssertNil(billingContact?.name)
+        XCTAssertNil(billingContact?.phoneNumber)
+
+        let postalAddress = billingContact?.postalAddress
+        XCTAssertNotNil(postalAddress)
+        XCTAssertEqual(postalAddress?.isoCountryCode, "GB")
+        XCTAssertEqual(postalAddress?.street, "")
+        XCTAssertEqual(postalAddress?.city, "")
+        XCTAssertEqual(postalAddress?.state, "")
+        XCTAssertEqual(postalAddress?.postalCode, "")
+    }
+
+    func testCreatePaymentRequest_CheckoutSession_PopulatesBillingContactWithLine1Only() {
+        let intent = Intent._testCheckoutSession(mode: .payment, amount: 2345, currency: "USD")
+        guard case .checkout(let checkout) = intent else {
+            XCTFail("Expected checkout intent")
+            return
+        }
+        checkout.stpSession.billingAddress = Checkout.ContactAddress(
+            name: "John Smith",
+            address: Checkout.Address(
+                country: "US",
+                line1: "123 Main St"
+            )
+        )
+
+        let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
+
+        let billingContact = sut.billingContact
+        XCTAssertNotNil(billingContact)
+        XCTAssertEqual(billingContact?.postalAddress?.street, "123 Main St")
+    }
+
+    func testCreatePaymentRequest_CheckoutSession_NoBillingContact_WhenNoBillingAddress() {
+        let intent = Intent._testCheckoutSession(mode: .payment, amount: 2345, currency: "USD")
+        guard case .checkout(let checkout) = intent else {
+            XCTFail("Expected checkout intent")
+            return
+        }
+        // billingAddress is nil by default
+        XCTAssertNil(checkout.stpSession.billingAddress)
+
+        let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
+
+        XCTAssertNil(sut.billingContact)
+    }
+
+    func testCreatePaymentRequest_NonCheckoutIntent_NoBillingContact() {
+        // Non-checkout intents should never have billingContact populated
+        let intent = Intent._testValue()
+        let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
+        XCTAssertNil(sut.billingContact)
+    }
+
     func testCreatePaymentRequest_CheckoutSession_MerchantPaymentSummaryItemsTakePrecedence() {
         let merchantItems: [PKPaymentSummaryItem] = [
             PKPaymentSummaryItem(label: "Custom", amount: NSDecimalNumber(string: "9.99"), type: .final),


### PR DESCRIPTION
## Summary
When using CheckoutSessions with PaymentSheet or Embedded, pre-populate the PKPaymentRequest's billingContact from the session's billingAddress. This allows the Apple Pay sheet to display the customer's previously entered billing information, reducing friction.

- Add makeBillingContact helper to convert Checkout.ContactAddress to PKContact
- Set billingContact on the payment request when a checkout intent has a billing address
- Add tests covering full address, country-only, line1-only, nil, and non-checkout intents


## Motivation
- CheckoutSessions

## Testing
- New unit tests

## Changelog
N/A