### PR TITLE
Fix embedded payment element confirm with checkout sessions

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard2.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard2.xctestplan
@@ -31,6 +31,7 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
+        "CheckoutSessionUITests",
         "CustomerSheetSnapshotTests",
         "CustomerSheetUITest",
         "EmbeddedUITests",

--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard3.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard3.xctestplan
@@ -31,6 +31,7 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
+        "CheckoutSessionUITests",
         "CustomerSheetSnapshotTests",
         "CustomerSheetUITest",
         "EmbeddedUITests",

--- a/Example/PaymentSheet Example/PaymentSheet Example-Shard4.xctestplan
+++ b/Example/PaymentSheet Example/PaymentSheet Example-Shard4.xctestplan
@@ -31,6 +31,7 @@
     {
       "parallelizable" : true,
       "skippedTests" : [
+        "CheckoutSessionUITests",
         "CustomerSheetSnapshotTests",
         "CustomerSheetUITest",
         "FCLiteUITests",

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutSessionUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutSessionUITests.swift
@@ -1,0 +1,49 @@
+//
+//  CheckoutSessionUITests.swift
+//  PaymentSheet Example
+//
+
+import XCTest
+
+class CheckoutSessionUITests: PaymentSheetUITestCase {
+
+    // MARK: - Embedded Payment Element
+
+    func testCheckoutSession_Embedded_Card() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.uiStyle = .embedded
+        settings.integrationType = .checkoutSession
+        settings.mode = .payment
+        settings.formSheetAction = .continue
+        loadPlayground(app, settings)
+
+        app.buttons["Present embedded payment element"].waitForExistenceAndTap()
+        app.buttons["Card"].waitForExistenceAndTap()
+        try fillCardData(app, postalEnabled: true)
+        app.buttons["Continue"].tap()
+        // After dismissing the form, tap the confirm button
+        app.buttons["Checkout"].waitForExistenceAndTap()
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 15))
+    }
+
+    // MARK: - FlowController
+
+    func testCheckoutSession_FlowController_Card() throws {
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.uiStyle = .flowController
+        settings.integrationType = .checkoutSession
+        settings.mode = .payment
+        loadPlayground(app, settings)
+
+        // Open payment options
+        app.buttons["Payment method"].waitForExistenceAndTap()
+        app.buttons["+ Add"].waitForExistenceAndTap()
+        app.buttons["Card"].waitForExistenceAndTap()
+        try fillCardData(app)
+        app.buttons["Continue"].tap()
+
+        // Confirm
+        app.buttons["Confirm"].waitForExistenceAndTap()
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 15))
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutSessionUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutSessionUITests.swift
@@ -21,8 +21,8 @@ class CheckoutSessionUITests: PaymentSheetUITestCase {
         app.buttons["Card"].waitForExistenceAndTap()
         try fillCardData(app, postalEnabled: true)
         app.buttons["Continue"].tap()
-        // After dismissing the form, tap the confirm button
-        app.buttons["Checkout"].waitForExistenceAndTap()
+        // After dismissing the form, scroll down and tap the confirm button
+        app.buttons["Checkout"].scrollToAndTap(in: app)
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 15))
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -346,14 +346,14 @@ public final class Checkout: ObservableObject {
     ///
     /// Client-side address overrides are copied from the current session to `newSession`
     /// automatically. To update an address, set it on `stpSession` before calling this method.
-    func commitSession(_ newSession: STPCheckoutSession) async throws {
+    func commitSession(_ newSession: STPCheckoutSession, skipIntegrationNotification: Bool = false) async throws {
         // Preserve client-side address overrides on the new session.
         newSession.billingAddress = stpSession?.billingAddress
         newSession.shippingAddress = stpSession?.shippingAddress
         stpSession = newSession
         session = newSession.makePublicSession()
         // Skip delegate if another op is queued—it'll notify when it commits.
-        if isLastPendingOperation {
+        if isLastPendingOperation && !skipIntegrationNotification {
             try await integrationDelegate?.checkoutDidUpdate(self)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
@@ -84,7 +84,7 @@ extension PaymentSheet {
             )
 
             // Update the Checkout instance with the confirmed session response
-            try await checkout.commitSession(response)
+            try await checkout.commitSession(response, skipIntegrationNotification: true)
 
             // 4. Handle response based on checkout session mode
             return try await handleCheckoutSessionConfirmResponse(


### PR DESCRIPTION
## Summary
- Fix a bug where confirming with a checkout session in the embedded payment element would trigger a spurious element reload, causing UI presentation errors.
- During confirm, `commitSession` was notifying the integration delegate which triggered a full `performUpdate` reload while the confirm was still in flight. Added a `skipIntegrationNotification` flag so the confirm-path commit doesn't kick off a redundant reload.

## Motivation
CheckoutSessions

## Testing
- Added new UI tests

## Changelog
N/A