### PR TITLE
Restore accepted embedded form on cancellation

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/EmbeddedUITests.swift
@@ -684,15 +684,16 @@ class EmbeddedUITests: PaymentSheetUITestCase {
         cardNumberField.tap()
         app.typeText(XCUIKeyboardKey.delete.rawValue)
         app.buttons["Close"].waitForExistenceAndTap()
-        // ...should de-select the row and clear the payment option
-        XCTAssertFalse(app.staticTexts["Payment method"].waitForExistence(timeout: 1))
-        XCTAssertFalse(app.buttons["New card"].isSelected)
-        XCTAssertFalse(app.buttons["Checkout"].isEnabled)
+        // ...should restore the last accepted card
+        XCTAssertTrue(app.staticTexts["Payment method"].waitForExistence(timeout: 1))
+        XCTAssertEqual(app.staticTexts["Payment method"].label, "•••• 4444")
+        XCTAssertTrue(app.buttons["New card"].isSelected)
+        XCTAssertTrue(app.buttons["Checkout"].isEnabled)
 
-        // Tapping back into card form should preserve previous form details
+        // Tapping back into card form should restore the last accepted form details
         app.buttons["New card"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Add new card"].waitForExistence(timeout: 2))
-        XCTAssertEqual(cardNumberField.value as? String, "555555555555444, Your card number is incomplete.")
+        XCTAssertEqual(cardNumberField.value as? String, "5555555555554444")
     }
 
     func testApplePay() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedFormViewController.swift
@@ -92,8 +92,8 @@ class EmbeddedFormViewController: UIViewController {
     private weak var checkout: Checkout?
     private var error: Swift.Error?
     private var isPaymentInFlight: Bool = false
-    /// Previous customer input - in the `update` flow, this is the customer input prior to `update`, used so we can restore their state in this VC.
-    private(set) var previousPaymentOption: PaymentOption?
+    /// The payment option to restore if the customer cancels this form.
+    private(set) var paymentOptionToRestoreOnCancellation: PaymentOption?
 
     // MARK: - UI properties
 
@@ -124,13 +124,7 @@ class EmbeddedFormViewController: UIViewController {
     }()
 
     private lazy var paymentMethodFormViewController: PaymentMethodFormViewController = {
-        let previousCustomerInput: IntentConfirmParams? = {
-            if case let .new(confirmParams: confirmParams) = previousPaymentOption {
-                return confirmParams
-            } else {
-                return nil
-            }
-        }()
+        let previousCustomerInput = paymentOptionToRestoreOnCancellation?.formConfirmParamsForCancellationRestoration
 
         let headerView = FormHeaderView(
             paymentMethodType: paymentMethodType,
@@ -179,7 +173,7 @@ class EmbeddedFormViewController: UIViewController {
         self.elementsSession = elementsSession
         self.shouldUseNewCardNewCardHeader = shouldUseNewCardNewCardHeader
         self.configuration = configuration
-        self.previousPaymentOption = previousPaymentOption
+        self.paymentOptionToRestoreOnCancellation = previousPaymentOption
         self.analyticsHelper = analyticsHelper
         self.paymentMethodMessagingPromotionsHelper = paymentMethodMessagingPromotionsHelper
         self.checkout = checkout
@@ -268,6 +262,11 @@ class EmbeddedFormViewController: UIViewController {
             stpAssertionFailure()
             dismiss(animated: true)
         }
+    }
+
+    /// Captures the valid form state accepted by Continue so later canceled edits can restore it.
+    func capturePaymentOptionForCancellationRestoration() {
+        paymentOptionToRestoreOnCancellation = selectedPaymentOption
     }
 
     required init?(coder: NSCoder) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -146,7 +146,8 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         // Note `paymentOption` derives from this property
         self.selectedFormViewController = Self.makeFormViewControllerIfNecessary(
             selection: embeddedPaymentMethodsView.selectedRowButton?.type,
-            previousPaymentOption: selectedFormViewController?.previousPaymentOption,
+            // Carry the accepted option into the next form so cancel can restore the previous row.
+            previousPaymentOption: selectedFormViewController?.paymentOptionToRestoreOnCancellation,
             configuration: configuration,
             intent: intent,
             elementsSession: elementsSession,
@@ -427,25 +428,53 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
         }
     }
 
-    func embeddedFormViewControllerDidCancel(_ embeddedFormViewController: EmbeddedFormViewController) {
-        let lastSelection = embeddedPaymentMethodsView.previousSelectedRowButton?.type
-        let currentlySelectedType = embeddedPaymentMethodsView.selectedRowButton?.type
+    private func restoreAcceptedForm(
+        from paymentOption: PaymentOption?,
+        for selection: RowButtonType?
+    ) -> Bool {
+        guard case let .new(paymentMethodType) = selection,
+              let paymentOption,
+              paymentOption.formConfirmParamsForCancellationRestoration?.paymentMethodType == paymentMethodType else {
+            return false
+        }
 
-        // If the user re-selects a valid payment option w/ form, then modifies it, then hits close, we clear selection
-        // Ideally we would revert back to the valid payment option that existed when the form was presented rather than totally clear selection
-        // To restore to the previous payment option we need to restore the previous form VC that contained the previous payment option
-        // TODO (https://jira.corp.stripe.com/browse/MOBILESDK-3361): Consider restoring the form VC and form cache to revert to the last valid payment option
-        if lastSelection == currentlySelectedType,
-           lastUpdatedPaymentOption != paymentOption {
-            embeddedPaymentMethodsView.resetSelection()
+        // The cached form contains the canceled edits. Rebuild it from the last accepted option.
+        formCache[paymentMethodType] = nil
+        selectedFormViewController = Self.makeFormViewControllerIfNecessary(
+            selection: selection,
+            previousPaymentOption: paymentOption,
+            configuration: configuration,
+            intent: intent,
+            elementsSession: elementsSession,
+            savedPaymentMethods: savedPaymentMethods,
+            analyticsHelper: analyticsHelper,
+            paymentMethodMessagingPromotionsHelper: loadResult.paymentMethodMessagingPromotionsHelper,
+            checkout: checkout,
+            formCache: formCache,
+            delegate: self
+        )
+        return selectedFormViewController != nil
+    }
+
+    func embeddedFormViewControllerDidCancel(_ embeddedFormViewController: EmbeddedFormViewController) {
+        let previousSelection = embeddedPaymentMethodsView.previousSelectedRowButton?.type
+        let currentSelection = embeddedPaymentMethodsView.selectedRowButton?.type
+        let paymentOptionToRestore = embeddedFormViewController.paymentOptionToRestoreOnCancellation
+
+        if previousSelection == currentSelection {
+            // Re-selecting the same row doesn't rebuild its form, so restore it explicitly.
+            if !restoreAcceptedForm(from: paymentOptionToRestore, for: currentSelection),
+               lastUpdatedPaymentOption != paymentOption {
+                embeddedPaymentMethodsView.resetSelection()
+            }
         } else {
-            // Go back to the previous selection if there was one
+            // Changing rows rebuilds the previous form from `paymentOptionToRestoreOnCancellation`.
             embeddedPaymentMethodsView.resetSelectionToLastSelection()
         }
 
         // Show change button if the newly selected row needs it
-        if let currentlySelectedType = embeddedPaymentMethodsView.selectedRowButton?.type{
-            updateChangeButtonAndSublabelState(for: currentlySelectedType)
+        if let currentSelection = embeddedPaymentMethodsView.selectedRowButton?.type {
+            updateChangeButtonAndSublabelState(for: currentSelection)
         }
 
         embeddedFormViewController.dismiss(animated: true) {
@@ -456,6 +485,8 @@ extension EmbeddedPaymentElement: EmbeddedFormViewControllerDelegate {
     }
 
     func embeddedFormViewControllerDidContinue(_ embeddedFormViewController: EmbeddedFormViewController) {
+        embeddedFormViewController.capturePaymentOptionForCancellationRestoration()
+
         // Show change button if the selected row needs it
         if let newSelectedType = embeddedPaymentMethodsView.selectedRowButton?.type {
             updateChangeButtonAndSublabelState(for: newSelectedType)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -879,6 +879,44 @@ class EmbeddedPaymentElementTest: XCTestCase {
         XCTAssertNil(sut.paymentOption, "Payment option should be nil after filling out the card form, but hitting cancel.")
     }
 
+    func testCancelingEditedFormRestoresAcceptedForm() async throws {
+        // Given an EmbeddedPaymentElement with a selected card
+        let sut = try await EmbeddedPaymentElement.create(
+            intentConfiguration: paymentIntentConfig,
+            configuration: configuration
+        )
+        sut.delegate = self
+        sut.presentingViewController = UIViewController()
+        sut.embeddedPaymentMethodsView.didTap(
+            rowButton: sut.embeddedPaymentMethodsView.getRowButton(accessibilityIdentifier: "Card")
+        )
+        var cardForm = sut.formCache[.stripe(.card)]!
+        cardForm.getTextFieldElement("Card number").setText("4242424242424242")
+        cardForm.getTextFieldElement("MM / YY").setText("1240")
+        cardForm.getTextFieldElement("CVC").setText("123")
+        cardForm.getTextFieldElement("ZIP").setText("12345")
+        sut.selectedFormViewController?.didTapPrimaryButton()
+        XCTAssertEqual(sut.paymentOption?.label, "•••• 4242")
+
+        // When the element is updated and the same card row is reopened
+        let updateResult = await sut.update(intentConfiguration: paymentIntentConfig)
+        XCTAssertEqual(updateResult, .succeeded)
+        sut.embeddedPaymentMethodsView.didTap(
+            rowButton: sut.embeddedPaymentMethodsView.getRowButton(accessibilityIdentifier: "Card")
+        )
+        cardForm = sut.formCache[.stripe(.card)]!
+
+        // ...and its CVC is edited before the form is canceled
+        cardForm.getTextFieldElement("CVC").setText("999")
+        sut.selectedFormViewController?.didTapOrSwipeToDismiss()
+
+        // Then the selected card and its CVC are restored even though its display data did not change
+        XCTAssertEqual(sut.paymentOption?.label, "•••• 4242")
+        cardForm = sut.formCache[.stripe(.card)]!
+        XCTAssertEqual(cardForm.getTextFieldElement("Card number").text, "4242424242424242")
+        XCTAssertEqual(cardForm.getTextFieldElement("CVC").text, "123")
+    }
+
     // MARK: - Checkout Session update tests
 
     func testUpdateCheckoutSession() async throws {


### PR DESCRIPTION
## Summary
- When canceling an edited embedded form for the currently selected row, restore the last accepted payment option instead of clearing selection, even if the display data (e.g. card brand/last4) didn't change.
- Renamed `previousPaymentOption` to `paymentOptionToRestoreOnCancellation` for clarity and added `capturePaymentOptionForCancellationRestoration()`, called on `didContinue` to snapshot the accepted option.
- Added `restoreAcceptedForm` to rebuild the form from the last accepted option when re-selecting the same row after canceling edits.
- Updated the UI test to assert the card and its form details are restored instead of cleared.

## Motivation
- CheckoutSessions

## Testing
- New unit test: `testCancelingEditedFormRestoresAcceptedForm`
- Existing UI test updated

## Changelog
N/A