### PR TITLE
Make update(checkout) internal

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+SwiftUI.swift
@@ -163,9 +163,7 @@ public final class EmbeddedPaymentElementViewModel: ObservableObject {
     /// - Parameter checkout: The Checkout instance whose session has been updated.
     /// - Returns: The result of the update. Any calls made to `update` before this call that are still in progress will return a `.canceled` result.
     /// - Note: Upon completion, `paymentOption` may become nil if it's no longer available.
-    @_spi(STP)
-    @_spi(ReactNativeSDK)
-    public func update(
+    func update(
         checkout: Checkout
     ) async -> EmbeddedPaymentElement.UpdateResult {
         // Wait for the load task to complete if it exists

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -167,9 +167,7 @@ public final class EmbeddedPaymentElement {
     /// - Returns: The result of the update.
     /// - Note: Upon completion, `paymentOption` may become nil if it's no longer available.
     /// - Note: If you call `update` while a previous call to `update` is still in progress, the previous call returns `.canceled`.
-    @_spi(STP)
-    @_spi(ReactNativeSDK)
-    public func update(
+    func update(
         checkout: Checkout
     ) async -> UpdateResult {
         do {
@@ -539,26 +537,6 @@ extension EmbeddedPaymentElement {
     ) {
         Task {
             let result = await update(intentConfiguration: intentConfiguration)
-            DispatchQueue.main.async {
-                completion(result)
-            }
-        }
-    }
-
-    /// Call this method when the CheckoutSession you used to initialize `EmbeddedPaymentElement` changes.
-    /// This ensures the appropriate payment methods are displayed, collect the right fields, etc.
-    /// - Parameter checkout: The Checkout instance whose session has been updated.
-    /// - Parameter completion: A completion block containing the result of the update. Called on the main thread.
-    /// - Returns: The result of the update. Any calls made to `update` before this call that are still in progress will return a `.canceled` result.
-    /// - Note: Upon completion, `paymentOption` may become nil if it's no longer available.
-    @_spi(STP)
-    @_spi(ReactNativeSDK)
-    public func update(
-        checkout: Checkout,
-        completion: @escaping (UpdateResult) -> Void
-    ) {
-        Task {
-            let result = await update(checkout: checkout)
             DispatchQueue.main.async {
                 completion(result)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController+AsyncPublicAPIs.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController+AsyncPublicAPIs.swift
@@ -141,9 +141,7 @@ extension PaymentSheet.FlowController {
     /// - Parameter checkout: The Checkout instance whose session has been updated.
     /// - Throws: An error if the update fails. You should retry the update; the FlowController instance is not usable until the update succeeds.
     /// - Note: Don't call `confirm` or `present` until the update succeeds. Don't call this method while PaymentSheet is being presented.
-    @_spi(STP)
-    @_spi(ReactNativeSDK)
-    public func update(checkout: Checkout) async throws {
+    func update(checkout: Checkout) async throws {
         return try await withCheckedThrowingContinuation { continuation in
             Task { @MainActor in
                 update(checkout: checkout) { error in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -747,12 +747,10 @@ extension PaymentSheet {
         /// Call this method when the CheckoutSession you used to initialize PaymentSheet.FlowController changes.
         /// This ensures the appropriate payment methods are displayed, etc.
         /// - Parameter checkout: The Checkout instance whose session has been updated.
-        /// - Parameter completion: Called when the update completes with an optional error. Your implementation should get the customer's updated payment option by using the `paymentOption` property and update your UI. If an error occurred, retry.
+        /// - Parameter completion: Called when the update completes with an optional error.
         /// - Note: Don't call `confirm` or `present` until the update succeeds. Don't call this method while PaymentSheet is being presented.
-        @_spi(STP)
-        @_spi(ReactNativeSDK)
         @MainActor
-        public func update(
+        func update(
             checkout: Checkout,
             completion: @escaping (Error?) -> Void
         ) {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -923,27 +923,6 @@ class EmbeddedPaymentElementTest: XCTestCase {
         XCTAssertEqual(updateResult2, .succeeded)
     }
 
-    func testUpdateCheckoutSessionWithCompletionBlock() async throws {
-        let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
-        let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        let checkout = try await Checkout(clientSecret: response.clientSecret, apiClient: apiClient)
-
-        var config = EmbeddedPaymentElement.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
-        config.apiClient = apiClient
-        config.defaultBillingDetails.email = "test@example.com"
-
-        let sut = try await EmbeddedPaymentElement.create(checkout: checkout, configuration: config)
-        sut.delegate = self
-        sut.presentingViewController = UIViewController()
-
-        let updateExpectation = expectation(description: "Update completes")
-        sut.update(checkout: checkout) { result in
-            XCTAssertEqual(result, .succeeded)
-            updateExpectation.fulfill()
-        }
-        await fulfillment(of: [updateExpectation], timeout: STPTestingNetworkRequestTimeout)
-    }
-
     // MARK: Immediate action tests
 
     func testCreateFails_whenImmediateActionWithConfirmAndCustomer() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -1191,34 +1191,6 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
         try await sut.update(checkout: checkout)
     }
 
-    @MainActor
-    func testUpdateCheckoutSessionIgnoresInFlightUpdate() async throws {
-        let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
-        let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        let checkout = try await Checkout(clientSecret: response.clientSecret, apiClient: apiClient)
-
-        var config = PaymentSheet.Configuration()
-        config.apiClient = apiClient
-        config.defaultBillingDetails.email = "test@example.com"
-
-        let sut = try await PaymentSheet.FlowController.create(checkout: checkout, configuration: config)
-
-        let firstUpdateExpectation = expectation(description: "First update should not invoke callback")
-        firstUpdateExpectation.isInverted = true
-        let secondUpdateExpectation = expectation(description: "Second update succeeds")
-
-        // Fire two updates; the first should be ignored
-        sut.update(checkout: checkout) { _ in
-            firstUpdateExpectation.fulfill()
-        }
-        sut.update(checkout: checkout) { error in
-            XCTAssertNil(error)
-            secondUpdateExpectation.fulfill()
-        }
-
-        await fulfillment(of: [firstUpdateExpectation, secondUpdateExpectation], timeout: STPTestingNetworkRequestTimeout)
-    }
-
     // MARK: - other tests
 
     func testMakeShippingParamsReturnsNilIfPaymentIntentHasDifferentShipping() {


### PR DESCRIPTION
## Summary
  Make update(checkout:) methods internal and async-only

  - Removed @_spi(STP) @_spi(ReactNativeSDK) public from update(checkout:) in FlowController, EmbeddedPaymentElement, and EmbeddedPaymentElementViewModel, now internal
  - Removed completion handler overload update(checkout:completion:) from EmbeddedPaymentElement (the async version is the only API now)
  - Removed tests that specifically tested the removed completion handler API

## Motivation
- CheckoutSession

## Testing
- Removed tests that are no longer relevant (or the APIs were removed). We have other coverage for the existing

## Changelog
N/A