### PR TITLE
Improve LPM Confirm flow testability

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLPMConfirmFlowTests.swift
@@ -16,14 +16,43 @@ import StripeCoreTestUtils
 import SwiftUI
 import XCTest
 
-/// These tests exercise 9 different confirm flows based on the combination of:
-/// - The Stripe Intent: PaymentIntent or PaymentIntent+SFU or SetupIntent
-/// - The confirmation type: "Normal" intent-first client-side confirmation or "Deferred" client-side confirmation or "Deferred" server-side confirmation
+/// These tests exercise confirm flows based on the combination of:
+/// - The Stripe Intent: PaymentIntent, PaymentIntent+SFU, PaymentIntent+PMO-SFU, or SetupIntent
+/// - The confirmation type: intent-first, deferred, or Checkout Session
 /// They can also test the presence/absence of particular fields for a payment method form e.g. the SEPA test asserts that there's a mandate element.
-/// 👀  See `testIdealConfirmFlows` for an example with comments.
+/// 👀  See `testiDEALConfirmFlows` for an example with comments.
 @MainActor
 final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
+    // MARK: Select which confirm flows to record
+
+    // All entries should remain enabled in committed code so CI exercises the full matrix.
+    // To record a smaller slice, temporarily comment out entries in either list. For example:
+    // - Leave only `.checkoutSession` to record Checkout Session flows.
+    // - Leave only `.deferredIntent` to record all deferred flows (client-side, server-side,
+    //   and confirmation-token variants).
+    // - Combine either of those with only `.setupIntent` to record just that intent-kind slice.
+    //
+    // Restore every entry before committing.
+    static let intentKindsToTest: Set<IntentKind> = [
+        .paymentIntent,
+        .paymentIntentWithSetupFutureUsage,
+        .paymentIntentWithPMOSetupFutureUsage,
+        .setupIntent,
+    ]
+
+    static let confirmationTypesToTest: Set<ConfirmationType> = [
+        .intentFirst,
+        .deferredIntent,
+        .checkoutSession,
+    ]
+
     let window: UIWindow = UIWindow(frame: .init(x: 0, y: 0, width: 428, height: 926))
