### PR TITLE
CryptoOnramp SDK: Addresses Unknown Case Compiler Warning in Example App

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/Extensions/ComplianceRegulation+DisplayName.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/Extensions/ComplianceRegulation+DisplayName.swift
@@ -17,6 +17,8 @@ extension ComplianceRegulation {
             return "CRS/CARF"
         case .euMiCA:
             return "MiCA"
+        @unknown default:
+            return rawValue
         }
     }
 }


### PR DESCRIPTION
## Summary
Address an unknown case compiler warning in a switch statement in the CryptoOnramp example app.

## Motivation
To keep the example project warning-free.

## Testing
Cleaned and built to ensure the warning disappeared.

## Changelog
N/A, only changes example app