### PR TITLE
Disable link for CheckoutSessions <> Automatic tax (billing)

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -70,6 +70,9 @@ import Foundation
     /// A flag that indicates that this instance was created as a best-effort
     let isBackupInstance: Bool
 
+    // Link doesn't support automatic tax from billing address
+    var disableLinkForAutomaticTaxBilling: Bool = false
+
     public let allResponseFields: [AnyHashable: Any]
 
     internal init(

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/v1-elements-sessions/STPElementsSession.swift
@@ -70,6 +70,7 @@ import Foundation
     /// A flag that indicates that this instance was created as a best-effort
     let isBackupInstance: Bool
 
+    // TODO(joyceqin) Re-enable as part of the ECE workstream
     // Link doesn't support automatic tax from billing address
     var disableLinkForAutomaticTaxBilling: Bool = false
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -151,6 +151,8 @@ extension PaymentSheet {
         case cardBrandFiltering = "card_brand_filtering"
         /// Billing details collection is requested and native Link isn't available.
         case billingDetailsCollection = "billing_details_collection"
+        /// Automatic tax with billing address source is incompatible with Link.
+        case automaticTaxBillingAddress = "automatic_tax_billing_address"
     }
 
     enum LinkSignupDisabledReason: String {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -102,6 +102,10 @@ extension PaymentSheet {
             reasons.append(.billingDetailsCollection)
         }
 
+        if elementsSession.disableLinkForAutomaticTaxBilling {
+            reasons.append(.automaticTaxBillingAddress)
+        }
+
         return reasons
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -488,6 +488,7 @@ final class PaymentSheetLoader {
                   let decodedElementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJSON) else {
                 throw PaymentSheetError.unknown(debugDescription: "Failed to decode elements session from provided checkout session object")
             }
+            decodedElementsSession.disableLinkForAutomaticTaxBilling = checkout.stpSession.shouldSendTaxRegion(for: "billing")
             elementsSession = decodedElementsSession
             intent = .checkout(checkout)
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
@@ -185,6 +185,29 @@ final class PaymentMethodAvailabilityTests: XCTestCase {
         XCTAssertFalse(isLinkEnabled, "Link should be disabled when display is set to .never")
     }
 
+    func testIsLinkEnabled_automaticTaxBilling_linkDisabled() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card", "link"],
+            isLinkPassthroughModeEnabled: true
+        )
+        elementsSession.disableLinkForAutomaticTaxBilling = true
+        let configuration = PaymentSheet.Configuration()
+
+        XCTAssertFalse(PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration))
+        XCTAssertTrue(PaymentSheet.linkDisabledReasons(elementsSession: elementsSession, configuration: configuration).contains(.automaticTaxBillingAddress))
+    }
+
+    func testIsLinkEnabled_automaticTaxBillingFalse_linkEnabled() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card", "link"],
+            isLinkPassthroughModeEnabled: true
+        )
+        elementsSession.disableLinkForAutomaticTaxBilling = false
+        let configuration = PaymentSheet.Configuration()
+
+        XCTAssertTrue(PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration))
+    }
+
     func testIsLinkSignupEnabled_enabled_for_linkSignupOptInFeatureEnabled_if_general_signup_disabled() {
         // Lookup happened during initialization and an email was provided
         LinkAccountContext.shared.account = ._testValue(email: "john@doe.com", isRegistered: false)


### PR DESCRIPTION
## Summary
- Disables Link if auto tax is enabled and billing address is the source

## Motivation
- https://docs.google.com/document/d/1CWglcOHR6I8cOWKjztPfnhnVG8axucpv-j5cWIoey7E/edit?tab=t.k2ogcb9623lq#heading=h.a2lhvmal87zq

## Testing
Unit tests

## Changelog
N/A