### PR TITLE
CryptoOnramp SDK: Wallet Address Deletion Example App Updates

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example/WalletSelectionRowView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/WalletSelectionRowView.swift
@@ -25,6 +25,9 @@ struct WalletSelectionRowView: View {
     /// Called when the wallet ownership verification action is selected.
     let onVerifyWalletOwnership: () -> Void
 
+    /// Called when the wallet deletion action is selected.
+    let onDelete: () -> Void
+
     // MARK: - View
 
     var body: some View {
@@ -37,31 +40,33 @@ struct WalletSelectionRowView: View {
             }
             .buttonStyle(.plain)
 
-            if shouldShowVerifyWalletButton {
-                Divider()
-                    .padding(.horizontal)
+            Divider()
+                .padding(.horizontal)
 
-                Button(action: onVerifyWalletOwnership) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "checkmark.shield")
-                            .font(.caption)
-
-                        Text("Verify Ownership")
+            HStack(spacing: 16) {
+                if shouldShowVerifyWalletButton {
+                    Button(action: onVerifyWalletOwnership) {
+                        Label("Verify Ownership", systemImage: "checkmark.shield")
                             .font(.caption.weight(.medium))
-
-                        Spacer()
+                            .foregroundStyle(.tint)
                     }
-                    .foregroundStyle(.tint)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.horizontal)
-                    .padding(.top, 12)
-                    .padding(.bottom)
-                    .contentShape(Rectangle())
+                    .buttonStyle(.plain)
+                }
+
+                Spacer()
+
+                Button(role: .destructive, action: onDelete) {
+                    Label("Delete", systemImage: "trash")
+                        .font(.caption.weight(.medium))
+                        .foregroundStyle(.red)
                 }
                 .buttonStyle(.plain)
-                .disabled(isLoading)
-                .opacity(isLoading ? 0.5 : 1)
             }
+            .padding(.horizontal)
+            .padding(.top, 12)
+            .padding(.bottom)
+            .disabled(isLoading)
+            .opacity(isLoading ? 0.5 : 1)
         }
         .background(
             RoundedRectangle(cornerRadius: 8)
@@ -142,7 +147,8 @@ struct WalletSelectionRowView: View {
             isSelected: true,
             isLoading: false,
             onSelect: {},
-            onVerifyWalletOwnership: {}
+            onVerifyWalletOwnership: {},
+            onDelete: {}
         )
 
         WalletSelectionRowView(
@@ -157,7 +163,8 @@ struct WalletSelectionRowView: View {
             isSelected: false,
             isLoading: false,
             onSelect: {},
-            onVerifyWalletOwnership: {}
+            onVerifyWalletOwnership: {},
+            onDelete: {}
         )
     }
     .padding()

--- a/Example/CryptoOnramp Example/CryptoOnramp Example/WalletSelectionView.swift
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example/WalletSelectionView.swift
@@ -92,8 +92,12 @@ struct WalletSelectionView: View {
                                 },
                                 onVerifyWalletOwnership: {
                                     startWalletOwnershipVerification(for: wallet)
+                                },
+                                onDelete: {
+                                    deleteWallet(wallet)
                                 }
                             )
+                            .transition(.move(edge: .trailing).combined(with: .opacity))
                         }
                     }
 
@@ -171,6 +175,31 @@ struct WalletSelectionView: View {
             alert: $alert
         ) { session in
             walletOwnershipVerificationSession = session
+        }
+    }
+
+    private func deleteWallet(_ wallet: Wallet) {
+        isLoading.wrappedValue = true
+
+        Task {
+            do {
+                try await coordinator.deleteWalletAddress(walletId: wallet.id)
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+
+                    withAnimation {
+                        wallets.removeAll { $0.id == wallet.id }
+                        if selectedWallet == wallet {
+                            selectedWallet = wallets.first
+                        }
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    isLoading.wrappedValue = false
+                    alert = Alert(title: "Failed to delete wallet", message: error.localizedDescription)
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->
Makes use of the newly added wallet deletion API in #6846 in the example app, allowing you to delete previously added wallet addresses from the wallet selection view.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Slack Link: [Stripe](https://stripe.slack.com/archives/C094P3BRBL1/p1785884145885309) | [Lickability](https://lickability.slack.com/archives/C094P3BRBL1/p1785884145885309)

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
1. Logged into an existing account.
2. Added a few wallet addresses.
3. Used the new delete button to delete wallets and saw them animate disappearance from the UI.
4. Ensured that when deleting a selected wallet, the first remaining wallet in the list would become selected.
5. Ensured that when deleting the last wallet, no wallet was selected and the UI returned to its empty state.

<img width="300" alt="Simulator Screenshot - iPhone 17 - 2026-08-05 at 09 28 50" src="https://github.com/user-attachments/assets/b2b99a61-986b-4a41-b2ac-935e6b04d428" />


## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A