### PR TITLE
Ignore ReactNativeSDK SPI interface changes

### DIFF
--- a/.github/workflows/verify-public-interface.yml
+++ b/.github/workflows/verify-public-interface.yml
@@ -69,7 +69,7 @@ jobs:
             - Do these changes require API review?
 
             If you confirm these APIs need to be added/updated and have undergone necessary review, add the label `modifies public API` to this PR to acknowledge the interface change.
-            Additionally, if you modified or removed an existing API, ensure you update the changelog to reflect the necessary version bump for your changes. Regular public API changes require a MAJOR version bump, and SPI API changes (other than `@_spi(STP)`-only declarations) require a MINOR or MAJOR version bump.
+            Additionally, if you modified or removed an existing API, ensure you update the changelog to reflect the necessary version bump for your changes. Regular public API changes require a MAJOR version bump, and SPI API changes (other than declarations using only `@_spi(STP)` and/or `@_spi(ReactNativeSDK)`) require a MINOR or MAJOR version bump.
 
             ℹ️ If this comment appears to be left in error, make sure your branch is up-to-date with `master`.
           edit-mode: replace

--- a/ci_scripts/api_diff/diff_public_interface.rb
+++ b/ci_scripts/api_diff/diff_public_interface.rb
@@ -7,6 +7,7 @@ SPI_SEVERITY = 'spi'.freeze
 NO_SEVERITY = 'none'.freeze
 DIFF_OUTPUT_PATH = 'diff_result.txt'.freeze
 SEVERITY_OUTPUT_PATH = 'api_change_severity.txt'.freeze
+IGNORED_SPI_NAMES = %w[STP ReactNativeSDK].freeze
 
 def normalize_line(line)
   spi_attrs = line.scan(/@_spi\([^)]+\)/).sort
@@ -46,9 +47,9 @@ def sorted_diff_lines(old_path, new_path)
   end
 end
 
-def non_stp_spi_line?(line)
+def non_ignored_spi_line?(line)
   spi_names = line.scan(/@_spi\(([^)]+)\)/).flatten.map(&:strip)
-  spi_names.any? { |spi_name| spi_name != 'STP' }
+  spi_names.any? { |spi_name| !IGNORED_SPI_NAMES.include?(spi_name) }
 end
 
 def has_non_additive_changes?(lines)
@@ -86,7 +87,7 @@ GetFrameworks.framework_names('./modules.yaml').each do |framework_name|
   master_private_interface_path = "#{framework_name}-master.xcframework/#{simulator_slice}/#{public_interface_dir}/arm64-apple-ios-simulator.private.swiftinterface"
   branch_private_interface_path = "#{framework_name}-new.xcframework/#{simulator_slice}/#{public_interface_dir}/arm64-apple-ios-simulator.private.swiftinterface"
   spi_diff_lines = sorted_diff_lines(master_private_interface_path, branch_private_interface_path).select do |line|
-    line.include?('@_spi(') && non_stp_spi_line?(line)
+    line.include?('@_spi(') && non_ignored_spi_line?(line)
   end
 
   if has_non_additive_changes?(public_diff_lines)


### PR DESCRIPTION
## Summary
- Treat `@_spi(ReactNativeSDK)` like `@_spi(STP)` in verify-public-interface SPI severity detection.
- Update the workflow guidance to document that declarations using only those SPI namespaces do not require a MINOR/MAJOR changelog bump.

## Testing
- `rbenv exec ruby -c ci_scripts/api_diff/diff_public_interface.rb`
- `rbenv exec ruby -c ci_scripts/check_public_interface_changelog.rb`
- Synthetic API diff cases verifying ReactNativeSDK/STP-only SPI removals produce `none` while other SPI namespaces still produce `spi`.
