### PR TITLE
Return to login screen after logging out of Link wallet in standalone flow

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -144,7 +144,7 @@ extension PayWithLinkViewController {
         }
 
         var cancelButtonConfiguration: Button.Configuration? {
-            context.canPayAnotherWay ? .linkPlain(foregroundColor: linkAppearance?.colors?.primary ?? .linkTextBrand) : nil
+            context.canContinueWithoutLink ? .linkPlain(foregroundColor: linkAppearance?.colors?.primary ?? .linkTextBrand) : nil
         }
 
         /// Whether or not we must re-collect the card CVC.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController-WalletViewModel.swift
@@ -144,7 +144,7 @@ extension PayWithLinkViewController {
         }
 
         var cancelButtonConfiguration: Button.Configuration? {
-            context.shouldShowSecondaryCta ? .linkPlain(foregroundColor: linkAppearance?.colors?.primary ?? .linkTextBrand) : nil
+            context.canPayAnotherWay ? .linkPlain(foregroundColor: linkAppearance?.colors?.primary ?? .linkTextBrand) : nil
         }
 
         /// Whether or not we must re-collect the card CVC.

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -85,7 +85,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         var linkBrand: LinkBrand
         let shouldOfferApplePay: Bool
         let shouldFinishOnClose: Bool
-        let shouldShowSecondaryCta: Bool
+        let canPayAnotherWay: Bool
         let launchedFromFlowController: Bool
         let initiallySelectedPaymentDetailsID: String?
         let callToAction: ConfirmButton.CallToActionType
@@ -137,7 +137,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         ///   - configuration: PaymentSheet configuration.
         ///   - shouldOfferApplePay: Whether or not to show Apple Pay as a payment option.
         ///   - shouldFinishOnClose: Whether or not Link should finish with `.canceled` result instead of returning to Payment Sheet when the close button is tapped.
-        ///   - shouldShowSecondaryCta: Whether or not a secondary CTA to pay another way should be shown.
+        ///   - canPayAnotherWay: Whether the user can exit Link and pay with a different method (e.g. via PaymentSheet).
         ///   - launchedFromFlowController: Whether the flow was opened from `FlowController`.
         ///   - initiallySelectedPaymentDetailsID: The ID of an initially selected payment method. This is set when opened instead of FlowController.
         ///   - callToAction: A custom CTA to display on the confirm button. If `nil`, will display `intent`'s default CTA.
@@ -152,7 +152,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
             linkBrand: LinkBrand,
             shouldOfferApplePay: Bool,
             shouldFinishOnClose: Bool,
-            shouldShowSecondaryCta: Bool = true,
+            canPayAnotherWay: Bool = true,
             launchedFromFlowController: Bool = false,
             initiallySelectedPaymentDetailsID: String?,
             callToAction: ConfirmButton.CallToActionType?,
@@ -167,7 +167,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
             self.linkBrand = linkBrand
             self.shouldOfferApplePay = shouldOfferApplePay
             self.shouldFinishOnClose = shouldFinishOnClose
-            self.shouldShowSecondaryCta = shouldShowSecondaryCta
+            self.canPayAnotherWay = canPayAnotherWay
             self.launchedFromFlowController = launchedFromFlowController
             self.initiallySelectedPaymentDetailsID = initiallySelectedPaymentDetailsID
             self.callToAction = callToAction ?? .makeDefaultType(intent: intent, withLock: false)
@@ -213,7 +213,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         configuration: PaymentElementConfiguration,
         shouldOfferApplePay: Bool = false,
         shouldFinishOnClose: Bool = false,
-        shouldShowSecondaryCta: Bool = true,
+        canPayAnotherWay: Bool = true,
         launchedFromFlowController: Bool = false,
         initiallySelectedPaymentDetailsID: String? = nil,
         callToAction: ConfirmButton.CallToActionType? = nil,
@@ -232,7 +232,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
                 linkBrand: configuration.resolvedLinkBrand(elementsSession: elementsSession, linkAccount: linkAccount),
                 shouldOfferApplePay: shouldOfferApplePay,
                 shouldFinishOnClose: shouldFinishOnClose,
