### PR TITLE
Use Link PM type, and attach mandate data to confirm params

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
@@ -67,6 +67,15 @@ struct ExampleLinkControllerPreviewView: View {
                         }
                     }
 
+                    DemoSection(title: "Intent Payment Method Types") {
+                        Picker("Intent Payment Method Types", selection: $configuration.paymentMethodTypesMode) {
+                            ForEach(LinkControllerDemoConfiguration.PaymentMethodTypesMode.allCases, id: \.self) { mode in
+                                Text(mode.rawValue).tag(mode)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                    }
+
                     DemoSection(title: "Intent Mode") {
                         VStack(alignment: .leading, spacing: 16) {
                             Picker("Intent Mode", selection: $configuration.intentMode) {

--- a/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoConfiguration.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoConfiguration.swift
@@ -9,7 +9,22 @@ struct LinkControllerDemoConfiguration {
     var email: String = "foo@bar.com"
     var phone: String = ""
     var supportedPaymentMethodTypes: Set<LinkPaymentMethodType> = Set(LinkPaymentMethodType.allCases)
+    var paymentMethodTypesMode: PaymentMethodTypesMode = .automatic
     var intentMode: IntentMode = .sdkManaged
+
+    var paymentMethodTypes: [String]? {
+        switch paymentMethodTypesMode {
+        case .automatic:
+            return nil
+        case .link:
+            return ["link"]
+        }
+    }
+
+    enum PaymentMethodTypesMode: String, CaseIterable {
+        case automatic = "Automatic"
+        case link = "Link"
+    }
 
     enum IntentMode: String, CaseIterable {
         case sdkManaged = "SDK Managed"

--- a/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoView.swift
@@ -193,6 +193,7 @@ struct LinkControllerDemoView: View {
             linkController = try await LinkController.create(
                 configuration: .init(
                     supportedPaymentMethodTypes: Array(configuration.supportedPaymentMethodTypes),
+                    paymentMethodTypes: configuration.paymentMethodTypes,
                     merchantDisplayName: "Example, Inc."
                 )
             )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
@@ -20,6 +20,10 @@ public struct LinkConfiguration {
     /// The payment method types to support in the Link sheet. If `nil` or empty, all available types are shown.
     @_spi(LinkControllerPreview) public let supportedPaymentMethodTypes: [LinkPaymentMethodType]?
 
+    /// The payment method types to use when creating the setup intent.
+    /// If `nil`, the payment method types used will be chosen automatically.
+    @_spi(LinkControllerPreview) public let paymentMethodTypes: [String]?
+
     /// The merchant name displayed in Link UI (e.g. consent text).
     /// If `nil`, defaults to the host app's `CFBundleDisplayName` / `CFBundleName`.
     @_spi(LinkControllerPreview) public let merchantDisplayName: String?
@@ -35,22 +39,26 @@ public struct LinkConfiguration {
         self.hintMessage = hintMessage
         self.allowLogout = allowLogout
         self.supportedPaymentMethodTypes = nil
+        self.paymentMethodTypes = nil
         self.merchantDisplayName = nil
     }
 
     /// Creates a new instance of `LinkConfiguration`.
     /// - Parameters:
     ///   - supportedPaymentMethodTypes: The payment method types to support in the Link sheet. If `nil` or empty, all available types are shown.
+    ///   - paymentMethodTypes: The payment method types to use when creating the setup intent. If `nil`, the payment method types used will be chosen automatically.
     ///   - allowLogout: Whether to allow the user to log out. When `false`, the logout menu button will be hidden. Defaults to `true`.
     ///   - merchantDisplayName: The merchant name displayed in Link UI. If `nil`, defaults to the app's `CFBundleDisplayName`.
     @_spi(LinkControllerPreview) public init(
         supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
+        paymentMethodTypes: [String]? = nil,
         allowLogout: Bool = true,
         merchantDisplayName: String? = nil
     ) {
         self.hintMessage = nil
         self.allowLogout = allowLogout
         self.supportedPaymentMethodTypes = supportedPaymentMethodTypes
+        self.paymentMethodTypes = paymentMethodTypes
         self.merchantDisplayName = merchantDisplayName
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -268,6 +268,7 @@ import UIKit
 
                 let loadResult = try await Self.loadElementsSession(
                     paymentElementConfiguration: paymentElementConfiguration,
+                    linkConfiguration: configuration,
                     analyticsHelper: analyticsHelper
                 )
 
@@ -331,6 +332,7 @@ import UIKit
 
                 let loadResult = try await Self.loadElementsSession(
                     paymentElementConfiguration: paymentElementConfiguration,
+                    linkConfiguration: configuration,
                     analyticsHelper: analyticsHelper
                 )
 
@@ -1059,6 +1061,7 @@ import UIKit
 
     private static func loadElementsSession(
         paymentElementConfiguration: PaymentElementConfiguration,
+        linkConfiguration: LinkConfiguration? = nil,
         analyticsHelper: PaymentSheetAnalyticsHelper
     ) async throws -> PaymentSheetLoader.LoadResult {
         // Stub path: no real intent, PM creation and confirmation handled externally.
@@ -1067,7 +1070,7 @@ import UIKit
                 currency: nil,
                 setupFutureUsage: .offSession
             ),
-            paymentMethodTypes: ["link"],
+            paymentMethodTypes: linkConfiguration?.paymentMethodTypes,
             confirmHandler: { _, _ in
                 stpAssertionFailure("The confirmHandler is not expected to be called in the LinkController.")
                 return PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -929,6 +929,10 @@ import UIKit
         let confirmParams = STPSetupIntentConfirmParams(clientSecret: clientSecret)
         confirmParams.paymentMethodID = paymentMethod.stripeId
 
+        // Required for off-session link PMs: captures consent given during the Link flow.
+        let mandateData = STPMandateDataParams.makeWithInferredValues()
+        confirmParams.mandateData = mandateData
+
         let authContext = ViewControllerAuthenticationContext(viewController: viewController)
         STPPaymentHandler.shared().confirmSetupIntent(
             params: confirmParams,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
@@ -11,6 +11,7 @@ final class LinkControllerPreviewAPITests: XCTestCase {
     func testPreviewSPISurfaceCompiles() {
         _ = LinkPaymentMethodType.card
         _ = LinkConfiguration(supportedPaymentMethodTypes: [.card])
+        _ = LinkConfiguration(paymentMethodTypes: ["link"]).paymentMethodTypes
         _ = LinkConfiguration(supportedPaymentMethodTypes: [.card], allowLogout: false).allowLogout
         _ = LinkConfiguration(supportedPaymentMethodTypes: [.card], merchantDisplayName: "Example Merchant")
 
@@ -19,14 +20,14 @@ final class LinkControllerPreviewAPITests: XCTestCase {
 
         if false {
             LinkController.create(
-                configuration: .init(supportedPaymentMethodTypes: [.card])
+                configuration: .init(supportedPaymentMethodTypes: [.card], paymentMethodTypes: ["link"])
             ) { result in
                 _ = result
             }
 
             Task { @MainActor in
                 let controller = try await LinkController.create(
-                    configuration: .init(supportedPaymentMethodTypes: [.card])
+                    configuration: .init(supportedPaymentMethodTypes: [.card], paymentMethodTypes: ["link"])
                 )
                 _ = controller.paymentMethodPreview
 


### PR DESCRIPTION
## Summary

1. Attaches mandate data to the setup intent before confirming it. This is required for bank payments, which would fail otherwise with `Missing required param: mandate_data`.
2. Sets `pmt=link` on the intent

## Motivation

1 is required for bank payments to work, 2 is needed for those to be treated as IBP, not ACH

## Testing

Tested manually

## Changelog

N/a
