### PR TITLE
CryptoOnramp SDK: Improves InvalidWalletOwnershipChallengeError Messages

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Resources/Localizations/en.lproj/Localizable.strings
@@ -13,11 +13,11 @@
 /* Error message shown when the wallet network is not supported for crypto onramp */
 "This wallet network isn't supported. Please choose a different network." = "This wallet network isn't supported. Please choose a different network.";
 
+/* Error message shown when the wallet ownership challenge is invalid */
+"This wallet verification request can't be used. Please try again." = "This wallet verification request can't be used. Please try again.";
+
 /* Error message shown when the wallet ownership challenge has expired */
 "This wallet verification request expired. Please try again." = "This wallet verification request expired. Please try again.";
-
-/* Error message shown when the wallet ownership challenge is invalid */
-"This wallet verification request is no longer valid. Please try again." = "This wallet verification request is no longer valid. Please try again.";
 
 /* Error message shown when the submitted wallet ownership signature is invalid */
 "We couldn't verify ownership of this wallet. Please try again." = "We couldn't verify ownership of this wallet. Please try again.";

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Resources/Localizations/en.lproj/Localizable.strings
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Resources/Localizations/en.lproj/Localizable.strings
@@ -13,11 +13,11 @@
 /* Error message shown when the wallet network is not supported for crypto onramp */
 "This wallet network isn't supported. Please choose a different network." = "This wallet network isn't supported. Please choose a different network.";
 
-/* Error message shown when the wallet ownership challenge is invalid */
-"This wallet verification request can't be used. Please try again." = "This wallet verification request can't be used. Please try again.";
-
 /* Error message shown when the wallet ownership challenge has expired */
 "This wallet verification request expired. Please try again." = "This wallet verification request expired. Please try again.";
+
+/* Error message shown when the wallet ownership challenge is invalid */
+"This wallet verification request is invalid. Please try again." = "This wallet verification request is invalid. Please try again.";
 
 /* Error message shown when the submitted wallet ownership signature is invalid */
 "We couldn't verify ownership of this wallet. Please try again." = "We couldn't verify ownership of this wallet. Please try again.";

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/Errors/Concrete Error Types/InvalidWalletOwnershipChallengeError.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/Errors/Concrete Error Types/InvalidWalletOwnershipChallengeError.swift
@@ -46,7 +46,7 @@ public struct InvalidWalletOwnershipChallengeError: StripeCryptoOnrampAPIError, 
         return StripeCryptoOnrampErrorRenderer.renderAPIErrorDeveloperMessage(
             apiErrorContext: apiErrorContext,
             diagnosticContext: diagnosticContext,
-            summary: apiMessage ?? "Wallet ownership verification failed: the challenge is invalid, already consumed, missing, or not associated with the authenticated consumer.",
+            summary: apiMessage ?? "Wallet ownership verification failed: the challenge does not exist, belongs to a different authenticated consumer, was already consumed, or is otherwise invalid.",
             code: code,
             nextStep: "Request a new challenge for the registered wallet and authenticated consumer, then submit that challenge ID with its signature."
         )

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/String+Localized.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/String+Localized.swift
@@ -42,7 +42,7 @@ extension String.Localized {
 
     static var cryptoOnrampErrorInvalidWalletOwnershipChallenge: String {
         return STPLocalizedString(
-            "This wallet verification request is no longer valid. Please try again.",
+            "This wallet verification request can't be used. Please try again.",
             "Error message shown when the wallet ownership challenge is invalid"
         )
     }

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/String+Localized.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/String+Localized.swift
@@ -42,7 +42,7 @@ extension String.Localized {
 
     static var cryptoOnrampErrorInvalidWalletOwnershipChallenge: String {
         return STPLocalizedString(
-            "This wallet verification request can't be used. Please try again.",
+            "This wallet verification request is invalid. Please try again.",
             "Error message shown when the wallet ownership challenge is invalid"
         )
     }

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/CryptoOnrampCoordinatorErrorMappingTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/CryptoOnrampCoordinatorErrorMappingTests.swift
@@ -170,7 +170,7 @@ final class CryptoOnrampCoordinatorErrorMappingTests: XCTestCase {
             code: "crypto_onramp_invalid_wallet_ownership_challenge",
             message: "The challenge does not exist, belongs to a different authenticated consumer, was already consumed, or is otherwise invalid.",
             expectedType: InvalidWalletOwnershipChallengeError.self,
-            expectedUserMessage: "This wallet verification request can't be used. Please try again."
+            expectedUserMessage: "This wallet verification request is invalid. Please try again."
         )
 
         XCTAssertTrue(apiError.developerMessage.contains("The challenge does not exist, belongs to a different authenticated consumer, was already consumed, or is otherwise invalid."))

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/CryptoOnrampCoordinatorErrorMappingTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/CryptoOnrampCoordinatorErrorMappingTests.swift
@@ -168,12 +168,12 @@ final class CryptoOnrampCoordinatorErrorMappingTests: XCTestCase {
     func testMappedErrorMapsInvalidWalletOwnershipChallengeError() throws {
         let apiError = try assertMapsWalletOwnershipError(
             code: "crypto_onramp_invalid_wallet_ownership_challenge",
-            message: "The wallet ownership challenge is invalid.",
+            message: "The challenge does not exist, belongs to a different authenticated consumer, was already consumed, or is otherwise invalid.",
             expectedType: InvalidWalletOwnershipChallengeError.self,
-            expectedUserMessage: "This wallet verification request is no longer valid. Please try again."
+            expectedUserMessage: "This wallet verification request can't be used. Please try again."
         )
 
-        XCTAssertTrue(apiError.developerMessage.contains("The wallet ownership challenge is invalid."))
+        XCTAssertTrue(apiError.developerMessage.contains("The challenge does not exist, belongs to a different authenticated consumer, was already consumed, or is otherwise invalid."))
         XCTAssertTrue(apiError.developerMessage.contains("Code: crypto_onramp_invalid_wallet_ownership_challenge"))
         XCTAssertTrue(apiError.developerMessage.contains("Next step: Request a new challenge for the registered wallet"))
     }


### PR DESCRIPTION
## Summary
After reviewing specific error scenarios for EU Travel Rule work, the `userMessage` for `crypto_onramp_invalid_wallet_ownership_challenge` needed a bit of tweaking to sound less like an expiration caused the issue. I’ve tweaked the `userMessage` to be a bit more generic, and updated the `apiMessage` fallback to more accurately reflect what's documented in the EU Travel Rule API Review (linked below).

## Motivation
[EU Travel Rule API Review](https://docs.google.com/document/d/1yZHCc3zzFclpoHl1XSxw5QCO_SsCxvEl-vibwzCcwFc/edit?pli=1&tab=t.0)

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
- Updated unit tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A, no breaking changes, and the existing entries cover the new error types added in the same upcoming release.