### PR TITLE
Use TaskLocal to prevent deadlock in awaitPendingOperations

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -42,7 +42,10 @@ extension Checkout {
             // Wait for the previous operation, if one exists, to finish.
             // Use `try?` so that we still continue even if the predecessor throws an error.
             if let predecessor { _ = try? await predecessor.value }
-            return try await body()
+            // Flag this task so awaitPendingOperations won't try to wait on itself
+            return try await Checkout.$isInsideOperation.withValue(true) {
+                try await body()
+            }
         }
 
         // The erased task discards T so it can be stored in the homogeneous

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -92,6 +92,9 @@ public final class Checkout: ObservableObject {
         pendingOperations.count <= 1
     }
 
+    /// True when running inside a queued operation body; prevents awaitPendingOperations from deadlocking on itself.
+    @TaskLocal static var isInsideOperation: Bool = false
+
     /// Default timeout used by ``awaitPendingOperations(timeout:)``.
     nonisolated static let defaultPendingOperationsTimeout: TimeInterval = 30
 
@@ -174,6 +177,8 @@ public final class Checkout: ObservableObject {
     func awaitPendingOperations(
         timeout: TimeInterval = Checkout.defaultPendingOperationsTimeout
     ) async throws {
+        // If we're already inside the current operation, waiting here would deadlock.
+        if Self.isInsideOperation { return }
         let snapshot = pendingOperations
         guard !snapshot.isEmpty else { return }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -92,7 +92,7 @@ public final class Checkout: ObservableObject {
         pendingOperations.count <= 1
     }
 
-    /// True when running inside a queued operation body; prevents awaitPendingOperations from deadlocking on itself.
+    /// Only ever true from within a queued operation's own task, so it knows not to await itself.
     @TaskLocal static var isInsideOperation: Bool = false
 
     /// Default timeout used by ``awaitPendingOperations(timeout:)``.

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
@@ -125,6 +125,28 @@ final class CheckoutPendingOperationsTests: XCTestCase {
 
     // MARK: - Delegate skipping
 
+    func testCommitSessionDoesNotDeadlockWhenDelegateAwaitsCurrentOp() async throws {
+        let checkout = await makeCheckoutWithOpenSession()
+        let delegate = AwaitsPendingOpsIntegrationDelegate()
+        checkout.integrationDelegate = delegate
+
+        let result = await withTimeout(3) { @MainActor in
+            try await checkout.enqueueSessionUpdate {
+                try await checkout.commitSession(CheckoutTestHelpers.makeOpenSession())
+            }
+        }
+
+        if case .failure(let error) = result {
+            if error is TimeoutError {
+                XCTFail("Deadlocked — delegate calling awaitPendingOperations inside an operation")
+            } else {
+                throw error
+            }
+        }
+
+        XCTAssertTrue(checkout.pendingOperations.isEmpty)
+    }
+
     func testCommitSessionSkipsDelegateWhenAnotherOpIsQueued() async throws {
         let checkout = await makeCheckoutWithOpenSession()
         let delegate = AwaitsPendingOpsIntegrationDelegate()


### PR DESCRIPTION
## Summary
- Use a TaskLocal flag to detect when `awaitPendingOperations` is called from within an already-running operation (e.g. commitSession fires a delegate that tries to await). In that case we return early instead of deadlocking.
- This flag is only ever true from within it's own task so the task can know not to wait on itself.

## Motivation
- CheckoutSessions

## Testing
- Added test

## Changelog
N/A