### PR TITLE
Fix deadlock in Checkout.swift

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -83,6 +83,9 @@ extension Checkout {
             } catch {
                 // Restore loaded state on failure so the UI doesn't stay stuck in loading.
                 self.state = .loaded(self.state.session)
+                if self.isLastPendingOperation {
+                    try? await self.integrationDelegate?.checkoutDidUpdate(self)
+                }
                 throw CheckoutError.apiError(message: error.nonGenericDescription)
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -83,6 +83,8 @@ extension Checkout {
             } catch {
                 // Restore loaded state on failure so the UI doesn't stay stuck in loading.
                 self.state = .loaded(self.state.session)
+                // If a prior op skipped the delegate and we're failing before we
+                // get to commitSession ourselves, still notify so the UI updates.
                 if self.isLastPendingOperation {
                     try? await self.integrationDelegate?.checkoutDidUpdate(self)
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -145,13 +145,10 @@ public final class Checkout: ObservableObject {
     ///
     /// - Parameters:
     ///   - timeout: Maximum time to wait, in seconds.
-    ///   - excludingCurrent: If true, skips the currently executing operation.
     func awaitPendingOperations(
-        timeout: TimeInterval = Checkout.defaultPendingOperationsTimeout,
-        excludingCurrent: Bool = false
+        timeout: TimeInterval = Checkout.defaultPendingOperationsTimeout
     ) async throws {
-        // First element is always the currently executing op (it awaits its predecessor, removed on completion).
-        let snapshot = excludingCurrent ? Array(pendingOperations.dropFirst()) : pendingOperations
+        let snapshot = pendingOperations
         guard !snapshot.isEmpty else { return }
 
         let result = await withTimeout(timeout) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -62,6 +62,10 @@ public final class Checkout: ObservableObject {
     /// Serial queue of in-flight session updates. Each task waits for the previous task before running.
     var pendingOperations: [Task<Void, Error>] = []
 
+    var isLastPendingOperation: Bool {
+        pendingOperations.count <= 1
+    }
+
     /// Default timeout used by ``awaitPendingOperations(timeout:)``.
     nonisolated static let defaultPendingOperationsTimeout: TimeInterval = 30
 
@@ -141,15 +145,13 @@ public final class Checkout: ObservableObject {
     ///
     /// - Parameters:
     ///   - timeout: Maximum time to wait, in seconds.
-    ///   - excludingCurrent: If true, excludes the last enqueued operation from the wait.
+    ///   - excludingCurrent: If true, skips the currently executing operation.
     func awaitPendingOperations(
         timeout: TimeInterval = Checkout.defaultPendingOperationsTimeout,
         excludingCurrent: Bool = false
     ) async throws {
-        var snapshot = pendingOperations
-        if excludingCurrent {
-            snapshot = Array(snapshot.dropLast(1))
-        }
+        // First element is always the currently executing op (it awaits its predecessor, removed on completion).
+        let snapshot = excludingCurrent ? Array(pendingOperations.dropFirst()) : pendingOperations
         guard !snapshot.isEmpty else { return }
 
         let result = await withTimeout(timeout) {
@@ -324,7 +326,10 @@ public final class Checkout: ObservableObject {
         stpSession = newSession
         let publicSession = newSession.makePublicSession()
         state = pendingOperations.isEmpty ? .loaded(publicSession) : .loading(publicSession)
-        try await integrationDelegate?.checkoutDidUpdate(self)
+        // Skip delegate if another op is queued—it'll notify when it commits.
+        if isLastPendingOperation {
+            try await integrationDelegate?.checkoutDidUpdate(self)
+        }
         delegate?.checkout(self, didChangeState: state)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -173,9 +173,7 @@ public final class EmbeddedPaymentElement {
         checkout: Checkout
     ) async -> UpdateResult {
         do {
-            // The calling mutation is still in the queue (it awaits us before returning),
-            // so exclude it to avoid a deadlock.
-            try await checkout.awaitPendingOperations(excludingCurrent: true)
+            try await checkout.awaitPendingOperations()
         } catch {
             return .failed(error: error)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -761,9 +761,7 @@ extension PaymentSheet {
             let updateID = beginUpdate()
             Task { @MainActor in
                 do {
-                    // The calling mutation is still in the queue (it awaits us before returning),
-                    // so exclude it to avoid a deadlock.
-                    try await checkout.awaitPendingOperations(excludingCurrent: true)
+                    try await checkout.awaitPendingOperations()
                 } catch {
                     self.failUpdate(updateID)
                     completion(error)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
@@ -192,7 +192,7 @@ private final class AwaitsPendingOpsIntegrationDelegate: CheckoutIntegrationDele
     var isSheetPresented: Bool = false
 
     func checkoutDidUpdate(_ checkout: Checkout) async throws {
-        try await checkout.awaitPendingOperations(excludingCurrent: true)
+        try await checkout.awaitPendingOperations()
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
@@ -121,6 +121,48 @@ final class CheckoutPendingOperationsTests: XCTestCase {
         XCTAssertTrue(checkout.pendingOperations.isEmpty)
     }
 
+    // MARK: - Delegate skipping
+
+    func testCommitSessionSkipsDelegateWhenAnotherOpIsQueued() async throws {
+        let checkout = await makeCheckoutWithOpenSession()
+        let delegate = AwaitsPendingOpsIntegrationDelegate()
+        checkout.integrationDelegate = delegate
+
+        let gate = CheckoutPendingOperationsTestGate()
+
+        let firstTask = Task { @MainActor in
+            try await checkout.enqueueSessionUpdate {
+                await gate.wait()
+                try await checkout.commitSession(CheckoutTestHelpers.makeOpenSession())
+            }
+        }
+
+        try await waitUntil { checkout.pendingOperations.count == 1 }
+
+        let secondTask = Task { @MainActor in
+            try await checkout.enqueueSessionUpdate { }
+        }
+
+        try await waitUntil { checkout.pendingOperations.count == 2 }
+
+        gate.open()
+
+        let result = await withTimeout(3) { @MainActor in
+            _ = try await firstTask.value
+            _ = try await secondTask.value
+        }
+
+        if case .failure(let error) = result {
+            if error is TimeoutError {
+                XCTFail("Deadlocked — commitSession should skip delegate when another op is queued")
+            } else {
+                throw error
+            }
+        }
+
+        XCTAssertTrue(checkout.pendingOperations.isEmpty)
+    }
+
     // MARK: - Helpers
 
     private func makeCheckoutWithOpenSession() async -> Checkout {
@@ -142,6 +184,15 @@ final class CheckoutPendingOperationsTests: XCTestCase {
             }
             await Task.yield()
         }
+    }
+}
+
+@MainActor
+private final class AwaitsPendingOpsIntegrationDelegate: CheckoutIntegrationDelegate {
+    var isSheetPresented: Bool = false
+
+    func checkoutDidUpdate(_ checkout: Checkout) async throws {
+        try await checkout.awaitPendingOperations(excludingCurrent: true)
     }
 }
 


### PR DESCRIPTION
## Summary
When two mutations are queued on a Checkout and the first calls `commitSession()`, it triggers `checkoutDidUpdate` on the integration delegate (FC/Embedded), which calls `awaitPendingOperations()`. The old `excludingCurrent` logic used `dropLast` to try to skip the "current" operation, but it dropped the wrong one — causing the first op to await itself and deadlock for 30s until timeout.

**Fix:** Don't call `integrationDelegate?.checkoutDidUpdate` at all when there are more ops queued behind us. The next op will call it when it commits. This makes `excludingCurrent` unnecessary (it was always a no-op given the guard), so it's removed entirely.

Also added: if a later op fails before reaching its own `commitSession`, we still relay the delegate call so the UI doesn't get stuck with stale data.

## Motivation
- https://stripe.slack.com/archives/C09MLFD2KU7/p1782349888747439

## Testing
- New unit test that failed previously

## Changelog
N/A
