### PR TITLE
CryptoOnramp SDK: Example App Manual Wallet Verification

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/PaymentSummaryView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/PaymentSummaryView.swift
@@ -45,6 +45,7 @@ struct PaymentSummaryView: View {
     @State private var alert: Alert?
     @State private var pendingWalletOwnershipVerificationContext: WalletOwnershipVerificationContext?
     @State private var isPresentingWalletOwnershipVerificationAlert = false
+    @State private var walletOwnershipVerificationSession: WalletOwnershipVerificationSession?
 
     private var isPresentingAlert: Binding<Bool> {
         Binding(get: {
@@ -175,6 +176,15 @@ struct PaymentSummaryView: View {
                 pendingWalletOwnershipVerificationContext = nil
             }
         )
+        .sheet(item: $walletOwnershipVerificationSession) { session in
+            WalletOwnershipVerificationSheet(
+                session: session,
+                coordinator: coordinator
+            ) {
+                pendingWalletOwnershipVerificationContext = nil
+                checkout()
+            }
+        }
     }
 
     // MARK: - PaymentSummaryView
@@ -224,7 +234,10 @@ struct PaymentSummaryView: View {
             } catch let error as WalletOwnershipVerificationRequiredError {
                 await MainActor.run {
                     isLoading.wrappedValue = false
-                    if let context = WalletOwnershipVerificationContext(transactionDetails: error.response.transactionDetails) {
+                    if let context = WalletOwnershipVerificationContext(
+                        transactionDetails: error.response.transactionDetails,
+                        isTestMode: !error.response.livemode
+                    ) {
                         pendingWalletOwnershipVerificationContext = context
                         isPresentingWalletOwnershipVerificationAlert = true
                     } else {
@@ -246,14 +259,13 @@ struct PaymentSummaryView: View {
             return
         }
 
-        WalletOwnershipVerification.startVerification(
+        WalletOwnershipVerification.requestChallenge(
             context: context,
             coordinator: coordinator,
             isLoading: isLoading,
             alert: $alert
-        ) {
-            pendingWalletOwnershipVerificationContext = nil
-            checkout()
+        ) { session in
+            walletOwnershipVerificationSession = session
         }
     }
 }

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/PaymentView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/PaymentView.swift
@@ -158,6 +158,7 @@ struct PaymentView: View {
     @State private var achSettlementSpeed: CreateOnrampSessionRequest.SettlementSpeed = .instant
     @State private var pendingWalletOwnershipVerificationCryptoPaymentTokenId: String?
     @State private var isPresentingWalletOwnershipVerificationAlert = false
+    @State private var walletOwnershipVerificationSession: WalletOwnershipVerificationSession?
 
     private var isPresentingAlert: Binding<Bool> {
         Binding(get: {
@@ -476,6 +477,14 @@ struct PaymentView: View {
                 pendingWalletOwnershipVerificationCryptoPaymentTokenId = nil
             }
         )
+        .sheet(item: $walletOwnershipVerificationSession) { session in
+            WalletOwnershipVerificationSheet(
+                session: session,
+                coordinator: coordinator
+            ) {
+                retryPendingCreateOnrampSession()
+            }
+        }
     }
 
     // MARK: - PaymentView
@@ -912,13 +921,13 @@ struct PaymentView: View {
             return
         }
 
-        WalletOwnershipVerification.startVerification(
+        WalletOwnershipVerification.requestChallenge(
             context: context,
             coordinator: coordinator,
             isLoading: isLoading,
             alert: $alert
-        ) {
-            retryPendingCreateOnrampSession()
+        ) { session in
+            walletOwnershipVerificationSession = session
         }
     }
 

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/WalletOwnershipVerification.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/WalletOwnershipVerification.swift
@@ -19,13 +19,18 @@ struct WalletOwnershipVerificationContext {
     /// The Stripe crypto network for the wallet address.
     let network: CryptoNetwork
 
+    /// Whether the wallet is being verified in test mode.
+    let isTestMode: Bool
+
     /// Creates a wallet ownership verification context.
     /// - Parameters:
     ///   - walletAddress: The wallet address being verified.
     ///   - network: The Stripe crypto network for the wallet address.
-    init(walletAddress: String, network: CryptoNetwork) {
+    ///   - isTestMode: Whether the wallet is being verified in test mode.
+    init(walletAddress: String, network: CryptoNetwork, isTestMode: Bool) {
         self.walletAddress = walletAddress
         self.network = network
+        self.isTestMode = isTestMode
     }
 
     /// Creates a wallet ownership verification context from a customer wallet response.
@@ -35,17 +40,44 @@ struct WalletOwnershipVerificationContext {
             return nil
         }
 
-        self.init(walletAddress: wallet.walletAddress, network: network)
+        self.init(
+            walletAddress: wallet.walletAddress,
+            network: network,
+            isTestMode: !wallet.livemode
+        )
     }
 
     /// Creates a wallet ownership verification context from transaction details returned by session creation.
-    /// - Parameter transactionDetails: The transaction details from a create-onramp-session response.
-    init?(transactionDetails: CreateOnrampSessionResponse.TransactionDetails) {
+    /// - Parameters:
+    ///   - transactionDetails: The transaction details from a create-onramp-session response.
+    ///   - isTestMode: Whether the wallet is being verified in test mode.
+    init?(transactionDetails: CreateOnrampSessionResponse.TransactionDetails, isTestMode: Bool) {
         guard let network = CryptoNetwork(rawValue: transactionDetails.destinationNetwork) else {
             return nil
         }
 
-        self.init(walletAddress: transactionDetails.walletAddress, network: network)
+        self.init(
+            walletAddress: transactionDetails.walletAddress,
+            network: network,
+            isTestMode: isTestMode
+        )
+    }
+}
+
+/// A server-issued challenge ready to be displayed for wallet ownership verification.
+struct WalletOwnershipVerificationSession: Identifiable {
+
+    /// The challenge that must be signed.
+    let challenge: WalletOwnershipChallenge
+
+    /// Whether the wallet is being verified in test mode.
+    let isTestMode: Bool
+
+    // MARK: - Identifiable
+
+    /// The identifier used to present this challenge in a sheet.
+    var id: String {
+        challenge.challengeId
     }
 }
 
@@ -67,42 +99,38 @@ enum WalletOwnershipVerification {
         response.transactionDetails.lastError == requiredLastError
     }
 
-    /// Starts wallet ownership verification and updates shared loading and alert UI state.
+    /// Requests a wallet ownership challenge and updates shared loading and alert UI state.
     /// - Parameters:
     ///   - context: Context needed to verify wallet ownership.
     ///   - coordinator: The coordinator used to call wallet ownership APIs.
     ///   - isLoading: Binding that controls the example app's shared loading state.
     ///   - alert: Binding used to present verification failure alerts.
-    ///   - onVerified: Called when Stripe returns the wallet as verified.
-    static func startVerification(
+    ///   - onChallengeReceived: Called when the challenge is ready to display.
+    static func requestChallenge(
         context: WalletOwnershipVerificationContext,
         coordinator: CryptoOnrampCoordinator,
         isLoading: Binding<Bool>,
         alert: Binding<Alert?>,
-        onVerified: @escaping @MainActor () -> Void
+        onChallengeReceived: @escaping @MainActor (WalletOwnershipVerificationSession) -> Void
     ) {
         isLoading.wrappedValue = true
         alert.wrappedValue = nil
 
         Task {
             do {
-                let wallet = try await verify(
-                    context: context,
-                    coordinator: coordinator
+                let challenge = try await coordinator.getWalletOwnershipChallenge(
+                    walletAddress: context.walletAddress,
+                    network: context.network
                 )
 
                 await MainActor.run {
                     isLoading.wrappedValue = false
-                    if wallet.verifiedOwnership {
-                        onVerified()
-                    } else {
-                        // The request to verify the wallet succeeded, but the backend is still erroneously reporting that
-                        // `verifiedOwnership` is `false`. This is not an expected use case.
-                        alert.wrappedValue = Alert(
-                            title: "Wallet verification failed",
-                            message: "Stripe did not mark this wallet as verified. Please try again."
+                    onChallengeReceived(
+                        WalletOwnershipVerificationSession(
+                            challenge: challenge,
+                            isTestMode: context.isTestMode
                         )
-                    }
+                    )
                 }
             } catch {
                 await MainActor.run {
@@ -114,28 +142,6 @@ enum WalletOwnershipVerification {
                 }
             }
         }
-    }
-
-    /// Requests a wallet ownership challenge, signs it, and submits the signature.
-    /// - Parameters:
-    ///   - context: Context needed to verify wallet ownership.
-    ///   - coordinator: The coordinator used to call wallet ownership APIs.
-    private static func verify(
-        context: WalletOwnershipVerificationContext,
-        coordinator: CryptoOnrampCoordinator
-    ) async throws -> CryptoConsumerWallet {
-        let challenge = try await coordinator.getWalletOwnershipChallenge(
-            walletAddress: context.walletAddress,
-            network: context.network
-        )
-
-        // Note: This constant signature is accepted in test mode. For live mode, an actual signature
-        // of `challenge.message` must be produced using the wallet.
-        let signature = "abcd"
-        return try await coordinator.submitWalletOwnershipSignature(
-            challengeId: challenge.challengeId,
-            signature: signature
-        )
     }
 }
 

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/WalletOwnershipVerificationSheet.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/WalletOwnershipVerificationSheet.swift
@@ -1,0 +1,182 @@
+//
+//  WalletOwnershipVerificationSheet.swift
+//  CryptoOnramp Example
+//
+//  Created by Michael Liberatore on 7/21/26.
+//
+
+import Foundation
+import SwiftUI
+import UIKit
+
+@_spi(CryptoOnrampAlpha)
+import StripeCryptoOnramp
+
+/// A sheet for copying a wallet ownership challenge and submitting its signature.
+struct WalletOwnershipVerificationSheet: View {
+
+    /// The challenge and mode to display.
+    let session: WalletOwnershipVerificationSession
+
+    /// The coordinator used to submit the signature.
+    let coordinator: CryptoOnrampCoordinator
+
+    /// Called when Stripe returns the wallet as verified.
+    let onVerified: @MainActor () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.isLoading) private var isLoading
+
+    @State private var alert: Alert?
+    @State private var signature: String
+
+    private var isPresentingAlert: Binding<Bool> {
+        Binding(get: {
+            alert != nil
+        }, set: { newValue in
+            if !newValue {
+                alert = nil
+            }
+        })
+    }
+
+    private var signatureToSubmit: String {
+        signature.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var isSubmitDisabled: Bool {
+        isLoading.wrappedValue || signatureToSubmit.isEmpty
+    }
+
+    /// Creates a wallet ownership verification sheet.
+    /// - Parameters:
+    ///   - session: The challenge and mode to display.
+    ///   - coordinator: The coordinator used to submit the signature.
+    ///   - onVerified: Called when Stripe returns the wallet as verified.
+    init(
+        session: WalletOwnershipVerificationSession,
+        coordinator: CryptoOnrampCoordinator,
+        onVerified: @escaping @MainActor () -> Void
+    ) {
+        self.session = session
+        self.coordinator = coordinator
+        self.onVerified = onVerified
+        _signature = State(initialValue: session.isTestMode ? "abcd" : "")
+    }
+
+    // MARK: - View
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: 20) {
+                    Text("Sign the challenge message with your wallet, then paste the signature below.")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+
+                    FormField("Challenge Message") {
+                        Text(session.challenge.message)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, minHeight: 160, alignment: .topLeading)
+                            .padding(10)
+                            .background(Color(.secondarySystemBackground))
+                            .clipShape(RoundedRectangle(cornerRadius: 6))
+                            .overlay {
+                                RoundedRectangle(cornerRadius: 6)
+                                    .stroke(Color(.separator))
+                            }
+                        Button {
+                            UIPasteboard.general.string = session.challenge.message
+                        } label: {
+                            Label("Copy Message", systemImage: "doc.on.doc")
+                        }
+                        .buttonStyle(.bordered)
+                    }
+
+                    FormField("Signature") {
+                        TextField("Paste signature", text: $signature)
+                            .textFieldStyle(.roundedBorder)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+
+                        if session.isTestMode {
+                            Text("test mode supports a constant 'abcd' as a valid signature")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+                .padding()
+            }
+            .navigationTitle("Verify Wallet")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Submit") {
+                        submitSignature()
+                    }
+                    .disabled(isSubmitDisabled)
+                    .opacity(isSubmitDisabled ? 0.5 : 1)
+                }
+            }
+        }
+        .loadingOverlay(isVisible: isLoading.wrappedValue)
+        .alert(
+            alert?.title ?? "Error",
+            isPresented: isPresentingAlert,
+            presenting: alert,
+            actions: { _ in
+                Button("OK") {}
+            }, message: { alert in
+                Text(alert.message)
+            }
+        )
+    }
+
+    // MARK: - WalletOwnershipVerificationSheet
+
+    private func submitSignature() {
+        isLoading.wrappedValue = true
+        alert = nil
+
+        Task {
+            do {
+                let wallet = try await coordinator.submitWalletOwnershipSignature(
+                    challengeId: session.challenge.challengeId,
+                    signature: signatureToSubmit
+                )
+
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    if wallet.verifiedOwnership {
+                        dismiss()
+                        onVerified()
+                    } else {
+                        // The request to verify the wallet succeeded, but the backend is still erroneously reporting that
+                        // `verifiedOwnership` is `false`. This is not an expected use case.
+                        alert = Alert(
+                            title: "Wallet verification failed",
+                            message: "Stripe did not mark this wallet as verified. Please try again."
+                        )
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    alert = Alert(
+                        title: "Wallet verification failed",
+                        message: error.localizedDescription
+                    )
+                }
+            }
+        }
+    }
+}

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/WalletSelectionView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/WalletSelectionView.swift
@@ -25,6 +25,7 @@ struct WalletSelectionView: View {
     @State private var showAttachWalletSheet = false
     @State private var selectedWallet: Wallet?
     @State private var alert: Alert?
+    @State private var walletOwnershipVerificationSession: WalletOwnershipVerificationSession?
 
     @Environment(\.isLoading) private var isLoading
 
@@ -129,6 +130,17 @@ struct WalletSelectionView: View {
                 }
             )
         }
+        .sheet(item: $walletOwnershipVerificationSession) { session in
+            WalletOwnershipVerificationSheet(
+                session: session,
+                coordinator: coordinator
+            ) {
+                refreshWallets(
+                    selectingWalletWithAddress: session.challenge.walletAddress,
+                    network: session.challenge.network
+                )
+            }
+        }
         .onAppear {
             refreshWallets()
         }
@@ -152,13 +164,13 @@ struct WalletSelectionView: View {
             return
         }
 
-        WalletOwnershipVerification.startVerification(
+        WalletOwnershipVerification.requestChallenge(
             context: context,
             coordinator: coordinator,
             isLoading: isLoading,
             alert: $alert
-        ) {
-            refreshWallets(selectingWalletWithAddress: context.walletAddress, network: context.network)
+        ) { session in
+            walletOwnershipVerificationSession = session
         }
     }
 


### PR DESCRIPTION
## Summary
Adds the ability to manually verify a wallet in the example app. Currently, the wallet verification signature is hardcoded to `abcd`, and verifying ownership would automatically request and complete the challenge. Now, verifying ownership will request and display the challenge, and allow the user to copy the challenge message to manually provide a signature. In test mode, the signature field is pre-filled with `abcd`.

<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-07-21 at 14 48 32" src="https://github.com/user-attachments/assets/9598c93a-f806-4465-8223-e863708ac787" />


## Motivation
Suggested as an improvement at https://github.com/stripe/stripe-ios/pull/6698#discussion_r3618459413. 

## Testing
1. Manually tested in test mode by submitting the default `abcd` signature, and a manually signed challenge using https://solscan.io/verifiedsignatures to ensure the feature worked as expected.
2. Intentionally submitted an invalid signature, and waited for the expiration time to submit again to ensure failures were properly reported.

| Invalid | Expired |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/479f4daa-faff-4002-a54e-e317f6e6f114" width="300" /> | <img src="https://github.com/user-attachments/assets/cf9cd133-6022-4587-96af-167d6ca9769d" width="300" /> |

## Changelog
N/A, example app changes only.