### PR TITLE
Return from Link early when no funding sources available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ The next release's version bump will so far be:
 PATCH
 
 ## X.Y.Z - changes pending release
+### PaymentSheet
+* [Fixed] LinkController (private preview) now returns an error when no funding sources are available for a Link session, rather than silently falling back to card.
 
 ## 26.5.0 2026-08-03
 ### CryptoOnramp (Alpha)

--- a/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Helpers/PaymentSheetLinkAccount.swift
@@ -712,11 +712,6 @@ extension PaymentSheetLinkAccount {
             }
         }
 
-        if supportedPaymentMethodTypes.isEmpty {
-            // Card is the default payment method type when no other type is available.
-            supportedPaymentMethodTypes.append(.card)
-        }
-
         return supportedPaymentMethodTypes
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -70,11 +70,17 @@ protocol PayWithLinkCoordinating: AnyObject {
 @objc(STP_Internal_PayWithLinkViewController)
 final class PayWithLinkViewController: BottomSheetViewController {
 
-    enum LinkAccountError: Error {
+    enum LinkAccountError: LocalizedError {
         case noLinkAccount
+        case noFundingSources
 
-        var localizedDescription: String {
-            "No Link account is set"
+        var errorDescription: String? {
+            switch self {
+            case .noLinkAccount:
+                return "No Link account is set"
+            case .noFundingSources:
+                return "No supported payment methods available for this Link session"
+            }
         }
     }
 
@@ -113,7 +119,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
         }
 
         /// Returns the supported payment details types for the current Link account, filtered by the supportedPaymentMethodTypes.
-        /// Returns [.card] as fallback if no types are supported after filtering.
+        /// Returns an empty set if no funding sources are available at the session-level, consumer-level, or their intersection.
         func getSupportedPaymentDetailsTypes(linkAccount: PaymentSheetLinkAccount) -> Set<ParsedEnum<ConsumerPaymentDetails.DetailsType>> {
             var allSupportedPaymentDetailsTypes = linkAccount.supportedPaymentDetailsTypes(for: elementsSession)
 
@@ -122,12 +128,7 @@ final class PayWithLinkViewController: BottomSheetViewController {
                 allSupportedPaymentDetailsTypes = allSupportedPaymentDetailsTypes.intersection(supportedPaymentDetailsTypes)
             }
 
-            if !allSupportedPaymentDetailsTypes.isEmpty {
-                return allSupportedPaymentDetailsTypes
-            } else {
-                // Card is the default payment method type when no other type is available.
-                return [ParsedEnum(.card)]
-            }
+            return allSupportedPaymentDetailsTypes
         }
 
         /// Creates a new Context object.
@@ -409,6 +410,12 @@ private extension PayWithLinkViewController {
         }
 
         let supportedPaymentDetailsTypesSet = context.getSupportedPaymentDetailsTypes(linkAccount: linkAccount)
+
+        guard !supportedPaymentDetailsTypesSet.isEmpty else {
+            finish(withResult: .failed(error: LinkAccountError.noFundingSources), deferredIntentConfirmationType: nil)
+            return
+        }
+
         let supportedPaymentDetailsTypes = supportedPaymentDetailsTypesSet.toSortedArray()
 
         Task { @MainActor in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -519,7 +519,7 @@ import UIKit
             linkAppearance: appearance,
             linkConfiguration: configuration,
             canContinueWithoutLink: false
-        ) { [weak self] confirmOption, shouldClearSelection in
+        ) { [weak self] confirmOption, shouldClearSelection, _ in
             guard let confirmOption else {
                 if shouldClearSelection {
                     self?.internalPaymentOption = nil
@@ -577,8 +577,12 @@ import UIKit
                 linkAppearance: self.appearance,
                 linkConfiguration: self.configuration,
                 canContinueWithoutLink: false
-            ) { [weak self] confirmOption, _ in
+            ) { [weak self] confirmOption, _, error in
                 guard let self else { return }
+                if let error {
+                    completion(.failure(error))
+                    return
+                }
                 guard let confirmOption else {
                     completion(.success(.canceled))
                     return

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkFlowControllerHelpers.swift
@@ -29,7 +29,7 @@ extension UIViewController {
         linkAppearance: LinkAppearance? = nil,
         linkConfiguration: LinkConfiguration? = nil,
         canContinueWithoutLink: Bool = true,
-        callback: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
+        callback: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool, _ error: Error?) -> Void
     ) {
         let payWithLinkController = PayWithNativeLinkController(
             mode: .paymentMethodSelection,
@@ -46,8 +46,9 @@ extension UIViewController {
         payWithLinkController.presentForPaymentMethodSelection(
             from: self,
             initiallySelectedPaymentDetailsID: selectedPaymentDetailsID,
-            canContinueWithoutLink: canContinueWithoutLink,
-            completion: callback
-        )
+            canContinueWithoutLink: canContinueWithoutLink
+        ) { confirmOption, shouldReturnToPaymentSheet, error in
+            callback(confirmOption, shouldReturnToPaymentSheet, error)
+        }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/PayWithNativeLinkController.swift
@@ -115,7 +115,7 @@ final class PayWithNativeLinkController {
         from presentingController: UIViewController,
         initiallySelectedPaymentDetailsID: String?,
         canContinueWithoutLink: Bool = true,
-        completion: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool) -> Void
+        completion: @escaping (_ confirmOption: PaymentSheet.LinkConfirmOption?, _ shouldReturnToPaymentSheet: Bool, _ error: Error?) -> Void
     ) {
         presentAsBottomSheetInternal(
             from: presentingController,
@@ -127,11 +127,14 @@ final class PayWithNativeLinkController {
             shouldFinishOnClose: false,
             canContinueWithoutLink: canContinueWithoutLink
         ) { completionResult in
-            guard case .paymentMethodSelection(let confirmOption, let shouldReturnToPaymentSheet) = completionResult else {
-                return
+            switch completionResult {
+            case .paymentMethodSelection(let confirmOption, let shouldReturnToPaymentSheet):
+                completion(confirmOption, shouldReturnToPaymentSheet, nil)
+            case .full(let result, _, _):
+                if case .failed(let error) = result {
+                    completion(nil, false, error)
+                }
             }
-
-            completion(confirmOption, shouldReturnToPaymentSheet)
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -652,7 +652,7 @@ extension PaymentSheet {
             selectedPaymentDetailsID: String? = nil,
             returnToPaymentSheet: @escaping () -> Void
         ) {
-            let completionCallback: (PaymentSheet.LinkConfirmOption?, Bool) -> Void = { [weak self] confirmOption, shouldReturnToPaymentSheet in
+            let completionCallback: (PaymentSheet.LinkConfirmOption?, Bool, Error?) -> Void = { [weak self] confirmOption, shouldReturnToPaymentSheet, _ in
                 guard let self else { return }
 
                 if let confirmOption {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -584,7 +584,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
             intent: intent,
             elementsSession: elementsSession,
             analyticsHelper: analyticsHelper,
-            callback: { [weak self] confirmOption, _ in
+            callback: { [weak self] confirmOption, _, _ in
                 guard let self else { return }
                 self.linkConfirmOption = confirmOption
                 self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -350,7 +350,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
             intent: intent,
             elementsSession: elementsSession,
             analyticsHelper: analyticsHelper
-        ) { [weak self] confirmOption, _ in
+        ) { [weak self] confirmOption, _, _ in
             guard let self else { return }
             self.linkConfirmOption = confirmOption
             self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -160,7 +160,7 @@ typealias ExpressType = PaymentSheet.WalletButtonsVisibility.ExpressType
                 from: WindowAuthenticationContext().authenticationPresentingViewController(),
                 initiallySelectedPaymentDetailsID: nil,
                 canContinueWithoutLink: false,
-                completion: { confirmOptions, _ in
+                completion: { confirmOptions, _, _ in
                     guard let confirmOptions else {
                         return
                     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/PayWithLinkViewController-WalletViewModelTests.swift
@@ -210,6 +210,28 @@ class PayWithLinkViewController_WalletViewModelTests: XCTestCase {
         XCTAssertEqual(sut.supportedPaymentMethodTypes, [ParsedEnum(.card)])
     }
 
+    func test_supportedPaymentMethodTypes_whenSessionFundingSourcesEmpty_returnsEmpty() throws {
+        // Given a session with no funding sources
+        let sut = try makeSUT(
+            supportedPaymentDetailsTypes: [ParsedEnum(.card)],
+            linkFundingSources: []
+        )
+
+        // When no funding sources are available at the session level, the result should be empty
+        XCTAssertTrue(sut.supportedPaymentMethodTypes.isEmpty)
+    }
+
+    func test_supportedPaymentMethodTypes_whenIntersectionIsEmpty_returnsEmpty() throws {
+        // Given a session that only allows bank accounts, but the consumer only supports cards
+        let sut = try makeSUT(
+            supportedPaymentDetailsTypes: [ParsedEnum(.card)],
+            linkFundingSources: ["BANK_ACCOUNT"]
+        )
+
+        // When the intersection of session-level and consumer-level funding sources is empty, the result should be empty
+        XCTAssertTrue(sut.supportedPaymentMethodTypes.isEmpty)
+    }
+
     func test_cardBrandFiltering_passThroughEnabled() throws {
         let sut = try makeSUT(supportedPaymentDetailsTypes: [ParsedEnum(.card)],
                               linkFundingSources: ["CARD"],

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLinkAccountTests.swift
@@ -366,3 +366,89 @@ final class FundingSourceDetailsTypeMappingTests: XCTestCase {
         XCTAssertEqual(supported.first?.value, .card)
     }
 }
+
+// MARK: - supportedPaymentMethodTypes tests
+
+final class SupportedPaymentMethodTypesTests: XCTestCase {
+
+    func test_supportedPaymentMethodTypes_returnsEmptyWhenSessionFundingSourcesEmpty() throws {
+        // Given a consumer session that supports cards, but the session-level funding sources list is empty
+        let consumerSession = ConsumerSession.make(
+            clientSecret: "client_secret",
+            emailAddress: "user@example.com",
+            redactedFormattedPhoneNumber: "(***) *** **55",
+            unredactedPhoneNumber: nil,
+            phoneNumberCountry: nil,
+            verificationSessions: [],
+            supportedPaymentDetailsTypes: [ParsedEnum(.card)],
+            mobileFallbackWebviewParams: nil
+        )
+        let linkAccount = PaymentSheetLinkAccount(
+            email: "user@example.com",
+            session: consumerSession,
+            publishableKey: nil,
+            displayablePaymentDetails: nil,
+            useMobileEndpoints: false,
+            canSyncAttestationState: false
+        )
+
+        let (_, elementsSession) = try PayWithLinkTestHelpers.makePaymentIntentAndElementsSession(linkFundingSources: [])
+        let result = linkAccount.supportedPaymentMethodTypes(for: elementsSession)
+
+        XCTAssertTrue(result.isEmpty, "Should return empty array when session has no funding sources")
+    }
+
+    func test_supportedPaymentMethodTypes_returnsEmptyWhenIntersectionIsEmpty() throws {
+        // Given a session that allows only bank accounts, but the consumer only supports cards
+        let consumerSession = ConsumerSession.make(
+            clientSecret: "client_secret",
+            emailAddress: "user@example.com",
+            redactedFormattedPhoneNumber: "(***) *** **55",
+            unredactedPhoneNumber: nil,
+            phoneNumberCountry: nil,
+            verificationSessions: [],
+            supportedPaymentDetailsTypes: [ParsedEnum(.card)],
+            mobileFallbackWebviewParams: nil
+        )
+        let linkAccount = PaymentSheetLinkAccount(
+            email: "user@example.com",
+            session: consumerSession,
+            publishableKey: nil,
+            displayablePaymentDetails: nil,
+            useMobileEndpoints: false,
+            canSyncAttestationState: false
+        )
+
+        let (_, elementsSession) = try PayWithLinkTestHelpers.makePaymentIntentAndElementsSession(linkFundingSources: ["BANK_ACCOUNT"])
+        let result = linkAccount.supportedPaymentMethodTypes(for: elementsSession)
+
+        XCTAssertTrue(result.isEmpty, "Should return empty array when intersection of session and consumer funding sources is empty")
+    }
+
+    func test_supportedPaymentMethodTypes_returnsCardWhenBothSidesHaveCard() throws {
+        // Given a session and consumer that both support cards
+        let consumerSession = ConsumerSession.make(
+            clientSecret: "client_secret",
+            emailAddress: "user@example.com",
+            redactedFormattedPhoneNumber: "(***) *** **55",
+            unredactedPhoneNumber: nil,
+            phoneNumberCountry: nil,
+            verificationSessions: [],
+            supportedPaymentDetailsTypes: [ParsedEnum(.card)],
+            mobileFallbackWebviewParams: nil
+        )
+        let linkAccount = PaymentSheetLinkAccount(
+            email: "user@example.com",
+            session: consumerSession,
+            publishableKey: nil,
+            displayablePaymentDetails: nil,
+            useMobileEndpoints: false,
+            canSyncAttestationState: false
+        )
+
+        let (_, elementsSession) = try PayWithLinkTestHelpers.makePaymentIntentAndElementsSession(linkFundingSources: ["CARD"])
+        let result = linkAccount.supportedPaymentMethodTypes(for: elementsSession)
+
+        XCTAssertEqual(result, [.card])
+    }
+}


### PR DESCRIPTION
## Summary

Instead of falling back to the card form when no funding sources are available, we now throw an error. Funding sources are determined by taking an intersection between:

1. `elementsSession.linkFundingSources` what the merchant has configured as allowed on their Stripe account
2. `consumerSession.supportedPaymentDetailsTypes` what the server says this consumer can use
3. `linkConfiguration.supportedPaymentMethodTypes` what the merchant has configured as allowed on the Link mobile SDK 

And if none are available, we used to fallback to `[card]`, which would cause payments to fail for IBP-only merchants.

## Motivation

Resolves https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-231

## Testing

Before: 

https://github.com/user-attachments/assets/fadae1f7-dc73-4831-a9ec-b9ecc045db8f

After:

https://github.com/user-attachments/assets/e4072b3e-3b50-47b1-84bf-e28acf3e05f9


## Changelog

```
### PaymentSheet
* [Fixed] LinkController (private preview) now returns an error when no funding sources are available for a Link session, rather than silently falling back to card.
```