### PR TITLE
Remove awaitPendingOperations from Checkout delegate path

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -105,11 +105,6 @@ extension Checkout {
                 //  the UI can't handle.
                 try await self.commitSession(updatedSessionAPIResponse, applying: localMutation)
             } catch {
-                // If a prior op skipped the delegate and we're failing before we
-                // get to commitSession ourselves, still notify so the UI updates.
-                if self.isLastPendingOperation {
-                    try? await self.integrationDelegate?.checkoutDidUpdate(self)
-                }
                 throw CheckoutError.apiError(message: error.nonGenericDescription)
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -89,10 +89,6 @@ public final class Checkout: ObservableObject {
         }
     }
 
-    var isLastPendingOperation: Bool {
-        pendingOperations.count <= 1
-    }
-
     /// Default timeout used by ``awaitPendingOperations(timeout:)``.
     nonisolated static let defaultPendingOperationsTimeout: TimeInterval = 30
 
@@ -371,9 +367,6 @@ public final class Checkout: ObservableObject {
         // Update the session and notify delegates.
         session = finalSession
 
-        // Skip delegate if another op is queued—it'll notify when it commits.
-        if isLastPendingOperation {
-            try await integrationDelegate?.checkoutDidUpdate(self)
-        }
+        try await integrationDelegate?.checkoutDidUpdate(self)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -174,11 +174,6 @@ public final class EmbeddedPaymentElement {
         guard checkout.sessionIsOpen else {
             return .succeeded
         }
-        do {
-            try await checkout.awaitPendingOperations()
-        } catch {
-            return .failed(error: error)
-        }
         checkout.session.applyAddressOverrides(to: &configuration)
         return await performUpdate(mode: .checkout(checkout))
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -776,13 +776,6 @@ extension PaymentSheet {
             assert(!isPresented, "PaymentSheet.FlowController.update must be when PaymentSheet is not presented.")
             let updateID = beginUpdate()
             Task { @MainActor in
-                do {
-                    try await checkout.awaitPendingOperations()
-                } catch {
-                    self.failUpdate(updateID)
-                    completion(error)
-                    return
-                }
                 guard !self.isPresented else {
                     let message = "PaymentSheet.FlowController.update must be called when PaymentSheet is not presented."
                     assertionFailure(message)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
@@ -123,48 +123,6 @@ final class CheckoutPendingOperationsTests: XCTestCase {
         XCTAssertTrue(checkout.pendingOperations.isEmpty)
     }
 
-    // MARK: - Delegate skipping
-
-    func testCommitSessionSkipsDelegateWhenAnotherOpIsQueued() async throws {
-        let checkout = await makeCheckoutWithOpenSession()
-        let delegate = AwaitsPendingOpsIntegrationDelegate()
-        checkout.integrationDelegate = delegate
-
-        let gate = CheckoutPendingOperationsTestGate()
-
-        let firstTask = Task { @MainActor in
-            try await checkout.enqueueSessionUpdate {
-                await gate.wait()
-                try await checkout.commitSession(CheckoutTestHelpers.makeOpenSession())
-            }
-        }
-
-        try await waitUntil { checkout.pendingOperations.count == 1 }
-
-        let secondTask = Task { @MainActor in
-            try await checkout.enqueueSessionUpdate { }
-        }
-
-        try await waitUntil { checkout.pendingOperations.count == 2 }
-
-        gate.open()
-
-        let result = await withTimeout(3) { @MainActor in
-            _ = try await firstTask.value
-            _ = try await secondTask.value
-        }
-
-        if case .failure(let error) = result {
-            if error is TimeoutError {
-                XCTFail("Deadlocked — commitSession should skip delegate when another op is queued")
-            } else {
-                throw error
-            }
-        }
-
-        XCTAssertTrue(checkout.pendingOperations.isEmpty)
-    }
-
     // MARK: - Confirm with pending operations
 
     func testEPEConfirmFailsWhenCheckoutPendingOperationsExist() async throws {
@@ -422,15 +380,6 @@ final class CheckoutPendingOperationsTests: XCTestCase {
             }
             try await Task.sleep(nanoseconds: 1_000_000)
         }
-    }
-}
-
-@MainActor
-private final class AwaitsPendingOpsIntegrationDelegate: CheckoutIntegrationDelegate {
-    var isSheetPresented: Bool = false
-
-    func checkoutDidUpdate(_ checkout: Checkout) async throws {
-        try await checkout.awaitPendingOperations()
     }
 }
 


### PR DESCRIPTION
## Summary

Checkout batches mutations (e.g. updating billing address, then shipping) into a pending-operations queue. We had an optimization where `commitSession` would skip notifying MPE if more operations were still queued. The idea was "why reload if another update is about to land?" This PR removes that optimization.

**The problem:** when `commitSession` called `checkoutDidUpdate`, the delegate would `awaitPendingOperations`, which includes the *currently executing* operation. That's a deadlock on MainActor. We already needed workarounds (#6655) and it's not worth the complexity.

**Why it's safe to remove:** both EPE and FlowController already discard stale updates. Redundant updates just get thrown away, there is no wasted network traffic.

**Other changes:** removes `awaitPendingOperations` from the delegate's `update(checkout:)` paths in EPE and FlowController. No longer needed since the delegate is only called after a session is fully committed.

## Motivation

CheckoutSessions

## Testing

- Existing unit tests (CheckoutPendingOperationsTests) pass
- Manual testing

## Changelog

N/A