### PR TITLE
Retry UI tests when the test runner hangs

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -230,11 +230,20 @@ workflows:
     - prep_all
     steps:
     - xcode-test@6:
-        inputs:
+        is_skippable: true
+        inputs: &financial_connections_stability_tests_inputs
         - destination: $DEFAULT_TEST_DEVICE
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "2"
         - scheme: FinancialConnections Example
+    - script@1:
+        is_always_run: true
+        title: Retry gate for test-runner hang
+        inputs:
+        - content: ./ci_scripts/xcode_test_runner_hang_gate.sh
+    - xcode-test@6:
+        run_if: '{{enveq "STRIPE_RETRY_XCODE_TEST" "yes"}}'
+        inputs: *financial_connections_stability_tests_inputs
     - slack@3:
         is_always_run: true
         run_if: .IsBuildFailed
@@ -268,11 +277,20 @@ workflows:
     - prep_all
     steps:
     - xcode-test@6:
-        inputs:
+        is_skippable: true
+        inputs: &financial_connections_stability_tests_for_edge_inputs
         - destination: $DEFAULT_TEST_DEVICE
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "2"
         - scheme: FinancialConnections Example
+    - script@1:
+        is_always_run: true
+        title: Retry gate for test-runner hang
+        inputs:
+        - content: ./ci_scripts/xcode_test_runner_hang_gate.sh
+    - xcode-test@6:
+        run_if: '{{enveq "STRIPE_RETRY_XCODE_TEST" "yes"}}'
+        inputs: *financial_connections_stability_tests_for_edge_inputs
     - deploy-to-bitrise-io@2: {}
     envs:
     - DEFAULT_TEST_DEVICE: platform=iOS Simulator,name=iPhone 12 mini,OS=16.4
@@ -511,12 +529,21 @@ workflows:
   integration-all:
     steps:
     - xcode-test@6:
-        inputs:
+        is_skippable: true
+        inputs: &integration_all_inputs
         - destination: $DEFAULT_TEST_DEVICE
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "2"
         - scheme: IntegrationTester
         - log_formatter: xcbeautify
+    - script@1:
+        is_always_run: true
+        title: Retry gate for test-runner hang
+        inputs:
+        - content: ./ci_scripts/xcode_test_runner_hang_gate.sh
+    - xcode-test@6:
+        run_if: '{{enveq "STRIPE_RETRY_XCODE_TEST" "yes"}}'
+        inputs: *integration_all_inputs
     - deploy-to-bitrise-io@2: {}
     before_run:
     - prep_all

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -743,8 +743,12 @@ workflows:
         inputs:
         - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
         title: Warm up emulator (iPhone 12 mini, OS=16.4)
+    # First attempt is is_skippable so the runner-hang flake does not
+    # immediately fail the build; the gate script decides retry-vs-fail.
+    # The retry step reuses these inputs via a YAML anchor.
     - xcode-test@6:
-        inputs:
+        is_skippable: true
+        inputs: &ui_tests_paymentsheet_inputs
         - destination: $DEFAULT_TEST_DEVICE
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "2"
@@ -752,7 +756,16 @@ workflows:
         - test_plan: $TEST_PLAN_SHARD
         - log_formatter: xcbeautify
         - xcodebuild_options: -parallel-testing-enabled YES -maximum-parallel-testing-workers 2
-    - deploy-to-bitrise-io@2: {}
+    - script@1:
+        is_always_run: true
+        title: Retry gate for test-runner hang
+        inputs:
+        - content: ./ci_scripts/xcode_test_runner_hang_gate.sh
+    - xcode-test@6:
+        run_if: '{{enveq "STRIPE_RETRY_XCODE_TEST" "yes"}}'
+        inputs: *ui_tests_paymentsheet_inputs
+    - deploy-to-bitrise-io@2:
+        is_always_run: true
     before_run:
     - install-runtime-16
     - prep_all
@@ -767,7 +780,8 @@ workflows:
         - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
         title: Warm up emulator (iPhone 12 mini, OS=16.4)
     - xcode-test@6:
-        inputs:
+        is_skippable: true
+        inputs: &ui_tests_connect_inputs
         - destination: $DEFAULT_TEST_DEVICE
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "2"
@@ -775,7 +789,16 @@ workflows:
         - test_plan: StripeConnectExample
         - log_formatter: xcbeautify
         - xcodebuild_options: -parallel-testing-enabled YES -maximum-parallel-testing-workers 2
-    - deploy-to-bitrise-io@2: {}
+    - script@1:
+        is_always_run: true
+        title: Retry gate for test-runner hang
+        inputs:
+        - content: ./ci_scripts/xcode_test_runner_hang_gate.sh
+    - xcode-test@6:
+        run_if: '{{enveq "STRIPE_RETRY_XCODE_TEST" "yes"}}'
+        inputs: *ui_tests_connect_inputs
+    - deploy-to-bitrise-io@2:
+        is_always_run: true
     before_run:
     - install-runtime-16
     - prep_all
@@ -790,7 +813,8 @@ workflows:
         - content: IOS_SIMULATOR_UDID=`xcrun xctrace list devices 2>&1 | grep "iPhone 12 mini Simulator\ (16.4)" | awk -F " " '{print $NF}' | tr -d "()" |tail -1` && open -a "simulator" --args -CurrentDeviceUDID $IOS_SIMULATOR_UDID
         title: Warm up emulator (iPhone 12 mini, OS=16.4)
     - xcode-test@6:
