### PR TITLE
Update Checkout billing address prior to dismissing MPE

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
@@ -17,9 +17,7 @@ struct CheckoutCartContentView: View {
 
     @State private var promoCodeInput = ""
     @State private var showShippingAddressSheet = false
-    @State private var showBillingAddressSheet = false
     @State private var shippingAddressDetails: AddressElement.AddressDetails?
-    @State private var billingAddressDetails: AddressElement.AddressDetails?
 
     var body: some View {
         ScrollView {
@@ -35,7 +33,6 @@ struct CheckoutCartContentView: View {
                 currencySelectorSection
                 lineItemsSection
                 shippingAddressSection
-                billingAddressSection
                 promotionCodeSection
                 orderSummarySection
 
@@ -153,34 +150,6 @@ struct CheckoutCartContentView: View {
                 configuration: makeAddressConfiguration(
                     title: "Shipping Address",
                     override: checkout.session.shippingAddress
-                )
-            )
-        }
-    }
-
-    @ViewBuilder
-    private var billingAddressSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Billing Address")
-                .font(.title2).bold()
-                .padding(.horizontal)
-
-            if let override = checkout.session.billingAddress {
-                addressCard(
-                    name: override.name,
-                    address: override.address,
-                    onEdit: { showBillingAddressSheet = true }
-                )
-            } else {
-                emptyAddressCard(label: "Add billing address", onAdd: { showBillingAddressSheet = true })
-            }
-        }
-        .sheet(isPresented: $showBillingAddressSheet) {
-            AddressElement(
-                address: billingAddressBinding,
-                configuration: makeAddressConfiguration(
-                    title: "Billing Address",
-                    override: checkout.session.billingAddress
                 )
             )
         }
@@ -490,40 +459,12 @@ struct CheckoutCartContentView: View {
         )
     }
 
