### PR TITLE
Fix PaymentElement SwiftUI height test on iOS 15

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementViewTests.swift
@@ -13,8 +13,8 @@ import XCTest
 @MainActor
 final class PaymentElementViewTests: XCTestCase {
 
-    // TODO(yuki): Re-enable. Disabled because EmbeddedPaymentMethodsView.testHeightChange() doesn't notify the height-change delegate, so this times out.
-    func _testSwiftUIViewUpdatesHeightWhenEmbeddedPaymentElementHeightChanges() async throws {
+    func testSwiftUIViewUpdatesHeightWhenEmbeddedPaymentElementHeightChanges() async throws {
+        // Given a PaymentElement SwiftUI view hosted in a window
         var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
         configuration.paymentElement.displaysMandateText = true
         let checkout = await Checkout(
@@ -32,18 +32,25 @@ final class PaymentElementViewTests: XCTestCase {
         window.makeKeyAndVisible()
         hostingController.view.frame = window.bounds
 
+        // When the initial SwiftUI height has been resolved
         layout(hostingController)
         try await waitUntil {
+            window.setNeedsLayout()
+            window.layoutIfNeeded()
             layout(hostingController)
-            return paymentElement.uiView.frame.height > 0
+            return hostingController.sizeThatFits(in: window.bounds.size).height > 0
         }
-        let initialHeight = paymentElement.uiView.frame.height
+        let initialHeight = hostingController.sizeThatFits(in: window.bounds.size).height
 
+        // ...and the embedded payment element updates its height
         paymentElement.embeddedPaymentElement.testHeightChange()
 
+        // Then the hosted SwiftUI view updates its height
         try await waitUntil {
+            window.setNeedsLayout()
+            window.layoutIfNeeded()
             layout(hostingController)
-            return abs(paymentElement.uiView.frame.height - initialHeight) > 1
+            return abs(hostingController.sizeThatFits(in: window.bounds.size).height - initialHeight) > 1
         }
     }
 


### PR DESCRIPTION
## Summary
Re-enable the PaymentElement SwiftUI height update test and make it assert the hosted SwiftUI view size instead of the internal UIView frame.

## Motivation
`testSwiftUIViewUpdatesHeightWhenEmbeddedPaymentElementHeightChanges` failed on iPhone 12 mini iOS 15.5 because the test observed `paymentElement.uiView.frame.height` inside a `UIHostingController`.

While debugging the iOS 15.5 failure, I observed that the production height propagation path was working:
- `EmbeddedPaymentMethodsView` detected the natural height change from `54.0` to `145.0`.
- `PaymentElement.embeddedPaymentElementDidUpdateHeight(...)` was called.
- `PaymentElementViewModel` measured the updated fitting height as `145.0`.

The timeout came from the test watching the embedded UIKit view frame. During initial layout on iOS 15.5, I observed:

```
paymentElement.uiView.frame = (0.0, 0.0, 320.0, 750.0)
fitting height at width 320 = 54.0
```

So the raw `PaymentElementUIView` frame height inside the SwiftUI hosting hierarchy was not the SwiftUI root view height the test intended to assert. This updates the test to measure the hosted SwiftUI view with `UIHostingController.sizeThatFits(in:)`.

## Testing
.
 
## Changelog
Not user-facing.