### PR TITLE
fix: guard PaymentSheet saved-PM row image against zero-size assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ PATCH
 
 ### PaymentSheet
 * [Added] Added standalone Link wallet APIs in private preview via `LinkController`.
+* [Fixed] Fixed a crash when a saved payment method icon fails to load.
 
 ### StripeConnect
 * [Changed] `PaymentsViewController`, `PaymentsViewControllerDelegate`, `PayoutsViewController`, `PayoutsViewControllerDelegate`, and `EmbeddedComponentManager.PaymentsListDefaultFiltersOptions` are now part of the public API and no longer require `@_spi(PreviewConnect)` to access.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentOption+Images.swift
@@ -338,14 +338,20 @@ extension STPPaymentMethodCard {
 
 extension UIImage {
     func rounded(radius: CGFloat) -> UIImage {
+        guard size.width > 0, size.height > 0 else {
+            return self
+        }
         let rect = CGRect(origin: .zero, size: size)
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
         UIBezierPath(roundedRect: rect, cornerRadius: radius).addClip()
         draw(in: rect)
-        return UIGraphicsGetImageFromCurrentImageContext()!
+        return UIGraphicsGetImageFromCurrentImageContext() ?? self
     }
 
     func roundedWithBorder(radius: CGFloat, borderWidth: CGFloat = 1, borderColor: UIColor = UIColor.black.withAlphaComponent(0.2)) -> UIImage {
+        guard size.width > 0, size.height > 0 else {
+            return self
+        }
         let rect = CGRect(origin: .zero, size: size)
         UIGraphicsBeginImageContextWithOptions(size, false, 0)
         let path = UIBezierPath(roundedRect: rect, cornerRadius: radius)
@@ -356,6 +362,6 @@ extension UIImage {
         borderColor.setStroke()
         borderPath.lineWidth = borderWidth
         borderPath.stroke()
-        return UIGraphicsGetImageFromCurrentImageContext()!
+        return UIGraphicsGetImageFromCurrentImageContext() ?? self
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentOption+ImagesTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentOption+ImagesTest.swift
@@ -9,6 +9,27 @@ import XCTest
 
 final class PaymentOptionImagesTest: XCTestCase {
 
+    // MARK: - UIImage rounding
+
+    func testRounded_zeroSizeImageReturnsOriginalImage() {
+        let image = UIImage()
+
+        XCTAssertTrue(image.rounded(radius: 3) === image)
+    }
+
+    func testRoundedWithBorder_zeroSizeImageReturnsOriginalImage() {
+        let image = UIImage()
+
+        XCTAssertTrue(image.roundedWithBorder(radius: 3) === image)
+    }
+
+    func testRounded_nonZeroSizeImagePreservesDimensions() {
+        let image = UIGraphicsImageRenderer(size: CGSize(width: 10, height: 10)).image { _ in }
+
+        XCTAssertEqual(image.rounded(radius: 3).size, image.size)
+        XCTAssertEqual(image.roundedWithBorder(radius: 3).size, image.size)
+    }
+
     // MARK: - STPPaymentMethod.cardArtURL
 
     func testCardArtURL_nilWhenNoCardArt() {


### PR DESCRIPTION
## Summary

`UIImage.rounded(radius:)` and `roundedWithBorder(...)` in PaymentSheet crashed when handed a zero-size image: they called `UIGraphicsBeginImageContextWithOptions` with a `{0,0}` size and force-unwrapped the resulting context image.

## Motivation

Fixes #5870. When the U.S. bank icon asset fails to load, the `.USBankAccount` branch of `makeSavedPaymentMethodRowImage` passes a zero-size image into `rounded(radius:)`. That hits the `size={0,0}` `UIGraphicsBeginImageContextWithOptions` assertion and the force-unwrap of `UIGraphicsGetImageFromCurrentImageContext()`, crashing PaymentSheet on open (reported as [P1] with the matching `size={0, 0}` trace).

This adds a zero-size guard (returns the image unchanged) and replaces the force-unwrap with a safe fallback to the original image, in both `rounded(radius:)` and `roundedWithBorder(...)`. Valid images render exactly as before.

## Testing

`xcodebuild test -workspace Stripe.xcworkspace -scheme StripePaymentSheet -only-testing:StripePaymentSheetTests/PaymentOptionImagesTest` on the iPhone 17 Pro simulator: 7 tests pass, including new cases asserting that a zero-size image does not crash and returns gracefully for both helpers.

## Changelog

Added a `[Fixed]` line to `CHANGELOG.md` for the PaymentSheet zero-size image crash.
