### PR TITLE
Fix Alipay EVO redirect return URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ PATCH
 
 ## X.Y.Z - changes pending release
 
+### Payments
+* [Fixed] Fixed an issue where some Alipay payments incorrectly reported failure after succeeding.
+
 ## 26.4.0 2026-07-20
 ### StripeCore
 * [Added] `STPAPIClient.betas` is now public, allowing merchants to opt in to beta features that require a preview flag on the `Stripe-Version` header.

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -149,6 +149,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case myr
         case mxn
         case jpy
+        case cny
         case brl
         case thb
         case sek
@@ -167,6 +168,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
         case MY
         case MX
         case JP
+        case CN
         case BR
         case TH
         case DE

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetStandardLPMUIOneTests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetStandardLPMUIOneTests.swift
@@ -8,6 +8,38 @@
 import XCTest
 
 class PaymentSheetStandardLPMUIOneTests: PaymentSheetStandardLPMUICase {
+    // acct_1ONGjdKULGu5EgSk is enrolled in alipay_cn_to_alipay_plus_migration_gate,
+    // so its Alipay redirects use the pm-redirects.stripe.com EVO trampoline.
+    func testAlipayEVO() {
+        // Given PaymentSheet configured for the gated China merchant
+        var settings = PaymentSheetTestPlaygroundSettings.defaultValues()
+        settings.layout = .horizontal
+        settings.customerMode = .guest
+        settings.apmsEnabled = .off
+        settings.applePayEnabled = .off
+        settings.currency = .cny
+        settings.merchantCountryCode = .CN
+        settings.supportedPaymentMethods = "card,alipay"
+        loadPlayground(app, settings)
+
+        // When the customer authorizes an Alipay payment through the EVO redirect
+        app.buttons["Present PaymentSheet"].waitForExistenceAndTap()
+        tapPaymentMethod("Alipay")
+        let payButton = app.buttons.matching(
+            NSPredicate(format: "label BEGINSWITH %@", "Pay ")
+        ).firstMatch
+        payButton.waitForExistenceAndTap()
+
+        XCTAssertTrue(
+            webviewAuthorizePaymentButton.waitForExistence(timeout: 30.0),
+            "Alipay redirect webview did not present in time"
+        )
+        webviewAuthorizePaymentButton.waitForExistenceAndTap()
+
+        // Then the trampoline returns to the app and PaymentSheet completes
+        XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 30.0))
+    }
+
     // This Cash App test is a good way to test the cancellation/success behavior
     // of the refresh endpoint E2E.
     func testRefreshEndpointUsingCashAppPay() throws {

--- a/Stripe/StripeiOSTests/STPPaymentHandlerStubbedMockedFilesTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerStubbedMockedFilesTests.swift
@@ -621,12 +621,13 @@ class STPPaymentHandlerStubbedMockedFilesTests: APIStubbedTestCase, STPAuthentic
             didRedirect.fulfill()
         }
 
