### PR TITLE
Disable iOS 26 number pad popover for payment text fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ The next release's version bump will so far be:
 MINOR
 
 ## X.Y.Z - changes pending release
+### PaymentSheet
+* [Changed] Disables `allowsNumberPadPopover` on text fields to opt-out of the number pad popover for iOS26+
 
 ### CryptoOnramp (Alpha)
 * [Changed] Renamed `CryptoOnrampCoordinator.presentCRSCARFDeclaration(from:)` to `presentUserAttestation(from:)`, and renamed `CRSCARFDeclarationResult` to `UserAttestationResult`.

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldView.swift
@@ -69,6 +69,11 @@ class TextFieldView: UIView {
         textField.spellCheckingType = .no
         textField.adjustsFontForContentSizeCategory = true
         textField.font = viewModel.theme.fonts.subheadline
+        if #available(iOS 26.0, *) {
+            // Opt-out of iOS 26 behavior which shows a floating numpad popover on iPad that
+            // may misposition it self or lead to showing two keyboards.
+            textField.allowsNumberPadPopover = false
+        }
         return textField
     }()
     private lazy var textFieldView: FloatingPlaceholderTextFieldView = {


### PR DESCRIPTION
## Summary
Opt-out of number pad popover behavior, which can lead to mis-positioning of the numpad, or showing both a full keyboard and a popup.

## Motivation
Visual discrepancy

## Testing
Manually

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
