### PR TITLE
Remove shipping options & phone number from Checkout playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
@@ -18,7 +18,6 @@ struct CheckoutCartContentView: View {
     @State private var promoCodeInput = ""
     @State private var showShippingAddressSheet = false
     @State private var showBillingAddressSheet = false
-    @State private var lastSelectedShippingOptionId: String?
     @State private var shippingAddressDetails: AddressElement.AddressDetails?
     @State private var billingAddressDetails: AddressElement.AddressDetails?
 
@@ -35,7 +34,6 @@ struct CheckoutCartContentView: View {
 
                 currencySelectorSection
                 lineItemsSection
-                shippingOptionsSection
                 shippingAddressSection
                 billingAddressSection
                 promotionCodeSection
@@ -121,63 +119,6 @@ struct CheckoutCartContentView: View {
 
                         if item.id != items.last?.id {
                             Divider().padding(.leading, 112)
-                        }
-                    }
-                }
-                .background(Color(UIColor.systemBackground))
-                .cornerRadius(16)
-                .padding(.horizontal)
-                .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: 4)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var shippingOptionsSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Shipping Options")
-                .font(.title2).bold()
-                .padding(.horizontal)
-
-            let options = checkout.state.session.shippingOptions
-            if options.isEmpty {
-                Text("No shipping options available")
-                    .foregroundColor(.secondary)
-                    .padding(.horizontal)
-            } else {
-                let selectedId = selectedShippingOptionId ?? ""
-                VStack(spacing: 0) {
-                    ForEach(options) { option in
-                        Button(action: {
-                            selectShippingOption(option.id)
-                        }) {
-                            HStack {
-                                VStack(alignment: .leading, spacing: 4) {
-                                    Text(option.displayName ?? "Shipping")
-                                        .font(.body)
-                                        .foregroundColor(.primary)
-                                    Text(option.amount.amount)
-                                        .font(.subheadline)
-                                        .foregroundColor(.secondary)
-                                }
-                                Spacer()
-                                if option.id == selectedId {
-                                    Image(systemName: "checkmark.circle.fill")
-                                        .foregroundColor(.blue)
-                                        .font(.system(size: 24))
-                                } else {
-                                    Image(systemName: "circle")
-                                        .foregroundColor(.gray.opacity(0.5))
-                                        .font(.system(size: 24))
-                                }
-                            }
-                            .padding()
-                            .contentShape(Rectangle())
-                        }
-                        .buttonStyle(PlainButtonStyle())
-
-                        if option.id != options.last?.id {
-                            Divider().padding(.leading, 16)
                         }
                     }
                 }
@@ -338,8 +279,7 @@ struct CheckoutCartContentView: View {
                     postalCode: override.address.postalCode,
                     state: override.address.state
                 ),
-                name: override.name,
-                phone: override.phone
+                name: override.name
             )
         }
         return config
@@ -494,21 +434,6 @@ struct CheckoutCartContentView: View {
         }
     }
 
-    private var selectedShippingOptionId: String? {
-        let options = checkout.state.session.shippingOptions
-        guard !options.isEmpty else {
-            return nil
-        }
-        guard let shippingAmount = checkout.state.session.total?.shippingRate.minorUnitsAmount else {
-            return lastSelectedShippingOptionId
-        }
-        let matchingOptions = options.filter { $0.amount.minorUnitsAmount == shippingAmount }
-        if matchingOptions.count == 1 {
-            return matchingOptions[0].id
-        }
-        return lastSelectedShippingOptionId
-    }
-
     private var appliedPromotionCode: String? {
         checkout.state.session.discountAmounts.first(where: { $0.promotionCode != nil })?.promotionCode
     }
