### PR TITLE
Remove MX card from testNoAuthenticationCustomCard

### DIFF
--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUICardEntryTests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUICardEntryTests.swift
@@ -31,7 +31,6 @@ class IntegrationTesterUICardEntryTests: IntegrationTesterUITests {
             // Non-US
             "4000000760000002", // br
             "4000001240000000", // ca
-            "4000004840008001", // mx
         ]
         for card in cardNumbers {
             testAuthentication(cardNumber: card)


### PR DESCRIPTION
## Summary

Removes the Mexico test card `4000004840008001` from `IntegrationTesterUICardEntryTests.testNoAuthenticationCustomCard`.

The card started presenting an interactive 3DS2 OTP challenge in test mode, so it no longer completes without authentication. Since `testAuthentication` runs with `confirmationBehavior: .none` (no challenge handling), the payment stays on the OTP screen, the "Payment status view" never appears, and the test fails on CI (observed failing both retry iterations on Bitrise build 44482, `integration-all`). The other non-US cards in the loop (BR, CA) are unaffected.

## Testing

Existing `testNoAuthenticationCustomCard` now runs the remaining cards to completion.

## Changelog

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)