### PR TITLE
Fix keyboard animation when pushing `AutoCompleteViewController`

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -330,7 +330,8 @@ extension AddressViewController {
 
     @objc func presentAutocomplete() {
         assert(navigationController != nil)
-        let autoCompleteViewController = AutoCompleteViewController(configuration: configuration, initialLine1Text: addressSection?.line1?.text, selectedCountry: addressSection?.selectedCountryCode, addressSpecProvider: addressSpecProvider)
+        let keyboardShowing = view.firstResponder() != nil
+        let autoCompleteViewController = AutoCompleteViewController(configuration: configuration, initialLine1Text: addressSection?.line1?.text, selectedCountry: addressSection?.selectedCountryCode, addressSpecProvider: addressSpecProvider, keyboardAlreadyShowing: keyboardShowing)
         autoCompleteViewController.delegate = self
         navigationController?.pushViewController(autoCompleteViewController, animated: true)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AutoCompleteViewController.swift
@@ -27,6 +27,8 @@ class AutoCompleteViewController: UIViewController {
     let addressSpecProvider: AddressSpecProvider
     /// Vertical offset for the view controller content. Negative values move content up, positive values move content down.
     let verticalOffset: CGFloat
+    /// Whether the keyboard was already visible when this view controller was presented.
+    let keyboardAlreadyShowing: Bool
     /// Session token for grouping autocomplete and place details calls.
     let sessionToken: String = UUID().uuidString
 
@@ -150,13 +152,15 @@ class AutoCompleteViewController: UIViewController {
         initialLine1Text: String?,
         selectedCountry: String?,
         addressSpecProvider: AddressSpecProvider = .shared,
-        verticalOffset: CGFloat = 0
+        verticalOffset: CGFloat = 0,
+        keyboardAlreadyShowing: Bool = false
     ) {
         self.configuration = configuration
         self.initialLine1Text = initialLine1Text
         self.selectedCountry = selectedCountry
         self.addressSpecProvider = addressSpecProvider
         self.verticalOffset = verticalOffset
+        self.keyboardAlreadyShowing = keyboardAlreadyShowing
         super.init(nibName: nil, bundle: nil)
         if let initialLine1Text = initialLine1Text, !initialLine1Text.isEmpty {
             if configuration.useAutocompleteEndpoints {
@@ -259,9 +263,16 @@ class AutoCompleteViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         registerForKeyboardNotifications()
-        autoCompleteLine.beginEditing()
         autocompleteStartTime = Date()
         STPAnalyticsClient.sharedClient.logAddressAutocompleteStart(apiClient: configuration.apiClient)
+
+        if let transitionCoordinator, !keyboardAlreadyShowing {
+            transitionCoordinator.animate(alongsideTransition: nil) { _ in
+                self.autoCompleteLine.beginEditing()
+            }
+        } else {
+            autoCompleteLine.beginEditing()
+        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

This pull request fixes an issue with the keyboard entry animation inside Address Element.

If the keyboard wasn't already visible on `AddressViewController`, it would previously slide in from the right with the `AutocompleteViewController`, which looks bad. Now, we wait for the navigation transition to end before popping up the keyboard.

The behavior for the case where the keyboard is already open on the `AddressViewController` is unchanged.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

[LINK_MOBILE-1057](https://jira.corp.stripe.com/browse/LINK_MOBILE-1057)

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

### Before

https://github.com/user-attachments/assets/a9864261-d845-447c-bceb-30e3b73c0f3c

### After

https://github.com/user-attachments/assets/c4059256-77bc-4c37-a97d-aec532d96b32

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->

N/A
