### PR TITLE
Intent.checkout -> Intent.checkoutSession

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPClientAttributionMetadata+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/STPClientAttributionMetadata+PaymentSheet.swift
@@ -34,11 +34,11 @@ extension STPClientAttributionMetadata {
             return .init(elementsSessionConfigId: elementsSessionConfigId,
                          paymentIntentCreationFlow: .deferred,
                          paymentMethodSelectionFlow: isAutomaticPaymentMethodsEnabled ? .automatic : .merchantSpecified)
-        case .checkout(let checkout):
+        case .checkout(let session):
             // CheckoutSession: Stripe owns the intent lifecycle, so omit `paymentIntentCreationFlow`
             // to match web's hosted Checkout behavior.
             return .init(elementsSessionConfigId: elementsSessionConfigId,
-                         checkoutSessionId: checkout.nonisolatedSession.id,
+                         checkoutSessionId: session.id,
                          paymentIntentCreationFlow: nil,
                          paymentMethodSelectionFlow: .automatic)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/SavedPaymentMethodManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/SavedPaymentMethodManager.swift
@@ -42,19 +42,19 @@ final class SavedPaymentMethodManager {
     func update(paymentMethod: STPPaymentMethod,
                 with updateParams: STPPaymentMethodUpdateParams) async throws -> STPPaymentMethod {
         switch intent {
-        case .checkout(let checkout):
+        case .checkout(let session):
             let billing = Checkout.PaymentMethodBillingDetails(updateParams.billingDetails)
             let expiry = Checkout.PaymentMethodExpiryDetails(updateParams.card)
             guard billing != nil || expiry != nil else {
                 throw PaymentSheetError.unknown(debugDescription: "Tried to update a payment method without billing details or expiry details.")
             }
-            let session = try await configuration.apiClient.updatePaymentMethod(
+            let updatedSession = try await configuration.apiClient.updatePaymentMethod(
                 paymentMethod.stripeId,
-                inCheckoutSession: checkout.session.id,
+                inCheckoutSession: session.id,
                 billingDetails: billing,
                 expiryDetails: expiry
             )
-            guard let updatedPaymentMethod = session.customer?.paymentMethods.first(where: { $0.stripeId == paymentMethod.stripeId }) else {
+            guard let updatedPaymentMethod = updatedSession.customer?.paymentMethods.first(where: { $0.stripeId == paymentMethod.stripeId }) else {
                 let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetError,
                                                   error: Error.missingUpdatedPaymentMethod,
                                                   additionalNonPIIParams: ["payment_method_id": paymentMethod.stripeId])
@@ -77,11 +77,11 @@ final class SavedPaymentMethodManager {
 
     func detach(paymentMethod: STPPaymentMethod) {
         switch intent {
-        case .checkout(let checkout):
+        case .checkout(let session):
             Task {
                 try? await configuration.apiClient.detachPaymentMethod(
                     paymentMethod.stripeId,
-                    fromCheckoutSession: checkout.nonisolatedSession.id
+                    fromCheckoutSession: session.id
                 )
             }
         case .paymentIntent, .setupIntent, .deferredIntent:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutSessionBillingAddressUpdater.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutSessionBillingAddressUpdater.swift
@@ -1,0 +1,64 @@
+//
+//  CheckoutSessionBillingAddressUpdater.swift
+//  StripePaymentSheet
+//
+//  Created by Yuki Tokuhiro on 7/17/26.
+//
+
+@_spi(STP) import StripePayments
+
+/// Narrow Checkout interface for MPE billing address updates.
+///
+/// This keeps MPE plumbing from depending on the full `Checkout` object or reading
+/// `checkout.session` directly. Callers must use these sanctioned update methods to sync
+/// billing changes or commit session updates.
+@MainActor
+protocol CheckoutSessionBillingAddressUpdater: AnyObject {
+    // TODO: Delete this when CheckoutSession confirmation no longer uses `PaymentSheet.confirm`.
+    func commitSession(
+        _ apiResponse: PaymentPagesAPIResponse?,
+        applying localMutation: (@MainActor @Sendable (Checkout.Session) -> Checkout.Session)?
+    ) async throws
+
+    func updateBillingAddressForPaymentSheet(
+        name: String?,
+        phone: String?,
+        address: Checkout.Address,
+        canUpdateWhileSheetPresented: Bool
+    ) async throws -> Checkout.Session
+}
+
+extension CheckoutSessionBillingAddressUpdater {
+    func commitSession(_ apiResponse: PaymentPagesAPIResponse) async throws {
+        try await commitSession(apiResponse, applying: nil)
+    }
+
+    func updateBillingAddressForPaymentSheet(
+        address: Checkout.Address,
+        canUpdateWhileSheetPresented: Bool
+    ) async throws -> Checkout.Session {
+        try await updateBillingAddressForPaymentSheet(
+            name: nil,
+            phone: nil,
+            address: address,
+            canUpdateWhileSheetPresented: canUpdateWhileSheetPresented
+        )
+    }
+}
+
+extension Checkout: CheckoutSessionBillingAddressUpdater {
+    func updateBillingAddressForPaymentSheet(
+        name: String?,
+        phone: String?,
+        address: Address,
+        canUpdateWhileSheetPresented: Bool
+    ) async throws -> Session {
+        try await updateBillingAddress(
+            name: name,
+            phone: phone,
+            address: address,
+            canUpdateWhileSheetPresented: canUpdateWhileSheetPresented
+        )
+        return session
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
@@ -89,6 +89,7 @@ class EmbeddedFormViewController: UIViewController {
     private let formCache: PaymentMethodFormCache
     private let analyticsHelper: PaymentSheetAnalyticsHelper
     private let paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper?
+    private weak var checkout: Checkout?
     private var error: Swift.Error?
     private var isPaymentInFlight: Bool = false
     /// Previous customer input - in the `update` flow, this is the customer input prior to `update`, used so we can restore their state in this VC.
@@ -170,6 +171,7 @@ class EmbeddedFormViewController: UIViewController {
          previousPaymentOption: PaymentOption? = nil,
          analyticsHelper: PaymentSheetAnalyticsHelper,
          paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper? = nil,
+         checkout: Checkout? = nil,
          formCache: PaymentMethodFormCache = .init(),
          delegate: EmbeddedFormViewControllerDelegate
     ) {
@@ -180,6 +182,7 @@ class EmbeddedFormViewController: UIViewController {
         self.previousPaymentOption = previousPaymentOption
         self.analyticsHelper = analyticsHelper
         self.paymentMethodMessagingPromotionsHelper = paymentMethodMessagingPromotionsHelper
+        self.checkout = checkout
         self.paymentMethodType = paymentMethodType
         self.formCache = formCache
         self.delegate = delegate
@@ -389,7 +392,7 @@ class EmbeddedFormViewController: UIViewController {
     /// Syncs billing address to the checkout session, then tells the delegate to continue.
     /// If the sync fails, stays on the sheet and shows the error instead.
     private func syncCheckoutBillingThenContinue() {
-        guard case .checkout(let checkout) = intent,
+        guard let checkout,
               let paymentOption = selectedPaymentOption else {
             delegate?.embeddedFormViewControllerDidContinue(self)
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -554,7 +554,8 @@ extension EmbeddedPaymentElement {
                 paymentHandler: self.paymentHandler,
                 integrationShape: .embedded,
                 confirmationChallenge: self.confirmationChallenge,
-                analyticsHelper: self.analyticsHelper
+                analyticsHelper: self.analyticsHelper,
+                checkout: self.checkout
             )
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -103,6 +103,7 @@ extension EmbeddedPaymentElement {
         savedPaymentMethods: [STPPaymentMethod],
         analyticsHelper: PaymentSheetAnalyticsHelper,
         paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper?,
+        checkout: Checkout?,
         formCache: PaymentMethodFormCache,
         delegate: EmbeddedFormViewControllerDelegate
     ) -> EmbeddedFormViewController? {
@@ -119,6 +120,7 @@ extension EmbeddedPaymentElement {
             previousPaymentOption: previousPaymentOption,
             analyticsHelper: analyticsHelper,
             paymentMethodMessagingPromotionsHelper: paymentMethodMessagingPromotionsHelper,
+            checkout: checkout,
             formCache: formCache,
             delegate: delegate
         )
@@ -151,6 +153,7 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
             savedPaymentMethods: savedPaymentMethods,
             analyticsHelper: analyticsHelper,
             paymentMethodMessagingPromotionsHelper: loadResult.paymentMethodMessagingPromotionsHelper,
+            checkout: checkout,
             formCache: formCache,
             delegate: self
         )
@@ -231,6 +234,7 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
             savedPaymentMethods: savedPaymentMethods,
             analyticsHelper: analyticsHelper,
             paymentMethodMessagingPromotionsHelper: nil, // This is just to check if there's a form, so this data isn't necessary
+            checkout: checkout,
             formCache: .init(),  // Use a fresh form cache to ensure forms aren't re-added to a different view controller's hierarchy
             delegate: self
         ) != nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -258,6 +258,7 @@ public final class EmbeddedPaymentElement {
                 savedPaymentMethods: loadResult.savedPaymentMethods,
                 analyticsHelper: self.analyticsHelper,
                 paymentMethodMessagingPromotionsHelper: loadResult.paymentMethodMessagingPromotionsHelper,
+                checkout: self.checkout,
                 formCache: self.formCache,
                 delegate: self
             )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Intent.swift
@@ -16,19 +16,19 @@ import UIKit
 
 // MARK: - Intent
 
-/// An internal type representing either a PaymentIntent, SetupIntent, a "deferred Intent", or a Checkout
+/// An internal type representing either a PaymentIntent, SetupIntent, a "deferred Intent", or a Checkout Session
 enum Intent {
     case paymentIntent(STPPaymentIntent)
     case setupIntent(STPSetupIntent)
     case deferredIntent(intentConfig: PaymentSheet.IntentConfiguration)
-    case checkout(Checkout)
+    case checkout(Checkout.Session)
 
     var stripeId: String? {
         switch self {
         case .paymentIntent(let intent): intent.stripeId
         case .setupIntent(let intent): intent.stripeID
         case .deferredIntent: nil
-        case .checkout(let checkout): checkout.nonisolatedSession.id
+        case .checkout(let session): session.id
         }
     }
 
@@ -45,8 +45,8 @@ enum Intent {
             case .setup:
                 return false
             }
-        case .checkout(let checkout):
-            return checkout.nonisolatedSession.mode == .payment || checkout.nonisolatedSession.mode == .subscription
+        case .checkout(let session):
+            return session.mode == .payment || session.mode == .subscription
         }
     }
 
@@ -97,8 +97,8 @@ enum Intent {
             case .setup(let currency, _):
                 return currency
             }
-        case .checkout(let checkout):
-            return checkout.nonisolatedSession.currency
+        case .checkout(let session):
+            return session.currency
         }
     }
 
@@ -115,8 +115,8 @@ enum Intent {
             case .setup:
                 return nil
             }
-        case .checkout(let checkout):
-            return checkout.nonisolatedSession.expectedAmount()
+        case .checkout(let session):
+            return session.expectedAmount()
         }
     }
 
@@ -129,10 +129,10 @@ enum Intent {
                 return setupFutureUsage?.rawValue
             }
             return nil
-        case .checkout(let checkout):
-            switch checkout.nonisolatedSession.mode {
+        case .checkout(let session):
+            switch session.mode {
             case .payment:
-                return checkout.nonisolatedSession.setupFutureUsage
+                return session.setupFutureUsage
             case .setup:
                 return nil
             case .subscription, .unknown:
@@ -156,8 +156,8 @@ enum Intent {
                 return !setupFutureUsageValues.isEmpty
             }
             return nil
-        case .checkout(let checkout):
-            return checkout.nonisolatedSession.isPaymentMethodOptionsSetupFutureUsageSet
+        case .checkout(let session):
+            return session.isPaymentMethodOptionsSetupFutureUsageSet
         case .setupIntent:
             return nil
         }
@@ -181,10 +181,10 @@ enum Intent {
             case .setup:
                 return true
             }
-        case .checkout(let checkout):
-            switch checkout.nonisolatedSession.mode {
+        case .checkout(let session):
+            switch session.mode {
             case .payment:
-                guard let setupFutureUsage = checkout.nonisolatedSession.setupFutureUsage(for: paymentMethodType) else {
+                guard let setupFutureUsage = session.setupFutureUsage(for: paymentMethodType) else {
                     return false
                 }
                 return setupFutureUsage != "none"
@@ -199,8 +199,8 @@ enum Intent {
 
     func allowsPaymentMethodRemoval(elementsSession: STPElementsSession) -> Bool {
         switch self {
-        case .checkout(let checkout):
-            return checkout.nonisolatedSession.customer?.canDetachPaymentMethod ?? false
+        case .checkout(let session):
+            return session.customer?.canDetachPaymentMethod ?? false
         case .paymentIntent, .setupIntent, .deferredIntent:
             return elementsSession.allowsRemovalOfPaymentMethodsForPaymentSheet()
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -25,7 +25,7 @@ extension UIViewController {
         intent: Intent,
         elementsSession: STPElementsSession,
         analyticsHelper: PaymentSheetAnalyticsHelper,
-        checkout: Checkout? = nil,
+        checkout: CheckoutSessionBillingAddressUpdater? = nil,
         supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -25,6 +25,7 @@ extension UIViewController {
         intent: Intent,
         elementsSession: STPElementsSession,
         analyticsHelper: PaymentSheetAnalyticsHelper,
+        checkout: Checkout? = nil,
         supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
@@ -40,7 +41,8 @@ extension UIViewController {
             analyticsHelper: analyticsHelper,
             supportedPaymentMethodTypes: supportedPaymentMethodTypes,
             linkAppearance: linkAppearance,
-            linkConfiguration: linkConfiguration
+            linkConfiguration: linkConfiguration,
+            checkout: checkout
         )
 
         payWithLinkController.presentForPaymentMethodSelection(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
@@ -27,9 +27,9 @@ final class PayWithLinkController {
     let configuration: PaymentElementConfiguration
     let analyticsHelper: PaymentSheetAnalyticsHelper
     private let confirmationChallenge: ConfirmationChallenge?
-    private weak var checkout: Checkout?
+    private weak var checkout: CheckoutSessionBillingAddressUpdater?
 
-    init(intent: Intent, elementsSession: STPElementsSession, configuration: PaymentElementConfiguration, analyticsHelper: PaymentSheetAnalyticsHelper, checkout: Checkout? = nil, confirmationChallenge: ConfirmationChallenge?) {
+    init(intent: Intent, elementsSession: STPElementsSession, configuration: PaymentElementConfiguration, analyticsHelper: PaymentSheetAnalyticsHelper, checkout: CheckoutSessionBillingAddressUpdater? = nil, confirmationChallenge: ConfirmationChallenge?) {
         self.intent = intent
         self.elementsSession = elementsSession
         self.configuration = configuration

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithLinkController.swift
@@ -27,13 +27,15 @@ final class PayWithLinkController {
     let configuration: PaymentElementConfiguration
     let analyticsHelper: PaymentSheetAnalyticsHelper
     private let confirmationChallenge: ConfirmationChallenge?
+    private weak var checkout: Checkout?
 
-    init(intent: Intent, elementsSession: STPElementsSession, configuration: PaymentElementConfiguration, analyticsHelper: PaymentSheetAnalyticsHelper, confirmationChallenge: ConfirmationChallenge?) {
+    init(intent: Intent, elementsSession: STPElementsSession, configuration: PaymentElementConfiguration, analyticsHelper: PaymentSheetAnalyticsHelper, checkout: Checkout? = nil, confirmationChallenge: ConfirmationChallenge?) {
         self.intent = intent
         self.elementsSession = elementsSession
         self.configuration = configuration
         self.paymentHandler = .init(apiClient: configuration.apiClient)
         self.analyticsHelper = analyticsHelper
+        self.checkout = checkout
         self.confirmationChallenge = confirmationChallenge
     }
 
@@ -74,6 +76,7 @@ extension PayWithLinkController: PayWithLinkWebControllerDelegate {
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
             integrationShape: .complete,
+            checkout: checkout,
             confirmationChallenge: confirmationChallenge,
             analyticsHelper: analyticsHelper
         ) { result, deferredIntentConfirmationType in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -59,6 +59,7 @@ final class PayWithNativeLinkController {
     private let linkAppearance: LinkAppearance?
     private let linkConfiguration: LinkConfiguration?
     private let confirmationChallenge: ConfirmationChallenge?
+    private weak var checkout: Checkout?
 
     init(
         mode: Mode,
@@ -70,6 +71,7 @@ final class PayWithNativeLinkController {
         supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
+        checkout: Checkout? = nil,
         confirmationChallenge: ConfirmationChallenge? = nil
     ) {
         self.mode = mode
@@ -82,6 +84,7 @@ final class PayWithNativeLinkController {
         self.paymentHandler = .init(apiClient: configuration.apiClient)
         self.linkAppearance = linkAppearance
         self.linkConfiguration = linkConfiguration
+        self.checkout = checkout
         self.confirmationChallenge = confirmationChallenge
     }
 
@@ -224,6 +227,7 @@ extension PayWithNativeLinkController: PayWithLinkViewControllerDelegate {
             elementsSession: elementsSession,
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
+            checkout: checkout,
             confirmationChallenge: confirmationChallenge,
             analyticsHelper: analyticsHelper,
             completion: { result, confirmationType in
@@ -281,6 +285,7 @@ extension PayWithNativeLinkController: PayWithLinkWebControllerDelegate {
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
             integrationShape: .complete,
+            checkout: checkout,
             confirmationChallenge: confirmationChallenge,
             analyticsHelper: analyticsHelper
         ) { result, deferredIntentConfirmationType in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -59,7 +59,7 @@ final class PayWithNativeLinkController {
     private let linkAppearance: LinkAppearance?
     private let linkConfiguration: LinkConfiguration?
     private let confirmationChallenge: ConfirmationChallenge?
-    private weak var checkout: Checkout?
+    private weak var checkout: CheckoutSessionBillingAddressUpdater?
 
     init(
         mode: Mode,
@@ -71,7 +71,7 @@ final class PayWithNativeLinkController {
         supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
-        checkout: Checkout? = nil,
+        checkout: CheckoutSessionBillingAddressUpdater? = nil,
         confirmationChallenge: ConfirmationChallenge? = nil
     ) {
         self.mode = mode

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -179,9 +179,9 @@ extension PaymentSheet {
             intent.isSetupFutureUsageSet(for: paymentMethodType) || elementsSession.forceSaveFutureUseBehaviorAndNewMandateText
         }
         let setAllowRedisplay: (IntentConfirmParams, STPPaymentMethodType) -> Void = { confirmParams, paymentMethodType in
-            if case .checkout(let checkout) = intent {
+            if case .checkout(let session) = intent {
                 confirmParams.setAllowRedisplayForCheckoutSession(
-                    merchantWillSavePaymentMethod: checkout.nonisolatedSession.merchantWillSavePaymentMethod(paymentMethodType)
+                    merchantWillSavePaymentMethod: session.merchantWillSavePaymentMethod(paymentMethodType)
                 )
             } else {
                 confirmParams.setAllowRedisplay(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -42,7 +42,7 @@ extension PaymentSheet {
         paymentHandler: STPPaymentHandler,
         integrationShape: IntegrationShape = .complete,
         paymentMethodID: String? = nil,
-        checkout: Checkout? = nil,
+        checkout: CheckoutSessionBillingAddressUpdater? = nil,
         confirmationChallenge: ConfirmationChallenge? = nil,
         analyticsHelper: PaymentSheetAnalyticsHelper,
         completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
@@ -125,7 +125,7 @@ extension PaymentSheet {
         confirmationChallenge: ConfirmationChallenge? = nil,
         analyticsHelper: PaymentSheetAnalyticsHelper,
         paymentMethodID: String? = nil,
-        checkout: Checkout? = nil
+        checkout: CheckoutSessionBillingAddressUpdater? = nil
     ) async -> (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) {
         await withCheckedContinuation { continuation in
             Task { @MainActor in
@@ -158,7 +158,7 @@ extension PaymentSheet {
         paymentHandler: STPPaymentHandler,
         isFlowController: Bool = false,
         paymentMethodID: String? = nil,
-        checkout: Checkout? = nil,
+        checkout: CheckoutSessionBillingAddressUpdater? = nil,
         confirmationChallenge: ConfirmationChallenge?,
         analyticsHelper: PaymentSheetAnalyticsHelper,
         completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
@@ -295,7 +295,7 @@ extension PaymentSheet {
                         completion(result.result, result.deferredIntentConfirmationType)
                     }
                     // MARK: ↪ Checkout
-                case .checkout:
+                case .checkout(let checkoutSession):
                     Task { @MainActor in
                         guard let checkout else {
                             let result = missingCheckoutControllerResult()
@@ -305,6 +305,7 @@ extension PaymentSheet {
                         }
                         let result = await handleCheckoutSessionConfirmation(
                             checkout: checkout,
+                            checkoutSession: checkoutSession,
                             confirmType: .new(
                                 params: confirmParams.paymentMethodParams,
                                 paymentOptions: confirmParams.confirmPaymentMethodOptions,
@@ -376,7 +377,7 @@ extension PaymentSheet {
                     completion(result.result, result.deferredIntentConfirmationType)
                 }
                 // MARK: ↪ Checkout
-            case .checkout:
+            case .checkout(let checkoutSession):
                 Task { @MainActor in
                     guard let checkout else {
                         completion(missingCheckoutControllerResult(), nil)
@@ -389,6 +390,7 @@ extension PaymentSheet {
                     : intentConfirmParamsFromSavedPaymentMethod?.confirmPaymentMethodOptions
                     let result = await handleCheckoutSessionConfirmation(
                         checkout: checkout,
+                        checkoutSession: checkoutSession,
                         confirmType: .saved(paymentMethod,
                                             paymentOptions: paymentOptions,
                                             clientAttributionMetadata: clientAttributionMetadata,
@@ -472,7 +474,7 @@ extension PaymentSheet {
                             await confirmationChallenge?.complete()
                             completion(result.result, result.deferredIntentConfirmationType)
                         }
-                    case .checkout:
+                    case .checkout(let checkoutSession):
                         guard let checkout else {
                             let result = missingCheckoutControllerResult()
                             await confirmationChallenge?.complete()
@@ -481,6 +483,7 @@ extension PaymentSheet {
                         }
                         let result = await handleCheckoutSessionConfirmation(
                             checkout: checkout,
+                            checkoutSession: checkoutSession,
                             confirmType: .new(
                                 params: paymentMethodParams,
                                 paymentOptions: STPConfirmPaymentMethodOptions(),
@@ -570,7 +573,7 @@ extension PaymentSheet {
                             await confirmationChallenge?.complete()
                             completion(result.result, result.deferredIntentConfirmationType)
                         }
-                    case .checkout:
+                    case .checkout(let checkoutSession):
                         guard let checkout else {
                             let result = missingCheckoutControllerResult()
                             await confirmationChallenge?.complete()
@@ -579,6 +582,7 @@ extension PaymentSheet {
                         }
                         let result = await handleCheckoutSessionConfirmation(
                             checkout: checkout,
+                            checkoutSession: checkoutSession,
                             confirmType: .saved(paymentMethod, paymentOptions: nil, clientAttributionMetadata: clientAttributionMetadata, radarOptions: radarOptions),
                             configuration: configuration,
                             authenticationContext: authenticationContext,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -200,6 +200,7 @@ extension PaymentSheet {
                     elementsSession: elementsSession,
                     configuration: configuration,
                     clientAttributionMetadata: clientAttributionMetadata,
+                    checkout: checkout,
                     completion: completion
                 )
             else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+API.swift
@@ -42,6 +42,7 @@ extension PaymentSheet {
         paymentHandler: STPPaymentHandler,
         integrationShape: IntegrationShape = .complete,
         paymentMethodID: String? = nil,
+        checkout: Checkout? = nil,
         confirmationChallenge: ConfirmationChallenge? = nil,
         analyticsHelper: PaymentSheetAnalyticsHelper,
         completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
@@ -61,7 +62,7 @@ extension PaymentSheet {
                                                 confirmAction: {
                 // If confirmed, dismiss the MandateView and complete the transaction:
                 authenticationContext.authenticationPresentingViewController().dismiss(animated: true)
-                confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: nil, paymentHandler: paymentHandler, confirmationChallenge: confirmationChallenge, analyticsHelper: analyticsHelper, completion: completion)
+                confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: nil, paymentHandler: paymentHandler, checkout: checkout, confirmationChallenge: confirmationChallenge, analyticsHelper: analyticsHelper, completion: completion)
             }, cancelAction: {
                 // Dismiss the MandateView and return to PaymentSheet
                 authenticationContext.authenticationPresentingViewController().dismiss(animated: true)
@@ -90,7 +91,7 @@ extension PaymentSheet {
                 configuration: configuration,
                 onCompletion: { vc, intentConfirmParams in
                     vc.dismiss(animated: true)
-                    confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: intentConfirmParams, paymentHandler: paymentHandler, confirmationChallenge: confirmationChallenge, analyticsHelper: analyticsHelper, completion: completion)
+                    confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: intentConfirmParams, paymentHandler: paymentHandler, checkout: checkout, confirmationChallenge: confirmationChallenge, analyticsHelper: analyticsHelper, completion: completion)
                 },
                 onCancel: { vc in
                     vc.dismiss(animated: true)
@@ -109,7 +110,7 @@ extension PaymentSheet {
             presentingViewController.presentAsBottomSheet(bottomSheetVC, appearance: configuration.appearance)
         } else {
             // MARK: - No local actions
-            confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: nil, paymentHandler: paymentHandler, confirmationChallenge: confirmationChallenge, analyticsHelper: analyticsHelper, completion: completion)
+            confirmAfterHandlingLocalActions(configuration: configuration, authenticationContext: authenticationContext, intent: intent, elementsSession: elementsSession, paymentOption: paymentOption, intentConfirmParamsForDeferredIntent: nil, paymentHandler: paymentHandler, checkout: checkout, confirmationChallenge: confirmationChallenge, analyticsHelper: analyticsHelper, completion: completion)
         }
     }
 
@@ -123,7 +124,8 @@ extension PaymentSheet {
         integrationShape: IntegrationShape = .complete,
         confirmationChallenge: ConfirmationChallenge? = nil,
         analyticsHelper: PaymentSheetAnalyticsHelper,
-        paymentMethodID: String? = nil
+        paymentMethodID: String? = nil,
+        checkout: Checkout? = nil
     ) async -> (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) {
         await withCheckedContinuation { continuation in
             Task { @MainActor in
@@ -136,6 +138,7 @@ extension PaymentSheet {
                     paymentHandler: paymentHandler,
                     integrationShape: integrationShape,
                     paymentMethodID: paymentMethodID,
+                    checkout: checkout,
                     confirmationChallenge: confirmationChallenge,
                     analyticsHelper: analyticsHelper
                 ) { result, deferredType in
@@ -155,6 +158,7 @@ extension PaymentSheet {
         paymentHandler: STPPaymentHandler,
         isFlowController: Bool = false,
         paymentMethodID: String? = nil,
+        checkout: Checkout? = nil,
         confirmationChallenge: ConfirmationChallenge?,
         analyticsHelper: PaymentSheetAnalyticsHelper,
         completion: @escaping (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) -> Void
@@ -165,6 +169,11 @@ extension PaymentSheet {
         }
 
         let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(intent: intent, elementsSession: elementsSession)
+        let missingCheckoutControllerResult: () -> PaymentSheetResult = {
+            let message = "Missing Checkout controller for CheckoutSession confirmation."
+            stpAssertionFailure(message)
+            return .failed(error: PaymentSheetError.unknown(debugDescription: message))
+        }
 
         let isSettingUp: (STPPaymentMethodType) -> Bool = { paymentMethodType in
             intent.isSetupFutureUsageSet(for: paymentMethodType) || elementsSession.forceSaveFutureUseBehaviorAndNewMandateText
@@ -285,8 +294,14 @@ extension PaymentSheet {
                         completion(result.result, result.deferredIntentConfirmationType)
                     }
                     // MARK: ↪ Checkout
-                case .checkout(let checkout):
+                case .checkout:
                     Task { @MainActor in
+                        guard let checkout else {
+                            let result = missingCheckoutControllerResult()
+                            await confirmationChallenge?.complete()
+                            completion(result, nil)
+                            return
+                        }
                         let result = await handleCheckoutSessionConfirmation(
                             checkout: checkout,
                             confirmType: .new(
@@ -360,8 +375,12 @@ extension PaymentSheet {
                     completion(result.result, result.deferredIntentConfirmationType)
                 }
                 // MARK: ↪ Checkout
-            case .checkout(let checkout):
+            case .checkout:
                 Task { @MainActor in
+                    guard let checkout else {
+                        completion(missingCheckoutControllerResult(), nil)
+                        return
+                    }
                     let paymentOptions = intentConfirmParamsForDeferredIntent?.confirmPaymentMethodOptions != nil
                     // Flow controller and embedded collects CVC using interstitial:
                     ? intentConfirmParamsForDeferredIntent?.confirmPaymentMethodOptions
@@ -452,7 +471,13 @@ extension PaymentSheet {
                             await confirmationChallenge?.complete()
                             completion(result.result, result.deferredIntentConfirmationType)
                         }
-                    case .checkout(let checkout):
+                    case .checkout:
+                        guard let checkout else {
+                            let result = missingCheckoutControllerResult()
+                            await confirmationChallenge?.complete()
+                            completion(result, nil)
+                            return
+                        }
                         let result = await handleCheckoutSessionConfirmation(
                             checkout: checkout,
                             confirmType: .new(
@@ -544,7 +569,13 @@ extension PaymentSheet {
                             await confirmationChallenge?.complete()
                             completion(result.result, result.deferredIntentConfirmationType)
                         }
-                    case .checkout(let checkout):
+                    case .checkout:
+                        guard let checkout else {
+                            let result = missingCheckoutControllerResult()
+                            await confirmationChallenge?.complete()
+                            completion(result, nil)
+                            return
+                        }
                         let result = await handleCheckoutSessionConfirmation(
                             checkout: checkout,
                             confirmType: .saved(paymentMethod, paymentOptions: nil, clientAttributionMetadata: clientAttributionMetadata, radarOptions: radarOptions),
@@ -645,12 +676,12 @@ extension PaymentSheet {
                 let useNativeLink = deviceCanUseNativeLink(elementsSession: elementsSession, configuration: configuration)
                 if useNativeLink {
                     // logPayment is false because callers of PaymentSheet.confirm() are responsible for logging the payment result.
-                    let linkController = PayWithNativeLinkController(mode: .full, intent: intent, elementsSession: elementsSession, configuration: configuration, logPayment: false, analyticsHelper: analyticsHelper, confirmationChallenge: confirmationChallenge)
+                    let linkController = PayWithNativeLinkController(mode: .full, intent: intent, elementsSession: elementsSession, configuration: configuration, logPayment: false, analyticsHelper: analyticsHelper, checkout: checkout, confirmationChallenge: confirmationChallenge)
                     linkController.presentAsBottomSheet(from: authenticationContext.authenticationPresentingViewController(), shouldOfferApplePay: false, shouldFinishOnClose: false, completion: { result, confirmationType, _ in
                         completion(result, confirmationType)
                     })
                 } else {
-                    let linkController = PayWithLinkController(intent: intent, elementsSession: elementsSession, configuration: configuration, analyticsHelper: analyticsHelper, confirmationChallenge: confirmationChallenge)
+                    let linkController = PayWithLinkController(intent: intent, elementsSession: elementsSession, configuration: configuration, analyticsHelper: analyticsHelper, checkout: checkout, confirmationChallenge: confirmationChallenge)
                     linkController.present(from: authenticationContext.authenticationPresentingViewController(),
                                            completion: completion)
                 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
@@ -24,7 +24,7 @@ extension PaymentSheet {
         let checkoutSession: Checkout.Session = checkout.nonisolatedSession
         do {
             let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(
-                intent: .checkout(checkout),
+                intent: .checkout(checkoutSession),
                 elementsSession: elementsSession
             )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+CheckoutSessionAPI.swift
@@ -14,14 +14,14 @@ extension PaymentSheet {
     /// Confirms a checkout session with a new payment method
     @MainActor
     static func handleCheckoutSessionConfirmation(
-        checkout: Checkout,
+        checkout: CheckoutSessionBillingAddressUpdater,
+        checkoutSession: Checkout.Session,
         confirmType: ConfirmPaymentMethodType,
         configuration: PaymentElementConfiguration,
         authenticationContext: STPAuthenticationContext,
         paymentHandler: STPPaymentHandler,
         elementsSession: STPElementsSession
     ) async -> PaymentSheetResult {
-        let checkoutSession: Checkout.Session = checkout.nonisolatedSession
         do {
             let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(
                 intent: .checkout(checkoutSession),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -68,13 +68,7 @@ extension PaymentSheet {
         shouldFinishOnClose: Bool,
         onClose: (() -> Void)? = nil
     ) {
-        let checkout: Checkout? = {
-            guard case .checkout(let checkout) = mode else {
-                return nil
-            }
-            return checkout
-        }()
-        let payWithNativeLink = PayWithNativeLinkController(mode: .full, intent: intent, elementsSession: elementsSession, configuration: configuration, analyticsHelper: analyticsHelper, checkout: checkout, confirmationChallenge: confirmationChallenge)
+        let payWithNativeLink = PayWithNativeLinkController(mode: .full, intent: intent, elementsSession: elementsSession, configuration: configuration, analyticsHelper: analyticsHelper, checkout: mode.checkout, confirmationChallenge: confirmationChallenge)
 
         payWithNativeLink.presentAsBottomSheet(from: presentingController, shouldOfferApplePay: shouldOfferApplePay, shouldFinishOnClose: shouldFinishOnClose, completion: { result, _, didFinish in
             if case let .failed(error) = result {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+Link.swift
@@ -68,7 +68,13 @@ extension PaymentSheet {
         shouldFinishOnClose: Bool,
         onClose: (() -> Void)? = nil
     ) {
-        let payWithNativeLink = PayWithNativeLinkController(mode: .full, intent: intent, elementsSession: elementsSession, configuration: configuration, analyticsHelper: analyticsHelper, confirmationChallenge: confirmationChallenge)
+        let checkout: Checkout? = {
+            guard case .checkout(let checkout) = mode else {
+                return nil
+            }
+            return checkout
+        }()
+        let payWithNativeLink = PayWithNativeLinkController(mode: .full, intent: intent, elementsSession: elementsSession, configuration: configuration, analyticsHelper: analyticsHelper, checkout: checkout, confirmationChallenge: confirmationChallenge)
 
         payWithNativeLink.presentAsBottomSheet(from: presentingController, shouldOfferApplePay: shouldOfferApplePay, shouldFinishOnClose: shouldFinishOnClose, completion: { result, _, didFinish in
             if case let .failed(error) = result {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -209,18 +209,18 @@ extension Intent: PaymentMethodRequirementProvider {
         case .deferredIntent:
             // Verification method is always 'automatic'
             return [.validUSBankVerificationMethod]
-        case let .checkout(checkout):
+        case let .checkout(session):
             var reqs = [PaymentMethodTypeRequirement]()
 
             // The session is configured to collect a shipping address, so payment methods
             // that require one can be offered.
-            if checkout.nonisolatedSession.requiresShippingAddress {
+            if session.requiresShippingAddress {
                 reqs.append(.shippingAddress)
             }
 
             // Mirror PaymentIntent/SetupIntent: valid us bank verification method
-            if let usBankOptions = checkout.nonisolatedSession.paymentMethodOptions?.usBankAccount,
-                usBankOptions.verificationMethod.isValidForPaymentSheet
+            if let usBankOptions = session.paymentMethodOptions?.usBankAccount,
+               usBankOptions.verificationMethod.isValidForPaymentSheet
             {
                 reqs.append(.validUSBankVerificationMethod)
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -275,6 +275,12 @@ public class PaymentSheet {
         loadResult: PaymentSheetLoader.LoadResult,
         previousPaymentOption: PaymentOption?
     ) -> PaymentSheetViewControllerProtocol {
+        let checkout: Checkout? = {
+            guard case .checkout(let checkout) = mode else {
+                return nil
+            }
+            return checkout
+        }()
         switch loadResult.paymentMethodOrientation {
         case .horizontal:
             let vc = PaymentSheetViewController(
@@ -291,6 +297,7 @@ public class PaymentSheet {
                 loadResult: loadResult,
                 isFlowController: false,
                 analyticsHelper: analyticsHelper,
+                checkout: checkout,
                 previousPaymentOption: previousPaymentOption
             )
             vc.paymentSheetDelegate = self

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -59,6 +59,15 @@ public class PaymentSheet {
             }
         }
 
+        var checkout: Checkout? {
+            switch self {
+            case .checkout(let checkout):
+                return checkout
+            case .paymentIntentClientSecret, .setupIntentClientSecret, .deferredIntent:
+                return nil
+            }
+        }
+
         var isDeferred: Bool {
             if case .deferredIntent = self {
                 return true
@@ -275,12 +284,6 @@ public class PaymentSheet {
         loadResult: PaymentSheetLoader.LoadResult,
         previousPaymentOption: PaymentOption?
     ) -> PaymentSheetViewControllerProtocol {
-        let checkout: Checkout? = {
-            guard case .checkout(let checkout) = mode else {
-                return nil
-            }
-            return checkout
-        }()
         switch loadResult.paymentMethodOrientation {
         case .horizontal:
             let vc = PaymentSheetViewController(
@@ -297,7 +300,7 @@ public class PaymentSheet {
                 loadResult: loadResult,
                 isFlowController: false,
                 analyticsHelper: analyticsHelper,
-                checkout: checkout,
+                checkout: mode.checkout,
                 previousPaymentOption: previousPaymentOption
             )
             vc.paymentSheetDelegate = self
@@ -324,12 +327,7 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
                 paymentOption: paymentOption,
                 paymentHandler: self.paymentHandler,
                 integrationShape: .complete,
-                checkout: {
-                    guard case .checkout(let checkout) = self.mode else {
-                        return nil
-                    }
-                    return checkout
-                }(),
+                checkout: self.mode.checkout,
                 confirmationChallenge: self.confirmationChallenge,
                 analyticsHelper: self.analyticsHelper
             ) { result, deferredIntentConfirmationType in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -324,6 +324,12 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
                 paymentOption: paymentOption,
                 paymentHandler: self.paymentHandler,
                 integrationShape: .complete,
+                checkout: {
+                    guard case .checkout(let checkout) = self.mode else {
+                        return nil
+                    }
+                    return checkout
+                }(),
                 confirmationChallenge: self.confirmationChallenge,
                 analyticsHelper: self.analyticsHelper
             ) { result, deferredIntentConfirmationType in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -638,6 +638,7 @@ extension PaymentSheet {
                 intent: intent,
                 elementsSession: elementsSession,
                 analyticsHelper: analyticsHelper,
+                checkout: checkout,
                 callback: completionCallback
             )
         }
@@ -706,6 +707,7 @@ extension PaymentSheet {
                         paymentOption: paymentOption,
                         paymentHandler: self.paymentHandler,
                         integrationShape: .flowController,
+                        checkout: self.checkout,
                         confirmationChallenge: self.confirmationChallenge,
                         analyticsHelper: self.analyticsHelper
                     ) { result, deferredIntentConfirmationType in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -421,6 +421,7 @@ extension PaymentSheet {
                 ) { result in
                     if case .success(let flowController) = result {
                         flowController.checkout = checkout
+                        flowController.viewController.checkout = checkout
                     }
                     completion(result)
                 }
@@ -820,6 +821,7 @@ extension PaymentSheet {
                         loadResult: loadResult,
                         analyticsHelper: analyticsHelper,
                         walletButtonsViewState: walletButtonsViewState,
+                        checkout: self.checkout,
                         previousPaymentOption: self.internalPaymentOption
                     )
                     self.viewController.flowControllerDelegate = self
@@ -905,6 +907,7 @@ extension PaymentSheet {
             loadResult: PaymentSheetLoader.LoadResult,
             analyticsHelper: PaymentSheetAnalyticsHelper,
             walletButtonsViewState: PaymentSheet.WalletButtonsViewState,
+            checkout: Checkout? = nil,
             previousPaymentOption: PaymentOption? = nil
         ) -> FlowControllerViewControllerProtocol {
             let controller: FlowControllerViewControllerProtocol
@@ -914,6 +917,7 @@ extension PaymentSheet {
                     configuration: configuration,
                     loadResult: loadResult,
                     analyticsHelper: analyticsHelper,
+                    checkout: checkout,
                     previousPaymentOption: previousPaymentOption
                 )
             case .vertical:
@@ -923,6 +927,7 @@ extension PaymentSheet {
                     isFlowController: true,
                     analyticsHelper: analyticsHelper,
                     walletButtonsViewState: walletButtonsViewState,
+                    checkout: checkout,
                     previousPaymentOption: previousPaymentOption
                 )
             }
@@ -1059,6 +1064,7 @@ internal protocol FlowControllerViewControllerProtocol: BottomSheetContentViewCo
     /// Note that, unlike selectedPaymentOption, this is non-nil even if the PM form is invalid.
     var selectedPaymentMethodType: PaymentSheet.PaymentMethodType? { get }
     var flowControllerDelegate: FlowControllerViewControllerDelegate? { get set }
+    var checkout: Checkout? { get set }
     func clearSelection()
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -1056,12 +1056,12 @@ extension PaymentSheetFormFactory {
         intent: Intent,
         elementsSession: STPElementsSession
     ) -> SavePaymentMethodConsentBehavior {
-        guard case .checkout(let checkout) = intent else {
+        guard case .checkout(let session) = intent else {
             return elementsSession.savePaymentMethodConsentBehavior
         }
 
-        guard checkout.nonisolatedSession.customerId != nil,
-              let offerSave = checkout.nonisolatedSession.savedPaymentMethodsOfferSave,
+        guard session.customerId != nil,
+              let offerSave = session.savedPaymentMethodsOfferSave,
               offerSave.enabled
         else {
             return .paymentSheetWithCheckoutSessionPaymentMethodSaveDisabled

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -489,7 +489,7 @@ final class PaymentSheetLoader {
             }
         case .checkout(let checkout):
             elementsSession = checkout.session.elementsSession
-            intent = .checkout(checkout)
+            intent = .checkout(checkout.session)
         }
 
         // Warn the merchant if we see unactivated payment method types in the Intent
@@ -541,8 +541,8 @@ final class PaymentSheetLoader {
         if let elementsSessionPaymentMethods = elementsSession.customer?.paymentMethods {
             // A. SPMs are on ElementSessions object when using CustomerSession.
             savedPaymentMethods = elementsSessionPaymentMethods
-        } else if case let .checkout(checkout) = intent,
-                  let customerPaymentMethods = checkout.nonisolatedSession.customer?.paymentMethods {
+        } else if case let .checkout(session) = intent,
+                  let customerPaymentMethods = session.customer?.paymentMethods {
             // B. SPMs are on CheckoutSession object
             savedPaymentMethods = customerPaymentMethods
         } else if let prefetchedSPMs {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+CheckoutSessionLineItems.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+CheckoutSessionLineItems.swift
@@ -17,12 +17,10 @@ extension STPApplePayContext {
     /// Builds Apple Pay summary items from a checkout session's current state.
     /// Falls back to a single total row (or .pending) when line items aren't available.
     static func makePaymentSummaryItems(
-        for checkout: Checkout,
+        for session: Checkout.Session,
         label: String,
         currency: String?
     ) -> [PKPaymentSummaryItem] {
-        let session: Checkout.Session = checkout.nonisolatedSession
-
         guard !session.lineItems.isEmpty, let total = session.total else {
             if let amount = session.expectedAmount() {
                 let decimalAmount = NSDecimalNumber.stp_decimalNumber(withAmount: amount, currency: currency)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -386,7 +386,7 @@ extension STPApplePayContext {
                         try? await checkout.updateBillingAddress(address: address, canUpdateWhileSheetPresented: true)
                     }
                     completion(PKPaymentRequestPaymentMethodUpdate(
-                        paymentSummaryItems: STPApplePayContext.makePaymentSummaryItems(for: checkout, label: label, currency: currency)
+                        paymentSummaryItems: STPApplePayContext.makePaymentSummaryItems(for: checkout.nonisolatedSession, label: label, currency: currency)
                     ))
                 }
             }
@@ -436,8 +436,8 @@ extension STPApplePayContext {
         if let paymentSummaryItems = applePay.paymentSummaryItems {
             // Use the merchant supplied paymentSummaryItems
             paymentRequest.paymentSummaryItems = paymentSummaryItems
-        } else if case .checkout(let checkout) = intent {
-            paymentRequest.paymentSummaryItems = STPApplePayContext.makePaymentSummaryItems(for: checkout,
+        } else if case .checkout(let session) = intent {
+            paymentRequest.paymentSummaryItems = STPApplePayContext.makePaymentSummaryItems(for: session,
                 label: label,
                 currency: intent.currency
             )
@@ -478,8 +478,8 @@ extension STPApplePayContext {
 
         // Pre-populate billingContact from the CheckoutSession's billing address, but only
         // if it has a street. Otherwise Apple Pay will show "Update Billing Address".
-        if case .checkout(let checkout) = intent,
-           let billingAddress = checkout.nonisolatedSession.billingAddress,
+        if case .checkout(let session) = intent,
+           let billingAddress = session.billingAddress,
            billingAddress.address.line1 != nil {
             paymentRequest.billingContact = Self.makeBillingContact(from: billingAddress)
         }
@@ -514,7 +514,7 @@ private func makeFallbackBillingDetails(
     var fallbackBillingDetails = StripeAPI.BillingDetails()
     var hasFallbackBillingDetails = false
 
-    if case .checkout(let checkout) = intent, let email = checkout.nonisolatedSession.email {
+    if case .checkout(let session) = intent, let email = session.email {
         fallbackBillingDetails.email = email
         hasFallbackBillingDetails = true
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -30,12 +30,12 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
 
     let intent: Intent
     let elementsSession: STPElementsSession
-    private weak var checkout: Checkout?
+    private weak var checkout: CheckoutSessionBillingAddressUpdater?
 
     init(
         intent: Intent,
         elementsSession: STPElementsSession,
-        checkout: Checkout?,
+        checkout: CheckoutSessionBillingAddressUpdater?,
         authorizationResultHandler: PaymentSheet.ApplePayConfiguration.Handlers.AuthorizationResultHandler?,
         shippingMethodUpdateHandler: (
             (PKShippingMethod, @escaping ((PKPaymentRequestShippingMethodUpdate) -> Void)) -> Void
@@ -70,7 +70,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
             return paymentIntent.clientSecret
         case .setupIntent(let setupIntent):
             return setupIntent.clientSecret
-        case .checkout:
+        case .checkout(let checkoutSession):
             guard let checkout else {
                 let message = "Missing Checkout controller for CheckoutSession Apple Pay confirmation."
                 stpAssertionFailure(message)
@@ -78,6 +78,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
             }
             return try await handleCheckoutSessionApplePay(
                 checkout: checkout,
+                checkoutSession: checkoutSession,
                 paymentMethod: paymentMethod,
                 paymentInformation: paymentInformation,
                 context: context
@@ -182,18 +183,14 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         return clientSecret
     }
 
-    // TODO(gbirch): Remove session parameter once MPE is MainActor-isolated; we can then
-    // access checkout.session directly. This is a temporary stopgap to provide a threadsafe
-    // version of the checkout session data.
     /// Handles Apple Pay confirmation for CheckoutSession by calling the confirm API with the payment method.
     private func handleCheckoutSessionApplePay(
-        checkout: Checkout,
+        checkout: CheckoutSessionBillingAddressUpdater,
+        checkoutSession: Checkout.Session,
         paymentMethod: StripeAPI.PaymentMethod,
         paymentInformation: PKPayment,
         context: STPApplePayContext
     ) async throws -> String {
-        let checkoutSession: Checkout.Session = checkout.nonisolatedSession
-
         // 1. Build client attribution metadata
         let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(
             intent: intent,
@@ -353,7 +350,7 @@ extension STPApplePayContext {
         elementsSession: STPElementsSession,
         configuration: PaymentElementConfiguration,
         clientAttributionMetadata: STPClientAttributionMetadata,
-        checkout: Checkout? = nil,
+        checkout: CheckoutSessionBillingAddressUpdater? = nil,
         completion: @escaping PaymentSheetResultCompletionBlock
     ) -> STPApplePayContext? {
         guard let applePay = configuration.applePay else {
@@ -372,7 +369,7 @@ extension STPApplePayContext {
 
         // Keep tax in sync with the billing address as the user switches cards.
         let paymentMethodUpdateHandler: ((PKPaymentMethod, @escaping ((PKPaymentRequestPaymentMethodUpdate) -> Void)) -> Void)? = {
-            guard case .checkout = intent else { return nil }
+            guard case .checkout(let checkoutSession) = intent else { return nil }
             guard let checkout else {
                 stpAssertionFailure("Missing Checkout controller for CheckoutSession Apple Pay payment method update.")
                 return nil
@@ -381,12 +378,13 @@ extension STPApplePayContext {
             let currency = intent.currency
             return { pkPaymentMethod, completion in
                 Task { @MainActor in
+                    var session = checkoutSession
                     if let postalAddress = pkPaymentMethod.billingAddress?.postalAddresses.first?.value,
                        let address = STPApplePayContext.makeCheckoutAddress(from: postalAddress) {
-                        try? await checkout.updateBillingAddress(address: address, canUpdateWhileSheetPresented: true)
+                        session = (try? await checkout.updateBillingAddressForPaymentSheet(address: address, canUpdateWhileSheetPresented: true)) ?? session
                     }
                     completion(PKPaymentRequestPaymentMethodUpdate(
-                        paymentSummaryItems: STPApplePayContext.makePaymentSummaryItems(for: checkout.nonisolatedSession, label: label, currency: currency)
+                        paymentSummaryItems: STPApplePayContext.makePaymentSummaryItems(for: session, label: label, currency: currency)
                     ))
                 }
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/STPApplePayContext+PaymentSheet.swift
@@ -30,10 +30,12 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
 
     let intent: Intent
     let elementsSession: STPElementsSession
+    private weak var checkout: Checkout?
 
     init(
         intent: Intent,
         elementsSession: STPElementsSession,
+        checkout: Checkout?,
         authorizationResultHandler: PaymentSheet.ApplePayConfiguration.Handlers.AuthorizationResultHandler?,
         shippingMethodUpdateHandler: (
             (PKShippingMethod, @escaping ((PKPaymentRequestShippingMethodUpdate) -> Void)) -> Void
@@ -53,6 +55,7 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
         self.paymentMethodUpdateHandler = paymentMethodUpdateHandler
         self.intent = intent
         self.elementsSession = elementsSession
+        self.checkout = checkout
         super.init()
         self.selfRetainer = self
     }
@@ -67,7 +70,12 @@ private class ApplePayContextClosureDelegate: NSObject, ApplePayContextDelegate 
             return paymentIntent.clientSecret
         case .setupIntent(let setupIntent):
             return setupIntent.clientSecret
-        case .checkout(let checkout):
+        case .checkout:
+            guard let checkout else {
+                let message = "Missing Checkout controller for CheckoutSession Apple Pay confirmation."
+                stpAssertionFailure(message)
+                throw PaymentSheetError.unknown(debugDescription: message)
+            }
             return try await handleCheckoutSessionApplePay(
                 checkout: checkout,
                 paymentMethod: paymentMethod,
@@ -345,6 +353,7 @@ extension STPApplePayContext {
         elementsSession: STPElementsSession,
         configuration: PaymentElementConfiguration,
         clientAttributionMetadata: STPClientAttributionMetadata,
+        checkout: Checkout? = nil,
         completion: @escaping PaymentSheetResultCompletionBlock
     ) -> STPApplePayContext? {
         guard let applePay = configuration.applePay else {
@@ -363,7 +372,11 @@ extension STPApplePayContext {
 
         // Keep tax in sync with the billing address as the user switches cards.
         let paymentMethodUpdateHandler: ((PKPaymentMethod, @escaping ((PKPaymentRequestPaymentMethodUpdate) -> Void)) -> Void)? = {
-            guard case .checkout(let checkout) = intent else { return nil }
+            guard case .checkout = intent else { return nil }
+            guard let checkout else {
+                stpAssertionFailure("Missing Checkout controller for CheckoutSession Apple Pay payment method update.")
+                return nil
+            }
             let label = intent.sellerDetails?.businessName ?? configuration.merchantDisplayName
             let currency = intent.currency
             return { pkPaymentMethod, completion in
@@ -382,6 +395,7 @@ extension STPApplePayContext {
         let delegate = ApplePayContextClosureDelegate(
             intent: intent,
             elementsSession: elementsSession,
+            checkout: checkout,
             authorizationResultHandler: configuration.applePay?.customHandlers?.authorizationResultHandler,
             shippingMethodUpdateHandler: configuration.applePay?.customHandlers?.shippingMethodUpdateHandler,
             shippingContactUpdateHandler: configuration.applePay?.customHandlers?.shippingContactUpdateHandler,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -574,6 +574,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
             intent: intent,
             elementsSession: elementsSession,
             analyticsHelper: analyticsHelper,
+            checkout: checkout,
             callback: { [weak self] confirmOption, _ in
                 guard let self else { return }
                 self.linkConfirmOption = confirmOption

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -78,6 +78,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     let intent: Intent
     let elementsSession: STPElementsSession
     let formCache: PaymentMethodFormCache = .init()
+    weak var checkout: Checkout?
     let analyticsHelper: PaymentSheetAnalyticsHelper
     let walletButtonsShownExternally: Bool
     var error: Swift.Error?
@@ -159,6 +160,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         isFlowController: Bool,
         analyticsHelper: PaymentSheetAnalyticsHelper,
         walletButtonsViewState: PaymentSheet.WalletButtonsViewState = .hidden,
+        checkout: Checkout? = nil,
         previousPaymentOption: PaymentOption? = nil
     ) {
         // Only call loadResult.intent.cvcRecollectionEnabled once per load
@@ -171,6 +173,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         self.configuration = configuration
         self.previousPaymentOption = previousPaymentOption
         self.isFlowController = isFlowController
+        self.checkout = checkout
         self.savedPaymentMethods = loadResult.savedPaymentMethods
         self.paymentMethodTypes = loadResult.paymentMethodTypes
         self.walletButtonsShownExternally = walletButtonsViewState.isVisible
@@ -776,7 +779,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     /// Syncs billing address to the checkout session, then closes the sheet.
     /// If the sync fails, stays on the sheet and shows the error instead.
     private func syncCheckoutBillingThenClose() {
-        guard case .checkout(let checkout) = intent,
+        guard let checkout,
               let paymentOption = selectedPaymentOption else {
             flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -364,10 +364,10 @@ extension PaymentMethodFormViewController {
                 return .setup(setupIntent.stripeID)
             case .deferredIntent:
                 return .deferred(elementsSession.sessionID)
-            case .checkout(let checkout):
+            case .checkout(let session):
                 // This ID is used for financial incentive eligibility. Ideally we'd use the underlying
                 // paymentIntentId or setupIntentId, but those are not yet populated on CheckoutSession.
-                return .deferred(checkout.nonisolatedSession.id)
+                return .deferred(session.id)
             }
         }()
 
@@ -557,13 +557,13 @@ extension PaymentMethodFormViewController {
                 intentType: .deferred,
                 financialConnectionsCompletion: financialConnectionsCompletion
             )
-        case .checkout(let checkout):
+        case .checkout(let session):
             client.collectBankAccountForDeferredIntentOrCheckoutSession(
                 sessionId: elementsSession.sessionID,
                 returnURL: configuration.returnURL,
                 onEvent: nil,
-                amount: checkout.nonisolatedSession.expectedAmount(),
-                currency: checkout.nonisolatedSession.currency,
+                amount: session.expectedAmount(),
+                currency: session.currency,
                 onBehalfOf: nil,
                 additionalParameters: additionalParameters,
                 elementsSessionContext: elementsSessionContext,
@@ -673,13 +673,13 @@ extension PaymentMethodFormViewController {
                 intentType: .deferred,
                 financialConnectionsCompletion: financialConnectionsCompletion
             )
-        case .checkout(let checkout):
+        case .checkout(let session):
             client.collectBankAccountForDeferredIntentOrCheckoutSession(
                 sessionId: elementsSession.sessionID,
                 returnURL: configuration.returnURL,
                 onEvent: nil,
-                amount: checkout.nonisolatedSession.expectedAmount(),
-                currency: checkout.nonisolatedSession.currency,
+                amount: session.expectedAmount(),
+                currency: session.currency,
                 onBehalfOf: nil,
                 additionalParameters: additionalParameters,
                 elementsSessionContext: elementsSessionContext,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -22,6 +22,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
     let formCache: PaymentMethodFormCache = .init()
     let analyticsHelper: PaymentSheetAnalyticsHelper
     let loadResult: PaymentSheetLoader.LoadResult
+    weak var checkout: Checkout?
     var savedPaymentMethods: [STPPaymentMethod] {
         return savedPaymentOptionsViewController.savedPaymentMethods
     }
@@ -172,11 +173,13 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         configuration: PaymentSheet.Configuration,
         loadResult: PaymentSheetLoader.LoadResult,
         analyticsHelper: PaymentSheetAnalyticsHelper,
+        checkout: Checkout? = nil,
         previousPaymentOption: PaymentOption? = nil
     ) {
         self.loadResult = loadResult
         self.intent = loadResult.intent
         self.elementsSession = loadResult.elementsSession
+        self.checkout = checkout
         self.isApplePayEnabled = PaymentSheet.isApplePayEnabled(elementsSession: elementsSession, configuration: configuration)
         self.isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
         self.couldShowLinkInHeader = isLinkEnabled && !isApplePayEnabled
@@ -486,7 +489,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
     /// Syncs billing address to the checkout session, then closes the sheet.
     /// If the sync fails, stays on the sheet and shows the error instead.
     private func syncCheckoutBillingThenClose() {
-        guard case .checkout(let checkout) = intent,
+        guard let checkout,
               let paymentOption = selectedPaymentOption else {
             flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
             return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -298,7 +298,8 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
             configuration: configuration,
             intent: intent,
             elementsSession: elementsSession,
-            analyticsHelper: analyticsHelper
+            analyticsHelper: analyticsHelper,
+            checkout: checkout
         ) { [weak self] confirmOption, _ in
             guard let self else { return }
             self.linkConfirmOption = confirmOption

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/ConfirmButton.swift
@@ -46,11 +46,11 @@ class ConfirmButton: UIControl {
                 case .setup:
                     return .setup
                 }
-            case .checkout(let checkout):
-                switch checkout.nonisolatedSession.mode {
+            case .checkout(let session):
+                switch session.mode {
                 case .payment:
-                    if let amount = checkout.nonisolatedSession.expectedAmount(),
-                       let currency = checkout.nonisolatedSession.currency {
+                    if let amount = session.expectedAmount(),
+                       let currency = session.currency {
                         return .pay(amount: amount, currency: currency, withLock: withLock)
                     }
                     stpAssertionFailure("Missing amount and currency in checkout session for .payment mode")

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -140,6 +140,7 @@ typealias ExpressType = PaymentSheet.WalletButtonsVisibility.ExpressType
                 elementsSession: flowController.elementsSession,
                 paymentOption: .applePay,
                 paymentHandler: flowController.paymentHandler,
+                checkout: flowController.checkout,
                 analyticsHelper: flowController.analyticsHelper
             ) { result, _ in
                 if case .completed = result {
@@ -154,7 +155,8 @@ typealias ExpressType = PaymentSheet.WalletButtonsVisibility.ExpressType
                 intent: flowController.intent,
                 elementsSession: flowController.elementsSession,
                 configuration: flowController.configuration,
-                analyticsHelper: flowController.analyticsHelper
+                analyticsHelper: flowController.analyticsHelper,
+                checkout: flowController.checkout
             )
             linkController.presentForPaymentMethodSelection(
                 from: WindowAuthenticationContext().authenticationPresentingViewController(),

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -70,6 +70,32 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertEqual(checkout.session.paymentOption?.paymentMethodType, "paynow")
     }
 
+    func testCheckoutAndPaymentElementDoNotRetainEachOther() async throws {
+        weak var weakCheckout: Checkout?
+        weak var weakPaymentElement: PaymentElement?
+        weak var weakFlowController: PaymentSheet.FlowController?
+        weak var weakEmbeddedPaymentElement: EmbeddedPaymentElement?
+
+        do {
+            let checkout = await Checkout(
+                clientSecret: "cs_test_123_secret_abc",
+                apiResponse: Self.makeOpenSession(paymentMethodTypes: ["card"])
+            )
+            let paymentElement = try await PaymentElement(checkout: checkout)
+            checkout.paymentElement = paymentElement
+
+            weakCheckout = checkout
+            weakPaymentElement = paymentElement
+            weakFlowController = paymentElement.paymentSheetFlowController
+            weakEmbeddedPaymentElement = paymentElement.embeddedPaymentElement
+        }
+
+        XCTAssertNil(weakCheckout)
+        XCTAssertNil(weakPaymentElement)
+        XCTAssertNil(weakFlowController)
+        XCTAssertNil(weakEmbeddedPaymentElement)
+    }
+
     private static func makeOpenSession(paymentMethodTypes: [String]) -> PaymentPagesAPIResponse {
         return PaymentPagesAPIResponse.decodedObject(
             fromAPIResponse: openSessionJSON(paymentMethodTypes: paymentMethodTypes)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
@@ -372,7 +372,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             "setup_future_usage": "off_session",
         ]).withCustomer()
 
-        XCTAssertEqual(Intent.checkout(Checkout(apiResponse: session)).setupFutureUsageString, "off_session")
+        XCTAssertEqual(Intent.checkout(session.makePublicSession()).setupFutureUsageString, "off_session")
     }
 
     func testCheckoutSessionIntent_isPaymentMethodOptionsSetupFutureUsageSet() {
@@ -383,7 +383,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             "payment_method_types": ["paypal"],
         ]).withCustomer()
 
-        XCTAssertEqual(Intent.checkout(Checkout(apiResponse: session)).isPaymentMethodOptionsSetupFutureUsageSet, true)
+        XCTAssertEqual(Intent.checkout(session.makePublicSession()).isPaymentMethodOptionsSetupFutureUsageSet, true)
     }
 
     func testCheckoutSessionIntent_isSetupFutureUsageSet_topLevel() {
@@ -392,7 +392,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             "payment_method_types": ["paypal"],
         ]).withCustomer()
 
-        XCTAssertTrue(Intent.checkout(Checkout(apiResponse: session)).isSetupFutureUsageSet(for: .payPal))
+        XCTAssertTrue(Intent.checkout(session.makePublicSession()).isSetupFutureUsageSet(for: .payPal))
     }
 
     func testCheckoutSessionIntent_isSetupFutureUsageSet_topLevelNone() {
@@ -401,8 +401,8 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             "payment_method_types": ["paypal"],
         ]).withCustomer()
 
-        XCTAssertEqual(Intent.checkout(Checkout(apiResponse: session)).setupFutureUsageString, "none")
-        XCTAssertFalse(Intent.checkout(Checkout(apiResponse: session)).isSetupFutureUsageSet(for: .payPal))
+        XCTAssertEqual(Intent.checkout(session.makePublicSession()).setupFutureUsageString, "none")
+        XCTAssertFalse(Intent.checkout(session.makePublicSession()).isSetupFutureUsageSet(for: .payPal))
     }
 
     func testCheckoutSessionIntent_isSetupFutureUsageSet_perPaymentMethod() {
@@ -413,7 +413,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             "payment_method_types": ["paypal"],
         ]).withCustomer()
 
-        XCTAssertTrue(Intent.checkout(Checkout(apiResponse: session)).isSetupFutureUsageSet(for: .payPal))
+        XCTAssertTrue(Intent.checkout(session.makePublicSession()).isSetupFutureUsageSet(for: .payPal))
     }
 
     func testCheckoutSessionIntent_isSetupFutureUsageSet_perPaymentMethodNoneOverridesTopLevel() {
@@ -425,7 +425,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             "payment_method_types": ["paypal"],
         ]).withCustomer()
 
-        XCTAssertFalse(Intent.checkout(Checkout(apiResponse: session)).isSetupFutureUsageSet(for: .payPal))
+        XCTAssertFalse(Intent.checkout(session.makePublicSession()).isSetupFutureUsageSet(for: .payPal))
     }
 
     // MARK: - TaxStatus Tests

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
@@ -300,6 +300,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
 
     func testCheckoutSessionConfirmWithNewPaymentMethodViaLink() {
         let checkoutSession = PaymentPagesAPIResponse.decodedObject(fromAPIResponse: MockJson.checkoutSession)!
+        let checkout = Checkout(apiResponse: checkoutSession)
 
         // In non-passthrough mode, Link payment details are converted to params and
         // a new payment method is created before calling checkout session confirm
@@ -357,10 +358,11 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(checkoutSession.makePublicSession()),
+            intent: .checkout(checkout.session),
             elementsSession: elementsSession,
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
+            checkout: checkout,
             analyticsHelper: ._testValue(),
             completion: { result, _ in
                 XCTAssertEqual(result, .completed)
@@ -373,6 +375,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
 
     func testCheckoutSessionConfirmWithNewPaymentMethodSelectedSendsSaveAndAllowRedisplay() {
         let checkoutSession = PaymentPagesAPIResponse.decodedObject(fromAPIResponse: MockJson.checkoutSession)!
+        let checkout = Checkout(apiResponse: checkoutSession)
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"])
         var confirmParams = MockParams.intentConfirmParams
         confirmParams.saveForFutureUseCheckboxState = .selected
@@ -390,10 +393,11 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(checkoutSession.makePublicSession()),
+            intent: .checkout(checkout.session),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
+            checkout: checkout,
             analyticsHelper: ._testValue(),
             completion: { result, _ in
                 XCTAssertEqual(result, .completed)
@@ -406,6 +410,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
 
     func testCheckoutSessionConfirmWithNewPaymentMethodDeselectedOmitsSaveAndUsesUnspecifiedAllowRedisplay() {
         let checkoutSession = PaymentPagesAPIResponse.decodedObject(fromAPIResponse: MockJson.checkoutSession)!
+        let checkout = Checkout(apiResponse: checkoutSession)
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"])
         var confirmParams = MockParams.intentConfirmParams
         confirmParams.saveForFutureUseCheckboxState = .deselected
@@ -423,10 +428,11 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(checkoutSession.makePublicSession()),
+            intent: .checkout(checkout.session),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
+            checkout: checkout,
             analyticsHelper: ._testValue(),
             completion: { result, _ in
                 XCTAssertEqual(result, .completed)
@@ -439,6 +445,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
 
     func testCheckoutSessionConfirmWithHiddenCheckboxOmitsSavePaymentMethod() {
         let checkoutSession = PaymentPagesAPIResponse.decodedObject(fromAPIResponse: MockJson.checkoutSession)!
+        let checkout = Checkout(apiResponse: checkoutSession)
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"])
         let confirmParams = MockParams.intentConfirmParams
 
@@ -455,10 +462,11 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(checkoutSession.makePublicSession()),
+            intent: .checkout(checkout.session),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
+            checkout: checkout,
             analyticsHelper: ._testValue(),
             completion: { result, _ in
                 XCTAssertEqual(result, .completed)
@@ -473,6 +481,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         var checkoutSessionJSON = MockJson.checkoutSession
         checkoutSessionJSON["setup_future_usage"] = "off_session"
         let checkoutSession = PaymentPagesAPIResponse.decodedObject(fromAPIResponse: checkoutSessionJSON)!
+        let checkout = Checkout(apiResponse: checkoutSession)
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"])
         var confirmParams = MockParams.intentConfirmParams
         confirmParams.saveForFutureUseCheckboxState = .deselected
@@ -490,10 +499,11 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(checkoutSession.makePublicSession()),
+            intent: .checkout(checkout.session),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
+            checkout: checkout,
             analyticsHelper: ._testValue(),
             completion: { result, _ in
                 XCTAssertEqual(result, .completed)
@@ -512,6 +522,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
             "status": "not_accepted",
         ]
         let checkoutSession = PaymentPagesAPIResponse.decodedObject(fromAPIResponse: checkoutSessionJSON)!
+        let checkout = Checkout(apiResponse: checkoutSession)
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["card"])
         var confirmParams = MockParams.intentConfirmParams
         confirmParams.saveForFutureUseCheckboxState = .hidden
@@ -529,10 +540,11 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(checkoutSession.makePublicSession()),
+            intent: .checkout(checkout.session),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
+            checkout: checkout,
             analyticsHelper: ._testValue(),
             completion: { result, _ in
                 XCTAssertEqual(result, .completed)
@@ -547,6 +559,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         var checkoutSessionJSON = MockJson.checkoutSession
         checkoutSessionJSON["payment_method_types"] = ["paypal"]
         let checkoutSession = PaymentPagesAPIResponse.decodedObject(fromAPIResponse: checkoutSessionJSON)!
+        let checkout = Checkout(apiResponse: checkoutSession)
         let elementsSession = STPElementsSession._testValue(paymentMethodTypes: ["paypal"])
         let confirmParams = IntentConfirmParams(type: .stripe(.payPal))
         confirmParams.saveForFutureUseCheckboxState = .selected
@@ -564,10 +577,11 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(checkoutSession.makePublicSession()),
+            intent: .checkout(checkout.session),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
+            checkout: checkout,
             analyticsHelper: ._testValue(),
             completion: { result, _ in
                 XCTAssertEqual(result, .completed)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APIMockTest.swift
@@ -357,7 +357,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(Checkout(apiResponse: checkoutSession)),
+            intent: .checkout(checkoutSession.makePublicSession()),
             elementsSession: elementsSession,
             paymentOption: paymentOption,
             paymentHandler: paymentHandler,
@@ -390,7 +390,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(Checkout(apiResponse: checkoutSession)),
+            intent: .checkout(checkoutSession.makePublicSession()),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
@@ -423,7 +423,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(Checkout(apiResponse: checkoutSession)),
+            intent: .checkout(checkoutSession.makePublicSession()),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
@@ -455,7 +455,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(Checkout(apiResponse: checkoutSession)),
+            intent: .checkout(checkoutSession.makePublicSession()),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
@@ -490,7 +490,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(Checkout(apiResponse: checkoutSession)),
+            intent: .checkout(checkoutSession.makePublicSession()),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
@@ -529,7 +529,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(Checkout(apiResponse: checkoutSession)),
+            intent: .checkout(checkoutSession.makePublicSession()),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,
@@ -564,7 +564,7 @@ final class PaymentSheetAPIMockTest: APIStubbedTestCase {
         PaymentSheet.confirm(
             configuration: configuration,
             authenticationContext: self,
-            intent: .checkout(Checkout(apiResponse: checkoutSession)),
+            intent: .checkout(checkoutSession.makePublicSession()),
             elementsSession: elementsSession,
             paymentOption: .new(confirmParams: confirmParams),
             paymentHandler: paymentHandler,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -77,7 +77,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             overrides["customer_managed_saved_payment_methods_offer_save"] = offerSave
         }
         let session = CheckoutTestHelpers.makeSession(overrides)
-        return .checkout(Checkout(apiResponse: session))
+        return .checkout(session.makePublicSession())
     }
 
     func testUpdatesParams() {
@@ -2875,7 +2875,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             }
             let checkoutSession = PaymentPagesAPIResponse.decodedObject(fromAPIResponse: json)!
             return PaymentSheetFormFactory(
-                intent: .checkout(Checkout(apiResponse: checkoutSession)),
+                intent: .checkout(checkoutSession.makePublicSession()),
                 elementsSession: ._testValue(paymentMethodTypes: ["paypal"]),
                 configuration: .paymentElement(PaymentSheet.Configuration._testValue_MostPermissive()),
                 paymentMethod: .stripe(.payPal),

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -1138,7 +1138,7 @@ extension PaymentSheetLPMConfirmFlowTests {
             intents = [
                 ("PaymentIntent", .paymentIntent(paymentIntent)),
                 ("Deferred PaymentIntent - client side confirmation", makeDeferredIntent(deferredCSC)),
-                ("CheckoutSession", .checkout(Checkout(apiResponse: checkoutSession))),
+                ("CheckoutSession", .checkout(checkoutSession.makePublicSession())),
             ]
             guard paymentMethod != .blik else {
                 // Blik doesn't support server-side confirmation
@@ -1279,7 +1279,7 @@ extension PaymentSheetLPMConfirmFlowTests {
                     checkoutSessionId: checkoutSessionResponse.id,
                     adaptivePricingAllowed: true
                 )
-                intents.append(("CheckoutSession w/ setup_future_usage", .checkout(Checkout(apiResponse: checkoutSession))))
+                intents.append(("CheckoutSession w/ setup_future_usage", .checkout(checkoutSession.makePublicSession())))
             }
 
             return intents
@@ -1391,7 +1391,7 @@ extension PaymentSheetLPMConfirmFlowTests {
                     checkoutSessionId: checkoutSessionResponse.id,
                     adaptivePricingAllowed: true
                 )
-                intents.append(("CheckoutSession w/ PMO setup_future_usage", .checkout(Checkout(apiResponse: checkoutSession))))
+                intents.append(("CheckoutSession w/ PMO setup_future_usage", .checkout(checkoutSession.makePublicSession())))
             }
 
             return intents
@@ -1431,7 +1431,7 @@ extension PaymentSheetLPMConfirmFlowTests {
                 ("Deferred SetupIntent - server side confirmation", makeDeferredIntent(deferredSSC)),
                 ("Deferred SetupIntent - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
                 ("Deferred SetupIntent - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
-                ("CheckoutSession", .checkout(Checkout(apiResponse: checkoutSession))),
+                ("CheckoutSession", .checkout(checkoutSession.makePublicSession())),
             ]
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -25,6 +25,18 @@ import XCTest
 final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
     let window: UIWindow = UIWindow(frame: .init(x: 0, y: 0, width: 428, height: 926))
 
+    struct TestIntent {
+        let description: String
+        let intent: Intent
+        let checkout: Checkout?
+
+        init(_ description: String, _ intent: Intent, checkout: Checkout? = nil) {
+            self.description = description
+            self.intent = intent
+            self.checkout = checkout
+        }
+    }
+
     enum MerchantCountry: String {
         case US = "us"
         case SG = "sg"
@@ -448,7 +460,9 @@ final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
                 return config
             }()
 
-            for (description, intent) in try await makeTestIntents(intentKind: intentKind, currency: "eur", paymentMethod: .SEPADebit, merchantCountry: .US, customer: customer, apiClient: apiClient) {
+            for testIntent in try await makeTestIntents(intentKind: intentKind, currency: "eur", paymentMethod: .SEPADebit, merchantCountry: .US, customer: customer, apiClient: apiClient) {
+                let description = testIntent.description
+                let intent = testIntent.intent
 
                 // Create elements session with customer configuration for proper ephemeral keys
                 let elementsSession: STPElementsSession
@@ -477,6 +491,7 @@ final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
                     elementsSession: elementsSession,
                     paymentOption: .saved(paymentMethod: savedSepaPM, confirmParams: nil),
                     paymentHandler: paymentHandler,
+                    checkout: testIntent.checkout,
                     analyticsHelper: ._testValue()
                 ) { result, _  in
                     e.fulfill()
@@ -705,7 +720,9 @@ final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
                 merchantCountry: merchantCountry,
                 apiClient: apiClient
             )
-            for (description, intent) in intents {
+            for testIntent in intents {
+                let description = testIntent.description
+                let intent = testIntent.intent
                 let e = expectation(description: "Confirm Apple Pay (\(description))")
                 let elementsSession = STPElementsSession._testValue(intent: intent)
                 let clientAttributionMetadata = STPClientAttributionMetadata.makeClientAttributionMetadata(
@@ -718,6 +735,7 @@ final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
                     elementsSession: elementsSession,
                     configuration: configuration,
                     clientAttributionMetadata: clientAttributionMetadata,
+                    checkout: testIntent.checkout,
                     completion: { result, _ in
                     switch result {
                     case .failed(error: let error):
@@ -975,7 +993,9 @@ extension PaymentSheetLPMConfirmFlowTests {
         // Check that the form respects billingDetailsCollection
         verifyFormRespectsBillingDetailsCollectionConfiguration(paymentMethodType: paymentMethodType, defaultCountry: defaultCountry)
 
-        for (description, intent) in intents {
+        for testIntent in intents {
+            let description = testIntent.description
+            let intent = testIntent.intent
 
             func makeFormVC(previousCustomerInput: IntentConfirmParams?) -> PaymentMethodFormViewController {
                 return PaymentMethodFormViewController(type: .stripe(paymentMethodType), intent: intent, elementsSession: ._testValue(intent: intent, allowsSetAsDefaultPM: allowsSetAsDefaultPM), previousCustomerInput: previousCustomerInput, formCache: .init(), configuration: configuration, paymentMethodOrientation: .vertical, headerView: nil, analyticsHelper: ._testValue(), delegate: self)
@@ -1054,6 +1074,7 @@ extension PaymentSheetLPMConfirmFlowTests {
                 elementsSession: ._testValue(intent: intent),
                 paymentOption: .new(confirmParams: intentConfirmParams),
                 paymentHandler: paymentHandler,
+                checkout: testIntent.checkout,
                 analyticsHelper: ._testValue()
             ) { result, _  in
                 switch result {
@@ -1078,7 +1099,7 @@ extension PaymentSheetLPMConfirmFlowTests {
         merchantCountry: MerchantCountry,
         customer: String? = nil,
         apiClient: STPAPIClient
-    ) async throws -> [(String, Intent)] {
+    ) async throws -> [TestIntent] {
         let paramsForServerSideConfirmation: [String: Any] = [ // We require merchants to set some extra parameters themselves for server-side confirmation
             "return_url": "foo://bar",
             "mandate_data": [
@@ -1095,7 +1116,7 @@ extension PaymentSheetLPMConfirmFlowTests {
             return .deferredIntent(intentConfig: intentConfig)
         }
 
-        var intents: [(String, Intent)] = []
+        var intents: [TestIntent] = []
         let paymentMethodTypes = [paymentMethod.identifier].compactMap { $0 }
         let setupFutureUsageSupport = setupFutureUsageSupport(for: paymentMethod)
         switch intentKind {
@@ -1134,11 +1155,12 @@ extension PaymentSheetLPMConfirmFlowTests {
                 checkoutSessionId: checkoutSessionResponse.id,
                 adaptivePricingAllowed: true
             )
+            let checkout = Checkout(apiResponse: checkoutSession)
 
             intents = [
-                ("PaymentIntent", .paymentIntent(paymentIntent)),
-                ("Deferred PaymentIntent - client side confirmation", makeDeferredIntent(deferredCSC)),
-                ("CheckoutSession", .checkout(checkoutSession.makePublicSession())),
+                TestIntent("PaymentIntent", .paymentIntent(paymentIntent)),
+                TestIntent("Deferred PaymentIntent - client side confirmation", makeDeferredIntent(deferredCSC)),
+                TestIntent("CheckoutSession", .checkout(checkout.session), checkout: checkout),
             ]
             guard paymentMethod != .blik else {
                 // Blik doesn't support server-side confirmation
@@ -1158,7 +1180,7 @@ extension PaymentSheetLPMConfirmFlowTests {
             }
 
             intents += [
-                ("Deferred PaymentIntent - server side confirmation", makeDeferredIntent(deferredSSC)),
+                TestIntent("Deferred PaymentIntent - server side confirmation", makeDeferredIntent(deferredSSC)),
             ]
 
             // Confirmation token variations
@@ -1185,8 +1207,8 @@ extension PaymentSheetLPMConfirmFlowTests {
             })
 
             intents += [
-                ("Deferred PaymentIntent - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
-                ("Deferred PaymentIntent - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
+                TestIntent("Deferred PaymentIntent - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
+                TestIntent("Deferred PaymentIntent - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
             ]
 
             return intents
@@ -1255,12 +1277,12 @@ extension PaymentSheetLPMConfirmFlowTests {
                 )
             })
 
-            var intents: [(String, Intent)] = [
-                ("PaymentIntent", .paymentIntent(paymentIntent)),
-                ("Deferred PaymentIntent w/ setup_future_usage - client side confirmation with payment method flow", makeDeferredIntent(deferredCSC)),
-                ("Deferred PaymentIntent w/ setup_future_usage - server side confirmation with payment method flow", makeDeferredIntent(deferredSSC)),
-                ("Deferred PaymentIntent w/ setup_future_usage - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
-                ("Deferred PaymentIntent w/ setup_future_usage - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
+            var intents: [TestIntent] = [
+                TestIntent("PaymentIntent", .paymentIntent(paymentIntent)),
+                TestIntent("Deferred PaymentIntent w/ setup_future_usage - client side confirmation with payment method flow", makeDeferredIntent(deferredCSC)),
+                TestIntent("Deferred PaymentIntent w/ setup_future_usage - server side confirmation with payment method flow", makeDeferredIntent(deferredSSC)),
+                TestIntent("Deferred PaymentIntent w/ setup_future_usage - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
+                TestIntent("Deferred PaymentIntent w/ setup_future_usage - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
             ]
 
             // Payment+SFU and PMO SFU are not always available on payment methods that support them for intents.
@@ -1279,7 +1301,8 @@ extension PaymentSheetLPMConfirmFlowTests {
                     checkoutSessionId: checkoutSessionResponse.id,
                     adaptivePricingAllowed: true
                 )
-                intents.append(("CheckoutSession w/ setup_future_usage", .checkout(checkoutSession.makePublicSession())))
+                let checkout = Checkout(apiResponse: checkoutSession)
+                intents.append(TestIntent("CheckoutSession w/ setup_future_usage", .checkout(checkout.session), checkout: checkout))
             }
 
             return intents
@@ -1368,12 +1391,12 @@ extension PaymentSheetLPMConfirmFlowTests {
                 }
             )
 
-            var intents: [(String, Intent)] = [
-                ("PaymentIntent", .paymentIntent(paymentIntent)),
-                ("Deferred PaymentIntent w/ PMO setup_future_usage - client side confirmation", makeDeferredIntent(deferredCSC)),
-                ("Deferred PaymentIntent w/ PMO setup_future_usage - server side confirmation", makeDeferredIntent(deferredSSC)),
-                ("Deferred PaymentIntent w/ PMO setup_future_usage - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
-                ("Deferred PaymentIntent w/ PMO setup_future_usage - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
+            var intents: [TestIntent] = [
+                TestIntent("PaymentIntent", .paymentIntent(paymentIntent)),
+                TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - client side confirmation", makeDeferredIntent(deferredCSC)),
+                TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - server side confirmation", makeDeferredIntent(deferredSSC)),
+                TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
+                TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
             ]
             if setupFutureUsageSupport.checkoutSessionPaymentMethodOptionsSetupFutureUsage {
                 let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
@@ -1391,7 +1414,8 @@ extension PaymentSheetLPMConfirmFlowTests {
                     checkoutSessionId: checkoutSessionResponse.id,
                     adaptivePricingAllowed: true
                 )
-                intents.append(("CheckoutSession w/ PMO setup_future_usage", .checkout(checkoutSession.makePublicSession())))
+                let checkout = Checkout(apiResponse: checkoutSession)
+                intents.append(TestIntent("CheckoutSession w/ PMO setup_future_usage", .checkout(checkout.session), checkout: checkout))
             }
 
             return intents
@@ -1424,14 +1448,15 @@ extension PaymentSheetLPMConfirmFlowTests {
             )
             let csApiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
             let checkoutSession = try await csApiClient.initCheckoutSession(checkoutSessionId: checkoutSessionResponse.id, adaptivePricingAllowed: true)
+            let checkout = Checkout(apiResponse: checkoutSession)
 
             return [
-                ("SetupIntent", .setupIntent(setupIntent)),
-                ("Deferred SetupIntent - client side confirmation", makeDeferredIntent(deferredCSC)),
-                ("Deferred SetupIntent - server side confirmation", makeDeferredIntent(deferredSSC)),
-                ("Deferred SetupIntent - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
-                ("Deferred SetupIntent - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
-                ("CheckoutSession", .checkout(checkoutSession.makePublicSession())),
+                TestIntent("SetupIntent", .setupIntent(setupIntent)),
+                TestIntent("Deferred SetupIntent - client side confirmation", makeDeferredIntent(deferredCSC)),
+                TestIntent("Deferred SetupIntent - server side confirmation", makeDeferredIntent(deferredSSC)),
+                TestIntent("Deferred SetupIntent - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
+                TestIntent("Deferred SetupIntent - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
+                TestIntent("CheckoutSession", .checkout(checkout.session), checkout: checkout),
             ]
         }
     }
@@ -1478,7 +1503,9 @@ extension PaymentSheetLPMConfirmFlowTests {
                 apiClient: apiClient
             )
 
-            for (description, intent) in intents {
+            for testIntent in intents {
+                let description = testIntent.description
+                let intent = testIntent.intent
                 let linkPaymentMethod = try await makeLinkPaymentMethod(apiClient)
 
                 let e = expectation(description: "Confirm Link (\(description))")
@@ -1506,6 +1533,7 @@ extension PaymentSheetLPMConfirmFlowTests {
                         )
                     ),
                     paymentHandler: paymentHandler,
+                    checkout: testIntent.checkout,
                     analyticsHelper: ._testValue()
                 ) { result, _ in
                     switch result {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -793,11 +793,11 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
             expectation.fulfill()
             switch result {
             case .success(let (loadResult, _)):
-                guard case let .checkout(loadedCheckout) = loadResult.intent else {
+                guard case let .checkout(loadedSession) = loadResult.intent else {
                     XCTFail("Expected checkout intent type")
                     return
                 }
-                XCTAssertEqual(loadedCheckout.session.id, checkoutSessionId)
+                XCTAssertEqual(loadedSession.id, checkoutSessionId)
                 XCTAssertTrue(loadResult.elementsSession.sessionID.hasPrefix("elements_session_"))
                 XCTAssertTrue(loadResult.elementsSession.orderedPaymentMethodTypes.contains(.card))
             case .failure(let error):
@@ -829,14 +829,14 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
             expectation.fulfill()
             switch result {
             case .success(let (loadResult, _)):
-                guard case let .checkout(loadedCheckout) = loadResult.intent else {
+                guard case let .checkout(loadedSession) = loadResult.intent else {
                     XCTFail("Expected checkout intent type")
                     return
                 }
-                XCTAssertEqual(loadedCheckout.session.id, checkoutSessionId)
-                XCTAssertEqual(loadedCheckout.session.mode, .setup)
-                XCTAssertEqual(loadedCheckout.session.status?.type, .open)
-                XCTAssertEqual(loadedCheckout.session.status?.paymentStatus, .noPaymentRequired)
+                XCTAssertEqual(loadedSession.id, checkoutSessionId)
+                XCTAssertEqual(loadedSession.mode, .setup)
+                XCTAssertEqual(loadedSession.status?.type, .open)
+                XCTAssertEqual(loadedSession.status?.paymentStatus, .noPaymentRequired)
                 XCTAssertTrue(loadResult.elementsSession.sessionID.hasPrefix("elements_session_"))
                 XCTAssertTrue(loadResult.elementsSession.orderedPaymentMethodTypes.contains(.card))
             case .failure(let error):

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -493,6 +493,7 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
     private func makeApplePayContext(
         for intent: Intent,
         configuration: PaymentSheet.Configuration? = nil,
+        checkout: CheckoutSessionBillingAddressUpdater? = nil,
         file: StaticString = #filePath,
         line: UInt = #line
     ) -> STPApplePayContext {
@@ -506,12 +507,20 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
             elementsSession: elementsSession,
             configuration: configuration ?? self.configuration,
             clientAttributionMetadata: clientAttributionMetadata,
+            checkout: checkout ?? Self.makeCheckoutUpdaterIfNecessary(for: intent),
             completion: { _, _ in }
         ) else {
             XCTFail("Failed to create Apple Pay context", file: file, line: line)
             fatalError("Unreachable")
         }
         return context
+    }
+
+    private static func makeCheckoutUpdaterIfNecessary(for intent: Intent) -> CheckoutSessionBillingAddressUpdater? {
+        guard case .checkout(let session) = intent else {
+            return nil
+        }
+        return TestCheckoutSessionBillingAddressUpdater(session: session)
     }
 
     private func makeMerchantConfiguration() -> PaymentSheet.Configuration {
@@ -832,6 +841,33 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
         XCTAssertEqual(sut.paymentSummaryItems.count, 1)
         XCTAssertEqual(sut.paymentSummaryItems[0].label, "Custom")
         XCTAssertEqual(sut.paymentSummaryItems[0].amount, NSDecimalNumber(string: "9.99"))
+    }
+}
+
+private final class TestCheckoutSessionBillingAddressUpdater: CheckoutSessionBillingAddressUpdater {
+    private var session: Checkout.Session
+
+    init(session: Checkout.Session) {
+        self.session = session
+    }
+
+    func commitSession(
+        _ apiResponse: PaymentPagesAPIResponse?,
+        applying localMutation: (@MainActor @Sendable (Checkout.Session) -> Checkout.Session)?
+    ) async throws {
+        session = localMutation?(apiResponse?.makePublicSession() ?? session) ?? apiResponse?.makePublicSession() ?? session
+    }
+
+    func updateBillingAddressForPaymentSheet(
+        name: String?,
+        phone: String?,
+        address: Checkout.Address,
+        canUpdateWhileSheetPresented: Bool
+    ) async throws -> Checkout.Session {
+        session = session.makeCopyOverriding(
+            billingAddress: .newValue(.init(name: name, phone: phone, address: address))
+        )
+        return session
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPApplePayContext+PaymentSheetTest.swift
@@ -712,12 +712,12 @@ final class STPApplePayContext_PaymentSheetTest: XCTestCase {
 
     func testCreatePaymentRequest_CheckoutSession_NoBillingContact_WhenNoBillingAddress() {
         let intent = Intent._testCheckoutSession(mode: .payment, amount: 2345, currency: "USD")
-        guard case .checkout(let checkout) = intent else {
+        guard case .checkout(let session) = intent else {
             XCTFail("Expected checkout intent")
             return
         }
         // billingAddress is nil by default
-        XCTAssertNil(checkout.session.billingAddress)
+        XCTAssertNil(session.billingAddress)
 
         let sut = STPApplePayContext.createPaymentRequest(intent: intent, configuration: configuration, applePay: applePayConfiguration)
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPFixtures+PaymentSheet.swift
@@ -233,8 +233,8 @@ extension STPElementsSession {
                 return setupIntent.paymentMethodTypes.map { STPPaymentMethod.string(from: $0) ?? "unknown" }
             case .deferredIntent(let intentConfig):
                 return intentConfig.paymentMethodTypes ?? []
-            case .checkout(let checkout):
-                return checkout.nonisolatedSession.elementsSession.orderedPaymentMethodTypes.map { STPPaymentMethod.string(from: $0) ?? "unknown" }
+            case .checkout(let session):
+                return session.elementsSession.orderedPaymentMethodTypes.map { STPPaymentMethod.string(from: $0) ?? "unknown" }
             }
         }()
         var customerSessionData: [String: Any]?
@@ -380,11 +380,11 @@ extension Intent {
         }
 
         let checkoutSession = PaymentPagesAPIResponse.decodedObject(fromAPIResponse: json)!
-        let checkout = Checkout(apiResponse: checkoutSession)
+        var session = checkoutSession.makePublicSession()
         if let billingAddress {
-            checkout.dangerouslySetSessionDirectly(checkout.session.makeCopyOverriding(billingAddress: .newValue(billingAddress)))
+            session = session.makeCopyOverriding(billingAddress: .newValue(billingAddress))
         }
-        return .checkout(checkout)
+        return .checkout(session)
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTests.swift
@@ -108,7 +108,7 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
         let sut = SavedPaymentMethodManager(
             configuration: configuration,
             elementsSession: ._testValue(paymentMethodTypes: ["card"]),
-            intent: .checkout(Checkout(apiResponse: checkoutSession))
+            intent: .checkout(checkoutSession.makePublicSession())
         )
 
         let card = STPPaymentMethodCardParams()
@@ -143,7 +143,7 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
         let sut = SavedPaymentMethodManager(
             configuration: configuration,
             elementsSession: ._testValue(paymentMethodTypes: ["card"]),
-            intent: .checkout(Checkout(apiResponse: checkoutSession))
+            intent: .checkout(checkoutSession.makePublicSession())
         )
 
         let card = STPPaymentMethodCardParams()
@@ -167,7 +167,7 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
         let sut = SavedPaymentMethodManager(
             configuration: configuration,
             elementsSession: ._testValue(paymentMethodTypes: ["card"]),
-            intent: .checkout(Checkout(apiResponse: checkoutSession))
+            intent: .checkout(checkoutSession.makePublicSession())
         )
 
         do {
@@ -231,7 +231,7 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
         let sut = SavedPaymentMethodManager(
             configuration: configuration,
             elementsSession: ._testValue(paymentMethodTypes: ["card"]),
-            intent: .checkout(Checkout(apiResponse: checkoutSession))
+            intent: .checkout(checkoutSession.makePublicSession())
         )
         sut.detach(paymentMethod: paymentMethod)
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/VerticalSavedPaymentMethodsViewControllerTests.swift
@@ -224,7 +224,7 @@ class VerticalSavedPaymentMethodsViewControllerTests: XCTestCase {
                 "can_detach_payment_method": canDetachPaymentMethod,
             ],
         ])
-        return .checkout(Checkout(apiResponse: session))
+        return .checkout(session.makePublicSession())
     }
 
 }


### PR DESCRIPTION
## Summary
- Change Intent.checkout to store Checkout.Session instead of Checkout
- Add a PaymentElement retain-cycle regression test

## Testing
- ci_scripts/run_tests.rb --test StripePaymentSheetTests/PaymentElementTest/testCheckoutAndPaymentElementDoNotRetainEachOther
- ci_scripts/run_tests.rb --scheme StripePaymentSheet --build-only
- ci_scripts/format_modified_files.sh
- ci_scripts/lint_modified_files.sh

Also verified the retain-cycle test fails when temporarily reverting Intent.checkout back to Checkout.