### PR TITLE
Fix dismiss animation in PS.FC

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
@@ -66,19 +66,10 @@ class BottomSheetPresentationAnimator: NSObject {
             let fromVC = transitionContext.viewController(forKey: .from)
         else { return }
 
-        // Custom dismissal removes the view directly, so UIKit does not automatically
-        // resign a text field that is still the first responder.
-        fromVC.view.endEditing(true)
-        let distainceToBottom = transitionContext.containerView.bounds.maxY - fromVC.view.frame.minY
-
         Self.animate({
-            // Auto Layout keeps the sheet pinned to the bottom during this transition.
-            // Animate a transform so a concurrent layout pass cannot snap the sheet back.
-            fromVC.view.transform = CGAffineTransform(translationX: 0, y: distainceToBottom)
+            fromVC.view.frame.origin.y = transitionContext.containerView.frame.height
         }) { didComplete in
             fromVC.view.removeFromSuperview()
-            // PaymentSheet can reuse this controller for a later presentation
-            fromVC.view.transform = .identity
             transitionContext.completeTransition(didComplete)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/BottomSheetPresentationAnimator.swift
@@ -66,10 +66,19 @@ class BottomSheetPresentationAnimator: NSObject {
             let fromVC = transitionContext.viewController(forKey: .from)
         else { return }
 
+        // Custom dismissal removes the view directly, so UIKit does not automatically
+        // resign a text field that is still the first responder.
+        fromVC.view.endEditing(true)
+        let distainceToBottom = transitionContext.containerView.bounds.maxY - fromVC.view.frame.minY
+
         Self.animate({
-            fromVC.view.frame.origin.y = transitionContext.containerView.frame.height
+            // Auto Layout keeps the sheet pinned to the bottom during this transition.
+            // Animate a transform so a concurrent layout pass cannot snap the sheet back.
+            fromVC.view.transform = CGAffineTransform(translationX: 0, y: distainceToBottom)
         }) { didComplete in
             fromVC.view.removeFromSuperview()
+            // PaymentSheet can reuse this controller for a later presentation
+            fromVC.view.transform = .identity
             transitionContext.completeTransition(didComplete)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
@@ -37,6 +37,8 @@ extension UIViewController {
             viewControllerToPresent.transitioningDelegate = BottomSheetTransitioningDelegate.default
         }
 
+        // Prevent the presenting view from regaining focus when editing ends in the bottom sheet.
+        viewIfLoaded?.endEditing(true)
         present(viewControllerToPresent, animated: true, completion: completion)
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
@@ -38,12 +38,8 @@ extension UIViewController {
         }
 
         // Prevent the presenting view from regaining focus when editing ends in the bottom sheet.
-        // Both calls are dispatched together (preserving their relative order) so endEditing's
-        // state mutation happens outside the current SwiftUI view update pass.
-        DispatchQueue.main.async { [weak self] in
-            self?.viewIfLoaded?.endEditing(true)
-            self?.present(viewControllerToPresent, animated: true, completion: completion)
-        }
+        viewIfLoaded?.endEditing(true)
+        present(viewControllerToPresent, animated: true, completion: completion)
     }
 
     var bottomSheetController: BottomSheetViewController? {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/BottomSheet/UIViewController+BottomSheet.swift
@@ -38,8 +38,12 @@ extension UIViewController {
         }
 
         // Prevent the presenting view from regaining focus when editing ends in the bottom sheet.
-        viewIfLoaded?.endEditing(true)
-        present(viewControllerToPresent, animated: true, completion: completion)
+        // Both calls are dispatched together (preserving their relative order) so endEditing's
+        // state mutation happens outside the current SwiftUI view update pass.
+        DispatchQueue.main.async { [weak self] in
+            self?.viewIfLoaded?.endEditing(true)
+            self?.present(viewControllerToPresent, animated: true, completion: completion)
+        }
     }
 
     var bottomSheetController: BottomSheetViewController? {


### PR DESCRIPTION
## Summary

Fixes a bug where closing MPE with the keyboard showing or some input field would cause it to jump/break.

### Before


https://github.com/user-attachments/assets/765c61e1-346f-4f0d-832f-8cffadf111cf


https://github.com/user-attachments/assets/0f0ebf54-7d10-4813-82b6-e1cb5bb72ef7



### After

https://github.com/user-attachments/assets/6d521752-1063-4de8-b1a5-7aaba692db96


https://github.com/user-attachments/assets/45ecae50-bc34-4565-a45a-fbd02a4f3e06





## Motivation
- PS.FC bug fix

## Testing
- Manual

## Changelog
N/A