### PR TITLE
Pass elements session ID to `intent_token` param as fallback

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -588,7 +588,7 @@ extension PayWithLinkViewController: PayWithLinkCoordinating {
             case .success(let session):
                 session.createLinkAccountSession(
                     linkMode: self?.context.elementsSession.linkSettings?.linkMode,
-                    intentToken: self?.context.intent.stripeId
+                    intentToken: self?.context.intent.stripeId ?? self?.context.elementsSession.sessionID
                 ) { [session, weak self] linkAccountSessionResult in
                     switch linkAccountSessionResult {
                     case .success(let linkAccountSession):


### PR DESCRIPTION
## Summary

When creating a Link Account Session for the Link wallet -> Add bank flow, we should pass up the elements session ID in the `intent_token` param when a payment or setup intent ID isn't available. This is what the web flow does, and allows the LAS be associated with the elements session.

The `intent_token` name is misnamed, IMO, but here is the backend code showing an elements session ID is accepted: https://stripe.sourcegraphcloud.com/r/stripe-internal/mint@e201794d72c39cfda6c93c299faa11dc1dbcf75f/-/blob/pay-server/lib/consumer/api/methods/payment_details/bank_account/create_connections_link_account_session_method.rb?L117-126

## Motivation

https://stripe.enterprise.slack.com/archives/C07TB59Q4HJ/p1784839402103419?thread_ts=1784748231.848969&channel=C07TB59Q4HJ&message_ts=1784839402.103419

## Testing

Example request: https://admin.corp.stripe.com/request-log/req_57xGSQzItVebpy

## Changelog

N/a
