### PR TITLE
CryptoOnramp SDK: Adds Unit test for `CryptoOnrampCoordinator.create` and Reenables Checkout Integration Test

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITests.swift
+++ b/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITests.swift
@@ -22,7 +22,7 @@ final class CryptoOnrampExampleUITests: XCTestCase {
     /// Tests a happy-path flow from log in (existing account) to successful checkout, followed by re-authentication using seamless sign-in.
     /// Disabled
     @MainActor
-    func _testCryptoOnrampEndToEnd() throws {
+    func testCryptoOnrampEndToEnd() throws {
         // Step 1: Enter email and password
         let emailField = app.textFields["Enter email address"].firstMatch
         XCTAssertTrue(emailField.waitForExistence(timeout: .networkTimeout), "Email field should exist")

--- a/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITests.swift
+++ b/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITests.swift
@@ -20,7 +20,6 @@ final class CryptoOnrampExampleUITests: XCTestCase {
     }
 
     /// Tests a happy-path flow from log in (existing account) to successful checkout, followed by re-authentication using seamless sign-in.
-    /// Disabled
     @MainActor
     func testCryptoOnrampEndToEnd() throws {
         // Step 1: Enter email and password

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/CryptoOnrampCoordinatorTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/CryptoOnrampCoordinatorTests.swift
@@ -1,0 +1,50 @@
+//
+//  CryptoOnrampCoordinatorTests.swift
+//  StripeCryptoOnrampTests
+//
+//  Created by Michael Liberatore on 7/20/26.
+//
+
+import Foundation
+import OHHTTPStubs
+import OHHTTPStubsSwift
+import StripeCore
+import StripeCoreTestUtils
+@testable @_spi(CryptoOnrampAlpha) import StripeCryptoOnramp
+import XCTest
+
+final class CryptoOnrampCoordinatorTests: APIStubbedTestCase {
+    func testCreateSucceedsWithoutSpecifyingPaymentMethodTypes() async throws {
+        stub { request in
+            request.url?.path == "/v1/elements/sessions"
+        } response: { request in
+            // Tests for a regression that occurred when `LinkController` briefly was passing
+            // "link" for `payment_method_types`, ultimately triggering a failure to initialize onramp.
+            XCTAssertFalse(request.url?.absoluteString.contains("payment_method_types") ?? true)
+            return HTTPStubsResponse(jsonObject: Self.linkElementsSession, statusCode: 200, headers: nil)
+        }
+
+        let apiClient = stubbedAPIClient()
+        apiClient.publishableKey = "pk_test_1234"
+
+        let coordinator = try await CryptoOnrampCoordinator.create(apiClient: apiClient)
+        XCTAssertNotNil(coordinator)
+    }
+
+    private static let linkElementsSession: [String: Any] = [
+        "config_id": "config_crypto_onramp",
+        "link_settings": [
+            "link_funding_sources": ["CARD"],
+            "link_mobile_use_attestation_endpoints": true,
+        ],
+        "merchant_country": "US",
+        "ordered_payment_method_types_and_wallets": ["card"],
+        "payment_method_preference": [
+            "country_code": "US",
+            "object": "payment_method_preference",
+            "ordered_payment_method_types": ["card"],
+            "type": "deferred_intent",
+        ],
+        "session_id": "elements_session_crypto_onramp",
+    ]
+}


### PR DESCRIPTION
## Summary
An issue came up recently which caused `CryptoOnrampCoordinator.create` to consistently fail in our example app. This PR adds a focused unit test which checks the `payment_method_types` query parameter that ultimately led to the error, and reenables our end-to-end checkout test which was previously disabled due to a demo backend issue that's since been resolved. This integration test would've also failed the build to prevent the issue from reaching `master`, so it warrants reenabling at this time in my opinion.

## Motivation
Slack Thread: [Stripe](https://stripe.slack.com/archives/C094P3BRBL1/p1784561637715339) | [Lickability](https://lickability.slack.com/archives/C094P3BRBL1/p1784561637715339)


## Testing
1. Ran the new unit test with and without the changes from https://github.com/stripe/stripe-ios/pull/6723/changes#diff-333fc873039e605d8f7ffbe6d272617d3b456422be10bf243e87ecfafdf8535eR1073 applied to confirm it passed with, and failed without the changes.
2. Ran the example app integration test with the changes applied to ensure it passed.
3. Confirmed that CI ran the integration test on this PR: https://app.bitrise.io/app/b220f4ba85d134a7/build/e6c3b446-8116-4730-8cd6-9a94d1d625ed

```
Testing started
Test Suite CryptoOnrampExampleUITests started on 'Clone 1 of iPhone 12 mini - CryptoOnrampExampleUITests-Runner (22514)'
    ✔ [CryptoOnrampExampleUITests] testCryptoOnrampEndToEnd on 'Clone 1 of iPhone 12 mini - CryptoOnrampExampleUITests-Runner (22514)' (82.997 seconds)
Test Succeeded
Xcode Test command succeeded.
```

## Changelog
N/A