+
+    enum ConfirmationType: Hashable {
+        case intentFirst
+        case deferredIntent
+        case checkoutSession
+    }
 
     struct TestIntent {
         let description: String
@@ -412,13 +441,18 @@ final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
     }
 
     func testSavedSEPA() async throws {
+        let intentKinds = selectedIntentKinds(from: [.paymentIntent, .paymentIntentWithSetupFutureUsage, .setupIntent])
+        guard !intentKinds.isEmpty, !Self.confirmationTypesToTest.isEmpty else {
+            return
+        }
+
         // Update the API client based on the merchant country
         let apiClient = STPAPIClient(publishableKey: MerchantCountry.US.publishableKey)
 
         // Confirm saved SEPA with every confirm variation
         // Use a fresh customer per intent kind to avoid lock contention on the Customer object
         // from async server-side processing (mandate creation, PM attachment) across iterations.
-        for intentKind in [IntentKind.paymentIntent, .paymentIntentWithSetupFutureUsage, .setupIntent] {
+        for intentKind in intentKinds {
             // Create customer session for confirmation token support
             let customerAndCustomerSession = try await STPTestingAPIClient.shared().fetchCustomerAndCustomerSessionClientSecret(
                 customerID: nil,
@@ -581,6 +615,11 @@ final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
     }
 
     func testCardConfirmFlowsSetAsDefault() async throws {
+        let intentKinds = selectedIntentKinds(from: [.paymentIntentWithSetupFutureUsage, .setupIntent])
+        guard !intentKinds.isEmpty, !Self.confirmationTypesToTest.isEmpty else {
+            return
+        }
+
         // Create a new customer with customer session
         let merchantCountry = MerchantCountry.US
         let apiClient = STPAPIClient(publishableKey: merchantCountry.publishableKey)
@@ -606,7 +645,7 @@ final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
             customerSessionClientSecret: customerAndCustomerSession.customerSessionClientSecret
         )
         try await _testConfirm(
-            intentKinds: [.paymentIntentWithSetupFutureUsage, .setupIntent],
+            intentKinds: intentKinds,
             currency: "USD",
             paymentMethodType: .card,
             merchantCountry: merchantCountry,
@@ -699,6 +738,11 @@ final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
     }
 
     func testApplePayConfirmFlows() async throws {
+        let intentKinds = selectedIntentKinds(from: [.paymentIntent, .paymentIntentWithSetupFutureUsage, .paymentIntentWithPMOSetupFutureUsage, .setupIntent])
+        guard !intentKinds.isEmpty, !Self.confirmationTypesToTest.isEmpty else {
+            return
+        }
+
         // Initialize PaymentSheet at least once to set the correct payment_user_agent for this process:
         let intentConfiguration = PaymentSheet.IntentConfiguration(mode: .setup(), confirmHandler: { _, _ in return "" })
         _ = PaymentSheet(mode: .deferredIntent(intentConfiguration), configuration: PaymentSheet.Configuration())
@@ -711,7 +755,6 @@ final class PaymentSheetLPMConfirmFlowTests: STPNetworkStubbingTestCase {
         configuration.allowsDelayedPaymentMethods = true
         configuration.apiClient = apiClient
 
-        let intentKinds: [IntentKind] = [.paymentIntent, .paymentIntentWithSetupFutureUsage, .paymentIntentWithPMOSetupFutureUsage, .setupIntent]
         for intentKind in intentKinds {
             let intents = try await makeTestIntents(
                 intentKind: intentKind,
@@ -870,7 +913,7 @@ extension PaymentSheetLPMConfirmFlowTests {
         )
     }
 
-    enum IntentKind: CaseIterable {
+    enum IntentKind: CaseIterable, Hashable {
         case paymentIntent
         case paymentIntentWithSetupFutureUsage
         case paymentIntentWithPMOSetupFutureUsage
@@ -917,6 +960,14 @@ extension PaymentSheetLPMConfirmFlowTests {
         Self.setupFutureUsageSupportByPaymentMethod[paymentMethod] ?? .fullySupported
     }
 
+    func selectedIntentKinds(from intentKinds: [IntentKind]) -> [IntentKind] {
+        intentKinds.filter(Self.intentKindsToTest.contains)
+    }
+
+    func shouldTest(_ confirmationType: ConfirmationType) -> Bool {
+        Self.confirmationTypesToTest.contains(confirmationType)
+    }
+
     func _testConfirm(
         intentKinds: [IntentKind],
         currency: String,
@@ -929,7 +980,7 @@ extension PaymentSheetLPMConfirmFlowTests {
         expectedHierarchy: FormHierarchyNode? = nil,
         formCompleter: (PaymentMethodElement) -> Void
     ) async throws {
-        for intentKind in intentKinds {
+        for intentKind in selectedIntentKinds(from: intentKinds) {
             try await _testConfirm(
                 intentKind: intentKind,
                 currency: currency,
@@ -1119,9 +1170,15 @@ extension PaymentSheetLPMConfirmFlowTests {
         var intents: [TestIntent] = []
         let paymentMethodTypes = [paymentMethod.identifier].compactMap { $0 }
         let setupFutureUsageSupport = setupFutureUsageSupport(for: paymentMethod)
+        guard !Self.confirmationTypesToTest.isEmpty else {
+            return []
+        }
         switch intentKind {
         case .paymentIntent:
-            let paymentIntent: STPPaymentIntent = try await {
+            let paymentIntent: STPPaymentIntent? = try await {
+                guard shouldTest(.intentFirst) else {
+                    return nil
+                }
                 let clientSecret = try await STPTestingAPIClient.shared.fetchPaymentIntent(
                     types: paymentMethodTypes,
                     currency: currency,
@@ -1142,26 +1199,28 @@ extension PaymentSheetLPMConfirmFlowTests {
                 )
             }
 
-            // CheckoutSession
-            let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
-                types: paymentMethodTypes,
-                currency: currency,
-                amount: amount,
-                merchantCountry: merchantCountry.rawValue,
-                customerID: customer
-            )
-            let csApiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-            let checkoutSession = try await csApiClient.initCheckoutSession(
-                checkoutSessionId: checkoutSessionResponse.id,
-                adaptivePricingAllowed: true
-            )
-            let checkout = Checkout(apiResponse: checkoutSession)
-
-            intents = [
-                TestIntent("PaymentIntent", .paymentIntent(paymentIntent)),
-                TestIntent("Deferred PaymentIntent - client side confirmation", makeDeferredIntent(deferredCSC)),
-                TestIntent("CheckoutSession", .checkout(checkout.session), checkout: checkout),
-            ]
+            if let paymentIntent {
+                intents.append(TestIntent("PaymentIntent", .paymentIntent(paymentIntent)))
+            }
+            if shouldTest(.deferredIntent) {
+                intents.append(TestIntent("Deferred PaymentIntent - client side confirmation", makeDeferredIntent(deferredCSC)))
+            }
+            if shouldTest(.checkoutSession) {
+                let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
+                    types: paymentMethodTypes,
+                    currency: currency,
+                    amount: amount,
+                    merchantCountry: merchantCountry.rawValue,
+                    customerID: customer
+                )
+                let csApiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+                let checkoutSession = try await csApiClient.initCheckoutSession(
+                    checkoutSessionId: checkoutSessionResponse.id,
+                    adaptivePricingAllowed: true
+                )
+                let checkout = Checkout(apiResponse: checkoutSession)
+                intents.append(TestIntent("CheckoutSession", .checkout(checkout.session), checkout: checkout))
+            }
             guard paymentMethod != .blik else {
                 // Blik doesn't support server-side confirmation
                 return intents
@@ -1179,9 +1238,11 @@ extension PaymentSheetLPMConfirmFlowTests {
                 )
             }
 
-            intents += [
-                TestIntent("Deferred PaymentIntent - server side confirmation", makeDeferredIntent(deferredSSC)),
-            ]
+            guard shouldTest(.deferredIntent) else {
+                return intents
+            }
+
+            intents.append(TestIntent("Deferred PaymentIntent - server side confirmation", makeDeferredIntent(deferredSSC)))
 
             // Confirmation token variations
             let deferredCSCWithConfirmationToken = PaymentSheet.IntentConfiguration(mode: .payment(amount: amount ?? 1099, currency: currency), paymentMethodTypes: [paymentMethod.identifier], confirmationTokenConfirmHandler: { _ in
@@ -1216,7 +1277,10 @@ extension PaymentSheetLPMConfirmFlowTests {
             guard setupFutureUsageSupport.paymentIntentSetupFutureUsage else {
                 return []
             }
-            let paymentIntent: STPPaymentIntent = try await {
+            let paymentIntent: STPPaymentIntent? = try await {
+                guard shouldTest(.intentFirst) else {
+                    return nil
+                }
                 let clientSecret = try await STPTestingAPIClient.shared.fetchPaymentIntent(
                     types: paymentMethodTypes,
                     currency: currency,
@@ -1277,17 +1341,22 @@ extension PaymentSheetLPMConfirmFlowTests {
                 )
             })
 
-            var intents: [TestIntent] = [
-                TestIntent("PaymentIntent", .paymentIntent(paymentIntent)),
-                TestIntent("Deferred PaymentIntent w/ setup_future_usage - client side confirmation with payment method flow", makeDeferredIntent(deferredCSC)),
-                TestIntent("Deferred PaymentIntent w/ setup_future_usage - server side confirmation with payment method flow", makeDeferredIntent(deferredSSC)),
-                TestIntent("Deferred PaymentIntent w/ setup_future_usage - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
-                TestIntent("Deferred PaymentIntent w/ setup_future_usage - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
-            ]
+            var intents: [TestIntent] = []
+            if let paymentIntent {
+                intents.append(TestIntent("PaymentIntent", .paymentIntent(paymentIntent)))
+            }
+            if shouldTest(.deferredIntent) {
+                intents += [
+                    TestIntent("Deferred PaymentIntent w/ setup_future_usage - client side confirmation with payment method flow", makeDeferredIntent(deferredCSC)),
+                    TestIntent("Deferred PaymentIntent w/ setup_future_usage - server side confirmation with payment method flow", makeDeferredIntent(deferredSSC)),
+                    TestIntent("Deferred PaymentIntent w/ setup_future_usage - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
+                    TestIntent("Deferred PaymentIntent w/ setup_future_usage - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
+                ]
+            }
 
             // Payment+SFU and PMO SFU are not always available on payment methods that support them for intents.
             // We conditionally add testing for them accordingly.
-            if setupFutureUsageSupport.checkoutSessionSetupFutureUsage {
+            if shouldTest(.checkoutSession), setupFutureUsageSupport.checkoutSessionSetupFutureUsage {
                 let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
                     types: paymentMethodTypes,
                     currency: currency,
@@ -1311,7 +1380,10 @@ extension PaymentSheetLPMConfirmFlowTests {
                 return []
             }
             // This tests the scenario where IntentConfiguration has PMO setup_future_usage.
-            let paymentIntent: STPPaymentIntent = try await {
+            let paymentIntent: STPPaymentIntent? = try await {
+                guard shouldTest(.intentFirst) else {
+                    return nil
+                }
                 // Regular PI: Backend DOES have PMO SFU set
                 let clientSecret = try await STPTestingAPIClient.shared.fetchPaymentIntent(
                     types: paymentMethodTypes,
@@ -1391,14 +1463,19 @@ extension PaymentSheetLPMConfirmFlowTests {
                 }
             )
 
-            var intents: [TestIntent] = [
-                TestIntent("PaymentIntent", .paymentIntent(paymentIntent)),
-                TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - client side confirmation", makeDeferredIntent(deferredCSC)),
-                TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - server side confirmation", makeDeferredIntent(deferredSSC)),
-                TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
-                TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
-            ]
-            if setupFutureUsageSupport.checkoutSessionPaymentMethodOptionsSetupFutureUsage {
+            var intents: [TestIntent] = []
+            if let paymentIntent {
+                intents.append(TestIntent("PaymentIntent", .paymentIntent(paymentIntent)))
+            }
+            if shouldTest(.deferredIntent) {
+                intents += [
+                    TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - client side confirmation", makeDeferredIntent(deferredCSC)),
+                    TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - server side confirmation", makeDeferredIntent(deferredSSC)),
+                    TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
+                    TestIntent("Deferred PaymentIntent w/ PMO setup_future_usage - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
+                ]
+            }
+            if shouldTest(.checkoutSession), setupFutureUsageSupport.checkoutSessionPaymentMethodOptionsSetupFutureUsage {
                 let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
                     types: paymentMethodTypes,
                     currency: currency,
@@ -1420,7 +1497,10 @@ extension PaymentSheetLPMConfirmFlowTests {
 
             return intents
         case .setupIntent:
-            let setupIntent: STPSetupIntent = try await {
+            let setupIntent: STPSetupIntent? = try await {
+                guard shouldTest(.intentFirst) else {
+                    return nil
+                }
                 let clientSecret = try await STPTestingAPIClient.shared.fetchSetupIntent(types: paymentMethodTypes, merchantCountry: merchantCountry.rawValue, customerID: customer)
                 return try await apiClient.retrieveSetupIntent(clientSecret: clientSecret)
             }()
@@ -1439,25 +1519,31 @@ extension PaymentSheetLPMConfirmFlowTests {
                 return try await STPTestingAPIClient.shared.fetchSetupIntent(types: paymentMethodTypes, merchantCountry: merchantCountry.rawValue, customerID: customer, confirm: true, otherParams: ["confirmation_token": confirmationToken.stripeId])
             })
 
-            // CheckoutSession
-            let checkoutSessionResponse = try await STPTestingAPIClient.shared().fetchCheckoutSessionSetupMode(
-                types: paymentMethodTypes,
-                currency: currency,
-                merchantCountry: merchantCountry.rawValue,
-                customerID: customer
-            )
-            let csApiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-            let checkoutSession = try await csApiClient.initCheckoutSession(checkoutSessionId: checkoutSessionResponse.id, adaptivePricingAllowed: true)
-            let checkout = Checkout(apiResponse: checkoutSession)
-
-            return [
-                TestIntent("SetupIntent", .setupIntent(setupIntent)),
-                TestIntent("Deferred SetupIntent - client side confirmation", makeDeferredIntent(deferredCSC)),
-                TestIntent("Deferred SetupIntent - server side confirmation", makeDeferredIntent(deferredSSC)),
-                TestIntent("Deferred SetupIntent - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
-                TestIntent("Deferred SetupIntent - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
-                TestIntent("CheckoutSession", .checkout(checkout.session), checkout: checkout),
-            ]
+            var intents: [TestIntent] = []
+            if let setupIntent {
+                intents.append(TestIntent("SetupIntent", .setupIntent(setupIntent)))
+            }
+            if shouldTest(.deferredIntent) {
+                intents += [
+                    TestIntent("Deferred SetupIntent - client side confirmation", makeDeferredIntent(deferredCSC)),
+                    TestIntent("Deferred SetupIntent - server side confirmation", makeDeferredIntent(deferredSSC)),
+                    TestIntent("Deferred SetupIntent - client side confirmation with confirmation token", makeDeferredIntent(deferredCSCWithConfirmationToken)),
+                    TestIntent("Deferred SetupIntent - server side confirmation with confirmation token", makeDeferredIntent(deferredSSCWithConfirmationToken)),
+                ]
+            }
+            if shouldTest(.checkoutSession) {
+                let checkoutSessionResponse = try await STPTestingAPIClient.shared().fetchCheckoutSessionSetupMode(
+                    types: paymentMethodTypes,
+                    currency: currency,
+                    merchantCountry: merchantCountry.rawValue,
+                    customerID: customer
+                )
+                let csApiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+                let checkoutSession = try await csApiClient.initCheckoutSession(checkoutSessionId: checkoutSessionResponse.id, adaptivePricingAllowed: true)
+                let checkout = Checkout(apiResponse: checkoutSession)
+                intents.append(TestIntent("CheckoutSession", .checkout(checkout.session), checkout: checkout))
+            }
+            return intents
         }
     }
 
@@ -1471,6 +1557,11 @@ extension PaymentSheetLPMConfirmFlowTests {
         linkFundingSources: Set<ParsedEnum<LinkSettings.FundingSource>>,
         makeLinkPaymentMethod: (STPAPIClient) async throws -> STPPaymentMethod
     ) async throws {
+        let intentKinds = selectedIntentKinds(from: intentKinds)
+        guard !intentKinds.isEmpty, !Self.confirmationTypesToTest.isEmpty else {
+            return
+        }
+
         // Initialize PaymentSheet at least once to set the correct payment_user_agent for this process:
         let intentConfiguration = PaymentSheet.IntentConfiguration(mode: .setup(), confirmHandler: { _, _ in return "" })
         _ = PaymentSheet(mode: .deferredIntent(intentConfiguration), configuration: PaymentSheet.Configuration())


### PR DESCRIPTION
## Summary
- Adds `intentKindsToTest` and `confirmationTypesToTest` static sets to `PaymentSheetLPMConfirmFlowTests` so specific slices of the confirm flow matrix (by intent kind or confirmation type) can be selectively recorded instead of always recording all of them
- Filters intent kinds and confirmation types (intent-first, deferred, checkout session) through these sets everywhere intents are built, skipping tests/branches for anything not selected
- All entries remain enabled by default so CI still exercises the full matrix

## Motivation
https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5358

## Testing
- Existing tests

## Changelog
N/A