### PR TITLE
[🪿] Make STPAPIClient.betas public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 The next release's version bump will so far be:
-PATCH
+MINOR
 
 ## X.Y.Z - changes pending release
 ### StripeCore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ The next release's version bump will so far be:
 PATCH
 
 ## X.Y.Z - changes pending release
+### StripeCore
+* [Added] `STPAPIClient.betas` is now public, allowing merchants to opt in to beta features that require a preview flag on the `Stripe-Version` header.
 
 ## 26.3.0 2026-07-13
 ### CryptoOnramp (Alpha)

--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -77,11 +77,7 @@ import UIKit
         configuration: StripeAPIConfiguration.sharedUrlSessionConfiguration
     )
 
-    /// A set of beta codes to enable on Stripe API requests, e.g. `["alipay_beta=v1"]`.
-    ///
-    /// Each value is appended to the `Stripe-Version` header, allowing merchants to opt in to
-    /// beta features that require a preview flag on the server. Only use this when a beta is
-    /// gated behind a server-side version header; most SDK betas are opted into via other APIs.
+    /// A set of beta headers to add to Stripe API requests e.g. `["alipay_beta=v1"]`.
     public var betas: Set<String> = []
 
     /// Returns `true` if `publishableKey` is actually a user key, `false` otherwise.

--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -77,8 +77,11 @@ import UIKit
         configuration: StripeAPIConfiguration.sharedUrlSessionConfiguration
     )
 
-    /// A set of beta headers to add to Stripe API requests e.g. `["alipay_beta=v1"]`.
-    @_spi(STP) public var betas: Set<String> = []
+    /// A set of beta codes to enable on Stripe API requests, e.g. `["alipay_beta=v1"]`.
+    ///
+    /// Each value is appended to the `Stripe-Version` header, allowing merchants to opt in to
+    /// beta features that require a preview flag on the server. Only use this when a beta is
+    /// gated behind a server-side version header; most SDK betas are opted into via other APIs.
     public var betas: Set<String> = []
 
     /// Returns `true` if `publishableKey` is actually a user key, `false` otherwise.

--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -77,8 +77,12 @@ import UIKit
         configuration: StripeAPIConfiguration.sharedUrlSessionConfiguration
     )
 
-    /// A set of beta headers to add to Stripe API requests e.g. `Set(["alipay_beta=v1"])`.
-    @_spi(STP) public var betas: Set<String> = []
+    /// A set of beta codes to enable on Stripe API requests, e.g. `["alipay_beta=v1"]`.
+    ///
+    /// Each value is appended to the `Stripe-Version` header, allowing merchants to opt in to
+    /// beta features that require a preview flag on the server. Only use this when a beta is
+    /// gated behind a server-side version header; most SDK betas are opted into via other APIs.
+    public var betas: Set<String> = []
 
     /// Returns `true` if `publishableKey` is actually a user key, `false` otherwise.
     @_spi(STP) public var publishableKeyIsUserKey: Bool {

--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -77,11 +77,8 @@ import UIKit
         configuration: StripeAPIConfiguration.sharedUrlSessionConfiguration
     )
 
-    /// A set of beta codes to enable on Stripe API requests, e.g. `["alipay_beta=v1"]`.
-    ///
-    /// Each value is appended to the `Stripe-Version` header, allowing merchants to opt in to
-    /// beta features that require a preview flag on the server. Only use this when a beta is
-    /// gated behind a server-side version header; most SDK betas are opted into via other APIs.
+    /// A set of beta headers to add to Stripe API requests e.g. `["alipay_beta=v1"]`.
+    @_spi(STP) public var betas: Set<String> = []
     public var betas: Set<String> = []
 
     /// Returns `true` if `publishableKey` is actually a user key, `false` otherwise.

--- a/StripeCore/StripeCoreTests/API Bindings/STPAPIClient+BetasTest.swift
+++ b/StripeCore/StripeCoreTests/API Bindings/STPAPIClient+BetasTest.swift
@@ -1,0 +1,40 @@
+//
+//  STPAPIClient+BetasTest.swift
+//  StripeCoreTests
+//
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+@_spi(STP) import StripeCore
+import XCTest
+
+class STPAPIClient_BetasTest: XCTestCase {
+    func testBetasAreAppendedToStripeVersionHeader() {
+        let apiClient = STPAPIClient(publishableKey: "pk_test_123")
+        apiClient.betas = ["alipay_beta=v1"]
+
+        let request = apiClient.configuredRequest(for: URL(string: "https://api.stripe.com/v1/tokens")!)
+        let stripeVersion = request.value(forHTTPHeaderField: "Stripe-Version")
+
+        XCTAssertNotNil(stripeVersion)
+        XCTAssertTrue(stripeVersion?.contains("alipay_beta=v1") ?? false)
+    }
+
+    func testMultipleBetasAreAppendedToStripeVersionHeader() {
+        let apiClient = STPAPIClient(publishableKey: "pk_test_123")
+        apiClient.betas = ["alipay_beta=v1", "some_other_beta=v2"]
+
+        let request = apiClient.configuredRequest(for: URL(string: "https://api.stripe.com/v1/tokens")!)
+        let stripeVersion = request.value(forHTTPHeaderField: "Stripe-Version")
+
+        XCTAssertNotNil(stripeVersion)
+        XCTAssertTrue(stripeVersion?.contains("alipay_beta=v1") ?? false)
+        XCTAssertTrue(stripeVersion?.contains("some_other_beta=v2") ?? false)
+    }
+
+    func testNoBetasByDefault() {
+        let apiClient = STPAPIClient(publishableKey: "pk_test_123")
+
+        XCTAssertTrue(apiClient.betas.isEmpty)
+    }
+}


### PR DESCRIPTION
## Summary
Previously `@_spi(STP)`, the ability to pass beta version headers is inherent to any Stripe API client and has valid merchant-facing use cases (e.g. beta-header-gated payment methods where the server requires a preview flag on the Stripe-Version header). Exposing it publicly is low risk since it simply widens access to an existing property.

Also updated the doc comment to use the `["alipay_beta=v1"]` example form and to note that beta headers should only be used when a feature can't be gated via `@_spi` and the server requires the header; most SDK betas are opted into via other APIs.

## Motivation
https://stripe.slack.com/archives/C0353FPANQ0/p1784214006249639

## Testing
Added tests covering single/multiple beta appending to the Stripe-Version header and the empty default.

## Changelog
See diff