-                shouldShowSecondaryCta: shouldShowSecondaryCta,
+                canPayAnotherWay: canPayAnotherWay,
                 launchedFromFlowController: launchedFromFlowController,
                 initiallySelectedPaymentDetailsID: initiallySelectedPaymentDetailsID,
                 callToAction: callToAction,
@@ -766,7 +766,7 @@ extension PayWithLinkViewController: PayWithLinkCoordinating {
         linkAccount?.logout()
         linkAccount = nil
 
-        if cancel {
+        if cancel && context.canPayAnotherWay {
             self.cancel(shouldReturnToPaymentSheet: true)
         } else {
             updateUI()

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -85,7 +85,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         var linkBrand: LinkBrand
         let shouldOfferApplePay: Bool
         let shouldFinishOnClose: Bool
-        let canPayAnotherWay: Bool
+        let canContinueWithoutLink: Bool
         let launchedFromFlowController: Bool
         let initiallySelectedPaymentDetailsID: String?
         let callToAction: ConfirmButton.CallToActionType
@@ -137,7 +137,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         ///   - configuration: PaymentSheet configuration.
         ///   - shouldOfferApplePay: Whether or not to show Apple Pay as a payment option.
         ///   - shouldFinishOnClose: Whether or not Link should finish with `.canceled` result instead of returning to Payment Sheet when the close button is tapped.
-        ///   - canPayAnotherWay: Whether the user can exit Link and pay with a different method (e.g. via PaymentSheet).
+        ///   - canContinueWithoutLink: Whether the user can exit Link and pay with a different method (e.g. via PaymentSheet).
         ///   - launchedFromFlowController: Whether the flow was opened from `FlowController`.
         ///   - initiallySelectedPaymentDetailsID: The ID of an initially selected payment method. This is set when opened instead of FlowController.
         ///   - callToAction: A custom CTA to display on the confirm button. If `nil`, will display `intent`'s default CTA.
@@ -152,7 +152,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
             linkBrand: LinkBrand,
             shouldOfferApplePay: Bool,
             shouldFinishOnClose: Bool,
-            canPayAnotherWay: Bool = true,
+            canContinueWithoutLink: Bool = true,
             launchedFromFlowController: Bool = false,
             initiallySelectedPaymentDetailsID: String?,
             callToAction: ConfirmButton.CallToActionType?,
@@ -167,7 +167,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
             self.linkBrand = linkBrand
             self.shouldOfferApplePay = shouldOfferApplePay
             self.shouldFinishOnClose = shouldFinishOnClose
-            self.canPayAnotherWay = canPayAnotherWay
+            self.canContinueWithoutLink = canContinueWithoutLink
             self.launchedFromFlowController = launchedFromFlowController
             self.initiallySelectedPaymentDetailsID = initiallySelectedPaymentDetailsID
             self.callToAction = callToAction ?? .makeDefaultType(intent: intent, withLock: false)
@@ -213,7 +213,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         configuration: PaymentElementConfiguration,
         shouldOfferApplePay: Bool = false,
         shouldFinishOnClose: Bool = false,
-        canPayAnotherWay: Bool = true,
+        canContinueWithoutLink: Bool = true,
         launchedFromFlowController: Bool = false,
         initiallySelectedPaymentDetailsID: String? = nil,
         callToAction: ConfirmButton.CallToActionType? = nil,
@@ -232,7 +232,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
                 linkBrand: configuration.resolvedLinkBrand(elementsSession: elementsSession, linkAccount: linkAccount),
                 shouldOfferApplePay: shouldOfferApplePay,
                 shouldFinishOnClose: shouldFinishOnClose,
-                canPayAnotherWay: canPayAnotherWay,
+                canContinueWithoutLink: canContinueWithoutLink,
                 launchedFromFlowController: launchedFromFlowController,
                 initiallySelectedPaymentDetailsID: initiallySelectedPaymentDetailsID,
                 callToAction: callToAction,
@@ -766,7 +766,7 @@ extension PayWithLinkViewController: PayWithLinkCoordinating {
         linkAccount?.logout()
         linkAccount = nil
 
-        if cancel && context.canPayAnotherWay {
+        if cancel && context.canContinueWithoutLink {
             self.cancel(shouldReturnToPaymentSheet: true)
         } else {
             updateUI()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -525,7 +525,7 @@ import UIKit
             ),
             linkAppearance: appearance,
             linkConfiguration: configuration,
-            shouldShowSecondaryCta: false
+            canPayAnotherWay: false
         ) { [weak self] confirmOption, shouldClearSelection in
             guard let confirmOption else {
                 if shouldClearSelection {
@@ -580,7 +580,7 @@ import UIKit
                 supportedPaymentMethodTypes: self.resolvedSupportedPaymentMethodTypes(override: nil),
                 linkAppearance: self.appearance,
                 linkConfiguration: self.configuration,
-                shouldShowSecondaryCta: false
+                canPayAnotherWay: false
             ) { [weak self] confirmOption, _ in
                 guard let self else { return }
                 guard let confirmOption else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -525,7 +525,7 @@ import UIKit
             ),
             linkAppearance: appearance,
             linkConfiguration: configuration,
-            canPayAnotherWay: false
+            canContinueWithoutLink: false
         ) { [weak self] confirmOption, shouldClearSelection in
             guard let confirmOption else {
                 if shouldClearSelection {
@@ -580,7 +580,7 @@ import UIKit
                 supportedPaymentMethodTypes: self.resolvedSupportedPaymentMethodTypes(override: nil),
                 linkAppearance: self.appearance,
                 linkConfiguration: self.configuration,
-                canPayAnotherWay: false
+                canContinueWithoutLink: false
             ) { [weak self] confirmOption, _ in
                 guard let self else { return }
                 guard let confirmOption else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -28,7 +28,7 @@ extension UIViewController {
         supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
-        canPayAnotherWay: Bool = true,
+        canContinueWithoutLink: Bool = true,
         callback: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
     ) {
         let payWithLinkController = PayWithNativeLinkController(
@@ -46,7 +46,7 @@ extension UIViewController {
         payWithLinkController.presentForPaymentMethodSelection(
             from: self,
             initiallySelectedPaymentDetailsID: selectedPaymentDetailsID,
-            canPayAnotherWay: canPayAnotherWay,
+            canContinueWithoutLink: canContinueWithoutLink,
             completion: callback
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -28,7 +28,7 @@ extension UIViewController {
         supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
-        shouldShowSecondaryCta: Bool = true,
+        canPayAnotherWay: Bool = true,
         callback: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
     ) {
         let payWithLinkController = PayWithNativeLinkController(
@@ -46,7 +46,7 @@ extension UIViewController {
         payWithLinkController.presentForPaymentMethodSelection(
             from: self,
             initiallySelectedPaymentDetailsID: selectedPaymentDetailsID,
-            shouldShowSecondaryCta: shouldShowSecondaryCta,
+            canPayAnotherWay: canPayAnotherWay,
             completion: callback
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -109,7 +109,7 @@ final class PayWithNativeLinkController {
     func presentForPaymentMethodSelection(
         from presentingController: UIViewController,
         initiallySelectedPaymentDetailsID: String?,
-        canPayAnotherWay: Bool = true,
+        canContinueWithoutLink: Bool = true,
         completion: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
     ) {
         presentAsBottomSheetInternal(
@@ -120,7 +120,7 @@ final class PayWithNativeLinkController {
             initiallySelectedPaymentDetailsID: initiallySelectedPaymentDetailsID,
             callToAction: .continue,
             shouldFinishOnClose: false,
-            canPayAnotherWay: canPayAnotherWay
+            canContinueWithoutLink: canContinueWithoutLink
         ) { completionResult in
             guard case .paymentMethodSelection(let confirmOption, let shouldReturnToPaymentSheet) = completionResult else {
                 return
@@ -138,7 +138,7 @@ final class PayWithNativeLinkController {
         initiallySelectedPaymentDetailsID: String? = nil,
         callToAction: ConfirmButton.CallToActionType? = nil,
         shouldFinishOnClose: Bool,
-        canPayAnotherWay: Bool = true,
+        canContinueWithoutLink: Bool = true,
         completion: @escaping (CompletionResult) -> Void
     ) {
         self.selfRetainer = self
@@ -154,7 +154,7 @@ final class PayWithNativeLinkController {
                 configuration: self.configuration,
                 shouldOfferApplePay: shouldOfferApplePay,
                 shouldFinishOnClose: shouldFinishOnClose,
-                canPayAnotherWay: canPayAnotherWay,
+                canContinueWithoutLink: canContinueWithoutLink,
                 launchedFromFlowController: launchedFromFlowController,
                 initiallySelectedPaymentDetailsID: initiallySelectedPaymentDetailsID,
                 callToAction: callToAction,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -109,7 +109,7 @@ final class PayWithNativeLinkController {
     func presentForPaymentMethodSelection(
         from presentingController: UIViewController,
         initiallySelectedPaymentDetailsID: String?,
-        shouldShowSecondaryCta: Bool = true,
+        canPayAnotherWay: Bool = true,
         completion: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
     ) {
         presentAsBottomSheetInternal(
@@ -120,7 +120,7 @@ final class PayWithNativeLinkController {
             initiallySelectedPaymentDetailsID: initiallySelectedPaymentDetailsID,
             callToAction: .continue,
             shouldFinishOnClose: false,
-            shouldShowSecondaryCta: shouldShowSecondaryCta
+            canPayAnotherWay: canPayAnotherWay
         ) { completionResult in
             guard case .paymentMethodSelection(let confirmOption, let shouldReturnToPaymentSheet) = completionResult else {
                 return
@@ -138,7 +138,7 @@ final class PayWithNativeLinkController {
         initiallySelectedPaymentDetailsID: String? = nil,
         callToAction: ConfirmButton.CallToActionType? = nil,
         shouldFinishOnClose: Bool,
-        shouldShowSecondaryCta: Bool = true,
+        canPayAnotherWay: Bool = true,
         completion: @escaping (CompletionResult) -> Void
     ) {
         self.selfRetainer = self
@@ -154,7 +154,7 @@ final class PayWithNativeLinkController {
                 configuration: self.configuration,
                 shouldOfferApplePay: shouldOfferApplePay,
                 shouldFinishOnClose: shouldFinishOnClose,
-                shouldShowSecondaryCta: shouldShowSecondaryCta,
+                canPayAnotherWay: canPayAnotherWay,
                 launchedFromFlowController: launchedFromFlowController,
                 initiallySelectedPaymentDetailsID: initiallySelectedPaymentDetailsID,
                 callToAction: callToAction,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -159,7 +159,7 @@ typealias ExpressType = PaymentSheet.WalletButtonsVisibility.ExpressType
             linkController.presentForPaymentMethodSelection(
                 from: WindowAuthenticationContext().authenticationPresentingViewController(),
                 initiallySelectedPaymentDetailsID: nil,
-                canPayAnotherWay: false,
+                canContinueWithoutLink: false,
                 completion: { confirmOptions, _ in
                     guard let confirmOptions else {
                         return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -159,7 +159,7 @@ typealias ExpressType = PaymentSheet.WalletButtonsVisibility.ExpressType
             linkController.presentForPaymentMethodSelection(
                 from: WindowAuthenticationContext().authenticationPresentingViewController(),
                 initiallySelectedPaymentDetailsID: nil,
-                shouldShowSecondaryCta: false,
+                canPayAnotherWay: false,
                 completion: { confirmOptions, _ in
                     guard let confirmOptions else {
                         return

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
@@ -383,12 +383,12 @@ class PayWithLinkViewController_WalletViewModelTests: XCTestCase {
     }
 
     func testShouldShowSecondaryButtonEnabled() throws {
-        let sut = try makeSUT(shouldShowSecondaryCta: true)
+        let sut = try makeSUT(canPayAnotherWay: true)
         XCTAssertNotNil(sut.cancelButtonConfiguration)
     }
 
     func testShouldShowSecondaryButtonDisabled() throws {
-        let sut = try makeSUT(shouldShowSecondaryCta: false)
+        let sut = try makeSUT(canPayAnotherWay: false)
         XCTAssertNil(sut.cancelButtonConfiguration)
     }
 }
@@ -405,7 +405,7 @@ extension PayWithLinkViewController_WalletViewModelTests {
         linkPassthroughModeEnabled: Bool? = nil,
         isSettingUp: Bool = false,
         linkPMOSFU: Bool? = nil,
-        shouldShowSecondaryCta: Bool = true
+        canPayAnotherWay: Bool = true
     ) throws -> PayWithLinkViewController.WalletViewModel {
         // Enable card funding filtering when allowedCardFundingTypes is not .all
         let cardFundingFilteringEnabled = allowedCardFundingTypes != .all
@@ -444,7 +444,7 @@ extension PayWithLinkViewController_WalletViewModelTests {
                 linkBrand: .link,
                 shouldOfferApplePay: false,
                 shouldFinishOnClose: false,
-                shouldShowSecondaryCta: shouldShowSecondaryCta,
+                canPayAnotherWay: canPayAnotherWay,
                 initiallySelectedPaymentDetailsID: nil,
                 callToAction: nil,
                 supportedPaymentMethodTypes: supportedPaymentMethodTypes,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
@@ -383,12 +383,12 @@ class PayWithLinkViewController_WalletViewModelTests: XCTestCase {
     }
 
     func testShouldShowSecondaryButtonEnabled() throws {
-        let sut = try makeSUT(canPayAnotherWay: true)
+        let sut = try makeSUT(canContinueWithoutLink: true)
         XCTAssertNotNil(sut.cancelButtonConfiguration)
     }
 
     func testShouldShowSecondaryButtonDisabled() throws {
-        let sut = try makeSUT(canPayAnotherWay: false)
+        let sut = try makeSUT(canContinueWithoutLink: false)
         XCTAssertNil(sut.cancelButtonConfiguration)
     }
 }
@@ -405,7 +405,7 @@ extension PayWithLinkViewController_WalletViewModelTests {
         linkPassthroughModeEnabled: Bool? = nil,
         isSettingUp: Bool = false,
         linkPMOSFU: Bool? = nil,
-        canPayAnotherWay: Bool = true
+        canContinueWithoutLink: Bool = true
     ) throws -> PayWithLinkViewController.WalletViewModel {
         // Enable card funding filtering when allowedCardFundingTypes is not .all
         let cardFundingFilteringEnabled = allowedCardFundingTypes != .all
@@ -444,7 +444,7 @@ extension PayWithLinkViewController_WalletViewModelTests {
                 linkBrand: .link,
                 shouldOfferApplePay: false,
                 shouldFinishOnClose: false,
-                canPayAnotherWay: canPayAnotherWay,
+                canContinueWithoutLink: canContinueWithoutLink,
                 initiallySelectedPaymentDetailsID: nil,
                 callToAction: nil,
                 supportedPaymentMethodTypes: supportedPaymentMethodTypes,


### PR DESCRIPTION
Resolves https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-212

## Summary

Updates Link Standalone logout behavior of returning to the login screen rather than dismissing the flow entirely. When the Link wallet is presented via MPE, logging out returns back to MPE, but in this integration there is no MPE to return to. This fixes that.

This integration is captured by `context.shouldShowSecondaryCta == false`, but that name wasn't really accurate. I renamed it to `canPayAnotherWay`.

## Motivation

https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-212

## Testing

Before:

https://github.com/user-attachments/assets/a18fe23e-b398-4ac3-8661-1b36900127b2

After:


https://github.com/user-attachments/assets/5a96c66f-a0ec-4bf7-bfc1-33411f2c5e03

MPE -> Link Wallet behavior of returning to MPE is unaffected:


https://github.com/user-attachments/assets/b4bb14d4-43f0-4b31-aa3d-0d41f289bc92



## Changelog

N/a