### PR TITLE
Discard payment selection changes on dismiss

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheet+AddressTests.swift
@@ -505,6 +505,16 @@ RO
         XCTAssertFalse(app.switches["Billing address is same as shipping"].isSelected)
 
         // ...and changing the shipping address...
+        // First tap Continue to persist the billing address change, then close
+        app.buttons["Continue"].tap()
+        app.buttons["Payment method"].waitForExistenceAndTap()
+
+        // The billing address change should be persisted since we tapped Continue
+        XCTAssertEqual(app.textFields["Country or region"].value as? String, "Uruguay")
+        XCTAssertEqual(app.textFields["Postal code"].value as? String, updatedBillingAddressPostalCode)
+        XCTAssertFalse(app.switches["Billing address is same as shipping"].isSelected)
+
+        // Now change shipping address
         app.buttons["Close"].tap()
         app.buttons["Address"].tap()
         app.textFields["Country or region"].waitForExistenceAndTap()

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetStandardUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetStandardUITests.swift
@@ -350,11 +350,12 @@ class PaymentSheetStandardUITests: PaymentSheetUITestCase {
         sleep(2)
         XCTAssertEqual(paymentMethodButton.label, "Link, link")
 
-        // Open again and choose to continue with card
+        // Open again and continue without changing anything - Link is the last confirmed
+        // selection, so it persists (the previously entered card was discarded on cancel).
         paymentMethodButton.tap()
         app.buttons["Continue"].tap()
         sleep(2)
-        XCTAssertEqual(paymentMethodButton.label, "•••• 4242, card, 12345, US")
+        XCTAssertEqual(paymentMethodButton.label, "Link, link")
     }
 
     func testPaymentSheetSwiftUI() throws {

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITests.swift
@@ -54,24 +54,17 @@ class PaymentSheetVerticalUITests: PaymentSheetUITestCase {
         app.textFields["Card number"].typeText("1")
         XCTAssertFalse(continueButton.isEnabled)
         app.tapCoordinate(at: .init(x: 200, y: 100))
-        // Tap out of FlowController and expect empty payment method
+        // Tap out of FlowController - cancelling reverts to the last confirmed selection
         app.tapCoordinate(at: .init(x: 200, y: 100))
-        XCTAssertEqual(paymentMethodButton.label, "None")
+        XCTAssertEqual(paymentMethodButton.label, "Cash App Pay, cashapp")
 
-        // Go back in
+        // Go back in - Cash App Pay should still be selected since we reverted
         paymentMethodButton.tap()
-        XCTAssertFalse(continueButton.isEnabled)
-        // Back out of card form
-        app.buttons["Back"].tap()
-        // Cash App Pay (the previous selection) should be selected
         XCTAssertTrue(app.buttons["Cash App Pay"].isSelected)
         XCTAssertTrue(continueButton.isEnabled)
 
         // Go back to card
         app.buttons["Card"].waitForExistenceAndTap()
-        // Make sure the card form retained previously entered details
-        XCTAssertEqual(app.textFields["Card number"].value as? String, "1, Your card number is invalid.")
-        app.textFields["Card number"].clearText()
         // Finish the card payment
         try! fillCardData(app, cardNumber: "4242424242424242", tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
         continueButton.tap()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -1021,6 +1021,14 @@ extension PaymentSheet.FlowController: FlowControllerViewControllerDelegate {
         _ flowControllerViewController: FlowControllerViewControllerProtocol,
         didCancel: Bool
     ) {
+        // If the user's previous PM was deleted during the session, treat cancel as continue
+        // since the deletion is permanent and we need to accept whatever is now selected.
+        var didCancel = didCancel
+        if didCancel, case .saved(let paymentMethod, _) = paymentOptionBeforePresenting,
+           !viewController.savedPaymentMethods.contains(where: { $0.stripeId == paymentMethod.stripeId }) {
+            didCancel = false
+        }
+
         if !didCancel {
             self.didPresentAndContinue = true
             if let customerPaymentOption = internalPaymentOption?.customerPaymentOption {
@@ -1032,15 +1040,9 @@ extension PaymentSheet.FlowController: FlowControllerViewControllerDelegate {
                 // The VC accumulates too much state during a session (link options, form input, SPM
                 // edits) to safely reset in place. Just rebuild it.
                 var savedPaymentMethods = self.viewController.savedPaymentMethods
-                var previousOption = self.paymentOptionBeforePresenting
-                if case .saved(let paymentMethod, _) = previousOption {
-                    if savedPaymentMethods.contains(where: { $0.stripeId == paymentMethod.stripeId }) {
-                        savedPaymentMethods.removeAll(where: { $0.stripeId == paymentMethod.stripeId })
-                        savedPaymentMethods.insert(paymentMethod, at: 0)
-                    } else {
-                        // The saved PM was removed during this session, don't revert
-                        previousOption = nil
-                    }
+                if case .saved(let paymentMethod, _) = self.paymentOptionBeforePresenting {
+                    savedPaymentMethods.removeAll(where: { $0.stripeId == paymentMethod.stripeId })
+                    savedPaymentMethods.insert(paymentMethod, at: 0)
                 }
                 let updatedLoadResult = PaymentSheetLoader.LoadResult(
                     intent: self.viewController.loadResult.intent,
@@ -1055,7 +1057,7 @@ extension PaymentSheet.FlowController: FlowControllerViewControllerDelegate {
                     loadResult: updatedLoadResult,
                     analyticsHelper: self.analyticsHelper,
                     walletButtonsViewState: self.walletButtonsViewState,
-                    previousPaymentOption: previousOption
+                    previousPaymentOption: self.paymentOptionBeforePresenting
                 )
                 self.viewController.flowControllerDelegate = self
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -1032,9 +1032,15 @@ extension PaymentSheet.FlowController: FlowControllerViewControllerDelegate {
                 // The VC accumulates too much state during a session (link options, form input, SPM
                 // edits) to safely reset in place. Just rebuild it.
                 var savedPaymentMethods = self.viewController.savedPaymentMethods
-                if case .saved(let paymentMethod, _) = self.paymentOptionBeforePresenting {
-                    savedPaymentMethods.removeAll(where: { $0.stripeId == paymentMethod.stripeId })
-                    savedPaymentMethods.insert(paymentMethod, at: 0)
+                var previousOption = self.paymentOptionBeforePresenting
+                if case .saved(let paymentMethod, _) = previousOption {
+                    if savedPaymentMethods.contains(where: { $0.stripeId == paymentMethod.stripeId }) {
+                        savedPaymentMethods.removeAll(where: { $0.stripeId == paymentMethod.stripeId })
+                        savedPaymentMethods.insert(paymentMethod, at: 0)
+                    } else {
+                        // The saved PM was removed during this session, don't revert
+                        previousOption = nil
+                    }
                 }
                 let updatedLoadResult = PaymentSheetLoader.LoadResult(
                     intent: self.viewController.loadResult.intent,
@@ -1049,12 +1055,11 @@ extension PaymentSheet.FlowController: FlowControllerViewControllerDelegate {
                     loadResult: updatedLoadResult,
                     analyticsHelper: self.analyticsHelper,
                     walletButtonsViewState: self.walletButtonsViewState,
-                    previousPaymentOption: self.paymentOptionBeforePresenting
+                    previousPaymentOption: previousOption
                 )
                 self.viewController.flowControllerDelegate = self
             }
             self.presentPaymentOptionsCompletionWithResult?(didCancel)
-            self.updatePaymentOption()
             self.isPresented = false
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -268,6 +268,7 @@ extension PaymentSheet {
         var viewController: FlowControllerViewControllerProtocol
 
         private var presentPaymentOptionsCompletionWithResult: ((Bool) -> Void)?
+        private var paymentOptionBeforePresenting: PaymentOption?
         private var didDismissLinkVerificationDialog: Bool = false
 
         // If a WalletButtonsView is currently visible
@@ -520,9 +521,9 @@ extension PaymentSheet {
                 return
             }
 
+            paymentOptionBeforePresenting = internalPaymentOption
             // Overwrite completion closure to retain self until called
             let wrappedCompletion: (Bool) -> Void = { didCancel in
-                self.updatePaymentOption()
                 completion?(didCancel)
                 self.presentPaymentOptionsCompletionWithResult = nil
             }
@@ -1019,8 +1020,36 @@ extension PaymentSheet.FlowController: FlowControllerViewControllerDelegate {
     ) {
         if !didCancel {
             self.didPresentAndContinue = true
+            if let customerPaymentOption = internalPaymentOption?.customerPaymentOption {
+                CustomerPaymentOption.setDefaultPaymentMethod(customerPaymentOption, forCustomer: configuration.customer?.id)
+            }
         }
         flowControllerViewController.dismiss(animated: true) {
+            if didCancel {
+                // The VC accumulates too much state during a session (link options, form input, SPM
+                // edits) to safely reset in place. Just rebuild it.
+                var savedPaymentMethods = self.viewController.savedPaymentMethods
+                if case .saved(let paymentMethod, _) = self.paymentOptionBeforePresenting {
+                    savedPaymentMethods.removeAll(where: { $0.stripeId == paymentMethod.stripeId })
+                    savedPaymentMethods.insert(paymentMethod, at: 0)
+                }
+                let updatedLoadResult = PaymentSheetLoader.LoadResult(
+                    intent: self.viewController.loadResult.intent,
+                    elementsSession: self.viewController.loadResult.elementsSession,
+                    savedPaymentMethods: savedPaymentMethods,
+                    paymentMethodTypes: self.viewController.loadResult.paymentMethodTypes,
+                    paymentMethodMessagingPromotionsHelper: self.viewController.loadResult.paymentMethodMessagingPromotionsHelper,
+                    paymentMethodOrientation: self.viewController.loadResult.paymentMethodOrientation
+                )
+                self.viewController = Self.makeViewController(
+                    configuration: self.configuration,
+                    loadResult: updatedLoadResult,
+                    analyticsHelper: self.analyticsHelper,
+                    walletButtonsViewState: self.walletButtonsViewState,
+                    previousPaymentOption: self.paymentOptionBeforePresenting
+                )
+                self.viewController.flowControllerDelegate = self
+            }
             self.presentPaymentOptionsCompletionWithResult?(didCancel)
             self.updatePaymentOption()
             self.isPresented = false
@@ -1085,6 +1114,19 @@ internal protocol FlowControllerViewControllerProtocol: BottomSheetContentViewCo
 }
 
 extension PaymentOption {
+    var customerPaymentOption: CustomerPaymentOption? {
+        switch self {
+        case .applePay:
+            return .applePay
+        case .link:
+            return .link
+        case .saved(let paymentMethod, _):
+            return .stripeId(paymentMethod.stripeId)
+        case .new, .external:
+            return nil
+        }
+    }
+
     var canLaunchLink: Bool {
         let hasLinkAccount = LinkAccountContext.shared.account?.isRegistered ?? false
         switch self {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -1036,11 +1036,13 @@ extension PaymentSheet.FlowController: FlowControllerViewControllerDelegate {
             }
         }
         flowControllerViewController.dismiss(animated: true) {
-            if didCancel {
+            // Only rebuild if there's a payment option to revert to; otherwise keep the current VC,
+            // which already holds whatever (possibly incomplete) input existed before presenting.
+            if didCancel, let paymentOptionBeforePresenting = self.paymentOptionBeforePresenting {
                 // The VC accumulates too much state during a session (link options, form input, SPM
                 // edits) to safely reset in place. Just rebuild it.
                 var savedPaymentMethods = self.viewController.savedPaymentMethods
-                if case .saved(let paymentMethod, _) = self.paymentOptionBeforePresenting {
+                if case .saved(let paymentMethod, _) = paymentOptionBeforePresenting {
                     savedPaymentMethods.removeAll(where: { $0.stripeId == paymentMethod.stripeId })
                     savedPaymentMethods.insert(paymentMethod, at: 0)
                 }
@@ -1057,7 +1059,7 @@ extension PaymentSheet.FlowController: FlowControllerViewControllerDelegate {
                     loadResult: updatedLoadResult,
                     analyticsHelper: self.analyticsHelper,
                     walletButtonsViewState: self.walletButtonsViewState,
-                    previousPaymentOption: self.paymentOptionBeforePresenting
+                    previousPaymentOption: paymentOptionBeforePresenting
                 )
                 self.viewController.flowControllerDelegate = self
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -524,6 +524,9 @@ extension PaymentSheet {
             paymentOptionBeforePresenting = internalPaymentOption
             // Overwrite completion closure to retain self until called
             let wrappedCompletion: (Bool) -> Void = { didCancel in
+                if !didCancel {
+                    self.updatePaymentOption()
+                }
                 completion?(didCancel)
                 self.presentPaymentOptionsCompletionWithResult = nil
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -596,15 +596,9 @@ extension SavedPaymentOptionsViewController: UICollectionViewDataSource, UIColle
                                               error: Error.collectionViewDidSelectItemAtAdd)
             STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
             stpAssertionFailure()
-        case .applePay:
-            CustomerPaymentOption.setDefaultPaymentMethod(.applePay, forCustomer: configuration.customerID)
-        case .link:
-            CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: configuration.customerID)
-        case .saved(let paymentMethod):
-            CustomerPaymentOption.setDefaultPaymentMethod(
-                .stripeId(paymentMethod.stripeId),
-                forCustomer: configuration.customerID
-            )
+        case .applePay, .link, .saved:
+            // Selection is persisted at the confirmation point (Continue/Pay), not on tap.
+            break
         }
         updateMandateView()
         cvcFormElement.clearTextFields()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -916,12 +916,9 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
         UISelectionFeedbackGenerator().selectionChanged()
 #endif
         switch selection {
-        case .applePay:
-            CustomerPaymentOption.setDefaultPaymentMethod(.applePay, forCustomer: configuration.customer?.id)
-        case .link:
-            CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: configuration.customer?.id)
-        case .saved(let paymentMethod):
-            CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(paymentMethod.stripeId), forCustomer: configuration.customer?.id)
+        case .applePay, .link, .saved:
+            // Selection is persisted at the confirmation point (Continue/Pay), not on tap.
+            break
         case let .new(paymentMethodType: paymentMethodType):
             let pmFormVC = makeFormVC(paymentMethodType: paymentMethodType)
             if pmFormVC.form.collectsUserInput || paymentMethodType.isBankPayment {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -712,8 +712,8 @@ extension PaymentSheetFlowControllerViewController: WalletHeaderViewDelegate {
         if canPresentLinkOnWalletButton {
             presentLink()
         } else {
-            didDismiss(didCancel: false)
             isHackyLinkButtonSelected = true
+            didDismiss(didCancel: false)
         }
 
         updateUI()

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -439,6 +439,112 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         wait(for: [legacyExpectation], timeout: 2.0)
     }
 
+    // MARK: - Cancel discards selection
+
+    private let testCustomerID = "cus_discard_selection_test"
+
+    private func makeFlowController() -> PaymentSheet.FlowController {
+        let savedPM = STPPaymentMethod._testCard()
+        var configuration = PaymentSheet.Configuration()
+        configuration.customer = .init(id: testCustomerID, ephemeralKeySecret: "")
+
+        let loadResult = PaymentSheetLoader.LoadResult(
+            intent: Intent._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: STPElementsSession._testCardValue(),
+            savedPaymentMethods: [savedPM],
+            paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
+        )
+
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(savedPM.stripeId), forCustomer: testCustomerID)
+        return PaymentSheet.FlowController(configuration: configuration, loadResult: loadResult, analyticsHelper: ._testValue())
+    }
+
+    private func present(_ fc: PaymentSheet.FlowController) -> XCTestExpectation {
+        let exp = expectation(description: "sheet dismissed")
+        fc.presentPaymentOptions(from: UIViewController()) { _ in exp.fulfill() }
+        return exp
+    }
+
+    private func selectLink(_ fc: PaymentSheet.FlowController) {
+        fc.viewController.linkConfirmOption = .wallet(brand: .link)
+    }
+
+    private func close(_ fc: PaymentSheet.FlowController, didCancel: Bool, expectation exp: XCTestExpectation) {
+        fc.flowControllerViewControllerShouldClose(fc.viewController, didCancel: didCancel)
+        wait(for: [exp], timeout: 2.0)
+    }
+
+    private func persistedDefault() -> CustomerPaymentOption? {
+        CustomerPaymentOption.selectedPaymentMethod(
+            for: testCustomerID,
+            elementsSession: STPElementsSession._testCardValue(),
+            surface: .paymentSheet
+        )
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: testCustomerID)
+    }
+
+    // Open, select Link, cancel. Reverts to card. UserDefaults unchanged.
+    func testCancelAfterChangingSelection_revertsPaymentOption() {
+        let fc = makeFlowController()
+        XCTAssertEqual(fc.paymentOption?.paymentMethodType, "card")
+
+        let exp = present(fc)
+        selectLink(fc)
+        close(fc, didCancel: true, expectation: exp)
+
+        XCTAssertEqual(fc.paymentOption?.paymentMethodType, "card")
+        XCTAssertEqual(persistedDefault(), .stripeId(STPPaymentMethod._testCard().stripeId))
+    }
+
+    // Open, select Link, continue. paymentOption updates to Link. UserDefaults persists Link.
+    func testContinueAfterChangingSelection_persistsNewSelection() {
+        let fc = makeFlowController()
+        XCTAssertEqual(fc.paymentOption?.paymentMethodType, "card")
+
+        let exp = present(fc)
+        selectLink(fc)
+        close(fc, didCancel: false, expectation: exp)
+
+        XCTAssertEqual(fc.paymentOption?.paymentMethodType, "link")
+        XCTAssertEqual(persistedDefault(), .link)
+    }
+
+    // Open, change nothing, cancel. No effect.
+    func testCancelWithoutChanging_preservesExistingSelection() {
+        let fc = makeFlowController()
+
+        let exp = present(fc)
+        close(fc, didCancel: true, expectation: exp)
+
+        XCTAssertEqual(fc.paymentOption?.paymentMethodType, "card")
+        XCTAssertEqual(persistedDefault(), .stripeId(STPPaymentMethod._testCard().stripeId))
+    }
+
+    // Confirm Link, then reopen, change selection, cancel. Reverts to Link (last confirmed).
+    func testCancelAfterPriorContinue_revertsToLastConfirmed() {
+        let fc = makeFlowController()
+
+        // First: confirm Link
+        let exp1 = present(fc)
+        selectLink(fc)
+        close(fc, didCancel: false, expectation: exp1)
+        XCTAssertEqual(fc.paymentOption?.paymentMethodType, "link")
+
+        // Second: open, deselect Link, cancel
+        let exp2 = present(fc)
+        fc.viewController.linkConfirmOption = nil
+        close(fc, didCancel: true, expectation: exp2)
+
+        XCTAssertEqual(fc.paymentOption?.paymentMethodType, "link")
+        XCTAssertEqual(persistedDefault(), .link)
+    }
+
     // MARK: - Checkout terminal session
 
     @MainActor

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -133,7 +133,11 @@ import UIKit
     public var collectionMode: CollectionMode {
         didSet {
             if oldValue != collectionMode {
-                updateAddressFields(for: countryCodes[country.selectedIndex], address: nil)
+                // If the "billing same as shipping" checkbox is selected, populate any newly displayed
+                // fields from the default (shipping) address so the displayed address still matches it.
+                // Otherwise, preserve the current field text.
+                let defaultAddress: AddressDetails.Address? = (!sameAsCheckbox.view.isHidden && sameAsCheckbox.isSelected) ? defaults.address : nil
+                updateAddressFields(for: countryCodes[country.selectedIndex], address: defaultAddress)
             }
         }
     }


### PR DESCRIPTION
## Summary

When a user opens the FlowController sheet, changes their payment method selection, and then dismisses without tapping Continue, the selection is now discarded. Previously it was persisted immediately on tap.

## Motivation
- CheckoutSessions

## Testing
- New tests, manual

## Changelog

N/A