### PR TITLE
Ignore import changes in public API check

### DIFF
--- a/ci_scripts/api_diff/diff_public_interface.rb
+++ b/ci_scripts/api_diff/diff_public_interface.rb
@@ -82,7 +82,9 @@ GetFrameworks.framework_names('./modules.yaml').each do |framework_name|
 
   master_public_interface_path = "#{framework_name}-master.xcframework/#{simulator_slice}/#{public_interface_dir}/arm64-apple-ios-simulator.swiftinterface"
   branch_public_interface_path = "#{framework_name}-new.xcframework/#{simulator_slice}/#{public_interface_dir}/arm64-apple-ios-simulator.swiftinterface"
-  public_diff_lines = sorted_diff_lines(master_public_interface_path, branch_public_interface_path)
+  public_diff_lines = sorted_diff_lines(master_public_interface_path, branch_public_interface_path).reject do |line|
+    line.match?(/^[+-]import\s/)
+  end
 
   master_private_interface_path = "#{framework_name}-master.xcframework/#{simulator_slice}/#{public_interface_dir}/arm64-apple-ios-simulator.private.swiftinterface"
   branch_private_interface_path = "#{framework_name}-new.xcframework/#{simulator_slice}/#{public_interface_dir}/arm64-apple-ios-simulator.private.swiftinterface"


### PR DESCRIPTION
## Summary
Ignores regular import lines when diffing generated public Swift interfaces. For example, #6845 reports the removal of import CoreGraphics as a public API change even though it doesn’t change the API exposed to SDK users.

## Motivation
https://github.com/stripe/stripe-ios/pull/6845

## Testing
- Ruby syntax check
- Verified regular imports are filtered while exported imports remain in the diff

## Changelog
N/A