### PR TITLE
Sync apple pay billing address for tax

### DIFF
--- a/Stripe/StripeiOSTests/STPApplePayContextTest.swift
+++ b/Stripe/StripeiOSTests/STPApplePayContextTest.swift
@@ -41,6 +41,16 @@ class STPApplePayTestDelegateiOS11: NSObject, STPApplePayContextDelegate {
         completion(.init(errors: nil, paymentSummaryItems: [], shippingMethods: []))
     }
 
+    var didSelectPaymentMethodCalled: Bool = false
+    func applePayContext(
+        _ context: STPApplePayContext,
+        didSelectPaymentMethod paymentMethod: PKPaymentMethod,
+        handler completion: @escaping (PKPaymentRequestPaymentMethodUpdate) -> Void
+    ) {
+        didSelectPaymentMethodCalled = true
+        completion(PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: []))
+    }
+
     func applePayContext(
         _ context: STPApplePayContext,
         didCompleteWith status: STPPaymentStatus,
@@ -142,6 +152,25 @@ class STPApplePayContextTest: XCTestCase {
         }
         wait(for: [couponCodeExpectation], timeout: 1)
         XCTAssertTrue(delegate.didChangeCouponCodeCalled)
+
+        // 4) ..didSelectPaymentMethod.. delegate method
+        XCTAssertTrue(
+            context.responds(
+                to: #selector(
+                    PKPaymentAuthorizationControllerDelegate.paymentAuthorizationController(
+                        _:
+                        didSelectPaymentMethod:
+                        handler:
+                    ))
+            )
+        )
+        XCTAssertFalse(delegate.didSelectPaymentMethodCalled)
+        let paymentMethodExpectation = expectation(description: "didSelectPaymentMethod forwarded")
+        context.paymentAuthorizationController(vc, didSelectPaymentMethod: PKPaymentMethod()) { _ in
+            paymentMethodExpectation.fulfill()
+        }
+        wait(for: [paymentMethodExpectation], timeout: 1)
+        XCTAssertTrue(delegate.didSelectPaymentMethodCalled)
 
         waitForExpectations(timeout: 2, handler: nil)
     }

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -566,7 +566,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
     }
 
     @objc
