### PR TITLE
Checkout Sessions — ignore default shipping address if not in allowed countries

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -359,7 +359,7 @@ extension Checkout {
            let address = billingDetails.address {
             try await updateBillingTaxRegionIfNecessary(address: address)
         }
-        
+
         // Set the passed default shipping address IF it is non-nil and the country is in the allowed shipping countries
         if let shippingDetails = defaults.shippingDetails,
            let address = shippingDetails.address,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -359,8 +359,11 @@ extension Checkout {
            let address = billingDetails.address {
             try await updateBillingTaxRegionIfNecessary(address: address)
         }
+        
+        // Set the passed default shipping address IF it is non-nil and the country is in the allowed shipping countries
         if let shippingDetails = defaults.shippingDetails,
-           let address = shippingDetails.address {
+           let address = shippingDetails.address,
+           session.allowedShippingCountries?.contains(address.country) != false {
             try await updateShippingAddress(
                 name: shippingDetails.name,
                 address: address

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -360,14 +360,18 @@ extension Checkout {
             try await updateBillingTaxRegionIfNecessary(address: address)
         }
 
-        // Set the passed default shipping address IF it is non-nil and the country is in the allowed shipping countries
         if let shippingDetails = defaults.shippingDetails,
-           let address = shippingDetails.address,
-           session.allowedShippingCountries?.contains(address.country) != false {
-            try await updateShippingAddress(
-                name: shippingDetails.name,
-                address: address
-            )
+           let address = shippingDetails.address {
+            do {
+                try await updateShippingAddress(
+                    name: shippingDetails.name,
+                    address: address
+                )
+            } catch CheckoutError.invalidShippingCountry {
+                // Treat a default address with a disallowed country as nil.
+            } catch {
+                throw error
+            }
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutDefaultsInitializationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutDefaultsInitializationTests.swift
@@ -71,6 +71,33 @@ final class CheckoutDefaultsInitializationTests: XCTestCase {
         XCTAssertEqual(checkout.session.shippingAddress?.name, "Shipping Name")
     }
 
+    func testInitIgnoresShippingDefaultWithDisallowedCountry() async throws {
+        // Given a Checkout Session that does not allow the default shipping address's country
+        stubCheckoutSessionRequests(automaticTaxAddressSource: "shipping")
+
+        var configuration = Checkout.Configuration(clientSecret: clientSecret, returnURL: "stripe-ios-test://checkout-return")
+        configuration.apiClient = STPAPIClient(publishableKey: "pk_test_123")
+        var shippingDetails = Checkout.Configuration.Defaults.ShippingDetails()
+        shippingDetails.name = "Shipping Name"
+        shippingDetails.address = .init(
+            country: "GB",
+            line1: "123 Shipping St",
+            city: "London",
+            postalCode: "SW1A 1AA"
+        )
+        configuration.defaults.shippingDetails = shippingDetails
+
+        // When Checkout initializes
+        let checkout = try await Checkout(configuration: configuration)
+        let paymentElement = checkout.getPaymentElement()
+
+        // Then the shipping default is treated as nil
+        XCTAssertEqual(requestRecorder.requests.map(\.kind), [.initSession])
+        XCTAssertNil(checkout.session.shippingAddress)
+        XCTAssertNil(paymentElement.paymentSheetFlowController.configuration.shippingDetails())
+        XCTAssertNil(paymentElement.embeddedPaymentElement.configuration.shippingDetails())
+    }
+
     // MARK: - Stubs
 
     private func stubCheckoutSessionRequests(


### PR DESCRIPTION
## Summary
If the merchant passes a default shipping address that is not in the allowed shipping countries, we silently treat it as nil.

## Motivation
https://docs.google.com/document/d/1CWglcOHR6I8cOWKjztPfnhnVG8axucpv-j5cWIoey7E/edit?tab=t.6mlp9ite2vpp#heading=h.fbn38s9qfcm0

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
