### PR TITLE
Fix flaky testCardArtImage_returnsNilWhenImageNotCached test 🪿✨

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPPaymentMethod+CardArtImageTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPPaymentMethod+CardArtImageTest.swift
@@ -21,7 +21,7 @@ final class STPPaymentMethodCardArtImageTest: APIStubbedTestCase {
         super.setUp()
         urlSessionConfig = APIStubbedTestCase.stubbedURLSessionConfig()
         urlSessionConfig.urlCache = URLCache(memoryCapacity: 5_000_000, diskCapacity: 0)
-        downloadManager = DownloadManager(urlSessionConfiguration: urlSessionConfig)
+        downloadManager = DownloadManager(urlSessionConfiguration: urlSessionConfig, isTesting: true)
         downloadManager.resetCache()
     }
 


### PR DESCRIPTION
[Minion run](https://orbit.corp.stripe.com/sessions/096fcbc6-2b35-4aeb-8ab3-4accbaff97e9)

## Summary
Pass `isTesting: true` when constructing `DownloadManager` in `STPPaymentMethodCardArtImageTest.setUp()` so the manager uses the test's explicit memory-only `URLCache` instead of a disk-backed one.

## Motivation
`testCardArtImage_returnsNilWhenImageNotCached` was flaky because `DownloadManager.init` (with `isTesting: false`, the default) unconditionally replaces the provided `URLSessionConfiguration`'s `urlCache` with a disk-backed `URLCache` at a fixed `STPCache` path — discarding the memory-only cache the test configured. When `testCardArtImage_returnsImageWhenCached` ran first, it seeded image data to that shared disk cache. A subsequent run of `testCardArtImage_returnsNilWhenImageNotCached` would create a new `URLCache` pointing to the same path, and `URLCache.removeAllCachedResponses()` (called in `resetCache()`) does not guarantee synchronous disk removal, so `promoteFromDiskCache` could still find and return the stale image — causing the `XCTAssertNil` to fail.

Passing `isTesting: true` skips the disk cache setup entirely. The `DownloadManager` then uses the `URLCache(memoryCapacity: 5_000_000, diskCapacity: 0)` already set on the config, eliminating the disk I/O race.

## Testing
Existing tests in `STPPaymentMethodCardArtImageTest` cover the fix — `testCardArtImage_returnsNilWhenImageNotCached` (previously flaky) and `testCardArtImage_returnsImageWhenCached` (verifies the positive case still works with the memory cache seeded via `seedURLCache`).

No tests were newly ignored.

## Changelog
No user-facing change.