-    private var billingAddressBinding: Binding<AddressElement.AddressDetails?> {
-        Binding(
-            get: { billingAddressDetails },
-            set: { newValue in
-                billingAddressDetails = newValue
-                guard let details = newValue else { return }
-                updateBillingAddress(details)
-            }
-        )
-    }
-
     private func updateShippingAddress(_ details: AddressElement.AddressDetails) {
         Task {
             isLoading = true
             errorMessage = nil
             do {
                 try await checkout.updateShippingAddress(
-                    name: details.name,
-                    phone: nil,
-                    address: checkoutAddress(from: details.address)
-                )
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-            isLoading = false
-        }
-    }
-
-    private func updateBillingAddress(_ details: AddressElement.AddressDetails) {
-        Task {
-            isLoading = true
-            errorMessage = nil
-            do {
-                try await checkout.updateBillingAddress(
                     name: details.name,
                     phone: nil,
                     address: checkoutAddress(from: details.address)

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartEmbeddedPaymentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartEmbeddedPaymentView.swift
@@ -175,6 +175,18 @@ struct CheckoutCartEmbeddedPaymentView: View {
         do {
             var configuration = EmbeddedPaymentElement.Configuration()
             configuration.returnURL = "payments-example://stripe-redirect"
+            configuration.billingDetailsCollectionConfiguration.name = .always
+            configuration.billingDetailsCollectionConfiguration.phone = .always
+            configuration.billingDetailsCollectionConfiguration.address = .full
+            configuration.defaultBillingDetails.name = "Jane Doe"
+            configuration.defaultBillingDetails.phone = "+15555555555"
+            configuration.defaultBillingDetails.address = .init(
+                city: "San Francisco",
+                country: "US",
+                line1: "510 Townsend St",
+                postalCode: "94103",
+                state: "CA"
+            )
             try await viewModel.load(checkout: checkout, configuration: configuration)
         } catch {
             loadError = error

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartEmbeddedPaymentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartEmbeddedPaymentView.swift
@@ -175,8 +175,11 @@ struct CheckoutCartEmbeddedPaymentView: View {
         do {
             var configuration = EmbeddedPaymentElement.Configuration()
             configuration.returnURL = "payments-example://stripe-redirect"
+            configuration.applePay = .init(
+                merchantId: "merchant.com.stripe.umbrella.test",
+                merchantCountryCode: "US"
+            )
             configuration.billingDetailsCollectionConfiguration.name = .always
-            configuration.billingDetailsCollectionConfiguration.phone = .always
             configuration.billingDetailsCollectionConfiguration.address = .full
             configuration.defaultBillingDetails.name = "Jane Doe"
             configuration.defaultBillingDetails.phone = "+15555555555"

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -105,8 +105,11 @@ struct CheckoutCartPaymentButton: View {
         isLoadingFlowController = true
         var configuration = PaymentSheet.Configuration()
         configuration.returnURL = "payments-example://stripe-redirect"
+        configuration.applePay = .init(
+            merchantId: "merchant.com.stripe.umbrella.test",
+            merchantCountryCode: "US"
+        )
         configuration.billingDetailsCollectionConfiguration.name = .always
-        configuration.billingDetailsCollectionConfiguration.phone = .always
         configuration.billingDetailsCollectionConfiguration.address = .full
         configuration.defaultBillingDetails.name = "Jane Doe"
         configuration.defaultBillingDetails.phone = "+15555555555"

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -105,6 +105,18 @@ struct CheckoutCartPaymentButton: View {
         isLoadingFlowController = true
         var configuration = PaymentSheet.Configuration()
         configuration.returnURL = "payments-example://stripe-redirect"
+        configuration.billingDetailsCollectionConfiguration.name = .always
+        configuration.billingDetailsCollectionConfiguration.phone = .always
+        configuration.billingDetailsCollectionConfiguration.address = .full
+        configuration.defaultBillingDetails.name = "Jane Doe"
+        configuration.defaultBillingDetails.phone = "+15555555555"
+        configuration.defaultBillingDetails.address = .init(
+            city: "San Francisco",
+            country: "US",
+            line1: "510 Townsend St",
+            postalCode: "94103",
+            state: "CA"
+        )
         PaymentSheet.FlowController.create(
             checkout: checkout,
             configuration: configuration

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutSessionUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutSessionUITests.swift
@@ -40,7 +40,12 @@ class CheckoutSessionUITests: PaymentSheetUITestCase {
         app.buttons["+ Add"].waitForExistenceAndTap()
         app.buttons["Card"].waitForExistenceAndTap()
         try fillCardData(app)
-        app.buttons["Continue"].tap()
+
+        let continueButton = app.buttons["Continue"]
+        continueButton.tap()
+        // Wait for sheet to dismiss (billing sync + session reload happens before dismiss)
+        let didDismiss = continueButton.waitForNonExistence(timeout: 10)
+        XCTAssertTrue(didDismiss, "Sheet did not dismiss after Continue")
 
         // Confirm
         app.buttons["Confirm"].waitForExistenceAndTap()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+BillingAddress.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+BillingAddress.swift
@@ -12,6 +12,8 @@ import Foundation
 extension Checkout {
     /// Syncs the billing address from the payment method's billing details onto the checkout session.
     func syncBillingAddress(from billingDetails: STPPaymentMethodBillingDetails?) async throws {
+        // We need at least a country to build an Address for tax region calculation. Billing details
+        // are optional on payment methods, so it's fine to just skip if we don't have enough info.
         guard let billingDetails,
               let country = billingDetails.address?.country?.nonEmpty else {
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+BillingAddress.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+BillingAddress.swift
@@ -1,39 +1,34 @@
 //
-//  Checkout+PaymentSheet.swift
+//  Checkout+BillingAddress.swift
 //  StripePaymentSheet
 //
 //  Created by Nick Porter on 7/7/26.
 //
 
 import Foundation
+@_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 
 extension Checkout {
     /// Syncs the billing address from the payment method's billing details onto the checkout session.
     func syncBillingAddress(from billingDetails: STPPaymentMethodBillingDetails?) async throws {
         guard let billingDetails,
-              let country = billingDetails.address?.country, !country.isEmpty else {
+              let country = billingDetails.address?.country?.nonEmpty else {
             return
         }
         let source = billingDetails.address
         let address = Address(
             country: country,
-            line1: source?.line1?.nilIfEmpty,
-            line2: source?.line2?.nilIfEmpty,
-            city: source?.city?.nilIfEmpty,
-            state: source?.state?.nilIfEmpty,
-            postalCode: source?.postalCode?.nilIfEmpty
+            line1: source?.line1?.nonEmpty,
+            line2: source?.line2?.nonEmpty,
+            city: source?.city?.nonEmpty,
+            state: source?.state?.nonEmpty,
+            postalCode: source?.postalCode?.nonEmpty
         )
         try await updateBillingAddress(
             name: billingDetails.name,
             phone: billingDetails.phone,
             address: address
         )
-    }
-}
-
-private extension String {
-    var nilIfEmpty: String? {
-        isEmpty ? nil : self
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+BillingAddress.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+BillingAddress.swift
@@ -30,7 +30,8 @@ extension Checkout {
         try await updateBillingAddress(
             name: billingDetails.name,
             phone: billingDetails.phone,
-            address: address
+            address: address,
+            canUpdateWhileSheetPresented: true
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -81,13 +81,14 @@ extension Checkout {
     /// - Parameters:
     ///   - update: The API mutation to perform, or nil for a local-only update.
     ///   - localMutation: A local change to the session to apply after the API call (or on its own).
+    ///   - canUpdateWhileSheetPresented: Bypasses the sheet-presented guard (e.g. billing sync on dismiss).
     func performUpdate(
         _ update: SessionUpdate? = nil,
         applying localMutation: (@MainActor @Sendable (Session) -> Session)? = nil,
-        allowWhileSheetPresented: Bool = false
+        canUpdateWhileSheetPresented: Bool = false
     ) async throws {
         try await enqueueSessionUpdate {
-            if !allowWhileSheetPresented {
+            if !canUpdateWhileSheetPresented {
                 try self.requireSheetNotPresented()
             }
             do {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -83,11 +83,13 @@ extension Checkout {
     ///   - localMutation: A local change to the session to apply after the API call (or on its own).
     func performUpdate(
         _ update: SessionUpdate? = nil,
-        applying localMutation: (@MainActor @Sendable (Session) -> Session)? = nil
+        applying localMutation: (@MainActor @Sendable (Session) -> Session)? = nil,
+        allowWhileSheetPresented: Bool = false
     ) async throws {
         try await enqueueSessionUpdate {
-            try self.requireSheetNotPresented()
-
+            if !allowWhileSheetPresented {
+                try self.requireSheetNotPresented()
+            }
             do {
                 let updatedSessionAPIResponse: STPCheckoutSessionAPIResponse?
                 if let update {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+PaymentSheet.swift
@@ -1,0 +1,39 @@
+//
+//  Checkout+PaymentSheet.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 7/7/26.
+//
+
+import Foundation
+@_spi(STP) import StripePayments
+
+extension Checkout {
+    /// Syncs the billing address on the checkout session from the selected payment method's billing details.
+    func syncBillingAddress(from billingDetails: STPPaymentMethodBillingDetails?) async throws {
+        guard let billingDetails,
+              let country = billingDetails.address?.country, !country.isEmpty else {
+            return
+        }
+        let source = billingDetails.address
+        let address = Address(
+            country: country,
+            line1: source?.line1?.nilIfEmpty,
+            line2: source?.line2?.nilIfEmpty,
+            city: source?.city?.nilIfEmpty,
+            state: source?.state?.nilIfEmpty,
+            postalCode: source?.postalCode?.nilIfEmpty
+        )
+        try await updateBillingAddress(
+            name: billingDetails.name,
+            phone: billingDetails.phone,
+            address: address
+        )
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+PaymentSheet.swift
@@ -9,7 +9,7 @@ import Foundation
 @_spi(STP) import StripePayments
 
 extension Checkout {
-    /// Syncs the billing address on the checkout session from the selected payment method's billing details.
+    /// Syncs the billing address from the payment method's billing details onto the checkout session.
     func syncBillingAddress(from billingDetails: STPPaymentMethodBillingDetails?) async throws {
         guard let billingDetails,
               let country = billingDetails.address?.country, !country.isEmpty else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -243,7 +243,7 @@ public final class Checkout: ObservableObject {
     ///     to a country-only region, pass a ``Checkout.Address`` with just the country.
     /// - Throws: ``CheckoutError`` if the session is not open, or if
     ///   the server request fails.
-    public func updateBillingAddress(
+    func updateBillingAddress(
         name: String? = nil,
         phone: String? = nil,
         address: Address
@@ -253,11 +253,11 @@ public final class Checkout: ObservableObject {
         if session.shouldSendTaxRegion(for: "billing") {
             try await performUpdate(.setTaxRegion(address), applying: { session in
                 session.makeCopyOverriding(billingAddress: contactAddress)
-            })
+            }, allowWhileSheetPresented: true)
         } else {
             try await performUpdate(applying: { session in
                 session.makeCopyOverriding(billingAddress: contactAddress)
-            })
+            }, allowWhileSheetPresented: true)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -246,18 +246,19 @@ public final class Checkout: ObservableObject {
     func updateBillingAddress(
         name: String? = nil,
         phone: String? = nil,
-        address: Address
+        address: Address,
+        canUpdateWhileSheetPresented: Bool = false
     ) async throws {
         let contactAddress = ContactAddress(name: name, phone: phone, address: address)
         guard session.billingAddress != contactAddress else { return }
         if session.shouldSendTaxRegion(for: "billing") {
             try await performUpdate(.setTaxRegion(address), applying: { session in
                 session.makeCopyOverriding(billingAddress: contactAddress)
-            }, canUpdateWhileSheetPresented: true)
+            }, canUpdateWhileSheetPresented: canUpdateWhileSheetPresented)
         } else {
             try await performUpdate(applying: { session in
                 session.makeCopyOverriding(billingAddress: contactAddress)
-            }, canUpdateWhileSheetPresented: true)
+            }, canUpdateWhileSheetPresented: canUpdateWhileSheetPresented)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -253,11 +253,11 @@ public final class Checkout: ObservableObject {
         if session.shouldSendTaxRegion(for: "billing") {
             try await performUpdate(.setTaxRegion(address), applying: { session in
                 session.makeCopyOverriding(billingAddress: contactAddress)
-            }, allowWhileSheetPresented: true)
+            }, canUpdateWhileSheetPresented: true)
         } else {
             try await performUpdate(applying: { session in
                 session.makeCopyOverriding(billingAddress: contactAddress)
-            }, allowWhileSheetPresented: true)
+            }, canUpdateWhileSheetPresented: true)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
@@ -379,21 +379,19 @@ class EmbeddedFormViewController: UIViewController {
 
         // If we defer confirmation, sync billing then close the sheet
         if shouldDeferConfirmation {
-            syncCheckoutBillingIfNeeded {
-                self.delegate?.embeddedFormViewControllerDidContinue(self)
-            }
+            syncCheckoutBillingThenContinue()
             return
         }
 
         pay(with: selectedPaymentOption)
     }
 
-    /// Syncs billing address to the checkout session.
-    /// - Note: `onSuccess` is only called on success; on failure the sheet stays open showing the error.
-    private func syncCheckoutBillingIfNeeded(onSuccess: @escaping () -> Void) {
+    /// Syncs billing address to the checkout session, then tells the delegate to continue.
+    /// If the sync fails, stays on the sheet and shows the error instead.
+    private func syncCheckoutBillingThenContinue() {
         guard case .checkout(let checkout) = intent,
               let paymentOption = selectedPaymentOption else {
-            onSuccess()
+            delegate?.embeddedFormViewControllerDidContinue(self)
             return
         }
 
@@ -405,13 +403,13 @@ class EmbeddedFormViewController: UIViewController {
         isUserInteractionEnabled = false
 
         Task { @MainActor [weak self] in
+            guard let self else { return }
             do {
                 try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
-                self?.isPaymentInFlight = false
-                self?.isUserInteractionEnabled = true
-                onSuccess()
+                self.isPaymentInFlight = false
+                self.isUserInteractionEnabled = true
+                self.delegate?.embeddedFormViewControllerDidContinue(self)
             } catch {
-                guard let self else { return }
                 self.isPaymentInFlight = false
                 self.isUserInteractionEnabled = true
                 self.error = error

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
@@ -377,13 +377,46 @@ class EmbeddedFormViewController: UIViewController {
         // Send analytic when primary button is tapped
         analyticsHelper.logConfirmButtonTapped(paymentOption: selectedPaymentOption)
 
-        // If we defer confirmation, simply close the sheet
+        // If we defer confirmation, sync billing then close the sheet
         if shouldDeferConfirmation {
-            self.delegate?.embeddedFormViewControllerDidContinue(self)
+            syncCheckoutBillingIfNeeded {
+                self.delegate?.embeddedFormViewControllerDidContinue(self)
+            }
             return
         }
 
         pay(with: selectedPaymentOption)
+    }
+
+    private func syncCheckoutBillingIfNeeded(completion: @escaping () -> Void) {
+        guard case .checkout(let checkout) = intent,
+              let paymentOption = selectedPaymentOption else {
+            completion()
+            return
+        }
+
+        view.endEditing(true)
+        error = nil
+        isPaymentInFlight = true
+        updateError()
+        updatePrimaryButton()
+        isUserInteractionEnabled = false
+
+        Task { @MainActor [weak self] in
+            do {
+                try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
+                self?.isPaymentInFlight = false
+                self?.isUserInteractionEnabled = true
+                completion()
+            } catch {
+                guard let self else { return }
+                self.isPaymentInFlight = false
+                self.isUserInteractionEnabled = true
+                self.error = error
+                self.updateError()
+                self.updatePrimaryButton()
+            }
+        }
     }
 
     @objc func didTapPrimaryButtonWhenDisabled() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
@@ -388,10 +388,12 @@ class EmbeddedFormViewController: UIViewController {
         pay(with: selectedPaymentOption)
     }
 
-    private func syncCheckoutBillingIfNeeded(completion: @escaping () -> Void) {
+    /// Syncs billing address to the checkout session.
+    /// - Note: `onSuccess` is only called on success; on failure the sheet stays open showing the error.
+    private func syncCheckoutBillingIfNeeded(onSuccess: @escaping () -> Void) {
         guard case .checkout(let checkout) = intent,
               let paymentOption = selectedPaymentOption else {
-            completion()
+            onSuccess()
             return
         }
 
@@ -407,7 +409,7 @@ class EmbeddedFormViewController: UIViewController {
                 try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
                 self?.isPaymentInFlight = false
                 self?.isUserInteractionEnabled = true
-                completion()
+                onSuccess()
             } catch {
                 guard let self else { return }
                 self.isPaymentInFlight = false

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -191,6 +191,14 @@ public final class EmbeddedPaymentElement {
             return result
         }
 
+        // If we currently have a sheet presented fail the update (unless it's a checkout session update, which may occur during billing sync)
+        if !mode.isCheckout,
+           presentingViewController?.presentedViewController is BottomSheetViewController {
+            let result: EmbeddedPaymentElement.UpdateResult = .failed(error: PaymentSheetError.embeddedPaymentElementUpdateWithFormPresented)
+            analyticsHelper.logEmbeddedUpdateFinished(result: result, duration: Date().timeIntervalSince(startTime))
+            return result
+        }
+
         embeddedPaymentMethodsView.isUserInteractionEnabled = false
         // Cancel the old task and let it finish so that merchants receive update results in order
         latestUpdateTask?.cancel()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -191,13 +191,6 @@ public final class EmbeddedPaymentElement {
             return result
         }
 
-        // If we currently have a sheet presented fail the update
-        guard !(presentingViewController?.presentedViewController is StripePaymentSheet.BottomSheetViewController) else {
-            let result: EmbeddedPaymentElement.UpdateResult = .failed(error: PaymentSheetError.embeddedPaymentElementUpdateWithFormPresented)
-            analyticsHelper.logEmbeddedUpdateFinished(result: result, duration: Date().timeIntervalSince(startTime))
-            return result
-        }
-
         embeddedPaymentMethodsView.isUserInteractionEnabled = false
         // Cancel the old task and let it finish so that merchants receive update results in order
         latestUpdateTask?.cancel()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -65,6 +65,13 @@ public class PaymentSheet {
             }
             return false
         }
+
+        var isCheckout: Bool {
+            if case .checkout = self {
+                return true
+            }
+            return false
+        }
     }
 
     /// This contains all configurable properties of PaymentSheet

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -133,6 +133,19 @@ extension PaymentSheet {
             }
             return false
         }
+
+        var billingDetails: STPPaymentMethodBillingDetails? {
+            switch self {
+            case .new(let confirmParams):
+                return confirmParams.paymentMethodParams.billingDetails
+            case .saved(_, let confirmParams):
+                return confirmParams?.paymentMethodParams.billingDetails
+            case .external(_, let billingDetails):
+                return billingDetails
+            case .link, .applePay:
+                return nil
+            }
+        }
     }
 
     /// A class that presents the individual steps of a payment flow
@@ -773,17 +786,8 @@ extension PaymentSheet {
                 return
             }
             assert(Thread.isMainThread, "PaymentSheet.FlowController.update must be called from the main thread.")
-            assert(!isPresented, "PaymentSheet.FlowController.update must be when PaymentSheet is not presented.")
             let updateID = beginUpdate()
             Task { @MainActor in
-                guard !self.isPresented else {
-                    let message = "PaymentSheet.FlowController.update must be called when PaymentSheet is not presented."
-                    assertionFailure(message)
-                    let error = PaymentSheetError.integrationError(nonPIIDebugDescription: message)
-                    self.failUpdate(updateID)
-                    completion(error)
-                    return
-                }
                 checkout.session.applyAddressOverrides(to: &configuration)
                 performUpdate(mode: .checkout(checkout), updateID: updateID, completion: completion)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -142,7 +142,11 @@ extension PaymentSheet {
                 return confirmParams?.paymentMethodParams.billingDetails
             case .external(_, let billingDetails):
                 return billingDetails
-            case .link, .applePay:
+            case .applePay:
+                // TODO(porter) Get Apple Pay working with automatic tax
+                return nil
+            case .link:
+                // Link does not support automatic tax with billing address as source
                 return nil
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -803,13 +803,6 @@ extension PaymentSheet {
             return updateID
         }
 
-        private func failUpdate(_ updateID: UUID) {
-            guard latestUpdateContext?.id == updateID else {
-                return
-            }
-            latestUpdateContext?.status = .failed
-        }
-
         private func performUpdate(
             mode: PaymentSheet.InitializationMode,
             updateID: UUID = UUID(),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -738,9 +738,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
 
         // If FlowController, sync billing then close the sheet
         if isFlowController {
-            syncCheckoutBillingIfNeeded {
-                self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
-            }
+            syncCheckoutBillingThenClose()
             return
         }
 
@@ -775,12 +773,12 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         }
     }
 
-    /// Syncs billing address to the checkout session.
-    /// - Note: `onSuccess` is only called on success; on failure the sheet stays open showing the error.
-    private func syncCheckoutBillingIfNeeded(onSuccess: @escaping () -> Void) {
+    /// Syncs billing address to the checkout session, then closes the sheet.
+    /// If the sync fails, stays on the sheet and shows the error instead.
+    private func syncCheckoutBillingThenClose() {
         guard case .checkout(let checkout) = intent,
               let paymentOption = selectedPaymentOption else {
-            onSuccess()
+            flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
             return
         }
 
@@ -791,13 +789,13 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         isUserInteractionEnabled = false
 
         Task { @MainActor [weak self] in
+            guard let self else { return }
             do {
                 try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
-                self?.isPaymentInFlight = false
-                self?.isUserInteractionEnabled = true
-                onSuccess()
+                self.isPaymentInFlight = false
+                self.isUserInteractionEnabled = true
+                self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
             } catch {
-                guard let self else { return }
                 self.isPaymentInFlight = false
                 self.isUserInteractionEnabled = true
                 self.error = error

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -736,9 +736,11 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
             return
         }
 
-        // If FlowController, simply close the sheet
+        // If FlowController, sync billing then close the sheet
         if isFlowController {
-            self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+            syncCheckoutBillingIfNeeded {
+                self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+            }
             return
         }
 
@@ -770,6 +772,35 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
 #endif
         if let paymentMethodFormViewController {
             paymentMethodFormViewController.form.showAllValidationErrors()
+        }
+    }
+
+    private func syncCheckoutBillingIfNeeded(completion: @escaping () -> Void) {
+        guard case .checkout(let checkout) = intent,
+              let paymentOption = selectedPaymentOption else {
+            completion()
+            return
+        }
+
+        view.endEditing(true)
+        error = nil
+        isPaymentInFlight = true
+        updateUI()
+        isUserInteractionEnabled = false
+
+        Task { @MainActor [weak self] in
+            do {
+                try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
+                self?.isPaymentInFlight = false
+                self?.isUserInteractionEnabled = true
+                completion()
+            } catch {
+                guard let self else { return }
+                self.isPaymentInFlight = false
+                self.isUserInteractionEnabled = true
+                self.error = error
+                self.updateUI()
+            }
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -799,7 +799,8 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                 self.isPaymentInFlight = false
                 self.isUserInteractionEnabled = true
                 self.error = error
-                self.updateUI()
+                self.updateError()
+                self.updatePrimaryButton()
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -775,10 +775,12 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         }
     }
 
-    private func syncCheckoutBillingIfNeeded(completion: @escaping () -> Void) {
+    /// Syncs billing address to the checkout session.
+    /// - Note: `onSuccess` is only called on success; on failure the sheet stays open showing the error.
+    private func syncCheckoutBillingIfNeeded(onSuccess: @escaping () -> Void) {
         guard case .checkout(let checkout) = intent,
               let paymentOption = selectedPaymentOption else {
-            completion()
+            onSuccess()
             return
         }
 
@@ -793,7 +795,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
                 try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
                 self?.isPaymentInFlight = false
                 self?.isUserInteractionEnabled = true
-                completion()
+                onSuccess()
             } catch {
                 guard let self else { return }
                 self.isPaymentInFlight = false

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -487,10 +487,12 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         }
     }
 
-    private func syncCheckoutBillingIfNeeded(completion: @escaping () -> Void) {
+    /// Syncs billing address to the checkout session.
+    /// - Note: `onSuccess` is only called on success; on failure the sheet stays open showing the error.
+    private func syncCheckoutBillingIfNeeded(onSuccess: @escaping () -> Void) {
         guard case .checkout(let checkout) = intent,
               let paymentOption = selectedPaymentOption else {
-            completion()
+            onSuccess()
             return
         }
 
@@ -506,7 +508,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
             do {
                 try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
                 // Don't re-enable UI as we will be dismissing
-                completion()
+                onSuccess()
             } catch {
                 guard let self else { return }
                 sendEventToSubviews(.shouldEnableUserInteraction, from: self.view)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -472,13 +472,53 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
 
         switch mode {
         case .selectingSaved:
-            self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+            syncCheckoutBillingIfNeeded {
+                self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+            }
         case .addingNew:
             if addPaymentMethodViewController.overridePrimaryButtonState != nil {
                 addPaymentMethodViewController.didTapCallToActionButton(from: self)
             } else {
                 addPaymentMethodViewController.logBillingAddressCompletionIfNeeded()
-                self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+                syncCheckoutBillingIfNeeded {
+                    self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+                }
+            }
+        }
+    }
+
+    private func syncCheckoutBillingIfNeeded(completion: @escaping () -> Void) {
+        guard case .checkout(let checkout) = intent,
+              let paymentOption = selectedPaymentOption else {
+            completion()
+            return
+        }
+
+        view.endEditing(true)
+        error = nil
+        isDismissable = false
+        confirmButton.update(status: .processing, animated: true)
+        view.isUserInteractionEnabled = false
+        navigationBar.isUserInteractionEnabled = false
+
+        Task { @MainActor [weak self] in
+            do {
+                try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
+                self?.isDismissable = true
+                self?.view.isUserInteractionEnabled = true
+                self?.navigationBar.isUserInteractionEnabled = true
+                completion()
+            } catch {
+                guard let self else { return }
+                self.isDismissable = true
+                self.view.isUserInteractionEnabled = true
+                self.navigationBar.isUserInteractionEnabled = true
+                self.error = error
+                self.errorLabel.text = error.nonGenericDescription
+                UIView.animate(withDuration: PaymentSheetUI.defaultAnimationDuration) {
+                    self.errorLabel.setHiddenIfNecessary(false)
+                }
+                self.updateButton()
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -472,27 +472,23 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
 
         switch mode {
         case .selectingSaved:
-            syncCheckoutBillingIfNeeded {
-                self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
-            }
+            syncCheckoutBillingThenClose()
         case .addingNew:
             if addPaymentMethodViewController.overridePrimaryButtonState != nil {
                 addPaymentMethodViewController.didTapCallToActionButton(from: self)
             } else {
                 addPaymentMethodViewController.logBillingAddressCompletionIfNeeded()
-                syncCheckoutBillingIfNeeded {
-                    self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
-                }
+                syncCheckoutBillingThenClose()
             }
         }
     }
 
-    /// Syncs billing address to the checkout session.
-    /// - Note: `onSuccess` is only called on success; on failure the sheet stays open showing the error.
-    private func syncCheckoutBillingIfNeeded(onSuccess: @escaping () -> Void) {
+    /// Syncs billing address to the checkout session, then closes the sheet.
+    /// If the sync fails, stays on the sheet and shows the error instead.
+    private func syncCheckoutBillingThenClose() {
         guard case .checkout(let checkout) = intent,
               let paymentOption = selectedPaymentOption else {
-            onSuccess()
+            flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
             return
         }
 
@@ -505,12 +501,11 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         navigationBar.isUserInteractionEnabled = false
 
         Task { @MainActor [weak self] in
+            guard let self else { return }
             do {
                 try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
-                // Don't re-enable UI as we will be dismissing
-                onSuccess()
+                self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
             } catch {
-                guard let self else { return }
                 sendEventToSubviews(.shouldEnableUserInteraction, from: self.view)
                 self.isDismissable = true
                 self.view.isUserInteractionEnabled = true

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -498,18 +498,18 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         error = nil
         isDismissable = false
         confirmButton.update(status: .processing, animated: true)
+        sendEventToSubviews(.shouldDisableUserInteraction, from: view)
         view.isUserInteractionEnabled = false
         navigationBar.isUserInteractionEnabled = false
 
         Task { @MainActor [weak self] in
             do {
                 try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
-                self?.isDismissable = true
-                self?.view.isUserInteractionEnabled = true
-                self?.navigationBar.isUserInteractionEnabled = true
+                // Don't re-enable UI as we will be dismissing
                 completion()
             } catch {
                 guard let self else { return }
+                sendEventToSubviews(.shouldEnableUserInteraction, from: self.view)
                 self.isDismissable = true
                 self.view.isUserInteractionEnabled = true
                 self.navigationBar.isUserInteractionEnabled = true


### PR DESCRIPTION
## Summary
When the user taps Continue in FlowController or EmbeddedPaymentElement, we now sync the billing address from the form onto the checkout session before dismissing.

- Shows a processing/disabled state while the update is in flight
- On success, dismisses normally
- On failure, re-enables the UI and shows the error inline
- Skips the update entirely for Apple Pay and Link (no billing to sync)
- Only applies to checkout sessions, no-ops for other intent types

Also:
- Made updateBillingAddress internal (no external callers per the product brief)
- Removed the standalone billing address section from the checkout playground (now handled in-sheet)
- Added Apple Pay config + full billing collection defaults to the playground for testing

### EPE Demo

https://github.com/user-attachments/assets/15d7e3f8-e4de-4f0f-bce3-c5b328d6582c

### PS.FC Demo

https://github.com/user-attachments/assets/1cae128b-f318-4d52-b984-1d5661c87344

## Motivation
- CheckoutSessions

## Testing
- Manual

## Changelog
N/A