### PR TITLE
Sync Checkout billing from embedded saved payment methods

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/SavedPaymentMethodManager.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/SavedPaymentMethodManager.swift
@@ -14,12 +14,12 @@ final class SavedPaymentMethodManager {
 
     enum Error: Swift.Error {
         case missingEphemeralKey
-        case missingUpdatedPaymentMethod
     }
 
     let configuration: PaymentElementConfiguration
     let elementsSession: STPElementsSession
     let intent: Intent
+    private weak var checkout: Checkout?
 
     private lazy var ephemeralKey: String? = {
         guard let ephemeralKey = configuration.customer?.ephemeralKeySecret(basedOn: elementsSession) else {
@@ -33,34 +33,44 @@ final class SavedPaymentMethodManager {
         return ephemeralKey
     }()
 
-    init(configuration: PaymentElementConfiguration, elementsSession: STPElementsSession, intent: Intent) {
+    init(
+        configuration: PaymentElementConfiguration,
+        elementsSession: STPElementsSession,
+        intent: Intent,
+        checkout: Checkout? = nil
+    ) {
         self.configuration = configuration
         self.elementsSession = elementsSession
         self.intent = intent
+        self.checkout = checkout
     }
 
     func update(paymentMethod: STPPaymentMethod,
                 with updateParams: STPPaymentMethodUpdateParams) async throws -> STPPaymentMethod {
         switch intent {
-        case .checkout(let session):
+        case .checkout:
             let billing = Checkout.PaymentMethodBillingDetails(updateParams.billingDetails)
             let expiry = Checkout.PaymentMethodExpiryDetails(updateParams.card)
             guard billing != nil || expiry != nil else {
                 throw PaymentSheetError.unknown(debugDescription: "Tried to update a payment method without billing details or expiry details.")
             }
-            let updatedSession = try await configuration.apiClient.updatePaymentMethod(
+            guard let checkout else {
+                let error = PaymentSheetError.unknown(
+                    debugDescription: "Failed to update a Checkout saved payment method without Checkout."
+                )
+                let errorAnalytic = ErrorAnalytic(
+                    event: .unexpectedPaymentSheetError,
+                    error: error
+                )
+                STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
+                stpAssertionFailure("SavedPaymentMethodManager requires Checkout for a Checkout intent.")
+                throw error
+            }
+            let updatedPaymentMethod = try await checkout.updateSavedPaymentMethod(
                 paymentMethod.stripeId,
-                inCheckoutSession: session.id,
                 billingDetails: billing,
                 expiryDetails: expiry
             )
-            guard let updatedPaymentMethod = updatedSession.customer?.paymentMethods.first(where: { $0.stripeId == paymentMethod.stripeId }) else {
-                let errorAnalytic = ErrorAnalytic(event: .unexpectedPaymentSheetError,
-                                                  error: Error.missingUpdatedPaymentMethod,
-                                                  additionalNonPIIParams: ["payment_method_id": paymentMethod.stripeId])
-                STPAnalyticsClient.sharedClient.log(analytic: errorAnalytic)
-                throw PaymentSheetError.unknown(debugDescription: "Checkout session response didn't include the updated payment method.")
-            }
             updatedPaymentMethod.updateLocalFields(from: paymentMethod)
             return updatedPaymentMethod
         case .paymentIntent, .setupIntent, .deferredIntent:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+BillingAddress.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+BillingAddress.swift
@@ -10,11 +10,19 @@ import Foundation
 @_spi(STP) import StripePayments
 
 extension Checkout {
+    /// Whether selecting a payment method with the given billing details requires a server update
+    /// to keep Checkout automatic tax in sync.
+    func requiresBillingAddressSync(from billingDetails: STPPaymentMethodBillingDetails?) -> Bool {
+        return session.collectsTaxFromBillingAddress
+            && billingDetails?.address?.country?.nonEmpty != nil
+    }
+
     /// Syncs the payment method's billing address to Checkout tax calculation when needed.
     func syncBillingAddress(from billingDetails: STPPaymentMethodBillingDetails?) async throws {
         // We need at least a country to build an Address for tax region calculation. Billing details
         // are optional on payment methods, so it's fine to just skip if we don't have enough info.
-        guard let billingDetails,
+        guard requiresBillingAddressSync(from: billingDetails),
+              let billingDetails,
               let country = billingDetails.address?.country?.nonEmpty else {
             return
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -29,6 +29,38 @@ extension Checkout {
         dangerouslySetSessionDirectly(session.makeCopyOverriding(paymentOption: .newValue(paymentOption)))
     }
 
+    func updateSavedPaymentMethod(
+        _ paymentMethodID: String,
+        billingDetails: PaymentMethodBillingDetails?,
+        expiryDetails: PaymentMethodExpiryDetails?
+    ) async throws -> STPPaymentMethod {
+        try await performUpdate(
+            .updateSavedPaymentMethod(
+                paymentMethodID: paymentMethodID,
+                billingDetails: billingDetails,
+                expiryDetails: expiryDetails
+            ),
+            canUpdateWhileSheetPresented: true
+        )
+        guard let paymentMethod = session.customer?.paymentMethods.first(where: {
+            $0.stripeId == paymentMethodID
+        }) else {
+            let message = "Checkout session response didn't include the updated payment method."
+            let error = CheckoutError.apiError(message: message)
+            STPAnalyticsClient.sharedClient.log(
+                analytic: ErrorAnalytic(
+                    event: .unexpectedPaymentSheetError,
+                    error: error,
+                    additionalNonPIIParams: ["payment_method_id": paymentMethodID]
+                )
+            )
+            stpAssertionFailure(message)
+            throw error
+        }
+        try await syncBillingAddress(from: paymentMethod.billingDetails)
+        return paymentMethod
+    }
+
     // MARK: - Session Updates
 
     /// Waits for all in-flight session updates (mutations, etc.) to complete.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutSessionUpdate.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutSessionUpdate.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+@_spi(STP) import StripeCore
 
 @_spi(STP)
 extension Checkout {
@@ -14,6 +15,11 @@ extension Checkout {
         case setPromotionCode(String)
         case setTaxRegion(Address)
         case setCurrency(String)
+        case updateSavedPaymentMethod(
+            paymentMethodID: String,
+            billingDetails: PaymentMethodBillingDetails?,
+            expiryDetails: PaymentMethodExpiryDetails?
+        )
 
         var parameters: [String: Any] {
             switch self {
@@ -30,6 +36,16 @@ extension Checkout {
                 ] as [String: Any?]).compactMapValues { $0 }
             case .setCurrency(let currency):
                 return ["updated_currency": currency]
+            case .updateSavedPaymentMethod(
+                let paymentMethodID,
+                let billingDetails,
+                let expiryDetails
+            ):
+                return STPAPIClient.updatePaymentMethodParameters(
+                    paymentMethodId: paymentMethodID,
+                    billingDetails: billingDetails,
+                    expiryDetails: expiryDetails
+                )
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -333,6 +333,8 @@ extension EmbeddedPaymentElement: EmbeddedPaymentMethodsViewDelegate {
         let verticalSavedPaymentMethodsViewController = VerticalSavedPaymentMethodsViewController(
             configuration: configuration,
             intent: intent,
+            checkout: checkout,
+            syncsCheckoutBillingBeforeCompletion: checkout != nil,
             selectedPaymentMethod: selectedSavedPaymentMethod,
             paymentMethods: savedPaymentMethods,
             elementsSession: elementsSession,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -438,7 +438,12 @@ public final class EmbeddedPaymentElement {
         }
     }
     internal private(set) lazy var savedPaymentMethodManager: SavedPaymentMethodManager = {
-        SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        SavedPaymentMethodManager(
+            configuration: configuration,
+            elementsSession: elementsSession,
+            intent: intent,
+            checkout: checkout
+        )
     }()
 
     internal private(set) lazy var paymentHandler: STPPaymentHandler = STPPaymentHandler(apiClient: configuration.apiClient)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet.swift
@@ -337,6 +337,7 @@ public class PaymentSheet {
                 loadResult: loadResult,
                 analyticsHelper: analyticsHelper,
                 delegate: self,
+                checkout: checkout,
                 previousPaymentOption: previousPaymentOption
             )
             return vc

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -114,7 +114,12 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
     var defaultPaymentMethod: STPPaymentMethod?
 
     private lazy var savedPaymentMethodManager: SavedPaymentMethodManager = {
-        SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        SavedPaymentMethodManager(
+            configuration: configuration,
+            elementsSession: elementsSession,
+            intent: intent,
+            checkout: checkout
+        )
     }()
 
     // MARK: - UI properties
@@ -854,6 +859,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         let vc = VerticalSavedPaymentMethodsViewController(
             configuration: configuration,
             intent: intent,
+            checkout: checkout,
             selectedPaymentMethod: selectedPaymentOption?.savedPaymentMethod,
             paymentMethods: savedPaymentMethods,
             elementsSession: elementsSession,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/SavedPaymentMethodRowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/SavedPaymentMethodRowButton.swift
@@ -69,6 +69,13 @@ final class SavedPaymentMethodRowButton: UIView {
 
     // MARK: Private views
 
+    private lazy var spinner: ActivityIndicator = {
+        let spinner = ActivityIndicator(size: .medium)
+        spinner.tintColor = appearance.colors.primary
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        return spinner
+    }()
+
     private(set) lazy var chevronButton: RowButton.RightAccessoryButton = {
         let chevronButton = RowButton.RightAccessoryButton(accessoryType: .update, appearance: appearance, didTap: handleUpdateButtonTapped)
         chevronButton.isHidden = !isEditing
@@ -107,6 +114,11 @@ final class SavedPaymentMethodRowButton: UIView {
         super.init(frame: .zero)
 
         addAndPinSubview(rowButton)
+        addSubview(spinner)
+        NSLayoutConstraint.activate([
+            spinner.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -16),
+            spinner.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -124,6 +136,21 @@ final class SavedPaymentMethodRowButton: UIView {
         } else {
             state = .selected
             delegate?.didSelectButton(self, with: paymentMethod)
+        }
+    }
+
+    /// Shows or hides the trailing spinner and dims the row content while loading.
+    func setLoading(_ loading: Bool) {
+        guard loading != spinner.isAnimating else {
+            return
+        }
+
+        if loading {
+            spinner.startAnimating()
+            rowButton.alpha = 0.6
+        } else {
+            spinner.stopAnimating()
+            rowButton.alpha = 1
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Saved Payment Method Screen/VerticalSavedPaymentMethodsViewController.swift
@@ -33,10 +33,11 @@ protocol VerticalSavedPaymentMethodsViewControllerDelegate: AnyObject {
 
 /// A view controller that shows a list of saved payment methods in a vertical orientation
 class VerticalSavedPaymentMethodsViewController: UIViewController {
-
     // MARK: Private properties
     private let configuration: PaymentElementConfiguration
     private let intent: Intent
+    private weak var checkout: Checkout?
+    private let syncsCheckoutBillingBeforeCompletion: Bool
     private let elementsSession: STPElementsSession
     private let paymentMethodRemove: Bool
     private let paymentMethodRemoveLast: Bool
@@ -129,7 +130,12 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
     }
 
     private lazy var savedPaymentMethodManager: SavedPaymentMethodManager = {
-        SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        SavedPaymentMethodManager(
+            configuration: configuration,
+            elementsSession: elementsSession,
+            intent: intent,
+            checkout: checkout
+        )
     }()
 
     // MARK: Internal properties
@@ -153,6 +159,12 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         return label
     }()
 
+    private lazy var errorLabel: UILabel = {
+        let label = ElementsUI.makeErrorLabel(theme: configuration.appearance.asElementsTheme)
+        label.isHidden = true
+        return label
+    }()
+
     private lazy var stackView: UIStackView = {
         let spacerView = UIView(frame: .zero)
         spacerView.translatesAutoresizingMaskIntoConstraints = false
@@ -161,7 +173,9 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         heightConstraint.priority = UILayoutPriority(rawValue: 1)
         heightConstraint.isActive = true
 
-        let stackView = UIStackView(arrangedSubviews: [headerLabel] + paymentMethodRows + [spacerView])
+        let stackView = UIStackView(
+            arrangedSubviews: [headerLabel] + paymentMethodRows + [errorLabel, spacerView]
+        )
         stackView.axis = .vertical
         stackView.spacing = 12
         stackView.setCustomSpacing(16, after: headerLabel)
@@ -173,9 +187,21 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
 
     private var paymentMethodRows: [SavedPaymentMethodRowButton] = []
 
+#if DEBUG
+    var _testPaymentMethodRows: [SavedPaymentMethodRowButton] {
+        return paymentMethodRows
+    }
+
+    var _testErrorLabel: UILabel {
+        return errorLabel
+    }
+#endif
+
     init(
         configuration: PaymentElementConfiguration,
         intent: Intent,
+        checkout: Checkout? = nil,
+        syncsCheckoutBillingBeforeCompletion: Bool = false,
         selectedPaymentMethod: STPPaymentMethod?,
         paymentMethods: [STPPaymentMethod],
         elementsSession: STPElementsSession,
@@ -184,6 +210,8 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
     ) {
         self.configuration = configuration
         self.intent = intent
+        self.checkout = checkout
+        self.syncsCheckoutBillingBeforeCompletion = syncsCheckoutBillingBeforeCompletion
         self.elementsSession = elementsSession
         self.defaultPaymentMethod = defaultPaymentMethod
         self.paymentMethodRemove = intent.allowsPaymentMethodRemoval(elementsSession: elementsSession)
@@ -193,6 +221,12 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
         self.isCBCEligible = elementsSession.isCardBrandChoiceEligible
         self.analyticsHelper = analyticsHelper
         super.init(nibName: nil, bundle: nil)
+        if syncsCheckoutBillingBeforeCompletion {
+            stpAssert(
+                checkout != nil,
+                "Checkout is required to sync billing before selection completion."
+            )
+        }
         self.paymentMethodRows = buildPaymentMethodRows(paymentMethods: paymentMethods)
         setInitialState(selectedPaymentMethod: selectedPaymentMethod)
     }
@@ -311,11 +345,13 @@ class VerticalSavedPaymentMethodsViewController: UIViewController {
 // MARK: - BottomSheetContentViewController
 extension VerticalSavedPaymentMethodsViewController: BottomSheetContentViewController {
     var allowsDragToDismiss: Bool {
-        return true
+        return view.isUserInteractionEnabled
     }
 
     func didTapOrSwipeToDismiss() {
-        complete(didTapToDismiss: true)
+        if view.isUserInteractionEnabled {
+            complete(didTapToDismiss: true)
+        }
     }
 
     var requiresFullScreen: Bool {
@@ -344,6 +380,10 @@ extension VerticalSavedPaymentMethodsViewController: SavedPaymentMethodRowButton
 
     func didSelectButton(_ button: SavedPaymentMethodRowButton, with paymentMethod: STPPaymentMethod) {
         analyticsHelper.logSavedPMScreenOptionSelected(option: .saved(paymentMethod: paymentMethod))
+        let previousSelectedButton = paymentMethodRows.first { $0 != button && $0.isSelected }
+        let previousCustomerPaymentOption = CustomerPaymentOption.localDefaultPaymentMethod(
+            for: configuration.customer?.id
+        )
         if !elementsSession.paymentMethodSetAsDefaultForPaymentSheet {
             // Set local storage default
             CustomerPaymentOption.setDefaultPaymentMethod(
@@ -353,13 +393,84 @@ extension VerticalSavedPaymentMethodsViewController: SavedPaymentMethodRowButton
         }
 
         // Deselect previous button
-        paymentMethodRows.first { $0 != button && $0.isSelected }?.state = .unselected
+        previousSelectedButton?.state = .unselected
 
         // Disable interaction to prevent double selecting or entering edit mode since we will be dismissing soon
-        self.view.isUserInteractionEnabled = false
-        self.navigationBar.isUserInteractionEnabled = false
+        view.isUserInteractionEnabled = false
+        navigationBar.isUserInteractionEnabled = false
 
-        self.complete()
+        guard syncsCheckoutBillingBeforeCompletion,
+              let checkout,
+              checkout.requiresBillingAddressSync(from: paymentMethod.billingDetails) else {
+            complete()
+            return
+        }
+
+        syncBillingAddressThenComplete(
+            checkout: checkout,
+            paymentMethod: paymentMethod,
+            button: button,
+            previousSelectedButton: previousSelectedButton,
+            previousCustomerPaymentOption: previousCustomerPaymentOption
+        )
+    }
+
+    private func syncBillingAddressThenComplete(
+        checkout: Checkout,
+        paymentMethod: STPPaymentMethod,
+        button: SavedPaymentMethodRowButton,
+        previousSelectedButton: SavedPaymentMethodRowButton?,
+        previousCustomerPaymentOption: CustomerPaymentOption?
+    ) {
+        showError(nil)
+        button.setLoading(true)
+        setSiblingRowsEnabled(false, selectedRow: button)
+
+        Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+            do {
+                try await checkout.syncBillingAddress(from: paymentMethod.billingDetails)
+                self.complete()
+            } catch {
+                button.setLoading(false)
+                self.setSiblingRowsEnabled(true, selectedRow: button)
+                button.state = button.previousSelectedState
+                previousSelectedButton?.state = .selected
+                if !self.elementsSession.paymentMethodSetAsDefaultForPaymentSheet {
+                    CustomerPaymentOption.setDefaultPaymentMethod(
+                        previousCustomerPaymentOption,
+                        forCustomer: self.configuration.customer?.id
+                    )
+                }
+                self.view.isUserInteractionEnabled = true
+                self.navigationBar.isUserInteractionEnabled = true
+                self.showError(error)
+            }
+        }
+    }
+
+    private func setSiblingRowsEnabled(
+        _ enabled: Bool,
+        selectedRow: SavedPaymentMethodRowButton
+    ) {
+        for row in paymentMethodRows where row != selectedRow {
+            sendEventToSubviews(
+                enabled ? .shouldEnableUserInteraction : .shouldDisableUserInteraction,
+                from: row
+            )
+        }
+    }
+
+    private func showError(_ error: Error?) {
+        errorLabel.text = error?.nonGenericDescription
+        if let lastPaymentMethodRow = paymentMethodRows.last {
+            stackView.setCustomSpacing(error == nil ? 0 : 12, after: lastPaymentMethodRow)
+        }
+        animateHeightChange {
+            self.errorLabel.setHiddenIfNecessary(error == nil)
+        }
     }
 
     func didSelectUpdateButton(_ button: SavedPaymentMethodRowButton, with paymentMethod: STPPaymentMethod) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -107,7 +107,12 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
     }
 
     private lazy var savedPaymentMethodManager: SavedPaymentMethodManager = {
-        return SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        return SavedPaymentMethodManager(
+            configuration: configuration,
+            elementsSession: elementsSession,
+            intent: intent,
+            checkout: checkout
+        )
     }()
 
     // MARK: - Views

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -49,6 +49,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
     let loadResult: PaymentSheetLoader.LoadResult
     let formCache: PaymentMethodFormCache = .init()
     let analyticsHelper: PaymentSheetAnalyticsHelper
+    private weak var checkout: Checkout?
 
     // MARK: - Writable Properties
     weak var delegate: PaymentSheetViewControllerDelegate?
@@ -64,7 +65,12 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
     private(set) var isDismissable: Bool = true
 
     private lazy var savedPaymentMethodManager: SavedPaymentMethodManager = {
-        return SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession, intent: intent)
+        return SavedPaymentMethodManager(
+            configuration: configuration,
+            elementsSession: elementsSession,
+            intent: intent,
+            checkout: checkout
+        )
     }()
 
     // MARK: - Views
@@ -146,6 +152,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
         loadResult: PaymentSheetLoader.LoadResult,
         analyticsHelper: PaymentSheetAnalyticsHelper,
         delegate: PaymentSheetViewControllerDelegate,
+        checkout: Checkout? = nil,
         previousPaymentOption: PaymentOption? = nil
     ) {
         // Only call loadResult.intent.cvcRecollectionEnabled once per load
@@ -159,6 +166,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
         self.isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
         self.isCVCRecollectionEnabled = isCVCRecollectionEnabled
         self.delegate = delegate
+        self.checkout = checkout
         self.savedPaymentOptionsViewController = SavedPaymentOptionsViewController(
             savedPaymentMethods: loadResult.savedPaymentMethods,
             configuration: .init(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodBillingSyncTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodBillingSyncTests.swift
@@ -1,0 +1,544 @@
+//
+//  SavedPaymentMethodBillingSyncTests.swift
+//  StripePaymentSheetTests
+//
+
+import OHHTTPStubs
+import OHHTTPStubsSwift
+@testable @_spi(STP) import StripeCore
+import StripeCoreTestUtils
+@testable @_spi(STP) import StripePayments
+@testable @_spi(STP) import StripePaymentSheet
+@testable @_spi(STP) import StripeUICore
+import XCTest
+
+@MainActor
+final class SavedPaymentMethodBillingSyncTests: APIStubbedTestCase {
+    override func setUp() async throws {
+        try await super.setUp()
+        CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: nil)
+        await AddressSpecProvider.shared.loadAddressSpecs()
+        await FormSpecProvider.shared.load()
+    }
+
+    // MARK: Embedded manage selection
+
+    func testEmbeddedManageSelection_syncsBeforeCompleting() async throws {
+        // Given
+        let checkout = try await makeCheckout(automaticTaxEnabled: true)
+        let updateRequest = stubCheckoutUpdate(checkout: checkout)
+        let firstPaymentMethod = makeSavedPaymentMethod(id: "pm_first", country: "US")
+        let secondPaymentMethod = makeSavedPaymentMethod(id: "pm_second", country: "CA")
+        let delegate = MockVerticalSavedPaymentMethodsDelegate()
+        let sut = makeEmbeddedManageController(
+            checkout: checkout,
+            paymentMethods: [firstPaymentMethod, secondPaymentMethod],
+            selectedPaymentMethod: firstPaymentMethod
+        )
+        sut.delegate = delegate
+        sut.loadViewIfNeeded()
+        let selectedRow = sut._testPaymentMethodRows[1]
+
+        // When
+        selectedRow.rowButton.handleTap()
+
+        // Then
+        XCTAssertEqual(selectedRow.rowButton.alpha, 0.6, accuracy: 0.001)
+        XCTAssertEqual(activityIndicator(in: selectedRow)?.isAnimating, true)
+        XCTAssertFalse(sut.allowsDragToDismiss)
+        XCTAssertEqual(delegate.completionCount, 0)
+        await fulfillment(of: [updateRequest, delegate.completed], timeout: 5)
+        XCTAssertEqual(selectedRow.rowButton.alpha, 0.6, accuracy: 0.001)
+        XCTAssertEqual(delegate.selectedPaymentMethod?.stripeId, secondPaymentMethod.stripeId)
+    }
+
+    func testEmbeddedManageSelection_syncFails_restoresSelectionAndShowsError() async throws {
+        // Given
+        let checkout = try await makeCheckout(automaticTaxEnabled: true)
+        let updateRequest = stubCheckoutUpdate(checkout: checkout, statusCode: 500)
+        let firstPaymentMethod = makeSavedPaymentMethod(id: "pm_first", country: "US")
+        let secondPaymentMethod = makeSavedPaymentMethod(id: "pm_second", country: "CA")
+        CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: nil)
+        let delegate = MockVerticalSavedPaymentMethodsDelegate()
+        let sut = makeEmbeddedManageController(
+            checkout: checkout,
+            paymentMethods: [firstPaymentMethod, secondPaymentMethod],
+            selectedPaymentMethod: firstPaymentMethod
+        )
+        sut.delegate = delegate
+        sut.loadViewIfNeeded()
+        let firstRow = sut._testPaymentMethodRows[0]
+        let secondRow = sut._testPaymentMethodRows[1]
+
+        // When
+        secondRow.rowButton.handleTap()
+        await fulfillment(of: [updateRequest], timeout: 5)
+        try await waitUntil { sut.view.isUserInteractionEnabled }
+
+        // Then
+        XCTAssertTrue(firstRow.isSelected)
+        XCTAssertFalse(secondRow.isSelected)
+        XCTAssertEqual(secondRow.rowButton.alpha, 1)
+        XCTAssertEqual(activityIndicator(in: secondRow)?.isAnimating, false)
+        XCTAssertFalse(sut._testErrorLabel.isHidden)
+        XCTAssertEqual(sut._testErrorLabel.text, "Tax update failed")
+        XCTAssertTrue(sut.allowsDragToDismiss)
+        XCTAssertEqual(CustomerPaymentOption.localDefaultPaymentMethod(for: nil), .link)
+        XCTAssertEqual(delegate.completionCount, 0)
+    }
+
+    func testEmbeddedManageSelection_syncFails_restoresAlreadySelectedRow() async throws {
+        // Given
+        let checkout = try await makeCheckout(automaticTaxEnabled: true)
+        let updateRequest = stubCheckoutUpdate(checkout: checkout, statusCode: 500)
+        let firstPaymentMethod = makeSavedPaymentMethod(id: "pm_first", country: "US")
+        let secondPaymentMethod = makeSavedPaymentMethod(id: "pm_second", country: "CA")
+        CustomerPaymentOption.setDefaultPaymentMethod(
+            .stripeId(firstPaymentMethod.stripeId),
+            forCustomer: nil
+        )
+        let sut = makeEmbeddedManageController(
+            checkout: checkout,
+            paymentMethods: [firstPaymentMethod, secondPaymentMethod],
+            selectedPaymentMethod: firstPaymentMethod
+        )
+        sut.loadViewIfNeeded()
+        let selectedRow = sut._testPaymentMethodRows[0]
+
+        // When
+        selectedRow.rowButton.handleTap()
+        await fulfillment(of: [updateRequest], timeout: 5)
+        try await waitUntil { sut.view.isUserInteractionEnabled }
+
+        // Then
+        XCTAssertTrue(selectedRow.isSelected)
+        XCTAssertEqual(
+            CustomerPaymentOption.localDefaultPaymentMethod(for: nil),
+            .stripeId(firstPaymentMethod.stripeId)
+        )
+        XCTAssertEqual(selectedRow.rowButton.alpha, 1)
+        XCTAssertEqual(activityIndicator(in: selectedRow)?.isAnimating, false)
+    }
+
+    func testEmbeddedManageSelection_withoutBillingTax_completesWithoutLoading() async throws {
+        try await assertEmbeddedSelectionCompletesWithoutLoading(
+            checkout: makeCheckout(automaticTaxEnabled: false)
+        )
+    }
+
+    func testEmbeddedManageSelection_withShippingTax_completesWithoutLoading() async throws {
+        try await assertEmbeddedSelectionCompletesWithoutLoading(
+            checkout: makeCheckout(
+                automaticTaxEnabled: true,
+                automaticTaxAddressSource: "session.shipping"
+            )
+        )
+    }
+
+    func testEmbeddedManageSelection_withoutBillingCountry_completesWithoutLoading() async throws {
+        try await assertEmbeddedSelectionCompletesWithoutLoading(
+            checkout: makeCheckout(automaticTaxEnabled: true),
+            selectedCountry: ""
+        )
+    }
+
+    func testEmbeddedManageSelection_withoutCheckout_completesWithoutLoading() async throws {
+        try await assertEmbeddedSelectionCompletesWithoutLoading(checkout: nil)
+    }
+
+    // MARK: Billing sync requirement
+
+    func testBillingSyncRequirement_requiresBillingTaxAndCountry() async throws {
+        // Given
+        let checkout = try await makeCheckout(automaticTaxEnabled: true)
+        let paymentMethodWithCountry = makeSavedPaymentMethod(id: "pm_country", country: "US")
+        let paymentMethodWithoutCountry = makeSavedPaymentMethod(id: "pm_no_country", country: "")
+
+        // Then
+        XCTAssertTrue(
+            checkout.requiresBillingAddressSync(
+                from: paymentMethodWithCountry.billingDetails
+            )
+        )
+        XCTAssertFalse(
+            checkout.requiresBillingAddressSync(
+                from: paymentMethodWithoutCountry.billingDetails
+            )
+        )
+    }
+
+    // MARK: Saved payment method updates
+
+    func testSavedPaymentMethodManager_checkoutUpdate_commitsSessionAndSyncsEditedBilling() async throws {
+        // Given
+        let checkout = try await makeCheckout(automaticTaxEnabled: true)
+        let paymentMethodUpdate = expectation(description: "Saved payment method updated")
+        let taxRegionUpdate = expectation(description: "Edited billing address synced")
+        var updatedSessionJSON = CheckoutTestHelpers.openSessionJSON
+        updatedSessionJSON["tax_context"] = [
+            "automatic_tax_enabled": true,
+            "automatic_tax_address_source": "session.billing",
+        ]
+        updatedSessionJSON["customer"] = [
+            "id": "cus_123",
+            "payment_methods": [
+                makeSavedPaymentMethodJSON(
+                    id: "pm_edited",
+                    country: "CA",
+                    city: "Toronto"
+                ),
+            ],
+        ]
+        stub { request in
+            request.httpMethod == "POST"
+                && request.url?.path == "/v1/payment_pages/\(checkout.session.id)"
+        } response: { request in
+            let params = RequestBodyTestHelpers.formEncodedBodyParams(from: request)
+            if params["payment_method_to_update[payment_method_id]"] == "pm_edited" {
+                paymentMethodUpdate.fulfill()
+            } else if params["tax_region[country]"] == "CA" {
+                taxRegionUpdate.fulfill()
+            }
+            return HTTPStubsResponse(
+                jsonObject: updatedSessionJSON,
+                statusCode: 200,
+                headers: nil
+            )
+        }
+
+        // When
+        let manager = makeSavedPaymentMethodManager(checkout: checkout)
+        let updatedPaymentMethod = try await manager.update(
+            paymentMethod: makeSavedPaymentMethod(id: "pm_edited", country: "US"),
+            with: makeBillingUpdateParams(country: "CA")
+        )
+
+        // Then
+        await fulfillment(of: [paymentMethodUpdate, taxRegionUpdate], timeout: 5)
+        XCTAssertEqual(updatedPaymentMethod.billingDetails?.address?.country, "CA")
+        XCTAssertEqual(updatedPaymentMethod.billingDetails?.address?.city, "Toronto")
+        XCTAssertEqual(
+            checkout.session.customer?.paymentMethods.first?.billingDetails?.address?.country,
+            "CA"
+        )
+    }
+
+    func testSavedPaymentMethodManager_taxSyncFailure_commitsEditAndThrowsError() async throws {
+        // Given
+        let checkout = try await makeCheckout(automaticTaxEnabled: true)
+        let paymentMethodUpdate = expectation(description: "Saved payment method updated")
+        let taxRegionUpdate = expectation(description: "Edited billing address sync attempted")
+        var updatedSessionJSON = CheckoutTestHelpers.openSessionJSON
+        updatedSessionJSON["tax_context"] = [
+            "automatic_tax_enabled": true,
+            "automatic_tax_address_source": "session.billing",
+        ]
+        updatedSessionJSON["customer"] = [
+            "id": "cus_123",
+            "payment_methods": [
+                makeSavedPaymentMethodJSON(id: "pm_edited", country: "CA"),
+            ],
+        ]
+        stub { request in
+            request.httpMethod == "POST"
+                && request.url?.path == "/v1/payment_pages/\(checkout.session.id)"
+        } response: { request in
+            let params = RequestBodyTestHelpers.formEncodedBodyParams(from: request)
+            if params["payment_method_to_update[payment_method_id]"] == "pm_edited" {
+                paymentMethodUpdate.fulfill()
+                return HTTPStubsResponse(
+                    jsonObject: updatedSessionJSON,
+                    statusCode: 200,
+                    headers: nil
+                )
+            }
+            taxRegionUpdate.fulfill()
+            return HTTPStubsResponse(
+                jsonObject: [
+                    "error": [
+                        "type": "card_error",
+                        "message": "Tax update failed",
+                    ],
+                ],
+                statusCode: 500,
+                headers: nil
+            )
+        }
+        let manager = makeSavedPaymentMethodManager(checkout: checkout)
+
+        // When
+        do {
+            _ = try await manager.update(
+                paymentMethod: makeSavedPaymentMethod(id: "pm_edited", country: "US"),
+                with: makeBillingUpdateParams(country: "CA")
+            )
+            XCTFail("Expected the tax sync to fail")
+        } catch {
+            // Then
+            XCTAssertEqual(error.nonGenericDescription, "Tax update failed")
+        }
+
+        await fulfillment(of: [paymentMethodUpdate, taxRegionUpdate], timeout: 5)
+        XCTAssertEqual(
+            checkout.session.customer?.paymentMethods.first?.billingDetails?.address?.country,
+            "CA"
+        )
+    }
+
+    func testSavedPaymentMethodManager_updateFailure_throwsWithoutChangingSession() async throws {
+        // Given
+        let checkout = try await makeCheckout(automaticTaxEnabled: true)
+        let paymentMethodUpdate = expectation(description: "Saved payment method update attempted")
+        stub { request in
+            request.httpMethod == "POST"
+                && request.url?.path == "/v1/payment_pages/\(checkout.session.id)"
+                && RequestBodyTestHelpers.formEncodedBodyParams(from: request)[
+                    "payment_method_to_update[payment_method_id]"
+                ] == "pm_edited"
+        } response: { _ in
+            paymentMethodUpdate.fulfill()
+            return HTTPStubsResponse(
+                jsonObject: [
+                    "error": [
+                        "type": "card_error",
+                        "message": "Payment method update failed",
+                    ],
+                ],
+                statusCode: 500,
+                headers: nil
+            )
+        }
+        let paymentMethodIDsBeforeUpdate = checkout.session.customer?.paymentMethods.map(\.stripeId)
+        let manager = makeSavedPaymentMethodManager(checkout: checkout)
+
+        // When
+        do {
+            _ = try await manager.update(
+                paymentMethod: makeSavedPaymentMethod(id: "pm_edited", country: "US"),
+                with: makeBillingUpdateParams(country: "CA")
+            )
+            XCTFail("Expected the payment method update to fail")
+        } catch {
+            // Then
+            XCTAssertEqual(error.nonGenericDescription, "Payment method update failed")
+        }
+
+        await fulfillment(of: [paymentMethodUpdate], timeout: 5)
+        XCTAssertEqual(
+            checkout.session.customer?.paymentMethods.map(\.stripeId),
+            paymentMethodIDsBeforeUpdate
+        )
+    }
+}
+
+// MARK: - Helpers
+
+private extension SavedPaymentMethodBillingSyncTests {
+    func makeCheckout(
+        automaticTaxEnabled: Bool,
+        automaticTaxAddressSource: String = "session.billing"
+    ) async throws -> Checkout {
+        var sessionJSON = CheckoutTestHelpers.openSessionJSON
+        sessionJSON["tax_context"] = [
+            "automatic_tax_enabled": automaticTaxEnabled,
+            "automatic_tax_address_source": automaticTaxAddressSource,
+        ]
+        let session = try XCTUnwrap(
+            PaymentPagesAPIResponse.decodedObject(fromAPIResponse: sessionJSON)
+        )
+        let configuration = CheckoutTestHelpers.makeConfiguration(apiResponse: session)
+        return try await Checkout(configuration: configuration)
+    }
+
+    func stubCheckoutUpdate(
+        checkout: Checkout,
+        statusCode: Int32 = 200,
+        requestRecorder: CheckoutSessionRequestRecorder? = nil
+    ) -> XCTestExpectation {
+        let expectation = expectation(description: "Checkout tax region update")
+        var responseJSON = CheckoutTestHelpers.openSessionJSON
+        responseJSON["tax_context"] = [
+            "automatic_tax_enabled": true,
+            "automatic_tax_address_source": "session.billing",
+        ]
+        stub { request in
+            request.httpMethod == "POST"
+                && request.url?.path == "/v1/payment_pages/\(checkout.session.id)"
+                && RequestBodyTestHelpers.formEncodedBodyParams(from: request)[
+                    "tax_region[country]"
+                ] != nil
+        } response: { _ in
+            requestRecorder?.append(
+                CheckoutSessionRequest(kind: .updateSession, params: [:])
+            )
+            expectation.fulfill()
+            if statusCode >= 400 {
+                return HTTPStubsResponse(
+                    jsonObject: [
+                        "error": [
+                            "type": "card_error",
+                            "message": "Tax update failed",
+                        ],
+                    ],
+                    statusCode: statusCode,
+                    headers: nil
+                )
+            }
+            return HTTPStubsResponse(
+                jsonObject: responseJSON,
+                statusCode: statusCode,
+                headers: nil
+            )
+        }
+        return expectation
+    }
+
+    func makeEmbeddedManageController(
+        checkout: Checkout?,
+        paymentMethods: [STPPaymentMethod],
+        selectedPaymentMethod: STPPaymentMethod
+    ) -> VerticalSavedPaymentMethodsViewController {
+        var configuration = EmbeddedPaymentElement.Configuration()
+        configuration.apiClient = APIStubbedTestCase.stubbedAPIClient()
+        return VerticalSavedPaymentMethodsViewController(
+            configuration: configuration,
+            intent: checkout.map { .checkout($0.session) } ?? ._testValue(),
+            checkout: checkout,
+            syncsCheckoutBillingBeforeCompletion: checkout != nil,
+            selectedPaymentMethod: selectedPaymentMethod,
+            paymentMethods: paymentMethods,
+            elementsSession: ._testValue(paymentMethodTypes: ["card", "sepa_debit"]),
+            analyticsHelper: ._testValue(),
+            defaultPaymentMethod: nil
+        )
+    }
+
+    func assertEmbeddedSelectionCompletesWithoutLoading(
+        checkout: Checkout?,
+        selectedCountry: String = "CA"
+    ) async throws {
+        let firstPaymentMethod = makeSavedPaymentMethod(id: "pm_first", country: "US")
+        let selectedPaymentMethod = makeSavedPaymentMethod(
+            id: "pm_second",
+            country: selectedCountry
+        )
+        let delegate = MockVerticalSavedPaymentMethodsDelegate()
+        let sut = makeEmbeddedManageController(
+            checkout: checkout,
+            paymentMethods: [firstPaymentMethod, selectedPaymentMethod],
+            selectedPaymentMethod: firstPaymentMethod
+        )
+        sut.delegate = delegate
+        sut.loadViewIfNeeded()
+        let selectedRow = sut._testPaymentMethodRows[1]
+
+        selectedRow.rowButton.handleTap()
+
+        XCTAssertEqual(selectedRow.rowButton.alpha, 1)
+        XCTAssertEqual(activityIndicator(in: selectedRow)?.isAnimating, false)
+        await fulfillment(of: [delegate.completed], timeout: 5)
+    }
+
+    func makeSavedPaymentMethodManager(checkout: Checkout) -> SavedPaymentMethodManager {
+        return SavedPaymentMethodManager(
+            configuration: PaymentSheet.Configuration(),
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            intent: .checkout(checkout.session),
+            checkout: checkout
+        )
+    }
+
+    func makeBillingUpdateParams(country: String) -> STPPaymentMethodUpdateParams {
+        let billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.address = STPPaymentMethodAddress()
+        billingDetails.address?.country = country
+        let updateParams = STPPaymentMethodUpdateParams()
+        updateParams.billingDetails = billingDetails
+        return updateParams
+    }
+
+    func makeSavedPaymentMethod(
+        id: String,
+        country: String,
+        type: String = "card"
+    ) -> STPPaymentMethod {
+        return STPPaymentMethod.decodedObject(
+            fromAPIResponse: makeSavedPaymentMethodJSON(
+                id: id,
+                country: country,
+                type: type
+            )
+        )!
+    }
+
+    func makeSavedPaymentMethodJSON(
+        id: String,
+        country: String,
+        city: String? = nil,
+        type: String = "card"
+    ) -> [AnyHashable: Any] {
+        var address: [String: String] = [
+            "country": country,
+        ]
+        address["city"] = city
+        var response: [AnyHashable: Any] = [
+            "id": id,
+            "type": type,
+            "created": 1_700_000_000,
+            "billing_details": [
+                "address": address,
+            ],
+        ]
+        if type == "card" {
+            response["card"] = [
+                "brand": "visa",
+                "last4": "4242",
+                "exp_month": 12,
+                "exp_year": 2050,
+            ]
+        } else if type == "sepa_debit" {
+            response["sepa_debit"] = [
+                "last4": "6789",
+            ]
+        }
+        return response
+    }
+
+    func waitUntil(
+        timeout: TimeInterval = 5,
+        _ condition: () -> Bool
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            if Date() >= deadline {
+                XCTFail("Condition not met within \(timeout) seconds")
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
+    func activityIndicator(in view: UIView) -> ActivityIndicator? {
+        return view.subviews.first { $0 is ActivityIndicator } as? ActivityIndicator
+    }
+}
+
+@MainActor
+private final class MockVerticalSavedPaymentMethodsDelegate:
+    VerticalSavedPaymentMethodsViewControllerDelegate
+{
+    let completed = XCTestExpectation(description: "Saved payment method selection completed")
+    private(set) var completionCount = 0
+    private(set) var selectedPaymentMethod: STPPaymentMethod?
+
+    func didComplete(
+        viewController: VerticalSavedPaymentMethodsViewController,
+        with selectedPaymentMethod: STPPaymentMethod?,
+        latestPaymentMethods: [STPPaymentMethod],
+        didTapToDismiss: Bool,
+        defaultPaymentMethod: STPPaymentMethod?
+    ) {
+        completionCount += 1
+        self.selectedPaymentMethod = selectedPaymentMethod
+        completed.fulfill()
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/SavedPaymentMethodManagerTests.swift
@@ -11,6 +11,7 @@ import OHHTTPStubsSwift
 import StripeCoreTestUtils
 @_spi(STP) @testable import StripePayments
 @_spi(STP)@testable import StripePaymentSheet
+@testable @_spi(STP) import StripeUICore
 import XCTest
 
 @MainActor
@@ -26,6 +27,17 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
         return configuration
     }
 
+    override func setUp() async throws {
+        try await super.setUp()
+        await AddressSpecProvider.shared.loadAddressSpecs()
+        await FormSpecProvider.shared.load()
+    }
+
+    override func tearDown() {
+        HTTPStubs.removeAllStubs()
+        super.tearDown()
+    }
+
     // MARK: Update tests
     func testUpdatePaymentMethod_legacy() async throws {
         let paymentMethod = STPPaymentMethod.stubbedPaymentMethod()
@@ -34,7 +46,11 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
         var configuration = configuration
         configuration.customer = .init(id: "cus_test123", ephemeralKeySecret: ephemeralKey)
 
-        let sut = SavedPaymentMethodManager(configuration: configuration, elementsSession: ._testCardValue(), intent: ._testValue())
+        let sut = SavedPaymentMethodManager(
+            configuration: configuration,
+            elementsSession: ._testCardValue(),
+            intent: ._testValue()
+        )
         let updatedPaymentMethod = try await sut.update(paymentMethod: paymentMethod,
                            with: STPPaymentMethodUpdateParams())
 
@@ -61,7 +77,11 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
             ],
         ])
 
-        let sut = SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession, intent: ._testValue())
+        let sut = SavedPaymentMethodManager(
+            configuration: configuration,
+            elementsSession: elementsSession,
+            intent: ._testValue()
+        )
         let updatedPaymentMethod = try await sut.update(paymentMethod: paymentMethod,
                            with: STPPaymentMethodUpdateParams())
 
@@ -88,7 +108,11 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
         var configuration = configuration
         configuration.customer = .init(id: "cus_test123", ephemeralKeySecret: ephemeralKey)
 
-        let sut = SavedPaymentMethodManager(configuration: configuration, elementsSession: ._testCardValue(), intent: ._testValue())
+        let sut = SavedPaymentMethodManager(
+            configuration: configuration,
+            elementsSession: ._testCardValue(),
+            intent: ._testValue()
+        )
         let updatedPaymentMethod = try await sut.update(paymentMethod: paymentMethod,
                                                         with: STPPaymentMethodUpdateParams())
 
@@ -99,16 +123,17 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
 
     func testUpdatePaymentMethod_checkoutSession() async throws {
         let checkoutSessionId = "cs_test_checkout_session"
+        let checkoutSession = makeCheckoutSession(id: checkoutSessionId)
+        let checkout = try await makeCheckout(session: checkoutSession)
         let (expectation, capturedBody) = stubCheckoutSessionUpdatePaymentMethod(
             checkoutSessionId: checkoutSessionId,
             paymentMethodId: paymentMethod.stripeId
         )
-
-        let checkoutSession = makeCheckoutSession(id: checkoutSessionId)
         let sut = SavedPaymentMethodManager(
             configuration: configuration,
             elementsSession: ._testValue(paymentMethodTypes: ["card"]),
-            intent: .checkout(checkoutSession.makePublicSession())
+            intent: .checkout(checkoutSession.makePublicSession()),
+            checkout: checkout
         )
 
         let card = STPPaymentMethodCardParams()
@@ -134,16 +159,17 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
 
     func testUpdatePaymentMethod_checkoutSession_expiryOnly() async throws {
         let checkoutSessionId = "cs_test_checkout_session"
+        let checkoutSession = makeCheckoutSession(id: checkoutSessionId)
+        let checkout = try await makeCheckout(session: checkoutSession)
         let (expectation, capturedBody) = stubCheckoutSessionUpdatePaymentMethod(
             checkoutSessionId: checkoutSessionId,
             paymentMethodId: paymentMethod.stripeId
         )
-
-        let checkoutSession = makeCheckoutSession(id: checkoutSessionId)
         let sut = SavedPaymentMethodManager(
             configuration: configuration,
             elementsSession: ._testValue(paymentMethodTypes: ["card"]),
-            intent: .checkout(checkoutSession.makePublicSession())
+            intent: .checkout(checkoutSession.makePublicSession()),
+            checkout: checkout
         )
 
         let card = STPPaymentMethodCardParams()
@@ -162,12 +188,14 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
         XCTAssertFalse(body.contains("payment_method_to_update%5Bbilling_details%5D"))
     }
 
-    func testUpdatePaymentMethod_checkoutSession_missingBillingAndExpiry_throws() async {
+    func testUpdatePaymentMethod_checkoutSession_missingBillingAndExpiry_throws() async throws {
         let checkoutSession = makeCheckoutSession(id: "cs_test_checkout_session")
+        let checkout = try await makeCheckout(session: checkoutSession)
         let sut = SavedPaymentMethodManager(
             configuration: configuration,
             elementsSession: ._testValue(paymentMethodTypes: ["card"]),
-            intent: .checkout(checkoutSession.makePublicSession())
+            intent: .checkout(checkoutSession.makePublicSession()),
+            checkout: checkout
         )
 
         do {
@@ -184,7 +212,11 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
         let expectation = stubDetachPaymentMethod(paymentMethod: STPPaymentMethod.stubbedPaymentMethod(),
                                                   ephemeralKey: ephemeralKey)
 
-        let sut = SavedPaymentMethodManager(configuration: configuration, elementsSession: ._testValue(paymentMethodTypes: ["card"]), intent: ._testValue())
+        let sut = SavedPaymentMethodManager(
+            configuration: configuration,
+            elementsSession: ._testValue(paymentMethodTypes: ["card"]),
+            intent: ._testValue()
+        )
         sut.detach(paymentMethod: paymentMethod)
 
         wait(for: [expectation], timeout: 5.0)
@@ -213,7 +245,11 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
                                              ],
                                          ])
 
-        let sut = SavedPaymentMethodManager(configuration: configuration, elementsSession: elementsSession, intent: ._testValue())
+        let sut = SavedPaymentMethodManager(
+            configuration: configuration,
+            elementsSession: elementsSession,
+            intent: ._testValue()
+        )
         sut.detach(paymentMethod: paymentMethod)
 
         wait(for: [listPaymentMethodsExpectation, detachExpectation], timeout: 5.0)
@@ -227,7 +263,6 @@ final class SavedPaymentMethodManagerTests: XCTestCase {
         )
 
         let checkoutSession = makeCheckoutSession(id: checkoutSessionId)
-
         let sut = SavedPaymentMethodManager(
             configuration: configuration,
             elementsSession: ._testValue(paymentMethodTypes: ["card"]),
@@ -286,7 +321,20 @@ extension SavedPaymentMethodManagerTests {
     }
 
     func makeCheckoutSession(id: String) -> PaymentPagesAPIResponse {
-        CheckoutTestHelpers.makeSession().withSessionId(id)
+        CheckoutTestHelpers.makeOpenSession().withSessionId(id)
+    }
+
+    func makeCheckout(session: PaymentPagesAPIResponse) async throws -> Checkout {
+        let clientSecret = "\(session.makePublicSession().id)_secret_test"
+        let configuration = CheckoutTestHelpers.makeConfiguration(
+            apiResponse: session,
+            configuration: .init(
+                clientSecret: clientSecret,
+                returnURL: "stripe-ios-test://checkout-return"
+            ),
+            stubAllOutgoingRequests: false
+        )
+        return try await Checkout(configuration: configuration)
     }
 
     func stubCheckoutSessionUpdatePaymentMethod(


### PR DESCRIPTION
## Summary

- Sync Checkout automatic-tax billing before the embedded saved-payment-method manage sheet commits and dismisses.
- Show a trailing row spinner while syncing, block interaction, and restore the previous selection/default with an inline error on failure.
- Route Checkout saved-payment-method edits through Checkout session updates and sync the refreshed billing address when required.
- Preserve the existing immediate behavior when billing-sourced automatic tax or a usable country is absent.

## Motivation

Follow-up to #6790. Inline EPE selection now keeps Checkout billing in sync, but selecting from the embedded “View more” manage sheet and editing a saved method need the same Checkout consistency guarantees.

## Testing

On the configured iOS 18.0 iPhone 12 mini:

- `ci_scripts/run_tests.rb --test StripePaymentSheetTests/SavedPaymentMethodBillingSyncTests` — 11 passed
- `ci_scripts/run_tests.rb --test StripePaymentSheetTests/SavedPaymentMethodManagerTests` — 9 passed
- `ci_scripts/run_tests.rb --test StripePaymentSheetTests/VerticalSavedPaymentMethodsViewControllerTests` — 13 passed
- Strict SwiftLint on all 14 changed Swift files

No tests were ignored.

## Changelog

None — this fixes Checkout automatic-tax consistency for existing saved-payment-method flows.