### PR TITLE
CryptoOnramp SDK: Override PKPaymentRequest MCC Code to 6051

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ MINOR
 ### StripeConnect
 * [Changed] `PaymentsViewController`, `PaymentsViewControllerDelegate`, `PayoutsViewController`, `PayoutsViewControllerDelegate`, and `EmbeddedComponentManager.PaymentsListDefaultFiltersOptions` are now part of the public API and no longer require `@_spi(PreviewConnect)` to access.
 
-## 26.2.0 2026-07-06
 ### CryptoOnramp (Alpha)
 * [Fixed] Automatically set PKPaymentRequest.merchantCategoryCode so unsupported payment methods are hidden from Apple Pay
+
+## 26.2.0 2026-07-06
+### CryptoOnramp (Alpha)
 * [Added] Added `AppAttestationUnavailableError`, a rich `StripeCryptoOnrampError` surfaced when configuration fails because app attestation is missing or native Link is unavailable.
 * [Removed] Removed public diagnostic-only properties from rich Crypto Onramp errors: `sdkVersions` from `StripeCryptoOnrampError` and concrete error types; `operation`, `appIdentifier`, and `mode` from `StripeCryptoOnrampAPIError`, `AppAttestationAPIError`, and `UncategorizedAPIError`; and `operation`, `appIdentifier`, `mode`, and `sdkVersions` from `APIErrorContext`. These diagnostics are still included in `developerMessage`.
 * [Changed] Renamed the public API-backed error context property from `context` to `apiErrorContext`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ MINOR
 
 ## 26.2.0 2026-07-06
 ### CryptoOnramp (Alpha)
+* [Fixed] Automatically set PKPaymentRequest.merchantCategoryCode so unsupported payment methods are hidden from Apple Pay
 * [Added] Added `AppAttestationUnavailableError`, a rich `StripeCryptoOnrampError` surfaced when configuration fails because app attestation is missing or native Link is unavailable.
 * [Removed] Removed public diagnostic-only properties from rich Crypto Onramp errors: `sdkVersions` from `StripeCryptoOnrampError` and concrete error types; `operation`, `appIdentifier`, and `mode` from `StripeCryptoOnrampAPIError`, `AppAttestationAPIError`, and `UncategorizedAPIError`; and `operation`, `appIdentifier`, `mode`, and `sdkVersions` from `APIErrorContext`. These diagnostics are still included in `developerMessage`.
 * [Changed] Renamed the public API-backed error context property from `context` to `apiErrorContext`.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -574,6 +574,9 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
         case .applePay(let paymentRequest):
             // This presents Apple Pay and promotes the pending payment source on success.
             pendingApplePayPaymentSource = nil
+            if #available(iOS 18.0, *) {
+                paymentRequest.merchantCategoryCode = PKPaymentRequest.MerchantCategoryCode(rawValue: 6051)
+            }
             do {
                 let status = try await presentApplePay(using: paymentRequest, from: viewController)
                 switch status {


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

- override PKPaymentRequest.merchantCategoryCode to 6051 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- hide unsupported payment methods when rendering Apple Pay (e.g. Apple Cash)

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

ran unit tests
manually tested on Onramp Example App

<img width="1290" height="757" alt="Image from iOS (3)" src="https://github.com/user-attachments/assets/58934beb-60e2-4a0b-ad5a-107c9cf06e7a" />

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
    - [Fixed] Automatically set PKPaymentRequest.merchantCategoryCode so unsupported payment methods are hidden from Apple Pay