### PR TITLE
Allow billing details collection configuration in LinkController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 The next release's version bump will so far be:
-PATCH
+MINOR
 
 ## X.Y.Z - changes pending release
+
+### PaymentSheet
+* [Added] Added `billingDetailsCollectionConfiguration` to `LinkConfiguration`, allowing `LinkControllerPreview` consumers to configure billing details collection in the Link sheet (private preview).
 
 ## 26.4.1 2026-07-23
 ### Payments

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
@@ -28,6 +28,10 @@ public struct LinkConfiguration {
     /// If `nil`, defaults to the host app's `CFBundleDisplayName` / `CFBundleName`.
     @_spi(LinkControllerPreview) public let merchantDisplayName: String?
 
+    /// Configures billing details collection in the Link sheet.
+    /// If `nil`, uses the billing details collection configuration from the `PaymentElementConfiguration` passed at init.
+    @_spi(LinkControllerPreview) public let billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration?
+
     /// Creates a new instance of `LinkConfiguration`.
     /// - Parameters:
     ///   - hintMessage: Custom hint message to display in the wallet view. If `nil`, no hint will be shown.
@@ -41,6 +45,7 @@ public struct LinkConfiguration {
         self.supportedPaymentMethodTypes = nil
         self.paymentMethodTypes = nil
         self.merchantDisplayName = nil
+        self.billingDetailsCollectionConfiguration = nil
     }
 
     /// Creates a new instance of `LinkConfiguration`.
@@ -49,16 +54,19 @@ public struct LinkConfiguration {
     ///   - paymentMethodTypes: The payment method types to use when creating the setup intent. If `nil`, the payment method types used will be chosen automatically.
     ///   - allowLogout: Whether to allow the user to log out. When `false`, the logout menu button will be hidden. Defaults to `true`.
     ///   - merchantDisplayName: The merchant name displayed in Link UI. If `nil`, defaults to the app's `CFBundleDisplayName`.
+    ///   - billingDetailsCollectionConfiguration: Configures billing details collection in the Link sheet. If `nil`, uses the billing details collection configuration from the `PaymentElementConfiguration` passed at init.
     @_spi(LinkControllerPreview) public init(
         supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         paymentMethodTypes: [String]? = nil,
         allowLogout: Bool = true,
-        merchantDisplayName: String? = nil
+        merchantDisplayName: String? = nil,
+        billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration? = nil
     ) {
         self.hintMessage = nil
         self.allowLogout = allowLogout
         self.supportedPaymentMethodTypes = supportedPaymentMethodTypes
         self.paymentMethodTypes = paymentMethodTypes
         self.merchantDisplayName = merchantDisplayName
+        self.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -497,6 +497,9 @@ import UIKit
         var paymentElementConfiguration = self.paymentElementConfiguration
         paymentElementConfiguration.defaultBillingDetails.email = email
 
+        if let billingConfig = configuration?.billingDetailsCollectionConfiguration {
+            paymentElementConfiguration.billingDetailsCollectionConfiguration = billingConfig
+        }
         if collectName {
             paymentElementConfiguration.billingDetailsCollectionConfiguration.name = .always
         }
@@ -559,6 +562,9 @@ import UIKit
             paymentElementConfiguration.defaultBillingDetails.email = email
             if let phoneNumber {
                 paymentElementConfiguration.defaultBillingDetails.phone = phoneNumber
+            }
+            if let billingConfig = self.configuration?.billingDetailsCollectionConfiguration {
+                paymentElementConfiguration.billingDetailsCollectionConfiguration = billingConfig
             }
 
             presentingViewController.presentNativeLink(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -683,7 +683,21 @@ extension PaymentSheet {
             }
         }
 
-        public init() {}
+        public init(
+            name: CollectionMode = .automatic,
+            phone: CollectionMode = .automatic,
+            email: CollectionMode = .automatic,
+            address: AddressCollectionMode = .automatic,
+            attachDefaultsToPaymentMethod: Bool = false,
+            allowedCountries: Set<String> = []
+        ) {
+            self.name = name
+            self.phone = phone
+            self.email = email
+            self.address = address
+            self.attachDefaultsToPaymentMethod = attachDefaultsToPaymentMethod
+            self.allowedCountries = allowedCountries
+        }
     }
 
     /// Configuration for external payment methods

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -682,6 +682,8 @@ extension PaymentSheet {
                 allowedCountries = Set(allowedCountries.map { $0.uppercased() })
             }
         }
+
+        public init() {}
     }
 
     /// Configuration for external payment methods

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
@@ -14,6 +14,8 @@ final class LinkControllerPreviewAPITests: XCTestCase {
         _ = LinkConfiguration(paymentMethodTypes: ["link"]).paymentMethodTypes
         _ = LinkConfiguration(supportedPaymentMethodTypes: [.card], allowLogout: false).allowLogout
         _ = LinkConfiguration(supportedPaymentMethodTypes: [.card], merchantDisplayName: "Example Merchant")
+        _ = LinkConfiguration(supportedPaymentMethodTypes: [.card], billingDetailsCollectionConfiguration: .init())
+        _ = LinkConfiguration(billingDetailsCollectionConfiguration: .init()).billingDetailsCollectionConfiguration
 
         let result: LinkController.PaymentMethodResult = .canceled
         _ = result


### PR DESCRIPTION
## Summary

This adds `billingDetailsCollectionConfiguration` as a field to the LinkConfiguration object to allow merchants specify which billing details they'd like to collect. It uses the existing `PaymentSheet.BillingDetailsCollectionConfiguration` object as the type.

## Motivation

https://stripe.slack.com/archives/C08G211PLER/p1784815838646309

## Testing

I set all the parameters to `.always` in the demo app and see this after selecting a payment method:

<img width=40% alt="Simulator Screenshot - iPhone 17 Pro - 2026-07-23 at 15 41 35" src="https://github.com/user-attachments/assets/26724197-20ea-47de-9287-3750bf8de223" />


## Changelog

```
### PaymentSheet
* [Added] Added `billingDetailsCollectionConfiguration` to `LinkConfiguration` (private preview).
```
