### PR TITLE
Require return URL for Checkout configuration

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -84,7 +84,7 @@ struct CheckoutCartView: View {
         isLoading = true
         errorMessage = nil
         do {
-            var config = Checkout.Configuration(clientSecret: clientSecret)
+            var config = Checkout.Configuration(clientSecret: clientSecret, returnURL: "payments-example://stripe-redirect")
             config.adaptivePricing.allowed = adaptivePricing
             checkout = try await Checkout(configuration: config)
         } catch {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -940,7 +940,7 @@ extension PlaygroundController {
                 // Load checkout session using Checkout SDK if using CheckoutSession
                 if let checkoutSessionClientSecret = json["checkoutSessionClientSecret"] {
                     do {
-                        var checkoutConfiguration = Checkout.Configuration(clientSecret: checkoutSessionClientSecret)
+                        var checkoutConfiguration = Checkout.Configuration(clientSecret: checkoutSessionClientSecret, returnURL: "payments-example://stripe-redirect")
                         checkoutConfiguration.adaptivePricing.allowed = settingsToLoad.csAdaptivePricing == .on
                         self.checkout = try await Checkout(configuration: checkoutConfiguration)
                     } catch {

--- a/Stripe/StripeiOSTestHostApp/Info.plist
+++ b/Stripe/StripeiOSTestHostApp/Info.plist
@@ -16,6 +16,19 @@
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.stripe.StripeiOSTestHostApp</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>stripe-ios-test</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -56,6 +56,7 @@ extension Checkout {
             self.returnURL = returnURL
         }
 
+        // MARK: - Debug-only return URL validation
 #if DEBUG
         /// Debug-only listener used to verify Checkout return URLs can be routed through
         /// `StripeAPI.handleURLCallback(with:)`.
@@ -72,10 +73,8 @@ extension Checkout {
                 return true
             }
         }
-#endif
 
         func validateReturnURL() {
-            #if DEBUG
             guard let url = URL(string: returnURL),
                   let scheme = url.scheme,
                   !scheme.isEmpty else {
@@ -104,8 +103,8 @@ extension Checkout {
                 registeredSchemes.contains(scheme.lowercased()),
                 "Checkout.Configuration.returnURL uses the custom URL scheme '\(scheme)', but it is not registered in CFBundleURLTypes."
             )
-            #endif
         }
+#endif
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -16,7 +16,10 @@ extension Checkout {
     /// Supply a configuration when creating a ``Checkout`` to customize behavior:
     ///
     /// ```swift
-    /// var config = Checkout.Configuration(clientSecret: "cs_xxx_secret_yyy")
+    /// var config = Checkout.Configuration(
+    ///     clientSecret: "cs_xxx_secret_yyy",
+    ///     returnURL: "my-app://stripe-redirect"
+    /// )
     /// config.adaptivePricing.allowed = true
     ///
     /// let checkout = try await Checkout(configuration: config)
@@ -24,6 +27,9 @@ extension Checkout {
     public struct Configuration {
         /// The client secret for your Checkout Session.
         public var clientSecret: String
+
+        /// A custom URL scheme that redirects back to your app after authenticating a payment method, e.g. `my-app://stripe-redirect`. Register this URL scheme in your app and forward incoming URLs to `StripeAPI.handleURLCallback(with:)`.
+        public var returnURL: String
 
         /// The API client used to make requests to Stripe.
         public var apiClient: STPAPIClient = .shared
@@ -44,8 +50,61 @@ extension Checkout {
 
         /// Creates a configuration.
         /// - Parameter clientSecret: The client secret for your Checkout Session.
-        public init(clientSecret: String) {
+        /// - Parameter returnURL: A custom URL scheme that redirects back to your app after authenticating a payment method, e.g. `my-app://stripe-redirect`. Register this URL scheme in your app and forward incoming URLs to `StripeAPI.handleURLCallback(with:)`.
+        public init(clientSecret: String, returnURL: String) {
             self.clientSecret = clientSecret
+            self.returnURL = returnURL
+        }
+
+#if DEBUG
+        /// Debug-only listener used to verify Checkout return URLs can be routed through
+        /// `StripeAPI.handleURLCallback(with:)`.
+        ///
+        /// Checkout receives its return URL before any payment authentication flow has
+        /// registered a real `STPPaymentHandler` listener. This temporary listener lets us
+        /// exercise the same callback router during configuration so malformed callback
+        /// URLs or missing app forwarding are caught earlier in integration.
+        private final class ReturnURLCallbackListener: NSObject, STPURLCallbackListener {
+            var handledURL: URL?
+
+            func handleURLCallback(_ url: URL) -> Bool {
+                handledURL = url
+                return true
+            }
+        }
+#endif
+
+        func validateReturnURL() {
+            #if DEBUG
+            guard let url = URL(string: returnURL),
+                  let scheme = url.scheme,
+                  !scheme.isEmpty else {
+                assertionFailure("Checkout.Configuration.returnURL must be a valid URL with a scheme.")
+                return
+            }
+
+            let listener = ReturnURLCallbackListener()
+            STPURLCallbackHandler.shared().register(listener, for: url)
+            let handled = StripeAPI.handleURLCallback(with: url)
+            STPURLCallbackHandler.shared().unregisterListener(listener)
+            assert(
+                handled && listener.handledURL == url,
+                "Checkout.Configuration.returnURL must be forwarded to StripeAPI.handleURLCallback(with:) when your app receives the URL in application(_:open:options:) or scene(_:openURLContexts:)."
+            )
+
+            guard scheme.lowercased() != "http" && scheme.lowercased() != "https" else {
+                return
+            }
+
+            let urlTypes = Bundle.main.object(forInfoDictionaryKey: "CFBundleURLTypes") as? [[String: Any]]
+            let registeredSchemes = urlTypes?
+                .flatMap { $0["CFBundleURLSchemes"] as? [String] ?? [] }
+                .map { $0.lowercased() } ?? []
+            assert(
+                registeredSchemes.contains(scheme.lowercased()),
+                "Checkout.Configuration.returnURL uses the custom URL scheme '\(scheme)', but it is not registered in CFBundleURLTypes."
+            )
+            #endif
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -109,6 +109,7 @@ public final class Checkout: ObservableObject {
         guard !clientSecret.isEmpty else {
             throw CheckoutError.invalidClientSecret
         }
+        configuration.validateReturnURL()
         self.clientSecret = clientSecret
         self.configuration = configuration
         self.apiClient = configuration.apiClient

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -109,7 +109,9 @@ public final class Checkout: ObservableObject {
         guard !clientSecret.isEmpty else {
             throw CheckoutError.invalidClientSecret
         }
+        #if DEBUG
         configuration.validateReturnURL()
+        #endif
         self.clientSecret = clientSecret
         self.configuration = configuration
         self.apiClient = configuration.apiClient

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutDefaultsInitializationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutDefaultsInitializationTests.swift
@@ -18,7 +18,7 @@ final class CheckoutDefaultsInitializationTests: XCTestCase {
     func testInitAppliesBillingDefaultThroughBillingTaxUpdateWhenNeeded() async throws {
         stubCheckoutSessionRequests()
 
-        var configuration = Checkout.Configuration(clientSecret: clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: "pk_test_123")
         var billingDetails = Checkout.Configuration.Defaults.BillingDetails()
         billingDetails.name = "Billing Name"
@@ -45,7 +45,7 @@ final class CheckoutDefaultsInitializationTests: XCTestCase {
         // Given a Checkout Session that uses shipping for tax
         stubCheckoutSessionRequests(automaticTaxAddressSource: "shipping")
 
-        var configuration = Checkout.Configuration(clientSecret: clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: "pk_test_123")
         var shippingDetails = Checkout.Configuration.Defaults.ShippingDetails()
         shippingDetails.name = "Shipping Name"

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -149,7 +149,7 @@ enum CheckoutTestHelpers {
     ) -> Checkout.Configuration {
         // Use the production Checkout initializer with a test-controlled API client.
         let clientSecret = configuration?.clientSecret ?? apiResponse.clientSecret ?? "cs_test_123_secret_abc"
-        var resolvedConfiguration = configuration ?? Checkout.Configuration(clientSecret: clientSecret)
+        var resolvedConfiguration = configuration ?? Checkout.Configuration(clientSecret: clientSecret, returnURL: "stripe-ios-test://checkout-return")
         resolvedConfiguration.apiClient = makeStubbedAPIClient(
             apiResponse: apiResponse,
             clientSecret: clientSecret,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
@@ -18,7 +18,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
 
     func testLoadCheckoutSession() async throws {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
         let checkout = try await Checkout(configuration: configuration)
 
@@ -36,7 +36,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             allowPromotionCodes: true
         )
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
         let checkout = try await Checkout(configuration: configuration)
 
@@ -61,7 +61,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             allowPromotionCodes: true
         )
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
         let checkout = try await Checkout(configuration: configuration)
 
@@ -81,7 +81,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             allowPromotionCodes: true
         )
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
         let checkout = try await Checkout(configuration: configuration)
 
@@ -103,7 +103,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             allowPromotionCodes: true
         )
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
         let checkout = try await Checkout(configuration: configuration)
 
@@ -122,7 +122,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             allowAdjustableLineItemQuantity: true
         )
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
         let checkout = try await Checkout(configuration: configuration)
 
@@ -141,7 +141,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             includeShippingOptions: true
         )
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
         let checkout = try await Checkout(configuration: configuration)
 
@@ -163,7 +163,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
             collectBillingAddress: true,
             automaticTax: true
         )
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
         let checkout = try await Checkout(configuration: configuration)
 
@@ -197,7 +197,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
             collectShippingAddress: true,
             automaticTax: true
         )
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
         let checkout = try await Checkout(configuration: configuration)
 
@@ -241,7 +241,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
             adaptivePricingEnabled: true,
             customerEmailLocation: "DE"
         )
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         configuration.adaptivePricing.allowed = true
         configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
         let checkout = try await Checkout(configuration: configuration)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -28,7 +28,7 @@ final class PaymentElementTest: XCTestCase {
 
     func testConfigurationSetsCheckoutDefaultBillingDetails() async throws {
         // Given Checkout billing defaults
-        var checkoutConfiguration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
         var billingDetails = Checkout.Configuration.Defaults.BillingDetails()
         billingDetails.name = "Jane Doe"
         billingDetails.address = .init(
@@ -50,6 +50,7 @@ final class PaymentElementTest: XCTestCase {
         let embeddedConfiguration = paymentElement.embeddedPaymentElement.configuration
 
         // Then both configurations receive the same default billing details
+        XCTAssertEqual(checkout.configuration.returnURL, "stripe-ios-test://checkout-return")
         XCTAssertEqual(paymentSheetConfiguration.defaultBillingDetails.name, "Jane Doe")
         XCTAssertEqual(paymentSheetConfiguration.defaultBillingDetails.address.country, "US")
         XCTAssertEqual(paymentSheetConfiguration.defaultBillingDetails.address.line1, "123 Main St")
@@ -63,7 +64,7 @@ final class PaymentElementTest: XCTestCase {
 
     func testConfigurationSetsCheckoutDefaultShippingDetails() async throws {
         // Given Checkout shipping defaults
-        var checkoutConfiguration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
         var shippingDetails = Checkout.Configuration.Defaults.ShippingDetails()
         shippingDetails.name = "Jane Doe"
         shippingDetails.address = .init(
@@ -104,7 +105,7 @@ final class PaymentElementTest: XCTestCase {
 
     func testConfigurationSetsFullBillingAddressCollectionWhenCheckoutRequiresBillingAddress() async throws {
         // Given automatic billing address collection in PaymentElement
-        let checkoutConfiguration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
+        let checkoutConfiguration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
         let session = CheckoutTestHelpers.makeOpenSession(billingAddressCollection: "required")
 
         // When Checkout requires billing address collection
@@ -123,7 +124,7 @@ final class PaymentElementTest: XCTestCase {
 
     func testConfigurationPreservesFullBillingAddressCollectionWhenCheckoutBillingAddressCollectionIsAutomatic() async throws {
         // Given full billing address collection in PaymentElement
-        var checkoutConfiguration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
         checkoutConfiguration.paymentElement.billingDetailsCollectionConfiguration.address = .full
 
         // When Checkout uses automatic billing address collection
@@ -139,7 +140,7 @@ final class PaymentElementTest: XCTestCase {
 
     func testCheckoutSessionUpdatePreservesFlowControllerPaymentOption() async throws {
         // Given a Checkout PaymentElement with PayNow available in the real FlowController sheet UI...
-        var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
+        var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
         configuration.paymentElement.paymentMethodLayout = .vertical
         let checkout = try await Checkout(
             configuration: CheckoutTestHelpers.makeConfiguration(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementViewTests.swift
@@ -15,7 +15,7 @@ final class PaymentElementViewTests: XCTestCase {
 
     func testSwiftUIViewUpdatesHeightWhenEmbeddedPaymentElementHeightChanges() async throws {
         // Given a PaymentElement SwiftUI view hosted in a window
-        var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
+        var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
         configuration.paymentElement.displaysMandateText = true
         let checkout = try await Checkout(configuration: CheckoutTestHelpers.makeConfiguration(configuration: configuration))
         let paymentElement = checkout.getPaymentElement()

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -884,7 +884,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
     func testUpdateCheckoutSession() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         checkoutConfiguration.apiClient = apiClient
         let checkout = try await Checkout(configuration: checkoutConfiguration)
 
@@ -904,7 +904,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
     func testUpdateCheckoutSessionCancelsInFlight() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         checkoutConfiguration.apiClient = apiClient
         let checkout = try await Checkout(configuration: checkoutConfiguration)
 
@@ -928,7 +928,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
     func testUpdateCheckoutSessionNoOpsForCompleteSession() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         checkoutConfiguration.apiClient = apiClient
         let checkout = try await Checkout(configuration: checkoutConfiguration)
 
@@ -959,7 +959,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
     func testUpdateCheckoutSessionNoOpsForExpiredSession() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         checkoutConfiguration.apiClient = apiClient
         let checkout = try await Checkout(configuration: checkoutConfiguration)
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheet+APITest.swift
@@ -1156,7 +1156,7 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
     func testUpdateCheckoutSession() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         checkoutConfiguration.apiClient = apiClient
         let checkout = try await Checkout(configuration: checkoutConfiguration)
 
@@ -1172,7 +1172,7 @@ class PaymentSheetAPITest: STPNetworkStubbingTestCase {
     func testUpdateCheckoutSessionFails() async throws {
         let response = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode()
         let apiClient = STPAPIClient(publishableKey: response.publishableKey)
-        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: response.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         checkoutConfiguration.apiClient = apiClient
         let checkout = try await Checkout(configuration: checkoutConfiguration)
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -780,7 +780,7 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
         configuration.apiClient = customApiClient
         configuration.defaultBillingDetails.email = "test@example.com"
 
-        var checkoutConfiguration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         checkoutConfiguration.apiClient = customApiClient
         let checkout = try await Checkout(configuration: checkoutConfiguration)
         PaymentSheetLoader.load(
@@ -816,7 +816,7 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
         configuration.apiClient = customApiClient
         configuration.defaultBillingDetails.email = "test@example.com"
 
-        var checkoutConfiguration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret)
+        var checkoutConfiguration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
         checkoutConfiguration.apiClient = customApiClient
         let checkout = try await Checkout(configuration: checkoutConfiguration)
 


### PR DESCRIPTION
## Summary
- Add a required `returnURL` to `Checkout.Configuration`.
- Add debug-time validation that the return URL can be routed through `StripeAPI.handleURLCallback(with:)`, and that custom URL schemes are registered in `CFBundleURLTypes`.
- Update Checkout playground and existing Checkout call sites/tests to pass a return URL.
- Leave MPE config and CheckoutSession confirm wiring unchanged.

## Motivation
Checkout needs to capture the app return URL at configuration initialization time so follow-up Checkout confirm handling can use it separately. The debug validation catches malformed or unregistered return URLs earlier during integration.

## Testing
- `ci_scripts/run_tests.rb --test StripePaymentSheetTests/PaymentElementTest/testConfigurationSetsCheckoutDefaultBillingDetails`
- `ci_scripts/format_modified_files.sh`
- `ci_scripts/lint_modified_files.sh`

## Changelog
Not added; Checkout is SPI and this only updates the configuration API.