### PR TITLE
CryptoOnramp SDK: Wallet Address Deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 The next release's version bump will so far be:
-PATCH
+MINOR
 
 ## X.Y.Z - changes pending release
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ PATCH
 
 ## X.Y.Z - changes pending release
 
+### CryptoOnramp (Alpha)
+* [Added] Added `CryptoOnrampCoordinator.deleteWalletAddress(walletId:)` to delete a registered wallet address.
+
 ## 26.5.0 2026-08-03
 ### CryptoOnramp (Alpha)
 * [Added] Added support for registering wallet addresses on the Tempo network.

--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -373,6 +373,26 @@ extension STPAPIClient {
         )
     }
 
+    /// Make a DELETE request using the passed parameters.
+    @_spi(STP) public func delete<T: Decodable>(
+        resource: String,
+        parameters: [String: Any],
+        ephemeralKeySecret: String? = nil,
+        consumerPublishableKey: String? = nil,
+        apiVersionOverride: String? = nil,
+        completion: @escaping (Result<T, Error>) -> Void
+    ) {
+        request(
+            method: .delete,
+            parameters: parameters,
+            ephemeralKeySecret: ephemeralKeySecret,
+            consumerPublishableKey: consumerPublishableKey,
+            apiVersionOverride: apiVersionOverride,
+            resource: resource,
+            completion: completion
+        )
+    }
+
     func request<T: Decodable>(
         method: HTTPMethod,
         parameters: [String: Any],
@@ -429,7 +449,7 @@ extension STPAPIClient {
         switch method {
         case .get:
             request.stp_addParameters(toURL: parameters)
-        case .post:
+        case .post, .delete:
             let formData = URLEncoder.queryString(from: parameters).data(using: .utf8)
             request.httpBody = formData
             request.setValue(
@@ -616,5 +636,6 @@ extension STPAPIClient {
     enum HTTPMethod: String {
         case get = "GET"
         case post = "POST"
+        case delete = "DELETE"
     }
 }

--- a/StripeCryptoOnramp/README.md
+++ b/StripeCryptoOnramp/README.md
@@ -33,7 +33,7 @@ StripeCryptoOnramp helps you build a headless crypto onramp flow in your iOS app
 - Present identification document verification using `verifyIdentity(from:)`
 
 **Wallets and payment methods**:
-- Register crypto wallet addresses with `registerWalletAddress(walletAddress:network:)`
+- Register and delete crypto wallets with `registerWalletAddress(walletAddress:network:)` and `deleteWalletAddress(walletId:)`
 - Collect payment methods via Link (card, bank account) or Apple Pay with `collectPaymentMethod(type:from:)`. To receive partial `KycInfo` from Apple Pay, configure the provided `PKPaymentRequest` to request Apple Pay billing `.name` and/or `.postalAddress`.
 - Create crypto payment tokens with `createCryptoPaymentToken()`
 

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -135,6 +135,13 @@ protocol CryptoOnrampCoordinatorProtocol {
     /// Throws if an authenticated Link user is not available, or an API error occurs.
     func registerWalletAddress(walletAddress: String, network: CryptoNetwork) async throws
 
+    /// Deletes the given crypto wallet from the current Link account.
+    /// Requires an authenticated Link user.
+    ///
+    /// - Parameter walletId: The ID of the crypto wallet to delete.
+    /// Throws if an authenticated Link user is not available, or an API error occurs.
+    func deleteWalletAddress(walletId: String) async throws
+
     /// Creates a short-lived server-issued challenge for a registered wallet.
     /// Requires an authenticated Link user.
     ///
@@ -550,6 +557,18 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
             analyticsClient.log(.walletRegistered(network: network.rawValue))
         } catch {
             try logAndThrow(error, during: .registerWalletAddress)
+        }
+    }
+
+    public func deleteWalletAddress(walletId: String) async throws {
+        do {
+            try await apiClient.deleteWalletAddress(
+                walletId: walletId,
+                linkAccountInfo: linkAccountInfo
+            )
+            analyticsClient.log(.walletDeleted)
+        } catch {
+            try logAndThrow(error, during: .deleteWalletAddress)
         }
     }
 

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/DeleteWalletRequest.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/DeleteWalletRequest.swift
@@ -1,0 +1,27 @@
+//
+//  DeleteWalletRequest.swift
+//  StripeCryptoOnramp
+//
+//  Created by Michael Liberatore on 8/5/26.
+//
+
+import Foundation
+
+/// Encodable model passed to the `/v1/crypto/internal/wallet` endpoint to delete a wallet.
+struct DeleteWalletRequest: Encodable {
+
+    /// The ID of the crypto wallet to delete.
+    let walletToken: String
+
+    /// Contains credentials required to make the request.
+    let credentials: Credentials
+
+    /// Creates a new `DeleteWalletRequest` instance.
+    /// - Parameters:
+    ///   - walletId: The ID of the crypto wallet to delete.
+    ///   - consumerSessionClientSecret: Contains credentials required to make the request.
+    init(walletId: String, consumerSessionClientSecret: String) {
+        walletToken = walletId
+        credentials = Credentials(consumerSessionClientSecret: consumerSessionClientSecret)
+    }
+}

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -239,6 +239,29 @@ extension STPAPIClient {
         return try await post(resource: endpoint, object: requestObject)
     }
 
+    /// Deletes the given crypto wallet from the current Link account.
+    /// - Parameters:
+    ///   - walletId: The ID of the crypto wallet to delete.
+    ///   - linkAccountInfo: Information associated with the link account including the client secret and whether the account has been verified.
+    /// Throws if `linkAccountSessionState` is not verified, a client secret doesn’t exist, or if an API error occurs.
+    func deleteWalletAddress(
+        walletId: String,
+        linkAccountInfo: PaymentSheetLinkAccountInfoProtocol
+    ) async throws {
+        guard let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret else {
+            throw CryptoOnrampAPIError.missingConsumerSessionClientSecret
+        }
+
+        try validateSessionState(using: linkAccountInfo)
+
+        let endpoint = "crypto/internal/wallet"
+        let requestObject = DeleteWalletRequest(
+            walletId: walletId,
+            consumerSessionClientSecret: consumerSessionClientSecret
+        )
+        let _: EmptyResponse = try await delete(resource: endpoint, object: requestObject)
+    }
+
     /// Creates a short-lived server-issued challenge for a registered wallet.
     /// - Parameters:
     ///   - walletAddress: The registered wallet address to verify.
@@ -361,6 +384,20 @@ private extension STPAPIClient {
             post(
                 resource: resource,
                 object: object,
+                apiVersionOverride: CryptoOnrampAPI.stripeAPIVersion
+            ) { (result: Result<T, Error>) in
+                continuation.resume(with: result)
+            }
+        }
+    }
+
+    /// Helper method to wrap the closure-based delete method for Swift concurrency.
+    func delete<T: Decodable>(resource: String, object: Encodable) async throws -> T {
+        let parameters = try object.encodeJSONDictionary()
+        return try await withCheckedThrowingContinuation { continuation in
+            delete(
+                resource: resource,
+                parameters: parameters,
                 apiVersionOverride: CryptoOnrampAPI.stripeAPIVersion
             ) { (result: Result<T, Error>) in
                 continuation.resume(with: result)

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -243,11 +243,13 @@ extension STPAPIClient {
     /// - Parameters:
     ///   - walletId: The ID of the crypto wallet to delete.
     ///   - linkAccountInfo: Information associated with the link account including the client secret and whether the account has been verified.
+    /// - Returns: An empty response.
     /// Throws if `linkAccountSessionState` is not verified, a client secret doesn’t exist, or if an API error occurs.
+    @discardableResult
     func deleteWalletAddress(
         walletId: String,
         linkAccountInfo: PaymentSheetLinkAccountInfoProtocol
-    ) async throws {
+    ) async throws -> EmptyResponse {
         guard let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret else {
             throw CryptoOnrampAPIError.missingConsumerSessionClientSecret
         }
@@ -259,7 +261,7 @@ extension STPAPIClient {
             walletId: walletId,
             consumerSessionClientSecret: consumerSessionClientSecret
         )
-        let _: EmptyResponse = try await delete(resource: endpoint, object: requestObject)
+        return try await delete(resource: endpoint, object: requestObject)
     }
 
     /// Creates a short-lived server-issued challenge for a registered wallet.

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CryptoOnrampAnalyticsEvent.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CryptoOnrampAnalyticsEvent.swift
@@ -21,6 +21,7 @@ enum CryptoOnrampOperation: String {
     case verifyKycInfo = "verify_kyc_info"
     case verifyIdentity = "verify_identity"
     case registerWalletAddress = "register_wallet_address"
+    case deleteWalletAddress = "delete_wallet_address"
     case getWalletOwnershipChallenge = "get_wallet_ownership_challenge"
     case submitWalletOwnershipSignature = "submit_wallet_ownership_signature"
     case collectPaymentMethod = "collect_payment_method"
@@ -47,6 +48,7 @@ enum CryptoOnrampAnalyticsEvent {
     case kycInfoVerificationStarted
     case kycInfoVerificationCompleted
     case walletRegistered(network: String)
+    case walletDeleted
     case walletOwnershipChallengeRetrieved(network: String)
     case walletOwnershipVerified(network: String)
     case collectPaymentMethodStarted(paymentMethodType: String)
@@ -93,6 +95,8 @@ enum CryptoOnrampAnalyticsEvent {
             return "onramp.kyc_info_verification_completed"
         case .walletRegistered:
             return "onramp.wallet_registered"
+        case .walletDeleted:
+            return "onramp.wallet_deleted"
         case .walletOwnershipChallengeRetrieved:
             return "onramp.wallet_ownership_challenge_retrieved"
         case .walletOwnershipVerified:
@@ -129,6 +133,7 @@ enum CryptoOnrampAnalyticsEvent {
              .userAttestationStarted,
              .kycInfoVerificationStarted,
              .kycInfoVerificationCompleted,
+             .walletDeleted,
              .userLoggedOut:
             return [:]
         case let .identifiersSubmitted(completed):

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
@@ -976,7 +976,7 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         var noSecretLinkAccountInfo = Constant.validLinkAccountInfo
         noSecretLinkAccountInfo.consumerSessionClientSecret = nil
         await XCTAssertThrowsErrorAsync(
-            try await apiClient.deleteWalletAddress(
+            _ = try await apiClient.deleteWalletAddress(
                 walletId: Constant.validWalletId,
                 linkAccountInfo: noSecretLinkAccountInfo
             )
@@ -985,7 +985,7 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         var unverifiedLinkAccountInfo = Constant.validLinkAccountInfo
         unverifiedLinkAccountInfo.sessionState = .requiresVerification
         await XCTAssertThrowsErrorAsync(
-            try await apiClient.deleteWalletAddress(
+            _ = try await apiClient.deleteWalletAddress(
                 walletId: Constant.validWalletId,
                 linkAccountInfo: unverifiedLinkAccountInfo
             )

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
@@ -125,11 +125,12 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         )
 
         // /v1/crypto/internal/wallet
-        static let collectWalletAddressAPIPath = "/v1/crypto/internal/wallet"
+        static let walletAPIPath = "/v1/crypto/internal/wallet"
         static let validWalletAddress = "11111111111111111111111111111111"
+        static let validWalletId = "ccw_12345"
         static let validNetwork = CryptoNetwork.solana
         static let registerWalletMockResponseObject = RegisterWalletResponse(
-            id: "ccw_12345"
+            id: validWalletId
         )
 
         // /v1/crypto/internal/wallet_ownership_challenge
@@ -830,7 +831,7 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         let mockResponseData = try jsonEncoder.encode(Constant.registerWalletMockResponseObject)
 
         stub { request in
-            XCTAssertEqual(request.url?.path, Constant.collectWalletAddressAPIPath)
+            XCTAssertEqual(request.url?.path, Constant.walletAPIPath)
             XCTAssertEqual(request.httpMethod, "POST")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Stripe-Version"), Constant.cryptoOnrampAPIVersion)
 
@@ -867,7 +868,7 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
 
     func testCollectWalletAddressFailure() async {
         stub { request in
-            XCTAssertEqual(request.url?.path, Constant.collectWalletAddressAPIPath)
+            XCTAssertEqual(request.url?.path, Constant.walletAPIPath)
             return true
         } response: { _ in
             return HTTPStubsResponse(error: NSError(domain: Constant.errorDomain, code: 400))
@@ -906,6 +907,86 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
             _ = try await apiClient.collectWalletAddress(
                 walletAddress: Constant.validWalletAddress,
                 network: Constant.validNetwork,
+                linkAccountInfo: unverifiedLinkAccountInfo
+            )
+        )
+    }
+
+    func testDeleteWalletAddressSuccess() async throws {
+        stub { request in
+            XCTAssertEqual(request.url?.path, Constant.walletAPIPath)
+            XCTAssertEqual(request.httpMethod, "DELETE")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer \(Constant.validPublishableKey)")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/x-www-form-urlencoded")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Stripe-Version"), Constant.cryptoOnrampAPIVersion)
+
+            guard let httpBody = request.ohhttpStubs_httpBody else {
+                XCTFail("Expected an httpBody data but found none.")
+                return false
+            }
+
+            let parameters = String(data: httpBody, encoding: .utf8)?.parsedHTTPParametersDictionary ?? [:]
+
+            XCTAssertEqual(parameters.count, 2)
+            XCTAssertEqual(parameters["credentials[consumer_session_client_secret]"], Constant.requestSecret)
+            XCTAssertEqual(parameters["wallet_token"], Constant.validWalletId)
+
+            return true
+        } response: { _ in
+            return HTTPStubsResponse(jsonObject: [:], statusCode: 200, headers: nil)
+        }
+
+        let apiClient = stubbedAPIClient()
+        apiClient.publishableKey = Constant.validPublishableKey
+
+        do {
+            try await apiClient.deleteWalletAddress(
+                walletId: Constant.validWalletId,
+                linkAccountInfo: Constant.validLinkAccountInfo
+            )
+        } catch {
+            XCTFail("Expected a success response but got an error: \(error).")
+        }
+    }
+
+    func testDeleteWalletAddressFailure() async {
+        stub { request in
+            XCTAssertEqual(request.url?.path, Constant.walletAPIPath)
+            return true
+        } response: { _ in
+            return HTTPStubsResponse(error: NSError(domain: Constant.errorDomain, code: 400))
+        }
+
+        let apiClient = stubbedAPIClient()
+
+        do {
+            try await apiClient.deleteWalletAddress(
+                walletId: Constant.validWalletId,
+                linkAccountInfo: Constant.validLinkAccountInfo
+            )
+            XCTFail("Expected failure but got success.")
+        } catch {
+            XCTAssertEqual((error as NSError).domain, Constant.errorDomain)
+        }
+    }
+
+    func testDeleteWalletAddressThrowsWithInvalidArguments() async {
+        let apiClient = stubbedAPIClient()
+
+        var noSecretLinkAccountInfo = Constant.validLinkAccountInfo
+        noSecretLinkAccountInfo.consumerSessionClientSecret = nil
+        await XCTAssertThrowsErrorAsync(
+            try await apiClient.deleteWalletAddress(
+                walletId: Constant.validWalletId,
+                linkAccountInfo: noSecretLinkAccountInfo
+            )
+        )
+
+        var unverifiedLinkAccountInfo = Constant.validLinkAccountInfo
+        unverifiedLinkAccountInfo.sessionState = .requiresVerification
+        await XCTAssertThrowsErrorAsync(
+            try await apiClient.deleteWalletAddress(
+                walletId: Constant.validWalletId,
                 linkAccountInfo: unverifiedLinkAccountInfo
             )
         )


### PR DESCRIPTION
## Summary
Adds the ability to delete a previously attached wallet.

## Motivation
Slack Link: [Stripe](https://stripe.slack.com/archives/C094P3BRBL1/p1785884145885309) | [Lickability](https://lickability.slack.com/archives/C094P3BRBL1/p1785884145885309)

## Testing
- Ran the new tests
- Manually tested wallet deletion using the example app in the next PR (#6847)

## Changelog
Updated to include the new public API