### PR TITLE
CryptoOnramp SDK: Adds Request ID When Available to Error Analytics

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -381,7 +381,11 @@ public final class CryptoOnrampCoordinator: NSObject, CryptoOnrampCoordinatorPro
             if let stripeError = error as? StripeError,
                case let .apiError(stripeAPIError) = stripeError,
                stripeAPIError.code == "link_auth_token_invalid" || stripeAPIError.code == "resource_missing" {
-                analyticsClient.log(.errorOccurred(during: .authenticateUserWithAuthToken, errorMessage: stripeAPIError.message ?? error.localizedDescription))
+                analyticsClient.log(.errorOccurred(
+                    during: .authenticateUserWithAuthToken,
+                    errorMessage: stripeAPIError.message ?? error.localizedDescription,
+                    requestID: stripeAPIError.requestID
+                ))
                 throw CryptoOnrampCoordinator.Error.seamlessSignInTokenInvalid(reason: stripeAPIError.message)
             } else {
                 try logAndThrow(error, during: .authenticateUserWithAuthToken)
@@ -975,7 +979,11 @@ private extension CryptoOnrampCoordinator {
            stripeAPIError.type == .invalidRequestError,
            let message = stripeAPIError.message,
            message.hasPrefix("There was an issue parsing the phone number") {
-            analyticsClient.log(.errorOccurred(during: operation, errorMessage: "Invalid phone number format"))
+            analyticsClient.log(.errorOccurred(
+                during: operation,
+                errorMessage: "Invalid phone number format",
+                requestID: stripeAPIError.requestID
+            ))
             throw Error.invalidPhoneFormat
         } else {
             try logAndThrow(error, during: operation)

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -955,7 +955,12 @@ private extension CryptoOnrampCoordinator {
             additionalSDKVersions: additionalSDKVersions
         )
         let errorMessage = (mappedError as? StripeCryptoOnrampError)?.developerMessage ?? mappedError.localizedDescription
-        analyticsClient.log(.errorOccurred(during: operation, errorMessage: errorMessage))
+        let requestID = (mappedError as? StripeCryptoOnrampAPIError)?.requestID
+        analyticsClient.log(.errorOccurred(
+            during: operation,
+            errorMessage: errorMessage,
+            requestID: requestID
+        ))
 
         #if DEBUG
         print("[Stripe SDK] CryptoOnrampCoordinator error: \(errorMessage)")

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CryptoOnrampAnalyticsEvent.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/CryptoOnrampAnalyticsEvent.swift
@@ -55,7 +55,7 @@ enum CryptoOnrampAnalyticsEvent {
     case checkoutStarted(onrampSessionId: String)
     case checkoutCompleted(onrampSessionId: String, requiredAction: Bool)
     case userLoggedOut
-    case errorOccurred(during: CryptoOnrampOperation, errorMessage: String)
+    case errorOccurred(during: CryptoOnrampOperation, errorMessage: String, requestID: String? = nil)
 
     var eventName: String {
         switch self {
@@ -156,11 +156,17 @@ enum CryptoOnrampAnalyticsEvent {
                 "onramp_session_id": onrampSessionId,
                 "required_action": requiredAction,
             ]
-        case let .errorOccurred(operationName, errorMessage):
-            return [
+        case let .errorOccurred(operationName, errorMessage, requestID):
+            var parameters: [String: Any] = [
                 "operation_name": operationName.rawValue,
                 "error_message": errorMessage,
             ]
+
+            if let requestID {
+                parameters["request_id"] = requestID
+            }
+
+            return parameters
         }
     }
 }

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/CryptoOnrampAnalyticsEventTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/CryptoOnrampAnalyticsEventTests.swift
@@ -1,0 +1,32 @@
+//
+//  CryptoOnrampAnalyticsEventTests.swift
+//  StripeCryptoOnrampTests
+//
+//  Created by Michael Liberatore on 8/5/26.
+//
+
+@testable @_spi(CryptoOnrampAlpha) import StripeCryptoOnramp
+import XCTest
+
+final class CryptoOnrampAnalyticsEventTests: XCTestCase {
+    func testErrorOccurredIncludesRequestIDWhenAvailable() {
+        let parameters = CryptoOnrampAnalyticsEvent.errorOccurred(
+            during: .hasLinkAccount,
+            errorMessage: "Test error",
+            requestID: "req_123"
+        ).parameters
+
+        XCTAssertEqual(parameters["operation_name"] as? String, "has_link_account")
+        XCTAssertEqual(parameters["error_message"] as? String, "Test error")
+        XCTAssertEqual(parameters["request_id"] as? String, "req_123")
+    }
+
+    func testErrorOccurredOmitsRequestIDWhenUnavailable() {
+        let parameters = CryptoOnrampAnalyticsEvent.errorOccurred(
+            during: .hasLinkAccount,
+            errorMessage: "Test error"
+        ).parameters
+
+        XCTAssertNil(parameters["request_id"])
+    }
+}


### PR DESCRIPTION
## Summary
Adds a `request_id` parameter to analytics error logs if the error originated from an API failure.

Note that I couldn't find any references to V2 analytics including a request id, but I’ve used the same parameter name as V1 analytics in StripeCore: https://github.com/stripe/stripe-ios/blob/1802a885380bc863a00d19043aeba6780c59c38c/StripeCore/StripeCore/Source/Analytics/AnalyticLoggableError.swift#L75


## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
- Discussed the addition of this parameter at yesterday's CryptoOnramp sync meeting.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
1. Ran the new tests.
2. Tested manually with both a rich mapped error and with one of the legacy errors that hasn't been updated yet to use the rich formatting.

Here are the analytics logs from both which now include `request_id`:

(Rich) `InvalidWalletOwnershipSignatureError`:
```
V2 LOG ANALYTICS: onramp.error_occurred
{
  "app_min_os_version" : "16.0",
  "app_name" : "CryptoOnramp Example",
  "app_version" : "1.0",
  "client_id" : "mobile-onramp-sdk",
  "created" : 1785947147.9262772,
  "device_id" : "69117D0F-CA80-43C4-968F-F2DCBF614588",
  "device_type" : "arm64",
  "error_message" : "The submitted signature could not be verified for this wallet.\n\nRequest Context:\n  operation: submit_wallet_ownership_signature\n  app_id: com.stripe.CryptoOnrampExample\n  mode: test\n  request_id: req_yTmyDmoIZrrFM9\n  type: invalid_request_error\n\nCode: crypto_onramp_invalid_wallet_ownership_signature\nNext step: Sign the exact challenge message with the registered wallet address, then submit the resulting signature for the same challenge ID.\nSDK: stripe-ios@26.5.0",
  "event_id" : "5ADF4BF6-3EAB-4BD6-AA6F-8A827CA1AECF",
  "event_name" : "onramp.error_occurred",
  "mobile_session_id" : "612eeae6-2f19-463d-8187-47a326842928",
  "operation_name" : "submit_wallet_ownership_signature",
  "os_version" : "26.5",
  "platform_info" : {
    "app_bundle_id" : "com.stripe.CryptoOnrampExample",
    "install" : "X"
  },
  "request_id" : "req_yTmyDmoIZrrFM9",
  "sdk_platform" : "ios",
  "sdk_version" : "26.5.0",
  "session_id" : "elements_session_1JO8U9VWx8T"
}
```

(Legacy) `CryptoOnrampCoordinator.Error.invalidPhoneNumber`:
```
V2 LOG ANALYTICS: onramp.error_occurred
{
  "app_min_os_version" : "16.0",
  "app_name" : "CryptoOnramp Example",
  "app_version" : "1.0",
  "client_id" : "mobile-onramp-sdk",
  "created" : 1785946530.7712069,
  "device_id" : "69117D0F-CA80-43C4-968F-F2DCBF614588",
  "device_type" : "arm64",
  "error_message" : "Invalid phone number format",
  "event_id" : "596E6B20-52CA-43A7-99AB-0CE67F9C58CA",
  "event_name" : "onramp.error_occurred",
  "mobile_session_id" : "ab2e4c34-8f26-4172-b8c9-c69a6bdba272",
  "operation_name" : "register_link_user",
  "os_version" : "26.5",
  "platform_info" : {
    "app_bundle_id" : "com.stripe.CryptoOnrampExample",
    "install" : "X"
  },
  "request_id" : "req_7olUi9XJTtKLkd",
  "sdk_platform" : "ios",
  "sdk_version" : "26.5.0",
  "session_id" : "elements_session_1aoS0IHOpYy"
}
```

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A