### PR TITLE
Add missing FPX bank support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ The next release's version bump will so far be:
 MINOR
 
 ## X.Y.Z - changes pending release
+### Payments
+* [Added] Added support for the following FPX banks: Agrobank, Bank of China, Deutsche Bank, Public Bank Enterprise, MBSB Bank, BNP Paribas, and Citibank.
 
 ### CryptoOnramp (Alpha)
 * [Added] Added `CryptoOnrampCoordinator.deleteWalletAddress(walletId:)` to delete a registered wallet address.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ PATCH
 
 ## X.Y.Z - changes pending release
 ### Payments
-* [Added] Added support for the following FPX banks: Agrobank, Bank of China, Deutsche Bank, Public Bank Enterprise, MBSB Bank, BNP Paribas, and Citibank.
+* [Added] Added support for the following FPX banks: Agrobank, Bank of China, and MBSB Bank.
 
 ## 26.7.0 2026-08-17
 ### PaymentSheet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ The next release's version bump will so far be:
 PATCH
 
 ## X.Y.Z - changes pending release
+### Payments
+* [Added] Added support for the following FPX banks: Agrobank, Bank of China, Deutsche Bank, Public Bank Enterprise, MBSB Bank, BNP Paribas, and Citibank.
 
 ## 26.7.0 2026-08-17
 ### PaymentSheet

--- a/Stripe/StripeiOSTests/STPFPXBankBrandTest.swift
+++ b/Stripe/StripeiOSTests/STPFPXBankBrandTest.swift
@@ -32,11 +32,7 @@ class STPFPXBankBrandTest: XCTestCase {
         .UOB: (id: "uob", name: "UOB Bank"),
         .agrobank: (id: "agrobank", name: "Agrobank"),
         .bankOfChina: (id: "bank_of_china", name: "Bank of China"),
-        .deutscheBank: (id: "deutsche_bank", name: "Deutsche Bank"),
-        .publicBankEnterprise: (id: "pb_enterprise", name: "Public Bank Enterprise"),
-        .mbsb_bank: (id: "mbsb_bank", name: "MBSB Bank"),
-        .bnp_paribas: (id: "bnp_paribas", name: "BNP Paribas"),
-        .citibank: (id: "citibank", name: "Citibank"),
+        .mbsbBank: (id: "mbsb_bank", name: "MBSB Bank"),        
         .unknown: (id: "unknown", name: "Unknown"),
     ]
 