-        inputs:
+        is_skippable: true
+        inputs: &ui_tests_crypto_inputs
         - destination: $DEFAULT_TEST_DEVICE
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "2"
@@ -798,7 +822,16 @@ workflows:
         - test_plan: CryptoOnrampExampleUITests
         - log_formatter: xcbeautify
         - xcodebuild_options: -parallel-testing-enabled YES -maximum-parallel-testing-workers 2
-    - deploy-to-bitrise-io@2: {}
+    - script@1:
+        is_always_run: true
+        title: Retry gate for test-runner hang
+        inputs:
+        - content: ./ci_scripts/xcode_test_runner_hang_gate.sh
+    - xcode-test@6:
+        run_if: '{{enveq "STRIPE_RETRY_XCODE_TEST" "yes"}}'
+        inputs: *ui_tests_crypto_inputs
+    - deploy-to-bitrise-io@2:
+        is_always_run: true
     before_run:
     - install-runtime-16
     - prep_all

--- a/ci_scripts/xcode_test_runner_hang_gate.sh
+++ b/ci_scripts/xcode_test_runner_hang_gate.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Gate script for recovering from the intermittent Xcode parallel-testing flake:
+#
+#   "<Runner> encountered an error (The test runner hung before establishing connection.)"
+#
+# When xcodebuild runs with `-parallel-testing-enabled YES`, it clones the base
+# simulator and launches a separate XCUITest runner in each clone. On the CI
+# machines a clone's runner occasionally fails to establish its IPC connection
+# back to xcodebuild within the launch timeout. xcodebuild then exits non-zero
+# even though every test that actually ran passed. `-retry-tests-on-failure`
+# does NOT recover from this because it is not a test-case failure.
+#
+# This script is run immediately after an (is_skippable) xcode-test step. It
+# inspects the raw xcodebuild log and decides whether to retry the whole shard:
+#
+#   - Attempt succeeded            -> exit 0 (nothing to do).
+#   - A real test case failed      -> exit 1 (fail the build; NEVER masked).
+#   - Only the runner-hang flake   -> set STRIPE_RETRY_XCODE_TEST=yes, exit 0
+#                                     so a second xcode-test step (guarded by
+#                                     run_if) re-runs the shard once.
+#   - Anything else (compile error,
+#     unknown failure)             -> exit 1 (fail the build).
+#
+# The bias is intentional: unless we positively identify the failure as the
+# runner-hang flake AND see no real test-case failures, we fail the build.
+
+set -euo pipefail
+
+RESULT="${BITRISE_XCODE_TEST_RESULT:-}"
+LOG_PATH="${BITRISE_XCODEBUILD_TEST_LOG_PATH:-}"
+
+if [ "$RESULT" = "succeeded" ]; then
+  echo "xcode-test succeeded; no retry needed."
+  exit 0
+fi
+
+echo "xcode-test result: '${RESULT:-unknown}'. Inspecting raw log to classify the failure."
+
+if [ -z "$LOG_PATH" ] || [ ! -f "$LOG_PATH" ]; then
+  echo "No raw xcodebuild log available (BITRISE_XCODEBUILD_TEST_LOG_PATH='${LOG_PATH}'). Treating as a real failure."
+  exit 1
+fi
+
+# Never mask a genuine test-case failure. xcodebuild's raw log prints
+# "Test case '-[Suite testX]' failed ..." for each failing case and a
+# "Failing tests:" summary block. Match case-insensitively to be safe.
+if grep -qiE "test case '.*' failed" "$LOG_PATH" || grep -qE "^Failing tests:" "$LOG_PATH"; then
+  echo "Detected at least one real test-case failure. Not retrying — failing the build."
+  exit 1
+fi
+
+# No real test failures. Was the only problem a parallel-worker runner that
+# hung before establishing its connection?
+if grep -qi "hung before establishing connection" "$LOG_PATH"; then
+  echo "Detected 'test runner hung before establishing connection' with no failing test cases."
+  echo "This is the parallel-testing simulator-clone flake. Retrying the shard once."
+  envman add --key STRIPE_RETRY_XCODE_TEST --value yes
+  exit 0
+fi
+
+echo "xcode-test failed for an unrecognized reason (no failing test cases and no runner-hang signature)."
+echo "Not retrying — failing the build so the failure is investigated."
+exit 1


### PR DESCRIPTION
## Summary

We're intermittently seeing UI tests fail with this shape:
> `PaymentSheetUITest-Runner (10939) encountered an error (The test runner hung before establishing connection.)`

I'm not sure *why* this is happening, but it causes the entire test to fail. What's interesting is that we've seen this even in cases where the tests *succeed* by running on a parallel worker.

[Example build](https://app.bitrise.io/app/b220f4ba85d134a7/build/9c470399-d6a6-47e0-bb68-ec6adbfef168?tab=tests&tests_filter_status=failed): all 51 tests passed on `Clone 1 … Runner (10321)`; the build went red solely because a second runner (`10939`) hung before connecting.

## Approach

We've added a script to intercept the failure and determine if it's a real failure or one of these spurious test runner failures. We'll also mark `xcode-test` as skippable, and then add a second copy of the `xcode-test` job.

* If it succeeds, great, we fall through.
* If it fails for reasons related to the tests failing, we fail.
* If it's failing due to this spurious issue, we set `STRIPE_RETRY_XCODE_TEST=yes`, which triggers a new copy of the build job.

## Testing

CI

## Changelog

N/A — CI only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)