-    public func paymentAuthorizationController(
+    @_spi(STP) public func paymentAuthorizationController(
         _ controller: PKPaymentAuthorizationController,
         didSelectPaymentMethod paymentMethod: PKPaymentMethod,
         handler completion: @escaping (PKPaymentRequestPaymentMethodUpdate) -> Void

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -571,6 +571,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
         didSelectPaymentMethod paymentMethod: PKPaymentMethod,
         handler completion: @escaping (PKPaymentRequestPaymentMethodUpdate) -> Void
     ) {
+        // Note: this method isn't called unless our delegate implements it (see this class's `responds(to:)` override)
         guard let delegate else {
             return
         }

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -56,12 +56,10 @@ import PassKit
         didSelectShippingContact contact: PKContact
     ) async -> PKPaymentRequestShippingContactUpdate
 
-    /// Called when the Apple Pay sheet opens and when the user selects a different payment method (card).
-    /// Inspect the payment method's billing address and invoke the completion block with an updated
-    /// `PKPaymentRequestPaymentMethodUpdate` (e.g. to recalculate tax from the billing address).
-    /// - Note: Apple exposes only a partial billing address here — in the US, postal code/city/state, not the
-    /// street; the full address arrives in the `paymentInformation` passed to
-    /// `applePayContext:didCreatePaymentMethod:paymentInformation:`.
+    /// Called when the Apple Pay sheet opens and when the user changes their selected card.
+    /// Use the partial billing address on `paymentMethod` to recalculate tax, then call the handler.
+    /// - Note: Apple only exposes postal code/city/state/country here; the full street address
+    /// arrives in `paymentInformation` at authorization time.
     @_spi(STP) @MainActor @preconcurrency
     @objc optional func applePayContext(
         _ context: STPApplePayContext,
@@ -69,8 +67,7 @@ import PassKit
         handler: @escaping (_ update: PKPaymentRequestPaymentMethodUpdate) -> Void
     )
 
-    /// Async variant of the completion-block `didSelectPaymentMethod` above; returns the updated
-    /// `PKPaymentRequestPaymentMethodUpdate` instead of taking a handler. Implement one or the other.
+    /// Async variant of `didSelectPaymentMethod`. Implement one or the other, not both.
     @_spi(STP)
     @objc optional func applePayContext(
         _ context: STPApplePayContext,
@@ -574,7 +571,6 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
         didSelectPaymentMethod paymentMethod: PKPaymentMethod,
         handler completion: @escaping (PKPaymentRequestPaymentMethodUpdate) -> Void
     ) {
-        // Note: this method isn't called unless our delegate implements it (see this class's `responds(to:)` override)
         guard let delegate else {
             return
         }
@@ -582,7 +578,7 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
         let asyncDelegateMethod = #selector(_stpinternal_STPApplePayContextDelegateBase.applePayContext(_:didSelectPaymentMethod:))
         let respondsToCompletionBlockDelegateMethod = delegate.responds(to: completionBlockDelegateMethod)
         let respondsToAsyncDelegateMethod = delegate.responds(to: asyncDelegateMethod)
-        assert(!(respondsToAsyncDelegateMethod && respondsToCompletionBlockDelegateMethod), "Only implement either the async or completion-block based didSelectPaymentMethod delegate method, not both.")
+        assert(!(respondsToAsyncDelegateMethod && respondsToCompletionBlockDelegateMethod), "Implement either async or completion-block didSelectPaymentMethod, not both.")
         if respondsToCompletionBlockDelegateMethod {
             delegate.applePayContext?(self, didSelectPaymentMethod: paymentMethod, handler: completion)
         } else if respondsToAsyncDelegateMethod {

--- a/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
+++ b/StripeApplePay/StripeApplePay/Source/ApplePayContext/STPApplePayContext.swift
@@ -56,6 +56,27 @@ import PassKit
         didSelectShippingContact contact: PKContact
     ) async -> PKPaymentRequestShippingContactUpdate
 
+    /// Called when the Apple Pay sheet opens and when the user selects a different payment method (card).
+    /// Inspect the payment method's billing address and invoke the completion block with an updated
+    /// `PKPaymentRequestPaymentMethodUpdate` (e.g. to recalculate tax from the billing address).
+    /// - Note: Apple exposes only a partial billing address here — in the US, postal code/city/state, not the
+    /// street; the full address arrives in the `paymentInformation` passed to
+    /// `applePayContext:didCreatePaymentMethod:paymentInformation:`.
+    @_spi(STP) @MainActor @preconcurrency
+    @objc optional func applePayContext(
+        _ context: STPApplePayContext,
+        didSelectPaymentMethod paymentMethod: PKPaymentMethod,
+        handler: @escaping (_ update: PKPaymentRequestPaymentMethodUpdate) -> Void
+    )
+
+    /// Async variant of the completion-block `didSelectPaymentMethod` above; returns the updated
+    /// `PKPaymentRequestPaymentMethodUpdate` instead of taking a handler. Implement one or the other.
+    @_spi(STP)
+    @objc optional func applePayContext(
+        _ context: STPApplePayContext,
+        didSelectPaymentMethod paymentMethod: PKPaymentMethod
+    ) async -> PKPaymentRequestPaymentMethodUpdate
+
     /// Called when the user has entered or updated a coupon code. You should validate the
     /// coupon and must invoke the completion block with a PKPaymentRequestCouponCodeUpdate object.
     @MainActor @preconcurrency
@@ -390,12 +411,18 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
         let stp_didSelectShippingContact = #selector(_stpinternal_STPApplePayContextDelegateBase.applePayContext(_:didSelectShippingContact:handler:))
         let stp_didSelectShippingContact_async = #selector(_stpinternal_STPApplePayContextDelegateBase.applePayContext(_:didSelectShippingContact:))
 
+        // didSelectPaymentMethod
+        let pk_didSelectPaymentMethod = #selector(PKPaymentAuthorizationControllerDelegate.paymentAuthorizationController(_:didSelectPaymentMethod:handler:))
+        let stp_didSelectPaymentMethod = #selector(_stpinternal_STPApplePayContextDelegateBase.applePayContext(_:didSelectPaymentMethod:handler:))
+        let stp_didSelectPaymentMethod_async = #selector(_stpinternal_STPApplePayContextDelegateBase.applePayContext(_:didSelectPaymentMethod:))
+
         // Note: We can't implement _both_ the PK completion-block-based didSelectShippingMethod and the async version (try it - you'll see a compiler error).
         // We only implement the completion-block based method. If our delegate implements the async version, we call it.
         // Our method should be called if our delegate  implements *either* our completion-block-based didSelectShippingMethod *o*  the async version.
         var delegateToAppleDelegateMapping = [
             pk_didSelectShippingMethod: [stp_didSelectShippingMethod, stp_didSelectShippingMethod_async],
             pk_didSelectShippingContact: [stp_didSelectShippingContact, stp_didSelectShippingContact_async],
+            pk_didSelectPaymentMethod: [stp_didSelectPaymentMethod, stp_didSelectPaymentMethod_async],
         ]
 
         // Apple Pay can accept coupon codes directly, so we need to broker the
@@ -536,6 +563,31 @@ public class STPApplePayContext: NSObject, PKPaymentAuthorizationControllerDeleg
         } else if respondsToAsyncDelegateMethod {
             Task {
                 let update = await delegate.applePayContext!(self, didSelectShippingContact: contact)
+                completion(update)
+            }
+        }
+    }
+
+    @objc
+    public func paymentAuthorizationController(
+        _ controller: PKPaymentAuthorizationController,
+        didSelectPaymentMethod paymentMethod: PKPaymentMethod,
+        handler completion: @escaping (PKPaymentRequestPaymentMethodUpdate) -> Void
+    ) {
+        // Note: this method isn't called unless our delegate implements it (see this class's `responds(to:)` override)
+        guard let delegate else {
+            return
+        }
+        let completionBlockDelegateMethod = #selector(_stpinternal_STPApplePayContextDelegateBase.applePayContext(_:didSelectPaymentMethod:handler:))
+        let asyncDelegateMethod = #selector(_stpinternal_STPApplePayContextDelegateBase.applePayContext(_:didSelectPaymentMethod:))
+        let respondsToCompletionBlockDelegateMethod = delegate.responds(to: completionBlockDelegateMethod)
+        let respondsToAsyncDelegateMethod = delegate.responds(to: asyncDelegateMethod)
+        assert(!(respondsToAsyncDelegateMethod && respondsToCompletionBlockDelegateMethod), "Only implement either the async or completion-block based didSelectPaymentMethod delegate method, not both.")
+        if respondsToCompletionBlockDelegateMethod {
+            delegate.applePayContext?(self, didSelectPaymentMethod: paymentMethod, handler: completion)
+        } else if respondsToAsyncDelegateMethod {
+            Task {
+                let update = await delegate.applePayContext!(self, didSelectPaymentMethod: paymentMethod)
                 completion(update)
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+CheckoutSessionLineItems.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+CheckoutSessionLineItems.swift
@@ -14,11 +14,8 @@ import PassKit
 @_spi(STP) import StripePayments
 
 extension STPApplePayContext {
-    /// Builds Apple Pay summary items from a checkout session's current state. Used both for the initial
-    /// payment request and to refresh the sheet after billing changes, so the two stay identical.
-    ///
-    /// Prefers itemized line items (one row per item, optional subtotal/shipping/tax/discount breakdown),
-    /// falls back to a single total row, or a .pending row if amount is unknown.
+    /// Builds Apple Pay summary items from a checkout session's current state.
+    /// Falls back to a single total row (or .pending) when line items aren't available.
     static func makePaymentSummaryItems(
         for checkout: Checkout,
         label: String,
@@ -27,7 +24,6 @@ extension STPApplePayContext {
         let session: Checkout.Session = checkout.nonisolatedSession
 
         guard !session.lineItems.isEmpty, let total = session.total else {
-            // No line items available, fall back to a single summary row
             if let amount = session.expectedAmount() {
                 let decimalAmount = NSDecimalNumber.stp_decimalNumber(withAmount: amount, currency: currency)
                 return [PKPaymentSummaryItem(label: label, amount: decimalAmount, type: .final)]
@@ -114,9 +110,8 @@ extension STPApplePayContext {
         return summaryItems
     }
 
-    // Checkout.Address from the partial billing address Apple Pay exposes while the sheet is open. nil if
-    // there's no country to key tax on. line1/line2 are omitted: Apple withholds the street until
-    // authorization, so we only get country/city/state/postal here (enough for a tax region).
+    // Partial billing address from the Apple Pay sheet (no street until authorization).
+    // Returns nil if there's no country to key tax on.
     static func makeCheckoutAddress(from postalAddress: CNPostalAddress) -> Checkout.Address? {
         guard let country = postalAddress.isoCountryCode.nonEmpty else {
             return nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+CheckoutSessionLineItems.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+CheckoutSessionLineItems.swift
@@ -14,20 +14,32 @@ import PassKit
 @_spi(STP) import StripePayments
 
 extension STPApplePayContext {
-    /// Builds Apple Pay summary items from a CheckoutSession's line items and totals.
+    /// Builds Apple Pay summary items from a checkout session's current state. Used both for the initial
+    /// payment request and to refresh the sheet after billing changes, so the two stay identical.
     ///
-    /// One row per line item, optional Subtotal/Shipping/Tax/Discount rows, then the grand total.
-    /// Callers must guard against empty `lineItems` and fall back to default summary items.
-    static func makeApplePayPaymentSummaryItems(
-        lineItems: [Checkout.LineItem],
-        total: Checkout.Total,
-        totalLabel: String,
+    /// Prefers itemized line items (one row per item, optional subtotal/shipping/tax/discount breakdown),
+    /// falls back to a single total row, or a .pending row if amount is unknown.
+    static func makePaymentSummaryItems(
+        for checkout: Checkout,
+        label: String,
         currency: String?
     ) -> [PKPaymentSummaryItem] {
+        let session: Checkout.Session = checkout.nonisolatedSession
+
+        guard !session.lineItems.isEmpty, let total = session.total else {
+            // No line items available, fall back to a single summary row
+            if let amount = session.expectedAmount() {
+                let decimalAmount = NSDecimalNumber.stp_decimalNumber(withAmount: amount, currency: currency)
+                return [PKPaymentSummaryItem(label: label, amount: decimalAmount, type: .final)]
+            } else {
+                return [PKPaymentSummaryItem(label: label, amount: .zero, type: .pending)]
+            }
+        }
+
         var summaryItems: [PKPaymentSummaryItem] = []
 
-        for lineItem in lineItems {
-            let label = lineItem.quantity > 1
+        for lineItem in session.lineItems {
+            let itemLabel = lineItem.quantity > 1
                 ? String.Localized.lineItemLabel(name: lineItem.name, quantity: lineItem.quantity)
                 : lineItem.name
             let unitMinorUnits = lineItem.unitAmount?.minorUnitsAmount ?? 0
@@ -35,7 +47,7 @@ extension STPApplePayContext {
                 withAmount: unitMinorUnits * lineItem.quantity,
                 currency: currency
             )
-            summaryItems.append(PKPaymentSummaryItem(label: label, amount: amount, type: .final))
+            summaryItems.append(PKPaymentSummaryItem(label: itemLabel, amount: amount, type: .final))
         }
 
         let shipping = total.shippingRate.minorUnitsAmount
@@ -90,7 +102,7 @@ extension STPApplePayContext {
         // Apple Pay convention: the last item is the grand total.
         summaryItems.append(
             PKPaymentSummaryItem(
-                label: totalLabel,
+                label: label,
                 amount: NSDecimalNumber.stp_decimalNumber(
                     withAmount: total.total.minorUnitsAmount,
                     currency: currency
@@ -100,6 +112,23 @@ extension STPApplePayContext {
         )
 
         return summaryItems
+    }
+
+    // Checkout.Address from the partial billing address Apple Pay exposes while the sheet is open. nil if
+    // there's no country to key tax on. line1/line2 are omitted: Apple withholds the street until
+    // authorization, so we only get country/city/state/postal here (enough for a tax region).
+    static func makeCheckoutAddress(from postalAddress: CNPostalAddress) -> Checkout.Address? {
+        guard let country = postalAddress.isoCountryCode.nonEmpty else {
+            return nil
+        }
+        return Checkout.Address(
+            country: country,
+            line1: nil,
+            line2: nil,
+            city: postalAddress.city.nonEmpty,
+            state: postalAddress.state.nonEmpty,
+            postalCode: postalAddress.postalCode.nonEmpty
+        )
     }
 
     /// Converts a `Checkout.ContactAddress` into a `PKContact` for pre-populating the Apple Pay sheet.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -193,23 +193,21 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         paymentInformation: PKPayment,
         context: STPApplePayContext
     ) async throws -> String {
-        // Sync the full billing address (now available post-authorization) so the server
-        // computes final tax before we read expectedAmount.
-        if let stpPaymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: paymentMethod.allResponseFields) {
-            try await checkout.syncBillingAddress(from: stpPaymentMethod.billingDetails)
-        }
-
         let checkoutSession: Checkout.Session = checkout.nonisolatedSession
 
+        // 1. Build client attribution metadata
         let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(
             intent: intent,
             elementsSession: elementsSession
         )
 
+        // 2. Get expected amount from checkout session
         let expectedAmount = checkoutSession.expectedAmount()
 
+        // 3. Extract shipping details from PKPayment (if provided)
         let shipping = makeShippingDetailsParams(from: paymentInformation)
 
+        // 4. Call confirm API with the Apple Pay payment method
         let response = try await context.apiClient.confirmCheckoutSession(
             sessionId: checkoutSession.id,
             paymentMethod: paymentMethod.id,
@@ -221,7 +219,10 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
             clientAttributionMetadata: clientAttributionMetadata
         )
 
+        // 5. Update the Checkout instance with the confirmed session response
         try await checkout.commitSession(response)
+
+        // 6. Return client secret based on checkout session mode
         return try response.intentClientSecret()
     }
 
@@ -359,24 +360,22 @@ extension STPApplePayContext {
         }
 
         // Keep tax in sync with the billing address as the user switches cards.
-        var paymentMethodUpdateHandler: ((PKPaymentMethod, @escaping ((PKPaymentRequestPaymentMethodUpdate) -> Void)) -> Void)?
-        if case .checkout(let checkout) = intent {
+        let paymentMethodUpdateHandler: ((PKPaymentMethod, @escaping ((PKPaymentRequestPaymentMethodUpdate) -> Void)) -> Void)? = {
+            guard case .checkout(let checkout) = intent else { return nil }
             let label = intent.sellerDetails?.businessName ?? configuration.merchantDisplayName
             let currency = intent.currency
-            paymentMethodUpdateHandler = { pkPaymentMethod, completion in
+            return { pkPaymentMethod, completion in
                 Task { @MainActor in
                     if let postalAddress = pkPaymentMethod.billingAddress?.postalAddresses.first?.value,
                        let address = STPApplePayContext.makeCheckoutAddress(from: postalAddress) {
                         try? await checkout.updateBillingAddress(address: address, canUpdateWhileSheetPresented: true)
                     }
-                    let items = STPApplePayContext.makePaymentSummaryItems(for: checkout,
-                        label: label,
-                        currency: currency
-                    )
-                    completion(PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: items))
+                    completion(PKPaymentRequestPaymentMethodUpdate(
+                        paymentSummaryItems: STPApplePayContext.makePaymentSummaryItems(for: checkout, label: label, currency: currency)
+                    ))
                 }
             }
-        }
+        }()
 
         let delegate = ApplePayContextClosureDelegate(
             intent: intent,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -57,15 +57,6 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         self.selfRetainer = self
     }
 
-    // didSelectPaymentMethod fires on every payment (including sheet open), so only
-    // advertise the selector when we actually have a handler.
-    override func responds(to aSelector: Selector!) -> Bool {
-        if aSelector == #selector(_stpinternal_STPApplePayContextDelegateBase.applePayContext(_:didSelectPaymentMethod:handler:)) {
-            return paymentMethodUpdateHandler != nil
-        }
-        return super.responds(to: aSelector)
-    }
-
     func applePayContext(
         _ context: STPApplePayContext,
         didCreatePaymentMethod paymentMethod: StripeAPI.PaymentMethod,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -24,16 +24,14 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
     ((PKShippingMethod, @escaping ((PKPaymentRequestShippingMethodUpdate) -> Void)) -> Void)?
     let shippingContactUpdateHandler:
     ((PKContact, @escaping ((PKPaymentRequestShippingContactUpdate) -> Void)) -> Void)?
-    // Recalculates tax from the selected card's billing address. Non-nil only for checkout sessions
-    // that source tax from the billing address.
+    // Non-nil only for checkout sessions that source tax from the billing address.
     let paymentMethodUpdateHandler:
     ((PKPaymentMethod, @escaping ((PKPaymentRequestPaymentMethodUpdate) -> Void)) -> Void)?
 
     let intent: Intent
     let elementsSession: STPElementsSession
 
-    // Billing address captured before presenting the sheet, so we can restore it on cancel (opening the
-    // sheet / switching cards mutates it). nil if none was set.
+    // Snapshotted before presenting the sheet so we can restore on cancel.
     let billingAddressSnapshot: Checkout.ContactAddress?
 
     init(
@@ -64,8 +62,8 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         self.selfRetainer = self
     }
 
-    // didSelectPaymentMethod fires on *every* Apple Pay payment (including sheet open), unlike the shipping
-    // callbacks. Only advertise the selector when we have a handler, so unrelated flows are unaffected.
+    // didSelectPaymentMethod fires on every payment (including sheet open), so only
+    // advertise the selector when we actually have a handler.
     override func responds(to aSelector: Selector!) -> Bool {
         if aSelector == #selector(_stpinternal_STPApplePayContextDelegateBase.applePayContext(_:didSelectPaymentMethod:handler:)) {
             return paymentMethodUpdateHandler != nil
@@ -200,29 +198,23 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         paymentInformation: PKPayment,
         context: STPApplePayContext
     ) async throws -> String {
-        // Sync the full billing address (incl. line1, now available post-authorization) so the server computes
-        // the final tax. This also drains any in-flight sheet-open tax update, so expectedAmount below reflects
-        // the latest tax rather than a stale, pre-tax value.
+        // Sync the full billing address (now available post-authorization) so the server
+        // computes final tax before we read expectedAmount.
         if let stpPaymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: paymentMethod.allResponseFields) {
             try await checkout.syncBillingAddress(from: stpPaymentMethod.billingDetails)
         }
 
-        // Re-read after the sync so the values below reflect the latest tax.
         let checkoutSession: Checkout.Session = checkout.nonisolatedSession
 
-        // 1. Build client attribution metadata
         let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(
             intent: intent,
             elementsSession: elementsSession
         )
 
-        // 2. Get expected amount from checkout session
         let expectedAmount = checkoutSession.expectedAmount()
 
-        // 3. Extract shipping details from PKPayment (if provided)
         let shipping = makeShippingDetailsParams(from: paymentInformation)
 
-        // 4. Call confirm API with the Apple Pay payment method
         let response = try await context.apiClient.confirmCheckoutSession(
             sessionId: checkoutSession.id,
             paymentMethod: paymentMethod.id,
@@ -234,10 +226,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
             clientAttributionMetadata: clientAttributionMetadata
         )
 
-        // 5. Update the Checkout instance with the confirmed session response
         try await checkout.commitSession(response)
-
-        // 6. Return client secret based on checkout session mode
         return try response.intentClientSecret()
     }
 
@@ -296,14 +285,13 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         case .error:
             completion(.failed(error: error!), confirmType)
         case .userCancellation:
-            restoreBillingAddressAfterCancel()
+//            restoreBillingAddressAfterCancel()
             completion(.canceled, confirmType)
         }
         selfRetainer = nil
     }
 
-    // On cancel, undo the billing-address mutation from opening the sheet / switching cards (which
-    // recalculated tax from a card the user abandoned).
+    // Undo billing-address changes from switching cards when the user cancels.
     private func restoreBillingAddressAfterCancel() {
         guard case .checkout(let checkout) = intent else {
             return
@@ -311,13 +299,10 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         let snapshot = billingAddressSnapshot
         Task { @MainActor in
             guard let snapshot else {
-                // No billing address before Apple Pay, and the server can't fully clear a tax region (finest
-                // reset is country-only), so we can't perfectly undo. Leave the last-computed value — a
-                // documented limitation (MOBILESDK-4638).
+                // Can't fully clear a tax region server-side (MOBILESDK-4638)
                 return
             }
             do {
-                // No-ops if the address never changed.
                 try await checkout.updateBillingAddress(
                     name: snapshot.name,
                     phone: snapshot.phone,
@@ -325,7 +310,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
                     canUpdateWhileSheetPresented: true
                 )
             } catch {
-                // payment's already cancelled, nothing to do if restore fails
+                // Already cancelled, best-effort
             }
         }
     }
@@ -403,9 +388,7 @@ extension STPApplePayContext {
             paymentRequest = paymentRequestHandler(paymentRequest)
         }
 
-        // For checkout sessions that source tax from the billing address, keep the session's billing address
-        // (and displayed tax) in sync with the sheet as the user opens it / switches cards. Snapshot the
-        // current address first so we can restore it on cancel.
+        // Keep tax in sync with the billing address as the user switches cards.
         var paymentMethodUpdateHandler: ((PKPaymentMethod, @escaping ((PKPaymentRequestPaymentMethodUpdate) -> Void)) -> Void)?
         var billingAddressSnapshot: Checkout.ContactAddress?
         if case .checkout(let checkout) = intent {
@@ -416,11 +399,8 @@ extension STPApplePayContext {
                 Task { @MainActor in
                     if let postalAddress = pkPaymentMethod.billingAddress?.postalAddresses.first?.value,
                        let address = STPApplePayContext.makeCheckoutAddress(from: postalAddress) {
-                        // on failure, fall through with the current (unchanged) items
                         try? await checkout.updateBillingAddress(address: address, canUpdateWhileSheetPresented: true)
                     }
-                    // recompute from the (maybe updated) session: new tax on success, current total otherwise,
-                    // never an empty item list
                     let items = STPApplePayContext.makePaymentSummaryItems(for: checkout,
                         label: label,
                         currency: currency
@@ -475,7 +455,6 @@ extension STPApplePayContext {
             // Use the merchant supplied paymentSummaryItems
             paymentRequest.paymentSummaryItems = paymentSummaryItems
         } else if case .checkout(let checkout) = intent {
-            // same helper used to refresh the sheet post-tax-recalc, so initial and updated lists match
             paymentRequest.paymentSummaryItems = STPApplePayContext.makePaymentSummaryItems(for: checkout,
                 label: label,
                 currency: intent.currency

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -322,6 +322,8 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
                     handler(result)
                 }
             } else {
+                // Note: this method isn't called unless our delegate implements it (see this class's `responds(to:)` override)
+                stpAssertionFailure("This method should not be called unless paymentMethodUpdateHandler is set")
                 handler(PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: []))
             }
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -461,9 +461,11 @@ extension STPApplePayContext {
             paymentRequest.merchantCapabilities = merchantCapabilities
         }
 
-        // Pre-populate billingContact from the CheckoutSession's billing address if available
+        // Pre-populate billingContact from the CheckoutSession's billing address, but only
+        // if it has a street. Otherwise Apple Pay will show "Update Billing Address".
         if case .checkout(let checkout) = intent,
-           let billingAddress = checkout.nonisolatedSession.billingAddress {
+           let billingAddress = checkout.nonisolatedSession.billingAddress,
+           billingAddress.address.line1 != nil {
             paymentRequest.billingContact = Self.makeBillingContact(from: billingAddress)
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -327,6 +327,15 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
                 handler(PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: []))
             }
         }
+
+    // Only advertise `didSelectPaymentMethod` if we have a handler for it, otherwise it'd get called
+    // when there's nothing to do.
+    override func responds(to aSelector: Selector!) -> Bool {
+        if aSelector == #selector(applePayContext(_:didSelectPaymentMethod:handler:)) {
+            return paymentMethodUpdateHandler != nil
+        }
+        return super.responds(to: aSelector)
+    }
 }
 
 extension STPApplePayContext {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -31,9 +31,6 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
     let intent: Intent
     let elementsSession: STPElementsSession
 
-    // Snapshotted before presenting the sheet so we can restore on cancel.
-    let billingAddressSnapshot: Checkout.ContactAddress?
-
     init(
         intent: Intent,
         elementsSession: STPElementsSession,
@@ -47,7 +44,6 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         paymentMethodUpdateHandler: (
             (PKPaymentMethod, @escaping ((PKPaymentRequestPaymentMethodUpdate) -> Void)) -> Void
         )? = nil,
-        billingAddressSnapshot: Checkout.ContactAddress? = nil,
         completion: @escaping PaymentSheetResultCompletionBlock
     ) {
         self.completion = completion
@@ -55,7 +51,6 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         self.shippingMethodUpdateHandler = shippingMethodUpdateHandler
         self.shippingContactUpdateHandler = shippingContactUpdateHandler
         self.paymentMethodUpdateHandler = paymentMethodUpdateHandler
-        self.billingAddressSnapshot = billingAddressSnapshot
         self.intent = intent
         self.elementsSession = elementsSession
         super.init()
@@ -285,34 +280,9 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         case .error:
             completion(.failed(error: error!), confirmType)
         case .userCancellation:
-//            restoreBillingAddressAfterCancel()
             completion(.canceled, confirmType)
         }
         selfRetainer = nil
-    }
-
-    // Undo billing-address changes from switching cards when the user cancels.
-    private func restoreBillingAddressAfterCancel() {
-        guard case .checkout(let checkout) = intent else {
-            return
-        }
-        let snapshot = billingAddressSnapshot
-        Task { @MainActor in
-            guard let snapshot else {
-                // Can't fully clear a tax region server-side (MOBILESDK-4638)
-                return
-            }
-            do {
-                try await checkout.updateBillingAddress(
-                    name: snapshot.name,
-                    phone: snapshot.phone,
-                    address: snapshot.address,
-                    canUpdateWhileSheetPresented: true
-                )
-            } catch {
-                // Already cancelled, best-effort
-            }
-        }
     }
 
     func applePayContext(
@@ -390,9 +360,7 @@ extension STPApplePayContext {
 
         // Keep tax in sync with the billing address as the user switches cards.
         var paymentMethodUpdateHandler: ((PKPaymentMethod, @escaping ((PKPaymentRequestPaymentMethodUpdate) -> Void)) -> Void)?
-        var billingAddressSnapshot: Checkout.ContactAddress?
         if case .checkout(let checkout) = intent {
-            billingAddressSnapshot = checkout.nonisolatedSession.billingAddress
             let label = intent.sellerDetails?.businessName ?? configuration.merchantDisplayName
             let currency = intent.currency
             paymentMethodUpdateHandler = { pkPaymentMethod, completion in
@@ -417,7 +385,6 @@ extension STPApplePayContext {
             shippingMethodUpdateHandler: configuration.applePay?.customHandlers?.shippingMethodUpdateHandler,
             shippingContactUpdateHandler: configuration.applePay?.customHandlers?.shippingContactUpdateHandler,
             paymentMethodUpdateHandler: paymentMethodUpdateHandler,
-            billingAddressSnapshot: billingAddressSnapshot,
             completion: completion
         )
         if let applePayContext = STPApplePayContext(paymentRequest: paymentRequest, delegate: delegate) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -24,9 +24,17 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
     ((PKShippingMethod, @escaping ((PKPaymentRequestShippingMethodUpdate) -> Void)) -> Void)?
     let shippingContactUpdateHandler:
     ((PKContact, @escaping ((PKPaymentRequestShippingContactUpdate) -> Void)) -> Void)?
+    // Recalculates tax from the selected card's billing address. Non-nil only for checkout sessions
+    // that source tax from the billing address.
+    let paymentMethodUpdateHandler:
+    ((PKPaymentMethod, @escaping ((PKPaymentRequestPaymentMethodUpdate) -> Void)) -> Void)?
 
     let intent: Intent
     let elementsSession: STPElementsSession
+
+    // Billing address captured before presenting the sheet, so we can restore it on cancel (opening the
+    // sheet / switching cards mutates it). nil if none was set.
+    let billingAddressSnapshot: Checkout.ContactAddress?
 
     init(
         intent: Intent,
@@ -38,16 +46,31 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         shippingContactUpdateHandler: (
             (PKContact, @escaping ((PKPaymentRequestShippingContactUpdate) -> Void)) -> Void
         )?,
+        paymentMethodUpdateHandler: (
+            (PKPaymentMethod, @escaping ((PKPaymentRequestPaymentMethodUpdate) -> Void)) -> Void
+        )? = nil,
+        billingAddressSnapshot: Checkout.ContactAddress? = nil,
         completion: @escaping PaymentSheetResultCompletionBlock
     ) {
         self.completion = completion
         self.authorizationResultHandler = authorizationResultHandler
         self.shippingMethodUpdateHandler = shippingMethodUpdateHandler
         self.shippingContactUpdateHandler = shippingContactUpdateHandler
+        self.paymentMethodUpdateHandler = paymentMethodUpdateHandler
+        self.billingAddressSnapshot = billingAddressSnapshot
         self.intent = intent
         self.elementsSession = elementsSession
         super.init()
         self.selfRetainer = self
+    }
+
+    // didSelectPaymentMethod fires on *every* Apple Pay payment (including sheet open), unlike the shipping
+    // callbacks. Only advertise the selector when we have a handler, so unrelated flows are unaffected.
+    override func responds(to aSelector: Selector!) -> Bool {
+        if aSelector == #selector(_stpinternal_STPApplePayContextDelegateBase.applePayContext(_:didSelectPaymentMethod:handler:)) {
+            return paymentMethodUpdateHandler != nil
+        }
+        return super.responds(to: aSelector)
     }
 
     func applePayContext(
@@ -177,6 +200,14 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         paymentInformation: PKPayment,
         context: STPApplePayContext
     ) async throws -> String {
+        // Sync the full billing address (incl. line1, now available post-authorization) so the server computes
+        // the final tax. This also drains any in-flight sheet-open tax update, so expectedAmount below reflects
+        // the latest tax rather than a stale, pre-tax value.
+        if let stpPaymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: paymentMethod.allResponseFields) {
+            try await checkout.syncBillingAddress(from: stpPaymentMethod.billingDetails)
+        }
+
+        // Re-read after the sync so the values below reflect the latest tax.
         let checkoutSession: Checkout.Session = checkout.nonisolatedSession
 
         // 1. Build client attribution metadata
@@ -265,9 +296,38 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         case .error:
             completion(.failed(error: error!), confirmType)
         case .userCancellation:
+            restoreBillingAddressAfterCancel()
             completion(.canceled, confirmType)
         }
         selfRetainer = nil
+    }
+
+    // On cancel, undo the billing-address mutation from opening the sheet / switching cards (which
+    // recalculated tax from a card the user abandoned).
+    private func restoreBillingAddressAfterCancel() {
+        guard case .checkout(let checkout) = intent else {
+            return
+        }
+        let snapshot = billingAddressSnapshot
+        Task { @MainActor in
+            guard let snapshot else {
+                // No billing address before Apple Pay, and the server can't fully clear a tax region (finest
+                // reset is country-only), so we can't perfectly undo. Leave the last-computed value — a
+                // documented limitation (MOBILESDK-4638).
+                return
+            }
+            do {
+                // No-ops if the address never changed.
+                try await checkout.updateBillingAddress(
+                    name: snapshot.name,
+                    phone: snapshot.phone,
+                    address: snapshot.address,
+                    canUpdateWhileSheetPresented: true
+                )
+            } catch {
+                // payment's already cancelled, nothing to do if restore fails
+            }
+        }
     }
 
     func applePayContext(
@@ -305,6 +365,19 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
                 handler(PKPaymentRequestShippingContactUpdate())
             }
         }
+
+    func applePayContext(
+        _ context: STPApplePayContext,
+        didSelectPaymentMethod paymentMethod: PKPaymentMethod,
+        handler: @escaping (PKPaymentRequestPaymentMethodUpdate) -> Void) {
+            if let paymentMethodUpdateHandler {
+                paymentMethodUpdateHandler(paymentMethod) { result in
+                    handler(result)
+                }
+            } else {
+                handler(PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: []))
+            }
+        }
 }
 
 extension STPApplePayContext {
@@ -329,12 +402,42 @@ extension STPApplePayContext {
         if let paymentRequestHandler = configuration.applePay?.customHandlers?.paymentRequestHandler {
             paymentRequest = paymentRequestHandler(paymentRequest)
         }
+
+        // For checkout sessions that source tax from the billing address, keep the session's billing address
+        // (and displayed tax) in sync with the sheet as the user opens it / switches cards. Snapshot the
+        // current address first so we can restore it on cancel.
+        var paymentMethodUpdateHandler: ((PKPaymentMethod, @escaping ((PKPaymentRequestPaymentMethodUpdate) -> Void)) -> Void)?
+        var billingAddressSnapshot: Checkout.ContactAddress?
+        if case .checkout(let checkout) = intent {
+            billingAddressSnapshot = checkout.nonisolatedSession.billingAddress
+            let label = intent.sellerDetails?.businessName ?? configuration.merchantDisplayName
+            let currency = intent.currency
+            paymentMethodUpdateHandler = { pkPaymentMethod, completion in
+                Task { @MainActor in
+                    if let postalAddress = pkPaymentMethod.billingAddress?.postalAddresses.first?.value,
+                       let address = STPApplePayContext.makeCheckoutAddress(from: postalAddress) {
+                        // on failure, fall through with the current (unchanged) items
+                        try? await checkout.updateBillingAddress(address: address, canUpdateWhileSheetPresented: true)
+                    }
+                    // recompute from the (maybe updated) session: new tax on success, current total otherwise,
+                    // never an empty item list
+                    let items = STPApplePayContext.makePaymentSummaryItems(for: checkout,
+                        label: label,
+                        currency: currency
+                    )
+                    completion(PKPaymentRequestPaymentMethodUpdate(paymentSummaryItems: items))
+                }
+            }
+        }
+
         let delegate = ApplePayContextClosureDelegate(
             intent: intent,
             elementsSession: elementsSession,
             authorizationResultHandler: configuration.applePay?.customHandlers?.authorizationResultHandler,
             shippingMethodUpdateHandler: configuration.applePay?.customHandlers?.shippingMethodUpdateHandler,
             shippingContactUpdateHandler: configuration.applePay?.customHandlers?.shippingContactUpdateHandler,
+            paymentMethodUpdateHandler: paymentMethodUpdateHandler,
+            billingAddressSnapshot: billingAddressSnapshot,
             completion: completion
         )
         if let applePayContext = STPApplePayContext(paymentRequest: paymentRequest, delegate: delegate) {
@@ -342,10 +445,7 @@ extension STPApplePayContext {
             applePayContext.apiClient = configuration.apiClient
             applePayContext.returnUrl = configuration.returnURL
             applePayContext.clientAttributionMetadata = clientAttributionMetadata
-            applePayContext.fallbackBillingDetails = makeFallbackBillingDetails(
-                intent: intent,
-                configuration: configuration
-            )
+            applePayContext.fallbackBillingDetails = makeFallbackBillingDetails(intent: intent, configuration: configuration)
             return applePayContext
         } else {
             // Delegate only deallocs when Apple Pay completes
@@ -374,13 +474,10 @@ extension STPApplePayContext {
         if let paymentSummaryItems = applePay.paymentSummaryItems {
             // Use the merchant supplied paymentSummaryItems
             paymentRequest.paymentSummaryItems = paymentSummaryItems
-        } else if case .checkout(let checkout) = intent,
-                  !checkout.nonisolatedSession.lineItems.isEmpty,
-                  let total = checkout.nonisolatedSession.total {
-            paymentRequest.paymentSummaryItems = STPApplePayContext.makeApplePayPaymentSummaryItems(
-                lineItems: checkout.nonisolatedSession.lineItems,
-                total: total,
-                totalLabel: label,
+        } else if case .checkout(let checkout) = intent {
+            // same helper used to refresh the sheet post-tax-recalc, so initial and updated lists match
+            paymentRequest.paymentSummaryItems = STPApplePayContext.makePaymentSummaryItems(for: checkout,
+                label: label,
                 currency: intent.currency
             )
         } else {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -673,6 +673,8 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
     }
 
     func testCreatePaymentRequest_CheckoutSession_PopulatesBillingContactWithCountryOnly() {
+        // A billing address without a street shouldn't be pre-populated on the Apple Pay sheet,
+        // otherwise Apple Pay shows "Update Billing Address" in red.
         let intent = Intent._testCheckoutSession(
             mode: .payment,
             amount: 2345,
@@ -684,18 +686,7 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
 
         let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
 
-        let billingContact = sut.billingContact
-        XCTAssertNotNil(billingContact)
-        XCTAssertNil(billingContact?.name)
-        XCTAssertNil(billingContact?.phoneNumber)
-
-        let postalAddress = billingContact?.postalAddress
-        XCTAssertNotNil(postalAddress)
-        XCTAssertEqual(postalAddress?.isoCountryCode, "GB")
-        XCTAssertEqual(postalAddress?.street, "")
-        XCTAssertEqual(postalAddress?.city, "")
-        XCTAssertEqual(postalAddress?.state, "")
-        XCTAssertEqual(postalAddress?.postalCode, "")
+        XCTAssertNil(sut.billingContact)
     }
 
     func testCreatePaymentRequest_CheckoutSession_PopulatesBillingContactWithLine1Only() {


### PR DESCRIPTION
## Summary
- Updates the billing address when Apple Pay is presented and when a new PM or the billing address changes
- Tax is reflected in the line items
- We do not reset the billing address to what it was prior to Apple Pay launching if a user closes it because Apple Pay remains selected, so the billing will be updated whenever the user selects a new payment method type and provides billing for that payment method.

#### Demo

https://github.com/user-attachments/assets/da4773bd-bf0b-43ea-8b3b-73fcbb1b758c



## Motivation
- CheckoutSessions

## Testing
- Unit test
- Manual

## Changelog
N/A