### PR TITLE
Validate shipping address country

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -257,6 +257,10 @@ public final class Checkout: ObservableObject {
         address: Address
     ) async throws {
         guard let currentSession = stpSession else { return }
+        if let allowedCountries = currentSession.allowedShippingCountries,
+           !allowedCountries.contains(address.country) {
+            throw CheckoutError.invalidShippingCountry(countryCode: address.country)
+        }
         let contactAddress = ContactAddress(name: name, phone: phone, address: address)
         guard currentSession.shippingAddress != contactAddress else { return }
         if currentSession.shouldSendTaxRegion(for: "shipping") {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutError.swift
@@ -24,6 +24,8 @@ public enum CheckoutError: Error, LocalizedError, Sendable {
     /// A pending Checkout operation did not complete before the timeout elapsed.
     case timedOut
 
+    case invalidShippingCountry(countryCode: String)
+
     /// The Stripe API returned an error with the given message.
     case apiError(message: String)
 
@@ -39,6 +41,8 @@ public enum CheckoutError: Error, LocalizedError, Sendable {
             return "A payment sheet or form is currently presented. Dismiss it before making changes."
         case .timedOut:
             return "Timed out waiting for a Checkout operation to complete."
+        case .invalidShippingCountry(let countryCode):
+            return "Country code '\(countryCode)' is not in allowedShippingCountries"
         case .apiError(let message):
             return message
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -43,6 +43,12 @@ enum CheckoutTestHelpers {
         return STPCheckoutSession.decodedObject(fromAPIResponse: json)!
     }
 
+    static func makeOpenSession(allowedCountries: [String]) -> STPCheckoutSession {
+        var json = makeOpenSessionJSON()
+        json["shipping_address_collection"] = ["allowed_countries": allowedCountries]
+        return STPCheckoutSession.decodedObject(fromAPIResponse: json)!
+    }
+
     static func makeAdaptivePricingSession(
         currency: String = "usd",
         adaptivePricingActive: Bool = true,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -133,6 +133,36 @@ final class CheckoutUnitTests: XCTestCase {
         XCTAssertTrue(delegate.didChangeStateCalled)
     }
 
+    func testUpdateShippingAddress_disallowedCountry_throws() async throws {
+        let session = CheckoutTestHelpers.makeOpenSession(allowedCountries: ["US", "CA"])
+        let checkout = await Checkout(clientSecret: "cs_test_123_secret_abc", session: session)
+
+        do {
+            try await checkout.updateShippingAddress(
+                address: .init(country: "DE")
+            )
+            XCTFail("Expected invalidShippingCountry error")
+        } catch let error as CheckoutError {
+            guard case .invalidShippingCountry("DE") = error else {
+                XCTFail("Wrong error case: \(error)")
+                return
+            }
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+
+    func testUpdateShippingAddress_allowedCountry_succeeds() async throws {
+        let session = CheckoutTestHelpers.makeOpenSession(allowedCountries: ["US", "CA", "GB"])
+        let checkout = await Checkout(clientSecret: "cs_test_123_secret_abc", session: session)
+
+        try await checkout.updateShippingAddress(
+            address: .init(country: "CA", line1: "80 Spadina Ave", city: "Toronto", state: "ON", postalCode: "M5V 2J4")
+        )
+
+        XCTAssertEqual(checkout.state.session.shippingAddress?.address.country, "CA")
+    }
+
     // MARK: - Sheet Presented Guard Tests
 
     func testRequireOpenSessionThrowsWhenSheetPresented() async {


### PR DESCRIPTION
## Summary
We weren't checking allowedShippingCountries client-side. If someone passed a country that isn't in the session's allowed list, we'd just send it to the backend and get a confusing error back. This adds a guard in updateShippingAddress that throws early with a clear message so callers can handle it locally without a round-trip.

## Motivation
- https://jira.corp.stripe.com/browse/MOBILESDK-4635

## Testing
- Unit tests

## Changelog
N/A