### PR TITLE
Sync initial saved payment option's billing address to Checkout tax region

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -112,6 +112,7 @@ public final class PaymentElement {
             embeddedPaymentElement.paymentOption.map(Checkout.Session.PaymentOptionDisplayData.init)
         )
         paymentOptionSourceOfTruthIsFlowController = false // We used embedded's payment option
+        try await checkout.syncBillingAddress(from: embeddedPaymentElement._paymentOption?.checkoutBillingDetails)
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -191,6 +191,17 @@ enum CheckoutTestHelpers {
             let data = try! JSONSerialization.data(withJSONObject: responseJSON, options: [])
             return HTTPStubsResponse(data: data, statusCode: 200, headers: nil)
         }
+        // Init can trigger a session update (e.g. billing address tax sync); just echo the session back.
+        stub(condition: { request in
+            request.httpMethod == "POST"
+                && request.url?.path == "/v1/payment_pages/\(sessionId)"
+        }) { _ in
+            var responseJSON = jsonObject(apiResponse.allResponseFields) as? [String: Any] ?? [:]
+            responseJSON["client_secret"] = resolvedClientSecret
+            responseJSON["session_id"] = responseJSON["session_id"] ?? sessionId
+            let data = try! JSONSerialization.data(withJSONObject: responseJSON, options: [])
+            return HTTPStubsResponse(data: data, statusCode: 200, headers: nil)
+        }
 
         return apiClient
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -5,6 +5,7 @@
 //  Created by Yuki Tokuhiro on 7/15/26.
 //
 
+import OHHTTPStubs
 @testable @_spi(STP) import StripeCore
 @testable @_spi(STP) import StripePayments
 @testable @_spi(STP) import StripePaymentSheet
@@ -24,6 +25,12 @@ final class PaymentElementTest: XCTestCase {
             }
         }
         waitForExpectations(timeout: 1)
+        CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: nil)
+    }
+
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+        super.tearDown()
     }
 
     func testConfigurationSetsCheckoutDefaultBillingDetails() async throws {
@@ -98,6 +105,28 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertEqual(paymentElement.embeddedPaymentElement.configuration.billingDetailsCollectionConfiguration.address, .full)
     }
 
+    func testInitialSavedPaymentOptionUpdatesCheckoutBillingTaxRegion() async throws {
+        // Given a Checkout Session with automatic tax sourced from billing and a saved card...
+        let (configuration, requestRecorder) = try stubAutomaticTaxSavedCardCheckout()
+
+        // When Checkout loads its PaymentElement...
+        let checkout = try await Checkout(configuration: configuration)
+
+        // Then the saved card's billing address is used to update the tax region...
+        let requests = requestRecorder.requests
+        XCTAssertEqual(requests.map(\.kind), [.initSession, .updateSession])
+        let updateRequest = try XCTUnwrap(requests.first { $0.kind == .updateSession })
+        XCTAssertEqual(updateRequest.params["tax_region[country]"], "US")
+        XCTAssertEqual(updateRequest.params["tax_region[line1]"], "354 Oyster Point Blvd")
+        XCTAssertEqual(updateRequest.params["tax_region[city]"], "South San Francisco")
+        XCTAssertEqual(updateRequest.params["tax_region[state]"], "CA")
+        XCTAssertEqual(updateRequest.params["tax_region[postal_code]"], "94080")
+
+        // ...and the saved card remains selected after PaymentElement refreshes.
+        XCTAssertEqual(checkout.session.paymentOption?.label, "•••• 4242")
+        XCTAssertEqual(checkout.session.paymentOption?.billingDetails?.address.country, "US")
+    }
+
     func testCheckoutSessionUpdatePreservesFlowControllerPaymentOption() async throws {
         // Given a Checkout PaymentElement with PayNow available in the real FlowController sheet UI...
         var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
@@ -166,6 +195,23 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertNil(weakPaymentElement)
         XCTAssertNil(weakFlowController)
         XCTAssertNil(weakEmbeddedPaymentElement)
+    }
+
+    /// `CheckoutSession.json` already has automatic tax sourced from billing and a saved card with a full billing address.
+    private func stubAutomaticTaxSavedCardCheckout() throws -> (
+        configuration: Checkout.Configuration,
+        requestRecorder: CheckoutSessionRequestRecorder
+    ) {
+        let sessionJSON = STPTestUtils.jsonNamed("CheckoutSession")!
+        let session = try XCTUnwrap(PaymentPagesAPIResponse.decodedObject(fromAPIResponse: sessionJSON))
+        let requestRecorder = CheckoutSessionRequestRecorder()
+        let configuration = CheckoutTestHelpers.makeConfiguration(apiResponse: session)
+        CheckoutTestHelpers.stubCheckoutSessionRequests(
+            sessionId: session.id,
+            requestRecorder: requestRecorder,
+            sessionJSON: { sessionJSON }
+        )
+        return (configuration, requestRecorder)
     }
 
     private static func makeOpenSession(paymentMethodTypes: [String]) -> PaymentPagesAPIResponse {


### PR DESCRIPTION
## Summary
- When `PaymentElement` loads `Checkout`'s initial payment option from Embedded on load, also sync that payment option's billing address to the Checkout Session's automatic tax region (via `Checkout.syncBillingAddress(from:)`).
- This keeps a saved card's billing address in sync with automatic tax on first load, matching the behavior already applied on subsequent payment option changes.

## Test plan
- New tests