### PR TITLE
Restore horizontal FlowController selection on cancellation

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetVerticalUITests.swift
@@ -54,25 +54,19 @@ class PaymentSheetVerticalUITests: PaymentSheetUITestCase {
         app.textFields["Card number"].typeText("1")
         XCTAssertFalse(continueButton.isEnabled)
         app.tapCoordinate(at: .init(x: 200, y: 100))
-        // Tap out of FlowController and expect empty payment method
+        // Tap out of FlowController and expect the previous payment method
         app.tapCoordinate(at: .init(x: 200, y: 100))
-        XCTAssertEqual(paymentMethodButton.label, "None")
+        XCTAssertEqual(paymentMethodButton.label, "Cash App Pay, cashapp")
 
         // Go back in
         paymentMethodButton.tap()
-        XCTAssertFalse(continueButton.isEnabled)
-        // Back out of card form
-        app.buttons["Back"].tap()
-        // Cash App Pay (the previous selection) should be selected
+        // Cash App Pay (the previous selection) should be restored and the canceled Card edit discarded
         XCTAssertTrue(app.buttons["Cash App Pay"].isSelected)
         XCTAssertTrue(continueButton.isEnabled)
 
-        // Go back to card
+        // Go back to Card and finish the payment
         app.buttons["Card"].waitForExistenceAndTap()
-        // Make sure the card form retained previously entered details
-        XCTAssertEqual(app.textFields["Card number"].value as? String, "1, Your card number is invalid.")
-        app.textFields["Card number"].clearText()
-        // Finish the card payment
+        XCTAssertFalse(continueButton.isEnabled)
         try! fillCardData(app, cardNumber: "4242424242424242", tapCheckboxWithText: "Save payment details to Example, Inc. for future purchases")
         continueButton.tap()
         sleep(1) // wait for 1 second for the sheet to dismiss

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerPaymentOption.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/CustomerAdapter/CustomerPaymentOption.swift
@@ -91,3 +91,52 @@ public enum CustomerPaymentOption: Equatable {
         return nil
     }
 }
