### PR TITLE
Fix flag display for special currencies (XAF, XOF, ANG, etc.)

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/AdaptivePricingFlagImageManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/AdaptivePricingFlagImageManager.swift
@@ -44,8 +44,11 @@ final class AdaptivePricingFlagImageManager {
             return
         }
 
-        let localCountry = Self.countryCode(for: local)
-        let integrationCountry = Self.countryCode(for: integration)
+        guard let localCountry = Self.countryCode(for: local),
+              let integrationCountry = Self.countryCode(for: integration) else {
+            imagesByCurrencyCode = nil
+            return
+        }
 
         let localResult = await downloadFlagImage(countryCode: localCountry)
         let integrationResult = await downloadFlagImage(countryCode: integrationCountry)
@@ -101,9 +104,8 @@ final class AdaptivePricingFlagImageManager {
         return (local, integration)
     }
 
-    /// Returns the two-letter country code for the given currency (e.g. `"GB"` from `"GBP"`).
-    private static func countryCode(for currency: CurrencyCode) -> String {
-        String(currency.displayValue.prefix(2))
+    private static func countryCode(for currency: CurrencyCode) -> String? {
+        CurrencySelectorUtilities.regionCode(for: currency)
     }
 
     // MARK: Image download

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CurrencySelectorUtilities.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CurrencySelectorUtilities.swift
@@ -163,8 +163,31 @@ enum CurrencySelectorUtilities {
 
     // MARK: - Flag emoji
 
+    // Most currency codes already start with the country code (USD→US, GBP→GB) per ISO 4217.
+    // ANG is the one exception among Stripe-supported currencies — it maps to NL, not the
+    // defunct "AN" (Netherlands Antilles). X-prefixed codes (XAF, XOF, etc.) are multi-country
+    // so we just skip the flag entirely.
+    // See also: stripe-js CURRENCY_TO_FLAG_CODES in src/lib/inner/components/FlagIcon/
+
+    private static let regionCodeOverrides: [String: String] = [
+        "ang": "NL",
+    ]
+
+    private static let unmappedCurrencies: Set<String> = [
+        "xaf", "xcd", "xof", "xpf",
+    ]
+
+    /// Region code for the currency, or nil for multi-country currencies (XAF, XOF, etc.)
+    static func regionCode(for currency: CurrencyCode) -> String? {
+        if unmappedCurrencies.contains(currency.apiValue) { return nil }
+        if let override = regionCodeOverrides[currency.apiValue] { return override }
+        return String(currency.displayValue.prefix(2))
+    }
+
     static func flagEmoji(for currency: CurrencyCode) -> String {
-        let regionCode = String(currency.displayValue.prefix(2))
+        guard let regionCode = regionCode(for: currency) else {
+            return ""
+        }
         return String.regionFlagEmoji(for: regionCode) ?? ""
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorViewTests.swift
@@ -139,6 +139,61 @@ final class CheckoutCurrencySelectorViewTests: XCTestCase {
         XCTAssertTrue(selectorView!.rightItem.displayText.string.contains("24"))
     }
 
+    // MARK: - Region code / flag tests
+
+    func testRegionCodeForCommonCurrencies() {
+        let cases: [(String, String)] = [
+            ("usd", "US"),
+            ("gbp", "GB"),
+            ("eur", "EU"),
+            ("chf", "CH"),
+            ("jpy", "JP"),
+            ("aud", "AU"),
+            ("cad", "CA"),
+            ("inr", "IN"),
+            ("krw", "KR"),
+            ("brl", "BR"),
+        ]
+        for (currency, expected) in cases {
+            let code = CurrencySelectorUtilities.CurrencyCode(currency)
+            XCTAssertEqual(CurrencySelectorUtilities.regionCode(for: code), expected, "Failed for \(currency)")
+        }
+    }
+
+    func testRegionCodeNilForXPrefixedCurrencies() {
+        for currency in ["xaf", "xof", "xpf", "xcd"] {
+            let code = CurrencySelectorUtilities.CurrencyCode(currency)
+            XCTAssertNil(CurrencySelectorUtilities.regionCode(for: code), "Expected nil for \(currency)")
+        }
+    }
+
+    func testANGMapsToNL() {
+        let ang = CurrencySelectorUtilities.CurrencyCode("ang")
+        XCTAssertEqual(CurrencySelectorUtilities.regionCode(for: ang), "NL")
+    }
+
+    func testRegionCodeCaseInsensitive() {
+        let lower = CurrencySelectorUtilities.CurrencyCode("usd")
+        let upper = CurrencySelectorUtilities.CurrencyCode("USD")
+        XCTAssertEqual(CurrencySelectorUtilities.regionCode(for: lower), "US")
+        XCTAssertEqual(CurrencySelectorUtilities.regionCode(for: upper), "US")
+    }
+
+    func testFlagEmojiUSD() {
+        let usd = CurrencySelectorUtilities.CurrencyCode("usd")
+        XCTAssertEqual(CurrencySelectorUtilities.flagEmoji(for: usd), "🇺🇸")
+    }
+
+    func testFlagEmojiEUR() {
+        let eur = CurrencySelectorUtilities.CurrencyCode("eur")
+        XCTAssertEqual(CurrencySelectorUtilities.flagEmoji(for: eur), "🇪🇺")
+    }
+
+    func testFlagEmojiEmptyForUnmappedCurrency() {
+        let xaf = CurrencySelectorUtilities.CurrencyCode("xaf")
+        XCTAssertTrue(CurrencySelectorUtilities.flagEmoji(for: xaf).isEmpty)
+    }
+
     // MARK: - Helpers
 
     private func makeSession(


### PR DESCRIPTION
## Summary
We were naively grabbing the first two characters of any currency code as the country code for flag display. That works for most currencies (USD -> US, GBP -> GB) but breaks for X-prefixed multi-country currencies like XAF and XOF where there's no single country to show a flag for, and for ANG which should map to NL not the no longer Netherlands Antilles code.

Now regionCode(for:) returns nil for those X-prefixed currencies (so we just don't show a flag) and has an override for ANG -> NL. The flag image prefetcher also handles the nil case gracefully instead of trying to download a flag for a
  nonsense country code.

## Motivation
- AP

## Testing
- New tests

## Changelog
N/A