### PR TITLE
Move elements session decoding onto STPCheckoutSession

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/STPCheckoutSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/STPCheckoutSession.swift
@@ -147,6 +147,8 @@ class STPCheckoutSession: NSObject {
     /// The address source used for automatic tax calculation (e.g. `"billing"` or `"shipping"`).
     let automaticTaxAddressSource: String?
 
+    /// TODO(porter or someone else) This is optional b/c we aren't sure if the /confirm endpoint populates this field
+    /// We need to solidify the backend contract to ensure this is always present
     /// The decoded elements session nested within this checkout session response.
     let elementsSession: STPElementsSession?
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/STPCheckoutSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/STPCheckoutSession.swift
@@ -147,6 +147,9 @@ class STPCheckoutSession: NSObject {
     /// The address source used for automatic tax calculation (e.g. `"billing"` or `"shipping"`).
     let automaticTaxAddressSource: String?
 
+    /// The decoded elements session nested within this checkout session response.
+    let elementsSession: STPElementsSession?
+
     /// The raw API response used to create this object.
     let allResponseFields: [AnyHashable: Any]
 
@@ -269,6 +272,7 @@ class STPCheckoutSession: NSObject {
         adaptivePricingActive: Bool,
         automaticTaxEnabled: Bool,
         automaticTaxAddressSource: String?,
+        elementsSession: STPElementsSession?,
         allResponseFields: [AnyHashable: Any]
     ) {
         self.id = id
@@ -308,6 +312,7 @@ class STPCheckoutSession: NSObject {
         self.adaptivePricingActive = adaptivePricingActive
         self.automaticTaxEnabled = automaticTaxEnabled
         self.automaticTaxAddressSource = automaticTaxAddressSource
+        self.elementsSession = elementsSession
         self.allResponseFields = allResponseFields
         super.init()
     }
@@ -490,6 +495,15 @@ extension STPCheckoutSession: STPAPIResponseDecodable {
 
         let businessName = (dict["elements_session"] as? [String: Any])?["business_name"] as? String
 
+        let elementsSession: STPElementsSession? = {
+            guard let json = dict["elements_session"] as? [AnyHashable: Any] else { return nil }
+            let decoded = STPElementsSession.decodedObject(fromAPIResponse: json)
+            if automaticTaxEnabled && automaticTaxAddressSource == "billing" {
+                decoded?.disableLinkForAutomaticTaxBilling = true
+            }
+            return decoded
+        }()
+
         let email = (dict["customer_email"] as? String) ?? customer?.email
 
         return STPCheckoutSession(
@@ -532,6 +546,7 @@ extension STPCheckoutSession: STPAPIResponseDecodable {
             adaptivePricingActive: adaptivePricingActive,
             automaticTaxEnabled: automaticTaxEnabled,
             automaticTaxAddressSource: automaticTaxAddressSource,
+            elementsSession: elementsSession,
             allResponseFields: dict
         ) as? Self
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -484,11 +484,9 @@ final class PaymentSheetLoader {
                 intent = .deferredIntent(intentConfig: intentConfig)
             }
         case .checkout(let checkout):
-            guard let elementsSessionJSON = checkout.stpSession.allResponseFields["elements_session"] as? [AnyHashable: Any],
-                  let decodedElementsSession = STPElementsSession.decodedObject(fromAPIResponse: elementsSessionJSON) else {
+            guard let decodedElementsSession = checkout.stpSession.elementsSession else {
                 throw PaymentSheetError.unknown(debugDescription: "Failed to decode elements session from provided checkout session object")
             }
-            decodedElementsSession.disableLinkForAutomaticTaxBilling = checkout.stpSession.shouldSendTaxRegion(for: "billing")
             elementsSession = decodedElementsSession
             intent = .checkout(checkout)
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/STPCheckoutSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/STPCheckoutSessionTest.swift
@@ -88,6 +88,8 @@ class STPCheckoutSessionTest: XCTestCase {
         XCTAssertEqual(session.customer?.paymentMethods[1].stripeId, "pm_1Sxae4Lu5o3P18ZplFiKexnM")
         XCTAssertEqual(session.customer?.paymentMethods[1].type, .USBankAccount)
         XCTAssertEqual(session.businessName, "CI Stuff")
+        XCTAssertNotNil(session.elementsSession)
+        XCTAssertEqual(session.elementsSession?.sessionID, "elements_session_test123")
         XCTAssertEqual(session.email, "test@example.com")
         XCTAssertEqual(session.url?.absoluteString, "https://checkout.stripe.com/c/pay/cs_test_a1b2c3d4e5f6g7h8i9j0")
         XCTAssertEqual(session.returnUrl, "https://example.com/return")
@@ -560,6 +562,46 @@ class STPCheckoutSessionTest: XCTestCase {
             ],
         ])
         XCTAssertEqual(session.tax.status, .ready)
+    }
+
+    // MARK: - Elements Session Tests
+
+    func testElementsSessionNilWhenMissing() {
+        let session = makeCheckoutSession([:])
+        XCTAssertNil(session.elementsSession)
+    }
+
+    func testElementsSessionNilWhenInvalid() {
+        let session = makeCheckoutSession([
+            "elements_session": ["business_name": "Test"],
+        ])
+        XCTAssertNil(session.elementsSession)
+    }
+
+    func testElementsSessionDisableLinkForAutomaticTaxBilling() {
+        let session = makeCheckoutSession([
+            "elements_session": [
+                "session_id": "es_123",
+                "payment_method_preference": ["ordered_payment_method_types": ["card"]],
+            ],
+            "tax_context": [
+                "automatic_tax_enabled": true,
+                "automatic_tax_address_source": "session.billing",
+            ],
+        ])
+        XCTAssertNotNil(session.elementsSession)
+        XCTAssertTrue(session.elementsSession!.disableLinkForAutomaticTaxBilling)
+    }
+
+    func testElementsSessionDoesNotDisableLinkWithoutAutomaticTax() {
+        let session = makeCheckoutSession([
+            "elements_session": [
+                "session_id": "es_123",
+                "payment_method_preference": ["ordered_payment_method_types": ["card"]],
+            ],
+        ])
+        XCTAssertNotNil(session.elementsSession)
+        XCTAssertFalse(session.elementsSession!.disableLinkForAutomaticTaxBilling)
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/STPCheckoutSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/STPCheckoutSessionTest.swift
@@ -566,19 +566,7 @@ class STPCheckoutSessionTest: XCTestCase {
 
     // MARK: - Elements Session Tests
 
-    func testElementsSessionNilWhenMissing() {
-        let session = makeCheckoutSession([:])
-        XCTAssertNil(session.elementsSession)
-    }
-
-    func testElementsSessionNilWhenInvalid() {
-        let session = makeCheckoutSession([
-            "elements_session": ["business_name": "Test"],
-        ])
-        XCTAssertNil(session.elementsSession)
-    }
-
-    func testElementsSessionDisableLinkForAutomaticTaxBilling() {
+    func testElementsSessionDecoding() {
         let session = makeCheckoutSession([
             "elements_session": [
                 "session_id": "es_123",
@@ -591,17 +579,18 @@ class STPCheckoutSessionTest: XCTestCase {
         ])
         XCTAssertNotNil(session.elementsSession)
         XCTAssertTrue(session.elementsSession!.disableLinkForAutomaticTaxBilling)
-    }
 
-    func testElementsSessionDoesNotDisableLinkWithoutAutomaticTax() {
-        let session = makeCheckoutSession([
+        let sessionWithoutTax = makeCheckoutSession([
             "elements_session": [
                 "session_id": "es_123",
                 "payment_method_preference": ["ordered_payment_method_types": ["card"]],
             ],
         ])
-        XCTAssertNotNil(session.elementsSession)
-        XCTAssertFalse(session.elementsSession!.disableLinkForAutomaticTaxBilling)
+        XCTAssertNotNil(sessionWithoutTax.elementsSession)
+        XCTAssertFalse(sessionWithoutTax.elementsSession!.disableLinkForAutomaticTaxBilling)
+
+        let sessionWithoutES = makeCheckoutSession([:])
+        XCTAssertNil(sessionWithoutES.elementsSession)
     }
 
 }

--- a/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CheckoutSession.json
+++ b/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CheckoutSession.json
@@ -211,6 +211,10 @@
     }
   },
   "elements_session": {
-    "business_name": "CI Stuff"
+    "business_name": "CI Stuff",
+    "session_id": "elements_session_test123",
+    "payment_method_preference": {
+      "ordered_payment_method_types": ["card"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- STPCheckoutSession now decodes the nested `elements_session` during init instead of having PaymentSheetLoader do it after the fact.
- PaymentSheetLoader was reaching into `allResponseFields["elements_session"]` to manually decode the elements session.

## Motivation
CheckoutSessions
## Testing
- New/updated tests

## Changelog
N/A