### PR TITLE
Add Checkout user interface style configuration

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -11,6 +11,8 @@ import Foundation
 @_spi(STP)
 @_spi(ReactNativeSDK)
 extension Checkout {
+    public typealias UserInterfaceStyle = PaymentSheet.UserInterfaceStyle
+
     /// Configuration options for a ``Checkout`` instance.
     ///
     /// Supply a configuration when creating a ``Checkout`` to customize behavior:
@@ -62,6 +64,9 @@ extension Checkout {
 
         /// Link configuration.
         public var linkConfiguration: LinkConfiguration?
+
+        /// The color styling to use for Checkout UI.
+        public var userInterfaceStyle: UserInterfaceStyle = .automatic
 
         /// Configuration for the Adaptive Pricing currency selector returned by
         /// ``Checkout.getCurrencySelectorElement()``.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -129,11 +129,13 @@ extension PaymentElement {
         func makeEmbeddedConfiguration(
             apiClient: STPAPIClient,
             defaults: Checkout.Configuration.Defaults,
-            merchantDisplayName: String
+            merchantDisplayName: String,
+            userInterfaceStyle: Checkout.UserInterfaceStyle
         ) -> EmbeddedPaymentElement.Configuration {
             var configuration = embeddedConfiguration
             configuration.apiClient = apiClient
             configuration.merchantDisplayName = merchantDisplayName
+            configuration.style = userInterfaceStyle
             configuration.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.paymentSheetConfiguration()
             if let billingDetails = defaults.billingDetails {
                 configuration.defaultBillingDetails.set(billingDetails)
@@ -144,11 +146,13 @@ extension PaymentElement {
         func makePaymentSheetConfiguration(
             apiClient: STPAPIClient,
             defaults: Checkout.Configuration.Defaults,
-            merchantDisplayName: String
+            merchantDisplayName: String,
+            userInterfaceStyle: Checkout.UserInterfaceStyle
         ) -> PaymentSheet.Configuration {
             var configuration = paymentSheetConfiguration
             configuration.apiClient = apiClient
             configuration.merchantDisplayName = merchantDisplayName
+            configuration.style = userInterfaceStyle
             configuration.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.paymentSheetConfiguration()
             if let billingDetails = defaults.billingDetails {
                 configuration.defaultBillingDetails.set(billingDetails)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -75,7 +75,8 @@ public final class PaymentElement {
         let paymentSheetConfiguration = configuration.makePaymentSheetConfiguration(
             apiClient: checkout.apiClient,
             defaults: checkout.configuration.defaults,
-            merchantDisplayName: checkout.effectiveMerchantDisplayName
+            merchantDisplayName: checkout.effectiveMerchantDisplayName,
+            userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
         self.paymentSheetFlowController = try await PaymentSheet.FlowController.create(
             checkout: checkout,
@@ -85,7 +86,8 @@ public final class PaymentElement {
         let embeddedConfiguration = configuration.makeEmbeddedConfiguration(
             apiClient: checkout.apiClient,
             defaults: checkout.configuration.defaults,
-            merchantDisplayName: checkout.effectiveMerchantDisplayName
+            merchantDisplayName: checkout.effectiveMerchantDisplayName,
+            userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
         self.embeddedPaymentElement = try await EmbeddedPaymentElement.create(
             checkout: checkout,
@@ -138,12 +140,14 @@ extension PaymentElement {
         paymentSheetFlowController.configuration = configuration.makePaymentSheetConfiguration(
             apiClient: checkout.apiClient,
             defaults: checkout.configuration.defaults,
-            merchantDisplayName: checkout.effectiveMerchantDisplayName
+            merchantDisplayName: checkout.effectiveMerchantDisplayName,
+            userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
         embeddedPaymentElement.configuration = configuration.makeEmbeddedConfiguration(
             apiClient: checkout.apiClient,
             defaults: checkout.configuration.defaults,
-            merchantDisplayName: checkout.effectiveMerchantDisplayName
+            merchantDisplayName: checkout.effectiveMerchantDisplayName,
+            userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
 
         // Update FlowController

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -75,6 +75,7 @@ final class PaymentElementTest: XCTestCase {
         // Given Checkout merchant display name
         var checkoutConfiguration = Checkout.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
         checkoutConfiguration.merchantDisplayName = "Configured Merchant"
+        checkoutConfiguration.userInterfaceStyle = .alwaysDark
 
         // When Checkout creates PaymentElement
         let checkout = try await Checkout(
@@ -90,6 +91,8 @@ final class PaymentElementTest: XCTestCase {
         // Then both configurations use the configured merchant display name
         XCTAssertEqual(paymentSheetConfiguration.merchantDisplayName, "Configured Merchant")
         XCTAssertEqual(embeddedConfiguration.merchantDisplayName, "Configured Merchant")
+        XCTAssertEqual(paymentSheetConfiguration.style, .alwaysDark)
+        XCTAssertEqual(embeddedConfiguration.style, .alwaysDark)
     }
 
     func testConfigurationDefaultsMerchantDisplayNameToCheckoutSessionBusinessName() async throws {


### PR DESCRIPTION
## Summary
- Add Checkout.Configuration.userInterfaceStyle backed by the existing PaymentSheet.UserInterfaceStyle
- Propagate the style into Checkout-created PaymentSheet and EmbeddedPaymentElement configurations
- Extend an existing Checkout configuration bridge test to cover style propagation

## Testing
- ci_scripts/run_tests.rb --test StripePaymentSheetTests/PaymentElementTest/testConfigurationSetsCheckoutMerchantDisplayName