### PR TITLE
Refactor how card brand choice is wired into the PAN text field

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/LinkPaymentMethodFormElement.swift
@@ -158,10 +158,14 @@ final class LinkPaymentMethodFormElement: Element {
             lastFour: paymentMethod.cardDetails?.last4 ?? "",
             editConfiguration: isCoBranded ? .readOnlyWithoutDisabledAppearance : .readOnly,
             cardBrand: paymentMethod.cardDetails?.cardBrand,
-            cardBrandChoiceElement: cardBrandSelector?.element
+            cardBrandChoiceDataSource: cardBrandSelector?.element
         )
 
-        return panElementConfig.makeElement(theme: LinkUI.appearance.asElementsTheme)
+        return TextFieldElement(
+            configuration: panElementConfig,
+            theme: LinkUI.appearance.asElementsTheme,
+            accessory: cardBrandSelector?.textFieldAccessory
+        )
     }()
 
     private lazy var cvcElement: TextFieldElement = {
@@ -214,7 +218,7 @@ final class LinkPaymentMethodFormElement: Element {
     private lazy var cardSection: SectionElement = {
         let allElements: [Element?] = [
             nameOnCardElement,
-            panElement, SectionElement.HiddenElement(cardBrandSelector),
+            panElement,
             SectionElement.MultiElementRow([expiryDateElement, cvcElement], theme: theme),
         ]
         let elements = allElements.compactMap { $0 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardBrandChoiceElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardBrandChoiceElement.swift
@@ -111,9 +111,8 @@ extension CardBrandChoiceElement: TextFieldElement.CardBrandChoiceDataSource {
 
 extension PaymentMethodElementWrapper where WrappedElementType == CardBrandChoiceElement {
     var textFieldAccessory: TextFieldElement.Accessory {
-        let cardBrandChoiceElement = element
-        return TextFieldElement.Accessory(element: self) { [weak cardBrandChoiceElement] _ in
-            return cardBrandChoiceElement?.shouldShowPicker ?? false
+        return TextFieldElement.Accessory(element: self) { [weak self] _ in
+            return self?.element.shouldShowPicker ?? false
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardBrandChoiceElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardBrandChoiceElement.swift
@@ -103,6 +103,21 @@ extension CardBrandChoiceElement: ElementDelegate {
     }
 }
 
+extension CardBrandChoiceElement: TextFieldElement.CardBrandChoiceDataSource {
+    var shouldShowPicker: Bool {
+        return allowedBrandCount > 1
+    }
+}
+
+extension PaymentMethodElementWrapper where WrappedElementType == CardBrandChoiceElement {
+    var textFieldAccessory: TextFieldElement.Accessory {
+        let cardBrandChoiceElement = element
+        return TextFieldElement.Accessory(element: self) { [weak cardBrandChoiceElement] _ in
+            return cardBrandChoiceElement?.shouldShowPicker ?? false
+        }
+    }
+}
+
 extension STPCardBrand {
     func makeCardBrandItem() -> SegmentedSelectorItem {
         return SegmentedSelectorItem(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/CardSection/CardSectionElement.swift
@@ -119,13 +119,19 @@ final class CardSectionElement: ContainerElement {
                 return params
             }
         }
-        let panElement = PaymentMethodElementWrapper(TextFieldElement.PANConfiguration(
+        let panConfiguration = TextFieldElement.PANConfiguration(
             defaultValue: defaultValues.pan,
-            cardBrandChoiceElement: cardBrandSelector?.element,
+            cardBrandChoiceDataSource: cardBrandSelector?.element,
             cardBrandFilter: cardBrandFilter,
             cardFundingFilter: cardFundingFilter,
             fundingBinController: fundingBinController
-        ), theme: theme) { field, params in
+        )
+        let panTextField = TextFieldElement(
+            configuration: panConfiguration,
+            theme: theme,
+            accessory: cardBrandSelector?.textFieldAccessory
+        )
+        let panElement = PaymentMethodElementWrapper(updatingParamsFrom: panTextField) { field, params in
             cardParams(for: params).number = field.text
             return params
         }
@@ -150,7 +156,7 @@ final class CardSectionElement: ContainerElement {
 
         let allSubElements: [Element?] = [
             nameElement,
-            panElement, SectionElement.HiddenElement(cardBrandSelector),
+            panElement,
             SectionElement.MultiElementRow([expiryElement, cvcElement], theme: theme),
         ]
         let subElements = allSubElements.compactMap { $0 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElement.swift
@@ -15,8 +15,8 @@ import Foundation
  This exists separate from `Element` because `IntentConfirmParams` is a type specific to `StripePaymentSheet`, whereas `Element` is shared
  across modules that don't have this type.
  
- - Remark:In practice, only "leaf" Elements - text fields, drop downs, etc. - have any user data to update params with. These elements can be wrapped in `PaymentMethodElementWrapper`.
- Other elements can rely on the default implementation provided in this file.
+ - Remark: In practice, Elements such as text fields and dropdowns that have user data to add to params can be wrapped in `PaymentMethodElementWrapper`.
+ Container Elements can rely on the default implementation provided in this file to collect params from their children.
  */
 protocol PaymentMethodElement: Element {
     /// Modify the params according to your input, or return nil if invalid.
@@ -59,6 +59,9 @@ extension ContainerElement {
 extension FormElement: PaymentMethodElement {}
 
 extension SectionElement: PaymentMethodElement {}
+
+// A text field can contain an accessory Element that contributes its own params.
+extension TextFieldElement: PaymentMethodElement {}
 
 extension StaticElement: PaymentMethodElement {
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/PaymentMethodElement/PaymentMethodElementWrapper.swift
@@ -47,6 +47,20 @@ class PaymentMethodElementWrapper<WrappedElementType: Element> {
         self.init(privateElement: element, defaultsApplier: defaultsApplier, paramsUpdater: paramsUpdater)
     }
 
+    /// Creates a wrapper that applies `paramsUpdater`, then lets the wrapped element contribute its own params.
+    convenience init(
+        updatingParamsFrom element: WrappedElementType,
+        defaultsApplier: DefaultsApplier? = nil,
+        paramsUpdater: @escaping ParamsUpdater
+    ) where WrappedElementType: PaymentMethodElement {
+        self.init(privateElement: element, defaultsApplier: defaultsApplier) { element, params in
+            guard let params = paramsUpdater(element, params) else {
+                return nil
+            }
+            return element.updateParams(params: params)
+        }
+    }
+
     convenience init(
         _ element: TextFieldElement,
         defaultsApplier: DefaultsApplier? = nil,
@@ -57,6 +71,20 @@ class PaymentMethodElementWrapper<WrappedElementType: Element> {
                 return nil
             }
             return paramsUpdater(textField, params)
+        }
+    }
+
+    /// Creates a validated text field wrapper that also collects params from the text field's children.
+    convenience init(
+        updatingParamsFrom element: TextFieldElement,
+        defaultsApplier: DefaultsApplier? = nil,
+        paramsUpdater: @escaping ParamsUpdater
+    ) where WrappedElementType == TextFieldElement {
+        self.init(element, defaultsApplier: defaultsApplier) { textField, params in
+            guard let params = paramsUpdater(textField, params) else {
+                return nil
+            }
+            return textField.updateParams(params: params)
         }
     }
     convenience init(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
@@ -18,7 +18,6 @@ extension TextFieldElement {
     protocol CardBrandChoiceDataSource: AnyObject {
         var selectedBrand: STPCardBrand? { get }
         var brandCount: Int { get }
-        var allowedBrandCount: Int { get }
     }
 
     struct PANConfiguration: TextFieldElementConfiguration {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Elements/TextField/TextFieldElement+Card.swift
@@ -15,6 +15,12 @@ import UIKit
 
 // MARK: - PAN Configuration
 extension TextFieldElement {
+    protocol CardBrandChoiceDataSource: AnyObject {
+        var selectedBrand: STPCardBrand? { get }
+        var brandCount: Int { get }
+        var allowedBrandCount: Int { get }
+    }
+
     struct PANConfiguration: TextFieldElementConfiguration {
         var label: String = String.Localized.card_number
         var binController = STPBINController.shared
@@ -22,7 +28,7 @@ extension TextFieldElement {
         let rotatingCardBrandsView = RotatingCardBrandsView()
         let defaultValue: String?
         let cardBrand: STPCardBrand?
-        let cardBrandChoiceElement: CardBrandChoiceElement?
+        weak var cardBrandChoiceDataSource: CardBrandChoiceDataSource?
         let cardBrandFilter: CardBrandFilter
         let cardFundingFilter: CardFundingFilter
         /// Separate BIN controller for funding filtering to avoid polluting
@@ -32,14 +38,14 @@ extension TextFieldElement {
         init(
             defaultValue: String? = nil,
             cardBrand: STPCardBrand? = nil,
-            cardBrandChoiceElement: CardBrandChoiceElement? = nil,
+            cardBrandChoiceDataSource: CardBrandChoiceDataSource? = nil,
             cardBrandFilter: CardBrandFilter = .default,
             cardFundingFilter: CardFundingFilter = .default,
             fundingBinController: STPBINController? = nil
         ) {
             self.defaultValue = defaultValue
             self.cardBrand = cardBrand
-            self.cardBrandChoiceElement = cardBrandChoiceElement
+            self.cardBrandChoiceDataSource = cardBrandChoiceDataSource
             self.cardBrandFilter = cardBrandFilter
             self.cardFundingFilter = cardFundingFilter
             self.fundingBinController = fundingBinController
@@ -47,11 +53,11 @@ extension TextFieldElement {
 
         private func cardBrand(for text: String) -> STPCardBrand {
             // Try to read the selected brand from the CBC selector
-            guard let cardBrandChoiceElement = cardBrandChoiceElement else {
+            guard let cardBrandChoiceDataSource else {
                 return STPCardValidator.brand(forNumber: text)
             }
 
-            let selectedBrand = cardBrandChoiceElement.selectedBrand ?? .unknown
+            let selectedBrand = cardBrandChoiceDataSource.selectedBrand ?? .unknown
             let cardBrandFromBin = STPCardValidator.brand(forNumber: text)
             return selectedBrand == .unknown ? cardBrandFromBin : selectedBrand
         }
@@ -62,7 +68,7 @@ extension TextFieldElement {
                 return label
             }
             // Show supported brands when no specific brand is detected
-            let isCBCEnabled = cardBrandChoiceElement != nil
+            let isCBCEnabled = cardBrandChoiceDataSource != nil
             let brands = RotatingCardBrandsView.orderedCardBrands(from: STPCardBrand.allCases.filter {
                 cardBrandFilter.isAccepted(cardBrand: $0) && ($0 != .cartesBancaires || isCBCEnabled)
             })
@@ -75,20 +81,16 @@ extension TextFieldElement {
         }
 
         func accessoryView(for text: String, theme: ElementsAppearance) -> UIView? {
-            // If CBC is enabled and the PAN is not empty...
-            if let cardBrandChoiceElement = cardBrandChoiceElement, !text.isEmpty {
+            if let cardBrandChoiceDataSource, !text.isEmpty {
                 // Show unknown card brand if we have under 9 pan digits and no card brands
-                if 9 > text.count && cardBrandChoiceElement.brandCount == 0 {
+                if 9 > text.count && cardBrandChoiceDataSource.brandCount == 0 {
                     return DynamicImageView.makeUnknownCardImageView(theme: theme)
-                } else if text.count >= 8 && cardBrandChoiceElement.allowedBrandCount > 1 {
-                    // Show the selector if we have 8 or more digits and at least 2 allowed brands, otherwise fall through and show brand as normal
-                    return cardBrandChoiceElement.view
                 }
             }
 
             // If this is coming from the LastFourConfiguration, cardBrand(for: text) will retrieve a card brand from •••• •••• •••• last4, which may be incorrect, so we pass in the card brand for that case
             if let cardBrand = cardBrand,
-               cardBrandChoiceElement == nil {
+               cardBrandChoiceDataSource == nil {
                 rotatingCardBrandsView.cardBrands = [cardBrand]
                 return rotatingCardBrandsView
             }
@@ -100,7 +102,7 @@ extension TextFieldElement {
                 } else {
                     // display all available card brands
                     // Only show Cartes Bancaires when card brand choice is enabled
-                    let isCBCEnabled = cardBrandChoiceElement != nil
+                    let isCBCEnabled = cardBrandChoiceDataSource != nil
                     rotatingCardBrandsView.cardBrands =
                     RotatingCardBrandsView.orderedCardBrands(from: STPCardBrand.allCases.filter {
                         cardBrandFilter.isAccepted(cardBrand: $0) && ($0 != .cartesBancaires || isCBCEnabled)
@@ -176,7 +178,7 @@ extension TextFieldElement {
 
             let cardBrand = cardBrand(for: text)
             // If the merchant is CBC eligible, don't show the disallowed error until we have time to hit the card metadata service to determine brands (at 8 digits)
-            let shouldShowDisallowedError = cardBrandChoiceElement == nil || text.count > 8
+            let shouldShowDisallowedError = cardBrandChoiceDataSource == nil || text.count > 8
             if !cardBrandFilter.isAccepted(cardBrand: cardBrand) && shouldShowDisallowedError {
                 return .invalid(Error.disallowedBrand(brand: cardBrand))
             }
@@ -425,15 +427,15 @@ extension TextFieldElement {
         let lastFour: String
         let editConfiguration: EditConfiguration
         let cardBrand: STPCardBrand?
-        let cardBrandChoiceElement: CardBrandChoiceElement?
+        weak var cardBrandChoiceDataSource: CardBrandChoiceDataSource?
 
         private var lastFourFormatted: String {
             "•••• •••• •••• \(lastFour)"
         }
 
-        init(lastFour: String, editConfiguration: EditConfiguration, cardBrand: STPCardBrand?, cardBrandChoiceElement: CardBrandChoiceElement?) {
+        init(lastFour: String, editConfiguration: EditConfiguration, cardBrand: STPCardBrand?, cardBrandChoiceDataSource: CardBrandChoiceDataSource?) {
             self.lastFour = lastFour
-            self.cardBrandChoiceElement = cardBrandChoiceElement
+            self.cardBrandChoiceDataSource = cardBrandChoiceDataSource
             self.cardBrand = cardBrand
             self.editConfiguration = editConfiguration
         }
@@ -444,7 +446,7 @@ extension TextFieldElement {
 
         func accessoryView(for text: String, theme: ElementsAppearance) -> UIView? {
             // Re-use same logic from PANConfiguration for accessory view
-            return TextFieldElement.PANConfiguration(cardBrand: cardBrand, cardBrandChoiceElement: cardBrandChoiceElement).accessoryView(for: lastFourFormatted, theme: theme)
+            return TextFieldElement.PANConfiguration(cardBrand: cardBrand, cardBrandChoiceDataSource: cardBrandChoiceDataSource).accessoryView(for: lastFourFormatted, theme: theme)
         }
 
         func validate(text: String, isOptional: Bool) -> ValidationState {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -982,7 +982,7 @@ extension PaymentSheetFormFactory {
 
     func makeDefaultsApplierWrapper<T: PaymentMethodElement>(for element: T) -> PaymentMethodElementWrapper<T> {
         return PaymentMethodElementWrapper(
-            element,
+            updatingParamsFrom: element,
             defaultsApplier: { [configuration] _, params in
                 // Only apply defaults when the flag is on.
                 guard configuration.billingDetailsCollectionConfiguration.attachDefaultsToPaymentMethod else {
@@ -1004,8 +1004,8 @@ extension PaymentSheetFormFactory {
                 }
                 return params
             },
-            paramsUpdater: { element, params in
-                return element.updateParams(params: params)
+            paramsUpdater: { _, params in
+                return params
             })
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethodFormFactory/SavedPaymentMethodFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethodFormFactory/SavedPaymentMethodFormFactory+Card.swift
@@ -46,9 +46,12 @@ extension SavedPaymentMethodFormFactory {
             let panElementConfig = TextFieldElement.LastFourConfiguration(lastFour: configuration.paymentMethod.card?.last4 ?? "",
                                                                           editConfiguration: cardBrandSelector != nil ? .readOnlyWithoutDisabledAppearance : .readOnly,
                                                                           cardBrand: configuration.paymentMethod.calculateCardBrandToDisplay(),
-                                                                          cardBrandChoiceElement: cardBrandSelector?.element)
-
-            let panElement = panElementConfig.makeElement(theme: theme)
+                                                                          cardBrandChoiceDataSource: cardBrandSelector?.element)
+            let panElement = TextFieldElement(
+                configuration: panElementConfig,
+                theme: theme,
+                accessory: cardBrandSelector?.textFieldAccessory
+            )
             return panElement
         }()
 
@@ -94,7 +97,6 @@ extension SavedPaymentMethodFormFactory {
         let cardSection: SectionElement = {
             let allSubElements: [Element?] = [
                 panElement,
-                SectionElement.HiddenElement(cardBrandSelector),
                 SectionElement.MultiElementRow([expiryDateElement, cvcElement], theme: theme),
             ]
             return SectionElement(title: billingAddressSection != nil ? String.Localized.card_information : nil,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethodFormFactory/SavedPaymentMethodFormFactory+Link.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/SavedPaymentMethodFormFactory/SavedPaymentMethodFormFactory+Link.swift
@@ -38,7 +38,7 @@ extension SavedPaymentMethodFormFactory {
                 lastFour: cardDetails.last4,
                 editConfiguration: .readOnly,
                 cardBrand: cardDetails.brand,
-                cardBrandChoiceElement: nil
+                cardBrandChoiceDataSource: nil
             )
 
             let panElement = panElementConfig.makeElement(theme: theme)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CardSectionElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/CardSectionElementTest.swift
@@ -17,19 +17,80 @@ class CardSectionElementTest: XCTestCase {
 
     private func makeCardSectionElement(
         preferredNetworks: [STPCardBrand]? = nil,
-        cardBrandFilter: CardBrandFilter = .default
+        cardBrandFilter: CardBrandFilter = .default,
+        cardBrandChoiceEligible: Bool = true
     ) -> CardSectionElement {
         return CardSectionElement(
             collectName: false,
             defaultValues: .init(),
             preferredNetworks: preferredNetworks,
-            cardBrandChoiceEligible: true,
+            cardBrandChoiceEligible: cardBrandChoiceEligible,
             hostedSurface: .paymentSheet,
             theme: .default,
             analyticsHelper: ._testValue(),
             cardBrandFilter: cardBrandFilter,
             opensCardScannerAutomatically: false
         )
+    }
+
+    // MARK: - Element hierarchy
+
+    func testCBCSelectorIsChildOfPANElement() {
+        // Given
+        let cardSection = makeCardSectionElement()
+
+        // Then
+        let selector = cardSection.cardBrandChoiceElement
+        XCTAssertEqual(cardSection.panElement.elements.count, 1)
+        XCTAssertTrue(cardSection.panElement.getAllUnwrappedSubElements().contains { $0 === selector })
+        XCTAssertFalse(cardSection.cardSection.elements.contains { $0 is SectionElement.HiddenElement })
+        XCTAssertTrue(cardSection.debugDescription.contains("CardBrandChoiceElement"))
+    }
+
+    func testPANElementHasNoChildWhenCBCIsIneligible() {
+        // Given
+        let cardSection = makeCardSectionElement(cardBrandChoiceEligible: false)
+
+        // Then
+        XCTAssertNil(cardSection.cardBrandChoiceElement)
+        XCTAssertTrue(cardSection.panElement.elements.isEmpty)
+    }
+
+    func testCBCSelectorVisibilityUsesAllowedBrandCount() {
+        // Given
+        let cardSection = makeCardSectionElement()
+        let selector = cardSection.cardBrandChoiceElement
+        XCTAssertFalse(selector?.shouldShowPicker ?? true)
+        XCTAssertFalse(cardSection.panElement.viewModel.accessoryView === selector?.view)
+
+        // When
+        cardSection.panElement.setText(cbcVisaTestCard)
+
+        // Then
+        XCTAssertTrue(selector?.shouldShowPicker ?? false)
+        XCTAssertTrue(cardSection.panElement.viewModel.accessoryView === selector?.view)
+
+        // When
+        cardSection.panElement.setText(String(cbcVisaTestCard.prefix(7)))
+
+        // Then
+        XCTAssertFalse(selector?.shouldShowPicker ?? true)
+        XCTAssertFalse(cardSection.panElement.viewModel.accessoryView === selector?.view)
+    }
+
+    func testCBCSelectorUpdatesPreferredNetworkParamsThroughPANHierarchy() {
+        // Given
+        let cardSection = makeCardSectionElement()
+        cardSection.panElement.setText(cbcVisaTestCard)
+        cardSection.expiryElement.setText("1232")
+        cardSection.cvcElement.setText("123")
+
+        // When
+        simulateTap(cardSection.cardBrandChoiceElement, brand: .cartesBancaires)
+        let params = cardSection.updateParams(params: IntentConfirmParams(type: .stripe(.card)))
+
+        // Then
+        XCTAssertEqual(params?.paymentMethodParams.card?.networks?.preferred, "cartes_bancaires")
     }
 
     /// Simulates a user tap on a brand

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -654,6 +654,8 @@ class EmbeddedPaymentElementTest: XCTestCase {
 
     func testChangeButtonStateRespectsCardBrandChoice() async throws {
         // Given an EmbeddedPaymentElement w/ CBC enabled...
+        await AddressSpecProvider.shared.loadAddressSpecs()
+        await FormSpecProvider.shared.load()
         let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
         let elementsSession = STPElementsSession._testValue(cardBrandChoice: ._testValue())
         let intent = Intent.deferredIntent(intentConfig: intentConfig)
@@ -673,8 +675,6 @@ class EmbeddedPaymentElementTest: XCTestCase {
         sut.delegate = self
         sut.presentingViewController = UIViewController()
         sut.view.autosizeHeight(width: 320)
-        await AddressSpecProvider.shared.loadAddressSpecs()
-        await FormSpecProvider.shared.load()
         // ...with card selected...
         let cardRowButton = sut.embeddedPaymentMethodsView.getRowButton(accessibilityIdentifier: "Card")
         sut.embeddedPaymentMethodsView.didTap(rowButton: cardRowButton)
@@ -688,10 +688,8 @@ class EmbeddedPaymentElementTest: XCTestCase {
         // ...the change button state label (the label that appears on the selected row) should read ****1001 w/o a network (b/c no network was selected)...
         sut.updateChangeButtonAndSublabelState(for: .new(paymentMethodType: .stripe(.card)))
         XCTAssertEqual(sut.embeddedPaymentMethodsView.selectedRowChangeButtonState?.sublabel, "•••• 1001")
-        // ...and setting a preferred network (ie what happens if you select a brand from the dropdown)...
-        // Hack: Since the dropdown field isn't properly hooked up to the Element hierarchy, we can't access it via `cardForm.getDropdownFieldElement`
-        // TODO(https://jira.corp.stripe.com/browse/MOBILESDK-3088): Make the CBC dropdown field participate in the Element hierarchy correctly!
-        let cardBrandChoiceElement = (cardForm.getTextFieldElement("Card number").configuration as! TextFieldElement.PANConfiguration).cardBrandChoiceElement
+        // ...and setting a preferred network (ie what happens if you select a brand from the selector)...
+        let cardBrandChoiceElement: CardBrandChoiceElement? = cardForm.getElement()
         cardBrandChoiceElement?.select(.cartesBancaires)
         // ...the label should read "Cartes Bancaire ****1001"
         sut.updateChangeButtonAndSublabelState(for: .new(paymentMethodType: .stripe(.card)))

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -15,19 +15,13 @@ import XCTest
 @testable@_spi(STP) import StripePaymentsUI
 @testable@_spi(STP) import StripeUICore
 
-class MockElement: Element {
+private final class ParamsCountingPaymentMethodElement: PaymentMethodElement {
     var collectsUserInput: Bool = false
-
-    var paramsUpdater: (IntentConfirmParams) -> IntentConfirmParams?
-
-    init(
-        paramsUpdater: @escaping (IntentConfirmParams) -> IntentConfirmParams?
-    ) {
-        self.paramsUpdater = paramsUpdater
-    }
+    var updateParamsCallCount = 0
 
     func updateParams(params: IntentConfirmParams) -> IntentConfirmParams? {
-        return paramsUpdater(params)
+        updateParamsCallCount += 1
+        return params
     }
 
     weak var delegate: ElementDelegate?
@@ -101,6 +95,68 @@ class PaymentSheetFormFactoryTest: XCTestCase {
         XCTAssertEqual(params?.paymentMethodParams.billingDetails?.email, "email@stripe.com")
         XCTAssertEqual(params?.paymentMethodParams.type, .SEPADebit)
         XCTAssertEqual(params?.paymentMethodType, .stripe(.SEPADebit))
+    }
+
+    func testPaymentMethodElementWrapperDoesNotImplicitlyUpdateParamsFromWrappedElement() {
+        // Given
+        let element = ParamsCountingPaymentMethodElement()
+        let wrapper = PaymentMethodElementWrapper(element) { _, params in params }
+
+        // When
+        _ = wrapper.updateParams(params: IntentConfirmParams(type: .stripe(.card)))
+
+        // Then
+        XCTAssertEqual(element.updateParamsCallCount, 0)
+    }
+
+    func testPaymentMethodElementWrapperExplicitlyUpdatesParamsFromWrappedElementOnce() {
+        // Given
+        let element = ParamsCountingPaymentMethodElement()
+        let wrapper = PaymentMethodElementWrapper(updatingParamsFrom: element) { _, params in params }
+
+        // When
+        _ = wrapper.updateParams(params: IntentConfirmParams(type: .stripe(.card)))
+
+        // Then
+        XCTAssertEqual(element.updateParamsCallCount, 1)
+    }
+
+    func testPaymentMethodElementWrapperUpdatingParamsFromTextFieldStillValidates() {
+        // Given
+        let textField = TextFieldElement(
+            configuration: TextFieldElement.PANConfiguration(),
+            theme: .default
+        )
+        var paramsUpdaterCallCount = 0
+        let wrapper = PaymentMethodElementWrapper(updatingParamsFrom: textField) { _, params in
+            paramsUpdaterCallCount += 1
+            return params
+        }
+
+        // When
+        let params = wrapper.updateParams(params: IntentConfirmParams(type: .stripe(.card)))
+
+        // Then
+        XCTAssertNil(params)
+        XCTAssertEqual(paramsUpdaterCallCount, 0)
+    }
+
+    func testDefaultsApplierWrapperUpdatesParamsFromWrappedElementOnce() {
+        // Given
+        let factory = PaymentSheetFormFactory(
+            intent: ._testValue(),
+            elementsSession: ._testCardValue(),
+            configuration: .paymentElement(PaymentSheet.Configuration()),
+            paymentMethod: .stripe(.card)
+        )
+        let element = ParamsCountingPaymentMethodElement()
+        let wrapper = factory.makeDefaultsApplierWrapper(for: element)
+
+        // When
+        _ = wrapper.updateParams(params: IntentConfirmParams(type: .stripe(.card)))
+
+        // Then
+        XCTAssertEqual(element.updateParamsCallCount, 1)
     }
 
     func testNameOverrideApiPathBySpec() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/TextFieldElement+CardTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/TextFieldElement+CardTest.swift
@@ -588,13 +588,27 @@ class TextFieldElementCardTest: STPNetworkStubbingTestCase {
 
     func testAccessoryView_includesCartesBancairesWithCBC() {
         let cardBrandChoiceElement = CardBrandChoiceElement()
-        let configuration = TextFieldElement.PANConfiguration(cardBrandChoiceElement: cardBrandChoiceElement)
+        let configuration = TextFieldElement.PANConfiguration(cardBrandChoiceDataSource: cardBrandChoiceElement)
         let view = configuration.accessoryView(for: "", theme: .default)
         let rotatingView = view as? RotatingCardBrandsView
         XCTAssertNotNil(rotatingView)
         XCTAssertTrue(rotatingView!.cardBrands.contains(.cartesBancaires))
         XCTAssertTrue(rotatingView!.cardBrands.contains(.visa))
         XCTAssertTrue(rotatingView!.cardBrands.contains(.mastercard))
+    }
+
+    func testCardBrandChoiceDataSourceIsWeaklyHeld() {
+        // Given
+        var cardBrandChoiceElement: CardBrandChoiceElement? = CardBrandChoiceElement()
+        weak var weakCardBrandChoiceElement = cardBrandChoiceElement
+
+        // When
+        let configuration = TextFieldElement.PANConfiguration(cardBrandChoiceDataSource: cardBrandChoiceElement)
+        cardBrandChoiceElement = nil
+
+        // Then
+        XCTAssertNil(weakCardBrandChoiceElement)
+        XCTAssertNil(configuration.cardBrandChoiceDataSource)
     }
 }
 

--- a/StripeUICore/StripeUICore/Source/Elements/Section/SectionElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/Section/SectionElement.swift
@@ -122,9 +122,8 @@ extension SectionElement: ElementDelegate {
 // MARK: HiddenElement
 
 extension SectionElement {
-    /// A simple container element where the element's view is hidden
-    /// Useful when an element is a part of a section but it's view is embeded into another element
-    /// E.g. card brand drop down embedded into the PAN textfield
+    /// A container for an Element that should participate in the hierarchy
+    /// without rendering its view in the enclosing section.
     /// - Note: `HiddenElement`'s are skipped by the `ContainerElement`'s auto advance logic
     @_spi(STP) public final class HiddenElement: ContainerElement {
         final class HiddenView: UIView {}

--- a/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
+++ b/StripeUICore/StripeUICore/Source/Elements/TextField/TextFieldElement.swift
@@ -27,6 +27,21 @@ import UIKit
             setText("")
         }
     }
+    /// An Element displayed in the text field's trailing accessory area when `shouldDisplay` returns true.
+    public struct Accessory {
+        let element: Element
+        let shouldDisplay: (String) -> Bool
+
+        public init(element: Element, shouldDisplay: @escaping (String) -> Bool) {
+            self.element = element
+            self.shouldDisplay = shouldDisplay
+        }
+    }
+
+    private let accessory: Accessory?
+    public var elements: [Element] {
+        return accessory.map { [$0.element] } ?? []
+    }
     public private(set) lazy var text: String = {
         sanitize(text: configuration.defaultValue ?? "")
     }()
@@ -87,6 +102,12 @@ import UIKit
     }
 
     var viewModel: ViewModel {
+        let accessoryView: UIView? = {
+            if let accessory, accessory.shouldDisplay(text) {
+                return accessory.element.view
+            }
+            return configuration.accessoryView(for: text, theme: theme)
+        }()
         let placeholder: String = {
             if !configuration.isOptional {
                 return configuration.label
@@ -101,7 +122,7 @@ import UIKit
             attributedText: configuration.makeDisplayText(for: text),
             keyboardProperties: configuration.keyboardProperties(for: text),
             validationState: configuration.validate(text: text, isOptional: configuration.isOptional),
-            accessoryView: configuration.accessoryView(for: text, theme: theme),
+            accessoryView: accessoryView,
             shouldShowClearButton: configuration.shouldShowClearButton,
             editConfiguration: configuration.editConfiguration,
             theme: theme,
@@ -111,9 +132,15 @@ import UIKit
 
     // MARK: - Initializer
 
-    public required init(configuration: TextFieldElementConfiguration, theme: ElementsAppearance = .default) {
+    public required init(
+        configuration: TextFieldElementConfiguration,
+        theme: ElementsAppearance = .default,
+        accessory: Accessory? = nil
+    ) {
         self.configuration = configuration
         self.theme = theme
+        self.accessory = accessory
+        accessory?.element.delegate = self
     }
 
     /// Call this to manually set the text of the text field.
@@ -140,7 +167,7 @@ import UIKit
 
 // MARK: - Element
 
-extension TextFieldElement: Element {
+extension TextFieldElement: ContainerElement {
     public var collectsUserInput: Bool { true }
     public var view: UIView {
         return textFieldView
@@ -177,6 +204,19 @@ extension TextFieldElement: Element {
     }
 }
 
+// MARK: - ElementDelegate
+
+extension TextFieldElement {
+    public func didUpdate(element: Element) {
+        textFieldView.updateUI(with: viewModel)
+        delegate?.didUpdate(element: self)
+    }
+
+    public func continueToNextField(element: Element) {
+        delegate?.continueToNextField(element: self)
+    }
+}
+
 // MARK: - TextFieldViewDelegate
 
 extension TextFieldElement: TextFieldViewDelegate {
@@ -208,6 +248,6 @@ extension TextFieldElement: TextFieldViewDelegate {
 // MARK: - DebugDescription
 extension TextFieldElement {
     public var debugDescription: String {
-        return "<TextFieldElement: \(Unmanaged.passUnretained(self).toOpaque())>; label = \(configuration.label); text = \(text); validationState = \(validationState)"
+        return "<TextFieldElement: \(Unmanaged.passUnretained(self).toOpaque())>; label = \(configuration.label); text = \(text); validationState = \(validationState)" + subElementDebugDescription
     }
 }

--- a/StripeUICore/StripeUICoreTests/Unit/Elements/TextFieldElementTest.swift
+++ b/StripeUICore/StripeUICoreTests/Unit/Elements/TextFieldElementTest.swift
@@ -7,6 +7,7 @@
 //
 
 @testable @_spi(STP) import StripeUICore
+import UIKit
 import XCTest
 
 class TextFieldElementTest: XCTestCase {
@@ -14,6 +15,26 @@ class TextFieldElementTest: XCTestCase {
         var defaultValue: String?
         var label: String = "label"
         func maxLength(for text: String) -> Int { "default value".count }
+    }
+
+    private final class TestElement: Element {
+        weak var delegate: ElementDelegate?
+        let view = UIView()
+        let collectsUserInput = true
+
+        func notifyDelegate() {
+            delegate?.didUpdate(element: self)
+        }
+    }
+
+    private final class TestElementDelegate: ElementDelegate {
+        var updatedElement: Element?
+
+        func didUpdate(element: Element) {
+            updatedElement = element
+        }
+
+        func continueToNextField(element: Element) {}
     }
 
     func testNoDefaultValue() {
@@ -108,5 +129,58 @@ class TextFieldElementTest: XCTestCase {
     func testDefaultValueWithEmojisIsSanitized() {
         let element = TextFieldElement(configuration: Configuration(defaultValue: "Hello 🌍 World Test Test"))
         XCTAssertEqual(element.text, "Hello  World ") // Truncated to maxLength
+    }
+
+    func testAccessoryElementParticipatesInElementHierarchy() {
+        // Given
+        let accessoryElement = TestElement()
+
+        // When
+        let element = TextFieldElement(
+            configuration: Configuration(),
+            accessory: .init(element: accessoryElement) { _ in true }
+        )
+
+        // Then
+        XCTAssertEqual(element.elements.count, 1)
+        XCTAssertTrue(element.elements.first === accessoryElement)
+        XCTAssertTrue(accessoryElement.delegate === element)
+        XCTAssertTrue(element.debugDescription.contains("TestElement"))
+    }
+
+    func testAccessoryElementUpdatePropagatesThroughTextFieldElement() {
+        // Given
+        let accessoryElement = TestElement()
+        let element = TextFieldElement(
+            configuration: Configuration(),
+            accessory: .init(element: accessoryElement) { _ in true }
+        )
+        let delegate = TestElementDelegate()
+        element.delegate = delegate
+
+        // When
+        accessoryElement.notifyDelegate()
+
+        // Then
+        XCTAssertTrue(delegate.updatedElement === element)
+    }
+
+    func testAccessoryElementAddedAfterDisablingRemainsNonInteractive() {
+        // Given
+        let accessoryElement = TestElement()
+        let element = TextFieldElement(
+            configuration: Configuration(),
+            accessory: .init(element: accessoryElement) { text in text == "show" }
+        )
+        XCTAssertNil(accessoryElement.view.superview)
+        sendEventToSubviews(.shouldDisableUserInteraction, from: element.view)
+
+        // When
+        element.setText("show")
+
+        // Then
+        XCTAssertNotNil(accessoryElement.view.superview)
+        XCTAssertFalse(element.view.isUserInteractionEnabled)
+        XCTAssertNil(element.view.hitTest(.zero, with: nil))
     }
 }


### PR DESCRIPTION
## Summary

- Give `TextFieldElement` a generic accessory concept (an Element shown in the trailing accessory view when a predicate says so) instead of the CBC picker being special-cased inside `PANConfiguration`.
- `TextFieldElement` is now a `ContainerElement` so the CBC picker actually participates in the Element hierarchy (params, delegate callbacks) instead of being tacked on as a hidden sibling.
- Replace the direct `CardBrandChoiceElement` reference in `PANConfiguration`/`LastFourConfiguration` with a small `CardBrandChoiceDataSource` protocol, held weakly.

## Motivation

https://jira.corp.stripe.com/browse/MOBILESDK-3088

## Testing

Existing tests updated

## Changelog

N/A