### PR TITLE
SAE — Add IntegrationDelegate

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -342,6 +342,7 @@ extension AddressViewController {
             do {
                 try await self.integrationDelegate?.save(
                     addressDetails: addressDetails,
+                    // TODO(gbirch) fill in loading UI behavior
                     setLoading: { _ in }
                 )
             } catch {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -57,6 +57,15 @@ public class AddressViewController: UIViewController {
     private var didLogAddressShow = false
 
     // MARK: - Internal properties
+
+    /// Delegate provided by the integration entry point (legacy Address Element or Checkout Sessions Shipping Address Element) that handles address saving and analytics
+    @MainActor
+    protocol IntegrationDelegate: AnyObject {
+        /// Handles completion with the customer's collected address details.
+        func save(addressDetails: AddressDetails?, setLoading: (Bool) -> Void) async throws
+    }
+
+    weak var integrationDelegate: IntegrationDelegate?
     let addressSpecProvider: AddressSpecProvider
     private var latestError: Error? {
         didSet {
@@ -218,13 +227,19 @@ public class AddressViewController: UIViewController {
         configuration: Configuration,
         delegate: AddressViewControllerDelegate
     ) {
-        self.init(addressSpecProvider: .shared, configuration: configuration, delegate: delegate)
+        self.init(
+            addressSpecProvider: .shared,
+            configuration: configuration,
+            delegate: delegate,
+            integrationDelegate: nil
+        )
     }
 
     init(
         addressSpecProvider: AddressSpecProvider,
         configuration: Configuration,
-        delegate: AddressViewControllerDelegate
+        delegate: AddressViewControllerDelegate,
+        integrationDelegate: IntegrationDelegate? = nil
     ) {
         self.addressSpecProvider = addressSpecProvider
         self.configuration = configuration
@@ -234,6 +249,9 @@ public class AddressViewController: UIViewController {
         if configuration.useNavigationBarTitle {
             title = configuration.title
         }
+
+        // Set the integration delegate if provided. Otherwise use the default legacy one
+        self.integrationDelegate = integrationDelegate ?? self
     }
 
     required init?(coder: NSCoder) {
@@ -320,8 +338,16 @@ extension AddressViewController {
 extension AddressViewController {
 
     func didContinue() {
-        logAddressCompleted()
-        delegate?.addressViewControllerDidFinish(self, with: addressDetails)
+        Task { @MainActor in
+            do {
+                try await self.integrationDelegate?.save(
+                    addressDetails: addressDetails,
+                    setLoading: { _ in }
+                )
+            } catch {
+                self.latestError = error
+            }
+        }
     }
 
     @objc func didTapBackground() {
@@ -485,6 +511,15 @@ extension AddressViewController {
             editDistance: editDistance,
             apiClient: configuration.apiClient
         )
+    }
+}
+
+// MARK: - IntegrationDelegate
+// Default implementation that logs completion and forwards address details to the merchant delegate
+extension AddressViewController: AddressViewController.IntegrationDelegate {
+    func save(addressDetails: AddressDetails?, setLoading: (Bool) -> Void) async throws {
+        logAddressCompleted()
+        delegate?.addressViewControllerDidFinish(self, with: addressDetails)
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerTests.swift
@@ -1,0 +1,229 @@
+//
+//  AddressViewControllerTests.swift
+//  StripePaymentSheetTests
+//
+//  Created by George Birch on 8/4/26.
+//
+
+@_spi(STP) @testable import StripeCore
+@_spi(STP) @testable import StripePaymentSheet
+@_spi(STP) @testable import StripeUICore
+import XCTest
+
+@MainActor
+final class AddressViewControllerTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        STPAnalyticsClient.sharedClient._testLogHistory = []
+    }
+
+    func testDidContinuePassesValidAddressToIntegrationDelegate() async {
+        // Given an AddressViewController with a valid address and a custom integration delegate
+        let merchantDelegate = MerchantDelegate()
+        let integrationDelegate = IntegrationDelegate()
+        integrationDelegate.saveExpectation = expectation(description: "Save address")
+        let viewController = makeViewController(
+            configuration: makeConfiguration(defaultAddress: .init(
+                city: "San Francisco",
+                country: "US",
+                line1: "354 Oyster Point Blvd",
+                postalCode: "94080",
+                state: "CA"
+            )),
+            merchantDelegate: merchantDelegate,
+            integrationDelegate: integrationDelegate
+        )
+        viewController.loadViewIfNeeded()
+
+        // When address collection completes
+        viewController.didContinue()
+        await fulfillment(of: [integrationDelegate.saveExpectation!])
+
+        // Then only the integration delegate receives the valid address
+        XCTAssertEqual(integrationDelegate.receivedAddressDetails.count, 1)
+        let addressDetails = integrationDelegate.receivedAddressDetails[0]
+        XCTAssertEqual(addressDetails?.address.city, "San Francisco")
+        XCTAssertEqual(addressDetails?.address.country, "US")
+        XCTAssertEqual(addressDetails?.address.line1, "354 Oyster Point Blvd")
+        XCTAssertEqual(addressDetails?.address.postalCode, "94080")
+        XCTAssertEqual(addressDetails?.address.state, "CA")
+        XCTAssertTrue(merchantDelegate.receivedAddressDetails.isEmpty)
+    }
+
+    func testDidContinuePassesNilAddressToIntegrationDelegate() async {
+        // Given an AddressViewController with an invalid address and a custom integration delegate
+        let merchantDelegate = MerchantDelegate()
+        let integrationDelegate = IntegrationDelegate()
+        integrationDelegate.saveExpectation = expectation(description: "Save nil address")
+        let viewController = makeViewController(
+            configuration: makeConfiguration(),
+            merchantDelegate: merchantDelegate,
+            integrationDelegate: integrationDelegate
+        )
+        viewController.loadViewIfNeeded()
+
+        // When address collection completes
+        viewController.didContinue()
+        await fulfillment(of: [integrationDelegate.saveExpectation!])
+
+        // Then only the integration delegate receives the nil address
+        XCTAssertEqual(integrationDelegate.receivedAddressDetails.count, 1)
+        XCTAssertNil(integrationDelegate.receivedAddressDetails[0])
+        XCTAssertTrue(merchantDelegate.receivedAddressDetails.isEmpty)
+    }
+
+    func testDefaultIntegrationDelegateLogsAndForwardsValidAddress() async {
+        // Given an AddressViewController using the default integration delegate
+        let merchantDelegate = MerchantDelegate()
+        merchantDelegate.completionExpectation = expectation(description: "Merchant completion")
+        let viewController = makeViewController(
+            configuration: makeConfiguration(defaultAddress: .init(
+                city: "San Francisco",
+                country: "US",
+                line1: "354 Oyster Point Blvd",
+                postalCode: "94080",
+                state: "CA"
+            )),
+            merchantDelegate: merchantDelegate
+        )
+        viewController.loadViewIfNeeded()
+
+        // When address collection completes
+        viewController.didContinue()
+        await fulfillment(of: [merchantDelegate.completionExpectation!])
+
+        // Then the merchant receives the address and completion is logged
+        XCTAssertEqual(merchantDelegate.receivedAddressDetails.count, 1)
+        XCTAssertEqual(merchantDelegate.receivedAddressDetails[0]?.address.line1, "354 Oyster Point Blvd")
+        XCTAssertNotNil(addressCompletionEvent)
+    }
+
+    func testDefaultIntegrationDelegateLogsAndForwardsNilAddress() async {
+        // Given an AddressViewController using the default integration delegate with an invalid address
+        let merchantDelegate = MerchantDelegate()
+        merchantDelegate.completionExpectation = expectation(description: "Merchant completion")
+        let viewController = makeViewController(
+            configuration: makeConfiguration(),
+            merchantDelegate: merchantDelegate
+        )
+        viewController.loadViewIfNeeded()
+
+        // When address collection completes
+        viewController.didContinue()
+        await fulfillment(of: [merchantDelegate.completionExpectation!])
+
+        // Then the merchant receives nil and completion is logged
+        XCTAssertEqual(merchantDelegate.receivedAddressDetails.count, 1)
+        XCTAssertNil(merchantDelegate.receivedAddressDetails[0])
+        XCTAssertNotNil(addressCompletionEvent)
+    }
+
+    func testDidContinueDisplaysIntegrationDelegateError() async {
+        // Given an AddressViewController whose integration delegate fails to save
+        let expectedError = NSError(
+            domain: "AddressViewControllerTests",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Unable to save the address."]
+        )
+        let merchantDelegate = MerchantDelegate()
+        let integrationDelegate = IntegrationDelegate(error: expectedError)
+        integrationDelegate.saveExpectation = expectation(description: "Save address")
+        let viewController = makeViewController(
+            configuration: makeConfiguration(),
+            merchantDelegate: merchantDelegate,
+            integrationDelegate: integrationDelegate
+        )
+        viewController.loadViewIfNeeded()
+
+        // When address collection completes
+        viewController.didContinue()
+        await fulfillment(of: [integrationDelegate.saveExpectation!])
+
+        // Then the error is displayed without notifying the merchant
+        XCTAssertEqual(viewController.errorLabel.text, expectedError.localizedDescription)
+        XCTAssertFalse(viewController.errorLabel.isHidden)
+        XCTAssertTrue(merchantDelegate.receivedAddressDetails.isEmpty)
+    }
+
+    private var addressCompletionEvent: [String: Any]? {
+        STPAnalyticsClient.sharedClient._testLogHistory.first {
+            $0["event"] as? String == "mc_address_completed"
+        }
+    }
+
+    private func makeConfiguration(
+        defaultAddress: PaymentSheet.Address? = nil
+    ) -> AddressViewController.Configuration {
+        var configuration = AddressViewController.Configuration()
+        configuration.allowedCountries = ["US"]
+        configuration.apiClient = STPAPIClient(publishableKey: "pk_test_123")
+        if let defaultAddress {
+            configuration.defaultValues = .init(address: defaultAddress)
+        }
+        return configuration
+    }
+
+    private func makeViewController(
+        configuration: AddressViewController.Configuration,
+        merchantDelegate: AddressViewControllerDelegate,
+        integrationDelegate: AddressViewController.IntegrationDelegate? = nil
+    ) -> AddressViewController {
+        AddressViewController(
+            addressSpecProvider: makeAddressSpecProvider(),
+            configuration: configuration,
+            delegate: merchantDelegate,
+            integrationDelegate: integrationDelegate
+        )
+    }
+
+    private func makeAddressSpecProvider() -> AddressSpecProvider {
+        let addressSpecProvider = AddressSpecProvider()
+        addressSpecProvider.addressSpecs = [
+            "US": AddressSpec(
+                format: "NOACSZ",
+                require: "ACSZ",
+                cityNameType: .city,
+                stateNameType: .state,
+                zip: "",
+                zipNameType: .zip
+            ),
+        ]
+        return addressSpecProvider
+    }
+}
+
+@MainActor
+private final class MerchantDelegate: AddressViewControllerDelegate {
+    var completionExpectation: XCTestExpectation?
+    var receivedAddressDetails: [AddressViewController.AddressDetails?] = []
+
+    func addressViewControllerDidFinish(
+        _ addressViewController: AddressViewController,
+        with address: AddressViewController.AddressDetails?
+    ) {
+        receivedAddressDetails.append(address)
+        completionExpectation?.fulfill()
+    }
+}
+
+@MainActor
+private final class IntegrationDelegate: AddressViewController.IntegrationDelegate {
+    var saveExpectation: XCTestExpectation?
+    var receivedAddressDetails: [AddressViewController.AddressDetails?] = []
+    private let error: Error?
+
+    init(error: Error? = nil) {
+        self.error = error
+    }
+
+    func save(
+        addressDetails: AddressViewController.AddressDetails?,
+        setLoading: (Bool) -> Void
+    ) async throws {
+        receivedAddressDetails.append(addressDetails)
+        saveExpectation?.fulfill()
+        if let error {
+            throw error
+        }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerTests.swift
@@ -42,6 +42,7 @@ final class AddressViewControllerTests: XCTestCase {
         // Then only the integration delegate receives the valid address
         XCTAssertEqual(integrationDelegate.receivedAddressDetails.count, 1)
         let addressDetails = integrationDelegate.receivedAddressDetails[0]
+        XCTAssertEqual(addressDetails?.name, "Jane Doe")
         XCTAssertEqual(addressDetails?.address.city, "San Francisco")
         XCTAssertEqual(addressDetails?.address.country, "US")
         XCTAssertEqual(addressDetails?.address.line1, "354 Oyster Point Blvd")
@@ -94,6 +95,7 @@ final class AddressViewControllerTests: XCTestCase {
 
         // Then the merchant receives the address and completion is logged
         XCTAssertEqual(merchantDelegate.receivedAddressDetails.count, 1)
+        XCTAssertEqual(merchantDelegate.receivedAddressDetails[0]?.name, "Jane Doe")
         XCTAssertEqual(merchantDelegate.receivedAddressDetails[0]?.address.line1, "354 Oyster Point Blvd")
         XCTAssertNotNil(addressCompletionEvent)
     }
@@ -158,7 +160,7 @@ final class AddressViewControllerTests: XCTestCase {
         configuration.allowedCountries = ["US"]
         configuration.apiClient = STPAPIClient(publishableKey: "pk_test_123")
         if let defaultAddress {
-            configuration.defaultValues = .init(address: defaultAddress)
+            configuration.defaultValues = .init(address: defaultAddress, name: "Jane Doe")
         }
         return configuration
     }


### PR DESCRIPTION
## Summary
The IntegrationDelegate provides an interface for address saving and analytics behavior, which will diverge between the legacy AE and the Checkout Sessions SAE. 

This PR is scoped to a refactor of the existing behavior — `setLoading()` is left blank and will be filled in with loading behavior in a future PR

## Motivation
https://docs.google.com/document/d/1CWglcOHR6I8cOWKjztPfnhnVG8axucpv-j5cWIoey7E/edit?tab=t.6mlp9ite2vpp

## Testing
Added unit tests

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
