### PR TITLE
Fix dyld crash on with LinkOpeningTextView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ MINOR
 ## X.Y.Z - changes pending release
 ### PaymentSheet
 * [Changed] Disables `allowsNumberPadPopover` on text fields to opt-out of the number pad popover for iOS26+
+* [Fixed] Fixes dyld crash with LinkOpeningTextView when integrating via Swift Package Manager
 
 ### CustomerSheet
 * [Fixed] Fixed an issue where a nil payment option was returned if the sheet was dismissed while loading.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEPromotionTextView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEPromotionTextView.swift
@@ -5,24 +5,28 @@
 //  Created by George Birch on 4/30/26.
 //
 
-@_spi(STP) import StripeUICore
 import UIKit
 
 /// Shared text view used by PMME surfaces that need tappable links without selectable text.
-class PMMEPromotionTextView: LinkOpeningTextView {
+/// Do NOT subclass from LinkOpeningTextView — subclassing `open` classes across SPM modules
+/// causes dyld crashes due. See: https://github.com/swiftlang/swift/issues/54323
+class PMMEPromotionTextView: UITextView {
+    private var isTextSelectable = true
+
+    override var isSelectable: Bool {
+        get {
+            return isTextSelectable
+        }
+        set {
+            super.isSelectable = true
+            isTextSelectable = newValue
+        }
+    }
 
     init(foregroundColor: UIColor) {
         super.init(frame: .zero, textContainer: nil)
         isScrollEnabled = false
         isEditable = false
-        /*
-         `LinkOpeningTextView` keeps the underlying actual `isSelectable` property set to `true`,
-         which is required for links to work. However, setting it `false` will disable events to
-         any point other than the link text. We still need to handle double tap selection on the
-         link, which we do below.
-         This is a workaround for UIKit not allowing links to work if the `UITextView` does not
-         have `isSelectable = true`.
-         */
         isSelectable = false
         backgroundColor = .clear
         textContainerInset = .zero
@@ -48,5 +52,22 @@ class PMMEPromotionTextView: LinkOpeningTextView {
 
         // Allow all other system gestures (scrolling, link clicks, etc.)
         return super.gestureRecognizerShouldBegin(gestureRecognizer)
+    }
+
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+        // Only override the default behavior if the view should not be selectable
+        guard !isTextSelectable else {
+            return super.point(inside: point, with: event)
+        }
+
+        guard let pos = closestPosition(to: point),
+              let range = tokenizer.rangeEnclosingPosition(pos, with: .character, inDirection: .layout(.left))
+        else {
+            return false
+        }
+
+        let startIndex = offset(from: beginningOfDocument, to: range.start)
+
+        return attributedText.attribute(.link, at: startIndex, effectiveRange: nil) != nil
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEPromotionTextView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEPromotionTextView.swift
@@ -9,25 +9,15 @@ import UIKit
 
 /// Shared text view used by PMME surfaces that need tappable links without selectable text.
 /// Do NOT subclass from LinkOpeningTextView — subclassing `open` classes across SPM modules
-/// causes dyld crashes due. See: https://github.com/swiftlang/swift/issues/54323
+/// causes dyld crashes. See: https://github.com/swiftlang/swift/issues/54323
 class PMMEPromotionTextView: UITextView {
-    private var isTextSelectable = true
-
-    override var isSelectable: Bool {
-        get {
-            return isTextSelectable
-        }
-        set {
-            super.isSelectable = true
-            isTextSelectable = newValue
-        }
-    }
 
     init(foregroundColor: UIColor) {
         super.init(frame: .zero, textContainer: nil)
         isScrollEnabled = false
         isEditable = false
-        isSelectable = false
+        // Keep super.isSelectable = true so UIKit allows link taps to work.
+        super.isSelectable = true
         backgroundColor = .clear
         textContainerInset = .zero
         textContainer.lineFragmentPadding = 0
@@ -40,26 +30,24 @@ class PMMEPromotionTextView: UITextView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // To avoid double-tap selection behavior we block double tap gestures. These double taps will instead open the link
-    public override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
-        // Intercept tap gesture recognizers
-        if let tapGesture = gestureRecognizer as? UITapGestureRecognizer {
-            // Block the gesture if it requires a double-tap
-            if tapGesture.numberOfTapsRequired == 2 {
-                return false
+    // Block double-tap gestures to the system menu from showing:
+    override var selectedTextRange: UITextRange? {
+        get { super.selectedTextRange }
+        set {
+            // Only allow collapsed cursors, reject actual selections
+            if newValue == nil || newValue?.isEmpty == true {
+                super.selectedTextRange = newValue
             }
         }
-
-        // Allow all other system gestures (scrolling, link clicks, etc.)
-        return super.gestureRecognizerShouldBegin(gestureRecognizer)
     }
 
-    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        // Only override the default behavior if the view should not be selectable
-        guard !isTextSelectable else {
-            return super.point(inside: point, with: event)
-        }
+    // Never show text being selected
+    override func selectionRects(for range: UITextRange) -> [UITextSelectionRect] {
+        return []
+    }
 
+    // Only register taps that land on a link — suppress all other touch events.
+    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         guard let pos = closestPosition(to: point),
               let range = tokenizer.rangeEnclosingPosition(pos, with: .character, inDirection: .layout(.left))
         else {
@@ -67,7 +55,6 @@ class PMMEPromotionTextView: UITextView {
         }
 
         let startIndex = offset(from: beginningOfDocument, to: range.start)
-
         return attributedText.attribute(.link, at: startIndex, effectiveRange: nil) != nil
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEPromotionTextView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingElement/PMMEPromotionTextView.swift
@@ -30,7 +30,7 @@ class PMMEPromotionTextView: UITextView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    // Block double-tap gestures to the system menu from showing:
+    // Block double-tap gestures to the system menu from showing
     override var selectedTextRange: UITextRange? {
         get { super.selectedTextRange }
         set {

--- a/StripeUICore/StripeUICore/Source/Views/LinkOpeningTextView.swift
+++ b/StripeUICore/StripeUICore/Source/Views/LinkOpeningTextView.swift
@@ -13,7 +13,7 @@ import UIKit
  Subclass of UITextView that allows for links to be opened on tap when the text is un-selectable.
  */
 @objc(STP_Internal_LinkOpeningTextView)
-@_spi(STP) open class LinkOpeningTextView: UITextView {
+@_spi(STP) public class LinkOpeningTextView: UITextView {
     private var isTextSelectable = true
 
     /*


### PR DESCRIPTION
## Summary
Changes LinkOpeningTextView back to `public` from `open`

While checking for regressions, we noticed that the workaround which hooks into the double-tap gesture recognizer was not working for iOS26.

The expected behavior was that:
* Text should not be selectable
* We should not show a system menu
However, we were observing both.

As such, we found a different workaround and verified a fix on both iOS18 and iOS26. 

While testing on iOS16.4, we noticed a minor visual artifact when double tapping the link. To work around this, we could add back the gesture recognizer, but given that traffic to iOS16.4 is quite low, we're opting to accept this minor visual artifact on iOS16.4

## Motivation
May crash when subclassing open classes across SPM modules

## Testing
Manually

## Changelog
Updated.
