### PR TITLE
Skip updates on terminal checkout sessions

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -342,18 +342,23 @@ public final class Checkout: ObservableObject {
 
     // MARK: - State updates
 
+    /// True if the session is still actionable (open or no status yet).
+    var sessionIsOpen: Bool {
+        session.status?.type == .open || session.status?.type == nil
+    }
+
     /// Replaces the current session, preserves client-side overrides, and notifies delegates.
     ///
     /// Client-side address overrides are copied from the current session to `newSession`
     /// automatically. To update an address, set it on `stpSession` before calling this method.
-    func commitSession(_ newSession: STPCheckoutSession, skipIntegrationNotification: Bool = false) async throws {
+    func commitSession(_ newSession: STPCheckoutSession) async throws {
         // Preserve client-side address overrides on the new session.
         newSession.billingAddress = stpSession?.billingAddress
         newSession.shippingAddress = stpSession?.shippingAddress
         stpSession = newSession
         session = newSession.makePublicSession()
         // Skip delegate if another op is queued—it'll notify when it commits.
-        if isLastPendingOperation && !skipIntegrationNotification {
+        if isLastPendingOperation {
             try await integrationDelegate?.checkoutDidUpdate(self)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -170,6 +170,10 @@ public final class EmbeddedPaymentElement {
     func update(
         checkout: Checkout
     ) async -> UpdateResult {
+        // Session moved to a terminal state (e.g. during confirm), nothing to do.
+        guard checkout.sessionIsOpen else {
+            return .succeeded
+        }
         do {
             try await checkout.awaitPendingOperations()
         } catch {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
@@ -84,7 +84,7 @@ extension PaymentSheet {
             )
 
             // Update the Checkout instance with the confirmed session response
-            try await checkout.commitSession(response, skipIntegrationNotification: true)
+            try await checkout.commitSession(response)
 
             // 4. Handle response based on checkout session mode
             return try await handleCheckoutSessionConfirmResponse(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -767,6 +767,11 @@ extension PaymentSheet {
             checkout: Checkout,
             completion: @escaping (Error?) -> Void
         ) {
+            // No-op if the session already reached a terminal state (complete/expired).
+            guard checkout.sessionIsOpen else {
+                completion(nil)
+                return
+            }
             assert(Thread.isMainThread, "PaymentSheet.FlowController.update must be called from the main thread.")
             assert(!isPresented, "PaymentSheet.FlowController.update must be when PaymentSheet is not presented.")
             let updateID = beginUpdate()

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -453,6 +453,22 @@ final class CheckoutUnitTests: XCTestCase {
         sessionSub.cancel()
     }
 
+    func testCommitSessionWithTerminalStatusStillNotifiesIntegrationDelegate() async throws {
+        let checkout = await makeCheckoutWithOpenSession()
+        let integrationDelegate = MockCheckoutIntegrationDelegate()
+        checkout.integrationDelegate = integrationDelegate
+
+        var completedJSON = CheckoutTestHelpers.makeOpenSessionJSON()
+        completedJSON["status"] = "complete"
+        completedJSON["payment_status"] = "paid"
+        let completedSession = STPCheckoutSession.decodedObject(fromAPIResponse: completedJSON)!
+
+        try await checkout.commitSession(completedSession)
+
+        XCTAssertEqual(integrationDelegate.checkoutDidUpdateCallCount, 1)
+        XCTAssertEqual(checkout.session.status?.type, .complete)
+    }
+
     // MARK: - State Convenience Tests
 
     func testSessionAvailableAfterInit() async {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -923,6 +923,60 @@ class EmbeddedPaymentElementTest: XCTestCase {
         XCTAssertEqual(updateResult2, .succeeded)
     }
 
+    func testUpdateCheckoutSessionNoOpsForCompleteSession() async throws {
+        let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
+        let apiClient = STPAPIClient(publishableKey: response.publishableKey)
+        let checkout = try await Checkout(clientSecret: response.clientSecret, apiClient: apiClient)
+
+        var config = EmbeddedPaymentElement.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
+        config.apiClient = apiClient
+        config.defaultBillingDetails.email = "test@example.com"
+
+        let sut = try await EmbeddedPaymentElement.create(checkout: checkout, configuration: config)
+        sut.delegate = self
+        sut.presentingViewController = UIViewController()
+
+        // Simulate the session completing
+        let completedSession = STPCheckoutSession.decodedObject(fromAPIResponse: {
+            var json = CheckoutTestHelpers.makeOpenSessionJSON()
+            json["status"] = "complete"
+            json["payment_status"] = "paid"
+            return json
+        }())!
+        try await checkout.commitSession(completedSession)
+        XCTAssertFalse(checkout.sessionIsOpen)
+
+        // Should no-op
+        let result = await sut.update(checkout: checkout)
+        XCTAssertEqual(result, .succeeded)
+        XCTAssertEqual(checkout.session.status?.type, .complete)
+    }
+
+    func testUpdateCheckoutSessionNoOpsForExpiredSession() async throws {
+        let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
+        let apiClient = STPAPIClient(publishableKey: response.publishableKey)
+        let checkout = try await Checkout(clientSecret: response.clientSecret, apiClient: apiClient)
+
+        var config = EmbeddedPaymentElement.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
+        config.apiClient = apiClient
+        config.defaultBillingDetails.email = "test@example.com"
+
+        let sut = try await EmbeddedPaymentElement.create(checkout: checkout, configuration: config)
+        sut.delegate = self
+        sut.presentingViewController = UIViewController()
+
+        let expiredSession = STPCheckoutSession.decodedObject(fromAPIResponse: {
+            var json = CheckoutTestHelpers.makeOpenSessionJSON()
+            json["status"] = "expired"
+            return json
+        }())!
+        try await checkout.commitSession(expiredSession)
+        XCTAssertFalse(checkout.sessionIsOpen)
+
+        let result = await sut.update(checkout: checkout)
+        XCTAssertEqual(result, .succeeded)
+    }
+
     // MARK: Immediate action tests
 
     func testCreateFails_whenImmediateActionWithConfirmAndCustomer() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -438,4 +438,48 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         // Wait for legacy callback
         wait(for: [legacyExpectation], timeout: 2.0)
     }
+
+    // MARK: - Checkout terminal session
+
+    @MainActor
+    func testUpdateCheckoutNoOpsForTerminalSession() async throws {
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
+        let elementsSession = STPElementsSession._testCardValue()
+        let loadResult = PaymentSheetLoader.LoadResult(
+            intent: intent,
+            elementsSession: elementsSession,
+            savedPaymentMethods: [],
+            paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
+        )
+        var configuration = PaymentSheet.Configuration()
+        configuration.apiClient = STPAPIClient(publishableKey: STPTestingDefaultPublishableKey)
+        let fc = PaymentSheet.FlowController(
+            configuration: configuration,
+            loadResult: loadResult,
+            analyticsHelper: ._testValue()
+        )
+
+        let session = CheckoutTestHelpers.makeOpenSession()
+        let checkout = await Checkout(clientSecret: "cs_test_123_secret_abc", session: session)
+
+        // Move session to complete
+        let completedSession = STPCheckoutSession.decodedObject(fromAPIResponse: {
+            var json = CheckoutTestHelpers.makeOpenSessionJSON()
+            json["status"] = "complete"
+            json["payment_status"] = "paid"
+            return json
+        }())!
+        try await checkout.commitSession(completedSession)
+        XCTAssertFalse(checkout.sessionIsOpen)
+
+        // FC update should bail immediately
+        let exp = expectation(description: "update completes")
+        fc.update(checkout: checkout) { error in
+            XCTAssertNil(error)
+            exp.fulfill()
+        }
+        await fulfillment(of: [exp], timeout: 2.0)
+    }
 }


### PR DESCRIPTION
## Summary
- Skip the update path in EmbeddedPaymentElement and FlowController when the CheckoutSession has already moved to a terminal state. Removes the `skipIntegrationNotification` parameter from `commitSession` since the guard handles this now. It was a bit smelly to have that logic live in Checkout.swift.
- During confirm the session can transition to complete/expired, which triggers the integration delegate and kicks off an update. That update is pointless and causes issues if the confirmation is successful.

## Motivation
- CheckoutSessions

## Testing
Added unit tests for the new `sessionIsOpen` property and the no-op behavior in both Embedded and FlowController paths.

## Changelog
N/A