### PR TITLE
Replace bank debit FormSpecs with explicit forms

### DIFF
--- a/Stripe/StripeiOSTests/STPFPXBankBrandTest.swift
+++ b/Stripe/StripeiOSTests/STPFPXBankBrandTest.swift
@@ -7,6 +7,8 @@
 //  Copyright © 2019 Stripe, Inc. All rights reserved.
 //
 
+@_spi(STP) import StripePayments
+
 class STPFPXBankBrandTest: XCTestCase {
     func testStringFromBrand() {
         for brand in STPFPXBankBrand.allCases {

--- a/Stripe/StripeiOSTests/STPFPXBankBrandTest.swift
+++ b/Stripe/StripeiOSTests/STPFPXBankBrandTest.swift
@@ -9,30 +9,7 @@
 
 class STPFPXBankBrandTest: XCTestCase {
     func testStringFromBrand() {
-        let brands: [STPFPXBankBrand] = [
-            .affinBank,
-            .allianceBank,
-            .ambank,
-            .bankIslam,
-            .bankMuamalat,
-            .bankRakyat,
-            .BSN,
-            .CIMB,
-            .hongLeongBank,
-            .HSBC,
-            .KFH,
-            .maybank2E,
-            .maybank2U,
-            .ocbc,
-            .publicBank,
-            .CIMB,
-            .RHB,
-            .standardChartered,
-            .UOB,
-            .unknown,
-        ]
-
-        for brand in brands {
+        for brand in STPFPXBankBrand.allCases {
             let brandName = STPFPXBank.stringFrom(brand)
             let brandID = STPFPXBank.identifierFrom(brand)
             let reverseTransformedBrand = STPFPXBank.brandFrom(brandID)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+BankDebits.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+BankDebits.swift
@@ -8,6 +8,7 @@
 //
 
 @_spi(STP) import StripeCore
+import StripePayments
 @_spi(STP) import StripeUICore
 
 extension PaymentSheetFormFactory {
@@ -196,24 +197,15 @@ private enum BankDropdown {
         ("Volkswagen Bank", "volkswagen_bank"),
     ]
 
-    static let fpx: [(name: String, value: String)] = [
-        ("Affin Bank", "affin_bank"),
-        ("Alliance Bank", "alliance_bank"),
-        ("AmBank", "ambank"),
-        ("Bank Islam", "bank_islam"),
-        ("Bank Muamalat", "bank_muamalat"),
-        ("Bank Rakyat", "bank_rakyat"),
-        ("BSN", "bsn"),
-        ("CIMB Clicks", "cimb"),
-        ("Hong Leong Bank", "hong_leong_bank"),
-        ("HSBC BANK", "hsbc"),
-        ("KFH", "kfh"),
-        ("Maybank2E", "maybank2e"),
-        ("Maybank2U", "maybank2u"),
-        ("OCBC Bank", "ocbc"),
-        ("Public Bank", "public_bank"),
-        ("RHB Bank", "rhb"),
-        ("Standard Chartered", "standard_chartered"),
-        ("UOB Bank", "uob"),
-    ]
+    static let fpx: [(name: String, value: String)] = STPFPXBankBrand.allCases
+        .compactMap { brand in
+            guard brand != .unknown,
+                  let name = STPFPXBank.stringFrom(brand),
+                  let value = STPFPXBank.identifierFrom(brand)
+            else {
+                return nil
+            }
+            return (name, value)
+        }
+        .sorted { $0.value < $1.value }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+BankDebits.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+BankDebits.swift
@@ -1,0 +1,219 @@
+//
+//  PaymentSheetFormFactory+BankDebits.swift
+//  StripePaymentSheet
+//
+//  Created by Nick Porter on 8/3/26.
+//
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+
+extension PaymentSheetFormFactory {
+    func makeEPS() -> PaymentMethodElement {
+        let name = configuration.billingDetailsCollectionConfiguration.name != .never
+            ? makeName(apiPath: "billing_details[name]") : nil
+        let email = configuration.billingDetailsCollectionConfiguration.email == .always ? makeEmail() : nil
+        let phone = configuration.billingDetailsCollectionConfiguration.phone == .always ? makePhone() : nil
+        let bank = makeBankDropdown(
+            label: STPLocalizedString("EPS Bank", "Label title for EPS Bank"),
+            apiPath: "eps[bank]",
+            banks: BankDropdown.eps
+        )
+        let address = makeBillingAddressSectionIfNecessary(requiredByPaymentMethod: false)
+            as? PaymentMethodElementWrapper<AddressSectionElement>
+        connectBillingDetailsFields(addressElement: address, phoneElement: phone)
+        let elements: [Element?] = [name, email, phone, bank, address]
+
+        return makeDefaultsApplierWrapper(
+            for: FormElement(
+                autoSectioningElements: elements.compactMap { $0 },
+                theme: theme
+            )
+        )
+    }
+
+    func makePrzelewy24() -> PaymentMethodElement {
+        let name = configuration.billingDetailsCollectionConfiguration.name != .never
+            ? makeName(apiPath: "billing_details[name]") : nil
+        let email = configuration.billingDetailsCollectionConfiguration.email != .never
+            ? makeEmail(apiPath: "billing_details[email]") : nil
+        let phone = configuration.billingDetailsCollectionConfiguration.phone == .always ? makePhone() : nil
+        let bank = makeBankDropdown(
+            label: STPLocalizedString("Przelewy24 Bank", "Label title for Przelewy24 Bank"),
+            apiPath: "p24[bank]",
+            banks: BankDropdown.przelewy24
+        )
+        let address = makeBillingAddressSectionIfNecessary(requiredByPaymentMethod: false)
+            as? PaymentMethodElementWrapper<AddressSectionElement>
+        connectBillingDetailsFields(addressElement: address, phoneElement: phone)
+        let elements: [Element?] = [name, email, phone, bank, address]
+
+        return makeDefaultsApplierWrapper(
+            for: FormElement(
+                autoSectioningElements: elements.compactMap { $0 },
+                theme: theme
+            )
+        )
+    }
+
+    func makeAUBECSDebit() -> PaymentMethodElement {
+        let name = configuration.billingDetailsCollectionConfiguration.name != .never
+            ? makeName(label: String.Localized.nameOnAccount, apiPath: "billing_details[name]") : nil
+        let email = configuration.billingDetailsCollectionConfiguration.email != .never
+            ? makeEmail(apiPath: "billing_details[email]") : nil
+        let phone = configuration.billingDetailsCollectionConfiguration.phone == .always ? makePhone() : nil
+        let bsb = makeBSB(apiPath: "au_becs_debit[bsb_number]")
+        let accountNumber = makeAUBECSAccountNumber(apiPath: "au_becs_debit[account_number]")
+        let address = makeBillingAddressSectionIfNecessary(requiredByPaymentMethod: false)
+            as? PaymentMethodElementWrapper<AddressSectionElement>
+        connectBillingDetailsFields(addressElement: address, phoneElement: phone)
+        let elements: [Element?] = [
+            name,
+            email,
+            phone,
+            bsb,
+            accountNumber,
+            address,
+            makeAUBECSMandate(),
+        ]
+
+        return makeDefaultsApplierWrapper(
+            for: FormElement(
+                autoSectioningElements: elements.compactMap { $0 },
+                theme: theme
+            )
+        )
+    }
+
+    func makeFPX() -> PaymentMethodElement {
+        let bank = makeBankDropdown(
+            label: STPLocalizedString("FPX Bank", "Select a bank dropdown for FPX"),
+            apiPath: "fpx[bank]",
+            banks: BankDropdown.fpx
+        )
+        let address = makeBillingAddressSectionIfNecessary(requiredByPaymentMethod: false)
+            as? PaymentMethodElementWrapper<AddressSectionElement>
+        let name = configuration.billingDetailsCollectionConfiguration.name == .always ? makeName() : nil
+        let email = configuration.billingDetailsCollectionConfiguration.email == .always ? makeEmail() : nil
+        let phone = configuration.billingDetailsCollectionConfiguration.phone == .always ? makePhone() : nil
+        connectBillingDetailsFields(addressElement: address, phoneElement: phone)
+        let elements: [Element?] = [bank, address, name, email, phone]
+
+        return makeDefaultsApplierWrapper(
+            for: FormElement(
+                autoSectioningElements: elements.compactMap { $0 },
+                theme: theme
+            )
+        )
+    }
+
+    private func makeBankDropdown(
+        label: String,
+        apiPath: String,
+        banks: [(name: String, value: String)]
+    ) -> PaymentMethodElementWrapper<DropdownFieldElement> {
+        let items = banks.map {
+            DropdownFieldElement.DropdownItem(
+                pickerDisplayName: $0.name,
+                labelDisplayName: $0.name,
+                accessibilityValue: $0.name,
+                rawData: $0.value
+            )
+        }
+        let defaultIndex = items.firstIndex {
+            $0.rawData == getPreviousCustomerInput(for: apiPath)
+        } ?? 0
+        let dropdown = DropdownFieldElement(
+            items: items,
+            defaultIndex: defaultIndex,
+            label: label,
+            theme: theme
+        )
+        return PaymentMethodElementWrapper(dropdown) { dropdown, params in
+            params.paymentMethodParams.additionalAPIParameters[apiPath] = dropdown.selectedItem.rawData
+            return params
+        }
+    }
+}
+
+private enum BankDropdown {
+    static let eps: [(name: String, value: String)] = [
+        ("Ärzte- und Apothekerbank", "arzte_und_apotheker_bank"),
+        ("Austrian Anadi Bank AG", "austrian_anadi_bank_ag"),
+        ("Bank Austria", "bank_austria"),
+        ("bank99 AG", "brull_kallmus_bank_ag"),
+        ("Bankhaus Carl Spängler & Co.AG", "bankhaus_carl_spangler"),
+        ("Bankhaus Schelhammer & Schattera AG", "bankhaus_schelhammer_und_schattera_ag"),
+        ("BAWAG P.S.K. AG", "bawag_psk_ag"),
+        ("BKS Bank AG", "bks_bank_ag"),
+        ("BTV VIER LÄNDER BANK", "btv_vier_lander_bank"),
+        ("Capital Bank Grawe Gruppe AG", "capital_bank_grawe_gruppe_ag"),
+        ("Dolomitenbank", "dolomitenbank"),
+        ("Easybank AG", "easybank_ag"),
+        ("Erste Bank und Sparkassen", "erste_bank_und_sparkassen"),
+        ("Hypo Alpe-Adria-Bank International AG", "hypo_alpeadriabank_international_ag"),
+        ("HYPO NOE LB für Niederösterreich u. Wien", "hypo_noe_lb_fur_niederosterreich_u_wien"),
+        ("HYPO Oberösterreich,Salzburg,Steiermark", "hypo_oberosterreich_salzburg_steiermark"),
+        ("Hypo Tirol Bank AG", "hypo_tirol_bank_ag"),
+        ("Hypo Vorarlberg Bank AG", "hypo_vorarlberg_bank_ag"),
+        ("HYPO-BANK BURGENLAND Aktiengesellschaft", "hypo_bank_burgenland_aktiengesellschaft"),
+        ("Marchfelder Bank", "marchfelder_bank"),
+        ("Oberbank AG", "oberbank_ag"),
+        ("Raiffeisen Bankengruppe Österreich", "raiffeisen_bankengruppe_osterreich"),
+        ("Schoellerbank AG", "schoellerbank_ag"),
+        ("Sparda-Bank Wien", "sparda_bank_wien"),
+        ("Volksbank Gruppe", "volksbank_gruppe"),
+        ("Volkskreditbank AG", "volkskreditbank_ag"),
+        ("VR-Bank Braunau", "vr_bank_braunau"),
+    ]
+
+    static let przelewy24: [(name: String, value: String)] = [
+        ("Alior Bank", "alior_bank"),
+        ("Bank Millenium", "bank_millennium"),
+        ("Bank Nowy BFG S.A.", "bank_nowy_bfg_sa"),
+        ("Bank PEKAO S.A", "bank_pekao_sa"),
+        ("Bank spółdzielczy", "banki_spbdzielcze"),
+        ("BLIK", "blik"),
+        ("BNP Paribas", "bnp_paribas"),
+        ("BOZ", "boz"),
+        ("CitiHandlowy", "citi_handlowy"),
+        ("Credit Agricole", "credit_agricole"),
+        ("e-Transfer Pocztowy24", "etransfer_pocztowy24"),
+        ("Getin Bank", "getin_bank"),
+        ("IdeaBank", "ideabank"),
+        ("ING", "ing"),
+        ("inteligo", "inteligo"),
+        ("mBank", "mbank_mtransfer"),
+        ("Nest Przelew", "nest_przelew"),
+        ("Noble Pay", "noble_pay"),
+        ("Płać z iPKO (PKO BP)", "pbac_z_ipko"),
+        ("Plus Bank", "plus_bank"),
+        ("Santander", "santander_przelew24"),
+        ("Toyota Bank", "toyota_bank"),
+        ("VeloBank", "velobank"),
+        ("Volkswagen Bank", "volkswagen_bank"),
+    ]
+
+    static let fpx: [(name: String, value: String)] = [
+        ("Affin Bank", "affin_bank"),
+        ("Alliance Bank", "alliance_bank"),
+        ("AmBank", "ambank"),
+        ("Bank Islam", "bank_islam"),
+        ("Bank Muamalat", "bank_muamalat"),
+        ("Bank Rakyat", "bank_rakyat"),
+        ("BSN", "bsn"),
+        ("CIMB Clicks", "cimb"),
+        ("Hong Leong Bank", "hong_leong_bank"),
+        ("HSBC BANK", "hsbc"),
+        ("KFH", "kfh"),
+        ("Maybank2E", "maybank2e"),
+        ("Maybank2U", "maybank2u"),
+        ("OCBC Bank", "ocbc"),
+        ("Public Bank", "public_bank"),
+        ("RHB Bank", "rhb"),
+        ("Standard Chartered", "standard_chartered"),
+        ("UOB Bank", "uob"),
+    ]
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+BankDebits.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+BankDebits.swift
@@ -8,7 +8,7 @@
 //
 
 @_spi(STP) import StripeCore
-import StripePayments
+@_spi(STP) import StripePayments
 @_spi(STP) import StripeUICore
 
 extension PaymentSheetFormFactory {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -291,7 +291,15 @@ class PaymentSheetFormFactory {
                 return makeContactInformationAndBillingAddressForm(
                     additionalElements: makeSetupMandateElements(for: paymentMethod)
                 )
-            case .FPX, .AUBECSDebit, .przelewy24, .EPS, .netBanking, .weChatPay,
+            case .EPS:
+                return makeEPS()
+            case .przelewy24:
+                return makePrzelewy24()
+            case .AUBECSDebit:
+                return makeAUBECSDebit()
+            case .FPX:
+                return makeFPX()
+            case .netBanking, .weChatPay,
                  .link, .cardPresent, .unknown:
                 return makeFormSpecBasedForm(for: paymentMethod)
             @unknown default:

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -37,6 +37,14 @@ private final class MockFormSpecProvider: FormSpecProvider {
     }
 }
 
+private struct BankFormExpectation {
+    let paymentMethod: STPPaymentMethodType
+    let apiPath: String
+    let itemCount: Int
+    let firstValue: String
+    let lastValue: String
+}
+
 @MainActor
 class PaymentSheetFormFactoryTest: XCTestCase {
     private func extractBNPLHeaderView(from subtitle: SubtitleElement) -> BNPLFormHeaderView? {
@@ -2021,6 +2029,76 @@ class PaymentSheetFormFactoryTest: XCTestCase {
                 "Expected \(paymentMethodType) not to request a form spec"
             )
         }
+    }
+
+    func testBankDebitFormsDoNotRequireFormSpecs() {
+        // Given no loaded form specs and billing detail collection disabled
+        let originalFormSpecProvider = FormSpecProvider.shared
+        defer { FormSpecProvider.shared = originalFormSpecProvider }
+        FormSpecProvider.shared = FormSpecProvider()
+        var configuration = PaymentSheet.Configuration()
+        configuration.billingDetailsCollectionConfiguration.name = .never
+        configuration.billingDetailsCollectionConfiguration.email = .never
+        configuration.billingDetailsCollectionConfiguration.phone = .never
+        configuration.billingDetailsCollectionConfiguration.address = .never
+        let bankForms: [BankFormExpectation] = [
+            .init(
+                paymentMethod: .EPS,
+                apiPath: "eps[bank]",
+                itemCount: 27,
+                firstValue: "arzte_und_apotheker_bank",
+                lastValue: "vr_bank_braunau"
+            ),
+            .init(
+                paymentMethod: .przelewy24,
+                apiPath: "p24[bank]",
+                itemCount: 24,
+                firstValue: "alior_bank",
+                lastValue: "volkswagen_bank"
+            ),
+            .init(
+                paymentMethod: .FPX,
+                apiPath: "fpx[bank]",
+                itemCount: 18,
+                firstValue: "affin_bank",
+                lastValue: "uob"
+            ),
+        ]
+
+        for bankForm in bankForms {
+            // When building a bank-selector form
+            let form = PaymentSheetFormFactory(
+                intent: ._testPaymentIntent(paymentMethodTypes: [bankForm.paymentMethod]),
+                elementsSession: ._testValue(paymentMethodTypes: [bankForm.paymentMethod.identifier]),
+                configuration: .paymentElement(configuration),
+                paymentMethod: .stripe(bankForm.paymentMethod)
+            ).make()
+
+            // Then the complete selector is built without consulting FormSpecProvider
+            let dropdown = form.getAllUnwrappedSubElements()
+                .compactMap { $0 as? DropdownFieldElement }
+                .first
+            XCTAssertEqual(dropdown?.items.count, bankForm.itemCount)
+            XCTAssertEqual(dropdown?.items.first?.rawData, bankForm.firstValue)
+            XCTAssertEqual(dropdown?.items.last?.rawData, bankForm.lastValue)
+            let params = form.updateParams(params: .init(type: .stripe(bankForm.paymentMethod)))
+            XCTAssertEqual(
+                params?.paymentMethodParams.additionalAPIParameters[bankForm.apiPath] as? String,
+                bankForm.firstValue
+            )
+        }
+
+        // And AU BECS keeps its two account fields without a form spec
+        let auBecsForm = PaymentSheetFormFactory(
+            intent: ._testPaymentIntent(paymentMethodTypes: [.AUBECSDebit]),
+            elementsSession: ._testValue(paymentMethodTypes: [STPPaymentMethodType.AUBECSDebit.identifier]),
+            configuration: .paymentElement(configuration),
+            paymentMethod: .stripe(.AUBECSDebit)
+        ).make()
+        XCTAssertEqual(
+            auBecsForm.getAllUnwrappedSubElements().compactMap { $0 as? TextFieldElement }.count,
+            2
+        )
     }
 
     func testLinkPMModeCardFormContainsMandateText() {

--- a/StripePayments/StripePayments/Source/API Bindings/Models/STPFPXBankBrand.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/STPFPXBankBrand.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// The various bank brands available for FPX payments.
-@objc public enum STPFPXBankBrand: Int {
+@objc public enum STPFPXBankBrand: Int, CaseIterable {
     /// Maybank2U
     case maybank2U
     /// CIMB Clicks

--- a/StripePayments/StripePayments/Source/API Bindings/Models/STPFPXBankBrand.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/STPFPXBankBrand.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// The various bank brands available for FPX payments.
-@objc public enum STPFPXBankBrand: Int, CaseIterable {
+@objc public enum STPFPXBankBrand: Int {
     /// Maybank2U
     case maybank2U
     /// CIMB Clicks
@@ -49,6 +49,8 @@ import Foundation
     /// An unknown bank
     case unknown
 }
+
+@_spi(STP) extension STPFPXBankBrand: CaseIterable {}
 
 /// Convenience methods for using FPX bank brands.
 public class STPFPXBank: NSObject {


### PR DESCRIPTION
## Summary

- Builds the EPS, Przelewy24, AU BECS Debit, and FPX forms without relying on remotely loaded form specs. This keeps their billing fields, bank selectors, account fields, and submitted parameters consistent while moving them onto explicit form construction.
- One final PR will come to remove FormSpecs JSON and infra.

## Motivation

Form spec removal

## Testing

- New unit test
- `ci_scripts/run_tests.rb --test StripePaymentSheetTests/PaymentSheetFormFactoryTest/testBankDebitFormsDoNotRequireFormSpecs`

## Changelog

N/A