### PR TITLE
Add getWalletOwnershipChallenge and submitWalletOwnershipSignature to CryptoOnrampCoordinator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ MINOR
 
 ## 26.2.0 2026-07-06
 ### CryptoOnramp (Alpha)
+* [Added] Added `getWalletOwnershipChallenge(walletAddress:network:)` to `CryptoOnrampCoordinator` to create a short-lived server-issued challenge for EU Travel Rule wallet ownership verification.
+* [Added] Added `submitWalletOwnershipSignature(challengeId:signature:)` to `CryptoOnrampCoordinator` to verify wallet ownership by submitting a signature over the challenge message.
+* [Added] Added `WalletOwnershipChallenge` public type containing the challenge identifier, wallet address, network, message to sign, and expiry timestamp.
+* [Added] Added `ConsumerWallet` public type returned by `submitWalletOwnershipSignature`, including the `verifiedOwnership` flag.
+* [Added] Added `CryptoOnrampCoordinator.Error` cases: `walletNotRegistered`, `unsupportedWalletNetwork`, `walletOwnershipChallengeExpired`, `invalidWalletOwnershipChallenge`, `invalidWalletOwnershipSignature`.
 * [Added] Added `AppAttestationUnavailableError`, a rich `StripeCryptoOnrampError` surfaced when configuration fails because app attestation is missing or native Link is unavailable.
 * [Removed] Removed public diagnostic-only properties from rich Crypto Onramp errors: `sdkVersions` from `StripeCryptoOnrampError` and concrete error types; `operation`, `appIdentifier`, and `mode` from `StripeCryptoOnrampAPIError`, `AppAttestationAPIError`, and `UncategorizedAPIError`; and `operation`, `appIdentifier`, `mode`, and `sdkVersions` from `APIErrorContext`. These diagnostics are still included in `developerMessage`.
 * [Changed] Renamed the public API-backed error context property from `context` to `apiErrorContext`.

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/WalletOwnershipVerificationView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/WalletOwnershipVerificationView.swift
@@ -1,0 +1,214 @@
+//
+//  WalletOwnershipVerificationView.swift
+//  CryptoOnramp Example
+//
+
+import SwiftUI
+
+@_spi(CryptoOnrampAlpha)
+import StripeCryptoOnramp
+
+/// A view that demonstrates the two-step wallet ownership verification flow:
+/// 1. Request a challenge for a registered wallet address.
+/// 2. Submit a signature over the challenge message.
+///
+/// In a real app, step 2 would route the `challenge.message` to the merchant's
+/// wallet stack for signing (e.g. via `eth_sign` or `ed25519`). This example
+/// uses a placeholder signature to illustrate the API surface.
+struct WalletOwnershipVerificationView: View {
+
+    /// The coordinator used to request and verify wallet ownership.
+    let coordinator: CryptoOnrampCoordinator
+
+    /// Callback invoked when ownership verification completes successfully.
+    let onVerified: ((ConsumerWallet) -> Void)?
+
+    @State private var walletAddress: String = ""
+    @State private var selectedNetwork: CryptoNetwork = .ethereum
+    @State private var pendingChallenge: WalletOwnershipChallenge?
+    @State private var signature: String = ""
+    @State private var errorMessage: String?
+
+    @Environment(\.isLoading) private var isLoading
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var walletFieldFocused: Bool
+
+    private var isRequestChallengeDisabled: Bool {
+        isLoading.wrappedValue || walletAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var isSubmitSignatureDisabled: Bool {
+        isLoading.wrappedValue || signature.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: 20) {
+                    if let challenge = pendingChallenge {
+                        // Step 2: show challenge message and collect signature
+                        VStack(alignment: .leading, spacing: 8) {
+                            Text("Challenge received. Sign the message below with your wallet and paste the signature.")
+                                .font(.subheadline)
+                                .foregroundColor(.secondary)
+
+                            Text("Challenge ID: \(challenge.challengeId)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+
+                            Text("Expires: \(challenge.expiresAt)")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                        FormField("Message to Sign") {
+                            Text(challenge.message)
+                                .font(.system(.body, design: .monospaced))
+                                .textSelection(.enabled)
+                                .padding(8)
+                                .background(Color(.systemGray6))
+                                .cornerRadius(8)
+                        }
+
+                        FormField("Signature") {
+                            TextField("Paste signature here", text: $signature, axis: .vertical)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                                .lineLimit(3...6)
+                        }
+
+                        if let errorMessage {
+                            ErrorMessageView(message: errorMessage)
+                        }
+
+                        Button("Submit Signature") {
+                            submitSignature(challenge: challenge)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(isSubmitSignatureDisabled)
+                        .opacity(isSubmitSignatureDisabled ? 0.5 : 1)
+
+                        Button("Start Over") {
+                            pendingChallenge = nil
+                            signature = ""
+                            errorMessage = nil
+                        }
+                        .foregroundColor(.secondary)
+
+                    } else {
+                        // Step 1: collect wallet address and request challenge
+                        Text("Enter a registered wallet address to start the ownership verification challenge.")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                        FormField("Wallet Address") {
+                            TextField("Enter wallet address", text: $walletAddress)
+                                .textFieldStyle(RoundedBorderTextFieldStyle())
+                                .autocapitalization(.none)
+                                .disableAutocorrection(true)
+                                .focused($walletFieldFocused)
+                        }
+
+                        FormField("Network") {
+                            Picker("Network", selection: $selectedNetwork) {
+                                ForEach(CryptoNetwork.allCases, id: \.rawValue) { network in
+                                    Text(network.rawValue.localizedCapitalized).tag(network)
+                                }
+                            }
+                            .pickerStyle(.menu)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        }
+
+                        if let errorMessage {
+                            ErrorMessageView(message: errorMessage)
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Verify Wallet Ownership")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+                if pendingChallenge == nil {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Request Challenge") {
+                            requestChallenge()
+                        }
+                        .disabled(isRequestChallengeDisabled)
+                        .opacity(isRequestChallengeDisabled ? 0.5 : 1)
+                    }
+                }
+            }
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                walletFieldFocused = true
+            }
+        }
+    }
+
+    private func requestChallenge() {
+        isLoading.wrappedValue = true
+        errorMessage = nil
+
+        let address = walletAddress.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        Task {
+            do {
+                let challenge = try await coordinator.getWalletOwnershipChallenge(
+                    walletAddress: address,
+                    network: selectedNetwork
+                )
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    pendingChallenge = challenge
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    errorMessage = "Failed to get challenge: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+
+    private func submitSignature(challenge: WalletOwnershipChallenge) {
+        isLoading.wrappedValue = true
+        errorMessage = nil
+
+        let sig = signature.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        Task {
+            do {
+                let wallet = try await coordinator.submitWalletOwnershipSignature(
+                    challengeId: challenge.challengeId,
+                    signature: sig
+                )
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    onVerified?(wallet)
+                    dismiss()
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    errorMessage = "Signature verification failed: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    PreviewWrapperView { coordinator in
+        WalletOwnershipVerificationView(coordinator: coordinator, onVerified: nil)
+    }
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -135,6 +135,24 @@ protocol CryptoOnrampCoordinatorProtocol {
     /// Throws if an authenticated Link user is not available, or an API error occurs.
     func registerWalletAddress(walletAddress: String, network: CryptoNetwork) async throws
 
+    /// Creates a short-lived challenge for verifying ownership of a registered wallet address.
+    /// Requires an authenticated Link user.
+    ///
+    /// - Parameter walletAddress: The crypto wallet address to verify ownership of.
+    /// - Parameter network: The crypto network for the wallet address.
+    /// - Returns: A `WalletOwnershipChallenge` whose `message` field should be signed by the merchant's wallet stack.
+    /// Throws if an authenticated Link user is not available, the wallet is not registered, or an API error occurs.
+    func getWalletOwnershipChallenge(walletAddress: String, network: CryptoNetwork) async throws -> WalletOwnershipChallenge
+
+    /// Submits a signature over a wallet ownership challenge to verify wallet ownership.
+    /// Requires an authenticated Link user.
+    ///
+    /// - Parameter challengeId: The identifier from a prior `getWalletOwnershipChallenge` call.
+    /// - Parameter signature: The signature over the challenge's `message` field.
+    /// - Returns: A `ConsumerWallet` with `verifiedOwnership` set to `true` on success.
+    /// Throws if an authenticated Link user is not available, the challenge is expired or invalid, the signature is invalid, or an API error occurs.
+    func submitWalletOwnershipSignature(challengeId: String, signature: String) async throws -> ConsumerWallet
+
     /// Presents UI to collect/select a payment method of the given type.
     ///
     /// - Parameters:
@@ -532,6 +550,45 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
             analyticsClient.log(.walletRegistered(network: network.rawValue))
         } catch {
             try logAndThrow(error, during: .registerWalletAddress)
+        }
+    }
+
+    public func getWalletOwnershipChallenge(walletAddress: String, network: CryptoNetwork) async throws -> WalletOwnershipChallenge {
+        do {
+            let response = try await apiClient.createWalletOwnershipChallenge(
+                walletAddress: walletAddress,
+                network: network,
+                linkAccountInfo: linkAccountInfo
+            )
+            analyticsClient.log(.walletOwnershipChallengeCreated(network: network.rawValue))
+            return WalletOwnershipChallenge(
+                challengeId: response.challenge_id,
+                walletAddress: response.wallet_address,
+                network: response.network,
+                message: response.message,
+                expiresAt: response.expires_at
+            )
+        } catch {
+            try logAndThrow(error, during: .getWalletOwnershipChallenge)
+        }
+    }
+
+    public func submitWalletOwnershipSignature(challengeId: String, signature: String) async throws -> ConsumerWallet {
+        do {
+            let response = try await apiClient.submitWalletOwnershipVerification(
+                challengeId: challengeId,
+                signature: signature,
+                linkAccountInfo: linkAccountInfo
+            )
+            analyticsClient.log(.walletOwnershipVerified)
+            return ConsumerWallet(
+                id: response.id,
+                walletAddress: response.wallet_address ?? "",
+                network: response.network ?? "",
+                verifiedOwnership: response.verified_ownership
+            )
+        } catch {
+            try logAndThrow(error, during: .submitWalletOwnershipSignature)
         }
     }
 

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/Errors/Legacy Errors/CryptoOnrampCoordinator+Error.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/Errors/Legacy Errors/CryptoOnrampCoordinator+Error.swift
@@ -32,6 +32,21 @@ public extension CryptoOnrampCoordinator {
         /// The provided sign-in token is invalid for a reason described in the non-localized associated value. Use the `authorize` API to sign in manually.
         case seamlessSignInTokenInvalid(reason: String?)
 
+        /// The wallet address is not registered with the current Link account.
+        case walletNotRegistered
+
+        /// The wallet network is not supported for ownership verification.
+        case unsupportedWalletNetwork
+
+        /// The wallet ownership challenge has expired. Request a new challenge via `getWalletOwnershipChallenge`.
+        case walletOwnershipChallengeExpired
+
+        /// The wallet ownership challenge is invalid or has already been used.
+        case invalidWalletOwnershipChallenge
+
+        /// The provided signature is invalid for the wallet ownership challenge.
+        case invalidWalletOwnershipSignature
+
         public var errorDescription: String? {
             switch self {
             case .invalidPhoneFormat:
@@ -48,6 +63,16 @@ public extension CryptoOnrampCoordinator {
                 return "No active Link consumer is available in a verified state."
             case .seamlessSignInTokenInvalid:
                 return "An error occurred while automatically signing in to your Link account. Please sign in manually."
+            case .walletNotRegistered:
+                return "The wallet address is not registered with the current Link account."
+            case .unsupportedWalletNetwork:
+                return "The wallet network is not supported for ownership verification."
+            case .walletOwnershipChallengeExpired:
+                return "The wallet ownership challenge has expired. Please request a new challenge."
+            case .invalidWalletOwnershipChallenge:
+                return "The wallet ownership challenge is invalid or has already been used."
+            case .invalidWalletOwnershipSignature:
+                return "The provided signature is invalid for the wallet ownership challenge."
             }
         }
     }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/RegisterWalletResponse.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/RegisterWalletResponse.swift
@@ -11,4 +11,13 @@ struct RegisterWalletResponse: Codable {
 
     /// The created crypto wallet's unique identifier.
     let id: String
+
+    /// The wallet's blockchain address.
+    let wallet_address: String?
+
+    /// The crypto network for the wallet address.
+    let network: String?
+
+    /// Whether the merchant has proven ownership of this wallet address via a signed challenge.
+    let verified_ownership: Bool?
 }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -239,6 +239,63 @@ extension STPAPIClient {
         return try await post(resource: endpoint, object: requestObject)
     }
 
+    /// Creates a short-lived, server-issued challenge for wallet ownership verification.
+    /// - Parameters:
+    ///   - walletAddress: The crypto wallet address to issue the challenge for.
+    ///   - network: The crypto network for the wallet address.
+    ///   - linkAccountInfo: Information associated with the link account including the client secret and whether the account has been verified.
+    /// - Returns: A `WalletOwnershipChallengeResponse` containing the challenge details.
+    /// Throws if a client secret doesn't exist, the session is unverified, or an API error occurs.
+    func createWalletOwnershipChallenge(
+        walletAddress: String,
+        network: CryptoNetwork,
+        linkAccountInfo: PaymentSheetLinkAccountInfoProtocol
+    ) async throws -> WalletOwnershipChallengeResponse {
+        guard let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret else {
+            throw CryptoOnrampAPIError.missingConsumerSessionClientSecret
+        }
+
+        try validateSessionState(using: linkAccountInfo)
+
+        let endpoint = "crypto/internal/wallet_ownership_challenge"
+        let requestObject = RegisterWalletRequest(
+            walletAddress: walletAddress,
+            network: network,
+            consumerSessionClientSecret: consumerSessionClientSecret
+        )
+
+        return try await post(resource: endpoint, object: requestObject)
+    }
+
+    /// Submits a signature over a previously issued wallet ownership challenge.
+    /// - Parameters:
+    ///   - challengeId: The identifier of the challenge to verify.
+    ///   - signature: The signature over the challenge message.
+    ///   - linkAccountInfo: Information associated with the link account including the client secret and whether the account has been verified.
+    /// - Returns: A `RegisterWalletResponse` for the verified wallet.
+    /// Throws if a client secret doesn't exist, the session is unverified, or an API error occurs.
+    @discardableResult
+    func submitWalletOwnershipVerification(
+        challengeId: String,
+        signature: String,
+        linkAccountInfo: PaymentSheetLinkAccountInfoProtocol
+    ) async throws -> RegisterWalletResponse {
+        guard let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret else {
+            throw CryptoOnrampAPIError.missingConsumerSessionClientSecret
+        }
+
+        try validateSessionState(using: linkAccountInfo)
+
+        let endpoint = "crypto/internal/wallet_ownership_verification"
+        let requestObject = WalletOwnershipVerificationRequest(
+            challengeId: challengeId,
+            signature: signature,
+            consumerSessionClientSecret: consumerSessionClientSecret
+        )
+
+        return try await post(resource: endpoint, object: requestObject)
+    }
+
     /// Retrieves an onramp session.
     /// - Parameters:
     ///   - sessionId: The onramp session identifier.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/WalletOwnershipChallengeResponse.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/WalletOwnershipChallengeResponse.swift
@@ -1,0 +1,14 @@
+//
+//  WalletOwnershipChallengeResponse.swift
+//  StripeCryptoOnramp
+//
+
+import Foundation
+
+struct WalletOwnershipChallengeResponse: Codable {
+    let challenge_id: String
+    let wallet_address: String
+    let network: String
+    let message: String
+    let expires_at: String
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/WalletOwnershipVerificationRequest.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/WalletOwnershipVerificationRequest.swift
@@ -1,0 +1,29 @@
+//
+//  WalletOwnershipVerificationRequest.swift
+//  StripeCryptoOnramp
+//
+
+import Foundation
+
+/// Encodable model passed to the `/v1/crypto/internal/wallet_ownership_verification` endpoint.
+struct WalletOwnershipVerificationRequest: Encodable {
+    /// The identifier of the challenge to verify.
+    let challenge_id: String
+
+    /// The signature over the challenge message.
+    let signature: String
+
+    /// Contains credentials required to make the request.
+    let credentials: Credentials
+
+    /// Creates a new `WalletOwnershipVerificationRequest` instance.
+    /// - Parameters:
+    ///   - challengeId: The identifier of the challenge to verify.
+    ///   - signature: The signature over the challenge message.
+    ///   - consumerSessionClientSecret: Contains credentials required to make the request.
+    init(challengeId: String, signature: String, consumerSessionClientSecret: String) {
+        self.challenge_id = challengeId
+        self.signature = signature
+        self.credentials = Credentials(consumerSessionClientSecret: consumerSessionClientSecret)
+    }
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CryptoOnrampAnalyticsEvent.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CryptoOnrampAnalyticsEvent.swift
@@ -21,6 +21,8 @@ enum CryptoOnrampOperation: String {
     case verifyKycInfo = "verify_kyc_info"
     case verifyIdentity = "verify_identity"
     case registerWalletAddress = "register_wallet_address"
+    case getWalletOwnershipChallenge = "get_wallet_ownership_challenge"
+    case submitWalletOwnershipSignature = "submit_wallet_ownership_signature"
     case collectPaymentMethod = "collect_payment_method"
     case createCryptoPaymentToken = "create_crypto_payment_token"
     case performCheckout = "perform_checkout"
@@ -45,6 +47,8 @@ enum CryptoOnrampAnalyticsEvent {
     case kycInfoVerificationStarted
     case kycInfoVerificationCompleted
     case walletRegistered(network: String)
+    case walletOwnershipChallengeCreated(network: String)
+    case walletOwnershipVerified
     case collectPaymentMethodStarted(paymentMethodType: String)
     case collectPaymentMethodCompleted(paymentMethodType: String)
     case cryptoPaymentTokenCreated(paymentMethodType: String)
@@ -89,6 +93,10 @@ enum CryptoOnrampAnalyticsEvent {
             return "onramp.kyc_info_verification_completed"
         case .walletRegistered:
             return "onramp.wallet_registered"
+        case .walletOwnershipChallengeCreated:
+            return "onramp.wallet_ownership_challenge_created"
+        case .walletOwnershipVerified:
+            return "onramp.wallet_ownership_verified"
         case .collectPaymentMethodStarted:
             return "onramp.collect_payment_method_started"
         case .collectPaymentMethodCompleted:
@@ -121,6 +129,7 @@ enum CryptoOnrampAnalyticsEvent {
              .userAttestationStarted,
              .kycInfoVerificationStarted,
              .kycInfoVerificationCompleted,
+             .walletOwnershipVerified,
              .userLoggedOut:
             return [:]
         case let .identifiersSubmitted(completed):
@@ -130,6 +139,8 @@ enum CryptoOnrampAnalyticsEvent {
         case let .linkAuthorizationCompleted(consented):
             return ["consented": consented]
         case let .walletRegistered(network):
+            return ["network": network]
+        case let .walletOwnershipChallengeCreated(network):
             return ["network": network]
         case let .collectPaymentMethodStarted(paymentMethodType):
             return ["payment_method_type": paymentMethodType]

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Public/ConsumerWallet.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Public/ConsumerWallet.swift
@@ -1,0 +1,24 @@
+//
+//  ConsumerWallet.swift
+//  StripeCryptoOnramp
+//
+
+import Foundation
+
+/// A registered crypto consumer wallet, returned after wallet registration or
+/// ownership verification.
+@_spi(CryptoOnrampAlpha)
+public struct ConsumerWallet {
+    /// The unique identifier for this wallet.
+    public let id: String
+
+    /// The wallet's blockchain address.
+    public let walletAddress: String
+
+    /// The crypto network for this wallet address.
+    public let network: String
+
+    /// Whether the merchant has proven ownership of this wallet address via a
+    /// signed challenge. `nil` if ownership verification has not been attempted.
+    public let verifiedOwnership: Bool?
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Public/WalletOwnershipChallenge.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Public/WalletOwnershipChallenge.swift
@@ -1,0 +1,27 @@
+//
+//  WalletOwnershipChallenge.swift
+//  StripeCryptoOnramp
+//
+
+import Foundation
+
+/// A short-lived challenge issued by Stripe for wallet ownership verification.
+/// The merchant's wallet stack should sign the `message` field and submit the
+/// signature via `CryptoOnrampCoordinator.submitWalletOwnershipSignature(challengeId:signature:)`.
+@_spi(CryptoOnrampAlpha)
+public struct WalletOwnershipChallenge {
+    /// The unique identifier for this challenge.
+    public let challengeId: String
+
+    /// The wallet address this challenge was issued for.
+    public let walletAddress: String
+
+    /// The crypto network for the wallet address.
+    public let network: String
+
+    /// The opaque message to be signed by the merchant's wallet stack.
+    public let message: String
+
+    /// The ISO 8601 timestamp at which this challenge expires.
+    public let expiresAt: String
+}

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
@@ -128,7 +128,10 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         static let validWalletAddress = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
         static let validNetwork = CryptoNetwork.bitcoin
         static let registerWalletMockResponseObject = RegisterWalletResponse(
-            id: "ccw_12345"
+            id: "ccw_12345",
+            wallet_address: nil,
+            network: nil,
+            verified_ownership: nil
         )
 
         // /v1/crypto/internal/onramp_session


### PR DESCRIPTION
## Summary
Ports wallet ownership verification methods from the Headless Onramp Web SDK ([stripe-internal/mint#2306389](https://git.corp.stripe.com/stripe-internal/mint/pull/2306389)) to the iOS SDK for EU Travel Rule compliance.

- Added `getWalletOwnershipChallenge(walletAddress:network:)` to `CryptoOnrampCoordinator` — creates a short-lived server-issued challenge whose `message` field the merchant's wallet stack should sign
- Added `submitWalletOwnershipSignature(challengeId:signature:)` to `CryptoOnrampCoordinator` — submits the signature and returns a `ConsumerWallet` with `verifiedOwnership = true` on success
- Added `WalletOwnershipChallenge` and `ConsumerWallet` public types
- Added `CryptoOnrampCoordinator.Error` cases: `walletNotRegistered`, `unsupportedWalletNetwork`, `walletOwnershipChallengeExpired`, `invalidWalletOwnershipChallenge`, `invalidWalletOwnershipSignature`
- Added analytics events: `walletOwnershipChallengeCreated`, `walletOwnershipVerified`
- Added `WalletOwnershipVerificationView` to the example app demonstrating the two-step challenge/signature flow

## Test plan
- [ ] `getWalletOwnershipChallenge` returns a `WalletOwnershipChallenge` with challenge ID, message, and expiry on success
- [ ] `getWalletOwnershipChallenge` propagates errors for unregistered wallets and unsupported networks
- [ ] `submitWalletOwnershipSignature` returns a `ConsumerWallet` with `verifiedOwnership = true` on success
- [ ] `submitWalletOwnershipSignature` propagates errors for expired/invalid challenges and invalid signatures
- [ ] `WalletOwnershipVerificationView` in the example app renders and walks through both steps
- [ ] Analytics events fire correctly for both operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)