-        paymentHandler.confirmPaymentIntent(
-            params: paymentIntentParams,
-            authenticationContext: self
-        ) { _, _, _ in }
-
-        wait(for: [didRedirect], timeout: 2.0)
+        confirmPaymentWithSucceed(
+            nextActionData: nextActionData,
+            paymentMethodData: paymentMethodData,
+            didRedirect: didRedirect,
+            paymentHandler: paymentHandler,
+            paymentIntentParams: paymentIntentParams
+        )
     }
 
     private func confirmPaymentWithSucceed(

--- a/Stripe/StripeiOSTests/STPPaymentHandlerStubbedMockedFilesTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentHandlerStubbedMockedFilesTests.swift
@@ -17,6 +17,20 @@ import XCTest
 @testable@_spi(STP) import StripePaymentsUI
 
 class STPPaymentHandlerStubbedMockedFilesTests: APIStubbedTestCase, STPAuthenticationContext {
+    func testCallConfirmAlipayRedirectUsesConfirmTimeReturnURL() {
+        assertAlipayRedirectReturnURL(
+            confirmTimeReturnURL: "payments-example://stripe-redirect",
+            expectedReturnURL: "payments-example://stripe-redirect"
+        )
+    }
+
+    func testCallConfirmAlipayRedirectWithoutConfirmTimeReturnURLUsesNextActionReturnURL() {
+        assertAlipayRedirectReturnURL(
+            confirmTimeReturnURL: nil,
+            expectedReturnURL: "https://pm-redirects.stripe.com/return/acct_123/pa_nonce_456"
+        )
+    }
+
     func testCallConfirmAfterpay_Redirect_thenCanceled() {
         let nextActionData = """
               {
@@ -547,6 +561,72 @@ class STPPaymentHandlerStubbedMockedFilesTests: APIStubbedTestCase, STPAuthentic
         // deinit should have reset the global flag
         let freshHandler = STPPaymentHandler(apiClient: stubbedAPIClient())
         XCTAssertFalse(freshHandler.isInProgress, "inProgress should be reset when handler is deallocated mid-flow")
+    }
+
+    private func assertAlipayRedirectReturnURL(
+        confirmTimeReturnURL: String?,
+        expectedReturnURL: String
+    ) {
+        // Given an EVO Alipay next action whose return URL is an intermediate Stripe trampoline
+        let nextActionData = """
+              {
+                "alipay_handle_redirect": {
+                  "native_url": "https://pm-redirects.stripe.com/authorize/acct_123/pa_nonce_123",
+                  "return_url": "https://pm-redirects.stripe.com/return/acct_123/pa_nonce_456",
+                  "url": "https://pm-redirects.stripe.com/authorize/acct_123/pa_nonce_123"
+                },
+                "type": "alipay_handle_redirect"
+              }
+            """
+        let paymentMethodData = """
+              {
+                "id": "pm_123",
+                "object": "payment_method",
+                "alipay": {},
+                "billing_details": {},
+                "created": 1658187899,
+                "livemode": false,
+                "type": "alipay"
+              }
+            """
+        let paymentHandler = STPPaymentHandler(apiClient: stubbedAPIClient())
+        stubConfirm(
+            fileMock: .paymentIntentResponse,
+            responseCallback: { data in
+                self.replaceData(
+                    data: data,
+                    variables: [
+                        "<next_action>": nextActionData,
+                        "<payment_method>": paymentMethodData,
+                        "<status>": "\"requires_action\"",
+                    ]
+                )
+            }
+        )
+
+        let paymentIntentParams = STPPaymentIntentConfirmParams(clientSecret: "pi_123456_secret_654321")
+        paymentIntentParams.returnURL = confirmTimeReturnURL
+        paymentIntentParams.paymentMethodParams = STPPaymentMethodParams(
+            alipay: STPPaymentMethodAlipayParams(),
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        // When confirmation starts the Alipay redirect
+        let didRedirect = expectation(description: "didRedirect")
+        paymentHandler._redirectShim = { _, returnToURL, _ in
+            // Then the handler uses the confirm-time URL when available and preserves
+            // the legacy fallback otherwise
+            XCTAssertEqual(returnToURL?.absoluteString, expectedReturnURL)
+            didRedirect.fulfill()
+        }
+
+        paymentHandler.confirmPaymentIntent(
+            params: paymentIntentParams,
+            authenticationContext: self
+        ) { _, _, _ in }
+
+        wait(for: [didRedirect], timeout: 2.0)
     }
 
     private func confirmPaymentWithSucceed(

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -1146,10 +1146,14 @@ public class STPPaymentHandler: NSObject {
 
         case .alipayHandleRedirect:
             if let alipayHandleRedirect = authenticationAction.alipayHandleRedirect {
+                // Post-EVO Alipay's next-action return URL is an intermediate tramopline.
+                // Register the confirm-time return URL as the expected callback instead.
+                let returnURL = currentAction.returnURLString.flatMap(URL.init(string:))
+                    ?? alipayHandleRedirect.returnURL
                 _handleRedirect(
                     to: alipayHandleRedirect.nativeURL,
                     fallbackURL: alipayHandleRedirect.url,
-                    return: alipayHandleRedirect.returnURL,
+                    return: returnURL,
                     useWebAuthSession: false
                 )
             } else {


### PR DESCRIPTION
## Summary
For merchants migrated to Alipay+ (EVO), the `alipay_handle_redirect` next action's `return_url` is an intermediate pm-redirects.stripe.com trampoline, not the app's actual return URL. We were passing that straight through as the redirect's return URL, so the SDK never recognized the final redirect back into the app and reported failure even though the payment succeeded.

- Use the confirm-time return URL (`currentAction.returnURLString`) as the expected redirect callback when it's set, falling back to `alipayHandleRedirect.returnURL` for merchants not on EVO
- Added a UI test (`testAlipayEVO`) against a China merchant enrolled in the EVO migration gate
- Added CNY/CN cases to the playground settings enums to support the new test
- Added unit tests covering both the confirm-time URL and legacy fallback paths

https://github.com/stripe/stripe-android/pull/13544

## Motivation
Alipay EVO migration

## Testing
- New unit tests
- New UI test

## Changelog
See diff