### PR TITLE
Add checkout session id to currency selector analytics

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Currency Selector Element/CurrencySelectorElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Currency Selector Element/CurrencySelectorElement.swift
@@ -52,7 +52,7 @@ public final class CurrencySelectorElement {
         STPAnalyticsClient.sharedClient.log(
             analytic: PaymentSheetAnalytic(
                 event: .adaptivePricingCurrencySelectorInit,
-                additionalParams: [:],
+                additionalParams: ["checkout_session_id": sessionSource.initialSession.id],
             )
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Currency Selector Element/CurrencySelectorElementUIView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Currency Selector Element/CurrencySelectorElementUIView.swift
@@ -25,6 +25,7 @@ public final class CurrencySelectorElementUIView: UIView {
 
     private weak var delegate: CurrencySelectorElementDelegate?
     private let appearance: CurrencySelectorElement.Appearance
+    private let checkoutSessionId: String
     private let flagImageManager = AdaptivePricingFlagImageManager()
     private var selectorView: TwoOptionSelectorView?
     private var lastSelectedCurrency: String?
@@ -45,6 +46,7 @@ public final class CurrencySelectorElementUIView: UIView {
     ) async {
         self.delegate = delegate
         self.appearance = appearance
+        self.checkoutSessionId = session.id
         super.init(frame: .zero)
 
         await flagImageManager.prefetchFlagImages(for: session)
@@ -204,7 +206,7 @@ extension CurrencySelectorElementUIView: TwoOptionSelectorViewDelegate {
                 STPAnalyticsClient.sharedClient.log(
                     analytic: PaymentSheetAnalytic(
                         event: .adaptivePricingCurrencyToggled,
-                        additionalParams: [:]
+                        additionalParams: ["checkout_session_id": checkoutSessionId]
                     )
                 )
             } catch {
@@ -216,7 +218,9 @@ extension CurrencySelectorElementUIView: TwoOptionSelectorViewDelegate {
                 STPAnalyticsClient.sharedClient.log(
                     analytic: PaymentSheetAnalytic(
                         event: .adaptivePricingCurrencyToggledFailed,
-                        additionalParams: error.serializeForV1Analytics()
+                        additionalParams: error.serializeForV1Analytics().merging(
+                            ["checkout_session_id": checkoutSessionId]
+                        ) { _, checkoutSessionId in checkoutSessionId }
                     )
                 )
                 showError(error.localizedDescription)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -71,6 +71,7 @@ final class CheckoutUnitTests: XCTestCase {
 
         let events = currencySelectorInitEvents(in: analyticsClient)
         XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(events.first?["checkout_session_id"] as? String, "cs_test_123")
     }
 
     func testSessionPaymentOptionUpdatesAndClears() async throws {


### PR DESCRIPTION
## Summary
Adds the checkout session id to the adaptive pricing currency selector's init, toggled, and toggled-failed analytics events so we can tie them back to a specific session.

## Motivation
Analytics

## Testing
- Existing tests updated

## Changelog
N/A