### PR TITLE
Revert persisted PaymentSheet selection on cancellation

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerPaymentOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerPaymentOption.swift
@@ -91,3 +91,52 @@ public enum CustomerPaymentOption: Equatable {
         return nil
     }
 }
+
+extension CustomerPaymentOption {
+    /// Captures the locally persisted selected payment option and the saved payment methods
+    /// available immediately before a payment surface is presented.
+    ///
+    /// On cancellation, use this snapshot to revert the persisted selection. A method that was
+    /// available before presentation but is missing at cancellation was deleted and is not restored.
+    /// A method missing at both points may be hidden or temporarily unavailable, so its selection is
+    /// restored.
+    struct PersistedSelectionSnapshot {
+        private let customerID: String?
+        private let selectedPaymentOptionBeforePresentation: CustomerPaymentOption?
+        private let availableSavedPaymentMethodIDsBeforePresentation: Set<String>
+
+        init(customerID: String?, availableSavedPaymentMethods: [STPPaymentMethod]) {
+            self.customerID = customerID
+            self.selectedPaymentOptionBeforePresentation = CustomerPaymentOption.localDefaultPaymentMethod(for: customerID)
+            self.availableSavedPaymentMethodIDsBeforePresentation = Set(availableSavedPaymentMethods.map(\.stripeId))
+        }
+
+        /// Reverts to the captured selection unless its saved payment method was deleted.
+        func revertPersistedSelection(using currentlyAvailableSavedPaymentMethods: [STPPaymentMethod]) {
+            if selectedPaymentMethodWasDeleted(from: currentlyAvailableSavedPaymentMethods) {
+                clearDeletedSelectionIfNeeded()
+            } else {
+                CustomerPaymentOption.setDefaultPaymentMethod(selectedPaymentOptionBeforePresentation, forCustomer: customerID)
+            }
+        }
+
+        private func selectedPaymentMethodWasDeleted(
+            from currentlyAvailableSavedPaymentMethods: [STPPaymentMethod]
+        ) -> Bool {
+            if case .stripeId(let selectedPaymentMethodID) = selectedPaymentOptionBeforePresentation,
+               availableSavedPaymentMethodIDsBeforePresentation.contains(selectedPaymentMethodID),
+               !currentlyAvailableSavedPaymentMethods.contains(where: { $0.stripeId == selectedPaymentMethodID }) {
+                return true
+            }
+            return false
+        }
+
+        private func clearDeletedSelectionIfNeeded() {
+            // Deletion may persist a fallback selection. Keep it, or clear the deleted selection
+            // if no fallback was persisted.
+            if CustomerPaymentOption.localDefaultPaymentMethod(for: customerID) == selectedPaymentOptionBeforePresentation {
+                CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID)
+            }
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -130,6 +130,21 @@ public class PaymentSheet {
         Task { @MainActor in
             // Overwrite completion closure to retain self until called
             let completion: (PaymentSheetResult) -> Void = { status in
+                // Every terminal path, including native Link, reaches this completion.
+                switch status {
+                case .canceled:
+                    if let paymentSheetViewController = self.bottomSheetViewController.contentStack.first(
+                        where: { $0 is PaymentSheetViewControllerProtocol }
+                    ) as? PaymentSheetViewControllerProtocol {
+                        self.revertPersistedSelectionAfterCancellation(
+                            using: paymentSheetViewController.savedPaymentMethods
+                        )
+                    }
+                case .completed, .failed:
+                    // PaymentSheet is finishing without cancellation, so discard its cancellation snapshot.
+                    self.persistedSelectionSnapshotBeforePresentation = nil
+                }
+
                 // Dismiss if necessary
                 if let presentingViewController = self.bottomSheetViewController.presentingViewController {
                     // Calling `dismiss()` on the presenting view controller causes
@@ -238,6 +253,9 @@ public class PaymentSheet {
     /// A user-supplied completion block. Nil until `present` is called.
     var completion: ((PaymentSheetResult) -> Void)?
 
+    /// Used to revert persisted selection changes if the customer cancels PaymentSheet.
+    private var persistedSelectionSnapshotBeforePresentation: CustomerPaymentOption.PersistedSelectionSnapshot?
+
     /// Loading View Controller
     lazy var loadingViewController = LoadingViewController(
         delegate: self,
@@ -275,6 +293,10 @@ public class PaymentSheet {
         loadResult: PaymentSheetLoader.LoadResult,
         previousPaymentOption: PaymentOption?
     ) -> PaymentSheetViewControllerProtocol {
+        persistedSelectionSnapshotBeforePresentation = .init(
+            customerID: configuration.customer?.id,
+            availableSavedPaymentMethods: loadResult.savedPaymentMethods
+        )
         switch loadResult.paymentMethodOrientation {
         case .horizontal:
             let vc = PaymentSheetViewController(
@@ -368,9 +390,24 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
     }
 
     func paymentSheetViewControllerDidCancel(_ paymentSheetViewController: PaymentSheetViewControllerProtocol) {
+        revertPersistedSelectionAfterCancellation(
+            using: paymentSheetViewController.savedPaymentMethods
+        )
         paymentSheetViewController.dismiss(animated: true) {
             self.completion?(.canceled)
         }
+    }
+
+    private func revertPersistedSelectionAfterCancellation(
+        using currentlyAvailableSavedPaymentMethods: [STPPaymentMethod]
+    ) {
+        guard let persistedSelectionSnapshot = persistedSelectionSnapshotBeforePresentation else {
+            return
+        }
+        // PaymentSheet is dismissing after cancellation. Clear the snapshot before applying it so
+        // a second callback cannot revert the selection again.
+        persistedSelectionSnapshotBeforePresentation = nil
+        persistedSelectionSnapshot.revertPersistedSelection(using: currentlyAvailableSavedPaymentMethods)
     }
 
     func paymentSheetViewControllerDidSelectPayWithLink(_ paymentSheetViewController: PaymentSheetViewControllerProtocol) {
@@ -406,6 +443,7 @@ extension PaymentSheet: LoadingViewControllerDelegate {
 internal protocol PaymentSheetViewControllerProtocol: UIViewController, BottomSheetContentViewController {
     var intent: Intent { get }
     var elementsSession: STPElementsSession { get }
+    var savedPaymentMethods: [STPPaymentMethod] { get }
 
     func pay(with paymentOption: PaymentOption)
     func clearTextFields()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -130,19 +130,23 @@ public class PaymentSheet {
         Task { @MainActor in
             // Overwrite completion closure to retain self until called
             let completion: (PaymentSheetResult) -> Void = { status in
-                // Every terminal path, including native Link, reaches this completion.
-                switch status {
-                case .canceled:
-                    if let paymentSheetViewController = self.bottomSheetViewController.contentStack.first(
-                        where: { $0 is PaymentSheetViewControllerProtocol }
-                    ) as? PaymentSheetViewControllerProtocol {
-                        self.revertPersistedSelectionAfterCancellation(
-                            using: paymentSheetViewController.savedPaymentMethods
-                        )
+                let finish = {
+                    // Every terminal path, including native Link, reaches this completion.
+                    switch status {
+                    case .canceled:
+                        if let paymentSheetViewController = self.bottomSheetViewController.contentStack.first(
+                            where: { $0 is PaymentSheetViewControllerProtocol }
+                        ) as? PaymentSheetViewControllerProtocol {
+                            self.revertPersistedSelectionAfterCancellation(
+                                using: paymentSheetViewController.savedPaymentMethods
+                            )
+                        }
+                    case .completed, .failed:
+                        // PaymentSheet is finishing without cancellation, so discard its cancellation snapshot.
+                        self.persistedSelectionSnapshotBeforePresentation = nil
                     }
-                case .completed, .failed:
-                    // PaymentSheet is finishing without cancellation, so discard its cancellation snapshot.
-                    self.persistedSelectionSnapshotBeforePresentation = nil
+
+                    completion(status)
                 }
 
                 // Dismiss if necessary
@@ -151,10 +155,10 @@ public class PaymentSheet {
                     // the bottom sheet and any presented view controller by
                     // bottom sheet (i.e. Link) to be dismissed all at the same time.
                     presentingViewController.dismiss(animated: true) {
-                        completion(status)
+                        finish()
                     }
                 } else {
-                    completion(status)
+                    finish()
                 }
                 self.completion = nil
             }
@@ -390,10 +394,10 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
     }
 
     func paymentSheetViewControllerDidCancel(_ paymentSheetViewController: PaymentSheetViewControllerProtocol) {
-        revertPersistedSelectionAfterCancellation(
-            using: paymentSheetViewController.savedPaymentMethods
-        )
         paymentSheetViewController.dismiss(animated: true) {
+            self.revertPersistedSelectionAfterCancellation(
+                using: paymentSheetViewController.savedPaymentMethods
+            )
             self.completion?(.canceled)
         }
     }
@@ -404,7 +408,7 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
         guard let persistedSelectionSnapshot = persistedSelectionSnapshotBeforePresentation else {
             return
         }
-        // PaymentSheet is dismissing after cancellation. Clear the snapshot before applying it so
+        // PaymentSheet has finished dismissing after cancellation. Clear the snapshot before applying it so
         // a second callback cannot revert the selection again.
         persistedSelectionSnapshotBeforePresentation = nil
         persistedSelectionSnapshot.revertPersistedSelection(using: currentlyAvailableSavedPaymentMethods)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -128,16 +128,20 @@ public class PaymentSheet {
         completion: @escaping (PaymentSheetResult) -> Void
     ) {
         Task { @MainActor in
-            // Overwrite completion closure to retain self until called
-            let completion: (PaymentSheetResult) -> Void = { status in
-                let finish = {
-                    // Every terminal path, including native Link, reaches this completion.
-                    switch status {
+            let merchantCompletion = completion
+            // Retain PaymentSheet until the presentation finishes.
+            let finishPresentation: (PaymentSheetResult) -> Void = { result in
+                // Clear this before dismissing so another terminal callback can't finish the presentation twice.
+                self.completion = nil
+
+                let completeAfterDismissal = {
+                    switch result {
                     case .canceled:
+                        // Native Link can finish without calling the PaymentSheet cancel delegate.
                         if let paymentSheetViewController = self.bottomSheetViewController.contentStack.first(
                             where: { $0 is PaymentSheetViewControllerProtocol }
                         ) as? PaymentSheetViewControllerProtocol {
-                            self.revertPersistedSelectionAfterCancellation(
+                            self.revertPersistedSelectionAfterCancellationIfNeeded(
                                 using: paymentSheetViewController.savedPaymentMethods
                             )
                         }
@@ -146,29 +150,27 @@ public class PaymentSheet {
                         self.persistedSelectionSnapshotBeforePresentation = nil
                     }
 
-                    completion(status)
+                    merchantCompletion(result)
                 }
 
-                // Dismiss if necessary
                 if let presentingViewController = self.bottomSheetViewController.presentingViewController {
                     // Calling `dismiss()` on the presenting view controller causes
                     // the bottom sheet and any presented view controller by
                     // bottom sheet (i.e. Link) to be dismissed all at the same time.
                     presentingViewController.dismiss(animated: true) {
-                        finish()
+                        completeAfterDismissal()
                     }
                 } else {
-                    finish()
+                    completeAfterDismissal()
                 }
-                self.completion = nil
             }
-            self.completion = completion
+            self.completion = finishPresentation
 
             // Guard against basic user error
             guard presentingViewController.presentedViewController == nil else {
                 assertionFailure(PaymentSheetError.alreadyPresented.debugDescription)
                 let error = PaymentSheetError.alreadyPresented
-                completion(.failed(error: error))
+                finishPresentation(.failed(error: error))
                 return
             }
             // Configure the Payment Sheet VC after loading the PI/SI, Customer, etc.
@@ -217,7 +219,7 @@ public class PaymentSheet {
                         presentPaymentSheet()
                     }
                 case .failure(let error):
-                    completion(.failed(error: error))
+                    finishPresentation(.failed(error: error))
                 }
             }
             self.bottomSheetViewController.setViewControllers([self.loadingViewController])
@@ -395,21 +397,22 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
 
     func paymentSheetViewControllerDidCancel(_ paymentSheetViewController: PaymentSheetViewControllerProtocol) {
         paymentSheetViewController.dismiss(animated: true) {
-            self.revertPersistedSelectionAfterCancellation(
+            // Restoring earlier can relayout the outgoing PaymentSheet during dismissal.
+            self.revertPersistedSelectionAfterCancellationIfNeeded(
                 using: paymentSheetViewController.savedPaymentMethods
             )
             self.completion?(.canceled)
         }
     }
 
-    private func revertPersistedSelectionAfterCancellation(
+    private func revertPersistedSelectionAfterCancellationIfNeeded(
         using currentlyAvailableSavedPaymentMethods: [STPPaymentMethod]
     ) {
         guard let persistedSelectionSnapshot = persistedSelectionSnapshotBeforePresentation else {
             return
         }
-        // PaymentSheet has finished dismissing after cancellation. Clear the snapshot before applying it so
-        // a second callback cannot revert the selection again.
+        // The cancel delegate and native Link completion can both reach this method. Clear the snapshot
+        // before applying it so the selection is reverted only once.
         persistedSelectionSnapshotBeforePresentation = nil
         persistedSelectionSnapshot.revertPersistedSelection(using: currentlyAvailableSavedPaymentMethods)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -128,49 +128,16 @@ public class PaymentSheet {
         completion: @escaping (PaymentSheetResult) -> Void
     ) {
         Task { @MainActor in
-            let merchantCompletion = completion
             // Retain PaymentSheet until the presentation finishes.
-            let finishPresentation: (PaymentSheetResult) -> Void = { result in
-                // Clear this before dismissing so another terminal callback can't finish the presentation twice.
-                self.completion = nil
-
-                let completeAfterDismissal = {
-                    switch result {
-                    case .canceled:
-                        // Native Link can finish without calling the PaymentSheet cancel delegate.
-                        if let paymentSheetViewController = self.bottomSheetViewController.contentStack.first(
-                            where: { $0 is PaymentSheetViewControllerProtocol }
-                        ) as? PaymentSheetViewControllerProtocol {
-                            self.revertPersistedSelectionAfterCancellationIfNeeded(
-                                using: paymentSheetViewController.savedPaymentMethods
-                            )
-                        }
-                    case .completed, .failed:
-                        // PaymentSheet is finishing without cancellation, so discard its cancellation snapshot.
-                        self.persistedSelectionSnapshotBeforePresentation = nil
-                    }
-
-                    merchantCompletion(result)
-                }
-
-                if let presentingViewController = self.bottomSheetViewController.presentingViewController {
-                    // Calling `dismiss()` on the presenting view controller causes
-                    // the bottom sheet and any presented view controller by
-                    // bottom sheet (i.e. Link) to be dismissed all at the same time.
-                    presentingViewController.dismiss(animated: true) {
-                        completeAfterDismissal()
-                    }
-                } else {
-                    completeAfterDismissal()
-                }
+            self.completion = { [self] result in
+                dismissAndCompletePresentation(with: result, merchantCompletion: completion)
             }
-            self.completion = finishPresentation
 
             // Guard against basic user error
             guard presentingViewController.presentedViewController == nil else {
                 assertionFailure(PaymentSheetError.alreadyPresented.debugDescription)
                 let error = PaymentSheetError.alreadyPresented
-                finishPresentation(.failed(error: error))
+                self.completion?(.failed(error: error))
                 return
             }
             // Configure the Payment Sheet VC after loading the PI/SI, Customer, etc.
@@ -219,12 +186,57 @@ public class PaymentSheet {
                         presentPaymentSheet()
                     }
                 case .failure(let error):
-                    finishPresentation(.failed(error: error))
+                    self.completion?(.failed(error: error))
                 }
             }
             self.bottomSheetViewController.setViewControllers([self.loadingViewController])
             presentingViewController.presentAsBottomSheet(bottomSheetViewController, appearance: configuration.appearance)
         }
+    }
+
+    private func dismissAndCompletePresentation(
+        with result: PaymentSheetResult,
+        merchantCompletion: @escaping (PaymentSheetResult) -> Void
+    ) {
+        // Clear the stored completion before dismissal so this presentation can't finish twice.
+        completion = nil
+
+        guard let presentingViewController = bottomSheetViewController.presentingViewController else {
+            completePresentation(with: result, merchantCompletion: merchantCompletion)
+            return
+        }
+
+        // This also dismisses anything presented by PaymentSheet, such as Link.
+        presentingViewController.dismiss(animated: true) { [self] in
+            completePresentation(with: result, merchantCompletion: merchantCompletion)
+        }
+    }
+
+    private func completePresentation(
+        with result: PaymentSheetResult,
+        merchantCompletion: (PaymentSheetResult) -> Void
+    ) {
+        switch result {
+        case .canceled:
+            // Native Link can return `.canceled` without calling the PaymentSheet cancel delegate.
+            revertPersistedSelectionUsingCurrentPaymentMethodsIfNeeded()
+        case .completed, .failed:
+            // The snapshot is only needed to undo a canceled presentation.
+            persistedSelectionSnapshotBeforePresentation = nil
+        }
+
+        merchantCompletion(result)
+    }
+
+    private func revertPersistedSelectionUsingCurrentPaymentMethodsIfNeeded() {
+        guard let paymentSheetViewController = bottomSheetViewController.contentStack.first(
+            where: { $0 is PaymentSheetViewControllerProtocol }
+        ) as? PaymentSheetViewControllerProtocol else {
+            return
+        }
+        revertPersistedSelectionAfterCancellationIfNeeded(
+            using: paymentSheetViewController.savedPaymentMethods
+        )
     }
 
     /// Presents a sheet for a customer to complete their payment

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetCancelPersistenceTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetCancelPersistenceTests.swift
@@ -2,8 +2,6 @@
 //  PaymentSheetCancelPersistenceTests.swift
 //  StripePaymentSheetTests
 //
-//  Created by Nick Porter on 7/18/26.
-//
 
 @_spi(STP) import StripeCore
 @testable @_spi(STP) import StripePayments
@@ -15,8 +13,15 @@ import XCTest
 @MainActor
 final class PaymentSheetCancelPersistenceTests: XCTestCase {
 
-    override func setUp() async throws {
-        await PaymentSheetLoader.loadMiscellaneousSingletons()
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        let expectation = expectation(description: "specs loaded")
+        AddressSpecProvider.shared.loadAddressSpecs {
+            FormSpecProvider.shared.load { _ in
+                expectation.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 1)
     }
 
     private func makeCard(id: String, last4: String) -> STPPaymentMethod {
@@ -76,6 +81,10 @@ final class PaymentSheetCancelPersistenceTests: XCTestCase {
             analyticsHelper: sheet.analyticsHelper
         )
         viewController.loadViewIfNeeded()
+        var didComplete = false
+        sheet.completion = { _ in
+            didComplete = true
+        }
 
         // When the customer selects card B and then cancels
         viewController.didTapPaymentMethod(.saved(paymentMethod: cardB))
@@ -83,12 +92,14 @@ final class PaymentSheetCancelPersistenceTests: XCTestCase {
 
         // Then the in-flight dismissal leaves card B persisted
         XCTAssertEqual(CustomerPaymentOption.localDefaultPaymentMethod(for: customerID), .stripeId(cardB.stripeId))
+        XCTAssertFalse(didComplete)
 
         // When dismissal finishes
         viewController.completeDismissal()
 
         // Then the persisted selection reverts to card A
         XCTAssertEqual(CustomerPaymentOption.localDefaultPaymentMethod(for: customerID), .stripeId(cardA.stripeId))
+        XCTAssertTrue(didComplete)
     }
 
     func testSnapshotDoesNotRestoreDeletedSavedPaymentMethod() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetCancelPersistenceTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetCancelPersistenceTests.swift
@@ -1,0 +1,129 @@
+//
+//  PaymentSheetCancelPersistenceTests.swift
+//  StripePaymentSheetTests
+//
+//  Created by Nick Porter on 7/18/26.
+//
+
+@_spi(STP) import StripeCore
+@testable @_spi(STP) import StripePayments
+@testable @_spi(STP) import StripePaymentSheet
+@_spi(STP) import StripePaymentsTestUtils
+@_spi(STP) import StripeUICore
+import XCTest
+
+@MainActor
+final class PaymentSheetCancelPersistenceTests: XCTestCase {
+
+    override func setUp() async throws {
+        await PaymentSheetLoader.loadMiscellaneousSingletons()
+    }
+
+    private func makeCard(id: String, last4: String) -> STPPaymentMethod {
+        return STPPaymentMethod.decodedObject(fromAPIResponse: [
+            "id": id,
+            "type": "card",
+            "created": "12345",
+            "card": [
+                "last4": last4,
+                "brand": "visa",
+                "exp_month": "01",
+                "exp_year": "2040",
+            ],
+        ])!
+    }
+
+    private func makeConfiguration(customerID: String) -> PaymentSheet.Configuration {
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
+        configuration.customer = .init(id: customerID, ephemeralKeySecret: "ek_test")
+        return configuration
+    }
+
+    private func makeLoadResult(
+        savedPaymentMethods: [STPPaymentMethod]
+    ) -> PaymentSheetLoader.LoadResult {
+        return PaymentSheetLoader.LoadResult(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            savedPaymentMethods: savedPaymentMethods,
+            paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
+        )
+    }
+
+    func testCancelRevertsPersistedSelection() {
+        // Given card A is persisted when PaymentSheet is presented
+        let customerID = "cus_ps_cancel"
+        defer { CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID) }
+        let cardA = makeCard(id: "pm_a", last4: "4242")
+        let cardB = makeCard(id: "pm_b", last4: "0005")
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(cardA.stripeId), forCustomer: customerID)
+        let configuration = makeConfiguration(customerID: customerID)
+        let sheet = PaymentSheet(
+            paymentIntentClientSecret: "pi_123_secret_456",
+            configuration: configuration
+        )
+        let viewController = sheet.makePaymentSheetVC(
+            loadResult: makeLoadResult(savedPaymentMethods: [cardA, cardB]),
+            previousPaymentOption: nil
+        ) as! PaymentSheetVerticalViewController
+        viewController.loadViewIfNeeded()
+
+        // When the customer selects card B and then cancels
+        viewController.didTapPaymentMethod(.saved(paymentMethod: cardB))
+        sheet.paymentSheetViewControllerDidCancel(viewController)
+
+        // Then the persisted selection reverts to card A
+        XCTAssertEqual(CustomerPaymentOption.localDefaultPaymentMethod(for: customerID), .stripeId(cardA.stripeId))
+    }
+
+    func testSnapshotDoesNotRestoreDeletedSavedPaymentMethod() {
+        let customerID = "cus_deleted"
+        defer { CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID) }
+        let deletedCard = makeCard(id: "pm_deleted", last4: "4242")
+        let remainingCard = makeCard(id: "pm_remaining", last4: "0005")
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(deletedCard.stripeId), forCustomer: customerID)
+        let snapshot = CustomerPaymentOption.PersistedSelectionSnapshot(
+            customerID: customerID,
+            availableSavedPaymentMethods: [deletedCard, remainingCard]
+        )
+
+        // A deleted selection is cleared when deletion did not persist a fallback.
+        snapshot.revertPersistedSelection(using: [remainingCard])
+        XCTAssertNil(CustomerPaymentOption.localDefaultPaymentMethod(for: customerID))
+
+        // A fallback persisted by deletion is preserved.
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(deletedCard.stripeId), forCustomer: customerID)
+        let snapshotWithFallback = CustomerPaymentOption.PersistedSelectionSnapshot(
+            customerID: customerID,
+            availableSavedPaymentMethods: [deletedCard, remainingCard]
+        )
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(remainingCard.stripeId), forCustomer: customerID)
+        snapshotWithFallback.revertPersistedSelection(using: [remainingCard])
+        XCTAssertEqual(
+            CustomerPaymentOption.localDefaultPaymentMethod(for: customerID),
+            .stripeId(remainingCard.stripeId)
+        )
+    }
+
+    func testSnapshotRestoresSavedPaymentMethodUnavailableAtBothTimes() {
+        let customerID = "cus_filtered"
+        defer { CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID) }
+        let hiddenCard = makeCard(id: "pm_hidden", last4: "4242")
+        let visibleCard = makeCard(id: "pm_visible", last4: "0005")
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(hiddenCard.stripeId), forCustomer: customerID)
+        let snapshot = CustomerPaymentOption.PersistedSelectionSnapshot(
+            customerID: customerID,
+            availableSavedPaymentMethods: [visibleCard]
+        )
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(visibleCard.stripeId), forCustomer: customerID)
+
+        snapshot.revertPersistedSelection(using: [visibleCard])
+
+        XCTAssertEqual(
+            CustomerPaymentOption.localDefaultPaymentMethod(for: customerID),
+            .stripeId(hiddenCard.stripeId)
+        )
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetCancelPersistenceTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetCancelPersistenceTests.swift
@@ -52,7 +52,7 @@ final class PaymentSheetCancelPersistenceTests: XCTestCase {
         )
     }
 
-    func testCancelRevertsPersistedSelection() {
+    func testCancelRevertsPersistedSelectionAfterDismissal() {
         // Given card A is persisted when PaymentSheet is presented
         let customerID = "cus_ps_cancel"
         defer { CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID) }
@@ -64,15 +64,28 @@ final class PaymentSheetCancelPersistenceTests: XCTestCase {
             paymentIntentClientSecret: "pi_123_secret_456",
             configuration: configuration
         )
-        let viewController = sheet.makePaymentSheetVC(
-            loadResult: makeLoadResult(savedPaymentMethods: [cardA, cardB]),
+        let loadResult = makeLoadResult(savedPaymentMethods: [cardA, cardB])
+        _ = sheet.makePaymentSheetVC(
+            loadResult: loadResult,
             previousPaymentOption: nil
-        ) as! PaymentSheetVerticalViewController
+        )
+        let viewController = DeferredDismissPaymentSheetVerticalViewController(
+            configuration: configuration,
+            loadResult: loadResult,
+            isFlowController: false,
+            analyticsHelper: sheet.analyticsHelper
+        )
         viewController.loadViewIfNeeded()
 
         // When the customer selects card B and then cancels
         viewController.didTapPaymentMethod(.saved(paymentMethod: cardB))
         sheet.paymentSheetViewControllerDidCancel(viewController)
+
+        // Then the in-flight dismissal leaves card B persisted
+        XCTAssertEqual(CustomerPaymentOption.localDefaultPaymentMethod(for: customerID), .stripeId(cardB.stripeId))
+
+        // When dismissal finishes
+        viewController.completeDismissal()
 
         // Then the persisted selection reverts to card A
         XCTAssertEqual(CustomerPaymentOption.localDefaultPaymentMethod(for: customerID), .stripeId(cardA.stripeId))
@@ -125,5 +138,18 @@ final class PaymentSheetCancelPersistenceTests: XCTestCase {
             CustomerPaymentOption.localDefaultPaymentMethod(for: customerID),
             .stripeId(hiddenCard.stripeId)
         )
+    }
+}
+
+private final class DeferredDismissPaymentSheetVerticalViewController: PaymentSheetVerticalViewController {
+    private var dismissalCompletion: (() -> Void)?
+
+    override func dismiss(animated flag: Bool, completion: (() -> Void)? = nil) {
+        dismissalCompletion = completion
+    }
+
+    func completeDismissal() {
+        dismissalCompletion?()
+        dismissalCompletion = nil
     }
 }


### PR DESCRIPTION
## Summary
- When a customer cancels PaymentSheet, any selection change they made is now reverted back to the selection that was persisted before the sheet was presented.
- This aligns with Android

### Demo
Before: pay with SPM -> select a different SPM card 4242 -> cancel -> re-open card 4242 selected
After: (pay with SPM -> select a different SPM  -> cancel -> re-open bank selected


https://github.com/user-attachments/assets/443f15f3-56d1-4c91-8e0c-68d32bdd079e





## Motivation
Previously, canceling out of PaymentSheet after switching payment methods would still persist the newly selected method, even though the customer never confirmed the change. This restores the original selection on cancellation.

## Testing
Added `PaymentSheetCancelPersistenceTests.swift` covering cancellation with and without a prior persisted selection.

## Changelog
N/A