### PR TITLE
Fix crash in FlowController when only Link is available

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -468,19 +468,26 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         // The user is continuing with an LPM, so we un-select Link
         isHackyLinkButtonSelected = false
 
-        if let selectedPaymentOption {
-            analyticsHelper.logConfirmButtonTapped(paymentOption: selectedPaymentOption)
-        } else {
-            stpAssertionFailure("didTapContinueButton called w/o a payment option")
-        }
-
         switch mode {
         case .selectingSaved:
+            if let selectedPaymentOption {
+                analyticsHelper.logConfirmButtonTapped(paymentOption: selectedPaymentOption)
+            } else {
+                stpAssertionFailure("didTapContinueButton called w/o a payment option")
+            }
             syncCheckoutBillingThenClose()
         case .addingNew:
+            // If the form has overridden the primary button (e.g. to initiate bank linking),
+            // hand control to the form before checking selectedPaymentOption — it will be nil
+            // until the bank linking flow completes.
             if addPaymentMethodViewController.overridePrimaryButtonState != nil {
                 addPaymentMethodViewController.didTapCallToActionButton(from: self)
             } else {
+                if let selectedPaymentOption {
+                    analyticsHelper.logConfirmButtonTapped(paymentOption: selectedPaymentOption)
+                } else {
+                    stpAssertionFailure("didTapContinueButton called w/o a payment option")
+                }
                 addPaymentMethodViewController.logBillingAddressCompletionIfNeeded()
                 syncCheckoutBillingThenClose()
             }


### PR DESCRIPTION
## Summary

When the elements session is configured to only support Link, opening FlowController and tapping Continue was causing a crash. This is fixed by no longer always expecting a selected payment option when the primary button state is overriden.

## Motivation

Fix a crash

## Testing

Before:

https://github.com/user-attachments/assets/a5744eb7-c0c5-40c7-bb80-c7b58e849da0

After:


https://github.com/user-attachments/assets/607ad190-0fbd-4ed6-a1f9-2203d0290030



## Changelog

N/a