### PR TITLE
Update Checkout Playground for unified mode

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
@@ -15,7 +15,6 @@ struct CheckoutCartContentView: View {
     @Binding var isLoading: Bool
     @Binding var errorMessage: String?
 
-    @State private var promoCodeInput = ""
     @State private var showShippingAddressSheet = false
     @State private var shippingAddressDetails: AddressElement.AddressDetails?
 
@@ -35,7 +34,6 @@ struct CheckoutCartContentView: View {
                 if showsShippingAddressSection {
                     shippingAddressSection
                 }
-                promotionCodeSection
                 orderSummarySection
 
                 Spacer().frame(height: 160)
@@ -233,81 +231,6 @@ struct CheckoutCartContentView: View {
     }
 
     @ViewBuilder
-    private var promotionCodeSection: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Promotion Code")
-                .font(.title2).bold()
-                .padding(.horizontal)
-
-            VStack {
-                if let appliedCode = appliedPromotionCode {
-                    HStack {
-                        Image(systemName: "tag.fill")
-                            .foregroundColor(.green)
-                        Text(appliedCode)
-                            .font(.headline)
-                            .foregroundColor(.green)
-                        Spacer()
-                        Button("Remove") {
-                            removePromotionCode()
-                        }
-                        .foregroundColor(.red)
-                        .font(.subheadline)
-                    }
-                    .padding()
-                    .background(Color.green.opacity(0.1))
-                    .cornerRadius(12)
-                } else {
-                    VStack(alignment: .leading, spacing: 12) {
-                        HStack {
-                            Image(systemName: "tag")
-                                .foregroundColor(.secondary)
-                            TextField("Enter code", text: $promoCodeInput)
-                                .autocapitalization(.allCharacters)
-                                .font(.body)
-                            Spacer()
-                            Button("Apply") {
-                                applyPromotionCode(promoCodeInput)
-                            }
-                            .foregroundColor(.blue)
-                            .font(.headline)
-                            .disabled(promoCodeInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                        }
-                        .padding()
-                        .background(Color(UIColor.systemBackground))
-                        .cornerRadius(16)
-                        .shadow(color: Color.black.opacity(0.05), radius: 8, x: 0, y: 4)
-
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: 8) {
-                                Button(action: { applyPromotionCode("IOSVIP25") }) {
-                                    Text("25% off")
-                                        .font(.caption).bold()
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 6)
-                                        .background(Color.blue.opacity(0.1))
-                                        .foregroundColor(.blue)
-                                        .cornerRadius(12)
-                                }
-                                Button(action: { applyPromotionCode("IOSWELCOME10") }) {
-                                    Text("10% off")
-                                        .font(.caption).bold()
-                                        .padding(.horizontal, 12)
-                                        .padding(.vertical, 6)
-                                        .background(Color.blue.opacity(0.1))
-                                        .foregroundColor(.blue)
-                                        .cornerRadius(12)
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-            .padding(.horizontal)
-        }
-    }
-
-    @ViewBuilder
     private var currencySelectorSection: some View {
         if let currencySelectorElement = checkout.getCurrencySelectorElement() {
             currencySelectorElement.view
@@ -383,26 +306,6 @@ struct CheckoutCartContentView: View {
         }
     }
 
-    private var appliedPromotionCode: String? {
-        checkout.session.discountAmounts.first(where: { $0.promotionCode != nil })?.promotionCode
-    }
-
-    // MARK: - Actions
-
-    private func applyPromotionCode(_ code: String) {
-        Task {
-            isLoading = true
-            errorMessage = nil
-            do {
-                try await checkout.applyPromotionCode(code)
-                promoCodeInput = ""
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-            isLoading = false
-        }
-    }
-
     private func checkoutAddress(from details: AddressElement.AddressDetails.Address) -> Checkout.Address {
         let line1 = details.line1.isEmpty ? nil : details.line1
         return Checkout.Address(
@@ -442,18 +345,6 @@ struct CheckoutCartContentView: View {
         }
     }
 
-    private func removePromotionCode() {
-        Task {
-            isLoading = true
-            errorMessage = nil
-            do {
-                try await checkout.removePromotionCode()
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-            isLoading = false
-        }
-    }
 }
 
 struct CheckoutCartSheet: View {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
@@ -158,9 +158,7 @@ struct CheckoutPlaygroundFeaturesSection: View {
     let customerType: CheckoutPlayground.CustomerType
     @Binding var shippingAddressCollection: Bool
     @Binding var billingAddressCollection: CheckoutPlayground.BillingAddressCollection
-    @Binding var allowPromotionCodes: Bool
     @Binding var automaticTax: Bool
-    @Binding var adaptivePricing: Bool
     @Binding var checkoutSessionPaymentMethodSave: Bool
     @Binding var checkoutSessionPaymentMethodRemove: Bool
     @Binding var adaptivePricingCountry: CheckoutPlayground.AdaptivePricingCountry
@@ -190,11 +188,6 @@ struct CheckoutPlaygroundFeaturesSection: View {
                     isOn: $automaticPaymentMethods,
                     tooltip: "Sends `automatic_payment_methods: true` instead of an explicit `payment_method_types` array. Stripe selects the best payment methods for the session."
                 )
-                CheckoutPlayground.ToggleRow(
-                    title: "Allow Promo Codes",
-                    isOn: $allowPromotionCodes,
-                    tooltip: "Sets `allow_promotion_codes: true`. Adds a coupon code input field to the checkout page."
-                )
                 if shouldShowAutomaticTax {
                     CheckoutPlayground.ToggleRow(
                         title: "Automatic Tax",
@@ -202,11 +195,6 @@ struct CheckoutPlaygroundFeaturesSection: View {
                         tooltip: "Sets `automatic_tax: { enabled: true }`. Enables Stripe Tax for automatic tax calculation based on shipping/billing address. Prices must use `tax_behavior: 'exclusive'` or `'inclusive'`."
                     )
                 }
-                CheckoutPlayground.ToggleRow(
-                    title: "Adaptive Pricing",
-                    isOn: $adaptivePricing,
-                    tooltip: "Sets `adaptive_pricing: { enabled: true }`. Displays prices in the customer's local currency."
-                )
                 CheckoutPlayground.ToggleRow(
                     title: "Payment Method Offer Save",
                     isOn: $checkoutSessionPaymentMethodSave,
@@ -217,15 +205,13 @@ struct CheckoutPlaygroundFeaturesSection: View {
                     isOn: $checkoutSessionPaymentMethodRemove,
                     tooltip: "Sets `saved_payment_method_options.payment_method_remove` to `enabled`. When on, Checkout can allow customers to remove saved payment methods."
                 )
-                if adaptivePricing {
-                    CheckoutPlayground.PickerRow(
-                        title: "Country",
-                        icon: "globe",
-                        selection: $adaptivePricingCountry,
-                        tooltip: "Simulates the customer's country for adaptive pricing by sending a location-formatted customer_email. 'None' skips the email override.",
-                        displayText: { $0.displayName }
-                    )
-                }
+                CheckoutPlayground.PickerRow(
+                    title: "Country",
+                    icon: "globe",
+                    selection: $adaptivePricingCountry,
+                    tooltip: "Simulates the customer's country for adaptive pricing by sending a location-formatted customer_email. 'None' skips the email override.",
+                    displayText: { $0.displayName }
+                )
             }
             .background(Color(uiColor: .secondarySystemGroupedBackground))
             .clipShape(RoundedRectangle(cornerRadius: 12))

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
@@ -43,18 +43,14 @@ struct CheckoutPlaygroundView: View {
                             customerType: viewModel.customerType,
                             shippingAddressCollection: $viewModel.shippingAddressCollection,
                             billingAddressCollection: $viewModel.billingAddressCollection,
-                            allowPromotionCodes: $viewModel.allowPromotionCodes,
                             automaticTax: $viewModel.automaticTax,
-                            adaptivePricing: $viewModel.adaptivePricing,
                             checkoutSessionPaymentMethodSave: $viewModel.checkoutSessionPaymentMethodSave,
                             checkoutSessionPaymentMethodRemove: $viewModel.checkoutSessionPaymentMethodRemove,
                             adaptivePricingCountry: $viewModel.adaptivePricingCountry,
                             automaticPaymentMethods: $viewModel.automaticPaymentMethods
                         )
 
-                        if viewModel.adaptivePricing {
-                            currencySelectorAppearanceSection
-                        }
+                        currencySelectorAppearanceSection
 
                         if !viewModel.automaticPaymentMethods {
                             CheckoutPlaygroundPaymentMethodSection(
@@ -85,7 +81,7 @@ struct CheckoutPlaygroundView: View {
                     CheckoutCartView(
                         clientSecret: clientSecret,
                         shippingAddressCollection: viewModel.shippingAddressCollection,
-                        adaptivePricing: viewModel.adaptivePricing,
+                        adaptivePricing: true,
                         integrationType: viewModel.integrationType,
                         showExpressCheckoutElement: viewModel.expressCheckoutElementOption == .show,
                         currencySelectorAppearance: viewModel.currencySelectorAppearance

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
@@ -10,8 +10,9 @@ import SwiftUI
 extension CheckoutPlayground {
     @MainActor
     final class ViewModel: ObservableObject {
+        // Unified mode currently supports card and Link.
         static let availablePaymentMethods = [
-            "card", "us_bank_account", "cashapp", "affirm", "klarna",
+            "card", "link",
         ]
 
         @Published var integrationType: IntegrationType = .flowController {
@@ -31,11 +32,9 @@ extension CheckoutPlayground {
         @Published var currency: Currency = .usd
         @Published var customerType: CustomerType = .guest
         @Published var lineItems: [LineItemConfig] = LineItemConfig.defaults
-        @Published var allowPromotionCodes = true
         @Published var shippingAddressCollection = true
         @Published var billingAddressCollection: BillingAddressCollection = .automatic
         @Published var automaticTax = true
-        @Published var adaptivePricing = false
         @Published var checkoutSessionPaymentMethodSave = true
         @Published var checkoutSessionPaymentMethodRemove = true
         @Published var adaptivePricingCountry: AdaptivePricingCountry = .none
@@ -99,13 +98,12 @@ extension CheckoutPlayground {
         private func buildRequestBody() -> [String: Any] {
             var body: [String: Any] = [
                 "merchant_country_code": "us_tax",
+                "mode": "unified",
                 "currency": currency.rawValue,
                 "customer": customerType.rawValue,
-                "allow_promotion_codes": allowPromotionCodes,
                 "shipping_address_collection": shippingAddressCollection,
                 "billing_address_collection": billingAddressCollection == .required,
                 "automatic_tax": automaticTax,
-                "adaptive_pricing": adaptivePricing,
                 "checkout_session_payment_method_save": checkoutSessionPaymentMethodSave ? "enabled" : "disabled",
                 "checkout_session_payment_method_remove": checkoutSessionPaymentMethodRemove ? "enabled" : "disabled",
             ]
@@ -114,7 +112,7 @@ extension CheckoutPlayground {
             } else {
                 body["payment_method_types"] = Array(paymentMethodTypes)
             }
-            if adaptivePricing, adaptivePricingCountry != .none {
+            if adaptivePricingCountry != .none {
                 let countryCode = adaptivePricingCountry.rawValue.uppercased()
                 body["customer_email"] = "test+location_\(countryCode)@example.com"
             }


### PR DESCRIPTION
## Summary
Updates Checkout Playground to create unified Checkout Sessions. It only exposes payment methods and controls supported by unified mode, and keeps adaptive-pricing controls available.

### Checkout Playground
<!-- TODO: add screen recording of unified Checkout Playground -->

## Motivation
CheckoutSessions

## Testing
- Manual

## Changelog
N/A
