### PR TITLE
Clear stale billing address fields on country change

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -550,6 +550,10 @@ extension PaymentSheetFormFactory {
             guard case .valid = section.validationState else {
                 return nil
             }
+            if let previousCountry = params.paymentMethodParams.billingDetails?.address?.country,
+               previousCountry.caseInsensitiveCompare(section.selectedCountryCode) != .orderedSame {
+                params.paymentMethodParams.nonnil_billingDetails.address = STPPaymentMethodAddress()
+            }
             if let line1 = section.line1 {
                 params.paymentMethodParams.nonnil_billingDetails.nonnil_address.line1 = line1.text
             }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -1776,6 +1776,37 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertEqual(billingDetails.country, defaultAddress.country)
     }
 
+    func testBillingAddressSectionClearsHiddenFieldsAfterCountryChange() throws {
+        let section = AddressSectionElement(
+            countries: ["US", "FR"],
+            locale: Locale(identifier: "en_US"),
+            addressSpecProvider: addressSpecProvider(countries: ["US", "FR"]),
+            defaults: .init(address: .init(city: "San Francisco", country: "US", line1: "1 Main Street", line2: "Apt 1", postalCode: "94107", state: "CA")),
+            collectionMode: .all
+        )
+        let sut = PaymentSheetFormFactory.makeBillingAddressPaymentMethodWrapper(section: section, countryAPIPath: nil)
+        let params = try XCTUnwrap(sut.updateParams(params: IntentConfirmParams(type: .stripe(.card))))
+
+        section.collectionMode = .countryAndPostal(countriesRequiringPostalCollection: ["FR"])
+        section.selectedCountryCode = "FR"
+        section.postalCode?.setText("75001")
+        _ = try XCTUnwrap(sut.updateParams(params: params))
+        XCTAssertNil(params.paymentMethodParams.billingDetails?.address?.line1)
+        XCTAssertNil(params.paymentMethodParams.billingDetails?.address?.line2)
+        XCTAssertNil(params.paymentMethodParams.billingDetails?.address?.city)
+        XCTAssertNil(params.paymentMethodParams.billingDetails?.address?.state)
+        XCTAssertEqual(params.paymentMethodParams.billingDetails?.address?.postalCode, "75001")
+
+        section.collectionMode = .countryOnly
+        section.selectedCountryCode = "US"
+        _ = try XCTUnwrap(sut.updateParams(params: params))
+        XCTAssertNil(params.paymentMethodParams.billingDetails?.address?.line1)
+        XCTAssertNil(params.paymentMethodParams.billingDetails?.address?.line2)
+        XCTAssertNil(params.paymentMethodParams.billingDetails?.address?.city)
+        XCTAssertNil(params.paymentMethodParams.billingDetails?.address?.state)
+        XCTAssertNil(params.paymentMethodParams.billingDetails?.address?.postalCode)
+    }
+
     func testPreferDefaultBillingDetailsOverShippingDetails() {
         var configuration = PaymentSheet.Configuration()
         configuration.customer = .init(id: "id", ephemeralKeySecret: "sec")

--- a/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Factories/Address/AddressSectionElement.swift
@@ -354,6 +354,8 @@ import UIKit
             } else {
                 line1 = TextFieldElement.Address.makeLine1(defaultValue: address.line1, theme: theme)
             }
+        } else {
+            line1 = nil
         }
         line2 = fieldOrdering.contains(.line) ?
             TextFieldElement.Address.makeLine2(defaultValue: address.line2, theme: theme) : nil

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/AddressSectionElementTest.swift
@@ -190,6 +190,13 @@ class AddressSectionElementTest: XCTestCase {
         XCTAssertNil(sut.autoCompleteLine)
         XCTAssertNotNil(sut.line1)
         XCTAssertLine1DoesNotHaveAutocompleteAccessory(sut)
+
+        sut.collectionMode = .countryOnly
+        XCTAssertNil(sut.line1)
+        XCTAssertNil(sut.line2)
+        XCTAssertNil(sut.city)
+        XCTAssertNil(sut.state)
+        XCTAssertNil(sut.postalCode)
     }
 
     func test_additionalFields() {


### PR DESCRIPTION
## Summary
- Clear billing address params when the selected country changes so fields not collected by the new country don't persist.
- Switching to a country that collects fewer address fields (e.g. US to a country-only or country-and-postal locale) left stale `line1`/`city`/`state` values on the payment method params. Two gaps caused this: `AddressSectionElement` never nil'd out `line1` when the line field was dropped, and `makeBillingAddressPaymentMethodWrapper` only wrote existing fields, never clearing removed ones. This resets the address on country change and nils `line1` when it's no longer collected.

## Motivation
- 🐛  fix

## Testing
- Added new test

## Changelog
N/A
