### PR TITLE
Checkout Sessions — Fix integration delegate errors reporting as API errors

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -110,6 +110,8 @@ extension Checkout {
             }
 
             localMutation?()
+            /* Commit the session. Note that the above `catch` block still throws, so this
+             * is not reached in that case, which is why we manually notify the delegate. */
             try await self.commitSession(updatedSession)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -87,29 +87,30 @@ extension Checkout {
     ) async throws {
         try await enqueueSessionUpdate {
             try self.requireSheetNotPresented()
-            do {
-                let updatedSession: STPCheckoutSession
-                if let update {
+
+            let updatedSession: STPCheckoutSession
+            if let update {
+                do {
                     let sessionId = Checkout.extractSessionId(from: self.clientSecret)
                     updatedSession = try await self.apiClient.updateCheckoutSession(
                         checkoutSessionId: sessionId,
                         parameters: update.parameters
                     )
-                } else {
-                    guard let session = self.stpSession else { return }
-                    updatedSession = session
+                } catch {
+                    // If a prior op skipped the delegate and we're failing before we
+                    // get to commitSession ourselves, still notify so the UI updates.
+                    if self.isLastPendingOperation {
+                        try? await self.integrationDelegate?.checkoutDidUpdate(self)
+                    }
+                    throw CheckoutError.apiError(message: error.nonGenericDescription)
                 }
-
-                localMutation?()
-                try await self.commitSession(updatedSession)
-            } catch {
-                // If a prior op skipped the delegate and we're failing before we
-                // get to commitSession ourselves, still notify so the UI updates.
-                if self.isLastPendingOperation {
-                    try? await self.integrationDelegate?.checkoutDidUpdate(self)
-                }
-                throw CheckoutError.apiError(message: error.nonGenericDescription)
+            } else {
+                guard let existingSession = self.stpSession else { return }
+                updatedSession = existingSession
             }
+
+            localMutation?()
+            try await self.commitSession(updatedSession)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -558,6 +558,24 @@ final class CheckoutUnitTests: XCTestCase {
         }
     }
 
+    func testPerformUpdateDoesNotWrapIntegrationDelegateErrorAsApiError() async {
+        let checkout = await makeCheckoutWithOpenSession()
+        let integrationDelegate = MockCheckoutIntegrationDelegate()
+        let testError = NSError(domain: "integration", code: 99)
+        integrationDelegate.shouldThrow = testError
+        checkout.integrationDelegate = integrationDelegate
+
+        do {
+            try await checkout.performUpdate()
+            XCTFail("Expected error to propagate")
+        } catch let error as CheckoutError {
+            XCTFail("Integration delegate error should not be wrapped as CheckoutError, got \(error)")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, "integration")
+            XCTAssertEqual((error as NSError).code, 99)
+        }
+    }
+
     // MARK: - updatePaymentMethod Parameter Encoding Tests
 
     func testUpdatePaymentMethodParameters_expiryOnly() {


### PR DESCRIPTION
## Summary
Previously, `commitSession()` was called in `performUpdate` in a `do` block that rewrites all errors at API errors. This was inaccurate since the errors coming from `commitSession()` are not necessarily API errors. 

Removed `commitSession()` from this block.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
Added test to enforce this behavior

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