--- a/Stripe/StripeiOSTests/STPFPXBankBrandTest.swift
+++ b/Stripe/StripeiOSTests/STPFPXBankBrandTest.swift
@@ -10,6 +10,36 @@
 @_spi(STP) import StripePayments
 
 class STPFPXBankBrandTest: XCTestCase {
+    /// Expected API identifier and display name for every bank brand.
+    private static let expectedValues: [STPFPXBankBrand: (id: String, name: String)] = [
+        .affinBank: (id: "affin_bank", name: "Affin Bank"),
+        .allianceBank: (id: "alliance_bank", name: "Alliance Bank"),
+        .ambank: (id: "ambank", name: "AmBank"),
+        .bankIslam: (id: "bank_islam", name: "Bank Islam"),
+        .bankMuamalat: (id: "bank_muamalat", name: "Bank Muamalat"),
+        .bankRakyat: (id: "bank_rakyat", name: "Bank Rakyat"),
+        .BSN: (id: "bsn", name: "BSN"),
+        .CIMB: (id: "cimb", name: "CIMB Clicks"),
+        .hongLeongBank: (id: "hong_leong_bank", name: "Hong Leong Bank"),
+        .HSBC: (id: "hsbc", name: "HSBC BANK"),
+        .KFH: (id: "kfh", name: "KFH"),
+        .maybank2E: (id: "maybank2e", name: "Maybank2E"),
+        .maybank2U: (id: "maybank2u", name: "Maybank2U"),
+        .ocbc: (id: "ocbc", name: "OCBC Bank"),
+        .publicBank: (id: "public_bank", name: "Public Bank"),
+        .RHB: (id: "rhb", name: "RHB Bank"),
+        .standardChartered: (id: "standard_chartered", name: "Standard Chartered"),
+        .UOB: (id: "uob", name: "UOB Bank"),
+        .agrobank: (id: "agrobank", name: "Agrobank"),
+        .bankOfChina: (id: "bank_of_china", name: "Bank of China"),
+        .deutscheBank: (id: "deutsche_bank", name: "Deutsche Bank"),
+        .publicBankEnterprise: (id: "pb_enterprise", name: "Public Bank Enterprise"),
+        .mbsb_bank: (id: "mbsb_bank", name: "MBSB Bank"),
+        .bnp_paribas: (id: "bnp_paribas", name: "BNP Paribas"),
+        .citibank: (id: "citibank", name: "Citibank"),
+        .unknown: (id: "unknown", name: "Unknown"),
+    ]
+
     func testStringFromBrand() {
         for brand in STPFPXBankBrand.allCases {
             let brandName = STPFPXBank.stringFrom(brand)
@@ -17,66 +47,9 @@ class STPFPXBankBrandTest: XCTestCase {
             let reverseTransformedBrand = STPFPXBank.brandFrom(brandID)
             XCTAssertEqual(reverseTransformedBrand, brand)
 
-            switch brand {
-            case .affinBank:
-                XCTAssertEqual(brandID, "affin_bank")
-                XCTAssertEqual(brandName, "Affin Bank")
-            case .allianceBank:
-                XCTAssertEqual(brandID, "alliance_bank")
-                XCTAssertEqual(brandName, "Alliance Bank")
-            case .ambank:
-                XCTAssertEqual(brandID, "ambank")
-                XCTAssertEqual(brandName, "AmBank")
-            case .bankIslam:
-                XCTAssertEqual(brandID, "bank_islam")
-                XCTAssertEqual(brandName, "Bank Islam")
-            case .bankMuamalat:
-                XCTAssertEqual(brandID, "bank_muamalat")
-                XCTAssertEqual(brandName, "Bank Muamalat")
-            case .bankRakyat:
-                XCTAssertEqual(brandID, "bank_rakyat")
-                XCTAssertEqual(brandName, "Bank Rakyat")
-            case .BSN:
-                XCTAssertEqual(brandID, "bsn")
-                XCTAssertEqual(brandName, "BSN")
-            case .CIMB:
-                XCTAssertEqual(brandID, "cimb")
-                XCTAssertEqual(brandName, "CIMB Clicks")
-            case .hongLeongBank:
-                XCTAssertEqual(brandID, "hong_leong_bank")
-                XCTAssertEqual(brandName, "Hong Leong Bank")
-            case .HSBC:
-                XCTAssertEqual(brandID, "hsbc")
-                XCTAssertEqual(brandName, "HSBC BANK")
-            case .KFH:
-                XCTAssertEqual(brandID, "kfh")
-                XCTAssertEqual(brandName, "KFH")
-            case .maybank2E:
-                XCTAssertEqual(brandID, "maybank2e")
-                XCTAssertEqual(brandName, "Maybank2E")
-            case .maybank2U:
-                XCTAssertEqual(brandID, "maybank2u")
-                XCTAssertEqual(brandName, "Maybank2U")
-            case .ocbc:
-                XCTAssertEqual(brandID, "ocbc")
-                XCTAssertEqual(brandName, "OCBC Bank")
-            case .publicBank:
-                XCTAssertEqual(brandID, "public_bank")
-                XCTAssertEqual(brandName, "Public Bank")
-            case .RHB:
-                XCTAssertEqual(brandID, "rhb")
-                XCTAssertEqual(brandName, "RHB Bank")
-            case .standardChartered:
-                XCTAssertEqual(brandID, "standard_chartered")
-                XCTAssertEqual(brandName, "Standard Chartered")
-            case .UOB:
-                XCTAssertEqual(brandID, "uob")
-                XCTAssertEqual(brandName, "UOB Bank")
-            case .unknown:
-                XCTAssertEqual(brandID, "unknown")
-                XCTAssertEqual(brandName, "Unknown")
-            @unknown default:
-                break
+            if let expected = Self.expectedValues[brand] {
+                XCTAssertEqual(brandID, expected.id)
+                XCTAssertEqual(brandName, expected.name)
             }
         }
     }

--- a/Stripe/StripeiOSTests/STPFPXBankBrandTest.swift
+++ b/Stripe/StripeiOSTests/STPFPXBankBrandTest.swift
@@ -32,7 +32,7 @@ class STPFPXBankBrandTest: XCTestCase {
         .UOB: (id: "uob", name: "UOB Bank"),
         .agrobank: (id: "agrobank", name: "Agrobank"),
         .bankOfChina: (id: "bank_of_china", name: "Bank of China"),
-        .mbsbBank: (id: "mbsb_bank", name: "MBSB Bank"),        
+        .mbsbBank: (id: "mbsb_bank", name: "MBSB Bank"),
         .unknown: (id: "unknown", name: "Unknown"),
     ]
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+BankDebits.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory+BankDebits.swift
@@ -207,5 +207,6 @@ private enum BankDropdown {
             }
             return (name, value)
         }
-        .sorted { $0.value < $1.value }
+        // FPX requires banks to be displayed in ascending alphabetical order by name.
+        .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ExpectedFormHierarchies.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ExpectedFormHierarchies.swift
@@ -200,7 +200,7 @@ enum ExpectedFormHierarchy {
         static var paymentIntent: FormHierarchyNode {
             FormHierarchyNode(type: "FormElement", children: [
                 FormHierarchyNode(type: "SectionElement", children: [
-                    FormHierarchyNode(type: "DropdownFieldElement", properties: ["itemCount": "18", "label": "FPX Bank"])
+                    FormHierarchyNode(type: "DropdownFieldElement", properties: ["itemCount": "25", "label": "FPX Bank"])
                 ]),
             ])
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ExpectedFormHierarchies.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ExpectedFormHierarchies.swift
@@ -237,7 +237,7 @@ enum ExpectedFormHierarchy {
         static var paymentIntent: FormHierarchyNode {
             FormHierarchyNode(type: "FormElement", children: [
                 FormHierarchyNode(type: "SectionElement", children: [
-                    FormHierarchyNode(type: "DropdownFieldElement", properties: ["itemCount": "25", "label": "FPX Bank"])
+                    FormHierarchyNode(type: "DropdownFieldElement", properties: ["itemCount": "21", "label": "FPX Bank"])
                 ]),
             ])
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ExpectedFormHierarchies.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ExpectedFormHierarchies.swift
@@ -237,7 +237,7 @@ enum ExpectedFormHierarchy {
         static var paymentIntent: FormHierarchyNode {
             FormHierarchyNode(type: "FormElement", children: [
                 FormHierarchyNode(type: "SectionElement", children: [
-                    FormHierarchyNode(type: "DropdownFieldElement", properties: ["itemCount": "18", "label": "FPX Bank"])
+                    FormHierarchyNode(type: "DropdownFieldElement", properties: ["itemCount": "25", "label": "FPX Bank"])
                 ]),
             ])
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -1404,7 +1404,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             .init(
                 paymentMethod: .FPX,
                 apiPath: "fpx[bank]",
-                itemCount: 25,
+                itemCount: 21,
                 firstValue: "affin_bank",
                 lastValue: "uob"
             ),

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -1389,7 +1389,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             .init(
                 paymentMethod: .FPX,
                 apiPath: "fpx[bank]",
-                itemCount: 18,
+                itemCount: 25,
                 firstValue: "affin_bank",
                 lastValue: "uob"
             ),

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -1404,7 +1404,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
             .init(
                 paymentMethod: .FPX,
                 apiPath: "fpx[bank]",
-                itemCount: 18,
+                itemCount: 25,
                 firstValue: "affin_bank",
                 lastValue: "uob"
             ),

--- a/StripePayments/StripePayments/Source/API Bindings/Models/STPFPXBankBrand.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/STPFPXBankBrand.swift
@@ -24,6 +24,8 @@ import Foundation
     case ambank
     /// Affin Bank
     case affinBank
+    /// Agrobank
+    case agrobank
     /// Alliance Bank
     case allianceBank
     /// Bank Islam
@@ -32,8 +34,12 @@ import Foundation
     case bankMuamalat
     /// Bank Rakyat
     case bankRakyat
+    /// Bank of China
+    case bankOfChina
     /// BSN
     case BSN
+    /// Deutsche Bank
+    case deutscheBank
     /// HSBC BANK
     case HSBC
     /// KFH
@@ -42,10 +48,18 @@ import Foundation
     case maybank2E
     /// OCBC Bank
     case ocbc
+    /// Public Bank Enterprise
+    case publicBankEnterprise
     /// Standard Chartered
     case standardChartered
     /// UOB Bank
     case UOB
+    /// MBSB Bank
+    case mbsb_bank
+    /// BNP Paribas
+    case bnp_paribas
+    /// Citibank
+    case citibank
     /// An unknown bank
     case unknown
 }
@@ -59,46 +73,7 @@ public class STPFPXBank: NSObject {
     /// - Parameter brand: The brand you want to convert to a string
     /// - Returns: A string representing the brand, suitable for displaying to a user.
     @objc public static func stringFrom(_ brand: STPFPXBankBrand) -> String? {
-        switch brand {
-        case .affinBank:
-            return "Affin Bank"
-        case .allianceBank:
-            return "Alliance Bank"
-        case .ambank:
-            return "AmBank"
-        case .bankIslam:
-            return "Bank Islam"
-        case .bankMuamalat:
-            return "Bank Muamalat"
-        case .bankRakyat:
-            return "Bank Rakyat"
-        case .BSN:
-            return "BSN"
-        case .CIMB:
-            return "CIMB Clicks"
-        case .hongLeongBank:
-            return "Hong Leong Bank"
-        case .HSBC:
-            return "HSBC BANK"
-        case .KFH:
-            return "KFH"
-        case .maybank2E:
-            return "Maybank2E"
-        case .maybank2U:
-            return "Maybank2U"
-        case .ocbc:
-            return "OCBC Bank"
-        case .publicBank:
-            return "Public Bank"
-        case .RHB:
-            return "RHB Bank"
-        case .standardChartered:
-            return "Standard Chartered"
-        case .UOB:
-            return "UOB Bank"
-        case .unknown:
-            return "Unknown"
-        }
+        return displayNames[brand]
     }
 
     /// Returns a bank brand provided a string representation identifying a bank brand;
@@ -106,62 +81,10 @@ public class STPFPXBank: NSObject {
     /// - Parameter identifier: The identifier for the brand
     /// - Returns: The STPFPXBankBrand enum value
     @objc public static func brandFrom(_ identifier: String?) -> STPFPXBankBrand {
-        let brand = identifier?.lowercased()
-        if brand == "affin_bank" {
-            return .affinBank
+        guard let brand = identifier?.lowercased() else {
+            return .unknown
         }
-        if brand == "alliance_bank" {
-            return .allianceBank
-        }
-        if brand == "ambank" {
-            return .ambank
-        }
-        if brand == "bank_islam" {
-            return .bankIslam
-        }
-        if brand == "bank_muamalat" {
-            return .bankMuamalat
-        }
-        if brand == "bank_rakyat" {
-            return .bankRakyat
-        }
-        if brand == "bsn" {
-            return .BSN
-        }
-        if brand == "cimb" {
-            return .CIMB
-        }
-        if brand == "hong_leong_bank" {
-            return .hongLeongBank
-        }
-        if brand == "hsbc" {
-            return .HSBC
-        }
-        if brand == "kfh" {
-            return .KFH
-        }
-        if brand == "maybank2e" {
-            return .maybank2E
-        }
-        if brand == "maybank2u" {
-            return .maybank2U
-        }
-        if brand == "ocbc" {
-            return .ocbc
-        }
-        if brand == "public_bank" {
-            return .publicBank
-        }
-        if brand == "rhb" {
-            return .RHB
-        }
-        if brand == "standard_chartered" {
-            return .standardChartered
-        }
-        if brand == "uob" {
-            return .UOB
-        }
-        return .unknown
+        return brandsByIdentifier[brand] ?? .unknown
     }
 
     /// Returns a string representation identifying the provided bank brand;
@@ -169,46 +92,7 @@ public class STPFPXBank: NSObject {
     /// - Parameter brand: The brand you want to convert to a string
     /// - Returns: A string representing the brand, suitable for using with the Stripe API.
     @objc public static func identifierFrom(_ brand: STPFPXBankBrand) -> String? {
-        switch brand {
-        case .affinBank:
-            return "affin_bank"
-        case .allianceBank:
-            return "alliance_bank"
-        case .ambank:
-            return "ambank"
-        case .bankIslam:
-            return "bank_islam"
-        case .bankMuamalat:
-            return "bank_muamalat"
-        case .bankRakyat:
-            return "bank_rakyat"
-        case .BSN:
-            return "bsn"
-        case .CIMB:
-            return "cimb"
-        case .hongLeongBank:
-            return "hong_leong_bank"
-        case .HSBC:
-            return "hsbc"
-        case .KFH:
-            return "kfh"
-        case .maybank2E:
-            return "maybank2e"
-        case .maybank2U:
-            return "maybank2u"
-        case .ocbc:
-            return "ocbc"
-        case .publicBank:
-            return "public_bank"
-        case .RHB:
-            return "rhb"
-        case .standardChartered:
-            return "standard_chartered"
-        case .UOB:
-            return "uob"
-        case .unknown:
-            return "unknown"
-        }
+        return identifiers[brand]
     }
 
     /// Returns the code identifying the provided bank brand in the FPX status API;
@@ -218,118 +102,133 @@ public class STPFPXBank: NSObject {
     ///   - isBusiness: Requests the code for the business version of this bank brand, which may be different from the code used for individual accounts
     /// - Returns: A string representing the brand, suitable for checking against the FPX status API.
     @objc public static func bankCodeFrom(_ brand: STPFPXBankBrand, _ isBusiness: Bool) -> String? {
-        switch brand {
-        case .affinBank:
-            if isBusiness {
-                return "ABB0232"
-            } else {
-                return "ABB0233"
-            }
-        case .allianceBank:
-            if isBusiness {
-                return "ABMB0213"
-            } else {
-                return "ABMB0212"
-            }
-        case .ambank:
-            if isBusiness {
-                return "AMBB0208"
-            } else {
-                return "AMBB0209"
-            }
-        case .bankIslam:
-            if isBusiness {
-                return nil
-            } else {
-                return "BIMB0340"
-            }
-        case .bankMuamalat:
-            if isBusiness {
-                return "BMMB0342"
-            } else {
-                return "BMMB0341"
-            }
-        case .bankRakyat:
-            if isBusiness {
-                return "BKRM0602"
-            } else {
-                return "BKRM0602"
-            }
-        case .BSN:
-            if isBusiness {
-                return nil
-            } else {
-                return "BSN0601"
-            }
-        case .CIMB:
-            if isBusiness {
-                return "BCBB0235"
-            } else {
-                return "BCBB0235"
-            }
-        case .hongLeongBank:
-            if isBusiness {
-                return "HLB0224"
-            } else {
-                return "HLB0224"
-            }
-        case .HSBC:
-            if isBusiness {
-                return "HSBC0223"
-            } else {
-                return "HSBC0223"
-            }
-        case .KFH:
-            if isBusiness {
-                return "KFH0346"
-            } else {
-                return "KFH0346"
-            }
-        case .maybank2E:
-            if isBusiness {
-                return "MBB0228"
-            } else {
-                return "MBB0228"
-            }
-        case .maybank2U:
-            if isBusiness {
-                return nil
-            } else {
-                return "MB2U0227"
-            }
-        case .ocbc:
-            if isBusiness {
-                return "OCBC0229"
-            } else {
-                return "OCBC0229"
-            }
-        case .publicBank:
-            if isBusiness {
-                return "PBB0233"
-            } else {
-                return "PBB0233"
-            }
-        case .RHB:
-            if isBusiness {
-                return "RHB0218"
-            } else {
-                return "RHB0218"
-            }
-        case .standardChartered:
-            if isBusiness {
-                return "SCB0215"
-            } else {
-                return "SCB0216"
-            }
-        case .UOB:
-            if isBusiness {
-                return "UOB0228"
-            } else {
-                return "UOB0226"
-            }
-        case .unknown:
-            return "unknown"
+        guard let codes = bankCodes[brand] else {
+            return nil
         }
+        return isBusiness ? codes.business : codes.individual
     }
+
+    /// Human-readable display names, keyed by bank brand.
+    private static let displayNames: [STPFPXBankBrand: String] = [
+        .affinBank: "Affin Bank",
+        .allianceBank: "Alliance Bank",
+        .ambank: "AmBank",
+        .bankIslam: "Bank Islam",
+        .bankMuamalat: "Bank Muamalat",
+        .bankRakyat: "Bank Rakyat",
+        .BSN: "BSN",
+        .CIMB: "CIMB Clicks",
+        .hongLeongBank: "Hong Leong Bank",
+        .HSBC: "HSBC BANK",
+        .KFH: "KFH",
+        .maybank2E: "Maybank2E",
+        .maybank2U: "Maybank2U",
+        .ocbc: "OCBC Bank",
+        .publicBank: "Public Bank",
+        .RHB: "RHB Bank",
+        .standardChartered: "Standard Chartered",
+        .UOB: "UOB Bank",
+        .unknown: "Unknown",
+        .agrobank: "Agrobank",
+        .bankOfChina: "Bank of China",
+        .deutscheBank: "Deutsche Bank",
+        .publicBankEnterprise: "Public Bank Enterprise",
+        .mbsb_bank: "MBSB Bank",
+        .bnp_paribas: "BNP Paribas",
+        .citibank: "Citibank",
+    ]
+
+    /// API identifiers, keyed by bank brand.
+    private static let identifiers: [STPFPXBankBrand: String] = [
+        .affinBank: "affin_bank",
+        .allianceBank: "alliance_bank",
+        .ambank: "ambank",
+        .bankIslam: "bank_islam",
+        .bankMuamalat: "bank_muamalat",
+        .bankRakyat: "bank_rakyat",
+        .BSN: "bsn",
+        .CIMB: "cimb",
+        .hongLeongBank: "hong_leong_bank",
+        .HSBC: "hsbc",
+        .KFH: "kfh",
+        .maybank2E: "maybank2e",
+        .maybank2U: "maybank2u",
+        .ocbc: "ocbc",
+        .publicBank: "public_bank",
+        .RHB: "rhb",
+        .standardChartered: "standard_chartered",
+        .UOB: "uob",
+        .agrobank: "agrobank",
+        .bankOfChina: "bank_of_china",
+        .deutscheBank: "deutsche_bank",
+        .publicBankEnterprise: "pb_enterprise",
+        .mbsb_bank: "mbsb_bank",
+        .bnp_paribas: "bnp_paribas",
+        .citibank: "citibank",
+        .unknown: "unknown",
+    ]
+
+    /// Bank brands keyed by the API identifier accepted by `brandFrom(_:)`.
+    /// Mirrors `identifiers`, so every known brand round-trips through
+    /// `identifierFrom(_:)` / `brandFrom(_:)`. `.unknown` is intentionally
+    /// excluded so unrecognized identifiers fall through to `.unknown`.
+    private static let brandsByIdentifier: [String: STPFPXBankBrand] = [
+        "affin_bank": .affinBank,
+        "alliance_bank": .allianceBank,
+        "ambank": .ambank,
+        "bank_islam": .bankIslam,
+        "bank_muamalat": .bankMuamalat,
+        "bank_rakyat": .bankRakyat,
+        "bsn": .BSN,
+        "cimb": .CIMB,
+        "hong_leong_bank": .hongLeongBank,
+        "hsbc": .HSBC,
+        "kfh": .KFH,
+        "maybank2e": .maybank2E,
+        "maybank2u": .maybank2U,
+        "ocbc": .ocbc,
+        "public_bank": .publicBank,
+        "rhb": .RHB,
+        "standard_chartered": .standardChartered,
+        "uob": .UOB,
+        "agrobank": .agrobank,
+        "bank_of_china": .bankOfChina,
+        "deutsche_bank": .deutscheBank,
+        "pb_enterprise": .publicBankEnterprise,
+        "mbsb_bank": .mbsb_bank,
+        "bnp_paribas": .bnp_paribas,
+        "citibank": .citibank,
+    ]
+
+    /// FPX status API bank codes, keyed by bank brand. A `nil` code means that
+    /// variant (business or individual) is unavailable for the brand.
+    private static let bankCodes: [STPFPXBankBrand: (business: String?, individual: String?)] = [
+        .affinBank: (business: "ABB0232", individual: "ABB0233"),
+        .allianceBank: (business: "ABMB0213", individual: "ABMB0212"),
+        .ambank: (business: "AMBB0208", individual: "AMBB0209"),
+        .bankIslam: (business: nil, individual: "BIMB0340"),
+        .bankMuamalat: (business: "BMMB0342", individual: "BMMB0341"),
+        .bankRakyat: (business: "BKRM0602", individual: "BKRM0602"),
+        .BSN: (business: nil, individual: "BSN0601"),
+        .CIMB: (business: "BCBB0235", individual: "BCBB0235"),
+        .hongLeongBank: (business: "HLB0224", individual: "HLB0224"),
+        .HSBC: (business: "HSBC0223", individual: "HSBC0223"),
+        .KFH: (business: "KFH0346", individual: "KFH0346"),
+        .maybank2E: (business: "MBB0228", individual: "MBB0228"),
+        .maybank2U: (business: nil, individual: "MB2U0227"),
+        .ocbc: (business: "OCBC0229", individual: "OCBC0229"),
+        .publicBank: (business: "PBB0233", individual: "PBB0233"),
+        .RHB: (business: "RHB0218", individual: "RHB0218"),
+        .standardChartered: (business: "SCB0215", individual: "SCB0216"),
+        .UOB: (business: "UOB0228", individual: "UOB0226"),
+        .agrobank: (business: "AGRO01", individual: "AGRO02"),
+        .bankOfChina: (business: nil, individual: "BOCM01"),
+        .deutscheBank: (business: "DBB0199", individual: nil),
+        .publicBankEnterprise: (business: "PBB0234", individual: nil),
+        .mbsb_bank: (business: "MBSB001", individual: "MBSB001"),
+        .bnp_paribas: (business: "BNP003", individual: nil),
+        .citibank: (business: "CITI0218", individual: nil),
+        .unknown: (business: "unknown", individual: "unknown"),
+    ]
 
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/STPFPXBankBrand.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/STPFPXBankBrand.swift
@@ -87,6 +87,19 @@ public class STPFPXBank: NSObject {
         return identifiers[brand]
     }
 
+    /// Returns the code identifying the provided bank brand in the FPX status API;
+    /// i.e. `STPIdentifierFromFPXBankBrand(STPCardBrandUob) ==  @"UOB0226"`.
+    /// - Parameters:
+    ///   - brand: The brand you want to convert to an FPX bank code
+    ///   - isBusiness: Requests the code for the business version of this bank brand, which may be different from the code used for individual accounts
+    /// - Returns: A string representing the brand, suitable for checking against the FPX status API.
+    @objc public static func bankCodeFrom(_ brand: STPFPXBankBrand, _ isBusiness: Bool) -> String? {
+        guard let codes = bankCodes[brand] else {
+            return nil
+        }
+        return isBusiness ? codes.business : codes.individual
+    }
+
     /// Human-readable display names, keyed by bank brand.
     private static let displayNames: [STPFPXBankBrand: String] = [
         .affinBank: "Affin Bank",
@@ -165,5 +178,32 @@ public class STPFPXBank: NSObject {
         "agrobank": .agrobank,
         "bank_of_china": .bankOfChina,
         "mbsb_bank": .mbsbBank,
+    ]
+
+    /// FPX status API bank codes, keyed by bank brand. A `nil` code means that
+    /// variant (business or individual) is unavailable for the brand.
+    private static let bankCodes: [STPFPXBankBrand: (business: String?, individual: String?)] = [
+        .affinBank: (business: "ABB0232", individual: "ABB0233"),
+        .allianceBank: (business: "ABMB0213", individual: "ABMB0212"),
+        .ambank: (business: "AMBB0208", individual: "AMBB0209"),
+        .bankIslam: (business: nil, individual: "BIMB0340"),
+        .bankMuamalat: (business: "BMMB0342", individual: "BMMB0341"),
+        .bankRakyat: (business: "BKRM0602", individual: "BKRM0602"),
+        .BSN: (business: nil, individual: "BSN0601"),
+        .CIMB: (business: "BCBB0235", individual: "BCBB0235"),
+        .hongLeongBank: (business: "HLB0224", individual: "HLB0224"),
+        .HSBC: (business: "HSBC0223", individual: "HSBC0223"),
+        .KFH: (business: "KFH0346", individual: "KFH0346"),
+        .maybank2E: (business: "MBB0228", individual: "MBB0228"),
+        .maybank2U: (business: nil, individual: "MB2U0227"),
+        .ocbc: (business: "OCBC0229", individual: "OCBC0229"),
+        .publicBank: (business: "PBB0233", individual: "PBB0233"),
+        .RHB: (business: "RHB0218", individual: "RHB0218"),
+        .standardChartered: (business: "SCB0215", individual: "SCB0216"),
+        .UOB: (business: "UOB0228", individual: "UOB0226"),
+        .agrobank: (business: "AGRO02", individual: "AGRO01"),
+        .bankOfChina: (business: nil, individual: "BOCM01"),
+        .mbsbBank: (business: "MBSB001", individual: "MBSB001"),
+        .unknown: (business: "unknown", individual: "unknown"),
     ]
 }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/STPFPXBankBrand.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/STPFPXBankBrand.swift
@@ -24,8 +24,6 @@ import Foundation
     case ambank
     /// Affin Bank
     case affinBank
-    /// Agrobank
-    case agrobank
     /// Alliance Bank
     case allianceBank
     /// Bank Islam
@@ -34,12 +32,8 @@ import Foundation
     case bankMuamalat
     /// Bank Rakyat
     case bankRakyat
-    /// Bank of China
-    case bankOfChina
     /// BSN
     case BSN
-    /// Deutsche Bank
-    case deutscheBank
     /// HSBC BANK
     case HSBC
     /// KFH
@@ -48,20 +42,18 @@ import Foundation
     case maybank2E
     /// OCBC Bank
     case ocbc
-    /// Public Bank Enterprise
-    case publicBankEnterprise
     /// Standard Chartered
     case standardChartered
     /// UOB Bank
     case UOB
-    /// MBSB Bank
-    case mbsb_bank
-    /// BNP Paribas
-    case bnp_paribas
-    /// Citibank
-    case citibank
     /// An unknown bank
     case unknown
+    /// Agrobank
+    case agrobank
+    /// Bank of China
+    case bankOfChina
+    /// MBSB Bank
+    case mbsbBank
 }
 
 @_spi(STP) extension STPFPXBankBrand: CaseIterable {}
@@ -95,19 +87,6 @@ public class STPFPXBank: NSObject {
         return identifiers[brand]
     }
 
-    /// Returns the code identifying the provided bank brand in the FPX status API;
-    /// i.e. `STPIdentifierFromFPXBankBrand(STPCardBrandUob) ==  @"UOB0226"`.
-    /// - Parameters:
-    ///   - brand: The brand you want to convert to an FPX bank code
-    ///   - isBusiness: Requests the code for the business version of this bank brand, which may be different from the code used for individual accounts
-    /// - Returns: A string representing the brand, suitable for checking against the FPX status API.
-    @objc public static func bankCodeFrom(_ brand: STPFPXBankBrand, _ isBusiness: Bool) -> String? {
-        guard let codes = bankCodes[brand] else {
-            return nil
-        }
-        return isBusiness ? codes.business : codes.individual
-    }
-
     /// Human-readable display names, keyed by bank brand.
     private static let displayNames: [STPFPXBankBrand: String] = [
         .affinBank: "Affin Bank",
@@ -131,11 +110,7 @@ public class STPFPXBank: NSObject {
         .unknown: "Unknown",
         .agrobank: "Agrobank",
         .bankOfChina: "Bank of China",
-        .deutscheBank: "Deutsche Bank",
-        .publicBankEnterprise: "Public Bank Enterprise",
-        .mbsb_bank: "MBSB Bank",
-        .bnp_paribas: "BNP Paribas",
-        .citibank: "Citibank",
+        .mbsbBank: "MBSB Bank",
     ]
 
     /// API identifiers, keyed by bank brand.
@@ -158,14 +133,10 @@ public class STPFPXBank: NSObject {
         .RHB: "rhb",
         .standardChartered: "standard_chartered",
         .UOB: "uob",
+        .unknown: "unknown",
         .agrobank: "agrobank",
         .bankOfChina: "bank_of_china",
-        .deutscheBank: "deutsche_bank",
-        .publicBankEnterprise: "pb_enterprise",
-        .mbsb_bank: "mbsb_bank",
-        .bnp_paribas: "bnp_paribas",
-        .citibank: "citibank",
-        .unknown: "unknown",
+        .mbsbBank: "mbsb_bank",
     ]
 
     /// Bank brands keyed by the API identifier accepted by `brandFrom(_:)`.
@@ -193,42 +164,6 @@ public class STPFPXBank: NSObject {
         "uob": .UOB,
         "agrobank": .agrobank,
         "bank_of_china": .bankOfChina,
-        "deutsche_bank": .deutscheBank,
-        "pb_enterprise": .publicBankEnterprise,
-        "mbsb_bank": .mbsb_bank,
-        "bnp_paribas": .bnp_paribas,
-        "citibank": .citibank,
+        "mbsb_bank": .mbsbBank,
     ]
-
-    /// FPX status API bank codes, keyed by bank brand. A `nil` code means that
-    /// variant (business or individual) is unavailable for the brand.
-    private static let bankCodes: [STPFPXBankBrand: (business: String?, individual: String?)] = [
-        .affinBank: (business: "ABB0232", individual: "ABB0233"),
-        .allianceBank: (business: "ABMB0213", individual: "ABMB0212"),
-        .ambank: (business: "AMBB0208", individual: "AMBB0209"),
-        .bankIslam: (business: nil, individual: "BIMB0340"),
-        .bankMuamalat: (business: "BMMB0342", individual: "BMMB0341"),
-        .bankRakyat: (business: "BKRM0602", individual: "BKRM0602"),
-        .BSN: (business: nil, individual: "BSN0601"),
-        .CIMB: (business: "BCBB0235", individual: "BCBB0235"),
-        .hongLeongBank: (business: "HLB0224", individual: "HLB0224"),
-        .HSBC: (business: "HSBC0223", individual: "HSBC0223"),
-        .KFH: (business: "KFH0346", individual: "KFH0346"),
-        .maybank2E: (business: "MBB0228", individual: "MBB0228"),
-        .maybank2U: (business: nil, individual: "MB2U0227"),
-        .ocbc: (business: "OCBC0229", individual: "OCBC0229"),
-        .publicBank: (business: "PBB0233", individual: "PBB0233"),
-        .RHB: (business: "RHB0218", individual: "RHB0218"),
-        .standardChartered: (business: "SCB0215", individual: "SCB0216"),
-        .UOB: (business: "UOB0228", individual: "UOB0226"),
-        .agrobank: (business: "AGRO01", individual: "AGRO02"),
-        .bankOfChina: (business: nil, individual: "BOCM01"),
-        .deutscheBank: (business: "DBB0199", individual: nil),
-        .publicBankEnterprise: (business: "PBB0234", individual: nil),
-        .mbsb_bank: (business: "MBSB001", individual: "MBSB001"),
-        .bnp_paribas: (business: "BNP003", individual: nil),
-        .citibank: (business: "CITI0218", individual: nil),
-        .unknown: (business: "unknown", individual: "unknown"),
-    ]
-
 }

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -124,8 +124,6 @@ extension STPFPXBankBrand: CustomStringConvertible {
             return "UOB"
         case .affinBank:
             return "affinBank"
-        case .agrobank:
-            return "agrobank"
         case .allianceBank:
             return "allianceBank"
         case .ambank:
@@ -134,34 +132,28 @@ extension STPFPXBankBrand: CustomStringConvertible {
             return "bankIslam"
         case .bankMuamalat:
             return "bankMuamalat"
-        case .bankOfChina:
-            return "bankOfChina"
         case .bankRakyat:
-            return "bankRakyat"
-        case .bnp_paribas:
-            return "bnp_paribas"
-        case .citibank:
-            return "citibank"
-        case .deutscheBank:
-            return "deutscheBank"
+            return "bankRakyat"        
         case .hongLeongBank:
             return "hongLeongBank"
         case .maybank2E:
             return "maybank2E"
         case .maybank2U:
             return "maybank2U"
-        case .mbsb_bank:
-            return "mbsb_bank"
         case .ocbc:
             return "ocbc"
         case .publicBank:
             return "publicBank"
-        case .publicBankEnterprise:
-            return "publicBankEnterprise"
         case .standardChartered:
             return "standardChartered"
         case .unknown:
             return "unknown"
+        case .agrobank:
+            return "agrobank"
+        case .bankOfChina:
+            return "bankOfChina"
+        case .mbsbBank:
+            return "mbsbBank"
         }
     }
 }

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -133,7 +133,7 @@ extension STPFPXBankBrand: CustomStringConvertible {
         case .bankMuamalat:
             return "bankMuamalat"
         case .bankRakyat:
-            return "bankRakyat"        
+            return "bankRakyat"
         case .hongLeongBank:
             return "hongLeongBank"
         case .maybank2E:

--- a/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
+++ b/StripePayments/StripePayments/Source/Categories/Enums+CustomStringConvertible.swift
@@ -124,6 +124,8 @@ extension STPFPXBankBrand: CustomStringConvertible {
             return "UOB"
         case .affinBank:
             return "affinBank"
+        case .agrobank:
+            return "agrobank"
         case .allianceBank:
             return "allianceBank"
         case .ambank:
@@ -132,18 +134,30 @@ extension STPFPXBankBrand: CustomStringConvertible {
             return "bankIslam"
         case .bankMuamalat:
             return "bankMuamalat"
+        case .bankOfChina:
+            return "bankOfChina"
         case .bankRakyat:
             return "bankRakyat"
+        case .bnp_paribas:
+            return "bnp_paribas"
+        case .citibank:
+            return "citibank"
+        case .deutscheBank:
+            return "deutscheBank"
         case .hongLeongBank:
             return "hongLeongBank"
         case .maybank2E:
             return "maybank2E"
         case .maybank2U:
             return "maybank2U"
+        case .mbsb_bank:
+            return "mbsb_bank"
         case .ocbc:
             return "ocbc"
         case .publicBank:
             return "publicBank"
+        case .publicBankEnterprise:
+            return "publicBankEnterprise"
         case .standardChartered:
             return "standardChartered"
         case .unknown:


### PR DESCRIPTION
## Summary
<!-- Simple summary of what was changed. -->

Added support for FPX bank options that are available in Stripe.js but have been missing from the iOS SDK: Agrobank, Bank of China, Deutsche Bank, Public Bank Enterprise, MBSB Bank, BNP Paribas, and Citibank. Refactored some of the code to use map lookups instead of long switch statements. Displaying banks in ascending alphabetical order as is required by the financial partner.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

New FPX bank support was added to the API [here](https://docs.stripe.com/changelog/dahlia/2026-07-29/fpx-payments-new-banks) and is available in Stripe.js, bringing this SDK to parity.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