+
+extension CustomerPaymentOption {
+    /// Captures the locally persisted selected payment option and the saved payment methods
+    /// available immediately before a payment surface is presented.
+    ///
+    /// On cancellation, use this snapshot to revert the persisted selection. A method that was
+    /// available before presentation but is missing at cancellation was deleted and is not restored.
+    /// A method missing at both points may be hidden or temporarily unavailable, so its selection is
+    /// restored.
+    struct PersistedSelectionSnapshot {
+        private let customerID: String?
+        private let selectedPaymentOptionBeforePresentation: CustomerPaymentOption?
+        private let availableSavedPaymentMethodIDsBeforePresentation: Set<String>
+
+        init(customerID: String?, availableSavedPaymentMethods: [STPPaymentMethod]) {
+            self.customerID = customerID
+            self.selectedPaymentOptionBeforePresentation = CustomerPaymentOption.localDefaultPaymentMethod(for: customerID)
+            self.availableSavedPaymentMethodIDsBeforePresentation = Set(availableSavedPaymentMethods.map(\.stripeId))
+        }
+
+        /// Reverts to the captured selection unless its saved payment method was deleted.
+        func revertPersistedSelection(using currentlyAvailableSavedPaymentMethods: [STPPaymentMethod]) {
+            if selectedPaymentMethodWasDeleted(from: currentlyAvailableSavedPaymentMethods) {
+                clearDeletedSelectionIfNeeded()
+            } else {
+                CustomerPaymentOption.setDefaultPaymentMethod(selectedPaymentOptionBeforePresentation, forCustomer: customerID)
+            }
+        }
+
+        private func selectedPaymentMethodWasDeleted(
+            from currentlyAvailableSavedPaymentMethods: [STPPaymentMethod]
+        ) -> Bool {
+            if case .stripeId(let selectedPaymentMethodID) = selectedPaymentOptionBeforePresentation,
+               availableSavedPaymentMethodIDsBeforePresentation.contains(selectedPaymentMethodID),
+               !currentlyAvailableSavedPaymentMethods.contains(where: { $0.stripeId == selectedPaymentMethodID }) {
+                return true
+            }
+            return false
+        }
+
+        private func clearDeletedSelectionIfNeeded() {
+            // Deletion may persist a fallback selection. Keep it, or clear the deleted selection
+            // if no fallback was persisted.
+            if CustomerPaymentOption.localDefaultPaymentMethod(for: customerID) == selectedPaymentOptionBeforePresentation {
+                CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID)
+            }
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/IntentConfirmParams.swift
@@ -37,6 +37,12 @@ final class IntentConfirmParams {
     var financialConnectionsLinkedBank: FinancialConnectionsLinkedBank?
     var instantDebitsLinkedBank: InstantDebitsLinkedBank?
 
+    /// Whether these params contain a linked bank represented as `.saved` but reconstructed through its
+    /// Instant Debits or Link Card Brand form.
+    var isFormBackedSavedPaymentMethod: Bool {
+        return instantDebitsLinkedBank != nil
+    }
+
     var paymentSheetLabel: String {
         return paymentSheetLabel(brand: .link)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -130,6 +130,21 @@ public class PaymentSheet {
         Task { @MainActor in
             // Overwrite completion closure to retain self until called
             let completion: (PaymentSheetResult) -> Void = { status in
+                // Every terminal path, including native Link, reaches this completion.
+                switch status {
+                case .canceled:
+                    if let paymentSheetViewController = self.bottomSheetViewController.contentStack.first(
+                        where: { $0 is PaymentSheetViewControllerProtocol }
+                    ) as? PaymentSheetViewControllerProtocol {
+                        self.revertPersistedSelectionAfterCancellation(
+                            using: paymentSheetViewController.savedPaymentMethods
+                        )
+                    }
+                case .completed, .failed:
+                    // PaymentSheet is finishing without cancellation, so discard its cancellation snapshot.
+                    self.persistedSelectionSnapshotBeforePresentation = nil
+                }
+
                 // Dismiss if necessary
                 if let presentingViewController = self.bottomSheetViewController.presentingViewController {
                     // Calling `dismiss()` on the presenting view controller causes
@@ -238,6 +253,9 @@ public class PaymentSheet {
     /// A user-supplied completion block. Nil until `present` is called.
     var completion: ((PaymentSheetResult) -> Void)?
 
+    /// Used to revert persisted selection changes if the customer cancels PaymentSheet.
+    private var persistedSelectionSnapshotBeforePresentation: CustomerPaymentOption.PersistedSelectionSnapshot?
+
     /// Loading View Controller
     lazy var loadingViewController = LoadingViewController(
         delegate: self,
@@ -275,6 +293,10 @@ public class PaymentSheet {
         loadResult: PaymentSheetLoader.LoadResult,
         previousPaymentOption: PaymentOption?
     ) -> PaymentSheetViewControllerProtocol {
+        persistedSelectionSnapshotBeforePresentation = .init(
+            customerID: configuration.customer?.id,
+            availableSavedPaymentMethods: loadResult.savedPaymentMethods
+        )
         switch loadResult.paymentMethodOrientation {
         case .horizontal:
             let vc = PaymentSheetViewController(
@@ -368,9 +390,24 @@ extension PaymentSheet: PaymentSheetViewControllerDelegate {
     }
 
     func paymentSheetViewControllerDidCancel(_ paymentSheetViewController: PaymentSheetViewControllerProtocol) {
+        revertPersistedSelectionAfterCancellation(
+            using: paymentSheetViewController.savedPaymentMethods
+        )
         paymentSheetViewController.dismiss(animated: true) {
             self.completion?(.canceled)
         }
+    }
+
+    private func revertPersistedSelectionAfterCancellation(
+        using currentlyAvailableSavedPaymentMethods: [STPPaymentMethod]
+    ) {
+        guard let persistedSelectionSnapshot = persistedSelectionSnapshotBeforePresentation else {
+            return
+        }
+        // PaymentSheet is dismissing after cancellation. Clear the snapshot before applying it so
+        // a second callback cannot revert the selection again.
+        persistedSelectionSnapshotBeforePresentation = nil
+        persistedSelectionSnapshot.revertPersistedSelection(using: currentlyAvailableSavedPaymentMethods)
     }
 
     func paymentSheetViewControllerDidSelectPayWithLink(_ paymentSheetViewController: PaymentSheetViewControllerProtocol) {
@@ -406,6 +443,7 @@ extension PaymentSheet: LoadingViewControllerDelegate {
 internal protocol PaymentSheetViewControllerProtocol: UIViewController, BottomSheetContentViewController {
     var intent: Intent { get }
     var elementsSession: STPElementsSession { get }
+    var savedPaymentMethods: [STPPaymentMethod] { get }
 
     func pay(with paymentOption: PaymentOption)
     func clearTextFields()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -41,12 +41,13 @@ extension PaymentSheet {
             }
         }
 
-        /// Returns confirm params for `.new` and `.external` options, nil otherwise.
-        /// This is often used to restore a customer's previous form input when re-presenting `AddPaymentMethodViewController`.
-        var newConfirmParams: IntentConfirmParams? {
+        /// Confirm params for selections reconstructed through a payment method form.
+        var formConfirmParams: IntentConfirmParams? {
             switch self {
-            case .applePay, .saved, .link:
+            case .applePay, .link:
                 return nil
+            case .saved(_, let confirmParams):
+                return confirmParams?.isFormBackedSavedPaymentMethod == true ? confirmParams : nil
             case .new(confirmParams: let params):
                 return params
             case let .external(paymentMethod, billingDetails):
@@ -251,6 +252,7 @@ extension PaymentSheet {
         var viewController: FlowControllerViewControllerProtocol
 
         private var presentPaymentOptionsCompletionWithResult: ((Bool) -> Void)?
+        private var selectionState: FlowControllerStateSnapshot.Source = .viewController
         private var didDismissLinkVerificationDialog: Bool = false
 
         // If a WalletButtonsView is currently visible
@@ -263,6 +265,9 @@ extension PaymentSheet {
 
         /// The desired, valid (ie passed client-side checks) payment option from the underlying payment options VC.
         private var internalPaymentOption: PaymentOption? {
+            if case let .restored(restoration) = selectionState {
+                return restoration.selection.paymentOption
+            }
             guard viewController.error == nil else {
                 return nil
             }
@@ -496,17 +501,35 @@ extension PaymentSheet {
                 break
             }
 
+            guard presentPaymentOptionsCompletionWithResult == nil else {
+                assertionFailure("PaymentSheet.FlowController is already presenting payment options")
+                completion?(true)
+                return
+            }
+
             guard presentingViewController.presentedViewController == nil else {
                 assertionFailure("presentingViewController is already presenting a view controller")
                 completion?(true)
                 return
             }
 
+            selectionState = .presented(
+                FlowControllerStateSnapshot(
+                    viewController: viewController,
+                    customerID: configuration.customer?.id
+                )
+            )
+
             // Overwrite completion closure to retain self until called
             let wrappedCompletion: (Bool) -> Void = { didCancel in
+                // The payment-options sheet has finished. Clear its presentation state before
+                // invoking merchant code, which may present it again immediately.
+                if case .presented = self.selectionState {
+                    self.selectionState = .viewController
+                }
+                self.presentPaymentOptionsCompletionWithResult = nil
                 self.updatePaymentOption()
                 completion?(didCancel)
-                self.presentPaymentOptionsCompletionWithResult = nil
             }
             presentPaymentOptionsCompletionWithResult = wrappedCompletion
 
@@ -627,8 +650,8 @@ extension PaymentSheet {
                     return
                 }
 
-                self.presentPaymentOptionsCompletionWithResult?(false)
                 self.isPresented = false
+                self.presentPaymentOptionsCompletionWithResult?(false)
             }
 
             presentingViewController.presentNativeLink(
@@ -814,13 +837,13 @@ extension PaymentSheet {
                 switch result {
                 case .success(let (loadResult, confirmationChallenge)):
                     // 2. Re-initialize PaymentSheetFlowControllerViewController to update the UI to match the newly loaded data e.g. payment method types may have changed.
-
+                    let selection = self.selectionForRebuilding()
                     self.viewController = Self.makeViewController(
                         configuration: self.configuration,
                         loadResult: loadResult,
                         analyticsHelper: analyticsHelper,
                         walletButtonsViewState: walletButtonsViewState,
-                        previousPaymentOption: self.internalPaymentOption
+                        previousPaymentOption: selection.paymentOption
                     )
                     self.viewController.flowControllerDelegate = self
                     self.confirmationChallenge = confirmationChallenge
@@ -839,25 +862,80 @@ extension PaymentSheet {
         }
 
         func updateForWalletButtonsView() {
-            // Recreate the view controller
-            // Use the original load result, but w/ updated saved PMs to avoid e.g. deleting PMs, then having this method be called and showing the deleted PMs again.
-            let updatedLoadResult = PaymentSheetLoader.LoadResult(
+            // Rebuild with the current saved methods so deleted methods don't reappear.
+            let selection = selectionForRebuilding()
+            self.viewController = Self.makeViewController(
+                configuration: self.configuration,
+                loadResult: makeLoadResultWithCurrentSavedPaymentMethods(),
+                analyticsHelper: analyticsHelper,
+                walletButtonsViewState: self.walletButtonsViewState,
+                previousPaymentOption: selection.paymentOption
+            )
+            self.viewController.flowControllerDelegate = self
+            updatePaymentOption()
+        }
+
+        private func makeLoadResultWithCurrentSavedPaymentMethods(
+            prioritizing paymentOption: PaymentOption? = nil
+        ) -> PaymentSheetLoader.LoadResult {
+            var savedPaymentMethods = viewController.savedPaymentMethods
+            // The vertical main screen displays one saved method. Move the captured method into
+            // that slot without changing horizontal carousel order.
+            if viewController.loadResult.paymentMethodOrientation == .vertical,
+               case let .saved(paymentMethod, _) = paymentOption,
+               let index = savedPaymentMethods.firstIndex(where: { $0.stripeId == paymentMethod.stripeId }) {
+                savedPaymentMethods.insert(savedPaymentMethods.remove(at: index), at: 0)
+            }
+            return PaymentSheetLoader.LoadResult(
                 intent: viewController.loadResult.intent,
                 elementsSession: viewController.loadResult.elementsSession,
-                savedPaymentMethods: viewController.savedPaymentMethods, // Note: not using load result!
+                savedPaymentMethods: savedPaymentMethods,
                 paymentMethodTypes: viewController.loadResult.paymentMethodTypes,
                 paymentMethodMessagingPromotionsHelper: viewController.loadResult.paymentMethodMessagingPromotionsHelper,
                 paymentMethodOrientation: viewController.loadResult.paymentMethodOrientation
             )
+        }
+
+        private func revertSelectionAfterCancellation() {
+            guard case let .presented(selectionSnapshot) = selectionState else {
+                return
+            }
+
+            // Horizontal selection restoration is added by the next change in this stack.
+            guard viewController.loadResult.paymentMethodOrientation == .vertical else {
+                return
+            }
+
+            let restoration = selectionSnapshot.restoration(using: viewController)
+            selectionState = .restored(restoration)
+            if restoration.requiresViewControllerRebuild {
+                rebuildViewController(restoring: restoration.selection)
+            }
+        }
+
+        private func rebuildViewController(
+            restoring selection: FlowControllerStateSnapshot.Selection
+        ) {
             self.viewController = Self.makeViewController(
-                configuration: self.configuration,
-                loadResult: updatedLoadResult,
+                configuration: configuration,
+                loadResult: makeLoadResultWithCurrentSavedPaymentMethods(
+                    prioritizing: selection.paymentOption
+                ),
                 analyticsHelper: analyticsHelper,
-                walletButtonsViewState: self.walletButtonsViewState,
-                previousPaymentOption: self.internalPaymentOption
+                walletButtonsViewState: walletButtonsViewState,
+                previousPaymentOption: selection.paymentOption
             )
             self.viewController.flowControllerDelegate = self
-            updatePaymentOption()
+            if selection.paymentOption == nil {
+                self.viewController.clearSelection()
+            }
+        }
+
+        private func selectionForRebuilding() -> FlowControllerStateSnapshot.Selection {
+            if case let .restored(restoration) = selectionState {
+                return restoration.selection
+            }
+            return viewController.stateForSnapshot
         }
 
         /// Updates the published paymentOption property based on the current state
@@ -977,8 +1055,8 @@ extension PaymentSheet.FlowController: LoadingViewControllerDelegate {
         pendingPresentTask?.cancel()
         pendingPresentTask = nil
         loadingViewController.dismiss(animated: true) {
+            self.isPresented = false
             self.presentPaymentOptionsCompletionWithResult?(true)
-            self.updatePaymentOption()
         }
     }
 }
@@ -999,9 +1077,11 @@ extension PaymentSheet.FlowController: FlowControllerViewControllerDelegate {
             self.didPresentAndContinue = true
         }
         flowControllerViewController.dismiss(animated: true) {
-            self.presentPaymentOptionsCompletionWithResult?(didCancel)
-            self.updatePaymentOption()
+            if didCancel {
+                self.revertSelectionAfterCancellation()
+            }
             self.isPresented = false
+            self.presentPaymentOptionsCompletionWithResult?(didCancel)
         }
     }
 }
@@ -1055,11 +1135,82 @@ internal protocol FlowControllerViewControllerProtocol: BottomSheetContentViewCo
     var savedPaymentMethods: [STPPaymentMethod] { get }
     var linkConfirmOption: PaymentSheet.LinkConfirmOption? { get set }
     var selectedPaymentOption: PaymentOption? { get }
+    var stateForSnapshot: FlowControllerStateSnapshot.Selection { get }
     /// The type of the Stripe payment method that's currently selected in the UI for new and saved PMs. Returns nil Apple Pay and .stripe(.link) for Link.
     /// Note that, unlike selectedPaymentOption, this is non-nil even if the PM form is invalid.
     var selectedPaymentMethodType: PaymentSheet.PaymentMethodType? { get }
     var flowControllerDelegate: FlowControllerViewControllerDelegate? { get set }
     func clearSelection()
+}
+
+extension FlowControllerViewControllerProtocol {
+    var stateForSnapshot: FlowControllerStateSnapshot.Selection {
+        return .init(
+            paymentOption: selectedPaymentOption,
+            formConfirmParams: selectedPaymentOption?.formConfirmParams
+        )
+    }
+}
+
+internal struct FlowControllerStateSnapshot {
+    enum Source {
+        case viewController
+        case presented(FlowControllerStateSnapshot)
+        case restored(Restoration)
+    }
+
+    struct Selection {
+        var paymentOption: PaymentOption?
+        let formConfirmParams: IntentConfirmParams?
+    }
+
+    struct Restoration {
+        let selection: Selection
+        let requiresViewControllerRebuild: Bool
+    }
+
+    private let selection: Selection
+    private let persistedSelection: CustomerPaymentOption.PersistedSelectionSnapshot
+
+    init(viewController: FlowControllerViewControllerProtocol, customerID: String?) {
+        self.selection = viewController.stateForSnapshot
+        self.persistedSelection = .init(
+            customerID: customerID,
+            availableSavedPaymentMethods: viewController.savedPaymentMethods
+        )
+    }
+
+    func restoration(
+        using viewController: FlowControllerViewControllerProtocol
+    ) -> Restoration {
+        persistedSelection.revertPersistedSelection(using: viewController.savedPaymentMethods)
+
+        var restoredSelection = selection
+        if case let .saved(paymentMethod, confirmParams) = restoredSelection.paymentOption,
+           confirmParams?.isFormBackedSavedPaymentMethod != true,
+           !viewController.savedPaymentMethods.contains(where: { $0.stripeId == paymentMethod.stripeId }) {
+            // Deletion is not canceled. Keep the fallback selected by the saved-method manager.
+            restoredSelection.paymentOption = viewController.selectedPaymentOption
+        }
+
+        let requiresViewControllerRebuild: Bool
+        switch (restoredSelection.paymentOption, viewController.selectedPaymentOption) {
+        case (nil, nil):
+            // There is no canceled selection state to discard. Reusing the form also lets it
+            // resolve dynamic configuration, such as shipping details, when it next appears.
+            requiresViewControllerRebuild = false
+        case (.link(.wallet)?, .link(.wallet)?):
+            // The accepted wallet remains selected. Reusing the controller preserves the
+            // accepted payment-method form cached behind the wallet header.
+            requiresViewControllerRebuild = false
+        default:
+            requiresViewControllerRebuild = true
+        }
+        return .init(
+            selection: restoredSelection,
+            requiresViewControllerRebuild: requiresViewControllerRebuild
+        )
+    }
 }
 
 extension PaymentOption {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -1146,8 +1146,7 @@ internal protocol FlowControllerViewControllerProtocol: BottomSheetContentViewCo
 extension FlowControllerViewControllerProtocol {
     var stateForSnapshot: FlowControllerStateSnapshot.Selection {
         return .init(
-            paymentOption: selectedPaymentOption,
-            formConfirmParams: selectedPaymentOption?.formConfirmParams
+            paymentOption: selectedPaymentOption
         )
     }
 }
@@ -1161,7 +1160,6 @@ internal struct FlowControllerStateSnapshot {
 
     struct Selection {
         var paymentOption: PaymentOption?
-        let formConfirmParams: IntentConfirmParams?
     }
 
     struct Restoration {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -843,7 +843,8 @@ extension PaymentSheet {
                         loadResult: loadResult,
                         analyticsHelper: analyticsHelper,
                         walletButtonsViewState: walletButtonsViewState,
-                        previousPaymentOption: selection.paymentOption
+                        previousPaymentOption: selection.paymentOption,
+                        previousFormConfirmParams: selection.formConfirmParams
                     )
                     self.viewController.flowControllerDelegate = self
                     self.confirmationChallenge = confirmationChallenge
@@ -869,7 +870,8 @@ extension PaymentSheet {
                 loadResult: makeLoadResultWithCurrentSavedPaymentMethods(),
                 analyticsHelper: analyticsHelper,
                 walletButtonsViewState: self.walletButtonsViewState,
-                previousPaymentOption: selection.paymentOption
+                previousPaymentOption: selection.paymentOption,
+                previousFormConfirmParams: selection.formConfirmParams
             )
             self.viewController.flowControllerDelegate = self
             updatePaymentOption()
@@ -900,12 +902,6 @@ extension PaymentSheet {
             guard case let .presented(selectionSnapshot) = selectionState else {
                 return
             }
-
-            // Horizontal selection restoration is added by the next change in this stack.
-            guard viewController.loadResult.paymentMethodOrientation == .vertical else {
-                return
-            }
-
             let restoration = selectionSnapshot.restoration(using: viewController)
             selectionState = .restored(restoration)
             if restoration.requiresViewControllerRebuild {
@@ -923,7 +919,8 @@ extension PaymentSheet {
                 ),
                 analyticsHelper: analyticsHelper,
                 walletButtonsViewState: walletButtonsViewState,
-                previousPaymentOption: selection.paymentOption
+                previousFormConfirmParams: selection.formConfirmParams,
+                selectionToRestore: selection.paymentOption
             )
             self.viewController.flowControllerDelegate = self
             if selection.paymentOption == nil {
@@ -983,7 +980,9 @@ extension PaymentSheet {
             loadResult: PaymentSheetLoader.LoadResult,
             analyticsHelper: PaymentSheetAnalyticsHelper,
             walletButtonsViewState: PaymentSheet.WalletButtonsViewState,
-            previousPaymentOption: PaymentOption? = nil
+            previousPaymentOption: PaymentOption? = nil,
+            previousFormConfirmParams: IntentConfirmParams? = nil,
+            selectionToRestore: PaymentOption? = nil
         ) -> FlowControllerViewControllerProtocol {
             let controller: FlowControllerViewControllerProtocol
             switch loadResult.paymentMethodOrientation {
@@ -992,7 +991,9 @@ extension PaymentSheet {
                     configuration: configuration,
                     loadResult: loadResult,
                     analyticsHelper: analyticsHelper,
-                    previousPaymentOption: previousPaymentOption
+                    previousPaymentOption: previousPaymentOption,
+                    previousFormConfirmParams: previousFormConfirmParams,
+                    selectionToRestore: selectionToRestore
                 )
             case .vertical:
                 controller = PaymentSheetVerticalViewController(
@@ -1001,7 +1002,7 @@ extension PaymentSheet {
                     isFlowController: true,
                     analyticsHelper: analyticsHelper,
                     walletButtonsViewState: walletButtonsViewState,
-                    previousPaymentOption: previousPaymentOption
+                    previousPaymentOption: selectionToRestore ?? previousPaymentOption
                 )
             }
             return controller
@@ -1146,7 +1147,8 @@ internal protocol FlowControllerViewControllerProtocol: BottomSheetContentViewCo
 extension FlowControllerViewControllerProtocol {
     var stateForSnapshot: FlowControllerStateSnapshot.Selection {
         return .init(
-            paymentOption: selectedPaymentOption
+            paymentOption: selectedPaymentOption,
+            formConfirmParams: selectedPaymentOption?.formConfirmParams
         )
     }
 }
@@ -1160,6 +1162,7 @@ internal struct FlowControllerStateSnapshot {
 
     struct Selection {
         var paymentOption: PaymentOption?
+        let formConfirmParams: IntentConfirmParams?
     }
 
     struct Restoration {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Saved Payment Method Screen/SavedPaymentOptionsViewController.swift
@@ -486,6 +486,33 @@ class SavedPaymentOptionsViewController: UIViewController {
         collectionView.reloadItems(at: [selectedIndexPath])
     }
 
+    /// Updates the carousel selection without persisting it or notifying the delegate.
+    func setSelection(to paymentOption: PaymentOption) {
+        let customerPaymentOption: CustomerPaymentOption? = {
+            switch paymentOption {
+            case .applePay:
+                return .applePay
+            case .link:
+                return .link
+            case .saved(let paymentMethod, _):
+                return .stripeId(paymentMethod.stripeId)
+            case .new, .external:
+                return nil
+            }
+        }()
+        guard let customerPaymentOption,
+              let index = viewModels.firstIndex(where: { $0 == customerPaymentOption }) else {
+            return
+        }
+
+        selectedViewModelIndex = index
+        collectionView.selectItem(at: selectedIndexPath, animated: false, scrollPosition: [])
+        updateMandateView()
+        if isViewLoaded {
+            updateFormElement()
+        }
+    }
+
     private func isDefaultPaymentMethod(savedPaymentMethodId: String?) -> Bool {
         guard configuration.allowsSetAsDefaultPM, let savedPaymentMethodId, let defaultPaymentMethod else { return false }
         return savedPaymentMethodId == defaultPaymentMethod.stripeId

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -86,8 +86,23 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     var isBusy: Bool { isPaymentInFlight || isReloading }
     private(set) var savedPaymentMethods: [STPPaymentMethod]
     let isFlowController: Bool
-    /// Previous customer input - in FlowController's `update` flow, this is the customer input prior to `update`, used so we can restore their state in this VC.
+    /// The selection used to seed this controller when it is rebuilt.
     private var previousPaymentOption: PaymentOption?
+    private var previousFormConfirmParams: IntentConfirmParams? {
+        guard let previousPaymentOption else {
+            return nil
+        }
+        switch previousPaymentOption {
+        case .saved(_, let confirmParams):
+            return confirmParams
+        case .new, .external:
+            return previousPaymentOption.formConfirmParams
+        case .link(let confirmOption):
+            return confirmOption.signupConfirmParams
+        case .applePay:
+            return nil
+        }
+    }
     weak var flowControllerDelegate: FlowControllerViewControllerDelegate?
     weak var paymentSheetDelegate: PaymentSheetViewControllerDelegate?
     let shouldShowApplePayInList: Bool
@@ -180,13 +195,12 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         self.analyticsHelper = analyticsHelper
         super.init(nibName: nil, bundle: nil)
 
-        regenerateUI()
-
         if case let .link(linkConfirmOption) = previousPaymentOption {
             self.linkConfirmOption = linkConfirmOption
         }
+        regenerateUI()
 
-        // Only use the previous customer input for the first form shown
+        // Initial construction is complete. Clear the seed so later UI regeneration preserves the customer's current selection.
         self.previousPaymentOption = nil
     }
 
@@ -230,27 +244,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
             let paymentMethodListViewController = makePaymentMethodListViewController(selection: updatedListSelection)
             self.paymentMethodListViewController = paymentMethodListViewController
 
-            let confirmParams: IntentConfirmParams? = {
-                guard let paymentOption = previousPaymentOption else {
-                    return nil
-                }
-                switch paymentOption {
-                case .saved(_, let confirmParams):
-                    if let confirmParams {
-                        return confirmParams
-                    } else {
-                        return nil
-                    }
-                case .new(let confirmParams):
-                    return confirmParams
-                case .link(let confirmOption):
-                    return confirmOption.signupConfirmParams
-                case .applePay, .external:
-                    return nil
-                }
-            }()
-
-            if let confirmParams,
+            if let confirmParams = previousFormConfirmParams,
                 paymentMethodTypes.contains(confirmParams.paymentMethodType),
                 shouldDisplayForm(for: confirmParams.paymentMethodType)
             {
@@ -944,17 +938,6 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
     }
 
     private func makeFormVC(paymentMethodType: PaymentSheet.PaymentMethodType) -> PaymentMethodFormViewController {
-        let previousCustomerInput: IntentConfirmParams? = {
-            if case let .new(confirmParams: confirmParams) = previousPaymentOption {
-                return confirmParams
-            } else if case let .saved(_, confirmParams) = previousPaymentOption {
-                return confirmParams
-            } else if case let .link(confirmOption) = previousPaymentOption {
-                return confirmOption.signupConfirmParams
-            } else {
-                return nil
-            }
-        }()
         let previousLinkInlineSignupAction: LinkInlineSignupViewModel.Action? = {
             if case let .link(confirmOption) = previousPaymentOption {
                 return confirmOption.signupAction
@@ -1009,7 +992,7 @@ extension PaymentSheetVerticalViewController: VerticalPaymentMethodListViewContr
             type: paymentMethodType,
             intent: intent,
             elementsSession: elementsSession,
-            previousCustomerInput: previousCustomerInput,
+            previousCustomerInput: previousFormConfirmParams,
             formCache: formCache,
             configuration: configuration,
             paymentMethodOrientation: loadResult.paymentMethodOrientation,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -30,8 +30,8 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         case .addingNew:
             if let linkConfirmOption {
                 return .link(option: linkConfirmOption)
-            } else if isHackyLinkButtonSelected {
-                return .link(option: .wallet(brand: configuration.resolvedLinkBrand(elementsSession: elementsSession, linkAccount: LinkAccountContext.shared.account)))
+            } else if let walletHeaderSelection {
+                return .link(option: walletHeaderSelection)
             } else if let paymentOption = addPaymentMethodViewController.paymentOption {
                 return paymentOption
             } else if let paymentOption = savedPaymentOptionsViewController.selectedPaymentOption {
@@ -92,8 +92,22 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
     private let isApplePayEnabled: Bool
     private let isLinkEnabled: Bool
     private let couldShowLinkInHeader: Bool
-    private var isHackyLinkButtonSelected: Bool = false
     var linkConfirmOption: PaymentSheet.LinkConfirmOption?
+    /// A wallet selected from the header while the payment-method form remains visible.
+    private var walletHeaderSelection: PaymentSheet.LinkConfirmOption?
+
+    var stateForSnapshot: FlowControllerStateSnapshot.Selection {
+        let formConfirmParams: IntentConfirmParams? = {
+            guard let paymentOption = addPaymentMethodViewController.paymentOption else {
+                return nil
+            }
+            if case let .link(confirmOption) = paymentOption {
+                return confirmOption.signupConfirmParams
+            }
+            return paymentOption.formConfirmParams
+        }()
+        return .init(paymentOption: selectedPaymentOption, formConfirmParams: formConfirmParams)
+    }
 
     private lazy var savedPaymentMethodManager: SavedPaymentMethodManager = {
         return SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession, intent: intent)
@@ -172,8 +186,11 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         configuration: PaymentSheet.Configuration,
         loadResult: PaymentSheetLoader.LoadResult,
         analyticsHelper: PaymentSheetAnalyticsHelper,
-        previousPaymentOption: PaymentOption? = nil
+        previousPaymentOption: PaymentOption? = nil,
+        previousFormConfirmParams: IntentConfirmParams? = nil,
+        selectionToRestore: PaymentOption? = nil
     ) {
+        let initialPaymentOption = selectionToRestore ?? previousPaymentOption
         self.loadResult = loadResult
         self.intent = loadResult.intent
         self.elementsSession = loadResult.elementsSession
@@ -183,15 +200,10 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         self.configuration = configuration
         self.analyticsHelper = analyticsHelper
 
-        // Restore the customer's previous payment method. For saved PMs, this happens naturally already, so we just need to handle new payment methods.
-        // Caveats:
-        // - Only payment method details (including checkbox state) and billing details are restored
-        // - Only restored if the previous input resulted in a completed form i.e. partial or invalid input is still discarded
-        let previousConfirmParams = previousPaymentOption?.formConfirmParams
-
-        // Default to saved payment selection mode, as long as we aren't restoring a customer's previous new payment method input
-        // and they have saved PMs or Apple Pay or Link is enabled
-        self.mode = (previousConfirmParams == nil) && (loadResult.savedPaymentMethods.count > 0 || isApplePayEnabled || isLinkEnabled)
+        // A PaymentOption only contains completed form input, so partial or invalid input is discarded.
+        let initialFormConfirmParams = previousFormConfirmParams ?? initialPaymentOption?.formConfirmParams
+        let hasSavedOrWalletOption = !loadResult.savedPaymentMethods.isEmpty || isApplePayEnabled || isLinkEnabled
+        self.mode = initialFormConfirmParams == nil && hasSavedOrWalletOption
                 ? .selectingSaved
                 : .addingNew
 
@@ -226,13 +238,35 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
             elementsSession: elementsSession,
             configuration: configuration,
             paymentMethodOrientation: loadResult.paymentMethodOrientation,
-            previousCustomerInput: previousConfirmParams, // Restore the customer's previous new payment method input
+            previousCustomerInput: initialFormConfirmParams,
             paymentMethodTypes: loadResult.paymentMethodTypes,
             formCache: formCache,
             analyticsHelper: analyticsHelper,
             paymentMethodMessagingPromotionsHelper: loadResult.paymentMethodMessagingPromotionsHelper
         )
         super.init(nibName: nil, bundle: nil)
+        // A cancellation-time selection takes precedence over defaults derived by the carousel.
+        if let selectionToRestore {
+            self.savedPaymentOptionsViewController.setSelection(to: selectionToRestore)
+            // setSelection(to:) above fully restores .applePay/.saved by selecting their row.
+            // Link needs more: the row only tells us Link is selected, not which LinkConfirmOption
+            // backed it, so selectedPaymentOption would otherwise collapse it to a generic .wallet.
+            if case let .link(linkConfirmOption) = selectionToRestore {
+                switch linkConfirmOption {
+                case .wallet where isLinkEnabled:
+                    if linkOnlyMode {
+                        // Link-only mode displays Link in the wallet header instead of the carousel.
+                        mode = .addingNew
+                        walletHeaderSelection = linkConfirmOption
+                    }
+                case .wallet:
+                    // Link is no longer available. Keep the fallback selected by the carousel.
+                    break
+                case .signUp, .withPaymentMethod, .withPaymentDetails:
+                    self.linkConfirmOption = linkConfirmOption
+                }
+            }
+        }
         self.savedPaymentOptionsViewController.delegate = self
         self.addPaymentMethodViewController.delegate = self
     }
@@ -461,8 +495,8 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
 
     @objc
     private func didTapContinueButton() {
-        // The user is continuing with an LPM, so we un-select Link
-        isHackyLinkButtonSelected = false
+        // Continue applies to the visible payment-method form, not its wallet header.
+        walletHeaderSelection = nil
 
         if let selectedPaymentOption {
             analyticsHelper.logConfirmButtonTapped(paymentOption: selectedPaymentOption)
@@ -718,8 +752,13 @@ extension PaymentSheetFlowControllerViewController: WalletHeaderViewDelegate {
         if canPresentLinkOnWalletButton {
             presentLink()
         } else {
+            walletHeaderSelection = .wallet(
+                brand: configuration.resolvedLinkBrand(
+                    elementsSession: elementsSession,
+                    linkAccount: LinkAccountContext.shared.account
+                )
+            )
             didDismiss(didCancel: false)
-            isHackyLinkButtonSelected = true
         }
 
         updateUI()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -187,7 +187,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         // Caveats:
         // - Only payment method details (including checkbox state) and billing details are restored
         // - Only restored if the previous input resulted in a completed form i.e. partial or invalid input is still discarded
-        let previousConfirmParams = previousPaymentOption?.newConfirmParams
+        let previousConfirmParams = previousPaymentOption?.formConfirmParams
 
         // Default to saved payment selection mode, as long as we aren't restoring a customer's previous new payment method input
         // and they have saved PMs or Apple Pay or Link is enabled

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -186,11 +186,16 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
             }
         )
 
-        // Restore the customer's previous payment method.
-        // For saved PMs, this happens naturally, so we just need to handle new payment methods.
-        let previousConfirmParams = previousPaymentOption?.newConfirmParams
+        // Saved payment methods are restored by the saved-method list. Only reuse input for a new payment method.
+        let previousNewPaymentMethodInput: IntentConfirmParams?
+        if case let .new(confirmParams) = previousPaymentOption {
+            previousNewPaymentMethodInput = confirmParams
+        } else {
+            // Saved and wallet selections are restored outside the new-payment form.
+            previousNewPaymentMethodInput = nil
+        }
 
-        if previousConfirmParams != nil {
+        if previousNewPaymentMethodInput != nil {
             self.mode = .addingNew
         } else if loadResult.savedPaymentMethods.isEmpty {
             self.mode = .addingNew
@@ -203,7 +208,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
             elementsSession: loadResult.elementsSession,
             configuration: configuration,
             paymentMethodOrientation: loadResult.paymentMethodOrientation,
-            previousCustomerInput: previousConfirmParams,
+            previousCustomerInput: previousNewPaymentMethodInput,
             paymentMethodTypes: loadResult.paymentMethodTypes,
             formCache: formCache,
             analyticsHelper: analyticsHelper,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
@@ -241,6 +241,64 @@ final class CheckoutPendingOperationsTests: XCTestCase {
         _ = try? await operationTask.value
     }
 
+    func testFCPresentPaymentOptionsWithPendingOperationsRevertsSelectionOnCancel() async throws {
+        await AddressSpecProvider.shared.loadAddressSpecs()
+
+        // Given a Checkout update is still pending
+        let checkout = await makeCheckoutWithOpenSession()
+        let gate = CheckoutPendingOperationsTestGate()
+
+        let operationTask = Task { @MainActor in
+            try await checkout.enqueueSessionUpdate {
+                await gate.wait()
+            }
+        }
+        defer { gate.open() }
+
+        try await waitUntil {
+            checkout.pendingOperations.count == 1 && gate.isWaiting
+        }
+
+        let loadResult = PaymentSheetLoader.LoadResult(
+            intent: .checkout(checkout),
+            elementsSession: checkout.session.elementsSession,
+            savedPaymentMethods: [],
+            paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
+        )
+        var configuration = PaymentSheet.Configuration()
+        configuration.paymentMethodLayout = .vertical
+        let fc = PaymentSheet.FlowController(
+            configuration: configuration,
+            loadResult: loadResult,
+            analyticsHelper: ._testValue()
+        )
+        fc.checkout = checkout
+
+        // When payment options finish loading, Link is selected and the sheet is canceled
+        let originalViewController = fc.viewController
+        let presentCompleted = expectation(description: "presentPaymentOptions completion called")
+        fc.presentPaymentOptions(from: UIViewController()) { didCancel in
+            XCTAssertTrue(didCancel)
+            presentCompleted.fulfill()
+        }
+
+        gate.open()
+        _ = try? await operationTask.value
+        try await waitUntil {
+            fc.viewController !== originalViewController
+        }
+
+        fc.viewController.linkConfirmOption = .wallet(brand: .link)
+        fc.viewController.didTapOrSwipeToDismiss()
+
+        await fulfillment(of: [presentCompleted], timeout: 2.0)
+
+        // Then the selection made during presentation is discarded
+        XCTAssertNil(fc.paymentOption)
+    }
+
     // MARK: - Loading & Emission Tests
 
     func testLoadingStatePersistsAcrossConsecutiveQueuedOperations() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FormBackedLinkedBankRevertSelectionTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/FormBackedLinkedBankRevertSelectionTests.swift
@@ -1,0 +1,106 @@
+//
+//  FormBackedLinkedBankRevertSelectionTests.swift
+//  StripePaymentSheetTests
+//
+//  Created by Nick Porter on 7/18/26.
+//
+
+@testable @_spi(STP) import StripeCore
+import StripeCoreTestUtils
+@testable @_spi(STP) import StripePayments
+@testable @_spi(STP) import StripePaymentSheet
+@_spi(STP) import StripePaymentsTestUtils
+@_spi(STP) import StripeUICore
+import XCTest
+
+@MainActor
+final class FormBackedLinkedBankRevertSelectionTests: XCTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        await AddressSpecProvider.shared.loadAddressSpecs()
+        await FormSpecProvider.shared.load()
+    }
+
+    func testFlowController_cancelAfterReplacingLinkedBank_restoresSelectedBank() throws {
+        // Given a linked bank was selected from the Instant Debits form
+        let customerID = "cus_fc_linked_bank"
+        defer { CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID) }
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
+        configuration.customer = .init(id: customerID, ephemeralKeySecret: "ek_test")
+        configuration.defaultBillingDetails.email = "test@example.com"
+        let loadResult = makeLoadResult()
+        let flowController = PaymentSheet.FlowController(
+            configuration: configuration,
+            loadResult: loadResult,
+            analyticsHelper: ._testValue()
+        )
+        let viewController = try XCTUnwrap(flowController.viewController as? PaymentSheetVerticalViewController)
+        viewController.loadViewIfNeeded()
+
+        let firstClose = present(flowController)
+        try tapRow(.new(paymentMethodType: .instantDebits), in: viewController)
+        let linkedBank = makeLinkedBank()
+        let bankForm = try XCTUnwrap(viewController.formCache[.instantDebits] as? InstantDebitsPaymentMethodElement)
+        bankForm.setLinkedBank(linkedBank)
+        flowController.flowControllerViewControllerShouldClose(viewController, didCancel: false)
+        wait(for: [firstClose], timeout: 2)
+        XCTAssertEqual(flowController.paymentOption?.labels.sublabel, "••••6789")
+
+        // When the user replaces it with Card, backs out to the list, and cancels
+        let secondClose = present(flowController)
+        viewController.sheetNavigationBarDidBack(viewController.navigationBar)
+        try tapRow(.new(paymentMethodType: .stripe(.card)), in: viewController)
+        viewController.sheetNavigationBarDidBack(viewController.navigationBar)
+        viewController.didTapOrSwipeToDismiss()
+        wait(for: [secondClose], timeout: 2)
+
+        // Then FlowController restores the selected linked-bank form, not a saved-PM row
+        let restoredViewController = try XCTUnwrap(flowController.viewController as? PaymentSheetVerticalViewController)
+        XCTAssertEqual(restoredViewController.paymentMethodFormViewController?.paymentMethodType, .instantDebits)
+        XCTAssertEqual(flowController.paymentOption?.labels.sublabel, "••••6789")
+        XCTAssertNil(CustomerPaymentOption.localDefaultPaymentMethod(for: customerID))
+    }
+
+    private func makeLoadResult() -> PaymentSheetLoader.LoadResult {
+        return PaymentSheetLoader.LoadResult(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"], isLinkPassthroughModeEnabled: true),
+            savedPaymentMethods: [],
+            paymentMethodTypes: [.stripe(.card), .instantDebits],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
+        )
+    }
+
+    private func makeLinkedBank() -> InstantDebitsLinkedBank {
+        let paymentMethod = STPPaymentMethod._testUSBankAccount()
+        var linkBankPaymentMethod = LinkBankPaymentMethod(id: paymentMethod.stripeId)
+        linkBankPaymentMethod._allResponseFieldsStorage = NonEncodableParameters(
+            storage: paymentMethod.allResponseFields as? [String: Any] ?? [:]
+        )
+        return InstantDebitsLinkedBank(
+            paymentMethod: linkBankPaymentMethod,
+            bankName: "StripeBank",
+            last4: "6789",
+            linkMode: .linkPaymentMethod,
+            incentiveEligible: false,
+            linkAccountSessionId: "fcsess_123"
+        )
+    }
+
+    private func present(_ flowController: PaymentSheet.FlowController) -> XCTestExpectation {
+        let closed = expectation(description: "presentPaymentOptions completion")
+        flowController.presentPaymentOptions(from: UIViewController()) {
+            closed.fulfill()
+        }
+        return closed
+    }
+
+    private func tapRow(_ type: RowButtonType, in viewController: PaymentSheetVerticalViewController) throws {
+        let row = try XCTUnwrap(
+            viewController.paymentMethodListViewController?.rowButtons.first(where: { $0.type == type }),
+            "No row button of type \(type)"
+        )
+        viewController.paymentMethodListViewController?.didTap(rowButton: row, selection: row.type)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetCancelPersistenceTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetCancelPersistenceTests.swift
@@ -1,0 +1,129 @@
+//
+//  PaymentSheetCancelPersistenceTests.swift
+//  StripePaymentSheetTests
+//
+//  Created by Nick Porter on 7/18/26.
+//
+
+@_spi(STP) import StripeCore
+@testable @_spi(STP) import StripePayments
+@testable @_spi(STP) import StripePaymentSheet
+@_spi(STP) import StripePaymentsTestUtils
+@_spi(STP) import StripeUICore
+import XCTest
+
+@MainActor
+final class PaymentSheetCancelPersistenceTests: XCTestCase {
+
+    override func setUp() async throws {
+        await PaymentSheetLoader.loadMiscellaneousSingletons()
+    }
+
+    private func makeCard(id: String, last4: String) -> STPPaymentMethod {
+        return STPPaymentMethod.decodedObject(fromAPIResponse: [
+            "id": id,
+            "type": "card",
+            "created": "12345",
+            "card": [
+                "last4": last4,
+                "brand": "visa",
+                "exp_month": "01",
+                "exp_year": "2040",
+            ],
+        ])!
+    }
+
+    private func makeConfiguration(customerID: String) -> PaymentSheet.Configuration {
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
+        configuration.customer = .init(id: customerID, ephemeralKeySecret: "ek_test")
+        return configuration
+    }
+
+    private func makeLoadResult(
+        savedPaymentMethods: [STPPaymentMethod]
+    ) -> PaymentSheetLoader.LoadResult {
+        return PaymentSheetLoader.LoadResult(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            savedPaymentMethods: savedPaymentMethods,
+            paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
+        )
+    }
+
+    func testCancelRevertsPersistedSelection() {
+        // Given card A is persisted when PaymentSheet is presented
+        let customerID = "cus_ps_cancel"
+        defer { CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID) }
+        let cardA = makeCard(id: "pm_a", last4: "4242")
+        let cardB = makeCard(id: "pm_b", last4: "0005")
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(cardA.stripeId), forCustomer: customerID)
+        let configuration = makeConfiguration(customerID: customerID)
+        let sheet = PaymentSheet(
+            paymentIntentClientSecret: "pi_123_secret_456",
+            configuration: configuration
+        )
+        let viewController = sheet.makePaymentSheetVC(
+            loadResult: makeLoadResult(savedPaymentMethods: [cardA, cardB]),
+            previousPaymentOption: nil
+        ) as! PaymentSheetVerticalViewController
+        viewController.loadViewIfNeeded()
+
+        // When the customer selects card B and then cancels
+        viewController.didTapPaymentMethod(.saved(paymentMethod: cardB))
+        sheet.paymentSheetViewControllerDidCancel(viewController)
+
+        // Then the persisted selection reverts to card A
+        XCTAssertEqual(CustomerPaymentOption.localDefaultPaymentMethod(for: customerID), .stripeId(cardA.stripeId))
+    }
+
+    func testSnapshotDoesNotRestoreDeletedSavedPaymentMethod() {
+        let customerID = "cus_deleted"
+        defer { CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID) }
+        let deletedCard = makeCard(id: "pm_deleted", last4: "4242")
+        let remainingCard = makeCard(id: "pm_remaining", last4: "0005")
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(deletedCard.stripeId), forCustomer: customerID)
+        let snapshot = CustomerPaymentOption.PersistedSelectionSnapshot(
+            customerID: customerID,
+            availableSavedPaymentMethods: [deletedCard, remainingCard]
+        )
+
+        // A deleted selection is cleared when deletion did not persist a fallback.
+        snapshot.revertPersistedSelection(using: [remainingCard])
+        XCTAssertNil(CustomerPaymentOption.localDefaultPaymentMethod(for: customerID))
+
+        // A fallback persisted by deletion is preserved.
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(deletedCard.stripeId), forCustomer: customerID)
+        let snapshotWithFallback = CustomerPaymentOption.PersistedSelectionSnapshot(
+            customerID: customerID,
+            availableSavedPaymentMethods: [deletedCard, remainingCard]
+        )
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(remainingCard.stripeId), forCustomer: customerID)
+        snapshotWithFallback.revertPersistedSelection(using: [remainingCard])
+        XCTAssertEqual(
+            CustomerPaymentOption.localDefaultPaymentMethod(for: customerID),
+            .stripeId(remainingCard.stripeId)
+        )
+    }
+
+    func testSnapshotRestoresSavedPaymentMethodUnavailableAtBothTimes() {
+        let customerID = "cus_filtered"
+        defer { CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID) }
+        let hiddenCard = makeCard(id: "pm_hidden", last4: "4242")
+        let visibleCard = makeCard(id: "pm_visible", last4: "0005")
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(hiddenCard.stripeId), forCustomer: customerID)
+        let snapshot = CustomerPaymentOption.PersistedSelectionSnapshot(
+            customerID: customerID,
+            availableSavedPaymentMethods: [visibleCard]
+        )
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(visibleCard.stripeId), forCustomer: customerID)
+
+        snapshot.revertPersistedSelection(using: [visibleCard])
+
+        XCTAssertEqual(
+            CustomerPaymentOption.localDefaultPaymentMethod(for: customerID),
+            .stripeId(hiddenCard.stripeId)
+        )
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -93,7 +93,8 @@ class PaymentSheetFlowControllerTests: XCTestCase {
     }
 
     private func makeFlowController(
-        savedPaymentMethods: [STPPaymentMethod]
+        savedPaymentMethods: [STPPaymentMethod],
+        orientation: PaymentSheet.PaymentMethodLayout.ResolvedLayout = .vertical
     ) -> PaymentSheet.FlowController {
         let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
         let elementsSession = STPElementsSession._testCardValue()
@@ -103,7 +104,7 @@ class PaymentSheetFlowControllerTests: XCTestCase {
             savedPaymentMethods: savedPaymentMethods,
             paymentMethodTypes: [.stripe(.card)],
             paymentMethodMessagingPromotionsHelper: ._testValue(),
-            paymentMethodOrientation: .vertical
+            paymentMethodOrientation: orientation
         )
         return PaymentSheet.FlowController(
             configuration: PaymentSheet.Configuration(),
@@ -498,6 +499,147 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         // Then the previous payment option and local default are restored
         XCTAssertEqual(savedPaymentMethodID(flowController.viewController.selectedPaymentOption), firstPaymentMethod.stripeId)
         XCTAssertEqual(CustomerPaymentOption.localDefaultPaymentMethod(for: nil), .stripeId(firstPaymentMethod.stripeId))
+    }
+
+    @MainActor
+    func testCancelingHorizontalPaymentOptionsRestoresPreviousSavedPaymentMethod() {
+        // Given a horizontal FlowController with a selected saved payment method
+        let firstPaymentMethod = makeCardPaymentMethod(id: "pm_first", last4: "4242", brand: "visa")
+        let secondPaymentMethod = makeCardPaymentMethod(id: "pm_second", last4: "0005", brand: "amex")
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(firstPaymentMethod.stripeId), forCustomer: nil)
+        let flowController = makeFlowController(
+            savedPaymentMethods: [firstPaymentMethod, secondPaymentMethod],
+            orientation: .horizontal
+        )
+        let completionExpectation = expectation(description: "Payment options dismissed")
+        flowController.presentPaymentOptions(from: UIViewController()) { didCancel in
+            XCTAssertTrue(didCancel)
+            completionExpectation.fulfill()
+        }
+
+        // When persistence changes while the horizontal sheet is open and the sheet is canceled
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(secondPaymentMethod.stripeId), forCustomer: nil)
+        flowController.updateForWalletButtonsView()
+        XCTAssertEqual(savedPaymentMethodID(flowController.viewController.selectedPaymentOption), secondPaymentMethod.stripeId)
+        flowController.flowControllerViewControllerShouldClose(flowController.viewController, didCancel: true)
+        wait(for: [completionExpectation], timeout: 2)
+
+        // Then cancel restores the previous payment option and persisted selection
+        XCTAssertEqual(savedPaymentMethodID(flowController.viewController.selectedPaymentOption), firstPaymentMethod.stripeId)
+        XCTAssertEqual(CustomerPaymentOption.localDefaultPaymentMethod(for: nil), .stripeId(firstPaymentMethod.stripeId))
+    }
+
+    @MainActor
+    func testHorizontalSelectionToRestoreOverridesServerDefault() {
+        // Given a horizontal FlowController where the server default is a saved bank account
+        let customerID = "cus_horizontal_server_default"
+        let bank = STPPaymentMethod._testUSBankAccount()
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
+        let elementsSession = STPElementsSession._testValue(
+            intent: intent,
+            defaultPaymentMethod: bank.stripeId,
+            paymentMethods: [bank.allResponseFields],
+            allowsSetAsDefaultPM: true
+        )
+        let loadResult = PaymentSheetLoader.LoadResult(
+            intent: intent,
+            elementsSession: elementsSession,
+            savedPaymentMethods: [bank],
+            paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .horizontal
+        )
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive(isApplePayEnabled: true)
+        configuration.customer = .init(id: customerID, ephemeralKeySecret: "ek_test")
+
+        let initialViewController = PaymentSheetFlowControllerViewController(
+            configuration: configuration,
+            loadResult: loadResult,
+            analyticsHelper: ._testValue()
+        )
+        XCTAssertEqual(savedPaymentMethodID(initialViewController.selectedPaymentOption), bank.stripeId)
+
+        // An ordinary previous option preserves form input without overriding the server default
+        let updateViewController = PaymentSheetFlowControllerViewController(
+            configuration: configuration,
+            loadResult: loadResult,
+            analyticsHelper: ._testValue(),
+            previousPaymentOption: .applePay
+        )
+        XCTAssertEqual(savedPaymentMethodID(updateViewController.selectedPaymentOption), bank.stripeId)
+
+        // When the controller is reconstructed with Apple Pay as the selection to restore
+        let restoredViewController = PaymentSheetFlowControllerViewController(
+            configuration: configuration,
+            loadResult: loadResult,
+            analyticsHelper: ._testValue(),
+            selectionToRestore: .applePay
+        )
+
+        // Then the selection to restore takes precedence over the server default
+        guard case .applePay = restoredViewController.selectedPaymentOption else {
+            return XCTFail("Expected Apple Pay to be restored")
+        }
+    }
+
+    @MainActor
+    func testHorizontalSelectionToRestorePreservesLinkConfirmOption() {
+        // Given Link confirmation details that aren't represented by the carousel selection
+        let linkConfirmOption = PaymentSheet.LinkConfirmOption.withPaymentMethod(
+            brand: .link,
+            paymentMethod: ._testCard()
+        )
+        let loadResult = PaymentSheetLoader.LoadResult(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"], isLinkPassthroughModeEnabled: false),
+            savedPaymentMethods: [._testUSBankAccount()],
+            paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .horizontal
+        )
+
+        // When the horizontal controller is rebuilt with that selection
+        let viewController = PaymentSheetFlowControllerViewController(
+            configuration: ._testValue_MostPermissive(isApplePayEnabled: false),
+            loadResult: loadResult,
+            analyticsHelper: ._testValue(),
+            selectionToRestore: .link(option: linkConfirmOption)
+        )
+
+        // Then it preserves the complete Link confirmation option
+        guard case .link(option: .withPaymentMethod) = viewController.selectedPaymentOption else {
+            return XCTFail("Expected the Link confirmation option to be restored")
+        }
+    }
+
+    @MainActor
+    func testHorizontalUnavailableLinkWalletSelectionUsesAvailableSavedMethod() {
+        // Given Link is no longer available but a saved method is
+        let savedPaymentMethod = STPPaymentMethod._testUSBankAccount()
+        let loadResult = PaymentSheetLoader.LoadResult(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            savedPaymentMethods: [savedPaymentMethod],
+            paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .horizontal
+        )
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
+        configuration.link.display = .never
+
+        // When the controller is rebuilt with a Link wallet selection
+        let viewController = PaymentSheetFlowControllerViewController(
+            configuration: configuration,
+            loadResult: loadResult,
+            analyticsHelper: ._testValue(),
+            selectionToRestore: .link(option: .wallet(brand: .link))
+        )
+
+        // Then it falls back to the available saved method
+        XCTAssertEqual(
+            savedPaymentMethodID(viewController.selectedPaymentOption),
+            savedPaymentMethod.stripeId
+        )
     }
 
     @MainActor

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -63,6 +63,7 @@ class PaymentSheetFlowControllerTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: nil)
         let expectation = expectation(description: "Load specs")
         AddressSpecProvider.shared.loadAddressSpecs {
             FormSpecProvider.shared.load { _ in
@@ -70,6 +71,78 @@ class PaymentSheetFlowControllerTests: XCTestCase {
             }
         }
         waitForExpectations(timeout: 1)
+    }
+
+    override func tearDown() {
+        CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: nil)
+        super.tearDown()
+    }
+
+    private func makeCardPaymentMethod(id: String, last4: String, brand: String) -> STPPaymentMethod {
+        return STPPaymentMethod.decodedObject(fromAPIResponse: [
+            "id": id,
+            "type": "card",
+            "created": "12345",
+            "card": [
+                "last4": last4,
+                "brand": brand,
+                "exp_month": "01",
+                "exp_year": "2040",
+            ],
+        ])!
+    }
+
+    private func makeFlowController(
+        savedPaymentMethods: [STPPaymentMethod]
+    ) -> PaymentSheet.FlowController {
+        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
+        let elementsSession = STPElementsSession._testCardValue()
+        let loadResult = PaymentSheetLoader.LoadResult(
+            intent: intent,
+            elementsSession: elementsSession,
+            savedPaymentMethods: savedPaymentMethods,
+            paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
+        )
+        return PaymentSheet.FlowController(
+            configuration: PaymentSheet.Configuration(),
+            loadResult: loadResult,
+            analyticsHelper: ._testValue()
+        )
+    }
+
+    private func savedPaymentMethodID(_ paymentOption: PaymentOption?) -> String? {
+        guard case let .saved(paymentMethod, _) = paymentOption else {
+            return nil
+        }
+        return paymentMethod.stripeId
+    }
+
+    @MainActor
+    private func selectSavedPaymentMethod(
+        _ paymentMethod: STPPaymentMethod,
+        from paymentMethods: [STPPaymentMethod],
+        in viewController: PaymentSheetVerticalViewController
+    ) {
+        let reorderedPaymentMethods = [paymentMethod] + paymentMethods.filter { $0.stripeId != paymentMethod.stripeId }
+        let manageViewController = VerticalSavedPaymentMethodsViewController(
+            configuration: viewController.configuration,
+            intent: viewController.intent,
+            selectedPaymentMethod: paymentMethod,
+            paymentMethods: reorderedPaymentMethods,
+            elementsSession: viewController.elementsSession,
+            analyticsHelper: viewController.analyticsHelper,
+            defaultPaymentMethod: nil
+        )
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(paymentMethod.stripeId), forCustomer: nil)
+        viewController.didComplete(
+            viewController: manageViewController,
+            with: paymentMethod,
+            latestPaymentMethods: reorderedPaymentMethods,
+            didTapToDismiss: false,
+            defaultPaymentMethod: nil
+        )
     }
 
     // MARK: - PaymentOptionDisplayData Labels Tests
@@ -394,7 +467,150 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         XCTAssertEqual(displayData.labels.sublabel, "My Checking •••• 6789")
     }
 
-    // MARK: - Enhanced Completion Block Tests
+    // MARK: - Selection restoration
+
+    @MainActor
+    func testCancelingPaymentOptionsRestoresPreviousSavedPaymentMethod() {
+        // Given a FlowController with a selected saved payment method
+        let firstPaymentMethod = makeCardPaymentMethod(id: "pm_first", last4: "4242", brand: "visa")
+        let secondPaymentMethod = makeCardPaymentMethod(id: "pm_second", last4: "0005", brand: "amex")
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(firstPaymentMethod.stripeId), forCustomer: nil)
+        let flowController = makeFlowController(savedPaymentMethods: [firstPaymentMethod, secondPaymentMethod])
+        XCTAssertEqual(savedPaymentMethodID(flowController.viewController.selectedPaymentOption), firstPaymentMethod.stripeId)
+
+        let completionExpectation = expectation(description: "Payment options dismissed")
+        flowController.presentPaymentOptions(from: UIViewController()) { didCancel in
+            XCTAssertTrue(didCancel)
+            completionExpectation.fulfill()
+        }
+
+        // When a different saved payment method is selected and the sheet is canceled
+        let presentedViewController = flowController.viewController as! PaymentSheetVerticalViewController
+        selectSavedPaymentMethod(
+            secondPaymentMethod,
+            from: [firstPaymentMethod, secondPaymentMethod],
+            in: presentedViewController
+        )
+        XCTAssertEqual(savedPaymentMethodID(presentedViewController.selectedPaymentOption), secondPaymentMethod.stripeId)
+        flowController.flowControllerViewControllerShouldClose(presentedViewController, didCancel: true)
+        wait(for: [completionExpectation], timeout: 2)
+
+        // Then the previous payment option and local default are restored
+        XCTAssertEqual(savedPaymentMethodID(flowController.viewController.selectedPaymentOption), firstPaymentMethod.stripeId)
+        XCTAssertEqual(CustomerPaymentOption.localDefaultPaymentMethod(for: nil), .stripeId(firstPaymentMethod.stripeId))
+    }
+
+    @MainActor
+    func testCancelingExternalPaymentMethodRestoresBillingDetails() throws {
+        let externalPaymentMethod = ExternalPaymentMethod(
+            type: "external_paypal",
+            label: "PayPal",
+            lightImageUrl: URL(string: "https://example.com/paypal.png")!,
+            darkImageUrl: nil
+        )
+        let externalConfiguration = PaymentSheet.ExternalPaymentMethodConfiguration(
+            externalPaymentMethods: ["external_paypal"],
+            externalPaymentMethodConfirmHandler: { _, _ in .completed }
+        )
+        let externalPaymentOption = try XCTUnwrap(
+            ExternalPaymentOption.from(externalPaymentMethod, configuration: externalConfiguration)
+        )
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
+        configuration.externalPaymentMethodConfiguration = externalConfiguration
+        configuration.billingDetailsCollectionConfiguration.name = .always
+        let loadResult = PaymentSheetLoader.LoadResult(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(
+                paymentMethodTypes: ["card"],
+                externalPaymentMethodTypes: ["external_paypal"]
+            ),
+            savedPaymentMethods: [],
+            paymentMethodTypes: [.stripe(.card), .external(externalPaymentOption)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
+        )
+        let flowController = PaymentSheet.FlowController(
+            configuration: configuration,
+            loadResult: loadResult,
+            analyticsHelper: ._testValue()
+        )
+        let viewController = flowController.viewController as! PaymentSheetVerticalViewController
+        viewController.loadViewIfNeeded()
+
+        // Given PayPal with collected billing details is selected
+        let continued = expectation(description: "Payment options continued")
+        flowController.presentPaymentOptions(from: UIViewController()) { didCancel in
+            XCTAssertFalse(didCancel)
+            continued.fulfill()
+        }
+        let row = try XCTUnwrap(
+            viewController.paymentMethodListViewController?.rowButtons.first(where: {
+                $0.type == .new(paymentMethodType: .external(externalPaymentOption))
+            })
+        )
+        viewController.paymentMethodListViewController?.didTap(
+            rowButton: row,
+            selection: row.type
+        )
+        let form = try XCTUnwrap(viewController.formCache[.external(externalPaymentOption)])
+        form.getTextFieldElement("Full name")?.setText("Jane Doe")
+        flowController.flowControllerViewControllerShouldClose(viewController, didCancel: false)
+        wait(for: [continued], timeout: 2)
+
+        // When the customer backs out of the form and cancels
+        let canceled = expectation(description: "Payment options canceled")
+        flowController.presentPaymentOptions(from: UIViewController()) { didCancel in
+            XCTAssertTrue(didCancel)
+            canceled.fulfill()
+        }
+        let presentedViewController = flowController.viewController as! PaymentSheetVerticalViewController
+        presentedViewController.sheetNavigationBarDidBack(presentedViewController.navigationBar)
+        presentedViewController.didTapOrSwipeToDismiss()
+        wait(for: [canceled], timeout: 2)
+
+        // Then PayPal is restored with its selected billing details
+        let restoredViewController = flowController.viewController as! PaymentSheetVerticalViewController
+        guard case .external(_, let billingDetails) = restoredViewController.selectedPaymentOption else {
+            return XCTFail("Expected PayPal to be restored")
+        }
+        XCTAssertEqual(billingDetails.name, "Jane Doe")
+        XCTAssertEqual(
+            restoredViewController.paymentMethodFormViewController?.paymentMethodType,
+            .external(externalPaymentOption)
+        )
+    }
+
+    @MainActor
+    func testCancelingPaymentOptionsDoesNotRestoreDeletedSavedPaymentMethod() {
+        // Given a FlowController with a selected saved payment method
+        let deletedPaymentMethod = makeCardPaymentMethod(id: "pm_deleted", last4: "4242", brand: "visa")
+        let remainingPaymentMethod = makeCardPaymentMethod(id: "pm_remaining", last4: "0005", brand: "amex")
+        CustomerPaymentOption.setDefaultPaymentMethod(.stripeId(deletedPaymentMethod.stripeId), forCustomer: nil)
+        let flowController = makeFlowController(savedPaymentMethods: [deletedPaymentMethod, remainingPaymentMethod])
+        let completionExpectation = expectation(description: "Payment options dismissed")
+        flowController.presentPaymentOptions(from: UIViewController()) { didCancel in
+            XCTAssertTrue(didCancel)
+            completionExpectation.fulfill()
+        }
+
+        // When the selected method is deleted while the sheet is open
+        let presentedViewController = flowController.viewController as! PaymentSheetVerticalViewController
+        selectSavedPaymentMethod(
+            remainingPaymentMethod,
+            from: [remainingPaymentMethod],
+            in: presentedViewController
+        )
+        flowController.flowControllerViewControllerShouldClose(presentedViewController, didCancel: true)
+        wait(for: [completionExpectation], timeout: 2)
+
+        // Then the deleted method is not restored
+        XCTAssertEqual(flowController.viewController.savedPaymentMethods.map(\.stripeId), [remainingPaymentMethod.stripeId])
+        XCTAssertEqual(
+            savedPaymentMethodID(flowController.viewController.selectedPaymentOption),
+            remainingPaymentMethod.stripeId
+        )
+        XCTAssertEqual(CustomerPaymentOption.localDefaultPaymentMethod(for: nil), .stripeId(remainingPaymentMethod.stripeId))
+    }
 
     func testPresentPaymentOptions_EnhancedCompletion_BothMethodsExist() {
         // Given a FlowController with mocked dependencies
@@ -437,6 +653,32 @@ class PaymentSheetFlowControllerTests: XCTestCase {
 
         // Wait for legacy callback
         wait(for: [legacyExpectation], timeout: 2.0)
+    }
+
+    func testCanPresentPaymentOptionsAgainFromCompletion() {
+        let flowController = makeFlowController(savedPaymentMethods: [])
+        let secondCompletion = expectation(description: "Second presentation completed")
+
+        flowController.presentPaymentOptions(from: UIViewController()) { firstDidCancel in
+            XCTAssertTrue(firstDidCancel)
+
+            flowController.presentPaymentOptions(from: UIViewController()) { secondDidCancel in
+                XCTAssertFalse(secondDidCancel)
+                secondCompletion.fulfill()
+            }
+            DispatchQueue.main.async {
+                flowController.flowControllerViewControllerShouldClose(
+                    flowController.viewController,
+                    didCancel: false
+                )
+            }
+        }
+        flowController.flowControllerViewControllerShouldClose(
+            flowController.viewController,
+            didCancel: true
+        )
+
+        wait(for: [secondCompletion], timeout: 2.0)
     }
 
     // MARK: - Checkout terminal session

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerSnapshotTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetVerticalViewControllerSnapshotTest.swift
@@ -264,6 +264,35 @@ final class PaymentSheetVerticalViewControllerSnapshotTest: STPSnapshotTestCase 
         verify(sut)
     }
 
+    func testInitialLinkSelectionEnablesPrimaryButton() {
+        // Given a form-only controller rebuilt with Link selected
+        let loadResult = PaymentSheetLoader.LoadResult(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.card]),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"], isLinkPassthroughModeEnabled: false),
+            savedPaymentMethods: [],
+            paymentMethodTypes: [.stripe(.card)],
+            paymentMethodMessagingPromotionsHelper: ._testValue(),
+            paymentMethodOrientation: .vertical
+        )
+        var configuration = PaymentSheet.Configuration._testValue_MostPermissive()
+        configuration.applePay = nil
+
+        // When the controller initializes its UI
+        let sut = PaymentSheetVerticalViewController(
+            configuration: configuration,
+            loadResult: loadResult,
+            isFlowController: true,
+            analyticsHelper: ._testValue(),
+            previousPaymentOption: .link(option: .wallet(brand: .link))
+        )
+
+        // Then its selected option and button state both reflect Link
+        guard case .link = sut.selectedPaymentOption else {
+            return XCTFail("Expected Link to be selected")
+        }
+        XCTAssertEqual(sut.primaryButton.status, .enabled)
+    }
+
     func testDisplaysMandateBelowList_cashapp() {
         // When loaded with cash app + sfu = off_session...
         let loadResult = PaymentSheetLoader.LoadResult(


### PR DESCRIPTION
## Summary
Fixes selection revert-on-cancel for the horizontal FlowController layout. The reverted-to selection is now applied directly to the rebuilt view controller instead of relying on default selection logic.

## Motivation
The previous commit's revert logic worked for the vertical layout but not horizontal, since the horizontal view controller derives its initial selection independently and had no way to be told which selection to restore. This adds a `selectionToRestore` path so the carousel and form state reflect the exact selection being reverted to, including Link selections.

## Testing
Added coverage in `PaymentSheetFlowControllerTests.swift` for reverting selection in the horizontal layout.

## Changelog
N/A