### PR TITLE
SAE — Initialize via Checkout

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -59,6 +59,10 @@ extension Checkout {
         /// Configuration for ExpressCheckoutElement.
         public var expressCheckoutElement: ExpressCheckoutElement.Configuration = .init()
 
+        /// Configuration for the Adaptive Pricing currency selector returned by
+        /// ``Checkout.getCurrencySelectorElement()``.
+        public var currencySelectorElement: CurrencySelectorElement.Configuration = .init()
+
         /// Configuration for the shipping address form returned by
         /// ``Checkout.getShippingAddressElement()``.
         public var shippingAddressElement: ShippingAddressElement.Configuration = .init()
@@ -71,10 +75,6 @@ extension Checkout {
 
         /// The color styling to use for Checkout UI.
         public var userInterfaceStyle: UserInterfaceStyle = .automatic
-
-        /// Configuration for the Adaptive Pricing currency selector returned by
-        /// ``Checkout.getCurrencySelectorElement()``.
-        public var currencySelectorElement: CurrencySelectorElement.Configuration = .init()
 
         /// Creates a configuration.
         /// - Parameter clientSecret: The client secret for your Checkout Session.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -59,6 +59,9 @@ public final class Checkout: ObservableObject {
     /// The CurrencySelectorElement for this Checkout instance, when Adaptive Pricing is available.
     private var currencySelectorElement: CurrencySelectorElement?
 
+    /// The ShippingAddressElement for this Checkout instance.
+    private var shippingAddressElement: ShippingAddressElement!
+
     // TODO(gbirch) TODO(porter) remove this nonisolatedSession
     //  once MPE is properly MainActor isolated
     /// A snapshot of the current ``session`` accessible from non-MainActor contexts.
@@ -133,6 +136,7 @@ public final class Checkout: ObservableObject {
             try await applyDefaults()
 
             // Load elements
+            self.shippingAddressElement = ShippingAddressElement(checkout: self)
             self.paymentElement = try await PaymentElement(checkout: self)
             let sessionSource = CheckoutSessionSource(initialSession: session, sessionPublisher: $session)
             self.expressCheckoutElement = ExpressCheckoutElement(
@@ -285,6 +289,11 @@ public final class Checkout: ObservableObject {
     /// Returns the CurrencySelectorElement when Adaptive Pricing is available for this Checkout instance.
     public func getCurrencySelectorElement() -> CurrencySelectorElement? {
         return currencySelectorElement
+    }
+
+    /// Returns the ShippingAddressElement for this Checkout instance.
+    public func getShippingAddressElement() -> ShippingAddressElement {
+        return shippingAddressElement
     }
 
     // MARK: - Confirm

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -60,7 +60,7 @@ public final class Checkout: ObservableObject {
     private var currencySelectorElement: CurrencySelectorElement?
 
     /// The ShippingAddressElement for this Checkout instance.
-    private var shippingAddressElement: ShippingAddressElement!
+    private let shippingAddressElement: ShippingAddressElement
 
     // TODO(gbirch) TODO(porter) remove this nonisolatedSession
     //  once MPE is properly MainActor isolated
@@ -131,12 +131,30 @@ public final class Checkout: ObservableObject {
             )
             let loadedSession = apiResponse.makePublicSession()
             self.session = loadedSession
-            self.nonisolatedSession = session // temporary hack
+            self.nonisolatedSession = loadedSession // temporary hack
+
+            let defaultShippingAddress: Session.ShippingAddress?
+            if let shippingDetails = configuration.defaults.shippingDetails,
+               let address = shippingDetails.address {
+                defaultShippingAddress = Session.ShippingAddress(
+                    name: shippingDetails.name,
+                    address: address
+                )
+            } else {
+                defaultShippingAddress = nil
+            }
+
+            self.shippingAddressElement = ShippingAddressElement(
+                configuration: configuration.shippingAddressElement,
+                initialShippingAddress: defaultShippingAddress ?? loadedSession.shippingAddress,
+                allowedCountries: loadedSession.allowedShippingCountries,
+                apiClient: configuration.apiClient,
+                useAutocompleteEndpoints: loadedSession.elementsSession.shouldUseAutocompleteProxyEndpoints
+            )
 
             try await applyDefaults()
 
-            // Load elements
-            self.shippingAddressElement = ShippingAddressElement(checkout: self)
+            // Load remaining elements
             self.paymentElement = try await PaymentElement(checkout: self)
             let sessionSource = CheckoutSessionSource(initialSession: session, sessionPublisher: $session)
             self.expressCheckoutElement = ExpressCheckoutElement(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Shipping Address Element/ShippingAddressElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Shipping Address Element/ShippingAddressElement.swift
@@ -4,6 +4,8 @@
 //
 //  Created by George Birch on 8/4/26.
 
+@_spi(STP) import StripeCore
+
 /// A shipping address form backed by a Checkout Session.
 @MainActor
 @_spi(STP)
@@ -12,15 +14,21 @@ public final class ShippingAddressElement {
 
     private(set) var addressViewController: AddressViewController!
 
-    init(checkout: Checkout) {
-        let configuration = checkout.configuration.shippingAddressElement.makeAddressViewControllerConfiguration(
-            shippingAddress: checkout.session.shippingAddress,
-            allowedCountries: checkout.session.allowedShippingCountries,
-            apiClient: checkout.apiClient,
-            useAutocompleteEndpoints: checkout.session.elementsSession.shouldUseAutocompleteProxyEndpoints
+    init(
+        configuration: Configuration,
+        initialShippingAddress: Checkout.Session.ShippingAddress?,
+        allowedCountries: [String]?,
+        apiClient: STPAPIClient,
+        useAutocompleteEndpoints: Bool
+    ) {
+        let addressViewControllerConfiguration = configuration.makeAddressViewControllerConfiguration(
+            shippingAddress: initialShippingAddress,
+            allowedCountries: allowedCountries,
+            apiClient: apiClient,
+            useAutocompleteEndpoints: useAutocompleteEndpoints
         )
         addressViewController = AddressViewController(
-            configuration: configuration,
+            configuration: addressViewControllerConfiguration,
             delegate: self
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Shipping Address Element/ShippingAddressElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Shipping Address Element/ShippingAddressElement.swift
@@ -8,4 +8,27 @@
 @MainActor
 @_spi(STP)
 @_spi(ReactNativeSDK)
-public final class ShippingAddressElement {}
+public final class ShippingAddressElement {
+
+    private(set) var addressViewController: AddressViewController!
+
+    init(checkout: Checkout) {
+        let configuration = checkout.configuration.shippingAddressElement.makeAddressViewControllerConfiguration(
+            shippingAddress: checkout.session.shippingAddress,
+            allowedCountries: checkout.session.allowedShippingCountries,
+            apiClient: checkout.apiClient,
+            useAutocompleteEndpoints: checkout.session.elementsSession.shouldUseAutocompleteProxyEndpoints
+        )
+        addressViewController = AddressViewController(
+            configuration: configuration,
+            delegate: self
+        )
+    }
+}
+
+extension ShippingAddressElement: AddressViewControllerDelegate {
+    public func addressViewControllerDidFinish(
+        _ addressViewController: AddressViewController,
+        with address: AddressViewController.AddressDetails?
+    ) {}
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Shipping Address Element/ShippingAddressElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Shipping Address Element/ShippingAddressElement.swift
@@ -30,5 +30,7 @@ extension ShippingAddressElement: AddressViewControllerDelegate {
     public func addressViewControllerDidFinish(
         _ addressViewController: AddressViewController,
         with address: AddressViewController.AddressDetails?
-    ) {}
+    ) {
+        // TODO(gbirch): populate when implementing presentation
+    }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/ShippingAddressElementConfigurationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/ShippingAddressElementConfigurationTests.swift
@@ -11,6 +11,55 @@ import XCTest
 
 @MainActor
 final class ShippingAddressElementConfigurationTests: XCTestCase {
+    func testCheckoutInitializesShippingAddressElement() async throws {
+        // Given
+        var sessionJSON = CheckoutTestHelpers.openSessionJSON
+        sessionJSON["shipping_address_collection"] = ["allowed_countries": ["US", "CA"]]
+        var elementsSessionJSON = CheckoutTestHelpers.minimalElementsSessionJSON
+        elementsSessionJSON["flags"] = ["ocs_mobile_should_use_autocomplete_proxy_endpoints": true]
+        sessionJSON["elements_session"] = elementsSessionJSON
+        let apiResponse = try XCTUnwrap(PaymentPagesAPIResponse.decodedObject(fromAPIResponse: sessionJSON))
+
+        var configuration = Checkout.Configuration(
+            clientSecret: "cs_test_123_secret_abc",
+            returnURL: "stripe-ios-test://checkout-return"
+        )
+        configuration.shippingAddressElement.title = "Delivery address"
+        configuration.shippingAddressElement.buttonTitle = "Save delivery address"
+        configuration.shippingAddressElement.appearance.colors.primary = .purple
+        var shippingDetails = Checkout.Configuration.Defaults.ShippingDetails()
+        shippingDetails.name = "Jenny Rosen"
+        shippingDetails.address = .init(
+            country: "US",
+            line1: "510 Townsend St.",
+            city: "San Francisco",
+            state: "CA",
+            postalCode: "94103"
+        )
+        configuration.defaults.shippingDetails = shippingDetails
+        configuration = CheckoutTestHelpers.makeConfiguration(
+            apiResponse: apiResponse,
+            configuration: configuration
+        )
+
+        // When
+        let checkout = try await Checkout(configuration: configuration)
+        let shippingAddressElement = checkout.getShippingAddressElement()
+        let addressConfiguration = shippingAddressElement.addressViewController.configuration
+
+        // Then
+        XCTAssertTrue(shippingAddressElement === checkout.getShippingAddressElement())
+        XCTAssertEqual(addressConfiguration.title, "Delivery address")
+        XCTAssertEqual(addressConfiguration.buttonTitle, "Save delivery address")
+        XCTAssertEqual(addressConfiguration.appearance.colors.primary, .purple)
+        XCTAssertEqual(addressConfiguration.allowedCountries, ["US", "CA"])
+        XCTAssertEqual(addressConfiguration.defaultValues.name, "Jenny Rosen")
+        XCTAssertEqual(addressConfiguration.defaultValues.address.country, "US")
+        XCTAssertEqual(addressConfiguration.defaultValues.address.line1, "510 Townsend St.")
+        XCTAssertTrue(addressConfiguration.apiClient === configuration.apiClient)
+        XCTAssertTrue(addressConfiguration.useAutocompleteEndpoints)
+    }
+
     func testMakeAddressViewControllerConfiguration() {
         // Given
         let apiClient = STPAPIClient(publishableKey: "pk_test_123")


### PR DESCRIPTION
## Summary
- initialize the Shipping Address Element using data from the configuration and checkout session
- expose public SAE getter

## Motivation
- eng design: https://docs.google.com/document/d/1CWglcOHR6I8cOWKjztPfnhnVG8axucpv-j5cWIoey7E/edit?tab=t.6mlp9ite2vpp#heading=h.fbn38s9qfcm0
- API review: https://docs.google.com/document/d/1pIrRtTJQzu7hAhnCjumM64cwatgOjNuR9N22QzGJUAg/edit?tab=t.0

## Testing
added unit test

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
