### PR TITLE
Update Checkout SDK API - part 1 / n - Move Checkout initialization params into Configuration

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -88,9 +88,9 @@ struct CheckoutCartView: View {
         isLoading = true
         errorMessage = nil
         do {
-            var config = Checkout.Configuration()
+            var config = Checkout.Configuration(clientSecret: clientSecret)
             config.adaptivePricing.allowed = adaptivePricing
-            checkout = try await Checkout(clientSecret: clientSecret, configuration: config)
+            checkout = try await Checkout(configuration: config)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -940,12 +940,9 @@ extension PlaygroundController {
                 // Load checkout session using Checkout SDK if using CheckoutSession
                 if let checkoutSessionClientSecret = json["checkoutSessionClientSecret"] {
                     do {
-                        var checkoutConfiguration = Checkout.Configuration()
+                        var checkoutConfiguration = Checkout.Configuration(clientSecret: checkoutSessionClientSecret)
                         checkoutConfiguration.adaptivePricing.allowed = settingsToLoad.csAdaptivePricing == .on
-                        self.checkout = try await Checkout(
-                            clientSecret: checkoutSessionClientSecret,
-                            configuration: checkoutConfiguration
-                        )
+                        self.checkout = try await Checkout(configuration: checkoutConfiguration)
                     } catch {
                         self.checkout = nil
                         print("Failed to load checkout session: \(error)")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/AdaptivePricingFlagImageManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/AdaptivePricingFlagImageManager.swift
@@ -12,7 +12,7 @@ import UIKit
 
 /// Downloads and caches country flag images for the adaptive pricing currency selector.
 ///
-/// Flag images are prefetched during ``Checkout.init(clientSecret:configuration:apiClient:)``
+/// Flag images are prefetched during ``Checkout.init(configuration:)``
 /// so they are available immediately when ``Checkout.CurrencySelectorView`` appears.
 /// If either download fails, both currencies fall back to emoji flags.
 @MainActor

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+@_spi(STP) import StripeCore
 
 @_spi(STP)
 @_spi(ReactNativeSDK)
@@ -15,15 +16,18 @@ extension Checkout {
     /// Supply a configuration when creating a ``Checkout`` to customize behavior:
     ///
     /// ```swift
-    /// var config = Checkout.Configuration()
+    /// var config = Checkout.Configuration(clientSecret: "cs_xxx_secret_yyy")
     /// config.adaptivePricing.allowed = true
     ///
-    /// let checkout = try await Checkout(
-    ///     clientSecret: "cs_xxx_secret_yyy",
-    ///     configuration: config
-    /// )
+    /// let checkout = try await Checkout(configuration: config)
     /// ```
     public struct Configuration {
+        /// The client secret for your Checkout Session.
+        public var clientSecret: String
+
+        /// The API client used to make requests to Stripe.
+        public var apiClient: STPAPIClient = .shared
+
         /// Controls whether adaptive pricing is requested for this session.
         ///
         /// When allowed, Stripe may present prices in the customer's local
@@ -32,8 +36,11 @@ extension Checkout {
         /// Default: ``AdaptivePricing.init()`` (`allowed: false`).
         public var adaptivePricing: AdaptivePricing = AdaptivePricing()
 
-        /// Creates a configuration with default values.
-        public init() {}
+        /// Creates a configuration.
+        /// - Parameter clientSecret: The client secret for your Checkout Session.
+        public init(clientSecret: String) {
+            self.clientSecret = clientSecret
+        }
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -14,7 +14,7 @@ import Foundation
 /// Manages a Checkout Session lifecycle.
 ///
 /// ```swift
-/// let checkout = try await Checkout(clientSecret: "cs_xxx_secret_yyy")
+/// let checkout = try await Checkout(configuration: .init(clientSecret: "cs_xxx_secret_yyy"))
 /// print(checkout.session)
 /// ```
 ///
@@ -99,26 +99,20 @@ public final class Checkout: ObservableObject {
 
     /// Loads a Checkout Session from Stripe and returns a ready-to-use instance.
     ///
-    /// - Parameters:
-    ///   - clientSecret: The client secret for your Checkout Session (e.g. `cs_xxx_secret_yyy`).
-    ///   - configuration: Configuration options for the checkout. Defaults to ``Configuration.init()``.
-    ///   - apiClient: The API client to use. Defaults to ``STPAPIClient.shared``.
+    /// - Parameter configuration: Configuration options for the checkout.
     /// - Throws: ``CheckoutError`` if the client secret is invalid or the session cannot be loaded.
-    public init(
-        clientSecret: String,
-        configuration: Configuration = Configuration(),
-        apiClient: STPAPIClient = .shared
-    ) async throws {
+    public init(configuration: Configuration) async throws {
+        let clientSecret = configuration.clientSecret
         guard !clientSecret.isEmpty else {
             throw CheckoutError.invalidClientSecret
         }
         self.clientSecret = clientSecret
         self.configuration = configuration
-        self.apiClient = apiClient
+        self.apiClient = configuration.apiClient
 
         let sessionId = Self.extractSessionId(from: clientSecret)
         do {
-            let apiResponse = try await apiClient.initCheckoutSession(
+            let apiResponse = try await configuration.apiClient.initCheckoutSession(
                 checkoutSessionId: sessionId,
                 adaptivePricingAllowed: configuration.adaptivePricing.allowed
             )
@@ -135,12 +129,14 @@ public final class Checkout: ObservableObject {
     /// Internal initializer for unit tests that injects a pre-loaded API response.
     init(
         clientSecret: String,
-        configuration: Configuration = Configuration(),
+        configuration: Configuration? = nil,
         apiResponse: STPCheckoutSessionAPIResponse,
         apiClient: STPAPIClient = .shared
     ) async {
         self.clientSecret = clientSecret
-        self.configuration = configuration
+        var resolvedConfiguration = configuration ?? Configuration(clientSecret: clientSecret)
+        resolvedConfiguration.apiClient = apiClient
+        self.configuration = resolvedConfiguration
         self.apiClient = apiClient
         let loadedSession = apiResponse.makePublicSession()
         await flagImageManager.prefetchFlagImages(for: loadedSession)
@@ -151,7 +147,7 @@ public final class Checkout: ObservableObject {
     /// Synchronous test-only initializer that wraps a pre-loaded API response without async work.
     init(apiResponse: STPCheckoutSessionAPIResponse) {
         self.clientSecret = ""
-        self.configuration = Configuration()
+        self.configuration = Configuration(clientSecret: "")
         self.apiClient = .shared
         self.session = apiResponse.makePublicSession()
         self.nonisolatedSession = session

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
@@ -18,10 +18,9 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
 
     func testLoadCheckoutSession() async throws {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
-        let checkout = try await Checkout(
-            clientSecret: checkoutSessionResponse.clientSecret,
-            apiClient: STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        )
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        let checkout = try await Checkout(configuration: configuration)
 
         let session = checkout.session
         XCTAssertEqual(session.id, checkoutSessionResponse.id)
@@ -37,10 +36,9 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             allowPromotionCodes: true
         )
-        let checkout = try await Checkout(
-            clientSecret: checkoutSessionResponse.clientSecret,
-            apiClient: STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        )
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        let checkout = try await Checkout(configuration: configuration)
 
         let delegate = MockCheckoutDelegate()
         checkout.delegate = delegate
@@ -61,10 +59,9 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             allowPromotionCodes: true
         )
-        let checkout = try await Checkout(
-            clientSecret: checkoutSessionResponse.clientSecret,
-            apiClient: STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        )
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        let checkout = try await Checkout(configuration: configuration)
 
         XCTAssertTrue(checkout.session.discountAmounts.isEmpty)
         XCTAssertNil(promotionCode(in: checkout.session))
@@ -82,10 +79,9 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             allowPromotionCodes: true
         )
-        let checkout = try await Checkout(
-            clientSecret: checkoutSessionResponse.clientSecret,
-            apiClient: STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        )
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        let checkout = try await Checkout(configuration: configuration)
 
         // Apply first
         try await checkout.applyPromotionCode("SAVE25")
@@ -105,10 +101,9 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             allowPromotionCodes: true
         )
-        let checkout = try await Checkout(
-            clientSecret: checkoutSessionResponse.clientSecret,
-            apiClient: STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        )
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        let checkout = try await Checkout(configuration: configuration)
 
         do {
             try await checkout.applyPromotionCode("BOGUS_CODE_123")
@@ -125,10 +120,9 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             allowAdjustableLineItemQuantity: true
         )
-        let checkout = try await Checkout(
-            clientSecret: checkoutSessionResponse.clientSecret,
-            apiClient: STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        )
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        let checkout = try await Checkout(configuration: configuration)
 
         XCTAssertEqual(5050, checkout.session.total?.total.minorUnitsAmount)
 
@@ -145,10 +139,9 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             includeShippingOptions: true
         )
-        let checkout = try await Checkout(
-            clientSecret: checkoutSessionResponse.clientSecret,
-            apiClient: STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        )
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        let checkout = try await Checkout(configuration: configuration)
 
         XCTAssertEqual(2500, checkout.session.total?.total.minorUnitsAmount)
 
@@ -168,10 +161,9 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
             collectBillingAddress: true,
             automaticTax: true
         )
-        let checkout = try await Checkout(
-            clientSecret: checkoutSessionResponse.clientSecret,
-            apiClient: STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        )
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        let checkout = try await Checkout(configuration: configuration)
 
         XCTAssertNil(checkout.session.billingAddress)
 
@@ -216,10 +208,9 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
             collectShippingAddress: true,
             automaticTax: true
         )
-        let checkout = try await Checkout(
-            clientSecret: checkoutSessionResponse.clientSecret,
-            apiClient: STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        )
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        let checkout = try await Checkout(configuration: configuration)
 
         XCTAssertNil(checkout.session.shippingAddress)
 
@@ -261,13 +252,10 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
             adaptivePricingEnabled: true,
             customerEmailLocation: "DE"
         )
-        var configuration = Checkout.Configuration()
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
         configuration.adaptivePricing.allowed = true
-        let checkout = try await Checkout(
-            clientSecret: checkoutSessionResponse.clientSecret,
-            configuration: configuration,
-            apiClient: STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        )
+        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        let checkout = try await Checkout(configuration: configuration)
 
         let initialSession = checkout.session
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -886,7 +886,9 @@ class EmbeddedPaymentElementTest: XCTestCase {
     func testUpdateCheckoutSession() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        let checkout = try await Checkout(clientSecret: response.clientSecret, apiClient: apiClient)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        checkoutConfiguration.apiClient = apiClient
+        let checkout = try await Checkout(configuration: checkoutConfiguration)
 
         var config = EmbeddedPaymentElement.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
         config.apiClient = apiClient
@@ -904,7 +906,9 @@ class EmbeddedPaymentElementTest: XCTestCase {
     func testUpdateCheckoutSessionCancelsInFlight() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        let checkout = try await Checkout(clientSecret: response.clientSecret, apiClient: apiClient)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        checkoutConfiguration.apiClient = apiClient
+        let checkout = try await Checkout(configuration: checkoutConfiguration)
 
         var config = EmbeddedPaymentElement.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
         config.apiClient = apiClient
@@ -926,7 +930,9 @@ class EmbeddedPaymentElementTest: XCTestCase {
     func testUpdateCheckoutSessionNoOpsForCompleteSession() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        let checkout = try await Checkout(clientSecret: response.clientSecret, apiClient: apiClient)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        checkoutConfiguration.apiClient = apiClient
+        let checkout = try await Checkout(configuration: checkoutConfiguration)
 
         var config = EmbeddedPaymentElement.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
         config.apiClient = apiClient
@@ -955,7 +961,9 @@ class EmbeddedPaymentElementTest: XCTestCase {
     func testUpdateCheckoutSessionNoOpsForExpiredSession() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        let checkout = try await Checkout(clientSecret: response.clientSecret, apiClient: apiClient)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        checkoutConfiguration.apiClient = apiClient
+        let checkout = try await Checkout(configuration: checkoutConfiguration)
 
         var config = EmbeddedPaymentElement.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
         config.apiClient = apiClient

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -1156,7 +1156,9 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
     func testUpdateCheckoutSession() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        let checkout = try await Checkout(clientSecret: response.clientSecret, apiClient: apiClient)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        checkoutConfiguration.apiClient = apiClient
+        let checkout = try await Checkout(configuration: checkoutConfiguration)
 
         var config = PaymentSheet.Configuration()
         config.apiClient = apiClient
@@ -1170,7 +1172,9 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
     func testUpdateCheckoutSessionFails() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        let checkout = try await Checkout(clientSecret: response.clientSecret, apiClient: apiClient)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        checkoutConfiguration.apiClient = apiClient
+        let checkout = try await Checkout(configuration: checkoutConfiguration)
 
         var config = PaymentSheet.Configuration()
         config.apiClient = apiClient


### PR DESCRIPTION
  ## Summary

  Moved Checkout initialization options into Checkout.Configuration: clientSecret is now required by the configuration, and apiClient is set on the configuration instead of passed to Checkout.init.

```
Map of planned changes:
- Initializer + Configuration <-- we are here
- Properties
- Methods
```

  ## Motivation

Align with the proposed [Checkout Elements API shape](https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE/edit?tab=t.0).

  ## Testing
Existing tests.

  ## Changelog

  Not user-facing; no changelog entry.