### PR TITLE
Fix 3DS2 Cancel button wrapping to two lines

### DIFF
--- a/Stripe3DS2/Stripe3DS2/UIViewController+Stripe3DS2.m
+++ b/Stripe3DS2/Stripe3DS2/UIViewController+Stripe3DS2.m
@@ -22,16 +22,22 @@
     // Cancel button
     STDSButtonCustomization *cancelButtonCustomization = [customization buttonCustomizationForButtonType:STDSUICustomizationButtonTypeCancel];
     UIButton *cancelButton = [UIButton _stds_buttonWithTitle:navigationBarCustomization.buttonText customization:cancelButtonCustomization];
-    // The cancel button's frame has a size of 0 in iOS 8
-    cancelButton.frame = CGRectMake(0, 0, cancelButton.intrinsicContentSize.width, cancelButton.intrinsicContentSize.height);
+    // Keep the title on a single line. Because this is a custom view in a bar button item, the
+    // navigation bar won't size it for us and we set an explicit frame below; without this the
+    // title can wrap to two lines (e.g. on iOS 26+ when the glass configuration adds padding).
+    cancelButton.titleLabel.numberOfLines = 1;
+    cancelButton.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     cancelButton.accessibilityIdentifier = @"Cancel";
     [cancelButton addTarget:self action:cancelButtonSelector forControlEvents:UIControlEventTouchUpInside];
-    UIBarButtonItem *cancelBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:cancelButton];
 #if defined(__IPHONE_26_0) && !STP_TARGET_VISION
     if (@available(iOS 26, *)) {
         cancelButton.configuration = UIButtonConfiguration.glassButtonConfiguration;
     }
 #endif
+    // Size the button after applying the final configuration so the frame accounts for the
+    // configuration's content insets. (The cancel button's frame has a size of 0 in iOS 8.)
+    cancelButton.frame = CGRectMake(0, 0, cancelButton.intrinsicContentSize.width, cancelButton.intrinsicContentSize.height);
+    UIBarButtonItem *cancelBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:cancelButton];
     self.navigationItem.rightBarButtonItem = cancelBarButtonItem;
     // Title
     self.title = navigationBarCustomization.headerText;

--- a/Stripe3DS2/Stripe3DS2/UIViewController+Stripe3DS2.m
+++ b/Stripe3DS2/Stripe3DS2/UIViewController+Stripe3DS2.m
@@ -31,7 +31,6 @@
         cancelButton.configuration = UIButtonConfiguration.glassButtonConfiguration;
     }
 #endif
-    cancelButton.frame = CGRectMake(0, 0, cancelButton.intrinsicContentSize.width, cancelButton.intrinsicContentSize.height);
     UIBarButtonItem *cancelBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:cancelButton];
     self.navigationItem.rightBarButtonItem = cancelBarButtonItem;
     // Title

--- a/Stripe3DS2/Stripe3DS2/UIViewController+Stripe3DS2.m
+++ b/Stripe3DS2/Stripe3DS2/UIViewController+Stripe3DS2.m
@@ -22,9 +22,6 @@
     // Cancel button
     STDSButtonCustomization *cancelButtonCustomization = [customization buttonCustomizationForButtonType:STDSUICustomizationButtonTypeCancel];
     UIButton *cancelButton = [UIButton _stds_buttonWithTitle:navigationBarCustomization.buttonText customization:cancelButtonCustomization];
-    // Keep the title on a single line. Because this is a custom view in a bar button item, the
-    // navigation bar won't size it for us and we set an explicit frame below; without this the
-    // title can wrap to two lines (e.g. on iOS 26+ when the glass configuration adds padding).
     cancelButton.titleLabel.numberOfLines = 1;
     cancelButton.titleLabel.lineBreakMode = NSLineBreakByTruncatingTail;
     cancelButton.accessibilityIdentifier = @"Cancel";
@@ -34,8 +31,6 @@
         cancelButton.configuration = UIButtonConfiguration.glassButtonConfiguration;
     }
 #endif
-    // Size the button after applying the final configuration so the frame accounts for the
-    // configuration's content insets. (The cancel button's frame has a size of 0 in iOS 8.)
     cancelButton.frame = CGRectMake(0, 0, cancelButton.intrinsicContentSize.width, cancelButton.intrinsicContentSize.height);
     UIBarButtonItem *cancelBarButtonItem = [[UIBarButtonItem alloc] initWithCustomView:cancelButton];
     self.navigationItem.rightBarButtonItem = cancelBarButtonItem;


### PR DESCRIPTION
* Remove the old manual frame setting hack we had for iOS 8.
* Don't create the barbuttonitem until we've set the liquid glass configuration.
* Set the button to only render on one line and truncate if needed

Fixes https://github.com/stripe/stripe-ios/issues/6685

## Testing
Manually in IntegrationTester on iOS 27 with/without `UIDesignRequiresCompatibility` enabled. This was only happening on iOS 27 with UIDesignRequiresCompatibility and a large font size.