### PR TITLE
Update deprecated swiftlint rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -13,7 +13,7 @@ disabled_rules:
   - file_length
   - force_cast
   - function_body_length        # Interesting overlap between these violations and cyclomatic_complexity
-  - operator_whitespace
+  - function_name_whitespace
   - todo
   - type_body_length
   - void_function_in_ternary


### PR DESCRIPTION
## Summary
This rule was renamed. CI was giving a warning that using the old name would become in error in future swiftlint versions

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
