### PR TITLE
Fix currency selector revert bug and clean up utilities

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+CurrencySelectorView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+CurrencySelectorView.swift
@@ -149,6 +149,7 @@ extension Checkout {
                 updateSelectorItems(session: session, exchangeRateMeta: exchangeRateMeta)
             }
 
+            lastSelectedCurrency = currency.apiValue
             updateCaption(currency: currency, exchangeRateMeta: exchangeRateMeta)
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CurrencySelectorUtilities.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CurrencySelectorUtilities.swift
@@ -98,6 +98,13 @@ enum CurrencySelectorUtilities {
         return formatExchangeRate(from: meta)
     }
 
+    private static let exchangeRateFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 2
+        formatter.maximumFractionDigits = 4
+        return formatter
+    }()
+
     static func formatExchangeRate(from meta: STPCheckoutSessionExchangeRateMeta) -> String {
         let localCurrency = CurrencyCode(meta.localizedCurrency).displayValue
         let integrationCurrency = CurrencyCode(meta.integrationCurrency).displayValue
@@ -105,10 +112,7 @@ enum CurrencySelectorUtilities {
         let formattedRate: String
         if let rateDouble = Double(meta.exchangeRate) {
             let inverse = 1.0 / rateDouble
-            let formatter = NumberFormatter()
-            formatter.minimumFractionDigits = 2
-            formatter.maximumFractionDigits = 4
-            formattedRate = formatter.string(from: NSNumber(value: inverse)) ?? meta.exchangeRate
+            formattedRate = exchangeRateFormatter.string(from: NSNumber(value: inverse)) ?? meta.exchangeRate
         } else {
             formattedRate = meta.exchangeRate
         }
@@ -138,11 +142,7 @@ enum CurrencySelectorUtilities {
     }
 
     private static func formatConversionFeePercent(bps: Int) -> String {
-        let percent = Double(bps) / 100.0
-        if percent.truncatingRemainder(dividingBy: 1) == 0 {
-            return String(format: "%.0f", percent)
-        }
-        return String(format: "%g", percent)
+        String(format: "%g", Double(bps) / 100.0)
     }
 
     // MARK: - Availability

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CurrencySelectorUtilities.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CurrencySelectorUtilities.swift
@@ -118,7 +118,7 @@ enum CurrencySelectorUtilities {
         }
 
         if meta.conversionMarkupBps > 0 {
-            let feePercent = formatConversionFeePercent(bps: meta.conversionMarkupBps)
+            let feePercent = String(format: "%g", Double(meta.conversionMarkupBps) / 100.0)
             return .Localized.exchangeRateWithConversionFee(
                 localCurrency: localCurrency,
                 rate: formattedRate,
@@ -139,10 +139,6 @@ enum CurrencySelectorUtilities {
     static func detailText(exchangeRateMeta meta: STPCheckoutSessionExchangeRateMeta) -> String? {
         guard meta.conversionMarkupBps > 0 else { return nil }
         return "This string will come from the translation layer in the future"
-    }
-
-    private static func formatConversionFeePercent(bps: Int) -> String {
-        String(format: "%g", Double(bps) / 100.0)
     }
 
     // MARK: - Availability


### PR DESCRIPTION
## Summary
Fix a bug where the currency selector can't revert on error during the first tap, plus a couple small cleanups in the utilities file.

## Motivation
- AP

## Testing
- Existing

## Changelog
- N/A