### PR TITLE
Sync billing on EPE SPM tap

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -12,6 +12,12 @@ import SafariServices
 import UIKit
 
 extension EmbeddedPaymentElement {
+    struct PendingBillingAddressSyncSelection {
+        let paymentMethod: STPPaymentMethod
+        let previousSelection: RowButtonType?
+        let previousPaymentOption: PaymentOption?
+    }
+
     @MainActor
     static func makeView(
         configuration: Configuration,
@@ -144,14 +150,14 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
     }
 
     func embeddedPaymentMethodsViewWillSelect(_ rowButtonType: RowButtonType) {
-        guard let checkout,
+        guard checkout != nil,
               case .saved(let paymentMethod) = rowButtonType else {
             persistDefaultPaymentMethodSelection(rowButtonType)
             return
         }
+        // Save the current selection now; the tap callback uses it after the selected row changes.
         pendingBillingAddressSyncSelection = .init(
-            paymentMethodID: paymentMethod.stripeId,
-            billingDetails: paymentMethod.billingDetails,
+            paymentMethod: paymentMethod,
             previousSelection: embeddedPaymentMethodsView.selectedRowButton?.type,
             previousPaymentOption: _paymentOption
         )
@@ -184,7 +190,7 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
     func embeddedPaymentMethodsViewDidTapPaymentMethodRow() {
         // 😓 Note: This method depends on `embeddedPaymentMethodsViewDidUpdateSelection` being called *before* this method is called when a row is tapped.
         guard let selectedFormViewController else {
-            finishSelectingPaymentMethodWithoutForm()
+            handleSelectionWithoutForm()
             return
         }
         // Present the current selection's form VC
@@ -196,61 +202,81 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         presentingViewController?.presentAsBottomSheet(bottomSheet, appearance: configuration.appearance)
     }
 
-    private func finishSelectingPaymentMethodWithoutForm() {
-        guard let pendingSelection = pendingBillingAddressSyncSelection else {
-            completeImmediateRowSelectionIfNeeded()
-            return
-        }
-        guard let checkout else {
+    private func handleSelectionWithoutForm() {
+        // We aren't in Checkout, or this selection doesn't need a billing sync.
+        guard let pendingSelection = pendingBillingAddressSyncSelection,
+              let checkout else {
             pendingBillingAddressSyncSelection = nil
             persistDefaultPaymentMethodSelection(embeddedPaymentMethodsView.selectedRowButton?.type)
             informDelegateIfPaymentOptionUpdated()
             completeImmediateRowSelectionIfNeeded()
             return
         }
-
         embeddedPaymentMethodsView.isUserInteractionEnabled = false
         let loadingRow = embeddedPaymentMethodsView.selectedRowButton
         loadingRow?.setLoading(true)
+
         Task { @MainActor [weak self, weak loadingRow] in
             guard let self else { return }
             do {
-                try await checkout.syncBillingAddress(from: pendingSelection.billingDetails)
-            } catch {
-                loadingRow?.setLoading(false)
-                self.embeddedPaymentMethodsView.resetSelectionToLastSelection()
-                _ = self.restoreAcceptedForm(
-                    from: pendingSelection.previousPaymentOption,
-                    for: pendingSelection.previousSelection
+                try await checkout.syncBillingAddress(from: pendingSelection.paymentMethod.billingDetails)
+                self.finishSelectionAfterBillingAddressSync(
+                    for: pendingSelection,
+                    loadingRow: loadingRow
                 )
-                if let restoredSelection = self.embeddedPaymentMethodsView.selectedRowButton?.type {
-                    self.updateChangeButtonAndSublabelState(for: restoredSelection)
-                }
-                self.pendingBillingAddressSyncSelection = nil
-                self.embeddedPaymentMethodsView.isUserInteractionEnabled = true
-                self.informDelegateIfPaymentOptionUpdated()
-                self.embeddedPaymentMethodsView.setError(error)
-#if !os(visionOS)
-                UINotificationFeedbackGenerator().notificationOccurred(.error)
-#endif
-                return
+            } catch {
+                self.restoreSelectionAfterBillingSyncFailure(
+                    error,
+                    pendingSelection: pendingSelection,
+                    loadingRow: loadingRow
+                )
             }
-            let didReselectPaymentMethod = self.embeddedPaymentMethodsView.selectSavedPaymentMethod(
-                withStripeId: pendingSelection.paymentMethodID
-            )
-            self.pendingBillingAddressSyncSelection = nil
-            let currentLoadingRow = self.embeddedPaymentMethodsView.selectedRowButton
-            loadingRow?.setLoading(false, animated: loadingRow === currentLoadingRow)
-            currentLoadingRow?.setLoading(false)
-            self.embeddedPaymentMethodsView.isUserInteractionEnabled = true
-            guard didReselectPaymentMethod else {
-                self.informDelegateIfPaymentOptionUpdated()
-                return
-            }
-            self.persistDefaultPaymentMethodSelection(self.embeddedPaymentMethodsView.selectedRowButton?.type)
-            self.informDelegateIfPaymentOptionUpdated()
-            self.completeImmediateRowSelectionIfNeeded()
         }
+    }
+
+    private func finishSelectionAfterBillingAddressSync(
+        for pendingSelection: PendingBillingAddressSyncSelection,
+        loadingRow: RowButton?
+    ) {
+        let didReselectPaymentMethod = embeddedPaymentMethodsView.selectSavedPaymentMethod(
+            withStripeId: pendingSelection.paymentMethod.stripeId
+        )
+        let selectedRow = embeddedPaymentMethodsView.selectedRowButton
+        loadingRow?.setLoading(false, animated: loadingRow === selectedRow)
+        selectedRow?.setLoading(false)
+        pendingBillingAddressSyncSelection = nil
+        embeddedPaymentMethodsView.isUserInteractionEnabled = true
+
+        guard didReselectPaymentMethod else {
+            informDelegateIfPaymentOptionUpdated()
+            return
+        }
+        persistDefaultPaymentMethodSelection(selectedRow?.type)
+        informDelegateIfPaymentOptionUpdated()
+        completeImmediateRowSelectionIfNeeded()
+    }
+
+    private func restoreSelectionAfterBillingSyncFailure(
+        _ error: Error,
+        pendingSelection: PendingBillingAddressSyncSelection,
+        loadingRow: RowButton?
+    ) {
+        loadingRow?.setLoading(false)
+        embeddedPaymentMethodsView.resetSelectionToLastSelection()
+        _ = restoreAcceptedForm(
+            from: pendingSelection.previousPaymentOption,
+            for: pendingSelection.previousSelection
+        )
+        if let restoredSelection = embeddedPaymentMethodsView.selectedRowButton?.type {
+            updateChangeButtonAndSublabelState(for: restoredSelection)
+        }
+        pendingBillingAddressSyncSelection = nil
+        embeddedPaymentMethodsView.isUserInteractionEnabled = true
+        informDelegateIfPaymentOptionUpdated()
+        embeddedPaymentMethodsView.setError(error)
+#if !os(visionOS)
+        UINotificationFeedbackGenerator().notificationOccurred(.error)
+#endif
     }
 
     private func completeImmediateRowSelectionIfNeeded() {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -145,16 +145,13 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
 
     func embeddedPaymentMethodsViewWillSelect(_ rowButtonType: RowButtonType) {
         guard let checkout,
-              case .saved(let paymentMethod) = rowButtonType,
-              let billingDetails = paymentMethod.billingDetails,
-              checkout.session.collectsTaxFromBillingAddress,
-              billingDetails.address?.country?.nonEmpty != nil else {
+              case .saved(let paymentMethod) = rowButtonType else {
             persistDefaultPaymentMethodSelection(rowButtonType)
             return
         }
         pendingBillingAddressSyncSelection = .init(
             paymentMethodID: paymentMethod.stripeId,
-            billingDetails: billingDetails,
+            billingDetails: paymentMethod.billingDetails,
             previousSelection: embeddedPaymentMethodsView.selectedRowButton?.type,
             previousPaymentOption: _paymentOption
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -76,7 +76,6 @@ extension EmbeddedPaymentElement {
             mandateProvider: mandateProvider,
             shouldShowMandate: configuration.embeddedViewDisplaysMandateText,
             savedPaymentMethods: loadResult.savedPaymentMethods,
-            customer: configuration.customer,
             currency: loadResult.intent.currency,
             incentive: loadResult.elementsSession.incentive,
             paymentMethodMessagingPromotionsHelper: loadResult.paymentMethodMessagingPromotionsHelper,
@@ -87,6 +86,9 @@ extension EmbeddedPaymentElement {
 
     /// Helper method to inform delegate only if the payment option changed
     func informDelegateIfPaymentOptionUpdated() {
+        // Checkout rebuilds EPE while applying the billing update. Don't publish the tapped
+        // payment method until that update finishes and the refreshed view restores its selection.
+        guard pendingBillingAddressSyncSelection == nil else { return }
         if lastUpdatedPaymentOption != paymentOption {
             delegate?.embeddedPaymentElementDidUpdatePaymentOption(embeddedPaymentElement: self)
             lastUpdatedPaymentOption = paymentOption
@@ -141,6 +143,23 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         delegate?.embeddedPaymentElementDidUpdateHeight(embeddedPaymentElement: self)
     }
 
+    func embeddedPaymentMethodsViewWillSelect(_ rowButtonType: RowButtonType) {
+        guard let checkout,
+              case .saved(let paymentMethod) = rowButtonType,
+              let billingDetails = paymentMethod.billingDetails,
+              checkout.session.collectsTaxFromBillingAddress,
+              billingDetails.address?.country?.nonEmpty != nil else {
+            persistDefaultPaymentMethodSelection(rowButtonType)
+            return
+        }
+        pendingBillingAddressSyncSelection = .init(
+            paymentMethodID: paymentMethod.stripeId,
+            billingDetails: billingDetails,
+            previousSelection: embeddedPaymentMethodsView.selectedRowButton?.type,
+            previousPaymentOption: _paymentOption
+        )
+    }
+
     func embeddedPaymentMethodsViewDidUpdateSelection() {
         // 1. Update the currently selection's form VC to match the selection.
         // Note `paymentOption` derives from this property
@@ -168,10 +187,7 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
     func embeddedPaymentMethodsViewDidTapPaymentMethodRow() {
         // 😓 Note: This method depends on `embeddedPaymentMethodsViewDidUpdateSelection` being called *before* this method is called when a row is tapped.
         guard let selectedFormViewController else {
-            // If the current selection has no form VC, simply alert the merchant of the selection if they are using immediateAction
-            if case .immediateAction(let didSelectPaymentOption) = configuration.rowSelectionBehavior {
-                didSelectPaymentOption()
-            }
+            finishSelectingPaymentMethodWithoutForm()
             return
         }
         // Present the current selection's form VC
@@ -181,6 +197,87 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         assert(presentingViewController != nil, "Presenting view controller not found, set EmbeddedPaymentElement.presentingViewController.")
         stpAssert(selectedFormViewController.delegate != nil)
         presentingViewController?.presentAsBottomSheet(bottomSheet, appearance: configuration.appearance)
+    }
+
+    private func finishSelectingPaymentMethodWithoutForm() {
+        guard let pendingSelection = pendingBillingAddressSyncSelection else {
+            completeImmediateRowSelectionIfNeeded()
+            return
+        }
+        guard let checkout else {
+            pendingBillingAddressSyncSelection = nil
+            persistDefaultPaymentMethodSelection(embeddedPaymentMethodsView.selectedRowButton?.type)
+            informDelegateIfPaymentOptionUpdated()
+            completeImmediateRowSelectionIfNeeded()
+            return
+        }
+
+        embeddedPaymentMethodsView.isUserInteractionEnabled = false
+        let loadingRow = embeddedPaymentMethodsView.selectedRowButton
+        loadingRow?.setLoading(true)
+        Task { @MainActor [weak self, weak loadingRow] in
+            guard let self else { return }
+            do {
+                try await checkout.syncBillingAddress(from: pendingSelection.billingDetails)
+            } catch {
+                loadingRow?.setLoading(false)
+                self.embeddedPaymentMethodsView.resetSelectionToLastSelection()
+                _ = self.restoreAcceptedForm(
+                    from: pendingSelection.previousPaymentOption,
+                    for: pendingSelection.previousSelection
+                )
+                if let restoredSelection = self.embeddedPaymentMethodsView.selectedRowButton?.type {
+                    self.updateChangeButtonAndSublabelState(for: restoredSelection)
+                }
+                self.pendingBillingAddressSyncSelection = nil
+                self.embeddedPaymentMethodsView.isUserInteractionEnabled = true
+                self.informDelegateIfPaymentOptionUpdated()
+                self.embeddedPaymentMethodsView.setError(error)
+#if !os(visionOS)
+                UINotificationFeedbackGenerator().notificationOccurred(.error)
+#endif
+                return
+            }
+            let didReselectPaymentMethod = self.embeddedPaymentMethodsView.selectSavedPaymentMethod(
+                withStripeId: pendingSelection.paymentMethodID
+            )
+            self.pendingBillingAddressSyncSelection = nil
+            let currentLoadingRow = self.embeddedPaymentMethodsView.selectedRowButton
+            loadingRow?.setLoading(false, animated: loadingRow === currentLoadingRow)
+            currentLoadingRow?.setLoading(false)
+            self.embeddedPaymentMethodsView.isUserInteractionEnabled = true
+            guard didReselectPaymentMethod else {
+                self.informDelegateIfPaymentOptionUpdated()
+                return
+            }
+            self.persistDefaultPaymentMethodSelection(self.embeddedPaymentMethodsView.selectedRowButton?.type)
+            self.informDelegateIfPaymentOptionUpdated()
+            self.completeImmediateRowSelectionIfNeeded()
+        }
+    }
+
+    private func completeImmediateRowSelectionIfNeeded() {
+        if case .immediateAction(let didSelectPaymentOption) = configuration.rowSelectionBehavior {
+            didSelectPaymentOption()
+        }
+    }
+
+    private func persistDefaultPaymentMethodSelection(_ rowButtonType: RowButtonType?) {
+        let paymentOption: CustomerPaymentOption
+        switch rowButtonType {
+        case .applePay:
+            paymentOption = .applePay
+        case .link:
+            paymentOption = .link
+        case .saved(let paymentMethod):
+            paymentOption = .stripeId(paymentMethod.stripeId)
+        case .new, nil:
+            return
+        }
+        CustomerPaymentOption.setDefaultPaymentMethod(
+            paymentOption,
+            forCustomer: configuration.customer?.id
+        )
     }
 
     func embeddedPaymentMethodsViewDidTapViewMoreSavedPaymentMethods(selectedSavedPaymentMethod: STPPaymentMethod?) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -15,6 +15,13 @@ import UIKit
 @MainActor
 public final class EmbeddedPaymentElement {
 
+    struct PendingBillingAddressSyncSelection {
+        let paymentMethodID: String
+        let billingDetails: STPPaymentMethodBillingDetails
+        let previousSelection: RowButtonType?
+        let previousPaymentOption: PaymentOption?
+    }
+
     /// A view that displays payment methods. It can present a sheet to collect more details or display saved payment methods.
     public var view: UIView {
         return containerView
@@ -280,6 +287,10 @@ public final class EmbeddedPaymentElement {
                 previousSelectedRowChangeButtonState: shouldSelectPreviousRow ? previousSelectedRowChangeButtonState : nil,
                 delegate: self
             )
+            if self.pendingBillingAddressSyncSelection != nil {
+                self.embeddedPaymentMethodsView.isUserInteractionEnabled = false
+                self.embeddedPaymentMethodsView.selectedRowButton?.setLoading(true, animated: false)
+            }
             self.containerView.updateEmbeddedPaymentMethodsView(embeddedPaymentMethodsView)
             informDelegateIfPaymentOptionUpdated()
             return .succeeded
@@ -299,7 +310,7 @@ public final class EmbeddedPaymentElement {
         if case .succeeded = updateResult {
             clearPaymentOptionIfNeeded()
         }
-        embeddedPaymentMethodsView.isUserInteractionEnabled = true
+        embeddedPaymentMethodsView.isUserInteractionEnabled = pendingBillingAddressSyncSelection == nil
         analyticsHelper.logEmbeddedUpdateFinished(result: updateResult, duration: Date().timeIntervalSince(startTime))
         return updateResult
     }
@@ -382,6 +393,8 @@ public final class EmbeddedPaymentElement {
     internal private(set) var formCache: PaymentMethodFormCache = .init()
     /// The form view controller for the currently selected payment method.
     internal var selectedFormViewController: EmbeddedFormViewController?
+    /// The saved payment method waiting for its billing address to sync to Checkout.
+    internal var pendingBillingAddressSyncSelection: PendingBillingAddressSyncSelection?
     /// Indicates if a payment has been successfully completed.
     internal var hasConfirmedIntent = false
     /// Tracks info about the currently in-flight or most recent update attempt.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -17,7 +17,7 @@ public final class EmbeddedPaymentElement {
 
     struct PendingBillingAddressSyncSelection {
         let paymentMethodID: String
-        let billingDetails: STPPaymentMethodBillingDetails
+        let billingDetails: STPPaymentMethodBillingDetails?
         let previousSelection: RowButtonType?
         let previousPaymentOption: PaymentOption?
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -15,13 +15,6 @@ import UIKit
 @MainActor
 public final class EmbeddedPaymentElement {
 
-    struct PendingBillingAddressSyncSelection {
-        let paymentMethodID: String
-        let billingDetails: STPPaymentMethodBillingDetails?
-        let previousSelection: RowButtonType?
-        let previousPaymentOption: PaymentOption?
-    }
-
     /// A view that displays payment methods. It can present a sheet to collect more details or display saved payment methods.
     public var view: UIView {
         return containerView
@@ -287,6 +280,7 @@ public final class EmbeddedPaymentElement {
                 previousSelectedRowChangeButtonState: shouldSelectPreviousRow ? previousSelectedRowChangeButtonState : nil,
                 delegate: self
             )
+            // Keep the rebuilt view loading while the billing sync finishes.
             if self.pendingBillingAddressSyncSelection != nil {
                 self.embeddedPaymentMethodsView.isUserInteractionEnabled = false
                 self.embeddedPaymentMethodsView.selectedRowButton?.setLoading(true, animated: false)
@@ -310,6 +304,7 @@ public final class EmbeddedPaymentElement {
         if case .succeeded = updateResult {
             clearPaymentOptionIfNeeded()
         }
+        // A billing sync may still be running when this update finishes.
         embeddedPaymentMethodsView.isUserInteractionEnabled = pendingBillingAddressSyncSelection == nil
         analyticsHelper.logEmbeddedUpdateFinished(result: updateResult, duration: Date().timeIntervalSince(startTime))
         return updateResult

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -334,6 +334,7 @@ class EmbeddedPaymentMethodsView: UIView {
         }
     }
 
+    /// Selects the saved payment method if it is still displayed.
     func selectSavedPaymentMethod(withStripeId stripeId: String) -> Bool {
         guard let rowButton = rowButtons.first(where: {
             $0.type.savedPaymentMethod?.stripeId == stripeId

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -348,7 +348,6 @@ class EmbeddedPaymentMethodsView: UIView {
 
     // MARK: Tap handling
     func didTap(rowButton: RowButton) {
-        guard isUserInteractionEnabled else { return }
         setError(nil)
         delegate?.embeddedPaymentMethodsViewWillSelect(rowButton.type)
         self.selectedRowButton = rowButton

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -103,7 +103,7 @@ class EmbeddedPaymentMethodsView: UIView {
         mandateView.directionalLayoutMargins.top = 12
         return mandateView
     }()
-    private lazy var errorLabel = ElementsUI.makeErrorLabel(theme: appearance.asElementsTheme)
+    lazy var errorLabel = ElementsUI.makeErrorLabel(theme: appearance.asElementsTheme)
     private lazy var errorContainerView: UIView = {
         let view = UIView()
         view.addAndPinSubview(
@@ -113,11 +113,6 @@ class EmbeddedPaymentMethodsView: UIView {
         view.setHiddenIfNecessary(true)
         return view
     }()
-#if DEBUG
-    var _test_displayedErrorMessage: String? {
-        return errorLabel.text
-    }
-#endif
     private var savedPaymentMethodButton: RowButton?
     private(set) var rowButtons: [RowButton]
     weak var delegate: EmbeddedPaymentMethodsViewDelegate?

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -14,6 +14,9 @@ import UIKit
 protocol EmbeddedPaymentMethodsViewDelegate: AnyObject {
     func embeddedPaymentMethodsViewDidUpdateHeight()
 
+    /// Called before the view changes its selected row.
+    func embeddedPaymentMethodsViewWillSelect(_ rowButtonType: RowButtonType)
+
     /// Called whenever a payment method row is tapped, after `didUpdateSelection`.
     func embeddedPaymentMethodsViewDidTapPaymentMethodRow()
 
@@ -38,7 +41,6 @@ class EmbeddedPaymentMethodsView: UIView {
     }
 
     private let appearance: PaymentSheet.Appearance
-    private let customer: PaymentSheet.CustomerConfiguration?
     private let currency: String?
     private let paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper?
     private(set) var previousSelectedRowButton: RowButton? {
@@ -101,6 +103,21 @@ class EmbeddedPaymentMethodsView: UIView {
         mandateView.directionalLayoutMargins.top = 12
         return mandateView
     }()
+    private lazy var errorLabel = ElementsUI.makeErrorLabel(theme: appearance.asElementsTheme)
+    private lazy var errorContainerView: UIView = {
+        let view = UIView()
+        view.addAndPinSubview(
+            errorLabel,
+            directionalLayoutMargins: .init(top: 12, leading: 0, bottom: 0, trailing: 0)
+        )
+        view.setHiddenIfNecessary(true)
+        return view
+    }()
+#if DEBUG
+    var _test_displayedErrorMessage: String? {
+        return errorLabel.text
+    }
+#endif
     private var savedPaymentMethodButton: RowButton?
     private(set) var rowButtons: [RowButton]
     weak var delegate: EmbeddedPaymentMethodsViewDelegate?
@@ -122,7 +139,6 @@ class EmbeddedPaymentMethodsView: UIView {
         mandateProvider: MandateTextProvider,
         shouldShowMandate: Bool = true,
         savedPaymentMethods: [STPPaymentMethod] = [],
-        customer: PaymentSheet.CustomerConfiguration? = nil,
         currency: String? = nil,
         incentive: PaymentMethodIncentive? = nil,
         paymentMethodMessagingPromotionsHelper: PaymentMethodMessagingPromotionsHelper? = nil,
@@ -132,7 +148,6 @@ class EmbeddedPaymentMethodsView: UIView {
         self.appearance = appearance
         self.mandateProvider = mandateProvider
         self.shouldShowMandate = shouldShowMandate
-        self.customer = customer
         self.currency = currency
         self.paymentMethodMessagingPromotionsHelper = paymentMethodMessagingPromotionsHelper
         self.analyticsHelper = analyticsHelper
@@ -165,7 +180,6 @@ class EmbeddedPaymentMethodsView: UIView {
             let applePayRowButton = RowButton.makeForApplePay(appearance: appearance,
                                                               isEmbedded: true,
                                                               didTap: { [weak self] rowButton in
-                CustomerPaymentOption.setDefaultPaymentMethod(.applePay, forCustomer: customer?.id)
                 self?.didTap(rowButton: rowButton)
             })
             rowButtons.append(applePayRowButton)
@@ -173,7 +187,6 @@ class EmbeddedPaymentMethodsView: UIView {
 
         if shouldShowLink {
             let linkRowButton = RowButton.makeForLink(appearance: appearance, linkBrand: linkBrand, isEmbedded: true) { [weak self] rowButton in
-                CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: customer?.id)
                 self?.didTap(rowButton: rowButton)
             }
             rowButtons.append(linkRowButton)
@@ -217,6 +230,7 @@ class EmbeddedPaymentMethodsView: UIView {
         // Set up mandate
         stackView.addArrangedSubview(mandateView)
         updateMandate(animated: false)
+        stackView.addArrangedSubview(errorContainerView)
 
         // Our content should respect `directionalLayoutMargins`. The default margins is `.zero`.
         addAndPinSubview(stackView, directionalLayoutMargins: .zero)
@@ -300,6 +314,34 @@ class EmbeddedPaymentMethodsView: UIView {
         selectedRowButton = nil
     }
 
+    /// Displays an error below the payment method rows, or clears it when `error` is nil.
+    func setError(_ error: Error?, animated: Bool = true) {
+        let message = error?.nonGenericDescription
+        guard message != errorLabel.text else { return }
+        errorLabel.text = message
+        let updates = {
+            self.errorContainerView.setHiddenIfNecessary(message == nil)
+            self.setNeedsLayout()
+            self.layoutIfNeeded()
+        }
+        if animated {
+            UIView.animate(withDuration: PaymentSheetUI.defaultAnimationDuration, animations: updates)
+        } else {
+            updates()
+        }
+        if message != nil {
+            UIAccessibility.post(notification: .layoutChanged, argument: errorLabel)
+        }
+    }
+
+    func selectSavedPaymentMethod(withStripeId stripeId: String) -> Bool {
+        guard let rowButton = rowButtons.first(where: {
+            $0.type.savedPaymentMethod?.stripeId == stripeId
+        }) else { return false }
+        selectedRowButton = rowButton
+        return true
+    }
+
     @objc
     func onLinkAccountChange(_ notification: Notification) {
         DispatchQueue.main.async { [weak self] in
@@ -310,6 +352,9 @@ class EmbeddedPaymentMethodsView: UIView {
 
     // MARK: Tap handling
     func didTap(rowButton: RowButton) {
+        guard isUserInteractionEnabled else { return }
+        setError(nil)
+        delegate?.embeddedPaymentMethodsViewWillSelect(rowButton.type)
         self.selectedRowButton = rowButton
         delegate?.embeddedPaymentMethodsViewDidTapPaymentMethodRow()
         analyticsHelper.logNewPaymentMethodSelected(paymentMethodTypeIdentifier: rowButton.type.analyticsIdentifier)
@@ -317,6 +362,7 @@ class EmbeddedPaymentMethodsView: UIView {
     }
 
     func didTapViewMoreSavedPaymentMethods() {
+        setError(nil)
         delegate?.embeddedPaymentMethodsViewDidTapViewMoreSavedPaymentMethods(selectedSavedPaymentMethod: selectedRowButton?.type.savedPaymentMethod)
     }
 
@@ -505,10 +551,6 @@ class EmbeddedPaymentMethodsView: UIView {
             isEmbedded: true,
             linkBrand: linkBrand,
             didTap: { [weak self] rowButton in
-                CustomerPaymentOption.setDefaultPaymentMethod(
-                    .stripeId(savedPaymentMethod.stripeId),
-                    forCustomer: self?.customer?.id
-                )
                 self?.didTap(rowButton: rowButton)
             }
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -32,10 +32,17 @@ class RowButton: UIView, EventHandler {
     let defaultBadgeLabel: UILabel?
     /// The view indicating any incentives associated with this payment method
     let promoBadge: PromoBadgeView?
+    private lazy var loadingIndicator: ActivityIndicator = {
+        let loadingIndicator = ActivityIndicator(size: .medium)
+        loadingIndicator.tintColor = appearance.colors.primary
+        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
+        return loadingIndicator
+    }()
 
     // MARK: State
 
     private(set) var isSelected: Bool = false
+    private(set) var isLoading: Bool = false
 
     /// When enabled the `didTap` closure will be called when the button is tapped. When false the `didTap` closure will not be called on taps
     var isEnabled: Bool = true {
@@ -183,9 +190,49 @@ class RowButton: UIView, EventHandler {
     }
 
     func setKeyContent(alpha: CGFloat) {
-        [imageView, label, sublabel].compactMap { $0 }.forEach {
-            $0.alpha = alpha
+        imageView.alpha = isLoading ? 0 : alpha
+        label.alpha = alpha
+        sublabel.alpha = alpha
+    }
+
+    /// Replaces the payment method icon with a spinner while work for this row is in flight.
+    func setLoading(_ loading: Bool, animated: Bool = true) {
+        guard loading != isLoading else { return }
+        isLoading = loading
+
+        if loading {
+            addSubview(loadingIndicator)
+            NSLayoutConstraint.activate([
+                loadingIndicator.centerXAnchor.constraint(equalTo: imageView.centerXAnchor),
+                loadingIndicator.centerYAnchor.constraint(equalTo: imageView.centerYAnchor),
+            ])
+            loadingIndicator.alpha = 0
+            loadingIndicator.startAnimating()
         }
+
+        let animations = { [weak self] in
+            guard let self else { return }
+            loadingIndicator.alpha = loading ? 1 : 0
+            imageView.alpha = loading ? 0 : label.alpha
+        }
+        let completion: (Bool) -> Void = { [weak self] _ in
+            guard let self, self.isLoading == loading, !loading else { return }
+            self.loadingIndicator.stopAnimating()
+            self.loadingIndicator.removeFromSuperview()
+        }
+
+        guard animated else {
+            animations()
+            completion(true)
+            return
+        }
+        UIView.animate(
+            withDuration: 0.2,
+            delay: 0,
+            options: .beginFromCurrentState,
+            animations: animations,
+            completion: completion
+        )
     }
 
     func updateSelectedState(_ isSelected: Bool, willDisplayForm: Bool) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -214,7 +214,7 @@ class RowButton: UIView, EventHandler {
             loadingIndicator.startAnimating()
         }
 
-        let animations = { [weak self] in
+        let updates = { [weak self] in
             guard let self else { return }
             loadingIndicator.alpha = loading ? 1 : 0
             imageView.alpha = loading ? 0 : keyContentAlpha
@@ -226,7 +226,7 @@ class RowButton: UIView, EventHandler {
         }
 
         guard animated else {
-            animations()
+            updates()
             completion(true)
             return
         }
@@ -234,7 +234,7 @@ class RowButton: UIView, EventHandler {
             withDuration: 0.2,
             delay: 0,
             options: .beginFromCurrentState,
-            animations: animations,
+            animations: updates,
             completion: completion
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -43,6 +43,7 @@ class RowButton: UIView, EventHandler {
 
     private(set) var isSelected: Bool = false
     private(set) var isLoading: Bool = false
+    private var keyContentAlpha: CGFloat = 1
 
     /// When enabled the `didTap` closure will be called when the button is tapped. When false the `didTap` closure will not be called on taps
     var isEnabled: Bool = true {
@@ -190,6 +191,7 @@ class RowButton: UIView, EventHandler {
     }
 
     func setKeyContent(alpha: CGFloat) {
+        keyContentAlpha = alpha
         imageView.alpha = isLoading ? 0 : alpha
         label.alpha = alpha
         sublabel.alpha = alpha
@@ -201,11 +203,13 @@ class RowButton: UIView, EventHandler {
         isLoading = loading
 
         if loading {
-            addSubview(loadingIndicator)
-            NSLayoutConstraint.activate([
-                loadingIndicator.centerXAnchor.constraint(equalTo: imageView.centerXAnchor),
-                loadingIndicator.centerYAnchor.constraint(equalTo: imageView.centerYAnchor),
-            ])
+            if loadingIndicator.superview == nil {
+                addSubview(loadingIndicator)
+                NSLayoutConstraint.activate([
+                    loadingIndicator.centerXAnchor.constraint(equalTo: imageView.centerXAnchor),
+                    loadingIndicator.centerYAnchor.constraint(equalTo: imageView.centerYAnchor),
+                ])
+            }
             loadingIndicator.alpha = 0
             loadingIndicator.startAnimating()
         }
@@ -213,7 +217,7 @@ class RowButton: UIView, EventHandler {
         let animations = { [weak self] in
             guard let self else { return }
             loadingIndicator.alpha = loading ? 1 : 0
-            imageView.alpha = loading ? 0 : label.alpha
+            imageView.alpha = loading ? 0 : keyContentAlpha
         }
         let completion: (Bool) -> Void = { [weak self] _ in
             guard let self, self.isLoading == loading, !loading else { return }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -239,7 +239,7 @@ enum CheckoutTestHelpers {
         requestRecorder: CheckoutSessionRequestRecorder,
         sessionJSON: @escaping () -> [AnyHashable: Any],
         initStatusCode: Int32 = 200,
-        updateStatusCode: @escaping () -> Int32 = { 200 }
+        updateStatusCode: @escaping (_ requestNumber: Int) -> Int32 = { _ in 200 }
     ) {
         stub { request in
             request.url?.path == "/v1/payment_pages/\(sessionId)/init"
@@ -262,7 +262,12 @@ enum CheckoutTestHelpers {
                     params: RequestBodyTestHelpers.formEncodedBodyParams(from: request)
                 )
             )
-            return HTTPStubsResponse(jsonObject: sessionJSON(), statusCode: updateStatusCode(), headers: nil)
+            let updateRequestNumber = requestRecorder.requests.filter { $0.kind == .updateSession }.count
+            return HTTPStubsResponse(
+                jsonObject: sessionJSON(),
+                statusCode: updateStatusCode(updateRequestNumber),
+                headers: nil
+            )
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -239,7 +239,7 @@ enum CheckoutTestHelpers {
         requestRecorder: CheckoutSessionRequestRecorder,
         sessionJSON: @escaping () -> [AnyHashable: Any],
         initStatusCode: Int32 = 200,
-        updateStatusCode: Int32 = 200
+        updateStatusCode: @escaping () -> Int32 = { 200 }
     ) {
         stub { request in
             request.url?.path == "/v1/payment_pages/\(sessionId)/init"
@@ -262,7 +262,7 @@ enum CheckoutTestHelpers {
                     params: RequestBodyTestHelpers.formEncodedBodyParams(from: request)
                 )
             )
-            return HTTPStubsResponse(jsonObject: sessionJSON(), statusCode: updateStatusCode, headers: nil)
+            return HTTPStubsResponse(jsonObject: sessionJSON(), statusCode: updateStatusCode(), headers: nil)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -239,7 +239,7 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertTrue(currentEmbeddedView.isUserInteractionEnabled)
         XCTAssertEqual(currentEmbeddedView.selectedRowButton?.type.savedPaymentMethod?.stripeId, paymentMethodID)
         let requests = requestRecorder.requests
-        XCTAssertEqual(requests.map(\.kind), [.initSession, .updateSession])
+        XCTAssertEqual(requests.map(\.kind), [.initSession, .updateSession, .updateSession])
         XCTAssertEqual(try XCTUnwrap(requests.last).params["tax_region[country]"], "US")
     }
 
@@ -372,7 +372,13 @@ final class PaymentElementTest: XCTestCase {
             paymentMethodTypes: paymentMethodTypes,
             customerSessionData: [:],
             paymentMethods: [
-                STPPaymentMethod._testCard(countryCode: "US").allResponseFields,
+                STPPaymentMethod._testCard(
+                    line1: "123 Main St",
+                    city: "San Francisco",
+                    state: "CA",
+                    postalCode: "94105",
+                    countryCode: "US"
+                ).allResponseFields,
             ]
         )
         var sessionJSON = Self.openSessionJSON(paymentMethodTypes: paymentMethodTypes)
@@ -385,7 +391,11 @@ final class PaymentElementTest: XCTestCase {
             sessionId: "cs_test_123",
             requestRecorder: requestRecorder,
             sessionJSON: { sessionJSON },
-            updateStatusCode: updateStatusCode
+            updateStatusCode: {
+                // Checkout syncs the initially selected card during setup. Only fail the re-selection.
+                let updateCount = requestRecorder.requests.filter { $0.kind == .updateSession }.count
+                return updateCount == 1 ? 200 : updateStatusCode
+            }
         )
 
         var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -391,10 +391,9 @@ final class PaymentElementTest: XCTestCase {
             sessionId: "cs_test_123",
             requestRecorder: requestRecorder,
             sessionJSON: { sessionJSON },
-            updateStatusCode: {
+            updateStatusCode: { updateRequestNumber in
                 // Checkout syncs the initially selected card during setup. Only fail the re-selection.
-                let updateCount = requestRecorder.requests.filter { $0.kind == .updateSession }.count
-                return updateCount == 1 ? 200 : updateStatusCode
+                return updateRequestNumber == 1 ? 200 : updateStatusCode
             }
         )
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -31,6 +31,7 @@ final class PaymentElementTest: XCTestCase {
 
     override func tearDown() {
         HTTPStubs.removeAllStubs()
+        CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: nil)
         super.tearDown()
     }
 
@@ -357,7 +358,6 @@ final class PaymentElementTest: XCTestCase {
     }
 
     private func makeSavedPaymentMethodSelectionFixture(
-        automaticTaxFromBilling: Bool = true,
         paymentMethodTypes: [String] = ["card"],
         updateStatusCode: Int32 = 200,
         didSelectPaymentOption: @escaping () -> Void
@@ -368,22 +368,27 @@ final class PaymentElementTest: XCTestCase {
         requestRecorder: CheckoutSessionRequestRecorder
     ) {
         let requestRecorder = CheckoutSessionRequestRecorder()
-        let sessionJSON = Self.openSessionJSONWithSavedPaymentMethod(
-            automaticTaxFromBilling: automaticTaxFromBilling,
-            paymentMethodTypes: paymentMethodTypes
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: paymentMethodTypes,
+            customerSessionData: [:],
+            paymentMethods: [
+                STPPaymentMethod._testCard(countryCode: "US").allResponseFields,
+            ]
         )
+        var sessionJSON = Self.openSessionJSON(paymentMethodTypes: paymentMethodTypes)
+        sessionJSON["elements_session"] = elementsSession.allResponseFields
+        sessionJSON["tax_context"] = [
+            "automatic_tax_enabled": true,
+            "automatic_tax_address_source": "session.billing",
+        ]
         CheckoutTestHelpers.stubCheckoutSessionRequests(
             sessionId: "cs_test_123",
             requestRecorder: requestRecorder,
             sessionJSON: { sessionJSON },
             updateStatusCode: updateStatusCode
         )
-        CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: nil)
 
-        var configuration = Checkout.Configuration(
-            clientSecret: "cs_test_123_secret_abc",
-            returnURL: "stripe-ios-test://checkout-return"
-        )
+        var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
         configuration.apiClient = STPAPIClient(publishableKey: "pk_test_123")
         configuration.paymentElement.rowSelectionBehavior = .immediateAction(
             didSelectPaymentOption: didSelectPaymentOption
@@ -399,37 +404,6 @@ final class PaymentElementTest: XCTestCase {
         embeddedPaymentElement.clearPaymentOption()
 
         return (checkout, embeddedPaymentElement, savedPaymentMethodRow, requestRecorder)
-    }
-
-    private static func openSessionJSONWithSavedPaymentMethod(
-        automaticTaxFromBilling: Bool,
-        paymentMethodTypes: [String]
-    ) -> [AnyHashable: Any] {
-        var savedPaymentMethod = STPPaymentMethod._testCardJSON
-        savedPaymentMethod["billing_details"] = [
-            "address": [
-                "country": "US",
-                "line1": "123 Main St",
-                "city": "San Francisco",
-                "state": "CA",
-                "postal_code": "94105",
-            ],
-        ]
-
-        let elementsSession = STPElementsSession._testValue(
-            paymentMethodTypes: paymentMethodTypes,
-            customerSessionData: [:],
-            paymentMethods: [savedPaymentMethod]
-        )
-        var json = openSessionJSON(paymentMethodTypes: paymentMethodTypes)
-        json["elements_session"] = elementsSession.allResponseFields
-        if automaticTaxFromBilling {
-            json["tax_context"] = [
-                "automatic_tax_enabled": true,
-                "automatic_tax_address_source": "session.billing",
-            ]
-        }
-        return json
     }
 
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -7,6 +7,7 @@
 
 import OHHTTPStubs
 @testable @_spi(STP) import StripeCore
+@testable @_spi(STP) import StripeCoreTestUtils
 @testable @_spi(STP) import StripePayments
 @testable @_spi(STP) import StripePaymentSheet
 @testable @_spi(STP) import StripePaymentsTestUtils
@@ -15,6 +16,12 @@ import XCTest
 
 @MainActor
 final class PaymentElementTest: XCTestCase {
+
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+        CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: nil)
+        super.tearDown()
+    }
 
     override func setUp() {
         super.setUp()
@@ -211,6 +218,101 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertEqual(checkout.session.paymentOption?.paymentMethodType, "paynow")
     }
 
+    func testSelectingSavedPaymentMethodInEmbeddedViewSyncsBillingAddress() async throws {
+        // Given an unselected saved payment method and a Checkout Session using billing address for automatic tax
+        let didSelectPaymentOption = expectation(description: "Saved payment method selection completes")
+        let (checkout, embeddedPaymentElement, savedPaymentMethodRow, requestRecorder) =
+            try await makeSavedPaymentMethodSelectionFixture(
+            didSelectPaymentOption: {
+                didSelectPaymentOption.fulfill()
+            }
+        )
+        let embeddedView = embeddedPaymentElement.embeddedPaymentMethodsView
+        let paymentMethodID = try XCTUnwrap(savedPaymentMethodRow.type.savedPaymentMethod?.stripeId)
+
+        // When the customer selects the saved payment method directly, without opening a sheet
+        embeddedView.didTap(rowButton: savedPaymentMethodRow)
+
+        // Then the row shows a loader and Checkout keeps the previous selection while billing syncs
+        XCTAssertTrue(savedPaymentMethodRow.isLoading)
+        XCTAssertNil(checkout.session.paymentOption)
+        await fulfillment(of: [didSelectPaymentOption])
+
+        // ...and the billing country is synced before selection completes
+        XCTAssertFalse(savedPaymentMethodRow.isLoading)
+        let currentEmbeddedView = embeddedPaymentElement.embeddedPaymentMethodsView
+        XCTAssertTrue(currentEmbeddedView.isUserInteractionEnabled)
+        XCTAssertEqual(currentEmbeddedView.selectedRowButton?.type.savedPaymentMethod?.stripeId, paymentMethodID)
+        let requests = requestRecorder.requests
+        XCTAssertEqual(requests.map(\.kind), [.initSession, .updateSession])
+        XCTAssertEqual(try XCTUnwrap(requests.last).params["tax_region[country]"], "US")
+    }
+
+    func testSelectingSavedPaymentMethodInEmbeddedViewWithoutBillingTaxCompletesSynchronously() async throws {
+        // Given a Checkout Session that doesn't calculate tax from billing address
+        var didSelectPaymentOption = false
+        let (_, embeddedPaymentElement, savedPaymentMethodRow, requestRecorder) =
+            try await makeSavedPaymentMethodSelectionFixture(
+            automaticTaxFromBilling: false,
+            didSelectPaymentOption: {
+                didSelectPaymentOption = true
+            }
+        )
+
+        // When the customer selects a saved payment method
+        embeddedPaymentElement.embeddedPaymentMethodsView.didTap(rowButton: savedPaymentMethodRow)
+
+        // Then selection completes synchronously without an unnecessary update
+        XCTAssertTrue(didSelectPaymentOption)
+        XCTAssertEqual(requestRecorder.requests.map(\.kind), [.initSession])
+        let savedPaymentMethod = try XCTUnwrap(savedPaymentMethodRow.type.savedPaymentMethod)
+        XCTAssertEqual(
+            CustomerPaymentOption.localDefaultPaymentMethod(for: nil),
+            .stripeId(savedPaymentMethod.stripeId)
+        )
+    }
+
+    func testSelectingSavedPaymentMethodInEmbeddedViewRevertsSelectionAndDisplaysBillingSyncError() async throws {
+        // Given PayNow is selected and the Checkout billing address update will fail
+        var didSelectPaymentOption = false
+        let (checkout, embeddedPaymentElement, savedPaymentMethodRow, _) =
+            try await makeSavedPaymentMethodSelectionFixture(
+            paymentMethodTypes: ["card", "paynow"],
+            updateStatusCode: 500,
+            didSelectPaymentOption: {
+                didSelectPaymentOption = true
+            }
+        )
+        let embeddedView = embeddedPaymentElement.embeddedPaymentMethodsView
+        let payNowRow = try XCTUnwrap(
+            embeddedView.rowButtons.first {
+                $0.type == .new(paymentMethodType: .stripe(.paynow))
+            }
+        )
+        embeddedPaymentElement.presentingViewController = UIViewController()
+        embeddedView.didTap(rowButton: payNowRow)
+        embeddedPaymentElement._test_paymentOption = .new(
+            confirmParams: IntentConfirmParams(type: .stripe(.paynow))
+        )
+        embeddedPaymentElement.informDelegateIfPaymentOptionUpdated()
+
+        // When the customer selects a saved payment method
+        let errorExpectation = notNullExpectation(for: embeddedView, keyPath: \._test_displayedErrorMessage)
+        embeddedView.didTap(rowButton: savedPaymentMethodRow)
+        await fulfillment(of: [errorExpectation])
+
+        // Then the previous selection is restored and the error is displayed under EPE
+        XCTAssertFalse(didSelectPaymentOption)
+        XCTAssertFalse(savedPaymentMethodRow.isLoading)
+        XCTAssertTrue(embeddedView.isUserInteractionEnabled)
+        XCTAssertEqual(
+            embeddedView.selectedRowButton?.type,
+            .new(paymentMethodType: .stripe(.paynow))
+        )
+        XCTAssertEqual(checkout.session.paymentOption?.paymentMethodType, "paynow")
+        XCTAssertFalse(try XCTUnwrap(embeddedView._test_displayedErrorMessage).isEmpty)
+    }
+
     func testCheckoutAndElementsDoNotRetainEachOther() async throws {
         weak var weakCheckout: Checkout?
         weak var weakPaymentElement: PaymentElement?
@@ -283,4 +385,78 @@ final class PaymentElementTest: XCTestCase {
         ]
         return json
     }
+
+    private func makeSavedPaymentMethodSelectionFixture(
+        automaticTaxFromBilling: Bool = true,
+        paymentMethodTypes: [String] = ["card"],
+        updateStatusCode: Int32 = 200,
+        didSelectPaymentOption: @escaping () -> Void
+    ) async throws -> (
+        checkout: Checkout,
+        embeddedPaymentElement: EmbeddedPaymentElement,
+        savedPaymentMethodRow: RowButton,
+        requestRecorder: CheckoutSessionRequestRecorder
+    ) {
+        let requestRecorder = CheckoutSessionRequestRecorder()
+        let sessionJSON = Self.openSessionJSONWithSavedPaymentMethod(
+            automaticTaxFromBilling: automaticTaxFromBilling,
+            paymentMethodTypes: paymentMethodTypes
+        )
+        CheckoutTestHelpers.stubCheckoutSessionRequests(
+            sessionId: "cs_test_123",
+            requestRecorder: requestRecorder,
+            sessionJSON: { sessionJSON },
+            updateStatusCode: updateStatusCode
+        )
+        CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: nil)
+
+        var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
+        configuration.apiClient = STPAPIClient(publishableKey: "pk_test_123")
+        configuration.paymentElement.rowSelectionBehavior = .immediateAction(
+            didSelectPaymentOption: didSelectPaymentOption
+        )
+
+        let checkout = try await Checkout(configuration: configuration)
+        let embeddedPaymentElement = checkout.getPaymentElement().embeddedPaymentElement
+        let savedPaymentMethodRow = try XCTUnwrap(
+            embeddedPaymentElement.embeddedPaymentMethodsView.rowButtons.first {
+                $0.type.isSaved
+            }
+        )
+        embeddedPaymentElement.clearPaymentOption()
+
+        return (checkout, embeddedPaymentElement, savedPaymentMethodRow, requestRecorder)
+    }
+
+    private static func openSessionJSONWithSavedPaymentMethod(
+        automaticTaxFromBilling: Bool,
+        paymentMethodTypes: [String]
+    ) -> [AnyHashable: Any] {
+        var savedPaymentMethod = STPPaymentMethod._testCardJSON
+        savedPaymentMethod["billing_details"] = [
+            "address": [
+                "country": "US",
+                "line1": "123 Main St",
+                "city": "San Francisco",
+                "state": "CA",
+                "postal_code": "94105",
+            ],
+        ]
+
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: paymentMethodTypes,
+            customerSessionData: [:],
+            paymentMethods: [savedPaymentMethod]
+        )
+        var json = openSessionJSON(paymentMethodTypes: paymentMethodTypes)
+        json["elements_session"] = elementsSession.allResponseFields
+        if automaticTaxFromBilling {
+            json["tax_context"] = [
+                "automatic_tax_enabled": true,
+                "automatic_tax_address_source": "session.billing",
+            ]
+        }
+        return json
+    }
+
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -268,7 +268,7 @@ final class PaymentElementTest: XCTestCase {
         embeddedPaymentElement.informDelegateIfPaymentOptionUpdated()
 
         // When the customer selects a saved payment method
-        let errorExpectation = notNullExpectation(for: embeddedView, keyPath: \._test_displayedErrorMessage)
+        let errorExpectation = notNullExpectation(for: embeddedView, keyPath: \.errorLabel.text)
         embeddedView.didTap(rowButton: savedPaymentMethodRow)
         await fulfillment(of: [errorExpectation])
 
@@ -281,7 +281,7 @@ final class PaymentElementTest: XCTestCase {
             .new(paymentMethodType: .stripe(.paynow))
         )
         XCTAssertEqual(checkout.session.paymentOption?.paymentMethodType, "paynow")
-        XCTAssertFalse(try XCTUnwrap(embeddedView._test_displayedErrorMessage).isEmpty)
+        XCTAssertFalse(try XCTUnwrap(embeddedView.errorLabel.text).isEmpty)
     }
 
     func testCheckoutAndElementsDoNotRetainEachOther() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -388,7 +388,7 @@ final class PaymentElementTest: XCTestCase {
             updateStatusCode: updateStatusCode
         )
 
-        var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
+        var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
         configuration.apiClient = STPAPIClient(publishableKey: "pk_test_123")
         configuration.paymentElement.rowSelectionBehavior = .immediateAction(
             didSelectPaymentOption: didSelectPaymentOption

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -17,12 +17,6 @@ import XCTest
 @MainActor
 final class PaymentElementTest: XCTestCase {
 
-    override func tearDown() {
-        HTTPStubs.removeAllStubs()
-        CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: nil)
-        super.tearDown()
-    }
-
     override func setUp() {
         super.setUp()
         let expectation = expectation(description: "Load specs")
@@ -248,30 +242,6 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertEqual(try XCTUnwrap(requests.last).params["tax_region[country]"], "US")
     }
 
-    func testSelectingSavedPaymentMethodInEmbeddedViewWithoutBillingTaxCompletesSynchronously() async throws {
-        // Given a Checkout Session that doesn't calculate tax from billing address
-        var didSelectPaymentOption = false
-        let (_, embeddedPaymentElement, savedPaymentMethodRow, requestRecorder) =
-            try await makeSavedPaymentMethodSelectionFixture(
-            automaticTaxFromBilling: false,
-            didSelectPaymentOption: {
-                didSelectPaymentOption = true
-            }
-        )
-
-        // When the customer selects a saved payment method
-        embeddedPaymentElement.embeddedPaymentMethodsView.didTap(rowButton: savedPaymentMethodRow)
-
-        // Then selection completes synchronously without an unnecessary update
-        XCTAssertTrue(didSelectPaymentOption)
-        XCTAssertEqual(requestRecorder.requests.map(\.kind), [.initSession])
-        let savedPaymentMethod = try XCTUnwrap(savedPaymentMethodRow.type.savedPaymentMethod)
-        XCTAssertEqual(
-            CustomerPaymentOption.localDefaultPaymentMethod(for: nil),
-            .stripeId(savedPaymentMethod.stripeId)
-        )
-    }
-
     func testSelectingSavedPaymentMethodInEmbeddedViewRevertsSelectionAndDisplaysBillingSyncError() async throws {
         // Given PayNow is selected and the Checkout billing address update will fail
         var didSelectPaymentOption = false
@@ -410,7 +380,10 @@ final class PaymentElementTest: XCTestCase {
         )
         CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: nil)
 
-        var configuration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc")
+        var configuration = Checkout.Configuration(
+            clientSecret: "cs_test_123_secret_abc",
+            returnURL: "stripe-ios-test://checkout-return"
+        )
         configuration.apiClient = STPAPIClient(publishableKey: "pk_test_123")
         configuration.paymentElement.rowSelectionBehavior = .immediateAction(
             didSelectPaymentOption: didSelectPaymentOption

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewSnapshotTests.swift
@@ -1473,7 +1473,6 @@ extension EmbeddedPaymentMethodsView {
         mandateProvider: MandateTextProvider = MockMandateProvider(),
         shouldShowMandate: Bool = true,
         savedPaymentMethods: [STPPaymentMethod] = [],
-        customer: PaymentSheet.CustomerConfiguration? = nil,
         incentive: PaymentMethodIncentive? = nil,
         delegate: EmbeddedPaymentMethodsViewDelegate? = nil
     ) {
@@ -1489,7 +1488,6 @@ extension EmbeddedPaymentMethodsView {
             mandateProvider: mandateProvider,
             shouldShowMandate: shouldShowMandate,
             savedPaymentMethods: savedPaymentMethods,
-            customer: customer,
             incentive: incentive,
             analyticsHelper: ._testValue(),
             delegate: nil

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
@@ -152,6 +152,28 @@ final class EmbeddedPaymentMethodsViewTests: XCTestCase {
         XCTAssertEqual(embeddedView.mandateText?.string, expectedPayPal)
     }
 
+    func testTappingPaymentMethodClearsError() {
+        let embeddedView = EmbeddedPaymentMethodsView(
+            paymentMethodTypes: [.stripe(.card)],
+            shouldShowApplePay: false,
+            shouldShowLink: false
+        )
+        embeddedView.autosizeHeight(width: 300)
+        let initialHeight = embeddedView.bounds.height
+
+        embeddedView.setError(
+            NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "Error"]),
+            animated: false
+        )
+        embeddedView.autosizeHeight(width: 300)
+        XCTAssertNotNil(embeddedView._test_displayedErrorMessage)
+        XCTAssertGreaterThan(embeddedView.bounds.height, initialHeight)
+
+        embeddedView.didTap(rowButton: embeddedView.getRowButton(accessibilityIdentifier: "Card"))
+        embeddedView.autosizeHeight(width: 300)
+        XCTAssertNil(embeddedView._test_displayedErrorMessage)
+        XCTAssertEqual(embeddedView.bounds.height, initialHeight)
+    }
 }
 
 private class MockEmbeddedPaymentMethodsViewDelegate: EmbeddedPaymentMethodsViewDelegate {
@@ -168,6 +190,8 @@ private class MockEmbeddedPaymentMethodsViewDelegate: EmbeddedPaymentMethodsView
     func embeddedPaymentMethodsViewDidUpdateHeight() {
         calls.append(.didUpdateHeight)
     }
+
+    func embeddedPaymentMethodsViewWillSelect(_ rowButtonType: RowButtonType) {}
 
     func embeddedPaymentMethodsViewDidTapPaymentMethodRow() {
         calls.append(.didTapPaymentMethodRow)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentMethodsViewTests.swift
@@ -166,12 +166,12 @@ final class EmbeddedPaymentMethodsViewTests: XCTestCase {
             animated: false
         )
         embeddedView.autosizeHeight(width: 300)
-        XCTAssertNotNil(embeddedView._test_displayedErrorMessage)
+        XCTAssertNotNil(embeddedView.errorLabel.text)
         XCTAssertGreaterThan(embeddedView.bounds.height, initialHeight)
 
         embeddedView.didTap(rowButton: embeddedView.getRowButton(accessibilityIdentifier: "Card"))
         embeddedView.autosizeHeight(width: 300)
-        XCTAssertNil(embeddedView._test_displayedErrorMessage)
+        XCTAssertNil(embeddedView.errorLabel.text)
         XCTAssertEqual(embeddedView.bounds.height, initialHeight)
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/RowButtonTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/RowButtonTests.swift
@@ -9,6 +9,20 @@ import XCTest
 @_spi(STP) @testable import StripePaymentSheet
 
 final class RowButtonTests: XCTestCase {
+    func testLoadingStatePreservesKeyContentAlpha() {
+        let rowButton = SavedPaymentMethodRowButton(
+            paymentMethod: STPPaymentMethod._testCard(),
+            appearance: .default
+        ).rowButton
+        rowButton.setKeyContent(alpha: 0.5)
+
+        rowButton.setLoading(true, animated: false)
+        XCTAssertEqual(rowButton.imageView.alpha, 0)
+
+        rowButton.setLoading(false, animated: false)
+        XCTAssertEqual(rowButton.imageView.alpha, 0.5)
+    }
+
     func testRowButtonForPaymentMethodType_usesPaymentMethodMessagingSublabelWhenInTreatment() {
         let promotionsHelper = PaymentMethodMessagingPromotionsHelper._testValueInTreatment()
         let rowButton = RowButton.makeForPaymentMethodType(


### PR DESCRIPTION
## Summary

Tapping a saved payment method in EPE now updates the Checkout session's billing address to match, so tax/totals stay correct without waiting for confirm. Row shows a loading state while it syncs, and reverts to the previous selection with an error if the sync fails.

### Demo happy path


https://github.com/user-attachments/assets/137219b2-d6db-4747-aa00-9a42810b6332




### Demo error path then recovery

https://github.com/user-attachments/assets/6c96797a-5142-4d63-ab9f-68d1257c1e6e



## Motivation

Embedded

## Testing

- New unit tests
- Manual

## Changelog

N/A