### PR TITLE
Filter tax-incomplete saved payment methods

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AutomaticTaxBillingAddressRequirements.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AutomaticTaxBillingAddressRequirements.swift
@@ -1,0 +1,82 @@
+//
+//  AutomaticTaxBillingAddressRequirements.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 7/24/26.
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+@_spi(STP) import StripeCore
+@_spi(STP) import StripePayments
+@_spi(STP) import StripeUICore
+
+/// The billing address fields needed to compute automatic tax.
+enum AutomaticTaxBillingAddressRequirements {
+    private enum Field: Hashable {
+        case line1
+        case city
+        case state
+        case postalCode
+    }
+
+    private enum Requirement {
+        case country
+        case countryAndPostal
+        case fullAddress(requiredFields: Set<Field>)
+
+        var fieldsToCollect: AddressSectionElement.FieldsToCollect {
+            switch self {
+            case .country:
+                return .country
+            case .countryAndPostal:
+                return .countryAndPostal
+            case .fullAddress:
+                return .all
+            }
+        }
+
+        var requiredFields: Set<Field> {
+            switch self {
+            case .country:
+                return []
+            case .countryAndPostal:
+                return [.postalCode]
+            case .fullAddress(let requiredFields):
+                return requiredFields
+            }
+        }
+    }
+
+    private static let requirementsByCountry: [String: Requirement] = [
+        "US": .fullAddress(requiredFields: [.line1, .city, .state, .postalCode]),
+        "PR": .fullAddress(requiredFields: [.line1, .city, .postalCode]),
+        "CA": .countryAndPostal,
+        "GB": .countryAndPostal,
+        "IN": .countryAndPostal,
+    ]
+
+    /// Per-country collection overrides used when building payment method forms.
+    static let minimumFieldsToCollectByCountry = requirementsByCountry.mapValues(\.fieldsToCollect)
+
+    /// Whether a saved payment method address contains the fields required to calculate tax.
+    static func areSatisfied(by address: STPPaymentMethodAddress?) -> Bool {
+        guard let address,
+              let country = address.country?.nonEmpty?.uppercased() else {
+            return false
+        }
+
+        let requirement = requirementsByCountry[country] ?? .country
+        return requirement.requiredFields.allSatisfy { field in
+            switch field {
+            case .line1:
+                return address.line1?.nonEmpty != nil
+            case .city:
+                return address.city?.nonEmpty != nil
+            case .state:
+                return address.state?.nonEmpty != nil
+            case .postalCode:
+                return address.postalCode?.nonEmpty != nil
+            }
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Tax.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+Tax.swift
@@ -9,15 +9,6 @@
 @_spi(STP) import StripeCore
 @_spi(STP) import StripeUICore
 
-/// The minimum address fields needed to compute tax in each country.
-private let taxMinimumFieldsToCollectByCountry: [String: AddressSectionElement.FieldsToCollect] = [
-    "US": .all,
-    "PR": .all,
-    "CA": .countryAndPostal,
-    "GB": .countryAndPostal,
-    "IN": .countryAndPostal,
-]
-
 extension PaymentSheetFormFactory {
     /// Applies tax requirements after the LPM form is built so they replace its country-specific minimums.
     func applyAutomaticTaxMinimumsIfNecessary(to form: PaymentMethodElement) -> PaymentMethodElement {
@@ -31,10 +22,15 @@ extension PaymentSheetFormFactory {
             "A payment method form should contain at most one billing address section"
         )
         guard let addressSection = addressSections.first else {
-            return appendingTaxAddressSection(to: form, minimums: taxMinimumFieldsToCollectByCountry)
+            return appendingTaxAddressSection(
+                to: form,
+                minimums: AutomaticTaxBillingAddressRequirements.minimumFieldsToCollectByCountry
+            )
         }
 
-        addressSection.addMinimumFieldsToCollectByCountry(taxMinimumFieldsToCollectByCountry)
+        addressSection.addMinimumFieldsToCollectByCountry(
+            AutomaticTaxBillingAddressRequirements.minimumFieldsToCollectByCountry
+        )
         return form
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -420,6 +420,13 @@ final class PaymentSheetLoader {
                 return false
             }
 
+            // Checkout automatic tax cannot use a saved payment method whose billing
+            // address is missing fields needed to calculate tax.
+            if intent.collectsTaxFromBillingAddress,
+               !AutomaticTaxBillingAddressRequirements.areSatisfied(by: paymentMethod.billingDetails?.address) {
+                return false
+            }
+
             // Filter out pm whose billing country is not allowed
             guard Self.shouldIncludePaymentMethod(paymentMethod, allowedCountries: configuration.billingDetailsCollectionConfiguration.allowedCountries) else {
                 return false

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderAutomaticTaxTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderAutomaticTaxTest.swift
@@ -1,0 +1,169 @@
+//
+//  PaymentSheetLoaderAutomaticTaxTest.swift
+//  StripePaymentSheetTests
+//
+//  Created by Nick Porter on 7/24/26.
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+import XCTest
+
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripePayments
+@testable@_spi(STP) import StripePaymentSheet
+@testable@_spi(STP) import StripePaymentsTestUtils
+
+@MainActor
+final class PaymentSheetLoaderAutomaticTaxTest: XCTestCase {
+    func testAutomaticTaxBillingAddressRequirements() {
+        let completeAddresses = [
+            ("US", makeCard()),
+            ("PR", makeCard(state: nil, country: "PR")),
+            ("CA", makeCard(line1: nil, city: nil, state: nil, postalCode: "not validated", country: "CA")),
+            ("GB", makeCard(line1: nil, city: nil, state: nil, postalCode: "EC1A 1BB", country: "GB")),
+            ("IN", makeCard(line1: nil, city: nil, state: nil, postalCode: "110001", country: "IN")),
+            ("Other", makeCard(line1: nil, city: nil, state: nil, postalCode: nil, country: "fr")),
+        ]
+        let incompleteAddresses = [
+            ("Missing country", makeCard(country: nil)),
+            ("Empty country", makeCard(country: "")),
+            ("Missing US line 1", makeCard(line1: nil)),
+            ("Empty US line 1", makeCard(line1: "")),
+            ("Missing US city", makeCard(city: nil)),
+            ("Empty US city", makeCard(city: "")),
+            ("Missing US state", makeCard(state: nil)),
+            ("Empty US state", makeCard(state: "")),
+            ("Missing US postal code", makeCard(postalCode: nil)),
+            ("Empty US postal code", makeCard(postalCode: "")),
+            ("Missing PR line 1", makeCard(line1: nil, state: nil, country: "PR")),
+            ("Missing PR city", makeCard(city: nil, state: nil, country: "PR")),
+            ("Missing PR postal code", makeCard(state: nil, postalCode: nil, country: "PR")),
+            ("Missing CA postal code", makeCard(postalCode: nil, country: "CA")),
+            ("Missing GB postal code", makeCard(postalCode: nil, country: "GB")),
+            ("Missing IN postal code", makeCard(postalCode: nil, country: "IN")),
+        ]
+
+        for (name, paymentMethod) in completeAddresses {
+            XCTAssertTrue(
+                AutomaticTaxBillingAddressRequirements.areSatisfied(by: paymentMethod.billingDetails?.address),
+                name
+            )
+        }
+        for (name, paymentMethod) in incompleteAddresses {
+            XCTAssertFalse(
+                AutomaticTaxBillingAddressRequirements.areSatisfied(by: paymentMethod.billingDetails?.address),
+                name
+            )
+        }
+    }
+
+    func testFiltersCheckoutAutomaticTaxFromBillingAndPreservesSessionSavedPaymentMethods() {
+        let completeIntent = makeCheckoutIntent(paymentMethods: [makeCard()])
+        let incompleteIntent = makeCheckoutIntent(paymentMethods: [makeCard(line1: nil)])
+
+        XCTAssertEqual(filterCheckoutSavedPaymentMethods(intent: completeIntent).count, 1)
+        XCTAssertTrue(filterCheckoutSavedPaymentMethods(intent: incompleteIntent).isEmpty)
+        guard case .checkout(let session) = incompleteIntent else {
+            return XCTFail("Expected a Checkout Session intent")
+        }
+        XCTAssertEqual(session.savedPaymentMethods.count, 1)
+    }
+
+    func testOnlyFiltersCheckoutAutomaticTaxFromBilling() {
+        let incomplete = makeCard(line1: nil)
+        let nonCheckoutIntents: [Intent] = [._testValue(), ._testSetupIntent()]
+        let checkoutIntents = [
+            makeCheckoutIntent(
+                paymentMethods: [incomplete],
+                automaticTaxEnabled: false,
+                automaticTaxAddressSource: "session.billing"
+            ),
+            makeCheckoutIntent(
+                paymentMethods: [incomplete],
+                automaticTaxEnabled: true,
+                automaticTaxAddressSource: "session.shipping"
+            ),
+        ]
+
+        for intent in nonCheckoutIntents {
+            XCTAssertEqual(
+                PaymentSheetLoader.filterSavedPaymentMethods(
+                    intent: intent,
+                    elementsSession: ._testCardValue(),
+                    configuration: PaymentSheet.Configuration(),
+                    prefetchedSPMs: [incomplete],
+                    loadTimings: .init()
+                ).count,
+                1
+            )
+        }
+        for intent in checkoutIntents {
+            XCTAssertEqual(filterCheckoutSavedPaymentMethods(intent: intent).count, 1)
+        }
+    }
+
+    func testTaxAddressFilteringComposesWithAllowedCountryFiltering() {
+        let completeUS = makeCard()
+        let incompleteUS = makeCard(line1: nil)
+        let completeCA = makeCard(postalCode: "M5V 3L9", country: "CA")
+        let intent = makeCheckoutIntent(paymentMethods: [completeUS, incompleteUS, completeCA])
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.allowedCountries = ["US"]
+
+        let filtered = filterCheckoutSavedPaymentMethods(
+            intent: intent,
+            configuration: configuration
+        )
+
+        XCTAssertEqual(filtered.count, 1)
+        XCTAssertEqual(filtered.first?.billingDetails?.address?.country, "US")
+        XCTAssertNotNil(filtered.first?.billingDetails?.address?.line1)
+    }
+
+    private func filterCheckoutSavedPaymentMethods(
+        intent: Intent,
+        configuration: PaymentSheet.Configuration = .init()
+    ) -> [STPPaymentMethod] {
+        PaymentSheetLoader.filterSavedPaymentMethods(
+            intent: intent,
+            elementsSession: ._testCardValue(),
+            configuration: configuration,
+            prefetchedSPMs: nil,
+            loadTimings: .init()
+        )
+    }
+
+    private func makeCheckoutIntent(
+        paymentMethods: [STPPaymentMethod],
+        automaticTaxEnabled: Bool = true,
+        automaticTaxAddressSource: String = "session.billing"
+    ) -> Intent {
+        let response = CheckoutTestHelpers.makeSession([
+            "customer": [
+                "id": "cus_123",
+                "payment_methods": paymentMethods.map(\.allResponseFields),
+            ],
+            "tax_context": [
+                "automatic_tax_enabled": automaticTaxEnabled,
+                "automatic_tax_address_source": automaticTaxAddressSource,
+            ],
+        ])
+        return .checkout(response.makePublicSession())
+    }
+
+    private func makeCard(
+        line1: String? = "123 Main St",
+        city: String? = "San Francisco",
+        state: String? = "CA",
+        postalCode: String? = "94111",
+        country: String? = "US"
+    ) -> STPPaymentMethod {
+        return ._testCard(
+            line1: line1,
+            city: city,
+            state: state,
+            postalCode: postalCode,
+            countryCode: country
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `AutomaticTaxBillingAddressRequirements`, which encodes per-country minimum billing address fields needed to calculate automatic tax (full address for US/PR, country + postal for CA/GB/IN, country otherwise)
- `PaymentSheetLoader` now filters out saved payment methods whose billing address doesn't satisfy those requirements when the intent collects tax from the billing address
- Reuses the same per-country field requirements in `PaymentSheetFormFactory+Tax` for the billing address collection form
- Matches EwCS

## Motivation
Checkout automatic tax

## Testing
- New unit tests (`PaymentSheetLoaderAutomaticTaxTest`)

## Changelog
N/A