### PR TITLE
CheckoutSessions — Initialize elements in parallel

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -167,20 +167,20 @@ public final class Checkout: ObservableObject {
             )
 
             // PE
-            async let paymentElement = PaymentElement(checkout: self)
+            let peTask = Task { try await PaymentElement(checkout: self) }
 
             // CSE
-            async let currencySelectorElement = configuration.adaptivePricing.allowed ?
-                CurrencySelectorElement(
+            let cseTask = Task {
+                configuration.adaptivePricing.allowed ? await CurrencySelectorElement(
                     sessionSource: sessionSource,
                     configuration: configuration.currencySelectorElement,
                     delegate: self
-                )
-            : nil
+                ) : nil
+            }
 
             // Wait for all of the initializations to finish.
-            self.paymentElement = try await paymentElement
-            self.currencySelectorElement = await currencySelectorElement
+            self.paymentElement = try await peTask.value
+            self.currencySelectorElement = await cseTask.value
         } catch {
             throw CheckoutError.apiError(message: error.nonGenericDescription)
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout.swift
@@ -154,22 +154,33 @@ public final class Checkout: ObservableObject {
 
             try await applyDefaults()
 
-            // Load remaining elements
-            self.paymentElement = try await PaymentElement(checkout: self)
+            // Load the remaining elements in parallel. Calling `async let` spins up the initializations concurrently.
+
+            // Generate a session source that can be used to initialize elements. This is a value type safe to share across parallel initializations.
             let sessionSource = CheckoutSessionSource(initialSession: session, sessionPublisher: $session)
+
+            // ECE (synchronous initializer)
             self.expressCheckoutElement = ExpressCheckoutElement(
                 sessionSource: sessionSource,
                 configuration: configuration,
                 delegate: self
             )
-            if configuration.adaptivePricing.allowed {
-                self.currencySelectorElement = await CurrencySelectorElement(
+
+            // PE
+            async let paymentElement = PaymentElement(checkout: self)
+
+            // CSE
+            async let currencySelectorElement = configuration.adaptivePricing.allowed ?
+                CurrencySelectorElement(
                     sessionSource: sessionSource,
                     configuration: configuration.currencySelectorElement,
                     delegate: self
                 )
-            }
+            : nil
 
+            // Wait for all of the initializations to finish.
+            self.paymentElement = try await paymentElement
+            self.currencySelectorElement = await currencySelectorElement
         } catch {
             throw CheckoutError.apiError(message: error.nonGenericDescription)
         }


### PR DESCRIPTION
## Summary
- Initialize elements in parallel instead of sequentially
- SAE is excluded since we need to initialize it to get the shipping address and update tax info
- PE needs the checkout itself to initialize. Other elements can and should use the sessionSource for thread safety across parallel initializations

## Motivation
Reducing loading latency

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