@@ -521,21 +446,6 @@ struct CheckoutCartContentView: View {
             errorMessage = nil
             do {
                 try await checkout.updateQuantity(lineItemId: lineItemId, quantity: quantity)
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-            isLoading = false
-        }
-    }
-
-    private func selectShippingOption(_ optionId: String) {
-        guard !optionId.isEmpty else { return }
-        Task {
-            isLoading = true
-            errorMessage = nil
-            do {
-                try await checkout.selectShippingOption(optionId)
-                lastSelectedShippingOptionId = optionId
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -598,7 +508,7 @@ struct CheckoutCartContentView: View {
             do {
                 try await checkout.updateShippingAddress(
                     name: details.name,
-                    phone: details.phone,
+                    phone: nil,
                     address: checkoutAddress(from: details.address)
                 )
             } catch {
@@ -615,7 +525,7 @@ struct CheckoutCartContentView: View {
             do {
                 try await checkout.updateBillingAddress(
                     name: details.name,
-                    phone: details.phone,
+                    phone: nil,
                     address: checkoutAddress(from: details.address)
                 )
             } catch {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
@@ -150,10 +150,8 @@ struct CheckoutPlaygroundLineItemCard: View {
 struct CheckoutPlaygroundFeaturesSection: View {
     let mode: CheckoutPlayground.SessionMode
     let customerType: CheckoutPlayground.CustomerType
-    @Binding var enableShipping: Bool
     @Binding var shippingAddressCollection: Bool
     @Binding var billingAddressCollection: Bool
-    @Binding var phoneNumberCollection: Bool
     @Binding var allowPromotionCodes: Bool
     @Binding var automaticTax: Bool
     @Binding var adaptivePricing: Bool
@@ -174,11 +172,6 @@ struct CheckoutPlaygroundFeaturesSection: View {
             CheckoutPlayground.SectionHeader(title: "Features", icon: "slider.horizontal.3")
             VStack(spacing: 1) {
                 CheckoutPlayground.ToggleRow(
-                    title: "Shipping Options",
-                    isOn: $enableShipping,
-                    tooltip: "Populates `shipping_options` with sample rates (e.g., $5.99 Standard). Requires `shipping_address_collection`."
-                )
-                CheckoutPlayground.ToggleRow(
                     title: "Collect Shipping Address",
                     isOn: $shippingAddressCollection,
                     tooltip: "Sets `shipping_address_collection` to allow specific countries (US, CA, GB, AU). Necessary for physical goods."
@@ -189,11 +182,6 @@ struct CheckoutPlaygroundFeaturesSection: View {
                     tooltip: "Sets `billing_address_collection: 'required'`. If off, defaults to 'auto' (only collected if the payment method needs it)."
                 )
                 if supportsSetupRestrictedFeatures {
-                    CheckoutPlayground.ToggleRow(
-                        title: "Collect Phone Number",
-                        isOn: $phoneNumberCollection,
-                        tooltip: "Sets `phone_number_collection: { enabled: true }`. Useful for SMS notifications or 3DS authentication fallback."
-                    )
                     CheckoutPlayground.ToggleRow(
                         title: "Allow Promo Codes",
                         isOn: $allowPromotionCodes,

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
@@ -43,10 +43,8 @@ struct CheckoutPlaygroundView: View {
                         CheckoutPlaygroundFeaturesSection(
                             mode: viewModel.mode,
                             customerType: viewModel.customerType,
-                            enableShipping: $viewModel.enableShipping,
                             shippingAddressCollection: $viewModel.shippingAddressCollection,
                             billingAddressCollection: $viewModel.billingAddressCollection,
-                            phoneNumberCollection: $viewModel.phoneNumberCollection,
                             allowPromotionCodes: $viewModel.allowPromotionCodes,
                             automaticTax: $viewModel.automaticTax,
                             adaptivePricing: $viewModel.adaptivePricing,

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
@@ -18,9 +18,7 @@ extension CheckoutPlayground {
         @Published var currency: Currency = .usd
         @Published var customerType: CustomerType = .guest
         @Published var lineItems: [LineItemConfig] = LineItemConfig.defaults
-        @Published var enableShipping = true
         @Published var allowPromotionCodes = true
-        @Published var phoneNumberCollection = false
         @Published var shippingAddressCollection = true
         @Published var billingAddressCollection = false
         @Published var automaticTax = true
@@ -89,7 +87,6 @@ extension CheckoutPlayground {
             // Send explicit safe values so setup mode never requests unsupported options.
             let supportsAdvancedCollection = mode != .setup
             let allowPromotionCodesForRequest = supportsAdvancedCollection ? allowPromotionCodes : false
-            let phoneNumberCollectionForRequest = supportsAdvancedCollection ? phoneNumberCollection : false
             let automaticTaxForRequest = supportsAdvancedCollection ? automaticTax : false
 
             var body: [String: Any] = [
@@ -98,10 +95,8 @@ extension CheckoutPlayground {
                 "currency": currency.rawValue,
                 "customer": customerType.rawValue,
                 "allow_promotion_codes": allowPromotionCodesForRequest,
-                "phone_number_collection": phoneNumberCollectionForRequest,
                 "shipping_address_collection": shippingAddressCollection,
                 "billing_address_collection": billingAddressCollection,
-                "include_shipping_options": enableShipping,
                 "automatic_tax": automaticTaxForRequest,
                 "payment_method_types": Array(paymentMethodTypes),
                 "adaptive_pricing": adaptivePricing,


### PR DESCRIPTION
## Summary
- Remove phone and shipping options from the Checkout playground. We won't support these in private preview.