### PR TITLE
Add EmbeddedPaymentElement option to Checkout playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartEmbeddedPaymentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartEmbeddedPaymentView.swift
@@ -1,0 +1,223 @@
+//
+//  CheckoutCartEmbeddedPaymentView.swift
+//  PaymentSheet Example
+//
+//  Created by Nick Porter on 7/2/26.
+//
+
+@_spi(STP) import StripePaymentSheet
+import SwiftUI
+
+struct CheckoutCartEmbeddedPaymentView: View {
+    @ObservedObject var checkout: Checkout
+    let onDismiss: () -> Void
+
+    @StateObject private var viewModel = EmbeddedPaymentElementViewModel()
+    @State private var isLoading = true
+    @State private var loadError: Error?
+    @State private var paymentResult: PaymentSheetResult?
+    @State private var isConfirming = false
+    @State private var showEmbeddedScreen = false
+
+    private var session: Checkout.Session { checkout.session }
+
+    var body: some View {
+        VStack {
+            if let result = paymentResult {
+                paymentResultView(result: result)
+            } else if viewModel.isLoaded {
+                paymentBarView
+            } else if isLoading {
+                ProgressView()
+                    .padding()
+            } else if let loadError {
+                errorView(error: loadError)
+            }
+        }
+        .task {
+            await load()
+        }
+    }
+
+    // MARK: - Payment Bar
+
+    @ViewBuilder
+    private var paymentBarView: some View {
+        VStack(spacing: 12) {
+            Button {
+                showEmbeddedScreen = true
+            } label: {
+                HStack {
+                    if let paymentOption = viewModel.paymentOption {
+                        Image(uiImage: paymentOption.image)
+                            .resizable()
+                            .scaledToFit()
+                            .frame(width: 30, height: 20)
+                        Text(paymentOption.label)
+                            .font(.subheadline)
+                            .foregroundColor(.primary)
+                    } else {
+                        Text("Select payment method")
+                            .font(.subheadline)
+                            .foregroundColor(.primary)
+                    }
+                    Spacer()
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .padding()
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                )
+            }
+            .padding(.horizontal)
+            .sheet(isPresented: $showEmbeddedScreen) {
+                CheckoutEmbeddedScreen(viewModel: viewModel)
+            }
+
+            Button {
+                confirm()
+            } label: {
+                HStack {
+                    if isConfirming {
+                        ProgressView()
+                            .tint(.white)
+                            .padding(.trailing, 8)
+                        Text("Processing...")
+                    } else {
+                        Text("Checkout")
+                        Spacer()
+                        if let total = session.total, let currency = session.currency {
+                            Text(formatCartCurrency(amount: total.total.minorUnitsAmount, currency: currency))
+                        }
+                    }
+                }
+                .font(.headline)
+                .foregroundColor(.white)
+                .padding()
+                .background(viewModel.paymentOption != nil && !isConfirming ? Color.blue : Color.gray)
+                .cornerRadius(14)
+            }
+            .disabled(viewModel.paymentOption == nil || isConfirming)
+            .padding(.horizontal)
+        }
+        .padding(.bottom, 16)
+        .padding(.top, 16)
+        .background(
+            Color(UIColor.systemBackground)
+                .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: -5)
+        )
+    }
+
+    // MARK: - Result Views
+
+    @ViewBuilder
+    private func paymentResultView(result: PaymentSheetResult) -> some View {
+        switch result {
+        case .completed:
+            VStack(spacing: 12) {
+                Image(systemName: "checkmark.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundColor(.green)
+                Text("Payment Successful!")
+                    .font(.headline)
+                    .foregroundColor(.primary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 24)
+            .background(
+                Color(UIColor.systemBackground)
+                    .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: -5)
+            )
+            .onAppear {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+                    onDismiss()
+                }
+            }
+        case .canceled:
+            Color.clear
+                .onAppear { paymentResult = nil }
+        case .failed(let error):
+            errorView(error: error)
+                .onAppear {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                        paymentResult = nil
+                    }
+                }
+        }
+    }
+
+    @ViewBuilder
+    private func errorView(error: Error) -> some View {
+        VStack(spacing: 8) {
+            Image(systemName: "xmark.circle.fill")
+                .font(.system(size: 36))
+                .foregroundColor(.red)
+            Text(error.localizedDescription)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(
+            Color(UIColor.systemBackground)
+                .shadow(color: Color.black.opacity(0.1), radius: 10, x: 0, y: -5)
+        )
+    }
+
+    // MARK: - Actions
+
+    private func load() async {
+        isLoading = true
+        do {
+            var configuration = EmbeddedPaymentElement.Configuration()
+            configuration.returnURL = "payments-example://stripe-redirect"
+            try await viewModel.load(checkout: checkout, configuration: configuration)
+        } catch {
+            loadError = error
+        }
+        isLoading = false
+    }
+
+    private func confirm() {
+        isConfirming = true
+        Task { @MainActor in
+            let result = await viewModel.confirm()
+            isConfirming = false
+            switch result {
+            case .completed, .failed:
+                paymentResult = result
+            case .canceled:
+                break
+            }
+        }
+    }
+}
+
+// MARK: - Embedded Payment Method Screen
+
+private struct CheckoutEmbeddedScreen: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var viewModel: EmbeddedPaymentElementViewModel
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                EmbeddedPaymentElementView(viewModel: viewModel)
+                    .padding()
+            }
+            .navigationTitle("Payment Method")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -18,6 +18,7 @@ struct CheckoutCartView: View {
 
     let clientSecret: String
     let adaptivePricing: Bool
+    let integrationType: CheckoutPlayground.IntegrationType
     var currencySelectorAppearance = Checkout.CurrencySelectorView.Appearance()
 
     var body: some View {
@@ -35,10 +36,18 @@ struct CheckoutCartView: View {
                     )
                     .overlay(alignment: .bottom) {
                         if checkout.session.total != nil {
-                            CheckoutCartPaymentButton(
-                                checkout: checkout,
-                                onDismiss: { dismiss() }
-                            )
+                            switch integrationType {
+                            case .flowController:
+                                CheckoutCartPaymentButton(
+                                    checkout: checkout,
+                                    onDismiss: { dismiss() }
+                                )
+                            case .embedded:
+                                CheckoutCartEmbeddedPaymentView(
+                                    checkout: checkout,
+                                    onDismiss: { dismiss() }
+                                )
+                            }
                         }
                     }
                 } else if isLoading {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
@@ -7,6 +7,7 @@
 import SwiftUI
 
 struct CheckoutPlaygroundConfigurationSection: View {
+    @Binding var integrationType: CheckoutPlayground.IntegrationType
     @Binding var mode: CheckoutPlayground.SessionMode
     @Binding var currency: CheckoutPlayground.Currency
     @Binding var customerType: CheckoutPlayground.CustomerType
@@ -17,6 +18,13 @@ struct CheckoutPlaygroundConfigurationSection: View {
         VStack(alignment: .leading, spacing: 12) {
             CheckoutPlayground.SectionHeader(title: "Configuration", icon: "gearshape.fill")
             VStack(spacing: 1) {
+                CheckoutPlayground.PickerRow(
+                    title: "Integration",
+                    icon: "square.stack.3d.up.fill",
+                    selection: $integrationType,
+                    tooltip: "Choose the payment integration.\n\n• FlowController: Uses PaymentSheet.FlowController with a payment method selector and confirm button.\n• Embedded: Uses EmbeddedPaymentElement inline in the checkout flow.",
+                    displayText: { $0.displayName }
+                )
                 CheckoutPlayground.PickerRow(
                     title: "Mode",
                     icon: "arrow.triangle.2.circlepath",

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundTypes.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundTypes.swift
@@ -115,6 +115,20 @@ enum CheckoutPlayground {
         }
     }
 
+    enum IntegrationType: String, CaseIterable, Identifiable {
+        case flowController
+        case embedded
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .flowController: return "FlowController"
+            case .embedded: return "Embedded"
+            }
+        }
+    }
+
     struct LineItemConfig: Identifiable {
         let id = UUID()
         var name: String

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
@@ -26,6 +26,7 @@ struct CheckoutPlaygroundView: View {
                         }
 
                         CheckoutPlaygroundConfigurationSection(
+                            integrationType: $viewModel.integrationType,
                             mode: $viewModel.mode,
                             currency: $viewModel.currency,
                             customerType: $viewModel.customerType,
@@ -84,6 +85,7 @@ struct CheckoutPlaygroundView: View {
                     CheckoutCartView(
                         clientSecret: clientSecret,
                         adaptivePricing: viewModel.adaptivePricing,
+                        integrationType: viewModel.integrationType,
                         currencySelectorAppearance: viewModel.currencySelectorAppearance
                     )
                 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
@@ -14,6 +14,7 @@ extension CheckoutPlayground {
             "card", "us_bank_account", "cashapp", "affirm", "klarna",
         ]
 
+        @Published var integrationType: IntegrationType = .flowController
         @Published var mode: SessionMode = .payment
         @Published var currency: Currency = .usd
         @Published var customerType: CustomerType = .guest


### PR DESCRIPTION
## Summary
- Adds an integration type picker to the Checkout playground so you can switch between FlowController and the EmbeddedPaymentElement.

## Motivation
- We need this to unblock the writing billing address in the sheet

## Testing
- Manual

## Changelog
N/A