### PR TITLE
Fall back to saved payment method billing details

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/PaymentOption+Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/PaymentOption+Checkout.swift
@@ -1,0 +1,34 @@
+//
+//  PaymentOption+Checkout.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 7/16/26.
+//
+
+import Foundation
+@_spi(STP) import StripePayments
+
+extension PaymentOption {
+    /// The billing details used to sync a CheckoutSession's billing address for tax calculation.
+    ///
+    /// This is only read on CheckoutSession confirm paths (see `Checkout.syncBillingAddress(from:)`);
+    /// other flows never consume it.
+    var checkoutBillingDetails: STPPaymentMethodBillingDetails? {
+        switch self {
+        case .new(let confirmParams):
+            return confirmParams.paymentMethodParams.billingDetails
+        case .saved(let paymentMethod, let confirmParams):
+            // Saved payment methods have nil confirmParams, so fall back to the payment method's
+            // own billing details. Otherwise the billing address is dropped and tax is miscalculated.
+            return confirmParams?.paymentMethodParams.billingDetails ?? paymentMethod.billingDetails
+        case .external(_, let billingDetails):
+            return billingDetails
+        case .applePay:
+            // TODO(porter) Get Apple Pay working with automatic tax
+            return nil
+        case .link:
+            // Link does not support automatic tax with billing address as source
+            return nil
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
@@ -405,7 +405,7 @@ class EmbeddedFormViewController: UIViewController {
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
+                try await checkout.syncBillingAddress(from: paymentOption.checkoutBillingDetails)
             } catch {
                 self.error = error
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -138,8 +138,8 @@ extension PaymentSheet {
             switch self {
             case .new(let confirmParams):
                 return confirmParams.paymentMethodParams.billingDetails
-            case .saved(_, let confirmParams):
-                return confirmParams?.paymentMethodParams.billingDetails
+            case .saved(let paymentMethod, let confirmParams):
+                return confirmParams?.paymentMethodParams.billingDetails ?? paymentMethod.billingDetails
             case .external(_, let billingDetails):
                 return billingDetails
             case .applePay:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -133,23 +133,6 @@ extension PaymentSheet {
             }
             return false
         }
-
-        var billingDetails: STPPaymentMethodBillingDetails? {
-            switch self {
-            case .new(let confirmParams):
-                return confirmParams.paymentMethodParams.billingDetails
-            case .saved(let paymentMethod, let confirmParams):
-                return confirmParams?.paymentMethodParams.billingDetails ?? paymentMethod.billingDetails
-            case .external(_, let billingDetails):
-                return billingDetails
-            case .applePay:
-                // TODO(porter) Get Apple Pay working with automatic tax
-                return nil
-            case .link:
-                // Link does not support automatic tax with billing address as source
-                return nil
-            }
-        }
     }
 
     /// A class that presents the individual steps of a payment flow

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -791,7 +791,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
+                try await checkout.syncBillingAddress(from: paymentOption.checkoutBillingDetails)
             } catch {
                 self.error = error
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -500,7 +500,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         Task { @MainActor [weak self] in
             guard let self else { return }
             do {
-                try await checkout.syncBillingAddress(from: paymentOption.billingDetails)
+                try await checkout.syncBillingAddress(from: paymentOption.checkoutBillingDetails)
             } catch {
                 self.error = error
             }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -482,4 +482,29 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         }
         await fulfillment(of: [exp], timeout: 2.0)
     }
+
+    // MARK: - PaymentOption.billingDetails
+
+    func testSavedPaymentOptionBillingDetails_fallsBackToSavedPaymentMethod() {
+        // Given a saved PM that carries its own billing address and no confirmParams (the usual saved case)...
+        let savedCard = STPPaymentMethod._testCard(line1: "123 Main St", city: "SF", state: "CA", postalCode: "94105", countryCode: "US")
+        let option = PaymentSheet.PaymentOption.saved(paymentMethod: savedCard, confirmParams: nil)
+
+        // ...billingDetails falls back to the saved PM's billing details (rather than returning nil).
+        XCTAssertEqual(option.billingDetails?.address?.country, "US")
+        XCTAssertEqual(option.billingDetails?.address?.line1, "123 Main St")
+        XCTAssertEqual(option.billingDetails?.address?.postalCode, "94105")
+    }
+
+    func testSavedPaymentOptionBillingDetails_prefersConfirmParams() {
+        // Given a saved PM plus confirmParams (e.g. CVC recollection) that carry their own billing...
+        let savedCard = STPPaymentMethod._testCard(line1: "123 Main St", postalCode: "94105", countryCode: "US")
+        let confirmParams = IntentConfirmParams(type: .stripe(.card))
+        confirmParams.paymentMethodParams.nonnil_billingDetails.address = STPPaymentMethodAddress()
+        confirmParams.paymentMethodParams.nonnil_billingDetails.address?.country = "CA"
+        let option = PaymentSheet.PaymentOption.saved(paymentMethod: savedCard, confirmParams: confirmParams)
+
+        // ...confirmParams billing wins over the saved PM's billing.
+        XCTAssertEqual(option.billingDetails?.address?.country, "CA")
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -483,20 +483,20 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         await fulfillment(of: [exp], timeout: 2.0)
     }
 
-    // MARK: - PaymentOption.billingDetails
+    // MARK: - PaymentOption.checkoutBillingDetails
 
-    func testSavedPaymentOptionBillingDetails_fallsBackToSavedPaymentMethod() {
+    func testSavedPaymentOptionCheckoutBillingDetails_fallsBackToSavedPaymentMethod() {
         // Given a saved PM that carries its own billing address and no confirmParams (the usual saved case)...
         let savedCard = STPPaymentMethod._testCard(line1: "123 Main St", city: "SF", state: "CA", postalCode: "94105", countryCode: "US")
         let option = PaymentSheet.PaymentOption.saved(paymentMethod: savedCard, confirmParams: nil)
 
-        // ...billingDetails falls back to the saved PM's billing details (rather than returning nil).
-        XCTAssertEqual(option.billingDetails?.address?.country, "US")
-        XCTAssertEqual(option.billingDetails?.address?.line1, "123 Main St")
-        XCTAssertEqual(option.billingDetails?.address?.postalCode, "94105")
+        // ...checkoutBillingDetails falls back to the saved PM's billing details (rather than returning nil).
+        XCTAssertEqual(option.checkoutBillingDetails?.address?.country, "US")
+        XCTAssertEqual(option.checkoutBillingDetails?.address?.line1, "123 Main St")
+        XCTAssertEqual(option.checkoutBillingDetails?.address?.postalCode, "94105")
     }
 
-    func testSavedPaymentOptionBillingDetails_prefersConfirmParams() {
+    func testSavedPaymentOptionCheckoutBillingDetails_prefersConfirmParams() {
         // Given a saved PM plus confirmParams (e.g. CVC recollection) that carry their own billing...
         let savedCard = STPPaymentMethod._testCard(line1: "123 Main St", postalCode: "94105", countryCode: "US")
         let confirmParams = IntentConfirmParams(type: .stripe(.card))
@@ -505,6 +505,6 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         let option = PaymentSheet.PaymentOption.saved(paymentMethod: savedCard, confirmParams: confirmParams)
 
         // ...confirmParams billing wins over the saved PM's billing.
-        XCTAssertEqual(option.billingDetails?.address?.country, "CA")
+        XCTAssertEqual(option.checkoutBillingDetails?.address?.country, "CA")
     }
 }


### PR DESCRIPTION
## Summary
- `PaymentOption.billingDetails` now falls back to a saved payment method's own billing details. Previously the `.saved` case only read `confirmParams`, which is nil for saved payment methods, so it returned nil.
- When a customer selects a saved payment method, its billing address was dropped. That address feeds the checkout billing update, so the checkout session never received it and tax calculation was wrong.
- Only impacts CheckoutSessions

## Motivation
- CheckoutSessions

## Testing
- New unit test

## Changelog
N/A
