### PR TITLE
DRY address overrides via generics, remove unused error

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -43,7 +43,7 @@ extension Checkout.Configuration {
     /// Options for adaptive pricing behavior.
     ///
     /// Adaptive pricing lets customers see prices converted to their local
-    /// currency. When ``allowed`` is `true` (the default), the Checkout Session
+    /// currency. When ``allowed`` is `true`, the Checkout Session
     /// init request tells Stripe that the integration supports adaptive pricing;
     /// Stripe then decides whether to activate it based on the session's
     /// server-side configuration.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutError.swift
@@ -15,9 +15,6 @@ public enum CheckoutError: Error, LocalizedError, Sendable {
     /// The client secret provided to ``Checkout`` is empty.
     case invalidClientSecret
 
-    /// The session is no longer open (e.g. it has been completed or expired).
-    case sessionNotOpen
-
     /// A payment sheet or form is currently presented. Dismiss it before making changes.
     case sheetCurrentlyPresented
 
@@ -35,8 +32,6 @@ public enum CheckoutError: Error, LocalizedError, Sendable {
         switch self {
         case .invalidClientSecret:
             return "Checkout was initialized with an empty client secret."
-        case .sessionNotOpen:
-            return "The session is no longer active."
         case .sheetCurrentlyPresented:
             return "A payment sheet or form is currently presented. Dismiss it before making changes."
         case .timedOut:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/STPCheckoutSession+AddressMerging.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/STPCheckoutSession+AddressMerging.swift
@@ -13,20 +13,7 @@ extension STPCheckoutSession {
 
     /// Populates empty fields in the configuration with checkout-collected addresses.
     /// Configuration values always take precedence over checkout-collected values.
-    func applyAddressOverrides(to configuration: inout PaymentSheet.Configuration) {
-        if let billing = billingAddress {
-            applyBillingAddress(billing, to: &configuration.defaultBillingDetails)
-        }
-        if let shipping = shippingAddress, configuration.shippingDetails() == nil {
-            let details = shippingAddressDetails(from: shipping)
-            configuration.shippingDetails = { details }
-        }
-        configuration.defaultBillingDetails.email = configuration.defaultBillingDetails.email ?? email
-    }
-
-    /// Populates empty fields in the embedded configuration with checkout-collected addresses.
-    /// Configuration values always take precedence over checkout-collected values.
-    func applyAddressOverrides(to configuration: inout EmbeddedPaymentElement.Configuration) {
+    func applyAddressOverrides<C: PaymentElementConfiguration>(to configuration: inout C) {
         if let billing = billingAddress {
             applyBillingAddress(billing, to: &configuration.defaultBillingDetails)
         }


### PR DESCRIPTION
## Summary
Consolidate the two `applyAddressOverrides` methods into one generic, remove a dead error case, and fix a doc comment.

## Motivation
- Code clean up

## Testing
- Existing tests 

## Changelog
N/A