### PR TITLE
Remove selectShippingOption and updateQuantity from Checkout SDK

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartContentView.swift
@@ -80,32 +80,8 @@ struct CheckoutCartContentView: View {
 
                                 Spacer()
 
-                                // Custom Stepper
-                                HStack {
-                                    Button(action: {
-                                        if item.quantity > 0 {
-                                            updateQuantity(for: item.id, to: item.quantity - 1)
-                                        }
-                                    }) {
-                                        Image(systemName: "minus.circle.fill")
-                                            .foregroundColor(item.quantity > 0 ? .primary : .gray.opacity(0.5))
-                                            .font(.system(size: 24))
-                                    }
-                                    .buttonStyle(PlainButtonStyle())
-
-                                    Text("\(item.quantity)")
-                                        .font(.body).bold()
-                                        .frame(minWidth: 24, alignment: .center)
-
-                                    Button(action: {
-                                        updateQuantity(for: item.id, to: item.quantity + 1)
-                                    }) {
-                                        Image(systemName: "plus.circle.fill")
-                                            .foregroundColor(.primary)
-                                            .font(.system(size: 24))
-                                    }
-                                    .buttonStyle(PlainButtonStyle())
-                                }
+                                Text("Qty: \(item.quantity)")
+                                    .font(.body).bold()
                             }
                             Spacer()
                             Text(formatCartCurrency(
@@ -412,19 +388,6 @@ struct CheckoutCartContentView: View {
     }
 
     // MARK: - Actions
-
-    private func updateQuantity(for lineItemId: String, to quantity: Int) {
-        Task {
-            isLoading = true
-            errorMessage = nil
-            do {
-                try await checkout.updateQuantity(lineItemId: lineItemId, quantity: quantity)
-            } catch {
-                errorMessage = error.localizedDescription
-            }
-            isLoading = false
-        }
-    }
 
     private func applyPromotionCode(_ code: String) {
         Task {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -167,26 +167,6 @@ public final class Checkout: ObservableObject {
         try await performUpdate(.setPromotionCode(""))
     }
 
-    // MARK: - Line Items
-
-    /// Updates the quantity of a line item.
-    /// - Parameters:
-    ///   - lineItemId: The line item ID to update.
-    ///   - quantity: The new quantity to set.
-    /// - Throws: ``CheckoutError`` if the update fails.
-    public func updateQuantity(lineItemId: String, quantity: Int) async throws {
-        try await performUpdate(.setLineItemQuantity(lineItemId: lineItemId, quantity: quantity))
-    }
-
-    // MARK: - Shipping
-
-    /// Selects a shipping option for the session.
-    /// - Parameter optionId: The ID of the shipping rate to select.
-    /// - Throws: ``CheckoutError`` if the update fails.
-    public func selectShippingOption(_ optionId: String) async throws {
-        try await performUpdate(.setShippingRate(optionId))
-    }
-
     // MARK: - Payment Option
 
     /// Clears the currently selected payment option.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutSessionUpdate.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutSessionUpdate.swift
@@ -12,8 +12,6 @@ import Foundation
 extension Checkout {
     enum SessionUpdate {
         case setPromotionCode(String)
-        case setLineItemQuantity(lineItemId: String, quantity: Int)
-        case setShippingRate(String)
         case setTaxRegion(Address)
         case setCurrency(String)
 
@@ -21,13 +19,6 @@ extension Checkout {
             switch self {
             case .setPromotionCode(let code):
                 return ["promotion_code": code]
-            case .setLineItemQuantity(let lineItemId, let quantity):
-                return [
-                    "updated_line_item_quantity[line_item_id]": lineItemId,
-                    "updated_line_item_quantity[quantity]": quantity,
-                ]
-            case .setShippingRate(let optionId):
-                return ["shipping_rate": optionId]
             case .setTaxRegion(let address):
                 return ([
                     "tax_region[country]": address.country,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
@@ -118,44 +118,6 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         }
     }
 
-    func testUpdateQuantity() async throws {
-        let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
-            allowAdjustableLineItemQuantity: true
-        )
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
-        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        let checkout = try await Checkout(configuration: configuration)
-
-        XCTAssertEqual(5050, checkout.session.total?.total.minorUnitsAmount)
-
-        let itemId = try XCTUnwrap(
-            checkout.session.lineItems.first?.id,
-            "Session should have at least one line item"
-        )
-
-        try await checkout.updateQuantity(lineItemId: itemId, quantity: 2)
-        XCTAssertEqual(10100, checkout.session.total?.total.minorUnitsAmount)
-    }
-
-    func testSelectShippingOption() async throws {
-        let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
-            includeShippingOptions: true
-        )
-        var configuration = Checkout.Configuration(clientSecret: checkoutSessionResponse.clientSecret, returnURL: "stripe-ios-test://checkout-return")
-        configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
-        let checkout = try await Checkout(configuration: configuration)
-
-        XCTAssertEqual(2500, checkout.session.total?.total.minorUnitsAmount)
-
-        let rateId = try XCTUnwrap(
-            checkout.session.shippingOptions.last?.id,
-            "Session should have at least one shipping option"
-        )
-
-        try await checkout.selectShippingOption(rateId)
-        XCTAssertEqual(3000, checkout.session.total?.total.minorUnitsAmount)
-    }
-
     func testUpdateBillingTaxRegionIfNecessary() async throws {
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.fetchCheckoutSessionPaymentMode(
             merchantCountry: "us_tax",


### PR DESCRIPTION
## Summary
Removes `selectShippingOption` and `updateQuantity` from the Checkout SDK's public API, along with their `SessionUpdate` cases, tests, and the example app's quantity stepper UI that called into them. These aren't ready for the private preview surface.

## Motivation
- https://stripe.slack.com/archives/C09MLFD2KU7/p1785350607819789

## Testing
- Existing tests updated

## Changelog
N/A