### PR TITLE
Forward email from CheckoutSession to Apple Pay

### DIFF
--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -326,6 +326,8 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
     @_spi(STP) public var confirmType: ConfirmType?
     /// Contains metadata with identifiers for the session and information about the integration
     @_spi(STP) public var clientAttributionMetadata: STPClientAttributionMetadata?
+    /// Billing details from the checkout session to merge with Apple Pay's contact info.
+    @_spi(STP) public var additionalBillingDetails: StripeAPI.BillingDetails?
 
     // Internal state
     private var startTime: Date?
@@ -642,7 +644,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
         }
 
         // 1. Create PaymentMethod
-        StripeAPI.PaymentMethod.create(apiClient: apiClient, payment: payment, clientAttributionMetadata: clientAttributionMetadata) { result in
+        StripeAPI.PaymentMethod.create(apiClient: apiClient, payment: payment, additionalBillingDetails: additionalBillingDetails, clientAttributionMetadata: clientAttributionMetadata) { result in
             guard !self.didFinish else {
                return // The user canceled mid-payment - just abort
             }

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -326,8 +326,8 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
     @_spi(STP) public var confirmType: ConfirmType?
     /// Contains metadata with identifiers for the session and information about the integration
     @_spi(STP) public var clientAttributionMetadata: STPClientAttributionMetadata?
-    /// Billing details from the checkout session to merge with Apple Pay's contact info.
-    @_spi(STP) public var additionalBillingDetails: StripeAPI.BillingDetails?
+    /// Billing details used as fallbacks when Apple Pay's contact info doesn't include a field.
+    @_spi(STP) public var fallbackBillingDetails: StripeAPI.BillingDetails?
 
     // Internal state
     private var startTime: Date?
@@ -644,7 +644,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
         }
 
         // 1. Create PaymentMethod
-        StripeAPI.PaymentMethod.create(apiClient: apiClient, payment: payment, additionalBillingDetails: additionalBillingDetails, clientAttributionMetadata: clientAttributionMetadata) { result in
+        StripeAPI.PaymentMethod.create(apiClient: apiClient, payment: payment, fallbackBillingDetails: fallbackBillingDetails, clientAttributionMetadata: clientAttributionMetadata) { result in
             guard !self.didFinish else {
                return // The user canceled mid-payment - just abort
             }

--- a/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Models/BillingDetails.swift
+++ b/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Models/BillingDetails.swift
@@ -50,7 +50,7 @@ extension StripeAPI {
         public var _additionalParametersStorage: NonEncodableParameters?
         public var _allResponseFieldsStorage: NonEncodableParameters?
 
-        public init(
+        @_spi(STP) public init(
             address: Address? = nil,
             email: String? = nil,
             name: String? = nil,

--- a/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Models/BillingDetails.swift
+++ b/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Models/BillingDetails.swift
@@ -49,6 +49,18 @@ extension StripeAPI {
 
         public var _additionalParametersStorage: NonEncodableParameters?
         public var _allResponseFieldsStorage: NonEncodableParameters?
+
+        public init(
+            address: Address? = nil,
+            email: String? = nil,
+            name: String? = nil,
+            phone: String? = nil
+        ) {
+            self.address = address
+            self.email = email
+            self.name = name
+            self.phone = phone
+        }
     }
 
 }

--- a/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/PaymentMethod+API.swift
+++ b/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/PaymentMethod+API.swift
@@ -37,6 +37,7 @@ extension StripeAPI.PaymentMethod {
     @_spi(STP) public static func create(
         apiClient: STPAPIClient = .shared,
         payment: PKPayment,
+        additionalBillingDetails: StripeAPI.BillingDetails? = nil,
         clientAttributionMetadata: STPClientAttributionMetadata?,
         completion: @escaping PaymentMethodCompletionBlock
     ) {
@@ -51,7 +52,12 @@ extension StripeAPI.PaymentMethod {
             }
             var cardParams = StripeAPI.PaymentMethodParams.Card()
             cardParams.token = token.id
-            let billingDetails = StripeAPI.BillingDetails(from: payment)
+            var billingDetails = StripeAPI.BillingDetails(from: payment) ?? StripeAPI.BillingDetails()
+            if let additional = additionalBillingDetails {
+                billingDetails.email = billingDetails.email ?? additional.email
+                billingDetails.name = billingDetails.name ?? additional.name
+                billingDetails.phone = billingDetails.phone ?? additional.phone
+            }
             var paymentMethodParams = StripeAPI.PaymentMethodParams(type: .card, card: cardParams)
             paymentMethodParams.billingDetails = billingDetails
             paymentMethodParams.clientAttributionMetadata = clientAttributionMetadata

--- a/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/PaymentMethod+API.swift
+++ b/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/PaymentMethod+API.swift
@@ -37,7 +37,7 @@ extension StripeAPI.PaymentMethod {
     @_spi(STP) public static func create(
         apiClient: STPAPIClient = .shared,
         payment: PKPayment,
-        additionalBillingDetails: StripeAPI.BillingDetails? = nil,
+        fallbackBillingDetails: StripeAPI.BillingDetails? = nil,
         clientAttributionMetadata: STPClientAttributionMetadata?,
         completion: @escaping PaymentMethodCompletionBlock
     ) {
@@ -53,7 +53,7 @@ extension StripeAPI.PaymentMethod {
             var cardParams = StripeAPI.PaymentMethodParams.Card()
             cardParams.token = token.id
             var billingDetails = StripeAPI.BillingDetails(from: payment) ?? StripeAPI.BillingDetails()
-            if let additional = additionalBillingDetails {
+            if let additional = fallbackBillingDetails {
                 billingDetails.email = billingDetails.email ?? additional.email
                 billingDetails.name = billingDetails.name ?? additional.name
                 billingDetails.phone = billingDetails.phone ?? additional.phone

--- a/StripeApplePay/StripeApplePayTests/BillingDetails+ApplePayTest.swift
+++ b/StripeApplePay/StripeApplePayTests/BillingDetails+ApplePayTest.swift
@@ -136,6 +136,29 @@ final class BillingDetailsApplePayTest: XCTestCase {
         XCTAssertNil(billingDetails?.address)
     }
 
+    // MARK: - Memberwise Init
+
+    func testBillingDetailsInitWithEmailOnly() {
+        let billingDetails = StripeAPI.BillingDetails(email: "test@example.com")
+        XCTAssertEqual(billingDetails.email, "test@example.com")
+        XCTAssertNil(billingDetails.name)
+        XCTAssertNil(billingDetails.phone)
+        XCTAssertNil(billingDetails.address)
+    }
+
+    func testBillingDetailsInitWithAllFields() {
+        let billingDetails = StripeAPI.BillingDetails(
+            address: StripeAPI.BillingDetails.Address(),
+            email: "shipping@example.com",
+            name: "Jane Smith",
+            phone: "+14155551234"
+        )
+        XCTAssertEqual(billingDetails.email, "shipping@example.com")
+        XCTAssertEqual(billingDetails.name, "Jane Smith")
+        XCTAssertEqual(billingDetails.phone, "+14155551234")
+        XCTAssertNotNil(billingDetails.address)
+    }
+
     // MARK: - Helper Methods
 
     private func createMockPKPayment(billingContact: PKContact?, shippingContact: PKContact?) -> PKPayment {

--- a/StripeApplePay/StripeApplePayTests/BillingDetails+ApplePayTest.swift
+++ b/StripeApplePay/StripeApplePayTests/BillingDetails+ApplePayTest.swift
@@ -7,7 +7,7 @@
 
 import Contacts
 import PassKit
-@testable import StripeApplePay
+@_spi(STP) @testable import StripeApplePay
 @_spi(STP) import StripeCore
 import XCTest
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -340,7 +340,7 @@ extension STPApplePayContext {
             applePayContext.returnUrl = configuration.returnURL
             applePayContext.clientAttributionMetadata = clientAttributionMetadata
             if case .checkout(let checkout) = intent, let email = checkout.stpSession.email {
-                applePayContext.additionalBillingDetails = StripeAPI.BillingDetails(email: email)
+                applePayContext.fallbackBillingDetails = StripeAPI.BillingDetails(email: email)
             }
             return applePayContext
         } else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -339,6 +339,9 @@ extension STPApplePayContext {
             applePayContext.apiClient = configuration.apiClient
             applePayContext.returnUrl = configuration.returnURL
             applePayContext.clientAttributionMetadata = clientAttributionMetadata
+            if case .checkout(let checkout) = intent, let email = checkout.stpSession.email {
+                applePayContext.additionalBillingDetails = StripeAPI.BillingDetails(email: email)
+            }
             return applePayContext
         } else {
             // Delegate only deallocs when Apple Pay completes

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -5,7 +5,7 @@
 //  Created by Yuki Tokuhiro on 8/2/23.
 //
 
-@testable import StripeApplePay
+@testable @_spi(STP) import StripeApplePay
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 @testable @_spi(STP) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(SharedPaymentToken) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
@@ -490,6 +490,25 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
 
     // MARK: - CheckoutSession Line Items Tests
 
+    private func makeApplePayContext(for intent: Intent, file: StaticString = #filePath, line: UInt = #line) -> STPApplePayContext {
+        let elementsSession = STPElementsSession._testValue()
+        let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(
+            intent: intent,
+            elementsSession: elementsSession
+        )
+        guard let context = STPApplePayContext.create(
+            intent: intent,
+            elementsSession: elementsSession,
+            configuration: configuration,
+            clientAttributionMetadata: clientAttributionMetadata,
+            completion: { _, _ in }
+        ) else {
+            XCTFail("Failed to create Apple Pay context", file: file, line: line)
+            fatalError("Unreachable")
+        }
+        return context
+    }
+
     private func makeMerchantConfiguration() -> PaymentSheet.Configuration {
         var config = PaymentSheet.Configuration._testValue_MostPermissive()
         config.merchantDisplayName = "Acme"
@@ -714,6 +733,26 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
         let intent = Intent._testValue()
         let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
         XCTAssertNil(sut.billingContact)
+    }
+
+    // MARK: - Checkout session billing details
+
+    func testCreate_CheckoutSessionForwardsEmailToBillingDetails() {
+        let intent = Intent._testCheckoutSession(mode: .payment, amount: 2345, currency: "USD", email: "guest@example.com")
+        let applePayContext = makeApplePayContext(for: intent)
+        XCTAssertEqual(applePayContext.additionalBillingDetails?.email, "guest@example.com")
+    }
+
+    func testCreate_CheckoutSessionWithNoEmail_additionalBillingDetailsNil() {
+        let intent = Intent._testCheckoutSession(mode: .payment, amount: 2345, currency: "USD")
+        let applePayContext = makeApplePayContext(for: intent)
+        XCTAssertNil(applePayContext.additionalBillingDetails)
+    }
+
+    func testCreate_paymentIntent_doesNotSetAdditionalBillingDetails() {
+        let intent = Intent._testValue()
+        let applePayContext = makeApplePayContext(for: intent)
+        XCTAssertNil(applePayContext.additionalBillingDetails)
     }
 
     func testCreatePaymentRequest_CheckoutSession_MerchantPaymentSummaryItemsTakePrecedence() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -740,19 +740,19 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
     func testCreate_CheckoutSessionForwardsEmailToBillingDetails() {
         let intent = Intent._testCheckoutSession(mode: .payment, amount: 2345, currency: "USD", email: "guest@example.com")
         let applePayContext = makeApplePayContext(for: intent)
-        XCTAssertEqual(applePayContext.additionalBillingDetails?.email, "guest@example.com")
+        XCTAssertEqual(applePayContext.fallbackBillingDetails?.email, "guest@example.com")
     }
 
-    func testCreate_CheckoutSessionWithNoEmail_additionalBillingDetailsNil() {
+    func testCreate_CheckoutSessionWithNoEmail_fallbackBillingDetailsNil() {
         let intent = Intent._testCheckoutSession(mode: .payment, amount: 2345, currency: "USD")
         let applePayContext = makeApplePayContext(for: intent)
-        XCTAssertNil(applePayContext.additionalBillingDetails)
+        XCTAssertNil(applePayContext.fallbackBillingDetails)
     }
 
     func testCreate_paymentIntent_doesNotSetAdditionalBillingDetails() {
         let intent = Intent._testValue()
         let applePayContext = makeApplePayContext(for: intent)
-        XCTAssertNil(applePayContext.additionalBillingDetails)
+        XCTAssertNil(applePayContext.fallbackBillingDetails)
     }
 
     func testCreatePaymentRequest_CheckoutSession_MerchantPaymentSummaryItemsTakePrecedence() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -301,6 +301,7 @@ extension Intent {
         mode: Checkout.Mode = .payment,
         amount: Int? = 2345,
         currency: String = "USD",
+        email: String? = nil,
         lineItems: [Checkout.LineItem] = [],
         subtotal: Int? = nil,
         shippingAmount: Int = 0,
@@ -329,6 +330,9 @@ extension Intent {
             "livemode": false,
             "payment_method_types": ["card"],
         ]
+        if let email {
+            json["customer_email"] = email
+        }
         if let amount {
             json["total_summary"] = [
                 "due": amount,


### PR DESCRIPTION
## Summary
- Confirming with apple pay previously failed if you were checking out as a guest
- This was caused by not attaching the email from the Checkout to the Apple Pay PM

## Motivation
- https://docs.google.com/document/d/1CWglcOHR6I8cOWKjztPfnhnVG8axucpv-j5cWIoey7E/edit?tab=t.k2ogcb9623lq#heading=h.a2lhvmal87zq

## Testing
- Unit tests
- Manual

## Changelog
N/A
