### PR TITLE
CryptoOnramp SDK: Combines Change Log Entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ MINOR
 * [Added] Added `WalletOwnershipChallenge` and `CryptoConsumerWallet`, including `CryptoConsumerWallet.verifiedOwnership`, for wallet ownership verification responses.
 * [Added] Added rich Crypto Onramp API error mapping types: `WalletOwnershipChallengeExpiredError`, `InvalidWalletOwnershipChallengeError`, `InvalidWalletOwnershipSignatureError`, `WalletNotFoundError`, and `UnsupportedNetworkError`.
 * [Changed] Renamed `AppAttestationAPIError` to `AppAttestationError` and `UncategorizedAPIError` to `UncategorizedError`.
-* [Fixed] Automatically set PKPaymentRequest.merchantCategoryCode so unsupported payment methods are hidden from Apple Pay
+* [Fixed] Automatically set `PKPaymentRequest.merchantCategoryCode` so unsupported payment methods are hidden from Apple Pay.
 
 ### StripeConnect
 * [Changed] `PaymentsViewController`, `PaymentsViewControllerDelegate`, `PayoutsViewController`, `PayoutsViewControllerDelegate`, and `EmbeddedComponentManager.PaymentsListDefaultFiltersOptions` are now part of the public API and no longer require `@_spi(PreviewConnect)` to access.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,10 @@ MINOR
 * [Added] Added `WalletOwnershipChallenge` and `CryptoConsumerWallet`, including `CryptoConsumerWallet.verifiedOwnership`, for wallet ownership verification responses.
 * [Added] Added rich Crypto Onramp API error mapping types: `WalletOwnershipChallengeExpiredError`, `InvalidWalletOwnershipChallengeError`, `InvalidWalletOwnershipSignatureError`, `WalletNotFoundError`, and `UnsupportedNetworkError`.
 * [Changed] Renamed `AppAttestationAPIError` to `AppAttestationError` and `UncategorizedAPIError` to `UncategorizedError`.
+* [Fixed] Automatically set PKPaymentRequest.merchantCategoryCode so unsupported payment methods are hidden from Apple Pay
 
 ### StripeConnect
 * [Changed] `PaymentsViewController`, `PaymentsViewControllerDelegate`, `PayoutsViewController`, `PayoutsViewControllerDelegate`, and `EmbeddedComponentManager.PaymentsListDefaultFiltersOptions` are now part of the public API and no longer require `@_spi(PreviewConnect)` to access.
-
-### CryptoOnramp (Alpha)
-* [Fixed] Automatically set PKPaymentRequest.merchantCategoryCode so unsupported payment methods are hidden from Apple Pay
 
 ## 26.2.0 2026-07-06
 ### CryptoOnramp (Alpha)


### PR DESCRIPTION
## Summary
#6679 and #6684 both modified `CHANGELOG.md` to add `CryptoOnramp (Alpha)` sections for the next release, and both merged cleanly without conflicts. This combines the two sections in the change log with minor formatting edits.

## Motivation
To clean up the change log and ensure only one heading per modified framework.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
N/A

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
✅ 