### PR TITLE
Fix Apple Pay default billing details

### DIFF
--- a/StripeApplePay/StripeApplePay/Source/Extensions/BillingDetails+ApplePay.swift
+++ b/StripeApplePay/StripeApplePay/Source/Extensions/BillingDetails+ApplePay.swift
@@ -51,6 +51,19 @@ extension StripeContact {
 }
 
 extension StripeAPI.BillingDetails {
+    init(
+        from payment: PKPayment,
+        fallbackBillingDetails: StripeAPI.BillingDetails?
+    ) {
+        self = StripeAPI.BillingDetails(from: payment) ?? StripeAPI.BillingDetails()
+        if let fallbackBillingDetails {
+            email = email ?? fallbackBillingDetails.email
+            name = name ?? fallbackBillingDetails.name
+            phone = phone ?? fallbackBillingDetails.phone
+            address = address ?? fallbackBillingDetails.address
+        }
+    }
+
     init?(
         from payment: PKPayment
     ) {

--- a/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Models/BillingDetails.swift
+++ b/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/Models/BillingDetails.swift
@@ -38,6 +38,22 @@ extension StripeAPI {
 
             public var _additionalParametersStorage: NonEncodableParameters?
             public var _allResponseFieldsStorage: NonEncodableParameters?
+
+            @_spi(STP) public init(
+                city: String? = nil,
+                country: String? = nil,
+                line1: String? = nil,
+                line2: String? = nil,
+                postalCode: String? = nil,
+                state: String? = nil
+            ) {
+                self.city = city
+                self.country = country
+                self.line1 = line1
+                self.line2 = line2
+                self.postalCode = postalCode
+                self.state = state
+            }
         }
 
         /// Email address.

--- a/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/PaymentMethod+API.swift
+++ b/StripeApplePay/StripeApplePay/Source/PaymentsCore/API/PaymentMethod+API.swift
@@ -52,12 +52,10 @@ extension StripeAPI.PaymentMethod {
             }
             var cardParams = StripeAPI.PaymentMethodParams.Card()
             cardParams.token = token.id
-            var billingDetails = StripeAPI.BillingDetails(from: payment) ?? StripeAPI.BillingDetails()
-            if let additional = fallbackBillingDetails {
-                billingDetails.email = billingDetails.email ?? additional.email
-                billingDetails.name = billingDetails.name ?? additional.name
-                billingDetails.phone = billingDetails.phone ?? additional.phone
-            }
+            let billingDetails = StripeAPI.BillingDetails(
+                from: payment,
+                fallbackBillingDetails: fallbackBillingDetails
+            )
             var paymentMethodParams = StripeAPI.PaymentMethodParams(type: .card, card: cardParams)
             paymentMethodParams.billingDetails = billingDetails
             paymentMethodParams.clientAttributionMetadata = clientAttributionMetadata

--- a/StripeApplePay/StripeApplePayTests/BillingDetails+ApplePayTest.swift
+++ b/StripeApplePay/StripeApplePayTests/BillingDetails+ApplePayTest.swift
@@ -159,6 +159,62 @@ final class BillingDetailsApplePayTest: XCTestCase {
         XCTAssertNotNil(billingDetails.address)
     }
 
+    func testPaymentMethodBillingDetailsUsesFallbackWhenApplePayContactIsMissing() {
+        let payment = createMockPKPayment(billingContact: nil, shippingContact: nil)
+        let fallbackAddress = StripeAPI.BillingDetails.Address(
+            city: "San Francisco",
+            country: "US",
+            line1: "510 Townsend St",
+            line2: "Apt 2",
+            postalCode: "94103",
+            state: "CA"
+        )
+        let fallbackBillingDetails = StripeAPI.BillingDetails(
+            address: fallbackAddress,
+            email: "fallback@example.com",
+            name: "Fallback Customer",
+            phone: "+14155551234"
+        )
+
+        let billingDetails = StripeAPI.BillingDetails(
+            from: payment,
+            fallbackBillingDetails: fallbackBillingDetails
+        )
+
+        XCTAssertEqual(billingDetails.email, "fallback@example.com")
+        XCTAssertEqual(billingDetails.name, "Fallback Customer")
+        XCTAssertEqual(billingDetails.phone, "+14155551234")
+        XCTAssertEqual(billingDetails.address?.line1, "510 Townsend St")
+        XCTAssertEqual(billingDetails.address?.line2, "Apt 2")
+        XCTAssertEqual(billingDetails.address?.city, "San Francisco")
+        XCTAssertEqual(billingDetails.address?.state, "CA")
+        XCTAssertEqual(billingDetails.address?.postalCode, "94103")
+        XCTAssertEqual(billingDetails.address?.country, "US")
+    }
+
+    func testPaymentMethodBillingDetailsDoesNotOverwriteApplePayContactWithFallback() {
+        let billingContact = PKContact()
+        var name = PersonNameComponents()
+        name.givenName = "Apple"
+        name.familyName = "Pay"
+        billingContact.name = name
+        billingContact.emailAddress = "applepay@example.com"
+
+        let payment = createMockPKPayment(billingContact: billingContact, shippingContact: nil)
+        let fallbackBillingDetails = StripeAPI.BillingDetails(
+            email: "fallback@example.com",
+            name: "Fallback Customer"
+        )
+
+        let billingDetails = StripeAPI.BillingDetails(
+            from: payment,
+            fallbackBillingDetails: fallbackBillingDetails
+        )
+
+        XCTAssertEqual(billingDetails.email, "applepay@example.com")
+        XCTAssertEqual(billingDetails.name, "Apple Pay")
+    }
+
     // MARK: - Helper Methods
 
     private func createMockPKPayment(billingContact: PKContact?, shippingContact: PKContact?) -> PKPayment {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -342,9 +342,10 @@ extension STPApplePayContext {
             applePayContext.apiClient = configuration.apiClient
             applePayContext.returnUrl = configuration.returnURL
             applePayContext.clientAttributionMetadata = clientAttributionMetadata
-            if case .checkout(let checkout) = intent, let email = checkout.nonisolatedSession.email {
-                applePayContext.fallbackBillingDetails = StripeAPI.BillingDetails(email: email)
-            }
+            applePayContext.fallbackBillingDetails = makeFallbackBillingDetails(
+                intent: intent,
+                configuration: configuration
+            )
             return applePayContext
         } else {
             // Delegate only deallocs when Apple Pay completes
@@ -444,6 +445,51 @@ private func makeShippingDetails(from configuration: PaymentElementConfiguration
         name: name,
         phone: shippingDetails.phone
     )
+}
+
+private func makeFallbackBillingDetails(
+    intent: Intent,
+    configuration: PaymentElementConfiguration
+) -> StripeAPI.BillingDetails? {
+    var fallbackBillingDetails = StripeAPI.BillingDetails()
+    var hasFallbackBillingDetails = false
+
+    if case .checkout(let checkout) = intent, let email = checkout.nonisolatedSession.email {
+        fallbackBillingDetails.email = email
+        hasFallbackBillingDetails = true
+    }
+
+    guard configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod else {
+        return hasFallbackBillingDetails ? fallbackBillingDetails : nil
+    }
+
+    let defaultBillingDetails = configuration.defaultBillingDetails
+    if fallbackBillingDetails.email == nil, let email = defaultBillingDetails.email {
+        fallbackBillingDetails.email = email
+        hasFallbackBillingDetails = true
+    }
+    if let name = defaultBillingDetails.name {
+        fallbackBillingDetails.name = name
+        hasFallbackBillingDetails = true
+    }
+    if let phone = defaultBillingDetails.phone {
+        fallbackBillingDetails.phone = phone
+        hasFallbackBillingDetails = true
+    }
+    if defaultBillingDetails.address != .init() {
+        let address = defaultBillingDetails.address
+        fallbackBillingDetails.address = StripeAPI.BillingDetails.Address(
+            city: address.city,
+            country: address.country,
+            line1: address.line1,
+            line2: address.line2,
+            postalCode: address.postalCode,
+            state: address.state
+        )
+        hasFallbackBillingDetails = true
+    }
+
+    return hasFallbackBillingDetails ? fallbackBillingDetails : nil
 }
 
 private func makeRequiredBillingDetails(from configuration: PaymentElementConfiguration) -> Set<PKContactField> {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -490,7 +490,12 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
 
     // MARK: - CheckoutSession Line Items Tests
 
-    private func makeApplePayContext(for intent: Intent, file: StaticString = #filePath, line: UInt = #line) -> STPApplePayContext {
+    private func makeApplePayContext(
+        for intent: Intent,
+        configuration: PaymentSheet.Configuration? = nil,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> STPApplePayContext {
         let elementsSession = STPElementsSession._testValue()
         let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(
             intent: intent,
@@ -499,7 +504,7 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
         guard let context = STPApplePayContext.create(
             intent: intent,
             elementsSession: elementsSession,
-            configuration: configuration,
+            configuration: configuration ?? self.configuration,
             clientAttributionMetadata: clientAttributionMetadata,
             completion: { _, _ in }
         ) else {
@@ -741,6 +746,60 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
         let intent = Intent._testCheckoutSession(mode: .payment, amount: 2345, currency: "USD", email: "guest@example.com")
         let applePayContext = makeApplePayContext(for: intent)
         XCTAssertEqual(applePayContext.fallbackBillingDetails?.email, "guest@example.com")
+    }
+
+    func testCreate_DeferredIntentAttachesDefaultBillingDetailsToApplePayFallback() {
+        var configuration = configuration
+        configuration.defaultBillingDetails = PaymentSheet.BillingDetails(
+            address: PaymentSheet.Address(
+                city: "San Francisco",
+                country: "US",
+                line1: "510 Townsend St",
+                line2: "Apt 2",
+                postalCode: "94103",
+                state: "CA"
+            ),
+            email: "default@example.com",
+            name: "Default Customer",
+            phone: "+14155551234"
+        )
+        configuration.billingDetailsCollectionConfiguration.email = .never
+        configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = true
+        let intent = Intent.deferredIntent(
+            intentConfig: .init(
+                mode: .payment(amount: 2345, currency: "USD"),
+                confirmHandler: dummyDeferredConfirmHandler
+            )
+        )
+
+        let applePayContext = makeApplePayContext(for: intent, configuration: configuration)
+
+        XCTAssertEqual(applePayContext.fallbackBillingDetails?.email, "default@example.com")
+        XCTAssertEqual(applePayContext.fallbackBillingDetails?.name, "Default Customer")
+        XCTAssertEqual(applePayContext.fallbackBillingDetails?.phone, "+14155551234")
+        XCTAssertEqual(applePayContext.fallbackBillingDetails?.address?.line1, "510 Townsend St")
+        XCTAssertEqual(applePayContext.fallbackBillingDetails?.address?.line2, "Apt 2")
+        XCTAssertEqual(applePayContext.fallbackBillingDetails?.address?.city, "San Francisco")
+        XCTAssertEqual(applePayContext.fallbackBillingDetails?.address?.state, "CA")
+        XCTAssertEqual(applePayContext.fallbackBillingDetails?.address?.postalCode, "94103")
+        XCTAssertEqual(applePayContext.fallbackBillingDetails?.address?.country, "US")
+    }
+
+    func testCreate_DefaultBillingDetailsAreNotApplePayFallbackWhenAttachDefaultsDisabled() {
+        var configuration = configuration
+        configuration.defaultBillingDetails.email = "default@example.com"
+        configuration.billingDetailsCollectionConfiguration.email = .never
+        configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod = false
+        let intent = Intent.deferredIntent(
+            intentConfig: .init(
+                mode: .payment(amount: 2345, currency: "USD"),
+                confirmHandler: dummyDeferredConfirmHandler
+            )
+        )
+
+        let applePayContext = makeApplePayContext(for: intent, configuration: configuration)
+
+        XCTAssertNil(applePayContext.fallbackBillingDetails)
     }
 
     func testCreate_CheckoutSessionWithNoEmail_fallbackBillingDetailsNil() {


### PR DESCRIPTION
When billing details are provided to PaymentSheet but the sheet is configured to *not* collect billing details, the details didn't end up in the Apple Pay sheet and weren't included in the created PM. We need to pass them into the underlying PM on creation.