### PR TITLE
Collapse auto complete cases into one

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
@@ -267,7 +267,7 @@ final class LinkPaymentMethodFormElement: Element {
             countries: isBillingDetailsUpdateFlow ? configuration.billingDetailsCollectionConfiguration.allowedCountriesArray : nil,
             defaults: defaultBillingAddress,
             collectionMode: configuration.billingDetailsCollectionConfiguration.address == .full
-                ? .all()
+                ? .all
                 : .countryAndPostal(),
             additionalFields: additionalFields,
             theme: theme

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -419,9 +419,10 @@ extension AddressViewController {
     /// Expands the address section element and begin editing if the current country selection does not support auto complete
     private func expandAddressSectionIfNeeded() {
         // If we're in autocomplete mode and the country is not supported by autocomplete, switch to normal address collection
-        if let addressSection = addressSection, addressSection.collectionMode == .autoCompletable,
+        if let addressSection = addressSection,
+           case .autocomplete(_, .compact) = addressSection.collectionMode,
            !configuration.autocompleteCountries.caseInsensitiveContains(addressSection.selectedCountryCode) {
-            addressSection.collectionMode = .all(autocompletableCountries: configuration.autocompleteCountries)
+            addressSection.collectionMode = .autocomplete(autocompleteCountries: configuration.autocompleteCountries, presentation: .expanded)
         }
     }
 
@@ -435,7 +436,9 @@ extension AddressViewController {
             countries: configuration.allowedCountries.isEmpty ? nil : configuration.allowedCountries,
             addressSpecProvider: addressSpecProvider,
             defaults: .init(from: defaultValues),
-            collectionMode: showFullForm ? .all(autocompletableCountries: configuration.autocompleteCountries) : .autoCompletable,
+            collectionMode: showFullForm
+                ? .autocomplete(autocompleteCountries: configuration.autocompleteCountries, presentation: .expanded)
+                : .autocomplete(autocompleteCountries: configuration.autocompleteCountries),
             additionalFields: .init(from: configuration.additionalFields),
             theme: configuration.appearance.asElementsTheme,
             presentAutoComplete: { [weak self] in
@@ -535,7 +538,7 @@ extension AddressViewController: AutoCompleteViewControllerDelegate {
     func didSelectManualEntry(_ line1: String) {
         guard let addressSection = addressSection else { assertionFailure(); return }
         navigationController?.popViewController(animated: true)
-        addressSection.collectionMode = .all(autocompletableCountries: configuration.autocompleteCountries)
+        addressSection.collectionMode = .autocomplete(autocompleteCountries: configuration.autocompleteCountries, presentation: .expanded)
         addressSection.line1?.setText(line1)
     }
 
@@ -543,7 +546,7 @@ extension AddressViewController: AutoCompleteViewControllerDelegate {
         guard let addressSection = addressSection else { assertionFailure(); return }
         navigationController?.popViewController(animated: true)
         // Disable auto complete after address is selected
-        addressSection.collectionMode = .all(autocompletableCountries: configuration.autocompleteCountries)
+        addressSection.collectionMode = .autocomplete(autocompleteCountries: configuration.autocompleteCountries, presentation: .expanded)
         guard let address = address else {
             return
         }
@@ -635,7 +638,7 @@ extension AddressViewController {
             countries: configuration.allowedCountries.isEmpty ? nil : configuration.allowedCountries,
             addressSpecProvider: addressSpecProvider,
             defaults: .init(from: billingAddress),
-            collectionMode: .all(autocompletableCountries: configuration.autocompleteCountries),
+            collectionMode: .all,
             additionalFields: .init(from: configuration.additionalFields),
             theme: configuration.appearance.asElementsTheme,
             presentAutoComplete: { /* no-op for comparison */ }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerSheet/CustomerAddPaymentMethodViewController.swift
@@ -429,7 +429,7 @@ extension CustomerAddPaymentMethodViewController: AutoCompleteViewControllerDele
         // Dismiss the autocomplete view controller
         presentedViewController?.dismiss(animated: true) {
             // Switch to manual entry mode and set the line1 text
-            addressSectionElement.collectionMode = .allWithAutocomplete
+            addressSectionElement.collectionMode = .autocomplete(presentation: .expanded)
             addressSectionElement.line1?.setText(line1)
             addressSectionElement.line1?.beginEditing()
         }
@@ -441,7 +441,7 @@ extension CustomerAddPaymentMethodViewController: AutoCompleteViewControllerDele
         // Dismiss the autocomplete view controller
         presentedViewController?.dismiss(animated: true) {
             // Switch to manual entry mode after address selection
-            addressSectionElement.collectionMode = .allWithAutocomplete
+            addressSectionElement.collectionMode = .autocomplete(presentation: .expanded)
 
             guard let address = address else {
                 return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -96,7 +96,7 @@ extension PaymentSheetFormFactory {
             case .automatic:
                 return makeBillingAddressSection(collectionMode: .countryAndPostal(), countries: countries, includeEmail: shouldIncludeEmail, includePhone: shouldIncludePhone)
             case .full:
-                return makeBillingAddressSection(collectionMode: .autoCompletable, countries: countries, includeEmail: shouldIncludeEmail, includePhone: shouldIncludePhone)
+                return makeBillingAddressSection(collectionMode: .autocomplete(), countries: countries, includeEmail: shouldIncludeEmail, includePhone: shouldIncludePhone)
             case .never:
                 return nil
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -482,7 +482,7 @@ extension PaymentSheetFormFactory {
     }
 
     func makeBillingAddressSection(
-        collectionMode: AddressSectionElement.CollectionMode = .autoCompletable,
+        collectionMode: AddressSectionElement.CollectionMode = .autocomplete(),
         countries: [String]? = nil,
         countryAPIPath: String? = nil,
         includeEmail: Bool = false,
@@ -511,12 +511,13 @@ extension PaymentSheetFormFactory {
 
         // Determine the collection mode based on whether we have default values
         let finalCollectionMode: AddressSectionElement.CollectionMode = {
-            // If we have default address values (either from billing defaults or shipping details) and the requested mode would show all fields, use allWithAutocomplete
+            // If we have default address values, show the expanded form so those values are visible.
             let hasDefaultAddressValues = defaultBillingDetails().address != .init() || (configuration.shippingDetails() != nil && displayBillingSameAsShippingCheckbox)
             if hasDefaultAddressValues {
                 switch collectionMode {
-                case .autoCompletable:
-                    return .allWithAutocomplete
+                case .autocomplete(let autocompleteCountries, .compact):
+                    // Preserve any autocomplete country restrictions while expanding so default values are visible.
+                    return .autocomplete(autocompleteCountries: autocompleteCountries, presentation: .expanded)
                 default:
                     return collectionMode
                 }
@@ -699,7 +700,10 @@ extension PaymentSheetFormFactory {
 
         let phoneElement = configuration.billingDetailsCollectionConfiguration.phone == .always ? makePhone() : nil
         let addressElement = configuration.billingDetailsCollectionConfiguration.address == .full
-        ? makeBillingAddressSection(collectionMode: .autoCompletable, countries: configuration.billingDetailsCollectionConfiguration.allowedCountriesArray)
+            ? makeBillingAddressSection(
+                collectionMode: .autocomplete(),
+                countries: configuration.billingDetailsCollectionConfiguration.allowedCountriesArray
+            )
             : nil
         connectBillingDetailsFields(
             addressElement: addressElement,
@@ -795,7 +799,7 @@ extension PaymentSheetFormFactory {
         countryAPIPath: String? = nil
     ) -> PaymentMethodElementWrapper<AddressSectionElement> {
         makeBillingAddressSection(
-            collectionMode: configuration.billingDetailsCollectionConfiguration.address == .full ? .all() : .countryOnly,
+            collectionMode: configuration.billingDetailsCollectionConfiguration.address == .full ? .all : .countryOnly,
             countries: countries,
             countryAPIPath: countryAPIPath
         )
@@ -885,7 +889,7 @@ extension PaymentSheetFormFactory {
 
         let countries = configuration.billingDetailsCollectionConfiguration.allowedCountriesArray
         let addressElement = billingConfiguration.address == .full
-            ? makeBillingAddressSection(collectionMode: .autoCompletable, countries: countries)
+            ? makeBillingAddressSection(collectionMode: .autocomplete(), countries: countries)
             : nil
 
         // An email is required, so only hide the email field iff:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethodFormFactory/SavedPaymentMethodFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethodFormFactory/SavedPaymentMethodFormFactory+Card.swift
@@ -85,7 +85,7 @@ extension SavedPaymentMethodFormFactory {
             case .automatic:
                 return makeBillingAddressSection(configuration, collectionMode: .countryAndPostal(), countries: countries)
             case .full:
-                return makeBillingAddressSection(configuration, collectionMode: .all(), countries: countries)
+                return makeBillingAddressSection(configuration, collectionMode: .all, countries: countries)
             case .never:
                 return nil
             }
@@ -106,7 +106,7 @@ extension SavedPaymentMethodFormFactory {
 
     func makeBillingAddressSection(
         _ configuration: UpdatePaymentMethodViewController.Configuration,
-        collectionMode: AddressSectionElement.CollectionMode = .all(),
+        collectionMode: AddressSectionElement.CollectionMode = .all,
         countries: [String]? = nil) -> PaymentMethodElementWrapper<AddressSectionElement> {
             let section = AddressSectionElement(
                 title: String.Localized.billing_address_lowercase,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -179,7 +179,7 @@ class PaymentMethodFormViewController: UIViewController {
             let delegate = addressSection.delegate
             addressSection.delegate = nil  // Stop didUpdate delegate calls to avoid laying out while we're being presented
             if let newShippingAddress = configuration.shippingDetails()?.address {
-                addressSection.collectionMode = .allWithAutocomplete
+                addressSection.collectionMode = .autocomplete(presentation: .expanded)
                 addressSection.updateBillingSameAsShippingDefaultAddress(.init(newShippingAddress))
             } else {
                 addressSection.updateBillingSameAsShippingDefaultAddress(.init())
@@ -717,7 +717,7 @@ extension PaymentMethodFormViewController: AutoCompleteViewControllerDelegate {
         // Dismiss the autocomplete view controller
         presentedViewController?.dismiss(animated: true) {
             // Switch to manual entry mode and set the line1 text
-            addressSectionElement.collectionMode = .allWithAutocomplete
+            addressSectionElement.collectionMode = .autocomplete(presentation: .expanded)
             addressSectionElement.line1?.setText(line1)
             addressSectionElement.line1?.beginEditing()
         }
@@ -729,7 +729,7 @@ extension PaymentMethodFormViewController: AutoCompleteViewControllerDelegate {
         // Dismiss the autocomplete view controller
         presentedViewController?.dismiss(animated: true) {
             // Switch to manual entry mode after address selection
-            addressSectionElement.collectionMode = .allWithAutocomplete
+            addressSectionElement.collectionMode = .autocomplete(presentation: .expanded)
 
             guard let address = address else {
                 return

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
@@ -356,7 +356,7 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
         )
 
         let billingAddressSection = factory.makeBillingAddressSection(
-            collectionMode: .autoCompletable,
+            collectionMode: .autocomplete(),
             countries: nil,
             includeEmail: true,
             includePhone: true
@@ -386,7 +386,7 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
         )
 
         let billingAddressSection = factory.makeBillingAddressSection(
-            collectionMode: .autoCompletable,
+            collectionMode: .autocomplete(),
             countries: nil,
             includeEmail: false,
             includePhone: false

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -2508,7 +2508,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertFalse(instantDebitsSection.enableCTA)
 
         // Set a valid address
-        instantDebitsSection.addressElement?.collectionMode = .all() // simulate going to manual entry
+        instantDebitsSection.addressElement?.collectionMode = .all // simulate going to manual entry
         instantDebitsSection.addressElement?.city?.setText(defaultAddress.city!)
         instantDebitsSection.addressElement?.country.select(index: 0) // "US"
         instantDebitsSection.addressElement?.line1?.setText(defaultAddress.line1!)

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -67,18 +67,27 @@ import UIKit
 
     /// Describes which address fields to collect
     public enum CollectionMode: Equatable {
-        /// The default collection mode.
-        /// - Parameter autocompletableCountries: If non-empty, the line1 field displays an autocomplete accessory button if the current country is in this list. Set the `didTapAutocompleteButton` property to be notified when the button is tapped.
-        case all(autocompletableCountries: [String] = [])
-        /// Collects all address fields and always shows the autocomplete button for all countries.
-        case allWithAutocomplete
+        /// Shows all address fields without autocomplete.
+        case all
+        /// Shows address autocomplete.
+        /// - Parameters:
+        ///   - autocompleteCountries: Countries that support autocomplete. If nil, all countries are supported.
+        ///     Unsupported countries use manual entry in expanded mode.
+        ///     Compact mode callers should expand when an unsupported country is selected.
+        ///   - presentation: Whether to show only the autocomplete entry point or the full address form.
+        case autocomplete(autocompleteCountries: [String]? = nil, presentation: AutocompletePresentation = .compact)
         /// Collects country and postal code if the country is one of `countriesRequiringPostalCollection`
         /// - Note: Really only useful for cards, where we only collect postal for a handful of countries
         case countryAndPostal(countriesRequiringPostalCollection: [String] = ["US", "GB", "CA"])
-        /// Replaces the address line 1 field with `self.autoCompleteLine`
-        case autoCompletable
         /// Only collects the country. Used by Payment Methods that require a country but not the rest of the address.
         case countryOnly
+
+        public enum AutocompletePresentation: Equatable {
+            /// Shows country and the autocomplete line entry point.
+            case compact
+            /// Shows the full address form. Line 1 opens autocomplete when the selected country is supported.
+            case expanded
+        }
     }
     /// Fields that this section can collect in addition to the address
     public struct AdditionalFields {
@@ -178,7 +187,7 @@ import UIKit
         locale: Locale = .current,
         addressSpecProvider: AddressSpecProvider = .shared,
         defaults: AddressDetails = .empty,
-        collectionMode: CollectionMode = .all(),
+        collectionMode: CollectionMode = .all,
         additionalFields: AdditionalFields = .init(),
         theme: ElementsAppearance = .default,
         presentAutoComplete: @escaping () -> Void = { }
@@ -323,26 +332,21 @@ import UIKit
                 } else {
                    return false
                 }
-            case .autoCompletable:
+            case .autocomplete(_, .compact):
                 return false
-            case .allWithAutocomplete:
+            case .autocomplete(_, .expanded):
                 return true
             }
         }
 
-        if collectionMode == .autoCompletable {
+        if collectionMode.isCompactAutocomplete {
             autoCompleteLine = autoCompleteLine ?? DummyAddressLine(theme: theme, didTap: { [weak self] in self?.didTapAutocompleteButton() })
         } else {
             autoCompleteLine = nil
         }
         // Re-create the address fields
         if fieldOrdering.contains(.line) {
-            if case .all(let autocompletableCountries) = collectionMode, autocompletableCountries.caseInsensitiveContains(countryCode) {
-                line1 = TextFieldElement.Address.LineConfiguration(
-                    lineType: .line1Autocompletable(didTapAutocomplete: { [weak self] in self?.didTapAutocompleteButton() }),
-                    defaultValue: address.line1
-                ).makeElement(theme: theme)
-            } else if case .allWithAutocomplete = collectionMode {
+            if collectionMode.showsAutocompleteAccessory(for: countryCode) {
                 line1 = TextFieldElement.Address.LineConfiguration(
                     lineType: .line1Autocompletable(didTapAutocomplete: { [weak self] in self?.didTapAutocompleteButton() }),
                     defaultValue: address.line1
@@ -408,6 +412,26 @@ import UIKit
         return allDisplayedFieldsEqual
     }
 
+}
+
+private extension AddressSectionElement.CollectionMode {
+    var isCompactAutocomplete: Bool {
+        switch self {
+        case .autocomplete(_, .compact):
+            return true
+        case .all, .autocomplete(_, .expanded), .countryAndPostal, .countryOnly:
+            return false
+        }
+    }
+
+    func showsAutocompleteAccessory(for countryCode: String) -> Bool {
+        switch self {
+        case .autocomplete(let autocompleteCountries, .expanded):
+            return autocompleteCountries?.caseInsensitiveContains(countryCode) ?? true
+        case .all, .autocomplete(_, .compact), .countryAndPostal, .countryOnly:
+            return false
+        }
+    }
 }
 
 // MARK: - Element

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
@@ -131,6 +131,67 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertEqual(AddressSectionElement(title: "", countries: ["UK", "US"], addressSpecProvider: specProvider).countryCodes, ["UK", "US"])
     }
 
+    func testAutocompleteCompactPresentationShowsDummyAddressLine() {
+        let sut = AddressSectionElement(
+            title: "",
+            countries: ["US"],
+            locale: locale_enUS,
+            addressSpecProvider: dummyAddressSpecProvider,
+            collectionMode: .autocomplete(autocompleteCountries: ["US"])
+        )
+
+        XCTAssertNotNil(sut.autoCompleteLine)
+        XCTAssertNil(sut.line1)
+        XCTAssertNil(sut.line2)
+        XCTAssertNil(sut.city)
+        XCTAssertNil(sut.state)
+        XCTAssertNil(sut.postalCode)
+    }
+
+    func testAutocompleteExpandedPresentationShowsAutocompleteLine1() {
+        let sut = AddressSectionElement(
+            title: "",
+            countries: ["US"],
+            locale: locale_enUS,
+            addressSpecProvider: dummyAddressSpecProvider,
+            collectionMode: .autocomplete(presentation: .expanded)
+        )
+
+        XCTAssertNil(sut.autoCompleteLine)
+        XCTAssertNotNil(sut.line1)
+        XCTAssertLine1HasAutocompleteAccessory(sut)
+    }
+
+    func testAutocompleteExpandedPresentationRespectsSupportedCountries() {
+        let sut = AddressSectionElement(
+            title: "",
+            countries: ["US"],
+            locale: locale_enUS,
+            addressSpecProvider: dummyAddressSpecProvider,
+            collectionMode: .autocomplete(autocompleteCountries: ["CA"], presentation: .expanded)
+        )
+
+        XCTAssertLine1DoesNotHaveAutocompleteAccessory(sut)
+
+        sut.collectionMode = .autocomplete(autocompleteCountries: ["US"], presentation: .expanded)
+
+        XCTAssertLine1HasAutocompleteAccessory(sut)
+    }
+
+    func testAllCollectionModeDoesNotShowAutocomplete() {
+        let sut = AddressSectionElement(
+            title: "",
+            countries: ["US"],
+            locale: locale_enUS,
+            addressSpecProvider: dummyAddressSpecProvider,
+            collectionMode: .all
+        )
+
+        XCTAssertNil(sut.autoCompleteLine)
+        XCTAssertNotNil(sut.line1)
+        XCTAssertLine1DoesNotHaveAutocompleteAccessory(sut)
+    }
+
     func test_additionalFields() {
         for isOptional in [true, false] { // Test when the field is optional and when it's required
             // AddressSectionElement configured to collect a name and phone field...
@@ -353,5 +414,31 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertEqual(addressDetails.address.line2, linkBillingDetails.line2)
         XCTAssertEqual(addressDetails.address.postalCode, linkBillingDetails.postalCode)
         XCTAssertEqual(addressDetails.address.state, linkBillingDetails.state)
+    }
+
+    private func XCTAssertLine1HasAutocompleteAccessory(
+        _ sut: AddressSectionElement,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let configuration = sut.line1?.configuration as? TextFieldElement.Address.LineConfiguration else {
+            return XCTFail("Expected line1 to use LineConfiguration", file: file, line: line)
+        }
+        guard case .line1Autocompletable = configuration.lineType else {
+            return XCTFail("Expected line1 to show autocomplete", file: file, line: line)
+        }
+    }
+
+    private func XCTAssertLine1DoesNotHaveAutocompleteAccessory(
+        _ sut: AddressSectionElement,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let configuration = sut.line1?.configuration as? TextFieldElement.Address.LineConfiguration else {
+            return XCTFail("Expected line1 to use LineConfiguration", file: file, line: line)
+        }
+        guard case .line1 = configuration.lineType else {
+            return XCTFail("Expected line1 to omit autocomplete", file: file, line: line)
+        }
     }
 }


### PR DESCRIPTION
## Summary
Collapses the three overlapping "collect all address fields" cases on `AddressSectionElement.CollectionMode` (`.all(autocompletableCountries:)`, `.allWithAutocomplete`, `.autoCompletable`) into two clear cases: `.all` (no autocomplete) and `.autocomplete(autocompleteCountries:presentation:)` where presentation is `.compact` (entry point only) or `.expanded` (full form with line 1 autocomplete).

## Motivation
The old cases had overlapping semantics that were easy to mix up. Encoding "which countries get autocomplete" and "which fields to show" across three cases made call sites hard to read. The new shape makes both dimensions explicit.

## Testing
Added unit tests in `AddressSectionElementTest` covering compact vs expanded presentation, the supported-countries filter, and `.all` showing no autocomplete. Verified `StripeUICore` and `StripePaymentSheet` build clean including test targets.

## Changelog
N/A
