### PR TITLE
Checkout Sessions — Remove support for mode in Checkout Playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
@@ -8,7 +8,6 @@ import SwiftUI
 
 struct CheckoutPlaygroundConfigurationSection: View {
     @Binding var integrationType: CheckoutPlayground.IntegrationType
-    @Binding var mode: CheckoutPlayground.SessionMode
     @Binding var currency: CheckoutPlayground.Currency
     @Binding var customerType: CheckoutPlayground.CustomerType
     @Binding var checkoutEndpointOption: CheckoutPlayground.EndpointOption
@@ -24,13 +23,6 @@ struct CheckoutPlaygroundConfigurationSection: View {
                     selection: $integrationType,
                     tooltip: "Choose the PaymentElement presentation.\n\n• sheet: Presents PaymentElement as a payment method selector.\n• view: Displays PaymentElement in the checkout flow.",
                     displayText: { $0.displayName }
-                )
-                CheckoutPlayground.PickerRow(
-                    title: "Mode",
-                    icon: "arrow.triangle.2.circlepath",
-                    selection: $mode,
-                    tooltip: "Determines the type of checkout session.\n\n• Payment: One-time payment.\n• Subscription: Recurring payment.\n• Setup: Save payment details for future use.",
-                    displayText: { $0.rawValue.capitalized }
                 )
                 CheckoutPlayground.PickerRow(
                     title: "Currency",
@@ -156,7 +148,6 @@ struct CheckoutPlaygroundLineItemCard: View {
 }
 
 struct CheckoutPlaygroundFeaturesSection: View {
-    let mode: CheckoutPlayground.SessionMode
     let customerType: CheckoutPlayground.CustomerType
     @Binding var shippingAddressCollection: Bool
     @Binding var billingAddressCollection: Bool
@@ -168,12 +159,8 @@ struct CheckoutPlaygroundFeaturesSection: View {
     @Binding var adaptivePricingCountry: CheckoutPlayground.AdaptivePricingCountry
     @Binding var automaticPaymentMethods: Bool
 
-    private var supportsSetupRestrictedFeatures: Bool {
-        return mode != .setup
-    }
-
     private var shouldShowAutomaticTax: Bool {
-        return supportsSetupRestrictedFeatures && customerType != .new
+        return customerType != .new
     }
 
     var body: some View {
@@ -195,43 +182,41 @@ struct CheckoutPlaygroundFeaturesSection: View {
                     isOn: $automaticPaymentMethods,
                     tooltip: "Sends `automatic_payment_methods: true` instead of an explicit `payment_method_types` array. Stripe selects the best payment methods for the session."
                 )
-                if supportsSetupRestrictedFeatures {
+                CheckoutPlayground.ToggleRow(
+                    title: "Allow Promo Codes",
+                    isOn: $allowPromotionCodes,
+                    tooltip: "Sets `allow_promotion_codes: true`. Adds a coupon code input field to the checkout page."
+                )
+                if shouldShowAutomaticTax {
                     CheckoutPlayground.ToggleRow(
-                        title: "Allow Promo Codes",
-                        isOn: $allowPromotionCodes,
-                        tooltip: "Sets `allow_promotion_codes: true`. Adds a coupon code input field to the checkout page."
+                        title: "Automatic Tax",
+                        isOn: $automaticTax,
+                        tooltip: "Sets `automatic_tax: { enabled: true }`. Enables Stripe Tax for automatic tax calculation based on shipping/billing address. Prices must use `tax_behavior: 'exclusive'` or `'inclusive'`."
                     )
-                    if shouldShowAutomaticTax {
-                        CheckoutPlayground.ToggleRow(
-                            title: "Automatic Tax",
-                            isOn: $automaticTax,
-                            tooltip: "Sets `automatic_tax: { enabled: true }`. Enables Stripe Tax for automatic tax calculation based on shipping/billing address. Prices must use `tax_behavior: 'exclusive'` or `'inclusive'`."
-                        )
-                    }
-                    CheckoutPlayground.ToggleRow(
-                        title: "Adaptive Pricing",
-                        isOn: $adaptivePricing,
-                        tooltip: "Sets `adaptive_pricing: { enabled: true }`. Displays prices in the customer's local currency."
+                }
+                CheckoutPlayground.ToggleRow(
+                    title: "Adaptive Pricing",
+                    isOn: $adaptivePricing,
+                    tooltip: "Sets `adaptive_pricing: { enabled: true }`. Displays prices in the customer's local currency."
+                )
+                CheckoutPlayground.ToggleRow(
+                    title: "Payment Method Offer Save",
+                    isOn: $checkoutSessionPaymentMethodSave,
+                    tooltip: "Sets `saved_payment_method_options.payment_method_save` to `enabled`. When on, Checkout can offer to save the payment method for future use."
+                )
+                CheckoutPlayground.ToggleRow(
+                    title: "Payment Method Remove",
+                    isOn: $checkoutSessionPaymentMethodRemove,
+                    tooltip: "Sets `saved_payment_method_options.payment_method_remove` to `enabled`. When on, Checkout can allow customers to remove saved payment methods."
+                )
+                if adaptivePricing {
+                    CheckoutPlayground.PickerRow(
+                        title: "Country",
+                        icon: "globe",
+                        selection: $adaptivePricingCountry,
+                        tooltip: "Simulates the customer's country for adaptive pricing by sending a location-formatted customer_email. 'None' skips the email override.",
+                        displayText: { $0.displayName }
                     )
-                    CheckoutPlayground.ToggleRow(
-                        title: "Payment Method Offer Save",
-                        isOn: $checkoutSessionPaymentMethodSave,
-                        tooltip: "Sets `saved_payment_method_options.payment_method_save` to `enabled`. When on, Checkout can offer to save the payment method for future use."
-                    )
-                    CheckoutPlayground.ToggleRow(
-                        title: "Payment Method Remove",
-                        isOn: $checkoutSessionPaymentMethodRemove,
-                        tooltip: "Sets `saved_payment_method_options.payment_method_remove` to `enabled`. When on, Checkout can allow customers to remove saved payment methods."
-                    )
-                    if adaptivePricing {
-                        CheckoutPlayground.PickerRow(
-                            title: "Country",
-                            icon: "globe",
-                            selection: $adaptivePricingCountry,
-                            tooltip: "Simulates the customer's country for adaptive pricing by sending a location-formatted customer_email. 'None' skips the email override.",
-                            displayText: { $0.displayName }
-                        )
-                    }
                 }
             }
             .background(Color(uiColor: .secondarySystemGroupedBackground))

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundTypes.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundTypes.swift
@@ -47,14 +47,6 @@ enum CheckoutPlayground {
         }
     }
 
-    enum SessionMode: String, CaseIterable, Identifiable {
-        case payment
-        case subscription
-        case setup
-
-        var id: String { rawValue }
-    }
-
     enum Currency: String, CaseIterable, Identifiable {
         case usd
         case eur

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
@@ -27,22 +27,18 @@ struct CheckoutPlaygroundView: View {
 
                         CheckoutPlaygroundConfigurationSection(
                             integrationType: $viewModel.integrationType,
-                            mode: $viewModel.mode,
                             currency: $viewModel.currency,
                             customerType: $viewModel.customerType,
                             checkoutEndpointOption: $viewModel.checkoutEndpointOption,
                             checkoutEndpoint: $viewModel.checkoutEndpoint
                         )
 
-                        if viewModel.mode != .setup {
-                            CheckoutPlaygroundLineItemsSection(
-                                lineItems: viewModel.lineItems,
-                                currency: viewModel.currency
-                            )
-                        }
+                        CheckoutPlaygroundLineItemsSection(
+                            lineItems: viewModel.lineItems,
+                            currency: viewModel.currency
+                        )
 
                         CheckoutPlaygroundFeaturesSection(
-                            mode: viewModel.mode,
                             customerType: viewModel.customerType,
                             shippingAddressCollection: $viewModel.shippingAddressCollection,
                             billingAddressCollection: $viewModel.billingAddressCollection,

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
@@ -15,7 +15,6 @@ extension CheckoutPlayground {
         ]
 
         @Published var integrationType: IntegrationType = .flowController
-        @Published var mode: SessionMode = .payment
         @Published var currency: Currency = .usd
         @Published var customerType: CustomerType = .guest
         @Published var lineItems: [LineItemConfig] = LineItemConfig.defaults
@@ -39,7 +38,7 @@ extension CheckoutPlayground {
         @Published var navigateToCheckout = false
 
         var isButtonDisabled: Bool {
-            isCreating || (!automaticPaymentMethods && paymentMethodTypes.isEmpty) || (mode != .setup && lineItems.isEmpty)
+            isCreating || (!automaticPaymentMethods && paymentMethodTypes.isEmpty) || lineItems.isEmpty
         }
 
         func createSession() async {
@@ -85,21 +84,14 @@ extension CheckoutPlayground {
         }
 
         private func buildRequestBody() -> [String: Any] {
-            // The backend currently applies setup-mode restrictions for these fields.
-            // Send explicit safe values so setup mode never requests unsupported options.
-            let supportsAdvancedCollection = mode != .setup
-            let allowPromotionCodesForRequest = supportsAdvancedCollection ? allowPromotionCodes : false
-            let automaticTaxForRequest = supportsAdvancedCollection ? automaticTax : false
-
             var body: [String: Any] = [
                 "merchant_country_code": "us_tax",
-                "mode": mode.rawValue,
                 "currency": currency.rawValue,
                 "customer": customerType.rawValue,
-                "allow_promotion_codes": allowPromotionCodesForRequest,
+                "allow_promotion_codes": allowPromotionCodes,
                 "shipping_address_collection": shippingAddressCollection,
                 "billing_address_collection": billingAddressCollection,
-                "automatic_tax": automaticTaxForRequest,
+                "automatic_tax": automaticTax,
                 "adaptive_pricing": adaptivePricing,
                 "checkout_session_payment_method_save": checkoutSessionPaymentMethodSave ? "enabled" : "disabled",
                 "checkout_session_payment_method_remove": checkoutSessionPaymentMethodRemove ? "enabled" : "disabled",


### PR DESCRIPTION
## Summary
Remove mode toggle and related logic

## Motivation
Private Preview will only support one time payments

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
