### PR TITLE
Update ExampleLinkControllerPreviewView to call demo backend

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
@@ -7,18 +7,20 @@ import SwiftUI
 import UIKit
 
 @_spi(LinkControllerPreview) import StripePaymentSheet
+import StripePayments
 
 @available(iOS 16.0, *)
 struct ExampleLinkControllerPreviewView: View {
-    private static let publishableKey = "pk_test_51K9W3OHMaDsveWq0oLP0ZjldetyfHIqyJcz27k2BpMGHxu9v9Cei2tofzoHncPyk3A49jMkFEgTOBQyAMTUffRLa00xzzARtZO"
-
     @State private var linkController: LinkController?
     @State private var email: String = ""
     @State private var phone: String = ""
     @State private var isLoading: Bool = false
     @State private var errorMessage: String?
     @State private var statusMessage: String?
+    @State private var statusTint: Color = .secondary
     @State private var selectedPaymentMethodTypes: Set<LinkPaymentMethodType> = Set(LinkPaymentMethodType.allCases)
+    @State private var customerId: String?
+    @State private var savedPaymentMethods: [LinkControllerDemoBackendClient.PaymentMethodInfo] = []
     @FocusState private var isEmailFieldFocused: Bool
 
     private var supportedPaymentMethodTypes: [LinkPaymentMethodType] {
@@ -57,30 +59,73 @@ struct ExampleLinkControllerPreviewView: View {
                     }
                 }
 
-                DemoSection(title: "Supported Payment Method Types") {
-                    VStack(alignment: .leading, spacing: 16) {
-                        ForEach(LinkPaymentMethodType.allCases, id: \.self) { paymentMethodType in
-                            Button {
-                                Task { @MainActor in
-                                    await togglePaymentMethodType(paymentMethodType)
-                                }
-                            } label: {
-                                HStack(spacing: 12) {
-                                    Image(systemName: selectedPaymentMethodTypes.contains(paymentMethodType) ? "checkmark.square.fill" : "square")
-                                        .foregroundColor(selectedPaymentMethodTypes.contains(paymentMethodType) ? .blue : .gray)
-                                    Text(paymentMethodTypeTitle(paymentMethodType))
-                                        .foregroundColor(.primary)
-                                    Spacer()
-                                }
+                VStack(spacing: 16) {
+                    Button("Fetch Customer") {
+                        Task { @MainActor in
+                            do {
+                                try await fetchCustomer()
+                            } catch {
+                                errorMessage = "Failed to fetch customer: \(error.localizedDescription)"
                             }
-                            .buttonStyle(.plain)
-                            .disabled(isLoading)
                         }
                     }
-                }
+                    .buttonStyle(PreviewPrimaryButtonStyle())
+                    .disabled(isLoading || email.isEmpty)
 
-                VStack(spacing: 16) {
-                    Button("Present") {
+                    if !savedPaymentMethods.isEmpty {
+                        DemoSection(title: "Saved Payment Methods") {
+                            VStack(alignment: .leading, spacing: 12) {
+                                ForEach(savedPaymentMethods) { pm in
+                                    HStack(spacing: 12) {
+                                        Text(pm.displayLabel)
+                                            .font(.subheadline)
+                                        Spacer()
+                                        Button("Pay $10.99") {
+                                            Task { @MainActor in
+                                                await chargePaymentMethod(pm)
+                                            }
+                                        }
+                                        .buttonStyle(.bordered)
+                                        .fixedSize()
+                                        .disabled(isLoading)
+
+                                        Button("−") {
+                                            Task { @MainActor in
+                                                await removePaymentMethod(pm)
+                                            }
+                                        }
+                                        .buttonStyle(.bordered)
+                                        .tint(.red)
+                                        .disabled(isLoading)
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    DemoSection(title: "Supported Payment Method Types") {
+                        VStack(alignment: .leading, spacing: 16) {
+                            ForEach(LinkPaymentMethodType.allCases, id: \.self) { paymentMethodType in
+                                Button {
+                                    Task { @MainActor in
+                                        await togglePaymentMethodType(paymentMethodType)
+                                    }
+                                } label: {
+                                    HStack(spacing: 12) {
+                                        Image(systemName: selectedPaymentMethodTypes.contains(paymentMethodType) ? "checkmark.square.fill" : "square")
+                                            .foregroundColor(selectedPaymentMethodTypes.contains(paymentMethodType) ? .blue : .gray)
+                                        Text(paymentMethodTypeTitle(paymentMethodType))
+                                            .foregroundColor(.primary)
+                                        Spacer()
+                                    }
+                                }
+                                .buttonStyle(.plain)
+                                .disabled(isLoading)
+                            }
+                        }
+                    }
+
+                    Button("Present Link") {
                         Task { @MainActor in
                             await presentLinkFlow()
                         }
@@ -102,7 +147,7 @@ struct ExampleLinkControllerPreviewView: View {
                 }
 
                 if let statusMessage {
-                    MessageBanner(text: statusMessage, tint: .green)
+                    MessageBanner(text: statusMessage, tint: statusTint)
                 }
 
                 VStack(alignment: .leading, spacing: 12) {
@@ -142,23 +187,43 @@ struct ExampleLinkControllerPreviewView: View {
 
     @MainActor
     private func initializeLinkController() async {
-        STPAPIClient.shared.publishableKey = Self.publishableKey
-
         linkController = nil
         isLoading = true
         errorMessage = nil
         statusMessage = "Initializing LinkController..."
 
         do {
+            let config = try await LinkControllerDemoBackendClient.fetchConfig()
+            STPAPIClient.shared.publishableKey = config.publishableKey
+
             linkController = try await LinkController.create(
                 configuration: .init(supportedPaymentMethodTypes: supportedPaymentMethodTypes, merchantDisplayName: "Example, Inc.")
             )
             isLoading = false
+            statusTint = .secondary
             statusMessage = "LinkController initialized successfully"
         } catch {
             isLoading = false
             statusMessage = nil
             errorMessage = "Failed to initialize LinkController: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func fetchCustomer() async throws {
+        isLoading = true
+        errorMessage = nil
+        statusMessage = "Fetching customer..."
+        do {
+            customerId = try await LinkControllerDemoBackendClient.fetchOrCreateCustomer(email: email)
+            try await refreshSavedPaymentMethods()
+            isLoading = false
+            statusMessage = "Customer fetched (ID: \(customerId!))"
+        } catch {
+            isLoading = false
+            statusMessage = nil
+            customerId = nil
+            throw error
         }
     }
 
@@ -172,6 +237,19 @@ struct ExampleLinkControllerPreviewView: View {
         guard let rootViewController = findViewController() else {
             errorMessage = "Could not find root view controller"
             return
+        }
+
+        if customerId == nil {
+            guard !email.isEmpty else {
+                errorMessage = "Enter an email first"
+                return
+            }
+            do {
+                try await fetchCustomer()
+            } catch {
+                errorMessage = "Failed to fetch customer: \(error.localizedDescription)"
+                return
+            }
         }
 
         isEmailFieldFocused = false
@@ -190,7 +268,17 @@ struct ExampleLinkControllerPreviewView: View {
 
             switch result {
             case .completed(let paymentMethod):
-                statusMessage = "Payment method created (ID: \(paymentMethod.stripeId))"
+                statusMessage = "Saving payment method..."
+                do {
+                    try await LinkControllerDemoBackendClient.attachPaymentMethod(
+                        paymentMethod.stripeId,
+                        toCustomer: customerId!
+                    )
+                    try await refreshSavedPaymentMethods()
+                    statusMessage = "Payment method saved!"
+                } catch {
+                    statusMessage = "Payment method created (ID: \(paymentMethod.stripeId)) but failed to save: \(error.localizedDescription)"
+                }
             case .canceled:
                 statusMessage = "Present flow canceled"
             }
@@ -202,12 +290,105 @@ struct ExampleLinkControllerPreviewView: View {
     }
 
     @MainActor
+    private func refreshSavedPaymentMethods() async throws {
+        guard let customerId else { return }
+        savedPaymentMethods = try await LinkControllerDemoBackendClient.listPaymentMethods(for: customerId)
+    }
+
+    @MainActor
+    private func chargePaymentMethod(_ pm: LinkControllerDemoBackendClient.PaymentMethodInfo) async {
+        guard let customerId else { return }
+        isLoading = true
+        errorMessage = nil
+        do {
+            let response = try await LinkControllerDemoBackendClient.charge(
+                paymentMethodId: pm.id,
+                customerId: customerId
+            )
+
+            if response.code == "authentication_required", let secret = response.clientSecret {
+                guard let vc = findViewController() else {
+                    isLoading = false
+                    errorMessage = "Could not find view controller for 3DS authentication"
+                    return
+                }
+                let authContext = STPAuthenticationContextWrapper(vc)
+                let authStatus: STPPaymentHandlerActionStatus = await withCheckedContinuation { continuation in
+                    STPPaymentHandler.shared().handleNextAction(
+                        forPayment: secret,
+                        with: authContext,
+                        returnURL: nil
+                    ) { status, _, _ in
+                        continuation.resume(returning: status)
+                    }
+                }
+                isLoading = false
+                switch authStatus {
+                case .succeeded:
+                    statusMessage = "Payment authenticated and complete"
+                case .canceled:
+                    statusMessage = "Authentication canceled"
+                case .failed:
+                    errorMessage = "Authentication failed"
+                @unknown default:
+                    break
+                }
+            } else if response.status == "processing" {
+                isLoading = false
+                statusTint = .yellow
+                statusMessage = "Payment processing (ID: \(response.paymentIntentId))..."
+                await pollPaymentIntentStatus(piId: response.paymentIntentId)
+            } else {
+                isLoading = false
+                statusMessage = "Payment \(response.status) (ID: \(response.paymentIntentId))"
+            }
+        } catch {
+            isLoading = false
+            errorMessage = "Payment failed: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func pollPaymentIntentStatus(piId: String) async {
+        for _ in 0..<30 {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard let response = try? await LinkControllerDemoBackendClient.fetchPaymentIntentStatus(piId: piId) else {
+                continue
+            }
+            if response.status != "processing" {
+                statusTint = .green
+                statusMessage = "Payment \(response.status) (ID: \(piId))"
+                return
+            }
+        }
+        statusMessage = "Payment still processing (ID: \(piId))"
+    }
+
+    @MainActor
+    private func removePaymentMethod(_ pm: LinkControllerDemoBackendClient.PaymentMethodInfo) async {
+        isLoading = true
+        errorMessage = nil
+        do {
+            try await LinkControllerDemoBackendClient.detachPaymentMethod(pm.id)
+            try await refreshSavedPaymentMethods()
+            isLoading = false
+            statusMessage = "Payment method removed"
+        } catch {
+            isLoading = false
+            errorMessage = "Failed to remove payment method: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
     private func resetLinkController() async {
         linkController = nil
         errorMessage = nil
         statusMessage = nil
+        statusTint = .secondary
         email = ""
         phone = ""
+        customerId = nil
+        savedPaymentMethods = []
         selectedPaymentMethodTypes = Set(LinkPaymentMethodType.allCases)
 
         await initializeLinkController()
@@ -380,6 +561,12 @@ private struct PreviewTextButtonStyle: ButtonStyle {
             .padding(.vertical, 8)
             .opacity(configuration.isPressed ? 0.6 : 1.0)
     }
+}
+
+private class STPAuthenticationContextWrapper: NSObject, STPAuthenticationContext {
+    private let viewController: UIViewController
+    init(_ viewController: UIViewController) { self.viewController = viewController }
+    func authenticationPresentingViewController() -> UIViewController { viewController }
 }
 
 @available(iOS 16.0, *)

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
@@ -11,94 +11,35 @@ import StripePayments
 
 @available(iOS 16.0, *)
 struct ExampleLinkControllerPreviewView: View {
-    @State private var linkController: LinkController?
-    @State private var email: String = ""
-    @State private var phone: String = ""
-    @State private var isLoading: Bool = false
-    @State private var errorMessage: String?
-    @State private var statusMessage: String?
-    @State private var statusTint: Color = .secondary
-    @State private var selectedPaymentMethodTypes: Set<LinkPaymentMethodType> = Set(LinkPaymentMethodType.allCases)
-    @State private var customerId: String?
-    @State private var savedPaymentMethods: [LinkControllerDemoBackendClient.PaymentMethodInfo] = []
-    @FocusState private var isEmailFieldFocused: Bool
-
-    private var supportedPaymentMethodTypes: [LinkPaymentMethodType] {
-        LinkPaymentMethodType.allCases.filter(selectedPaymentMethodTypes.contains)
-    }
+    @State private var configuration = LinkControllerDemoConfiguration()
 
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 24) {
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("LinkControllerPreview Demo")
-                        .font(.system(size: 34, weight: .bold))
-                }
-                .frame(maxWidth: .infinity, alignment: .leading)
-
-                DemoSection(title: "User Information") {
-                    VStack(alignment: .leading, spacing: 16) {
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Email")
-                                .font(.subheadline)
-                            TextField("Enter email address", text: $email)
-                                .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .keyboardType(.emailAddress)
-                                .autocapitalization(.none)
-                                .disableAutocorrection(true)
-                                .focused($isEmailFieldFocused)
-                        }
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            Text("Phone Number (optional)")
-                                .font(.subheadline)
-                            TextField("Enter phone number (E.164 format)", text: $phone)
-                                .textFieldStyle(RoundedBorderTextFieldStyle())
-                                .keyboardType(.phonePad)
-                        }
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Link Standalone Demo")
+                            .font(.system(size: 34, weight: .bold))
                     }
-                }
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-                VStack(spacing: 16) {
-                    Button("Fetch Customer") {
-                        Task { @MainActor in
-                            do {
-                                try await fetchCustomer()
-                            } catch {
-                                errorMessage = "Failed to fetch customer: \(error.localizedDescription)"
+                    DemoSection(title: "User Information") {
+                        VStack(alignment: .leading, spacing: 16) {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Email")
+                                    .font(.subheadline)
+                                TextField("Enter email address", text: $configuration.email)
+                                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                                    .keyboardType(.emailAddress)
+                                    .autocapitalization(.none)
+                                    .disableAutocorrection(true)
                             }
-                        }
-                    }
-                    .buttonStyle(PreviewPrimaryButtonStyle())
-                    .disabled(isLoading || email.isEmpty)
 
-                    if !savedPaymentMethods.isEmpty {
-                        DemoSection(title: "Saved Payment Methods") {
-                            VStack(alignment: .leading, spacing: 12) {
-                                ForEach(savedPaymentMethods) { pm in
-                                    HStack(spacing: 12) {
-                                        Text(pm.displayLabel)
-                                            .font(.subheadline)
-                                        Spacer()
-                                        Button("Pay $10.99") {
-                                            Task { @MainActor in
-                                                await chargePaymentMethod(pm)
-                                            }
-                                        }
-                                        .buttonStyle(.bordered)
-                                        .fixedSize()
-                                        .disabled(isLoading)
-
-                                        Button("−") {
-                                            Task { @MainActor in
-                                                await removePaymentMethod(pm)
-                                            }
-                                        }
-                                        .buttonStyle(.bordered)
-                                        .tint(.red)
-                                        .disabled(isLoading)
-                                    }
-                                }
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text("Phone Number (optional)")
+                                    .font(.subheadline)
+                                TextField("Enter phone number (E.164 format)", text: $configuration.phone)
+                                    .textFieldStyle(RoundedBorderTextFieldStyle())
+                                    .keyboardType(.phonePad)
                             }
                         }
                     }
@@ -107,302 +48,62 @@ struct ExampleLinkControllerPreviewView: View {
                         VStack(alignment: .leading, spacing: 16) {
                             ForEach(LinkPaymentMethodType.allCases, id: \.self) { paymentMethodType in
                                 Button {
-                                    Task { @MainActor in
-                                        await togglePaymentMethodType(paymentMethodType)
+                                    if configuration.supportedPaymentMethodTypes.contains(paymentMethodType) {
+                                        configuration.supportedPaymentMethodTypes.remove(paymentMethodType)
+                                    } else {
+                                        configuration.supportedPaymentMethodTypes.insert(paymentMethodType)
                                     }
                                 } label: {
                                     HStack(spacing: 12) {
-                                        Image(systemName: selectedPaymentMethodTypes.contains(paymentMethodType) ? "checkmark.square.fill" : "square")
-                                            .foregroundColor(selectedPaymentMethodTypes.contains(paymentMethodType) ? .blue : .gray)
+                                        Image(systemName: configuration.supportedPaymentMethodTypes.contains(paymentMethodType) ? "checkmark.square.fill" : "square")
+                                            .foregroundColor(configuration.supportedPaymentMethodTypes.contains(paymentMethodType) ? .blue : .gray)
                                         Text(paymentMethodTypeTitle(paymentMethodType))
                                             .foregroundColor(.primary)
                                         Spacer()
                                     }
                                 }
                                 .buttonStyle(.plain)
-                                .disabled(isLoading)
                             }
                         }
                     }
 
-                    Button("Present Link") {
-                        Task { @MainActor in
-                            await presentLinkFlow()
+                    DemoSection(title: "Intent Mode") {
+                        VStack(alignment: .leading, spacing: 16) {
+                            Picker("Intent Mode", selection: $configuration.intentMode) {
+                                ForEach(LinkControllerDemoConfiguration.IntentMode.allCases, id: \.self) { mode in
+                                    Text(mode.rawValue).tag(mode)
+                                }
+                            }
+                            .pickerStyle(.segmented)
+
+                            switch configuration.intentMode {
+                            case .sdkManaged:
+                                Text("LinkController manages the session; the app attaches the payment method manually after `present` returns.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            case .serverSetupIntent:
+                                Text("A SetupIntent is created server-side before presenting. The SDK confirms and attaches automatically.")
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
                         }
                     }
-                    .buttonStyle(PreviewPrimaryButtonStyle())
-                    .disabled(isLoading || linkController == nil)
 
-                    Button("Reset LinkController") {
-                        Task { @MainActor in
-                            await resetLinkController()
-                        }
+                    NavigationLink {
+                        LinkControllerDemoView(configuration: configuration)
+                    } label: {
+                        Text("Continue")
+                            .frame(maxWidth: .infinity)
+                            .padding()
+                            .background(configuration.email.isEmpty ? Color.blue.opacity(0.4) : Color.blue)
+                            .foregroundColor(.white)
+                            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                     }
-                    .buttonStyle(PreviewTextButtonStyle())
-                    .disabled(isLoading)
+                    .disabled(configuration.email.isEmpty)
                 }
-
-                if let errorMessage {
-                    MessageBanner(text: errorMessage, tint: .red)
-                }
-
-                if let statusMessage {
-                    MessageBanner(text: statusMessage, tint: statusTint)
-                }
-
-                VStack(alignment: .leading, spacing: 12) {
-                    Text("Payment Method Preview")
-                        .font(.headline)
-                    if let linkController {
-                        LinkControllerPreviewPaymentMethodView(linkController: linkController)
-                    } else {
-                        StatusCard(
-                            text: "No payment method preview available",
-                            isPlaceholder: true
-                        )
-                    }
-                }
-            }
-            .padding()
+                .padding()
         }
-        .task {
-            guard linkController == nil, !isLoading else {
-                return
-            }
-            await initializeLinkController()
-        }
-        .overlay {
-            if isLoading {
-                ZStack {
-                    Color.black.opacity(0.2)
-                        .ignoresSafeArea()
-                    ProgressView("Loading...")
-                        .padding(20)
-                        .background(Color(UIColor.systemBackground))
-                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-                }
-            }
-        }
-    }
-
-    @MainActor
-    private func initializeLinkController() async {
-        linkController = nil
-        isLoading = true
-        errorMessage = nil
-        statusMessage = "Initializing LinkController..."
-
-        do {
-            let config = try await LinkControllerDemoBackendClient.fetchConfig()
-            STPAPIClient.shared.publishableKey = config.publishableKey
-
-            linkController = try await LinkController.create(
-                configuration: .init(supportedPaymentMethodTypes: supportedPaymentMethodTypes, merchantDisplayName: "Example, Inc.")
-            )
-            isLoading = false
-            statusTint = .secondary
-            statusMessage = "LinkController initialized successfully"
-        } catch {
-            isLoading = false
-            statusMessage = nil
-            errorMessage = "Failed to initialize LinkController: \(error.localizedDescription)"
-        }
-    }
-
-    @MainActor
-    private func fetchCustomer() async throws {
-        isLoading = true
-        errorMessage = nil
-        statusMessage = "Fetching customer..."
-        do {
-            customerId = try await LinkControllerDemoBackendClient.fetchOrCreateCustomer(email: email)
-            try await refreshSavedPaymentMethods()
-            isLoading = false
-            statusMessage = "Customer fetched (ID: \(customerId!))"
-        } catch {
-            isLoading = false
-            statusMessage = nil
-            customerId = nil
-            throw error
-        }
-    }
-
-    @MainActor
-    private func presentLinkFlow() async {
-        guard let linkController else {
-            errorMessage = "LinkController not initialized"
-            return
-        }
-
-        guard let rootViewController = findViewController() else {
-            errorMessage = "Could not find root view controller"
-            return
-        }
-
-        if customerId == nil {
-            guard !email.isEmpty else {
-                errorMessage = "Enter an email first"
-                return
-            }
-            do {
-                try await fetchCustomer()
-            } catch {
-                errorMessage = "Failed to fetch customer: \(error.localizedDescription)"
-                return
-            }
-        }
-
-        isEmailFieldFocused = false
-        isLoading = true
-        errorMessage = nil
-        statusMessage = "Presenting Link flow..."
-
-        do {
-            let result = try await linkController.present(
-                email: email,
-                phoneNumber: phone.isEmpty ? nil : phone,
-                from: rootViewController
-            )
-
-            isLoading = false
-
-            switch result {
-            case .completed(let paymentMethod):
-                statusMessage = "Saving payment method..."
-                do {
-                    try await LinkControllerDemoBackendClient.attachPaymentMethod(
-                        paymentMethod.stripeId,
-                        toCustomer: customerId!
-                    )
-                    try await refreshSavedPaymentMethods()
-                    statusMessage = "Payment method saved!"
-                } catch {
-                    statusMessage = "Payment method created (ID: \(paymentMethod.stripeId)) but failed to save: \(error.localizedDescription)"
-                }
-            case .canceled:
-                statusMessage = "Present flow canceled"
-            }
-        } catch {
-            isLoading = false
-            statusMessage = nil
-            errorMessage = "Present flow failed: \(error.localizedDescription)"
-        }
-    }
-
-    @MainActor
-    private func refreshSavedPaymentMethods() async throws {
-        guard let customerId else { return }
-        savedPaymentMethods = try await LinkControllerDemoBackendClient.listPaymentMethods(for: customerId)
-    }
-
-    @MainActor
-    private func chargePaymentMethod(_ pm: LinkControllerDemoBackendClient.PaymentMethodInfo) async {
-        guard let customerId else { return }
-        isLoading = true
-        errorMessage = nil
-        do {
-            let response = try await LinkControllerDemoBackendClient.charge(
-                paymentMethodId: pm.id,
-                customerId: customerId
-            )
-
-            if response.code == "authentication_required", let secret = response.clientSecret {
-                guard let vc = findViewController() else {
-                    isLoading = false
-                    errorMessage = "Could not find view controller for 3DS authentication"
-                    return
-                }
-                let authContext = STPAuthenticationContextWrapper(vc)
-                let authStatus: STPPaymentHandlerActionStatus = await withCheckedContinuation { continuation in
-                    STPPaymentHandler.shared().handleNextAction(
-                        forPayment: secret,
-                        with: authContext,
-                        returnURL: nil
-                    ) { status, _, _ in
-                        continuation.resume(returning: status)
-                    }
-                }
-                isLoading = false
-                switch authStatus {
-                case .succeeded:
-                    statusMessage = "Payment authenticated and complete"
-                case .canceled:
-                    statusMessage = "Authentication canceled"
-                case .failed:
-                    errorMessage = "Authentication failed"
-                @unknown default:
-                    break
-                }
-            } else if response.status == "processing" {
-                isLoading = false
-                statusTint = .yellow
-                statusMessage = "Payment processing (ID: \(response.paymentIntentId))..."
-                await pollPaymentIntentStatus(piId: response.paymentIntentId)
-            } else {
-                isLoading = false
-                statusMessage = "Payment \(response.status) (ID: \(response.paymentIntentId))"
-            }
-        } catch {
-            isLoading = false
-            errorMessage = "Payment failed: \(error.localizedDescription)"
-        }
-    }
-
-    @MainActor
-    private func pollPaymentIntentStatus(piId: String) async {
-        for _ in 0..<30 {
-            try? await Task.sleep(nanoseconds: 2_000_000_000)
-            guard let response = try? await LinkControllerDemoBackendClient.fetchPaymentIntentStatus(piId: piId) else {
-                continue
-            }
-            if response.status != "processing" {
-                statusTint = .green
-                statusMessage = "Payment \(response.status) (ID: \(piId))"
-                return
-            }
-        }
-        statusMessage = "Payment still processing (ID: \(piId))"
-    }
-
-    @MainActor
-    private func removePaymentMethod(_ pm: LinkControllerDemoBackendClient.PaymentMethodInfo) async {
-        isLoading = true
-        errorMessage = nil
-        do {
-            try await LinkControllerDemoBackendClient.detachPaymentMethod(pm.id)
-            try await refreshSavedPaymentMethods()
-            isLoading = false
-            statusMessage = "Payment method removed"
-        } catch {
-            isLoading = false
-            errorMessage = "Failed to remove payment method: \(error.localizedDescription)"
-        }
-    }
-
-    @MainActor
-    private func resetLinkController() async {
-        linkController = nil
-        errorMessage = nil
-        statusMessage = nil
-        statusTint = .secondary
-        email = ""
-        phone = ""
-        customerId = nil
-        savedPaymentMethods = []
-        selectedPaymentMethodTypes = Set(LinkPaymentMethodType.allCases)
-
-        await initializeLinkController()
-    }
-
-    @MainActor
-    private func togglePaymentMethodType(_ paymentMethodType: LinkPaymentMethodType) async {
-        if selectedPaymentMethodTypes.contains(paymentMethodType) {
-            selectedPaymentMethodTypes.remove(paymentMethodType)
-        } else {
-            selectedPaymentMethodTypes.insert(paymentMethodType)
-        }
-
-        await initializeLinkController()
+        .navigationTitle("Configuration")
     }
 
     private func paymentMethodTypeTitle(_ paymentMethodType: LinkPaymentMethodType) -> String {
@@ -415,23 +116,23 @@ struct ExampleLinkControllerPreviewView: View {
             fatalError()
         }
     }
+}
 
-    private func findViewController() -> UIViewController? {
-        let keyWindow = UIApplication.shared.connectedScenes
-            .compactMap { $0 as? UIWindowScene }
-            .flatMap(\.windows)
-            .first(where: \.isKeyWindow)
+func findViewController() -> UIViewController? {
+    let keyWindow = UIApplication.shared.connectedScenes
+        .compactMap { $0 as? UIWindowScene }
+        .flatMap(\.windows)
+        .first(where: \.isKeyWindow)
 
-        var topController = keyWindow?.rootViewController
-        while let presentedViewController = topController?.presentedViewController {
-            topController = presentedViewController
-        }
-        return topController
+    var topController = keyWindow?.rootViewController
+    while let presentedViewController = topController?.presentedViewController {
+        topController = presentedViewController
     }
+    return topController
 }
 
 @available(iOS 16.0, *)
-private struct LinkControllerPreviewPaymentMethodView: View {
+struct LinkControllerPreviewPaymentMethodView: View {
     @ObservedObject var linkController: LinkController
 
     var body: some View {
@@ -460,7 +161,7 @@ private struct LinkControllerPreviewPaymentMethodView: View {
     }
 }
 
-private struct DemoSection<Content: View>: View {
+struct DemoSection<Content: View>: View {
     let title: String
     let content: Content
 
@@ -483,7 +184,7 @@ private struct DemoSection<Content: View>: View {
 }
 
 @available(iOS 16.0, *)
-private struct PreviewInfoRow: View {
+struct PreviewInfoRow: View {
     let label: String
     let value: String
 
@@ -502,7 +203,7 @@ private struct PreviewInfoRow: View {
 }
 
 @available(iOS 16.0, *)
-private struct StatusCard: View {
+struct StatusCard: View {
     let text: String
     let isPlaceholder: Bool
 
@@ -524,7 +225,7 @@ private struct StatusCard: View {
 }
 
 @available(iOS 16.0, *)
-private struct MessageBanner: View {
+struct MessageBanner: View {
     let text: String
     let tint: Color
 
@@ -540,7 +241,7 @@ private struct MessageBanner: View {
 }
 
 @available(iOS 16.0, *)
-private struct PreviewPrimaryButtonStyle: ButtonStyle {
+struct PreviewPrimaryButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .frame(maxWidth: .infinity)
@@ -553,7 +254,7 @@ private struct PreviewPrimaryButtonStyle: ButtonStyle {
 }
 
 @available(iOS 16.0, *)
-private struct PreviewTextButtonStyle: ButtonStyle {
+struct PreviewTextButtonStyle: ButtonStyle {
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .frame(maxWidth: .infinity)
@@ -563,7 +264,7 @@ private struct PreviewTextButtonStyle: ButtonStyle {
     }
 }
 
-private class STPAuthenticationContextWrapper: NSObject, STPAuthenticationContext {
+class STPAuthenticationContextWrapper: NSObject, STPAuthenticationContext {
     private let viewController: UIViewController
     init(_ viewController: UIViewController) { self.viewController = viewController }
     func authenticationPresentingViewController() -> UIViewController { viewController }

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
@@ -78,11 +78,11 @@ struct ExampleLinkControllerPreviewView: View {
 
                             switch configuration.intentMode {
                             case .sdkManaged:
-                                Text("LinkController manages the session; the app attaches the payment method manually after `present` returns.")
+                                Text("LinkController manages the session and returns a payment method object; the merchant is responsible for attaching the payment method.")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             case .serverSetupIntent:
-                                Text("A SetupIntent is created server-side before presenting. The SDK confirms and attaches automatically.")
+                                Text("The merchant creates a setup intent passes it to the LinkController; the setup intent is automatically confirmed and the payment method is attached to the associated customer.")
                                     .font(.caption)
                                     .foregroundColor(.secondary)
                             }

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
@@ -6,8 +6,8 @@
 import SwiftUI
 import UIKit
 
-@_spi(LinkControllerPreview) import StripePaymentSheet
 import StripePayments
+@_spi(LinkControllerPreview) import StripePaymentSheet
 
 @available(iOS 16.0, *)
 struct ExampleLinkControllerPreviewView: View {

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkStandaloneComponent.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkStandaloneComponent.swift
@@ -660,17 +660,17 @@ enum CarType: CaseIterable {
     }
 }
 
-private func findViewController() -> UIViewController? {
-    let keyWindow = UIApplication.shared.connectedScenes
-        .compactMap { $0 as? UIWindowScene }
-        .flatMap { $0.windows }
-        .first { $0.isKeyWindow }
-    var topController = keyWindow?.rootViewController
-    while let presentedViewController = topController?.presentedViewController {
-        topController = presentedViewController
-    }
-    return topController
-}
+//private func findViewController() -> UIViewController? {
+//    let keyWindow = UIApplication.shared.connectedScenes
+//        .compactMap { $0 as? UIWindowScene }
+//        .flatMap { $0.windows }
+//        .first { $0.isKeyWindow }
+//    var topController = keyWindow?.rootViewController
+//    while let presentedViewController = topController?.presentedViewController {
+//        topController = presentedViewController
+//    }
+//    return topController
+//}
 
 struct ExampleLinkStandaloneComponent_Previews: PreviewProvider {
     static var previews: some View {

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkStandaloneComponent.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkStandaloneComponent.swift
@@ -660,18 +660,6 @@ enum CarType: CaseIterable {
     }
 }
 
-//private func findViewController() -> UIViewController? {
-//    let keyWindow = UIApplication.shared.connectedScenes
-//        .compactMap { $0 as? UIWindowScene }
-//        .flatMap { $0.windows }
-//        .first { $0.isKeyWindow }
-//    var topController = keyWindow?.rootViewController
-//    while let presentedViewController = topController?.presentedViewController {
-//        topController = presentedViewController
-//    }
-//    return topController
-//}
-
 struct ExampleLinkStandaloneComponent_Previews: PreviewProvider {
     static var previews: some View {
         if #available(iOS 16.0, *) {

--- a/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoBackendClient.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoBackendClient.swift
@@ -1,0 +1,172 @@
+//
+//  LinkControllerDemoBackendClient.swift
+//  PaymentSheet Example
+//
+
+import Foundation
+
+enum LinkControllerDemoBackendClient {
+
+    static let baseURL = URL(string: "https://link-controller-preview-demo.stripedemos.com")!
+
+    // MARK: - Config
+
+    struct Config: Decodable {
+        let publishableKey: String
+    }
+
+    static func fetchConfig() async throws -> Config {
+        try await get("config")
+    }
+
+    // MARK: - Customers
+
+    struct CustomerResponse: Decodable {
+        let customerId: String
+    }
+
+    static func fetchOrCreateCustomer(email: String) async throws -> String {
+        let response: CustomerResponse = try await post("customers", body: ["email": email])
+        return response.customerId
+    }
+
+    // MARK: - Payment Methods
+
+    struct PaymentMethodInfo: Decodable, Identifiable {
+        let id: String
+        let type: String
+
+        struct Card: Decodable {
+            let brand: String
+            let last4: String
+        }
+        struct UsBankAccount: Decodable {
+            let bankName: String
+            let last4: String
+        }
+
+        let card: Card?
+        let usBankAccount: UsBankAccount?
+        let metadata: [String: String]?
+
+        var mandateId: String? { metadata?["mandate_id"] }
+
+        var displayLabel: String {
+            if let card { return "\(card.brand.capitalized) •••• \(card.last4)" }
+            if let bank = usBankAccount { return "\(bank.bankName.capitalized) •••• \(bank.last4)" }
+            return type
+        }
+    }
+
+    struct PaymentMethodsResponse: Decodable {
+        let paymentMethods: [PaymentMethodInfo]
+    }
+
+    static func attachPaymentMethod(_ pmId: String, toCustomer customerId: String) async throws {
+        let _: EmptyResponse = try await post(
+            "payment-methods/attach",
+            body: ["paymentMethodId": pmId, "customerId": customerId]
+        )
+    }
+
+    static func listPaymentMethods(for customerId: String) async throws -> [PaymentMethodInfo] {
+        let response: PaymentMethodsResponse = try await get(
+            "payment-methods",
+            query: ["customerId": customerId]
+        )
+        return response.paymentMethods
+    }
+
+    static func detachPaymentMethod(_ pmId: String) async throws {
+        let _: EmptyResponse = try await delete("payment-methods/\(pmId)")
+    }
+
+    // MARK: - Charging
+
+    struct PaymentIntentResponse: Decodable {
+        let status: String
+        let paymentIntentId: String
+        let clientSecret: String?
+        let code: String?
+    }
+
+    static func charge(
+        paymentMethodId: String,
+        customerId: String,
+        amount: Int = 1099,
+        currency: String = "usd"
+    ) async throws -> PaymentIntentResponse {
+        let body: [String: Any] = [
+            "paymentMethodId": paymentMethodId,
+            "customerId": customerId,
+            "amount": amount,
+            "currency": currency,
+        ]
+        do {
+            return try await post("payment-intents", body: body)
+        } catch let err as HTTPError where err.statusCode == 402 {
+            let decoder = JSONDecoder()
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            return try decoder.decode(PaymentIntentResponse.self, from: err.data)
+        }
+    }
+
+    static func fetchPaymentIntentStatus(piId: String) async throws -> PaymentIntentResponse {
+        try await get("payment-intents/\(piId)")
+    }
+
+    // MARK: - HTTP helpers
+
+    private struct EmptyResponse: Decodable {}
+    private struct BackendError: Decodable { let error: String }
+
+    struct HTTPError: Error, LocalizedError {
+        let statusCode: Int
+        let data: Data
+        var errorDescription: String? {
+            let err = try? JSONDecoder().decode(BackendError.self, from: data)
+            return err?.error ?? "HTTP \(statusCode)"
+        }
+    }
+
+    private static func get<T: Decodable>(
+        _ path: String,
+        query: [String: String] = [:]
+    ) async throws -> T {
+        var components = URLComponents(
+            url: baseURL.appendingPathComponent(path),
+            resolvingAgainstBaseURL: true
+        )!
+        if !query.isEmpty {
+            components.queryItems = query.map { URLQueryItem(name: $0.key, value: $0.value) }
+        }
+        var request = URLRequest(url: components.url!, cachePolicy: .reloadIgnoringLocalCacheData)
+        request.httpMethod = "GET"
+        return try await perform(request)
+    }
+
+    private static func post<T: Decodable>(_ path: String, body: [String: Any]) async throws -> T {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path), cachePolicy: .reloadIgnoringLocalCacheData)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return try await perform(request)
+    }
+
+    private static func delete<T: Decodable>(_ path: String) async throws -> T {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path), cachePolicy: .reloadIgnoringLocalCacheData)
+        request.httpMethod = "DELETE"
+        return try await perform(request)
+    }
+
+    private static func perform<T: Decodable>(_ request: URLRequest) async throws -> T {
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let http = response as! HTTPURLResponse
+        guard (200..<300).contains(http.statusCode) else {
+            throw HTTPError(statusCode: http.statusCode, data: data)
+        }
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(T.self, from: data)
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoBackendClient.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoBackendClient.swift
@@ -45,8 +45,13 @@ enum LinkControllerDemoBackendClient {
             let last4: String
         }
 
+        struct Link: Decodable {
+            let email: String
+        }
+
         let card: Card?
         let usBankAccount: UsBankAccount?
+        let link: Link?
         let metadata: [String: String]?
 
         var mandateId: String? { metadata?["mandate_id"] }
@@ -54,6 +59,7 @@ enum LinkControllerDemoBackendClient {
         var displayLabel: String {
             if let card { return "\(card.brand.capitalized) •••• \(card.last4)" }
             if let bank = usBankAccount { return "\(bank.bankName.capitalized) •••• \(bank.last4)" }
+            if let link { return "Link • \(link.email)" }
             return type
         }
     }
@@ -113,6 +119,17 @@ enum LinkControllerDemoBackendClient {
 
     static func fetchPaymentIntentStatus(piId: String) async throws -> PaymentIntentResponse {
         try await get("payment-intents/\(piId)")
+    }
+
+    // MARK: - Setup Intents
+
+    struct SetupIntentResponse: Decodable {
+        let clientSecret: String
+    }
+
+    static func createSetupIntent(customerId: String) async throws -> String {
+        let response: SetupIntentResponse = try await post("setup-intents", body: ["customerId": customerId])
+        return response.clientSecret
     }
 
     // MARK: - HTTP helpers

--- a/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoConfiguration.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoConfiguration.swift
@@ -1,0 +1,18 @@
+//
+//  LinkControllerDemoConfiguration.swift
+//  PaymentSheet Example
+//
+
+@_spi(LinkControllerPreview) import StripePaymentSheet
+
+struct LinkControllerDemoConfiguration {
+    var email: String = ""
+    var phone: String = ""
+    var supportedPaymentMethodTypes: Set<LinkPaymentMethodType> = Set(LinkPaymentMethodType.allCases)
+    var intentMode: IntentMode = .sdkManaged
+
+    enum IntentMode: String, CaseIterable {
+        case sdkManaged = "SDK Managed"
+        case serverSetupIntent = "Server SetupIntent"
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoConfiguration.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoConfiguration.swift
@@ -6,7 +6,7 @@
 @_spi(LinkControllerPreview) import StripePaymentSheet
 
 struct LinkControllerDemoConfiguration {
-    var email: String = ""
+    var email: String = "foo@bar.com"
     var phone: String = ""
     var supportedPaymentMethodTypes: Set<LinkPaymentMethodType> = Set(LinkPaymentMethodType.allCases)
     var intentMode: IntentMode = .sdkManaged

--- a/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoView.swift
@@ -1,0 +1,361 @@
+//
+//  LinkControllerDemoView.swift
+//  PaymentSheet Example
+//
+
+import SwiftUI
+import UIKit
+
+@_spi(LinkControllerPreview) import StripePaymentSheet
+import StripePayments
+
+@available(iOS 16.0, *)
+struct LinkControllerDemoView: View {
+    let configuration: LinkControllerDemoConfiguration
+
+    @State private var phase: Phase = .initializing
+    @State private var customerId: String?
+    @State private var setupIntentClientSecret: String?
+    @State private var linkController: LinkController?
+    @State private var savedPaymentMethods: [LinkControllerDemoBackendClient.PaymentMethodInfo] = []
+    @State private var errorMessage: String?
+    @State private var statusMessage: String?
+    @State private var statusTint: Color = .secondary
+
+    enum Phase {
+        case initializing
+        case ready
+        case presenting
+        case completed(STPPaymentMethod)
+        case error(String)
+    }
+
+    private var isLoading: Bool {
+        switch phase {
+        case .initializing, .presenting: return true
+        default: return false
+        }
+    }
+
+    private var isReady: Bool {
+        switch phase {
+        case .ready, .completed: return true
+        default: return false
+        }
+    }
+
+    private var controllerStatusLabel: String {
+        switch phase {
+        case .initializing: return "Initializing..."
+        case .ready: return "Ready"
+        case .presenting: return "Presenting..."
+        case .completed: return "Completed"
+        case .error: return "Error"
+        }
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                DemoSection(title: "Setup") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        PreviewInfoRow(label: "Customer", value: customerId ?? "Creating...")
+                        PreviewInfoRow(label: "Intent Mode", value: configuration.intentMode.rawValue)
+                        if configuration.intentMode == .serverSetupIntent {
+                            PreviewInfoRow(
+                                label: "Setup Intent",
+                                value: setupIntentClientSecret.map { "..." + $0.suffix(8) } ?? "Created on Present tap"
+                            )
+                        }
+                        PreviewInfoRow(label: "Controller", value: controllerStatusLabel)
+                    }
+                }
+
+                if !savedPaymentMethods.isEmpty {
+                    DemoSection(title: "Saved Payment Methods") {
+                        VStack(alignment: .leading, spacing: 12) {
+                            ForEach(savedPaymentMethods) { pm in
+                                HStack(spacing: 12) {
+                                    Text(pm.displayLabel)
+                                        .font(.subheadline)
+                                    Spacer()
+                                    Button("Pay $10.99") {
+                                        Task { @MainActor in
+                                            await chargePaymentMethod(pm)
+                                        }
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .fixedSize()
+                                    .disabled(isLoading)
+
+                                    Button("−") {
+                                        Task { @MainActor in
+                                            await removePaymentMethod(pm)
+                                        }
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .tint(.red)
+                                    .disabled(isLoading)
+                                }
+                            }
+                        }
+                    }
+                }
+
+                VStack(spacing: 16) {
+                    Button("Present Link") {
+                        Task { @MainActor in
+                            await presentLinkFlow()
+                        }
+                    }
+                    .buttonStyle(PreviewPrimaryButtonStyle())
+                    .disabled(!isReady || isLoading)
+                }
+
+                if let errorMessage {
+                    MessageBanner(text: errorMessage, tint: .red)
+                }
+
+                if let statusMessage {
+                    MessageBanner(text: statusMessage, tint: statusTint)
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("Payment Method Preview")
+                        .font(.headline)
+                    if let linkController {
+                        LinkControllerPreviewPaymentMethodView(linkController: linkController)
+                    } else {
+                        StatusCard(
+                            text: "No payment method preview available",
+                            isPlaceholder: true
+                        )
+                    }
+                }
+
+                if case .completed(let pm) = phase {
+                    DemoSection(title: "Completed Payment Method") {
+                        VStack(alignment: .leading, spacing: 12) {
+                            PreviewInfoRow(label: "PM ID", value: pm.stripeId)
+                            PreviewInfoRow(label: "Mode", value: configuration.intentMode.rawValue)
+                        }
+                    }
+                }
+            }
+            .padding()
+        }
+        .navigationTitle("Demo")
+        .task {
+            await initialize()
+        }
+        .overlay {
+            if isLoading {
+                ZStack {
+                    Color.black.opacity(0.2)
+                        .ignoresSafeArea()
+                    ProgressView("Loading...")
+                        .padding(20)
+                        .background(Color(UIColor.systemBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func initialize() async {
+        phase = .initializing
+        errorMessage = nil
+        statusMessage = "Initializing LinkController..."
+
+        do {
+            let config = try await LinkControllerDemoBackendClient.fetchConfig()
+            STPAPIClient.shared.publishableKey = config.publishableKey
+
+            let cid = try await LinkControllerDemoBackendClient.fetchOrCreateCustomer(email: configuration.email)
+            customerId = cid
+
+            // In serverSetupIntent mode, SI + LinkController are created fresh on each Present tap.
+            if configuration.intentMode == .sdkManaged {
+                linkController = try await LinkController.create(
+                    setupIntentClientSecret: nil,
+                    configuration: .init(
+                        supportedPaymentMethodTypes: Array(configuration.supportedPaymentMethodTypes),
+                        merchantDisplayName: "Example, Inc."
+                    )
+                )
+            }
+
+            savedPaymentMethods = try await LinkControllerDemoBackendClient.listPaymentMethods(for: cid)
+
+            phase = .ready
+            statusTint = .secondary
+            statusMessage = "LinkController initialized successfully"
+        } catch {
+            phase = .error(error.localizedDescription)
+            statusMessage = nil
+            errorMessage = "Failed to initialize: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func presentLinkFlow() async {
+        guard isReady, let customerId else {
+            errorMessage = "LinkController not ready"
+            return
+        }
+
+        guard let rootViewController = findViewController() else {
+            errorMessage = "Could not find root view controller"
+            return
+        }
+
+        phase = .presenting
+        errorMessage = nil
+        statusMessage = "Presenting Link flow..."
+
+        do {
+            let activeController: LinkController
+            switch configuration.intentMode {
+            case .serverSetupIntent:
+                let secret = try await LinkControllerDemoBackendClient.createSetupIntent(customerId: customerId)
+                setupIntentClientSecret = secret
+                let controller = try await LinkController.create(
+                    setupIntentClientSecret: secret,
+                    configuration: .init(
+                        supportedPaymentMethodTypes: Array(configuration.supportedPaymentMethodTypes),
+                        merchantDisplayName: "Example, Inc."
+                    )
+                )
+                linkController = controller
+                activeController = controller
+            case .sdkManaged:
+                guard let existing = linkController else {
+                    phase = .ready
+                    errorMessage = "LinkController not initialized"
+                    return
+                }
+                activeController = existing
+            }
+
+            let result = try await activeController.present(
+                email: configuration.email,
+                phoneNumber: configuration.phone.isEmpty ? nil : configuration.phone,
+                from: rootViewController
+            )
+
+            switch result {
+            case .completed(let paymentMethod):
+                if configuration.intentMode == .sdkManaged {
+                    statusMessage = "Saving payment method..."
+                    do {
+                        try await LinkControllerDemoBackendClient.attachPaymentMethod(
+                            paymentMethod.stripeId,
+                            toCustomer: customerId
+                        )
+                    } catch {
+                        errorMessage = "Payment method created (ID: \(paymentMethod.stripeId)) but failed to save: \(error.localizedDescription)"
+                    }
+                }
+                try? await refreshSavedPaymentMethods()
+                statusTint = .green
+                statusMessage = "Payment method saved!"
+                phase = .completed(paymentMethod)
+            case .canceled:
+                statusMessage = "Present flow canceled"
+                phase = .ready
+            }
+        } catch {
+            phase = .ready
+            errorMessage = "Present flow failed: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func refreshSavedPaymentMethods() async throws {
+        guard let customerId else { return }
+        savedPaymentMethods = try await LinkControllerDemoBackendClient.listPaymentMethods(for: customerId)
+    }
+
+    @MainActor
+    private func chargePaymentMethod(_ pm: LinkControllerDemoBackendClient.PaymentMethodInfo) async {
+        guard let customerId else { return }
+        errorMessage = nil
+        do {
+            let response = try await LinkControllerDemoBackendClient.charge(
+                paymentMethodId: pm.id,
+                customerId: customerId
+            )
+
+            if response.code == "authentication_required", let secret = response.clientSecret {
+                guard let vc = findViewController() else {
+                    errorMessage = "Could not find view controller for 3DS authentication"
+                    return
+                }
+                let authContext = STPAuthenticationContextWrapper(vc)
+                let authStatus: STPPaymentHandlerActionStatus = await withCheckedContinuation { continuation in
+                    STPPaymentHandler.shared().handleNextAction(
+                        forPayment: secret,
+                        with: authContext,
+                        returnURL: nil
+                    ) { status, _, _ in
+                        continuation.resume(returning: status)
+                    }
+                }
+                switch authStatus {
+                case .succeeded:
+                    statusMessage = "Payment authenticated and complete"
+                case .canceled:
+                    statusMessage = "Authentication canceled"
+                case .failed:
+                    errorMessage = "Authentication failed"
+                @unknown default:
+                    break
+                }
+            } else if response.status == "processing" {
+                statusTint = .yellow
+                statusMessage = "Payment processing (ID: \(response.paymentIntentId))..."
+                await pollPaymentIntentStatus(piId: response.paymentIntentId)
+            } else {
+                statusMessage = "Payment \(response.status) (ID: \(response.paymentIntentId))"
+            }
+        } catch {
+            errorMessage = "Payment failed: \(error.localizedDescription)"
+        }
+    }
+
+    @MainActor
+    private func pollPaymentIntentStatus(piId: String) async {
+        for _ in 0..<30 {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard let response = try? await LinkControllerDemoBackendClient.fetchPaymentIntentStatus(piId: piId) else {
+                continue
+            }
+            if response.status != "processing" {
+                statusTint = .green
+                statusMessage = "Payment \(response.status) (ID: \(piId))"
+                return
+            }
+        }
+        statusMessage = "Payment still processing (ID: \(piId))"
+    }
+
+    @MainActor
+    private func removePaymentMethod(_ pm: LinkControllerDemoBackendClient.PaymentMethodInfo) async {
+        errorMessage = nil
+        do {
+            try await LinkControllerDemoBackendClient.detachPaymentMethod(pm.id)
+            try await refreshSavedPaymentMethods()
+            statusMessage = "Payment method removed"
+        } catch {
+            errorMessage = "Failed to remove payment method: \(error.localizedDescription)"
+        }
+    }
+}
+
+@available(iOS 16.0, *)
+#Preview {
+    var config = LinkControllerDemoConfiguration()
+    config.email = "test@example.com"
+    return LinkControllerDemoView(configuration: config)
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoView.swift
@@ -253,6 +253,7 @@ struct LinkControllerDemoView: View {
                             paymentMethod.stripeId,
                             toCustomer: customerId
                         )
+                        print("**** Payment method created (ID: \(paymentMethod.stripeId), type: \(paymentMethod.type))")
                     } catch {
                         errorMessage = "Payment method created (ID: \(paymentMethod.stripeId)) but failed to save: \(error.localizedDescription)"
                     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoView.swift
@@ -6,8 +6,8 @@
 import SwiftUI
 import UIKit
 
-@_spi(LinkControllerPreview) import StripePaymentSheet
 import StripePayments
+@_spi(LinkControllerPreview) import StripePaymentSheet
 
 @available(iOS 16.0, *)
 struct LinkControllerDemoView: View {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -921,16 +921,6 @@ import UIKit
         let confirmParams = STPSetupIntentConfirmParams(clientSecret: clientSecret)
         confirmParams.paymentMethodID = paymentMethod.stripeId
 
-        // Required for off-session link PMs: captures consent given during the Link flow.
-        // inferFromClient lets Stripe derive IP/user-agent from the request itself.
-        let onlineParams = STPMandateOnlineParams(ipAddress: "", userAgent: "")
-        onlineParams.inferFromClient = true
-        let acceptance = STPMandateCustomerAcceptanceParams()
-        acceptance.type = .online
-        acceptance.onlineParams = onlineParams
-        let mandateData = STPMandateDataParams(customerAcceptance: acceptance)
-        confirmParams.mandateData = mandateData
-
         let authContext = ViewControllerAuthenticationContext(viewController: viewController)
         STPPaymentHandler.shared().confirmSetupIntent(
             params: confirmParams,
@@ -1070,7 +1060,6 @@ import UIKit
                     currency: nil,
                     setupFutureUsage: .offSession
                 ),
-                paymentMethodTypes: ["link"],
                 confirmHandler: { _, _ in
                     stpAssertionFailure("The confirmHandler is not expected to be called in the LinkController.")
                     return PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -921,6 +921,16 @@ import UIKit
         let confirmParams = STPSetupIntentConfirmParams(clientSecret: clientSecret)
         confirmParams.paymentMethodID = paymentMethod.stripeId
 
+        // Required for off-session link PMs: captures consent given during the Link flow.
+        // inferFromClient lets Stripe derive IP/user-agent from the request itself.
+        let onlineParams = STPMandateOnlineParams(ipAddress: "", userAgent: "")
+        onlineParams.inferFromClient = true
+        let acceptance = STPMandateCustomerAcceptanceParams()
+        acceptance.type = .online
+        acceptance.onlineParams = onlineParams
+        let mandateData = STPMandateDataParams(customerAcceptance: acceptance)
+        confirmParams.mandateData = mandateData
+
         let authContext = ViewControllerAuthenticationContext(viewController: viewController)
         STPPaymentHandler.shared().confirmSetupIntent(
             params: confirmParams,
@@ -1060,6 +1070,7 @@ import UIKit
                     currency: nil,
                     setupFutureUsage: .offSession
                 ),
+                paymentMethodTypes: ["link"],
                 confirmHandler: { _, _ in
                     stpAssertionFailure("The confirmHandler is not expected to be called in the LinkController.")
                     return PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT


### PR DESCRIPTION
## Summary

Updates the LinkControllerPreview demo app to support the server-provided setup intent flow. It calls APIs from a demo backend server I'm working on here: https://git.corp.stripe.com/stripe-internal/sandbox-apps/pull/1196. 

## Motivation

Brings the example app up to date with the current API shape.

## Testing



https://github.com/user-attachments/assets/abbd9a8b-574b-4a8c-b31e-3b563a616964




## Changelog

N/a
