### PR TITLE
Fix typo in testOtp3DS2

### DIFF
--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
@@ -184,7 +184,7 @@ class IntegrationTesterUITests: XCTestCase {
         XCTAssertTrue(buyButton.waitForExistence(timeout: 60.0))
         buyButton.forceTapElement()
 
-        let challengeScreenPredicate = NSPredicate(format: "label CONTAINS[c] 'This is a test 3D Secure 2 authentication, showing a sample one-time-password (OTP) flow. In live mode, customers may be asked to verify their identify by entering a code sent by their bank to their mobile phone. For this test, enter 424242 to complete authentication, or any other value to fail authentication'")
+        let challengeScreenPredicate = NSPredicate(format: "label CONTAINS[c] 'This is a test 3D Secure 2 authentication, showing a sample one-time-password (OTP) flow. In live mode, customers may be asked to verify their identity by entering a code sent by their bank to their mobile phone. For this test, enter 424242 to complete authentication, or any other value to fail authentication'")
         let challengeText = app.staticTexts.matching(challengeScreenPredicate).element
         XCTAssertTrue(challengeText.waitForExistence(timeout: 10))
 


### PR DESCRIPTION
## Summary

`testOtp3DS2` was failing on my branch. Looks like there was a typo in the assertion.

<img width="2760" height="1573" alt="image" src="https://github.com/user-attachments/assets/ed7a9dac-f616-48eb-bdb0-5c9b18048f58" />


## Motivation

https://app.bitrise.io/app/b220f4ba85d134a7/build/20bc0ff6-cae1-45be-837b-052f238e3ba0

## Testing

Trust CI

## Changelog

N/a