### PR TITLE
Forward curated autocomplete country list to MPE

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController+Configuration.swift
@@ -164,7 +164,7 @@ public extension AddressViewController {
 
         /// A list of two-letter country codes that support autocomplete
         /// Defaults to a list of countries that Stripe has audited to ensure a good autocomplete experience.
-        public var autocompleteCountries: [String] = ["AU", "BE", "BR", "CA", "CH", "DE", "ES", "FR", "GB", "IE", "IN", "IT", "JP", "MX", "MY", "NL", "NO", "NZ", "PH", "PL", "RU", "SE", "SG", "TR", "US", "ZA"]
+        public var autocompleteCountries: [String] = AddressAutocomplete.supportedCountries
 
         /// The billing address to use for the "Use billing address for shipping" checkbox.
         /// When provided, shows a checkbox that allows customers to populate shipping fields with billing address data.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Card.swift
@@ -96,7 +96,12 @@ extension PaymentSheetFormFactory {
             case .automatic:
                 return makeBillingAddressSection(fieldsToCollect: .countryAndPostal(), countries: countries, includeEmail: shouldIncludeEmail, includePhone: shouldIncludePhone)
             case .full:
-                return makeBillingAddressSection(fieldsToCollect: .all(autocomplete: .init()), countries: countries, includeEmail: shouldIncludeEmail, includePhone: shouldIncludePhone)
+                return makeBillingAddressSection(
+                    fieldsToCollect: .all(autocomplete: .init(autocompleteCountries: AddressAutocomplete.supportedCountries)),
+                    countries: countries,
+                    includeEmail: shouldIncludeEmail,
+                    includePhone: shouldIncludePhone
+                )
             case .never:
                 return nil
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -482,7 +482,7 @@ extension PaymentSheetFormFactory {
     }
 
     func makeBillingAddressSection(
-        fieldsToCollect: AddressSectionElement.FieldsToCollect = .all(autocomplete: .init()),
+        fieldsToCollect: AddressSectionElement.FieldsToCollect = .all(autocomplete: .init(autocompleteCountries: AddressAutocomplete.supportedCountries)),
         countries: [String]? = nil,
         countryAPIPath: String? = nil,
         includeEmail: Bool = false,
@@ -684,7 +684,7 @@ extension PaymentSheetFormFactory {
         let phoneElement = configuration.billingDetailsCollectionConfiguration.phone == .always ? makePhone() : nil
         let addressElement = configuration.billingDetailsCollectionConfiguration.address == .full
             ? makeBillingAddressSection(
-                fieldsToCollect: .all(autocomplete: .init()),
+                fieldsToCollect: .all(autocomplete: .init(autocompleteCountries: AddressAutocomplete.supportedCountries)),
                 countries: configuration.billingDetailsCollectionConfiguration.allowedCountriesArray
             )
             : nil
@@ -872,7 +872,10 @@ extension PaymentSheetFormFactory {
 
         let countries = configuration.billingDetailsCollectionConfiguration.allowedCountriesArray
         let addressElement = billingConfiguration.address == .full
-            ? makeBillingAddressSection(fieldsToCollect: .all(autocomplete: .init()), countries: countries)
+            ? makeBillingAddressSection(
+                fieldsToCollect: .all(autocomplete: .init(autocompleteCountries: AddressAutocomplete.supportedCountries)),
+                countries: countries
+            )
             : nil
 
         // An email is required, so only hide the email field iff:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AddressAutocomplete.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/AutoComplete/AddressAutocomplete.swift
@@ -1,0 +1,12 @@
+//
+//  AddressAutocomplete.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 7/20/26.
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+enum AddressAutocomplete {
+    /// Countries that Stripe has audited to ensure a good autocomplete experience.
+    static let supportedCountries = ["AU", "BE", "BR", "CA", "CH", "DE", "ES", "FR", "GB", "IE", "IN", "IT", "JP", "MX", "MY", "NL", "NO", "NZ", "PH", "PL", "RU", "SE", "SG", "TR", "US", "ZA"]
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactory+CardEmailPhoneFieldsTest.swift
@@ -109,6 +109,30 @@ class PaymentSheetFormFactoryCardEmailPhoneFieldsTest: XCTestCase {
         XCTAssertNil(contactInfoSection, "Should not have separate contact information section when billing address includes email/phone")
     }
 
+    func testCardFormWithFullBilling_UsesSupportedAutocompleteCountries() {
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.address = .full
+
+        let factory = PaymentSheetFormFactory(
+            intent: ._testValue(),
+            elementsSession: ._testCardValue(),
+            configuration: .paymentElement(configuration),
+            paymentMethod: .stripe(.card),
+            addressSpecProvider: dummyAddressSpecProvider
+        )
+
+        let cardForm = factory.makeCard()
+        let billingAddressSection = (cardForm as? ContainerElement)?.elements.compactMap { element in
+            element as? PaymentMethodElementWrapper<AddressSectionElement>
+        }.first?.element
+
+        XCTAssertEqual(AddressViewController.Configuration().autocompleteCountries, AddressAutocomplete.supportedCountries)
+        XCTAssertEqual(
+            billingAddressSection?.fieldsToCollect,
+            .all(autocomplete: .init(autocompleteCountries: AddressAutocomplete.supportedCountries))
+        )
+    }
+
     func testCardFormWithEmailPhoneAlwaysAndNeverBilling_EmailPhoneInContactInfo() {
         var configuration = PaymentSheet.Configuration()
         configuration.billingDetailsCollectionConfiguration.email = .always


### PR DESCRIPTION
## Summary
- Moved the audited autocomplete country list out of `AddressViewController.Configuration` into a new `AddressAutocomplete.supportedCountries` constant
- MPE's billing address section now passes that same curated list into `.all(autocomplete:)` instead of using the autocomplete default, so PaymentSheet's autocomplete behavior matches AddressViewController's

## Motivation
Autocomplete filtering

## Testing
- New unit test

## Changelog
N/A