### PR TITLE
Collect min fields for tax

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartEmbeddedPaymentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartEmbeddedPaymentView.swift
@@ -179,17 +179,6 @@ struct CheckoutCartEmbeddedPaymentView: View {
                 merchantId: "merchant.com.stripe.umbrella.test",
                 merchantCountryCode: "US"
             )
-            configuration.billingDetailsCollectionConfiguration.name = .always
-            configuration.billingDetailsCollectionConfiguration.address = .full
-            configuration.defaultBillingDetails.name = "Jane Doe"
-            configuration.defaultBillingDetails.phone = "+15555555555"
-            configuration.defaultBillingDetails.address = .init(
-                city: "San Francisco",
-                country: "US",
-                line1: "510 Townsend St",
-                postalCode: "94103",
-                state: "CA"
-            )
             try await viewModel.load(checkout: checkout, configuration: configuration)
         } catch {
             loadError = error

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -109,17 +109,6 @@ struct CheckoutCartPaymentButton: View {
             merchantId: "merchant.com.stripe.umbrella.test",
             merchantCountryCode: "US"
         )
-        configuration.billingDetailsCollectionConfiguration.name = .always
-        configuration.billingDetailsCollectionConfiguration.address = .full
-        configuration.defaultBillingDetails.name = "Jane Doe"
-        configuration.defaultBillingDetails.phone = "+15555555555"
-        configuration.defaultBillingDetails.address = .init(
-            city: "San Francisco",
-            country: "US",
-            line1: "510 Townsend St",
-            postalCode: "94103",
-            state: "CA"
-        )
         PaymentSheet.FlowController.create(
             checkout: checkout,
             configuration: configuration

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session+Internal.swift
@@ -18,6 +18,10 @@ extension Checkout.Session {
         allowedShippingCountries != nil
     }
 
+    var automaticTaxUsesBillingAddress: Bool {
+        automaticTaxEnabled && automaticTaxAddressSource == "billing"
+    }
+
     var isPaymentMethodOptionsSetupFutureUsageSet: Bool {
         return !setupFutureUsageForPaymentMethodType.isEmpty
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session+Internal.swift
@@ -19,7 +19,7 @@ extension Checkout.Session {
     }
 
     var automaticTaxUsesBillingAddress: Bool {
-        automaticTaxEnabled && automaticTaxAddressSource == "billing"
+        shouldSendTaxRegion(for: "billing")
     }
 
     var isPaymentMethodOptionsSetupFutureUsageSet: Bool {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
@@ -72,6 +72,15 @@ enum Intent {
         }
     }
 
+    var collectsTaxRegionFromBillingAddress: Bool {
+        switch self {
+        case .checkout(let checkout):
+            return checkout.nonisolatedSession.automaticTaxUsesBillingAddress
+        case .paymentIntent, .setupIntent, .deferredIntent:
+            return false
+        }
+    }
+
     var cvcRecollectionEnabled: Bool {
         switch self {
         case .deferredIntent(let intentConfig):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+BLIK.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+BLIK.swift
@@ -15,9 +15,11 @@ extension PaymentSheetFormFactory {
 
     func makeBLIK() -> FormElement {
         let contactInformationElement = makeContactInformationSection(nameRequiredByPaymentMethod: false, emailRequiredByPaymentMethod: false, phoneRequiredByPaymentMethod: false)
-        let billingAddressElement = configuration.billingDetailsCollectionConfiguration.address == .full
-            ? makeBillingAddressSection(countries: configuration.billingDetailsCollectionConfiguration.allowedCountriesArray)
-            : nil
+        let billingAddressElement = makeBillingAddressSection(
+            merchantRequestsAddress: configuration.billingDetailsCollectionConfiguration.address == .full,
+            fullMode: .autoCompletable,
+            countries: configuration.billingDetailsCollectionConfiguration.allowedCountriesArray
+        )
         let phoneElement = contactInformationElement?.elements.compactMap {
             $0 as? PaymentMethodElementWrapper<PhoneNumberElement>
         }.first

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Boleto.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Boleto.swift
@@ -33,9 +33,11 @@ extension PaymentSheetFormFactory {
             elements: [taxIdElementWrapper],
             theme: theme
         )
-        let addressSection = configuration.billingDetailsCollectionConfiguration.address != .never
-            ? makeBillingAddressSection(countries: ["BR"])
-            : nil
+        let addressSection = makeBillingAddressSection(
+            merchantRequestsAddress: configuration.billingDetailsCollectionConfiguration.address != .never,
+            fullMode: .autoCompletable,
+            countries: ["BR"]
+        )
         let allElements: [Element?] = [contactInfoSection, taxIdSection, addressSection]
         let elements = allElements.compactMap { $0 }
         return FormElement(autoSectioningElements: elements, theme: theme)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -98,7 +98,10 @@ extension PaymentSheetFormFactory {
             case .full:
                 return makeBillingAddressSection(collectionMode: .autoCompletable, countries: countries, includeEmail: shouldIncludeEmail, includePhone: shouldIncludePhone)
             case .never:
-                return nil
+                // still need a region for tax, so collect the card minimum (country + postal)
+                return collectsTaxRegionFromBillingAddress
+                    ? makeBillingAddressSection(collectionMode: .countryAndPostal(), countries: countries, includeEmail: shouldIncludeEmail, includePhone: shouldIncludePhone)
+                    : nil
             }
         }()
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+FormSpec.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+FormSpec.swift
@@ -117,9 +117,11 @@ extension PaymentSheetFormFactory {
         case .selector(let selectorSpec):
             return makeDropdown(for: selectorSpec)
         case .billing_address(let countrySpec):
-            return configuration.billingDetailsCollectionConfiguration.address != .never
-                ? makeBillingAddressSection(countries: countrySpec.allowedCountryCodes)
-                : nil
+            return makeBillingAddressSection(
+                merchantRequestsAddress: configuration.billingDetailsCollectionConfiguration.address != .never,
+                fullMode: .autoCompletable,
+                countries: countrySpec.allowedCountryCodes
+            )
         case .country(let spec):
             return makeCountry(countryCodes: spec.allowedCountryCodes, apiPath: spec.apiPath?["v1"])
         case .affirm_header:
@@ -162,13 +164,18 @@ extension PaymentSheetFormFactory {
         case .phone:
             return configuration.billingDetailsCollectionConfiguration.phone == .always ? makePhone() : nil
         case .billingAddress:
-            return configuration.billingDetailsCollectionConfiguration.address == .full
-                ? makeBillingAddressSection(countries: configuration.billingDetailsCollectionConfiguration.allowedCountriesArray)
-                : nil
+            return makeBillingAddressSection(
+                merchantRequestsAddress: configuration.billingDetailsCollectionConfiguration.address == .full,
+                fullMode: .autoCompletable,
+                countries: configuration.billingDetailsCollectionConfiguration.allowedCountriesArray
+            )
         case .billingAddressWithoutCountry:
-            return configuration.billingDetailsCollectionConfiguration.address == .full
-                ? makeBillingAddressSection(collectionMode: .noCountry, countries: configuration.billingDetailsCollectionConfiguration.allowedCountriesArray)
-                : nil
+            return makeBillingAddressSection(
+                merchantRequestsAddress: configuration.billingDetailsCollectionConfiguration.address == .full,
+                fullMode: .noCountry,
+                taxMode: .noCountry,
+                countries: configuration.billingDetailsCollectionConfiguration.allowedCountriesArray
+            )
         case .unknown: return nil
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Klarna.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Klarna.swift
@@ -25,13 +25,13 @@ extension PaymentSheetFormFactory {
         // Klarna requires country selection
         let countryElement = makeKlarnaCountry()
 
-        // Address without country - only show if config requires full address
-        let addressElement = configuration.billingDetailsCollectionConfiguration.address == .full
-            ? makeBillingAddressSection(
-                collectionMode: .noCountry,
-                countries: configuration.billingDetailsCollectionConfiguration.allowedCountriesArray
-            )
-            : nil
+        // Address without country (Klarna has its own country dropdown)
+        let addressElement = makeBillingAddressSection(
+            merchantRequestsAddress: configuration.billingDetailsCollectionConfiguration.address == .full,
+            fullMode: .noCountry,
+            taxMode: .noCountry,
+            countries: configuration.billingDetailsCollectionConfiguration.allowedCountriesArray
+        )
 
         connectBillingDetailsFields(
             countryElement: countryElement as? PaymentMethodElementWrapper<DropdownFieldElement>,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -492,11 +492,6 @@ extension PaymentSheetFormFactory {
         includeEmail: Bool = false,
         includePhone: Bool = false
     ) -> PaymentMethodElementWrapper<AddressSectionElement> {
-        // For automatic tax based on billing, narrow to just the tax-region fields.
-        // .noCountry keeps its mode though; it needs the country selector to figure out the region.
-        let collectionMode: AddressSectionElement.CollectionMode =
-            (collectsTaxRegionFromBillingAddress && collectionMode != .noCountry) ? .taxRegion : collectionMode
-
         let displayBillingSameAsShippingCheckbox: Bool
         var defaultAddress: AddressSectionElement.AddressDetails
         if let shippingDetails = configuration.shippingDetails() {
@@ -541,6 +536,9 @@ extension PaymentSheetFormFactory {
             addressSpecProvider: addressSpecProvider,
             defaults: defaultAddress,
             collectionMode: finalCollectionMode,
+            // When automatic tax is calculated from the billing address, always collect at least the fields needed
+            // to determine the tax region, on top of whatever `collectionMode` already collects.
+            collectsTaxRegionFields: collectsTaxRegionFromBillingAddress,
             additionalFields: .init(
                 phone: includePhone ? .enabled(isOptional: false) : .disabled,
                 email: includeEmail ? .enabled(isOptional: false) : .disabled,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -485,6 +485,15 @@ extension PaymentSheetFormFactory {
         }
     }
 
+    // Country is enough for tax everywhere except the US (full address) and Canada (province).
+    static func taxAddressRequirement(for countryCode: String) -> AddressSectionElement.TaxAddressRequirement {
+        switch countryCode.uppercased() {
+        case "US": return .autocomplete
+        case "CA": return .stateOrProvince
+        default: return .none
+        }
+    }
+
     func makeBillingAddressSection(
         collectionMode: AddressSectionElement.CollectionMode = .autoCompletable,
         countries: [String]? = nil,
@@ -521,6 +530,9 @@ extension PaymentSheetFormFactory {
                 switch collectionMode {
                 case .autoCompletable:
                     return .allWithAutocomplete
+                case .countryAndPostal where collectsTaxRegionFromBillingAddress:
+                    // prefilled + not enough for tax -> show full form
+                    return .allWithAutocomplete
                 default:
                     return collectionMode
                 }
@@ -536,7 +548,9 @@ extension PaymentSheetFormFactory {
             addressSpecProvider: addressSpecProvider,
             defaults: defaultAddress,
             collectionMode: finalCollectionMode,
-            collectsAddressForTax: collectsTaxRegionFromBillingAddress,
+            taxAddressRequirement: collectsTaxRegionFromBillingAddress
+                ? { PaymentSheetFormFactory.taxAddressRequirement(for: $0) }
+                : { _ in .none },
             additionalFields: .init(
                 phone: includePhone ? .enabled(isOptional: false) : .disabled,
                 email: includeEmail ? .enabled(isOptional: false) : .disabled,
@@ -546,6 +560,23 @@ extension PaymentSheetFormFactory {
             theme: theme
         )
         return PaymentSheetFormFactory.makeBillingAddressPaymentMethodWrapper(section: section, countryAPIPath: countryAPIPath)
+    }
+
+    // fullMode when merchant asks, taxMode when only tax needs it
+    func makeBillingAddressSection(
+        merchantRequestsAddress: Bool,
+        fullMode: AddressSectionElement.CollectionMode,
+        taxMode: AddressSectionElement.CollectionMode = .countryAndPostal(),
+        countries: [String]? = nil,
+        includeEmail: Bool = false,
+        includePhone: Bool = false
+    ) -> PaymentMethodElementWrapper<AddressSectionElement>? {
+        if merchantRequestsAddress {
+            return makeBillingAddressSection(collectionMode: fullMode, countries: countries, includeEmail: includeEmail, includePhone: includePhone)
+        } else if collectsTaxRegionFromBillingAddress {
+            return makeBillingAddressSection(collectionMode: taxMode, countries: countries, includeEmail: includeEmail, includePhone: includePhone)
+        }
+        return nil
     }
 
     static func makeBillingAddressPaymentMethodWrapper(section: AddressSectionElement, countryAPIPath: String?) -> PaymentMethodElementWrapper<AddressSectionElement> {
@@ -998,15 +1029,16 @@ extension PaymentSheetFormFactory {
     }
 
     func makeBillingAddressSectionIfNecessary(requiredByPaymentMethod: Bool) -> Element? {
-        if configuration.billingDetailsCollectionConfiguration.address == .full
-            || (configuration.billingDetailsCollectionConfiguration.address == .automatic && requiredByPaymentMethod) {
-            let countries = configuration.billingDetailsCollectionConfiguration.allowedCountries.isEmpty
-                ? nil
-                : Array(configuration.billingDetailsCollectionConfiguration.allowedCountries)
-           return makeBillingAddressSection(countries: countries)
-        } else {
-            return nil
-        }
+        let address = configuration.billingDetailsCollectionConfiguration.address
+        let merchantRequestsAddress = address == .full || (address == .automatic && requiredByPaymentMethod)
+        let countries = configuration.billingDetailsCollectionConfiguration.allowedCountries.isEmpty
+            ? nil
+            : Array(configuration.billingDetailsCollectionConfiguration.allowedCountries)
+        return makeBillingAddressSection(
+            merchantRequestsAddress: merchantRequestsAddress,
+            fullMode: .autoCompletable,
+            countries: countries
+        )
     }
 
     func makeDefaultsApplierWrapper<T: PaymentMethodElement>(for element: T) -> PaymentMethodElementWrapper<T> {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -536,8 +536,7 @@ extension PaymentSheetFormFactory {
             addressSpecProvider: addressSpecProvider,
             defaults: defaultAddress,
             collectionMode: finalCollectionMode,
-            // When automatic tax is calculated from the billing address, always collect at least the fields needed
-            // to determine the tax region, on top of whatever `collectionMode` already collects.
+            // Automatic tax needs enough of the billing address to work out the tax region, so pull those fields in too.
             collectsTaxRegionFields: collectsTaxRegionFromBillingAddress,
             additionalFields: .init(
                 phone: includePhone ? .enabled(isOptional: false) : .disabled,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -536,8 +536,7 @@ extension PaymentSheetFormFactory {
             addressSpecProvider: addressSpecProvider,
             defaults: defaultAddress,
             collectionMode: finalCollectionMode,
-            // Automatic tax needs enough of the billing address to work out the tax region, so pull those fields in too.
-            collectsTaxRegionFields: collectsTaxRegionFromBillingAddress,
+            collectsAddressForTax: collectsTaxRegionFromBillingAddress,
             additionalFields: .init(
                 phone: includePhone ? .enabled(isOptional: false) : .disabled,
                 email: includeEmail ? .enabled(isOptional: false) : .disabled,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -52,6 +52,7 @@ class PaymentSheetFormFactory {
     let cardFundingFilter: CardFundingFilter
     let paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper?
     let paymentMethodOrientation: PaymentSheet.PaymentMethodLayout.ResolvedLayout
+    let collectsTaxRegionFromBillingAddress: Bool
 
     var shouldDisplaySaveCheckbox: Bool {
         // Don't show the save checkbox in Link
@@ -160,7 +161,8 @@ class PaymentSheetFormFactory {
                   linkBrand: linkBrand,
                   sellerName: intent.sellerDetails?.businessName,
                   previousLinkInlineSignupAction: previousLinkInlineSignupAction,
-                  cardFundingFilter: configuration.cardFundingFilter(for: elementsSession)
+                  cardFundingFilter: configuration.cardFundingFilter(for: elementsSession),
+                  collectsTaxRegionFromBillingAddress: intent.collectsTaxRegionFromBillingAddress
         )
     }
 
@@ -192,7 +194,8 @@ class PaymentSheetFormFactory {
         linkBrand: LinkBrand = .link,
         sellerName: String? = nil,
         previousLinkInlineSignupAction: LinkInlineSignupViewModel.Action? = nil,
-        cardFundingFilter: CardFundingFilter = .default
+        cardFundingFilter: CardFundingFilter = .default,
+        collectsTaxRegionFromBillingAddress: Bool = false
     ) {
         self.configuration = configuration
         self.paymentMethod = paymentMethod
@@ -227,6 +230,7 @@ class PaymentSheetFormFactory {
         self.sellerName = sellerName
         self.previousLinkInlineSignupAction = previousLinkInlineSignupAction
         self.cardFundingFilter = cardFundingFilter
+        self.collectsTaxRegionFromBillingAddress = collectsTaxRegionFromBillingAddress
     }
 
     func make() -> PaymentMethodElement {
@@ -488,6 +492,11 @@ extension PaymentSheetFormFactory {
         includeEmail: Bool = false,
         includePhone: Bool = false
     ) -> PaymentMethodElementWrapper<AddressSectionElement> {
+        // For automatic tax based on billing, narrow to just the tax-region fields.
+        // .noCountry keeps its mode though; it needs the country selector to figure out the region.
+        let collectionMode: AddressSectionElement.CollectionMode =
+            (collectsTaxRegionFromBillingAddress && collectionMode != .noCountry) ? .taxRegion : collectionMode
+
         let displayBillingSameAsShippingCheckbox: Bool
         var defaultAddress: AddressSectionElement.AddressDetails
         if let shippingDetails = configuration.shippingDetails() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -365,7 +365,10 @@ extension STPApplePayContext {
             country: applePay.merchantCountryCode,
             currency: intent.currency ?? "USD"
         )
-        paymentRequest.requiredBillingContactFields = makeRequiredBillingDetails(from: configuration)
+        paymentRequest.requiredBillingContactFields = makeRequiredBillingDetails(
+            from: configuration,
+            collectsTaxRegionFromBillingAddress: intent.collectsTaxRegionFromBillingAddress
+        )
         paymentRequest.requiredShippingContactFields = makeRequiredShippingDetails(from: configuration)
 
         let label = intent.sellerDetails?.businessName ?? configuration.merchantDisplayName
@@ -446,11 +449,15 @@ private func makeShippingDetails(from configuration: PaymentElementConfiguration
     )
 }
 
-private func makeRequiredBillingDetails(from configuration: PaymentElementConfiguration) -> Set<PKContactField> {
+private func makeRequiredBillingDetails(
+    from configuration: PaymentElementConfiguration,
+    collectsTaxRegionFromBillingAddress: Bool = false
+) -> Set<PKContactField> {
     var requiredPKContactFields = Set<PKContactField>()
     let billingConfig = configuration.billingDetailsCollectionConfiguration
     // By default, we always want to request the billing address (as it includes the postal code)
-    if billingConfig.address == .automatic || billingConfig.address == .full {
+    // ...and also when the session needs it to compute tax.
+    if billingConfig.address == .automatic || billingConfig.address == .full || collectsTaxRegionFromBillingAddress {
         requiredPKContactFields.insert(.postalAddress)
     }
     // Only request name field - phone and email go into shipping contact fields

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -455,8 +455,8 @@ private func makeRequiredBillingDetails(
 ) -> Set<PKContactField> {
     var requiredPKContactFields = Set<PKContactField>()
     let billingConfig = configuration.billingDetailsCollectionConfiguration
-    // By default, we always want to request the billing address (as it includes the postal code)
-    // ...and also when the session needs it to compute tax.
+    // By default, we always want to request the billing address (as it includes the postal code), plus
+    // when the session needs it for tax
     if billingConfig.address == .automatic || billingConfig.address == .full || collectsTaxRegionFromBillingAddress {
         requiredPKContactFields.insert(.postalAddress)
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -130,10 +130,20 @@ enum CheckoutTestHelpers {
         "elements_session": minimalElementsSessionJSON,
     ]
 
-    static func makeOpenSession(customerEmail: String? = nil, billingAddressCollection: String? = nil) -> STPCheckoutSessionAPIResponse {
+    static func makeOpenSession(
+        customerEmail: String? = nil,
+        billingAddressCollection: String? = nil,
+        automaticTaxEnabled: Bool = false,
+        automaticTaxAddressSource: String? = nil
+    ) -> STPCheckoutSessionAPIResponse {
         var json = openSessionJSON
         json["customer_email"] = customerEmail
         json["billing_address_collection"] = billingAddressCollection
+        if automaticTaxEnabled || automaticTaxAddressSource != nil {
+            var taxContext: [String: Any] = ["automatic_tax_enabled": automaticTaxEnabled]
+            taxContext["automatic_tax_address_source"] = automaticTaxAddressSource
+            json["tax_context"] = taxContext
+        }
         return STPCheckoutSessionAPIResponse.decodedObject(fromAPIResponse: json)!
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
@@ -468,18 +468,19 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
         }
         XCTAssertTrue(billingAddressSection.collectsAddressForTax)
 
-        // US needs the full address, which it collects via the autocomplete line rather than every field.
+        // US collects the full address via the autocomplete line.
         billingAddressSection.selectedCountryCode = "US"
         XCTAssertNotNil(billingAddressSection.autoCompleteLine)
         XCTAssertNil(billingAddressSection.line1)
 
-        // CA adds the province; the card form's postal is still there
+        // CA adds the province on top of the card form's postal.
         billingAddressSection.selectedCountryCode = "CA"
         XCTAssertNil(billingAddressSection.line1)
         XCTAssertNotNil(billingAddressSection.state)
         XCTAssertNotNil(billingAddressSection.postalCode)
     }
 
+    // Tax should never *shrink* a form that already collects everything.
     @MainActor
     func testMakeBillingAddressSection_autoTaxDoesNotNarrowFullAddressForm() {
         let session = CheckoutTestHelpers.makeOpenSession(
@@ -494,7 +495,6 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
             addressSpecProvider: dummyAddressSpecProvider
         )
 
-        // Autocomplete already collects more than tax needs, so leave it alone.
         let section = factory.makeBillingAddressSection(collectionMode: .autoCompletable).element
         XCTAssertTrue(section.collectsAddressForTax)
         section.selectedCountryCode = "US"

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
@@ -446,7 +446,7 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
     // MARK: - Automatic tax (billing source)
 
     @MainActor
-    func testCardFormWithAutomaticTaxBilling_collectsTaxRegionFields() {
+    func testCardFormWithAutomaticTaxBilling_collectsAddressForTax() {
         let session = CheckoutTestHelpers.makeOpenSession(
             automaticTaxEnabled: true,
             automaticTaxAddressSource: "session.billing"
@@ -466,13 +466,12 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
             XCTFail("Could not find billing address section")
             return
         }
-        XCTAssertTrue(billingAddressSection.collectsTaxRegionFields)
+        XCTAssertTrue(billingAddressSection.collectsAddressForTax)
 
-        // US wants the full address
+        // US needs the full address, which it collects via the autocomplete line rather than every field.
         billingAddressSection.selectedCountryCode = "US"
-        XCTAssertNotNil(billingAddressSection.line1)
-        XCTAssertNotNil(billingAddressSection.state)
-        XCTAssertNotNil(billingAddressSection.postalCode)
+        XCTAssertNotNil(billingAddressSection.autoCompleteLine)
+        XCTAssertNil(billingAddressSection.line1)
 
         // CA adds the province; the card form's postal is still there
         billingAddressSection.selectedCountryCode = "CA"
@@ -497,7 +496,7 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
 
         // Autocomplete already collects more than tax needs, so leave it alone.
         let section = factory.makeBillingAddressSection(collectionMode: .autoCompletable).element
-        XCTAssertTrue(section.collectsTaxRegionFields)
+        XCTAssertTrue(section.collectsAddressForTax)
         section.selectedCountryCode = "US"
         XCTAssertNotNil(section.autoCompleteLine)
         XCTAssertNil(section.line1)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
@@ -443,10 +443,8 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
         XCTAssertEqual(cardForm.validationState, .valid)
     }
 
-    // MARK: - Automatic tax (billing source)
-
     @MainActor
-    func testCardFormWithAutomaticTaxBilling_collectsAddressForTax() {
+    func testCardFormWithAutomaticTaxBilling_AddsTaxRegionFields() {
         let session = CheckoutTestHelpers.makeOpenSession(
             automaticTaxEnabled: true,
             automaticTaxAddressSource: "session.billing"
@@ -466,39 +464,146 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
             XCTFail("Could not find billing address section")
             return
         }
-        XCTAssertTrue(billingAddressSection.collectsAddressForTax)
-
-        // US collects the full address via the autocomplete line.
+        // US: full address via autocomplete line
         billingAddressSection.selectedCountryCode = "US"
         XCTAssertNotNil(billingAddressSection.autoCompleteLine)
         XCTAssertNil(billingAddressSection.line1)
 
-        // CA adds the province on top of the card form's postal.
+        // CA: province on top of postal
         billingAddressSection.selectedCountryCode = "CA"
         XCTAssertNil(billingAddressSection.line1)
         XCTAssertNotNil(billingAddressSection.state)
         XCTAssertNotNil(billingAddressSection.postalCode)
     }
 
-    // Tax shouldn't shrink a form that already collects the whole address.
+    func testTaxAddressRequirementMapping() {
+        XCTAssertEqual(PaymentSheetFormFactory.taxAddressRequirement(for: "US"), .autocomplete)
+        XCTAssertEqual(PaymentSheetFormFactory.taxAddressRequirement(for: "us"), .autocomplete)
+        XCTAssertEqual(PaymentSheetFormFactory.taxAddressRequirement(for: "CA"), .stateOrProvince)
+        XCTAssertEqual(PaymentSheetFormFactory.taxAddressRequirement(for: "FR"), AddressSectionElement.TaxAddressRequirement.none)
+        XCTAssertEqual(PaymentSheetFormFactory.taxAddressRequirement(for: "GB"), AddressSectionElement.TaxAddressRequirement.none)
+    }
+
+    // prefilled address promotes .countryAndPostal to the full form
     @MainActor
-    func testMakeBillingAddressSectionAutoTaxKeepsAutocomplete() {
+    func testAutomaticTaxBillingPromotesToFullAddressWhenPrefilled() {
         let session = CheckoutTestHelpers.makeOpenSession(
             automaticTaxEnabled: true,
             automaticTaxAddressSource: "session.billing"
         )
+        var configuration = PaymentSheet.Configuration()
+        configuration.defaultBillingDetails.address = .init(city: "San Francisco", country: "US", line1: "510 Townsend St", postalCode: "94103", state: "CA")
         let factory = PaymentSheetFormFactory(
             intent: .checkout(Checkout(apiResponse: session)),
             elementsSession: session.elementsSession,
-            configuration: .paymentElement(PaymentSheet.Configuration()),
+            configuration: .paymentElement(configuration),
             paymentMethod: .stripe(.card),
             addressSpecProvider: dummyAddressSpecProvider
         )
 
-        let section = factory.makeBillingAddressSection(collectionMode: .autoCompletable).element
-        XCTAssertTrue(section.collectsAddressForTax)
-        section.selectedCountryCode = "US"
-        XCTAssertNotNil(section.autoCompleteLine)
-        XCTAssertNil(section.line1)
+        let section = factory.makeBillingAddressSection(collectionMode: .countryAndPostal()).element
+        XCTAssertEqual(section.collectionMode, .allWithAutocomplete)
+        XCTAssertEqual(section.selectedCountryCode, "US")
+        XCTAssertEqual(section.line1?.text, "510 Townsend St")
+        XCTAssertEqual(section.city?.text, "San Francisco")
+        XCTAssertEqual(section.postalCode?.text, "94103")
+    }
+
+    private func firstAddressSection(in element: Element) -> AddressSectionElement? {
+        return element.getAllUnwrappedSubElements().compactMap { $0 as? AddressSectionElement }.first
+    }
+
+    @MainActor
+    private func taxFactory(_ configuration: PaymentSheet.Configuration, paymentMethod: PaymentSheet.PaymentMethodType = .stripe(.card)) -> PaymentSheetFormFactory {
+        let session = CheckoutTestHelpers.makeOpenSession(automaticTaxEnabled: true, automaticTaxAddressSource: "session.billing")
+        return PaymentSheetFormFactory(
+            intent: .checkout(Checkout(apiResponse: session)),
+            elementsSession: session.elementsSession,
+            configuration: .paymentElement(configuration),
+            paymentMethod: paymentMethod,
+            addressSpecProvider: dummyAddressSpecProvider
+        )
+    }
+
+    @MainActor
+    func testBillingAddressSectionIfNecessary_TaxForcesMinimalCollection() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.address = .automatic
+        let result = taxFactory(configuration).makeBillingAddressSectionIfNecessary(requiredByPaymentMethod: false)
+        let section = (result as? PaymentMethodElementWrapper<AddressSectionElement>)?.element
+        XCTAssertNotNil(section)
+        XCTAssertEqual(section?.collectionMode, .countryAndPostal())
+    }
+
+    // tax overrides an explicit .never, same as Apple Pay
+    @MainActor
+    func testBillingAddressSectionIfNecessary_TaxOverridesNever() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.address = .never
+        let result = taxFactory(configuration).makeBillingAddressSectionIfNecessary(requiredByPaymentMethod: false)
+        let section = (result as? PaymentMethodElementWrapper<AddressSectionElement>)?.element
+        XCTAssertNotNil(section)
+        XCTAssertEqual(section?.collectionMode, .countryAndPostal())
+    }
+
+    // Without tax, no address section unless the merchant asked or the PM requires it.
+    @MainActor
+    func testBillingAddressSectionIfNecessary_NoTaxUnchanged() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.address = .automatic
+        let factory = PaymentSheetFormFactory(
+            intent: ._testValue(),
+            elementsSession: ._testCardValue(),
+            configuration: .paymentElement(configuration),
+            paymentMethod: .stripe(.card),
+            addressSpecProvider: dummyAddressSpecProvider
+        )
+        XCTAssertNil(factory.makeBillingAddressSectionIfNecessary(requiredByPaymentMethod: false))
+
+        var neverConfiguration = PaymentSheet.Configuration()
+        neverConfiguration.billingDetailsCollectionConfiguration.address = .never
+        let neverFactory = PaymentSheetFormFactory(
+            intent: ._testValue(),
+            elementsSession: ._testCardValue(),
+            configuration: .paymentElement(neverConfiguration),
+            paymentMethod: .stripe(.card),
+            addressSpecProvider: dummyAddressSpecProvider
+        )
+        XCTAssertNil(neverFactory.makeBillingAddressSectionIfNecessary(requiredByPaymentMethod: false))
+    }
+
+    @MainActor
+    func testNonCardLPMCollectsTaxAddress() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.address = .automatic
+        let form = taxFactory(configuration, paymentMethod: .stripe(.afterpayClearpay)).makeAfterpayClearpay()
+        XCTAssertNotNil(firstAddressSection(in: form), "Afterpay should collect a billing address when automatic tax is on")
+    }
+
+    @MainActor
+    func testCardNeverPlusTaxCollectsMinimal() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.address = .never
+        let section = firstAddressSection(in: taxFactory(configuration, paymentMethod: .stripe(.card)).makeCard())
+        XCTAssertNotNil(section)
+        XCTAssertEqual(section?.collectionMode, .countryAndPostal())
+    }
+
+    // Klarna uses .noCountry with its own country dropdown. Tax must not force the autocomplete line, or
+    // completing autocomplete flips to .allWithAutocomplete and we get a duplicate country dropdown.
+    @MainActor
+    func testKlarnaAutomaticPlusTaxCollectsAddress() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.address = .automatic
+        guard let addressSection = firstAddressSection(in: taxFactory(configuration, paymentMethod: .stripe(.klarna)).makeKlarna()) else {
+            XCTFail("Klarna should collect a billing address when automatic tax is on")
+            return
+        }
+        addressSection.selectedCountryCode = "US"
+        XCTAssertNil(addressSection.autoCompleteLine)
+        XCTAssertNotNil(addressSection.line1)
+        XCTAssertNotNil(addressSection.city)
+        XCTAssertNotNil(addressSection.state)
+        XCTAssertNotNil(addressSection.postalCode)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
@@ -442,4 +442,60 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
         // Now should be valid
         XCTAssertEqual(cardForm.validationState, .valid)
     }
+
+    // MARK: - Automatic tax (billing source)
+
+    @MainActor
+    func testCardFormWithAutomaticTaxBilling_usesTaxRegionCollectionMode() {
+        let session = CheckoutTestHelpers.makeOpenSession(
+            automaticTaxEnabled: true,
+            automaticTaxAddressSource: "session.billing"
+        )
+        let configuration = PaymentSheet.Configuration()
+        let factory = PaymentSheetFormFactory(
+            intent: .checkout(Checkout(apiResponse: session)),
+            elementsSession: session.elementsSession,
+            configuration: .paymentElement(configuration),
+            paymentMethod: .stripe(.card),
+            addressSpecProvider: dummyAddressSpecProvider
+        )
+
+        let cardForm = factory.makeCard()
+        guard let containerElement = cardForm as? ContainerElement,
+              let billingAddressSection = containerElement.elements.compactMap({ $0 as? PaymentMethodElementWrapper<AddressSectionElement> }).first?.element else {
+            XCTFail("Could not find billing address section")
+            return
+        }
+        XCTAssertEqual(billingAddressSection.collectionMode, .taxRegion)
+
+        billingAddressSection.selectedCountryCode = "US"
+        XCTAssertNotNil(billingAddressSection.line1)
+        XCTAssertNotNil(billingAddressSection.state)
+        XCTAssertNotNil(billingAddressSection.postalCode)
+
+        // CA only needs the province
+        billingAddressSection.selectedCountryCode = "CA"
+        XCTAssertNil(billingAddressSection.line1)
+        XCTAssertNil(billingAddressSection.postalCode)
+        XCTAssertNotNil(billingAddressSection.state)
+    }
+
+    @MainActor
+    func testMakeBillingAddressSection_taxRegionOverrideRespectsNoCountry() {
+        let session = CheckoutTestHelpers.makeOpenSession(
+            automaticTaxEnabled: true,
+            automaticTaxAddressSource: "session.billing"
+        )
+        let factory = PaymentSheetFormFactory(
+            intent: .checkout(Checkout(apiResponse: session)),
+            elementsSession: session.elementsSession,
+            configuration: .paymentElement(PaymentSheet.Configuration()),
+            paymentMethod: .stripe(.card),
+            addressSpecProvider: dummyAddressSpecProvider
+        )
+
+        XCTAssertEqual(factory.makeBillingAddressSection(collectionMode: .autoCompletable).element.collectionMode, .taxRegion)
+        // .noCountry is left alone since it collects the country separately
+        XCTAssertEqual(factory.makeBillingAddressSection(collectionMode: .noCountry).element.collectionMode, .noCountry)
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
@@ -468,13 +468,13 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
         }
         XCTAssertTrue(billingAddressSection.collectsTaxRegionFields)
 
-        // US: the floor is the full address, so everything is collected.
+        // US wants the full address
         billingAddressSection.selectedCountryCode = "US"
         XCTAssertNotNil(billingAddressSection.line1)
         XCTAssertNotNil(billingAddressSection.state)
         XCTAssertNotNil(billingAddressSection.postalCode)
 
-        // CA: the province is added, and the postal that the base card form already collects is kept.
+        // CA adds the province; the card form's postal is still there
         billingAddressSection.selectedCountryCode = "CA"
         XCTAssertNil(billingAddressSection.line1)
         XCTAssertNotNil(billingAddressSection.state)
@@ -495,7 +495,7 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
             addressSpecProvider: dummyAddressSpecProvider
         )
 
-        // A `.full` billing form (autocomplete) already collects more than the tax region requires, so it's left as-is.
+        // Autocomplete already collects more than tax needs, so leave it alone.
         let section = factory.makeBillingAddressSection(collectionMode: .autoCompletable).element
         XCTAssertTrue(section.collectsTaxRegionFields)
         section.selectedCountryCode = "US"

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
@@ -480,9 +480,9 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
         XCTAssertNotNil(billingAddressSection.postalCode)
     }
 
-    // Tax should never *shrink* a form that already collects everything.
+    // Tax shouldn't shrink a form that already collects the whole address.
     @MainActor
-    func testMakeBillingAddressSection_autoTaxDoesNotNarrowFullAddressForm() {
+    func testMakeBillingAddressSectionAutoTaxKeepsAutocomplete() {
         let session = CheckoutTestHelpers.makeOpenSession(
             automaticTaxEnabled: true,
             automaticTaxAddressSource: "session.billing"

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
@@ -446,7 +446,7 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
     // MARK: - Automatic tax (billing source)
 
     @MainActor
-    func testCardFormWithAutomaticTaxBilling_usesTaxRegionCollectionMode() {
+    func testCardFormWithAutomaticTaxBilling_collectsTaxRegionFields() {
         let session = CheckoutTestHelpers.makeOpenSession(
             automaticTaxEnabled: true,
             automaticTaxAddressSource: "session.billing"
@@ -466,22 +466,23 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
             XCTFail("Could not find billing address section")
             return
         }
-        XCTAssertEqual(billingAddressSection.collectionMode, .taxRegion)
+        XCTAssertTrue(billingAddressSection.collectsTaxRegionFields)
 
+        // US: the floor is the full address, so everything is collected.
         billingAddressSection.selectedCountryCode = "US"
         XCTAssertNotNil(billingAddressSection.line1)
         XCTAssertNotNil(billingAddressSection.state)
         XCTAssertNotNil(billingAddressSection.postalCode)
 
-        // CA only needs the province
+        // CA: the province is added, and the postal that the base card form already collects is kept.
         billingAddressSection.selectedCountryCode = "CA"
         XCTAssertNil(billingAddressSection.line1)
-        XCTAssertNil(billingAddressSection.postalCode)
         XCTAssertNotNil(billingAddressSection.state)
+        XCTAssertNotNil(billingAddressSection.postalCode)
     }
 
     @MainActor
-    func testMakeBillingAddressSection_taxRegionOverrideRespectsNoCountry() {
+    func testMakeBillingAddressSection_autoTaxDoesNotNarrowFullAddressForm() {
         let session = CheckoutTestHelpers.makeOpenSession(
             automaticTaxEnabled: true,
             automaticTaxAddressSource: "session.billing"
@@ -494,8 +495,11 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
             addressSpecProvider: dummyAddressSpecProvider
         )
 
-        XCTAssertEqual(factory.makeBillingAddressSection(collectionMode: .autoCompletable).element.collectionMode, .taxRegion)
-        // .noCountry is left alone since it collects the country separately
-        XCTAssertEqual(factory.makeBillingAddressSection(collectionMode: .noCountry).element.collectionMode, .noCountry)
+        // A `.full` billing form (autocomplete) already collects more than the tax region requires, so it's left as-is.
+        let section = factory.makeBillingAddressSection(collectionMode: .autoCompletable).element
+        XCTAssertTrue(section.collectsTaxRegionFields)
+        section.selectedCountryCode = "US"
+        XCTAssertNotNil(section.autoCompleteLine)
+        XCTAssertNil(section.line1)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -290,6 +290,48 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
         XCTAssertTrue(sut.requiredShippingContactFields.contains(.phoneNumber))
     }
 
+    func testCreatePaymentRequest_requiredContactFields_automaticTaxForcesPostalAddress() {
+        var config = PaymentSheet.Configuration._testValue_MostPermissive()
+        config.applePay = applePayConfiguration
+        // Merchant turned off billing address collection, but the session needs it for tax, so
+        // Apple Pay still has to collect the postal address.
+        config.billingDetailsCollectionConfiguration.address = .never
+
+        let sut = STPApplePayContext.createPaymentRequest(
+            intent: makeCheckoutIntent(automaticTaxBilling: true),
+            configuration: config,
+            applePay: applePayConfiguration
+        )
+
+        XCTAssertTrue(sut.requiredBillingContactFields.contains(.postalAddress))
+    }
+
+    func testCreatePaymentRequest_requiredContactFields_noTaxRespectsAddressNever() {
+        var config = PaymentSheet.Configuration._testValue_MostPermissive()
+        config.applePay = applePayConfiguration
+        config.billingDetailsCollectionConfiguration.address = .never
+
+        let sut = STPApplePayContext.createPaymentRequest(
+            intent: makeCheckoutIntent(automaticTaxBilling: false),
+            configuration: config,
+            applePay: applePayConfiguration
+        )
+
+        XCTAssertFalse(sut.requiredBillingContactFields.contains(.postalAddress))
+    }
+
+    // Builds a .checkout intent, optionally with automatic tax on the billing address.
+    // Needs a total_summary since createPaymentRequest reads intent.amount.
+    private func makeCheckoutIntent(automaticTaxBilling: Bool) -> Intent {
+        let response = automaticTaxBilling
+            ? CheckoutTestHelpers.makeOpenSession(automaticTaxEnabled: true, automaticTaxAddressSource: "session.billing")
+            : CheckoutTestHelpers.makeOpenSession()
+        var json = response.allResponseFields as? [String: Any] ?? [:]
+        json["total_summary"] = ["subtotal": 5050, "total": 5050, "due": 5050]
+        let session = STPCheckoutSessionAPIResponse.decodedObject(fromAPIResponse: json)!
+        return .checkout(Checkout(apiResponse: session))
+    }
+
     func testCreatePaymentRequest_label_normalIntent() {
         var configuration = configuration
         configuration.merchantDisplayName = "Merchant Name"

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -293,8 +293,7 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
     func testCreatePaymentRequest_requiredContactFields_automaticTaxForcesPostalAddress() {
         var config = PaymentSheet.Configuration._testValue_MostPermissive()
         config.applePay = applePayConfiguration
-        // Merchant turned off billing address collection, but the session needs it for tax, so
-        // Apple Pay still has to collect the postal address.
+        // address collection off, but tax needs it, so Apple Pay still collects postal address
         config.billingDetailsCollectionConfiguration.address = .never
 
         let sut = STPApplePayContext.createPaymentRequest(
@@ -320,8 +319,7 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
         XCTAssertFalse(sut.requiredBillingContactFields.contains(.postalAddress))
     }
 
-    // Builds a .checkout intent, optionally with automatic tax on the billing address.
-    // Needs a total_summary since createPaymentRequest reads intent.amount.
+    // total_summary is needed because createPaymentRequest reads intent.amount
     private func makeCheckoutIntent(automaticTaxBilling: Bool) -> Intent {
         let response = automaticTaxBilling
             ? CheckoutTestHelpers.makeOpenSession(automaticTaxEnabled: true, automaticTaxAddressSource: "session.billing")

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -80,6 +80,15 @@ import UIKit
         /// Special case used by some Payment Methods that collect country separately.
         case noCountry
     }
+
+    /// Extra fields tax needs on top of `collectionMode`. Only applies to `.countryAndPostal`.
+    public enum TaxAddressRequirement: Equatable {
+        case none
+        /// Full street address, via the autocomplete line in minimal modes.
+        case autocomplete
+        case stateOrProvince
+    }
+
     /// Fields that this section can collect in addition to the address
     public struct AdditionalFields {
         public init(
@@ -155,8 +164,8 @@ import UIKit
     }
 
     public let countryCodes: [String]
-    /// Collect enough address to compute tax, on top of `collectionMode`.
-    public let collectsAddressForTax: Bool
+    // Per-country tax requirement, only used in .countryAndPostal (other modes already collect everything)
+    let taxAddressRequirement: (_ countryCode: String) -> TaxAddressRequirement
     let addressSpecProvider: AddressSpecProvider
     let theme: ElementsAppearance
     private(set) var defaults: AddressDetails
@@ -181,7 +190,7 @@ import UIKit
         addressSpecProvider: AddressSpecProvider = .shared,
         defaults: AddressDetails = .empty,
         collectionMode: CollectionMode = .all(),
-        collectsAddressForTax: Bool = false,
+        taxAddressRequirement: @escaping (_ countryCode: String) -> TaxAddressRequirement = { _ in .none },
         additionalFields: AdditionalFields = .init(),
         theme: ElementsAppearance = .default,
         presentAutoComplete: @escaping () -> Void = { }
@@ -189,7 +198,7 @@ import UIKit
         let dropdownCountries = countries?.map { $0.uppercased() } ?? addressSpecProvider.countries
         let countryCodes = locale.sortedByTheirLocalizedNames(dropdownCountries)
         self.collectionMode = collectionMode
-        self.collectsAddressForTax = collectsAddressForTax
+        self.taxAddressRequirement = taxAddressRequirement
         self.countryCodes = countryCodes
         self.country = DropdownFieldElement.Address.makeCountry(
             label: String.Localized.country_or_region,
@@ -298,21 +307,6 @@ import UIKit
         }
     }
 
-    private enum TaxRegion {
-        // Full address, via the autocomplete line (US).
-        case autocomplete
-        // Extra fields beyond what collectionMode collects (e.g. CA province). Empty = country alone is enough.
-        case extraFields(Set<AddressSpec.FieldType>)
-    }
-
-    private static func taxRegion(for countryCode: String) -> TaxRegion {
-        switch countryCode {
-        case "US": return .autocomplete
-        case "CA": return .extraFields([.state])
-        default: return .extraFields([])
-        }
-    }
-
     private func makeLine1Element(defaultValue: String?, countryCode: String) -> TextFieldElement {
         let showsAutocomplete: Bool
         switch collectionMode {
@@ -347,15 +341,17 @@ import UIKit
             state: state?.rawData
         )
 
-        // Only bother topping up for tax in the minimal modes. The autocomplete modes already collect the whole
-        // address, and skipping them avoids wiping fields the user just filled once an autocomplete selection
-        // flips us to .allWithAutocomplete.
+        // Only augment in .countryAndPostal; other modes already collect everything.
         var taxUsesAutocomplete = false
         var extraTaxFields: Set<AddressSpec.FieldType> = []
-        if collectsAddressForTax, collectionMode != .allWithAutocomplete, collectionMode != .autoCompletable {
-            switch Self.taxRegion(for: countryCode) {
-            case .autocomplete: taxUsesAutocomplete = true
-            case .extraFields(let fields): extraTaxFields = fields
+        if case .countryAndPostal = collectionMode {
+            switch taxAddressRequirement(countryCode) {
+            case .none:
+                break
+            case .autocomplete:
+                taxUsesAutocomplete = true
+            case .stateOrProvince:
+                extraTaxFields = [.state]
             }
         }
 

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -155,9 +155,9 @@ import UIKit
     }
 
     public let countryCodes: [String]
-    /// When true, always collect enough of the address to figure out the tax region (see `taxRegionFields`), on top of
-    /// whatever `collectionMode` would collect. Set when automatic tax is computed from the billing address.
-    public let collectsTaxRegionFields: Bool
+    /// When true, always collect enough of the address to compute tax (see `taxRegionCollection(for:)`), on top of
+    /// whatever `collectionMode` would collect.
+    public let collectsAddressForTax: Bool
     let addressSpecProvider: AddressSpecProvider
     let theme: ElementsAppearance
     private(set) var defaults: AddressDetails
@@ -182,7 +182,7 @@ import UIKit
         addressSpecProvider: AddressSpecProvider = .shared,
         defaults: AddressDetails = .empty,
         collectionMode: CollectionMode = .all(),
-        collectsTaxRegionFields: Bool = false,
+        collectsAddressForTax: Bool = false,
         additionalFields: AdditionalFields = .init(),
         theme: ElementsAppearance = .default,
         presentAutoComplete: @escaping () -> Void = { }
@@ -190,7 +190,7 @@ import UIKit
         let dropdownCountries = countries?.map { $0.uppercased() } ?? addressSpecProvider.countries
         let countryCodes = locale.sortedByTheirLocalizedNames(dropdownCountries)
         self.collectionMode = collectionMode
-        self.collectsTaxRegionFields = collectsTaxRegionFields
+        self.collectsAddressForTax = collectsAddressForTax
         self.countryCodes = countryCodes
         self.country = DropdownFieldElement.Address.makeCountry(
             label: String.Localized.country_or_region,
@@ -299,12 +299,21 @@ import UIKit
         }
     }
 
-    // What we need to pin down the tax region: full address in the US, just the province in Canada, country alone otherwise.
-    private static func taxRegionFields(for countryCode: String) -> Set<AddressSpec.FieldType> {
+    /// What to collect for automatic tax in a given country.
+    private enum TaxRegionCollection {
+        /// Collect the full address via the autocomplete line (e.g. the US).
+        case autocomplete
+        /// Collect these fields in addition to what `collectionMode` collects (e.g. Canada's province).
+        /// An empty set means the country selector alone is enough.
+        case fields(Set<AddressSpec.FieldType>)
+    }
+
+    // What we need to compute tax in each country: the full address in the US, the province in Canada, country alone otherwise.
+    private static func taxRegionCollection(for countryCode: String) -> TaxRegionCollection {
         switch countryCode {
-        case "US": return [.line, .city, .state, .postal]
-        case "CA": return [.state]
-        default: return []
+        case "US": return .autocomplete
+        case "CA": return .fields([.state])
+        default: return .fields([])
         }
     }
 
@@ -342,12 +351,22 @@ import UIKit
             state: state?.rawData
         )
 
+        // What automatic tax needs in this country. Only applies on top of the "minimal" collection modes; the
+        // autocomplete modes already collect the full address, so we leave them alone (this also keeps the filled-in
+        // fields visible after an autocomplete selection switches us to .allWithAutocomplete).
+        let taxCollection: TaxRegionCollection? = (collectsAddressForTax && collectionMode != .allWithAutocomplete && collectionMode != .autoCompletable)
+            ? Self.taxRegionCollection(for: countryCode)
+            : nil
+        // The US collects its full address via the autocomplete line rather than every field.
+        let taxUsesAutocomplete = { if case .autocomplete = taxCollection { return true } else { return false } }()
+        // Extra fields tax needs on top of `collectionMode` (e.g. Canada's province).
+        let taxFields: Set<AddressSpec.FieldType> = { if case .fields(let fields) = taxCollection { return fields } else { return [] } }()
+
         // Get the address spec for the country and filter out unused fields
         let spec = addressSpecProvider.addressSpec(for: countryCode)
-        let fieldOrdering = spec.fieldOrdering.filter { field in
-            // Force in the tax-region fields regardless of collectionMode. Skip .autoCompletable though — its
-            // autocomplete line already grabs the whole address, so adding these back would just duplicate it.
-            if collectsTaxRegionFields, collectionMode != .autoCompletable, Self.taxRegionFields(for: countryCode).contains(field) {
+        var fieldOrdering = spec.fieldOrdering.filter { field in
+            // Always pull in the fields tax needs, in addition to whatever collectionMode collects.
+            if taxFields.contains(field) {
                 return true
             }
             switch collectionMode {
@@ -360,7 +379,11 @@ import UIKit
             }
         }
 
-        if collectionMode == .autoCompletable {
+        if taxUsesAutocomplete {
+            fieldOrdering = []
+        }
+
+        if collectionMode == .autoCompletable || taxUsesAutocomplete {
             autoCompleteLine = autoCompleteLine ?? DummyAddressLine(theme: theme, didTap: { [weak self] in self?.didTapAutocompleteButton() })
         } else {
             autoCompleteLine = nil

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -79,8 +79,6 @@ import UIKit
         case autoCompletable
         /// Special case used by some Payment Methods that collect country separately.
         case noCountry
-        /// Collects only what's needed to determine the tax region: full address in the US, state in CA, country-only elsewhere.
-        case taxRegion
     }
     /// Fields that this section can collect in addition to the address
     public struct AdditionalFields {
@@ -157,6 +155,10 @@ import UIKit
     }
 
     public let countryCodes: [String]
+    /// When `true`, the fields needed to determine the tax region (full address in the US, the province in Canada,
+    /// and the country selector elsewhere) are always collected in addition to whatever `collectionMode` collects.
+    /// Used when automatic tax is calculated from the billing address.
+    public let collectsTaxRegionFields: Bool
     let addressSpecProvider: AddressSpecProvider
     let theme: ElementsAppearance
     private(set) var defaults: AddressDetails
@@ -181,6 +183,7 @@ import UIKit
         addressSpecProvider: AddressSpecProvider = .shared,
         defaults: AddressDetails = .empty,
         collectionMode: CollectionMode = .all(),
+        collectsTaxRegionFields: Bool = false,
         additionalFields: AdditionalFields = .init(),
         theme: ElementsAppearance = .default,
         presentAutoComplete: @escaping () -> Void = { }
@@ -188,6 +191,7 @@ import UIKit
         let dropdownCountries = countries?.map { $0.uppercased() } ?? addressSpecProvider.countries
         let countryCodes = locale.sortedByTheirLocalizedNames(dropdownCountries)
         self.collectionMode = collectionMode
+        self.collectsTaxRegionFields = collectsTaxRegionFields
         self.countryCodes = countryCodes
         self.country = DropdownFieldElement.Address.makeCountry(
             label: String.Localized.country_or_region,
@@ -296,6 +300,16 @@ import UIKit
         }
     }
 
+    /// The address fields required to determine the tax region for `countryCode`: the full address in the US, the
+    /// province in Canada, and nothing (country selector only) everywhere else.
+    private static func taxRegionFields(for countryCode: String) -> Set<AddressSpec.FieldType> {
+        switch countryCode {
+        case "US": return [.line, .city, .state, .postal]
+        case "CA": return [.state]
+        default: return []
+        }
+    }
+
     private func makeLine1Element(defaultValue: String?, countryCode: String) -> TextFieldElement {
         let showsAutocomplete: Bool
         switch collectionMode {
@@ -332,26 +346,20 @@ import UIKit
 
         // Get the address spec for the country and filter out unused fields
         let spec = addressSpecProvider.addressSpec(for: countryCode)
-        let fieldOrdering = spec.fieldOrdering.filter {
+        let fieldOrdering = spec.fieldOrdering.filter { field in
+            // For automatic tax, always collect at least the fields needed to determine the tax region, on top of
+            // whatever `collectionMode` collects. `.autoCompletable` is exempt: it already collects the full address
+            // via the autocomplete line, so we leave that form as-is rather than adding redundant fields.
+            if collectsTaxRegionFields, collectionMode != .autoCompletable, Self.taxRegionFields(for: countryCode).contains(field) {
+                return true
+            }
             switch collectionMode {
-            case .all, .noCountry:
+            case .all, .noCountry, .allWithAutocomplete:
                 return true
             case .countryAndPostal(let countriesRequiringPostalCollection):
-                if case .postal = $0 {
-                    return countriesRequiringPostalCollection.contains(countryCode)
-                } else {
-                   return false
-                }
+                return field == .postal && countriesRequiringPostalCollection.contains(countryCode)
             case .autoCompletable:
                 return false
-            case .allWithAutocomplete:
-                return true
-            case .taxRegion:
-                switch countryCode {
-                case "US": return [.line, .city, .state, .postal].contains($0)
-                case "CA": return $0 == .state
-                default: return false
-                }
             }
         }
 

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -155,8 +155,7 @@ import UIKit
     }
 
     public let countryCodes: [String]
-    /// When true, always collect enough of the address to compute tax (see `taxRegionCollection(for:)`), on top of
-    /// whatever `collectionMode` would collect.
+    /// When true, collect enough of the address to compute tax (on top of whatever `collectionMode` collects).
     public let collectsAddressForTax: Bool
     let addressSpecProvider: AddressSpecProvider
     let theme: ElementsAppearance
@@ -299,21 +298,18 @@ import UIKit
         }
     }
 
-    /// What to collect for automatic tax in a given country.
-    private enum TaxRegionCollection {
-        /// Collect the full address via the autocomplete line (e.g. the US).
+    private enum TaxRegion {
+        // US wants the full address, which we grab through the autocomplete line.
         case autocomplete
-        /// Collect these fields in addition to what `collectionMode` collects (e.g. Canada's province).
-        /// An empty set means the country selector alone is enough.
-        case fields(Set<AddressSpec.FieldType>)
+        // Fields to add on top of what collectionMode collects, e.g. CA's province. Empty = country picker is enough.
+        case extraFields(Set<AddressSpec.FieldType>)
     }
 
-    // What we need to compute tax in each country: the full address in the US, the province in Canada, country alone otherwise.
-    private static func taxRegionCollection(for countryCode: String) -> TaxRegionCollection {
+    private static func taxRegion(for countryCode: String) -> TaxRegion {
         switch countryCode {
         case "US": return .autocomplete
-        case "CA": return .fields([.state])
-        default: return .fields([])
+        case "CA": return .extraFields([.state])
+        default: return .extraFields([])
         }
     }
 
@@ -351,22 +347,22 @@ import UIKit
             state: state?.rawData
         )
 
-        // What automatic tax needs in this country. Only applies on top of the "minimal" collection modes; the
-        // autocomplete modes already collect the full address, so we leave them alone (this also keeps the filled-in
-        // fields visible after an autocomplete selection switches us to .allWithAutocomplete).
-        let taxCollection: TaxRegionCollection? = (collectsAddressForTax && collectionMode != .allWithAutocomplete && collectionMode != .autoCompletable)
-            ? Self.taxRegionCollection(for: countryCode)
-            : nil
-        // The US collects its full address via the autocomplete line rather than every field.
-        let taxUsesAutocomplete = { if case .autocomplete = taxCollection { return true } else { return false } }()
-        // Extra fields tax needs on top of `collectionMode` (e.g. Canada's province).
-        let taxFields: Set<AddressSpec.FieldType> = { if case .fields(let fields) = taxCollection { return fields } else { return [] } }()
+        // Only top up for tax in the minimal collection modes; the autocomplete modes already ask for the whole
+        // address. Skipping them also avoids clobbering fields the user just filled in when an autocomplete
+        // selection flips us over to .allWithAutocomplete.
+        var taxUsesAutocomplete = false
+        var extraTaxFields: Set<AddressSpec.FieldType> = []
+        if collectsAddressForTax, collectionMode != .allWithAutocomplete, collectionMode != .autoCompletable {
+            switch Self.taxRegion(for: countryCode) {
+            case .autocomplete: taxUsesAutocomplete = true
+            case .extraFields(let fields): extraTaxFields = fields
+            }
+        }
 
         // Get the address spec for the country and filter out unused fields
         let spec = addressSpecProvider.addressSpec(for: countryCode)
         var fieldOrdering = spec.fieldOrdering.filter { field in
-            // Always pull in the fields tax needs, in addition to whatever collectionMode collects.
-            if taxFields.contains(field) {
+            if extraTaxFields.contains(field) {
                 return true
             }
             switch collectionMode {

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -155,9 +155,8 @@ import UIKit
     }
 
     public let countryCodes: [String]
-    /// When `true`, the fields needed to determine the tax region (full address in the US, the province in Canada,
-    /// and the country selector elsewhere) are always collected in addition to whatever `collectionMode` collects.
-    /// Used when automatic tax is calculated from the billing address.
+    /// When true, always collect enough of the address to figure out the tax region (see `taxRegionFields`), on top of
+    /// whatever `collectionMode` would collect. Set when automatic tax is computed from the billing address.
     public let collectsTaxRegionFields: Bool
     let addressSpecProvider: AddressSpecProvider
     let theme: ElementsAppearance
@@ -300,8 +299,7 @@ import UIKit
         }
     }
 
-    /// The address fields required to determine the tax region for `countryCode`: the full address in the US, the
-    /// province in Canada, and nothing (country selector only) everywhere else.
+    // What we need to pin down the tax region: full address in the US, just the province in Canada, country alone otherwise.
     private static func taxRegionFields(for countryCode: String) -> Set<AddressSpec.FieldType> {
         switch countryCode {
         case "US": return [.line, .city, .state, .postal]
@@ -347,9 +345,8 @@ import UIKit
         // Get the address spec for the country and filter out unused fields
         let spec = addressSpecProvider.addressSpec(for: countryCode)
         let fieldOrdering = spec.fieldOrdering.filter { field in
-            // For automatic tax, always collect at least the fields needed to determine the tax region, on top of
-            // whatever `collectionMode` collects. `.autoCompletable` is exempt: it already collects the full address
-            // via the autocomplete line, so we leave that form as-is rather than adding redundant fields.
+            // Force in the tax-region fields regardless of collectionMode. Skip .autoCompletable though — its
+            // autocomplete line already grabs the whole address, so adding these back would just duplicate it.
             if collectsTaxRegionFields, collectionMode != .autoCompletable, Self.taxRegionFields(for: countryCode).contains(field) {
                 return true
             }

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -155,7 +155,7 @@ import UIKit
     }
 
     public let countryCodes: [String]
-    /// When true, collect enough of the address to compute tax (on top of whatever `collectionMode` collects).
+    /// Collect enough address to compute tax, on top of `collectionMode`.
     public let collectsAddressForTax: Bool
     let addressSpecProvider: AddressSpecProvider
     let theme: ElementsAppearance
@@ -299,9 +299,9 @@ import UIKit
     }
 
     private enum TaxRegion {
-        // US wants the full address, which we grab through the autocomplete line.
+        // Full address, via the autocomplete line (US).
         case autocomplete
-        // Fields to add on top of what collectionMode collects, e.g. CA's province. Empty = country picker is enough.
+        // Extra fields beyond what collectionMode collects (e.g. CA province). Empty = country alone is enough.
         case extraFields(Set<AddressSpec.FieldType>)
     }
 
@@ -347,9 +347,9 @@ import UIKit
             state: state?.rawData
         )
 
-        // Only top up for tax in the minimal collection modes; the autocomplete modes already ask for the whole
-        // address. Skipping them also avoids clobbering fields the user just filled in when an autocomplete
-        // selection flips us over to .allWithAutocomplete.
+        // Only bother topping up for tax in the minimal modes. The autocomplete modes already collect the whole
+        // address, and skipping them avoids wiping fields the user just filled once an autocomplete selection
+        // flips us to .allWithAutocomplete.
         var taxUsesAutocomplete = false
         var extraTaxFields: Set<AddressSpec.FieldType> = []
         if collectsAddressForTax, collectionMode != .allWithAutocomplete, collectionMode != .autoCompletable {

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -79,6 +79,8 @@ import UIKit
         case autoCompletable
         /// Special case used by some Payment Methods that collect country separately.
         case noCountry
+        /// Collects only what's needed to determine the tax region: full address in the US, state in CA, country-only elsewhere.
+        case taxRegion
     }
     /// Fields that this section can collect in addition to the address
     public struct AdditionalFields {
@@ -294,6 +296,25 @@ import UIKit
         }
     }
 
+    private func makeLine1Element(defaultValue: String?, countryCode: String) -> TextFieldElement {
+        let showsAutocomplete: Bool
+        switch collectionMode {
+        case .all(let autocompletableCountries):
+            showsAutocomplete = autocompletableCountries.caseInsensitiveContains(countryCode)
+        case .allWithAutocomplete:
+            showsAutocomplete = true
+        default:
+            showsAutocomplete = false
+        }
+        guard showsAutocomplete else {
+            return TextFieldElement.Address.makeLine1(defaultValue: defaultValue, theme: theme)
+        }
+        return TextFieldElement.Address.LineConfiguration(
+            lineType: .line1Autocompletable(didTapAutocomplete: { [weak self] in self?.didTapAutocompleteButton() }),
+            defaultValue: defaultValue
+        ).makeElement(theme: theme)
+    }
+
     /// - Parameter address: Populates the new fields with the provided defaults, or the current fields' text if `nil`.
     private func updateAddressFields(
         for countryCode: String,
@@ -325,6 +346,12 @@ import UIKit
                 return false
             case .allWithAutocomplete:
                 return true
+            case .taxRegion:
+                switch countryCode {
+                case "US": return [.line, .city, .state, .postal].contains($0)
+                case "CA": return $0 == .state
+                default: return false
+                }
             }
         }
 
@@ -334,21 +361,7 @@ import UIKit
             autoCompleteLine = nil
         }
         // Re-create the address fields
-        if fieldOrdering.contains(.line) {
-            if case .all(let autocompletableCountries) = collectionMode, autocompletableCountries.caseInsensitiveContains(countryCode) {
-                line1 = TextFieldElement.Address.LineConfiguration(
-                    lineType: .line1Autocompletable(didTapAutocomplete: { [weak self] in self?.didTapAutocompleteButton() }),
-                    defaultValue: address.line1
-                ).makeElement(theme: theme)
-            } else if case .allWithAutocomplete = collectionMode {
-                line1 = TextFieldElement.Address.LineConfiguration(
-                    lineType: .line1Autocompletable(didTapAutocomplete: { [weak self] in self?.didTapAutocompleteButton() }),
-                    defaultValue: address.line1
-                ).makeElement(theme: theme)
-            } else {
-                line1 = TextFieldElement.Address.makeLine1(defaultValue: address.line1, theme: theme)
-            }
-        }
+        line1 = fieldOrdering.contains(.line) ? makeLine1Element(defaultValue: address.line1, countryCode: countryCode) : nil
         line2 = fieldOrdering.contains(.line) ?
             TextFieldElement.Address.makeLine2(defaultValue: address.line2, theme: theme) : nil
         city = fieldOrdering.contains(.city) ?

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
@@ -124,7 +124,7 @@ class AddressSectionElementTest: XCTestCase {
             "CA": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .province, zip: "", zipNameType: .postal_code),
             "FR": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .postal_code),
         ]
-        // Base mode collects country + postal (for US/CA); the tax-region floor is unioned on top of it.
+        // Base mode is country + postal (US/CA); tax region fields get added on top.
         let sut = AddressSectionElement(
             title: "",
             countries: ["US", "CA", "FR"],
@@ -134,7 +134,7 @@ class AddressSectionElementTest: XCTestCase {
             collectsTaxRegionFields: true
         )
 
-        // US: the tax floor is the full address, so everything is collected.
+        // US wants the full address
         sut.selectedCountryCode = "US"
         XCTAssertNotNil(sut.line1)
         XCTAssertNotNil(sut.line2)
@@ -142,14 +142,14 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertNotNil(sut.state)
         XCTAssertNotNil(sut.postalCode)
 
-        // CA: the province is added by the floor, and the postal already collected by the base mode is kept.
+        // CA adds the province; postal from the base mode sticks around
         sut.selectedCountryCode = "CA"
         XCTAssertNil(sut.line1)
         XCTAssertNil(sut.city)
         XCTAssertNotNil(sut.state)
         XCTAssertNotNil(sut.postalCode)
 
-        // FR: the floor adds nothing (country only) and the base mode collects no postal for FR.
+        // FR adds nothing extra, and base mode doesn't collect postal here
         sut.selectedCountryCode = "FR"
         XCTAssertNil(sut.line1)
         XCTAssertNil(sut.city)
@@ -162,8 +162,8 @@ class AddressSectionElementTest: XCTestCase {
         specProvider.addressSpecs = [
             "US": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .zip),
         ]
-        // `.autoCompletable` already collects the full address via the autocomplete line — the floor must not add
-        // redundant individual fields on top.
+        // .autoCompletable already grabs the whole address via the autocomplete line, so we shouldn't tack on the
+        // individual fields too.
         let sut = AddressSectionElement(
             title: "",
             countries: ["US"],

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
@@ -117,14 +117,13 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertEqual(ZZTextFields.map { $0.configuration.isOptional }, expectedZZFields.map { $0.isOptional })
     }
 
-    func testTaxRegionFieldsUnionWithBaseCollectionMode() {
+    func testTaxRegionFieldsAddedOnTopOfCollectionMode() {
         let specProvider = AddressSpecProvider()
         specProvider.addressSpecs = [
             "US": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .zip),
             "CA": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .province, zip: "", zipNameType: .postal_code),
             "FR": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .postal_code),
         ]
-        // Base mode is country + postal (US/CA); tax region fields get added on top.
         let sut = AddressSectionElement(
             title: "",
             countries: ["US", "CA", "FR"],
@@ -134,7 +133,7 @@ class AddressSectionElementTest: XCTestCase {
             collectsAddressForTax: true
         )
 
-        // US needs the full address, which it collects via the autocomplete line rather than every field.
+        // US collects the full address via the autocomplete line, not the individual fields.
         sut.selectedCountryCode = "US"
         XCTAssertNotNil(sut.autoCompleteLine)
         XCTAssertNil(sut.line1)
@@ -142,14 +141,14 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertNil(sut.state)
         XCTAssertNil(sut.postalCode)
 
-        // CA adds the province; postal from the base mode sticks around
+        // CA adds the province on top of the postal that .countryAndPostal already collects.
         sut.selectedCountryCode = "CA"
         XCTAssertNil(sut.line1)
         XCTAssertNil(sut.city)
         XCTAssertNotNil(sut.state)
         XCTAssertNotNil(sut.postalCode)
 
-        // FR adds nothing extra, and base mode doesn't collect postal here
+        // FR needs nothing extra, and .countryAndPostal doesn't collect postal here.
         sut.selectedCountryCode = "FR"
         XCTAssertNil(sut.line1)
         XCTAssertNil(sut.city)
@@ -157,13 +156,12 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertNil(sut.postalCode)
     }
 
-    func testTaxRegionFloorLeavesAutocompleteFormsUnchanged() {
+    func testTaxRegionLeavesAutocompleteModeAlone() {
         let specProvider = AddressSpecProvider()
         specProvider.addressSpecs = [
             "US": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .zip),
         ]
-        // .autoCompletable already grabs the whole address via the autocomplete line, so we shouldn't tack on the
-        // individual fields too.
+        // .autoCompletable already grabs the whole address, so tax shouldn't add anything.
         let sut = AddressSectionElement(
             title: "",
             countries: ["US"],

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
@@ -21,6 +21,15 @@ class AddressSectionElementTest: XCTestCase {
         return specProvider
     }()
 
+    // mirrors PaymentSheet's tax requirement policy
+    private static func taxRequirement(for countryCode: String) -> AddressSectionElement.TaxAddressRequirement {
+        switch countryCode.uppercased() {
+        case "US": return .autocomplete
+        case "CA": return .stateOrProvince
+        default: return .none
+        }
+    }
+
     func testAddressFieldsMapsSpecs() throws {
         let specProvider = AddressSpecProvider()
         specProvider.addressSpecs = [
@@ -130,10 +139,10 @@ class AddressSectionElementTest: XCTestCase {
             locale: locale_enUS,
             addressSpecProvider: specProvider,
             collectionMode: .countryAndPostal(),
-            collectsAddressForTax: true
+            taxAddressRequirement: Self.taxRequirement(for:)
         )
 
-        // US goes through the autocomplete line, not the individual fields.
+        // US: autocomplete line, not individual fields
         sut.selectedCountryCode = "US"
         XCTAssertNotNil(sut.autoCompleteLine)
         XCTAssertNil(sut.line1)
@@ -141,14 +150,14 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertNil(sut.state)
         XCTAssertNil(sut.postalCode)
 
-        // CA adds the province on top of .countryAndPostal's postal.
+        // CA: province on top of postal
         sut.selectedCountryCode = "CA"
         XCTAssertNil(sut.line1)
         XCTAssertNil(sut.city)
         XCTAssertNotNil(sut.state)
         XCTAssertNotNil(sut.postalCode)
 
-        // FR needs nothing extra
+        // FR: nothing extra
         sut.selectedCountryCode = "FR"
         XCTAssertNil(sut.line1)
         XCTAssertNil(sut.city)
@@ -156,22 +165,49 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertNil(sut.postalCode)
     }
 
-    func testTaxRegionLeavesAutocompleteModeAlone() {
+    // .noCountry already collects the full address; a US tax requirement must not force the autocomplete
+    // line (that used to collapse the form and then inject a duplicate country dropdown).
+    func testTaxDoesNotCollapseNoCountryMode() {
         let specProvider = AddressSpecProvider()
         specProvider.addressSpecs = [
             "US": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .zip),
         ]
-        // .autoCompletable already grabs the whole address, so tax shouldn't add anything.
         let sut = AddressSectionElement(
             title: "",
             countries: ["US"],
             locale: locale_enUS,
             addressSpecProvider: specProvider,
-            collectionMode: .autoCompletable,
-            collectsAddressForTax: true
+            collectionMode: .noCountry,
+            taxAddressRequirement: Self.taxRequirement(for:)
+        )
+        sut.selectedCountryCode = "US"
+        XCTAssertNil(sut.autoCompleteLine)
+        // full address still collected
+        XCTAssertNotNil(sut.line1)
+        XCTAssertNotNil(sut.city)
+        XCTAssertNotNil(sut.state)
+        XCTAssertNotNil(sut.postalCode)
+    }
+
+    func testTaxAutocompleteLineClearedWhenSwitchingAwayFromUS() {
+        let specProvider = AddressSpecProvider()
+        specProvider.addressSpecs = [
+            "US": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .zip),
+            "FR": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .postal_code),
+        ]
+        let sut = AddressSectionElement(
+            title: "",
+            countries: ["US", "FR"],
+            locale: locale_enUS,
+            addressSpecProvider: specProvider,
+            collectionMode: .countryAndPostal(),
+            taxAddressRequirement: Self.taxRequirement(for:)
         )
         sut.selectedCountryCode = "US"
         XCTAssertNotNil(sut.autoCompleteLine)
+
+        sut.selectedCountryCode = "FR"
+        XCTAssertNil(sut.autoCompleteLine)
         XCTAssertNil(sut.line1)
         XCTAssertNil(sut.city)
         XCTAssertNil(sut.state)

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
@@ -131,16 +131,16 @@ class AddressSectionElementTest: XCTestCase {
             locale: locale_enUS,
             addressSpecProvider: specProvider,
             collectionMode: .countryAndPostal(),
-            collectsTaxRegionFields: true
+            collectsAddressForTax: true
         )
 
-        // US wants the full address
+        // US needs the full address, which it collects via the autocomplete line rather than every field.
         sut.selectedCountryCode = "US"
-        XCTAssertNotNil(sut.line1)
-        XCTAssertNotNil(sut.line2)
-        XCTAssertNotNil(sut.city)
-        XCTAssertNotNil(sut.state)
-        XCTAssertNotNil(sut.postalCode)
+        XCTAssertNotNil(sut.autoCompleteLine)
+        XCTAssertNil(sut.line1)
+        XCTAssertNil(sut.city)
+        XCTAssertNil(sut.state)
+        XCTAssertNil(sut.postalCode)
 
         // CA adds the province; postal from the base mode sticks around
         sut.selectedCountryCode = "CA"
@@ -170,7 +170,7 @@ class AddressSectionElementTest: XCTestCase {
             locale: locale_enUS,
             addressSpecProvider: specProvider,
             collectionMode: .autoCompletable,
-            collectsTaxRegionFields: true
+            collectsAddressForTax: true
         )
         sut.selectedCountryCode = "US"
         XCTAssertNotNil(sut.autoCompleteLine)

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
@@ -117,22 +117,24 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertEqual(ZZTextFields.map { $0.configuration.isOptional }, expectedZZFields.map { $0.isOptional })
     }
 
-    func testTaxRegionCollectionModeCollectsPerCountryFields() {
+    func testTaxRegionFieldsUnionWithBaseCollectionMode() {
         let specProvider = AddressSpecProvider()
         specProvider.addressSpecs = [
             "US": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .zip),
             "CA": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .province, zip: "", zipNameType: .postal_code),
             "FR": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .postal_code),
         ]
+        // Base mode collects country + postal (for US/CA); the tax-region floor is unioned on top of it.
         let sut = AddressSectionElement(
             title: "",
             countries: ["US", "CA", "FR"],
             locale: locale_enUS,
             addressSpecProvider: specProvider,
-            collectionMode: .taxRegion
+            collectionMode: .countryAndPostal(),
+            collectsTaxRegionFields: true
         )
 
-        // US: full address
+        // US: the tax floor is the full address, so everything is collected.
         sut.selectedCountryCode = "US"
         XCTAssertNotNil(sut.line1)
         XCTAssertNotNil(sut.line2)
@@ -140,18 +142,39 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertNotNil(sut.state)
         XCTAssertNotNil(sut.postalCode)
 
-        // CA: just the province
+        // CA: the province is added by the floor, and the postal already collected by the base mode is kept.
         sut.selectedCountryCode = "CA"
         XCTAssertNil(sut.line1)
-        XCTAssertNil(sut.line2)
         XCTAssertNil(sut.city)
         XCTAssertNotNil(sut.state)
-        XCTAssertNil(sut.postalCode)
+        XCTAssertNotNil(sut.postalCode)
 
-        // everywhere else: country only
+        // FR: the floor adds nothing (country only) and the base mode collects no postal for FR.
         sut.selectedCountryCode = "FR"
         XCTAssertNil(sut.line1)
-        XCTAssertNil(sut.line2)
+        XCTAssertNil(sut.city)
+        XCTAssertNil(sut.state)
+        XCTAssertNil(sut.postalCode)
+    }
+
+    func testTaxRegionFloorLeavesAutocompleteFormsUnchanged() {
+        let specProvider = AddressSpecProvider()
+        specProvider.addressSpecs = [
+            "US": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .zip),
+        ]
+        // `.autoCompletable` already collects the full address via the autocomplete line — the floor must not add
+        // redundant individual fields on top.
+        let sut = AddressSectionElement(
+            title: "",
+            countries: ["US"],
+            locale: locale_enUS,
+            addressSpecProvider: specProvider,
+            collectionMode: .autoCompletable,
+            collectsTaxRegionFields: true
+        )
+        sut.selectedCountryCode = "US"
+        XCTAssertNotNil(sut.autoCompleteLine)
+        XCTAssertNil(sut.line1)
         XCTAssertNil(sut.city)
         XCTAssertNil(sut.state)
         XCTAssertNil(sut.postalCode)

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
@@ -117,6 +117,46 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertEqual(ZZTextFields.map { $0.configuration.isOptional }, expectedZZFields.map { $0.isOptional })
     }
 
+    func testTaxRegionCollectionModeCollectsPerCountryFields() {
+        let specProvider = AddressSpecProvider()
+        specProvider.addressSpecs = [
+            "US": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .zip),
+            "CA": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .province, zip: "", zipNameType: .postal_code),
+            "FR": AddressSpec(format: "ACSZ", require: "ACSZ", cityNameType: .city, stateNameType: .state, zip: "", zipNameType: .postal_code),
+        ]
+        let sut = AddressSectionElement(
+            title: "",
+            countries: ["US", "CA", "FR"],
+            locale: locale_enUS,
+            addressSpecProvider: specProvider,
+            collectionMode: .taxRegion
+        )
+
+        // US: full address
+        sut.selectedCountryCode = "US"
+        XCTAssertNotNil(sut.line1)
+        XCTAssertNotNil(sut.line2)
+        XCTAssertNotNil(sut.city)
+        XCTAssertNotNil(sut.state)
+        XCTAssertNotNil(sut.postalCode)
+
+        // CA: just the province
+        sut.selectedCountryCode = "CA"
+        XCTAssertNil(sut.line1)
+        XCTAssertNil(sut.line2)
+        XCTAssertNil(sut.city)
+        XCTAssertNotNil(sut.state)
+        XCTAssertNil(sut.postalCode)
+
+        // everywhere else: country only
+        sut.selectedCountryCode = "FR"
+        XCTAssertNil(sut.line1)
+        XCTAssertNil(sut.line2)
+        XCTAssertNil(sut.city)
+        XCTAssertNil(sut.state)
+        XCTAssertNil(sut.postalCode)
+    }
+
     func testCountries() {
         let specProvider = AddressSpecProvider()
         specProvider.addressSpecs = [

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
@@ -133,7 +133,7 @@ class AddressSectionElementTest: XCTestCase {
             collectsAddressForTax: true
         )
 
-        // US collects the full address via the autocomplete line, not the individual fields.
+        // US goes through the autocomplete line, not the individual fields.
         sut.selectedCountryCode = "US"
         XCTAssertNotNil(sut.autoCompleteLine)
         XCTAssertNil(sut.line1)
@@ -141,14 +141,14 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertNil(sut.state)
         XCTAssertNil(sut.postalCode)
 
-        // CA adds the province on top of the postal that .countryAndPostal already collects.
+        // CA adds the province on top of .countryAndPostal's postal.
         sut.selectedCountryCode = "CA"
         XCTAssertNil(sut.line1)
         XCTAssertNil(sut.city)
         XCTAssertNotNil(sut.state)
         XCTAssertNotNil(sut.postalCode)
 
-        // FR needs nothing extra, and .countryAndPostal doesn't collect postal here.
+        // FR needs nothing extra
         sut.selectedCountryCode = "FR"
         XCTAssertNil(sut.line1)
         XCTAssertNil(sut.city)


### PR DESCRIPTION
## Summary
- When billing address is the source for tax calculation we ensure that the min fields are collected to compute tax. The rule is quite simple (and we match web). Just collect full billing for US, and always a state for Canada.
- For Apple Pay we don't have granularity like state, so we just have to always collect the full.

## Motivation
- CheckoutSessions

## Testing
- Manual
- New tests

## Changelog
N/A
