### PR TITLE
Remove FC URL Caching

### DIFF
--- a/Example/FinancialConnections Example/FinancialConnections Example/CollectBankAccountTokenViewController.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/CollectBankAccountTokenViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Vardges Avetisyan on 11/12/21.
 //
 
+@_spi(STP) import StripeCore
 import StripeFinancialConnections
 import UIKit
 
@@ -36,11 +37,12 @@ class CollectBankAccountTokenViewController: UIViewController {
         updateButtonState(isLoading: true)
 
         // Make request to our verification endpoint
-        let session = URLSession.shared
+        let session = STPAPIClient.nonCachingURLSession(from: .shared)
         let url = URL(string: baseURL + financialConnectionsEndpoint)!
 
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
+        urlRequest.cachePolicy = .reloadIgnoringLocalCacheData
 
         let task = session.dataTask(with: urlRequest) { [weak self] data, _, error in
             DispatchQueue.main.async { [weak self] in

--- a/Example/FinancialConnections Example/FinancialConnections Example/ConnectAccountViewController.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/ConnectAccountViewController.swift
@@ -5,6 +5,7 @@
 //  Created by Vardges Avetisyan on 11/12/21.
 //
 
+@_spi(STP) import StripeCore
 import StripeFinancialConnections
 import UIKit
 
@@ -37,11 +38,12 @@ class ConnectAccountViewController: UIViewController {
         updateButtonState(isLoading: true)
 
         // Make request to our verification endpoint
-        let session = URLSession.shared
+        let session = STPAPIClient.nonCachingURLSession(from: .shared)
         let url = URL(string: baseURL + financialConnectionsEndpoint)!
 
         var urlRequest = URLRequest(url: url)
         urlRequest.httpMethod = "POST"
+        urlRequest.cachePolicy = .reloadIgnoringLocalCacheData
 
         let task = session.dataTask(with: urlRequest) { [weak self] data, _, error in
             DispatchQueue.main.async { [weak self] in

--- a/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Playground/PlaygroundViewModel.swift
@@ -637,6 +637,7 @@ private func SetupPlayground(
 
     var urlRequest = URLRequest(url: url)
     urlRequest.httpMethod = "POST"
+    urlRequest.cachePolicy = .reloadIgnoringLocalCacheData
     urlRequest.httpBody = {
         var requestBody: [String: Any] = [:]
         requestBody["new_playground"] = true
@@ -653,7 +654,7 @@ private func SetupPlayground(
     urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
     urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-    URLSession.shared
+    nonCachingSession
         .dataTask(
             with: urlRequest
         ) { data, response, error in
@@ -774,6 +775,7 @@ private func CreatePaymentIntent(
 
     var urlRequest = URLRequest(url: url)
     urlRequest.httpMethod = "POST"
+    urlRequest.cachePolicy = .reloadIgnoringLocalCacheData
     urlRequest.httpBody = try! JSONSerialization.data(
         withJSONObject: configuration,
         options: .prettyPrinted
@@ -781,7 +783,7 @@ private func CreatePaymentIntent(
     urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
     urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-    URLSession.shared.dataTask(
+    nonCachingSession.dataTask(
         with: urlRequest,
         completionHandler: { data, _, error in
             guard error == nil, let data else {
@@ -800,6 +802,8 @@ private func CreatePaymentIntent(
     )
     .resume()
 }
+
+private let nonCachingSession = STPAPIClient.nonCachingURLSession(from: .shared)
 
 struct CreatePaymentIntentResponse: Decodable {
     let id: String

--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -236,6 +236,18 @@ import UIKit
         return publishableKey.lowercased().hasPrefix("pk_test") || (publishableKeyIsUserKey && !userKeyLiveMode)
     }
 
+    /// Creates a session that never persists responses to the URL cache.
+    @_spi(STP) public static func nonCachingURLSession(from session: URLSession) -> URLSession {
+        let configuration = session.configuration
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.urlCache = nil
+        return URLSession(
+            configuration: configuration,
+            delegate: session.delegate,
+            delegateQueue: session.delegateQueue
+        )
+    }
+
     /**
      Copies the api client.
      - Note: This should be used in cases where you need to make a request

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/FinancialConnectionsSheet.swift
@@ -103,7 +103,7 @@ final public class FinancialConnectionsSheet {
     public var onEvent: ((FinancialConnectionsEvent) -> Void)?
 
     /// The APIClient instance used to make requests to Stripe
-    public var apiClient: STPAPIClient = STPAPIClient.shared {
+    public var apiClient: STPAPIClient = STPAPIClient.shared.makeCopy() {
         didSet {
             APIVersion.configureFinancialConnectionsAPIVersion(apiClient: apiClient)
         }
@@ -316,6 +316,7 @@ final public class FinancialConnectionsSheet {
             }
         }
 
+        apiClient.urlSession = STPAPIClient.nonCachingURLSession(from: apiClient.urlSession)
         var financialConnectionsApiClient: any FinancialConnectionsAPI = FinancialConnectionsAsyncAPIClient(apiClient: apiClient)
 
         if let existingConsumer {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/UIImageView+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/UIImageView+Extensions.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+@_spi(STP) import StripeCore
 import UIKit
 
 extension UIImageView {
@@ -63,7 +64,7 @@ private func DownloadImage(
         completionHandler(nil)
         return
     }
-    URLSession.shared.dataTask(with: url) { data, response, _ in
+    STPAPIClient.nonCachingURLSession(from: .shared).dataTask(with: url) { data, response, _ in
         guard let response = response as? HTTPURLResponse else {
             assertionFailure("we always expect to get back `HTTPURLResponse`")
             completionHandler(nil)

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsSheetTests.swift
@@ -172,4 +172,23 @@ class FinancialConnectionsSheetTests: XCTestCase {
         )
         XCTAssertEqual(mockAnalyticsClient.productUsage, ["FinancialConnectionsSheet"])
     }
+
+    func testPresentUsesNonCachingURLSession() {
+        let sheet = FinancialConnectionsSheet(
+            financialConnectionsSessionClientSecret: mockClientSecret,
+            returnURL: nil,
+            configuration: .init(),
+            analyticsClient: mockAnalyticsClient
+        )
+        let originalSession = sheet.apiClient.urlSession
+
+        sheet.present(from: mockViewController) { (_: FinancialConnectionsSheet.Result) in }
+
+        XCTAssertFalse(sheet.apiClient.urlSession === originalSession)
+        XCTAssertEqual(
+            sheet.apiClient.urlSession.configuration.requestCachePolicy,
+            .reloadIgnoringLocalCacheData
+        )
+        XCTAssertNil(sheet.apiClient.urlSession.configuration.urlCache)
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/FinancialConnectionsLite.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/FC Lite/FinancialConnectionsLite.swift
@@ -53,7 +53,9 @@ import UIKit
         Self.activeInstance = self
         self.completionHandler = completion
 
-        var apiClient: FCLiteAPIClient = FCLiteAPIClient(backingAPIClient: .shared)
+        let stripeAPIClient = STPAPIClient.shared.makeCopy()
+        stripeAPIClient.urlSession = STPAPIClient.nonCachingURLSession(from: stripeAPIClient.urlSession)
+        var apiClient: FCLiteAPIClient = FCLiteAPIClient(backingAPIClient: stripeAPIClient)
         apiClient.consumerPublishableKey = existingConsumer?.publishableKey
 
         let containerVC = FCLiteContainerViewController(


### PR DESCRIPTION
## Summary
Removes unnecessary URL caching from the FC SDK.

## Testing

Including the following debug line on [app launch](https://stripe.sourcegraphcloud.com/r/stripe/stripe-ios/-/blob/Example/FinancialConnections%20Example/FinancialConnections%20Example/AppDelegate.swift?L15-21) is a helpful way to find the Cache.db.

```swift
if let bundleIdentifier = Bundle.main.bundleIdentifier,
    let cachesDirectory = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first {
        print("Financial Connections cache database: \(cachesDirectory.path)")
}
```

Open and complete the flow for FC Lite and FC Native to see that there is no data in the URL cache related to the user's session.

## Demo


| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/8115fdb7-f9db-42ae-b390-3076a6de5ec6" width="300" /> | <video src="https://github.com/user-attachments/assets/68172cc0-0138-492c-bc0e-8c5c2d47b771" width="300" /> |




