### PR TITLE
Reshape Checkout Session status

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
@@ -11,11 +11,6 @@ import Foundation
 extension PaymentPagesAPIResponse {
     /// Builds a public, read-only ``Checkout.Session`` snapshot from this API response object.
     func makePublicSession() -> Checkout.Session {
-        let publicPaymentStatus = Checkout.PaymentStatus.paymentStatus(from: paymentStatus)
-        let publicStatus = Checkout.Status(
-            type: Checkout.StatusType.statusType(from: status),
-            paymentStatus: publicPaymentStatus
-        )
         let elementsSessionValue = elementsSession.value
         let publicDiscountAmounts = Self.makeDiscountAmounts(
             from: recurringDetails?.totalDiscountAmounts ?? [],
@@ -60,10 +55,10 @@ extension PaymentPagesAPIResponse {
             minorUnitsAmountDivisor: Self.makeMinorUnitsAmountDivisor(currency: currency),
             paymentOption: nil,
             shippingAddress: nil,
-            status: publicStatus,
+            status: status,
             tax: publicTax,
             totals: publicTotals,
-            paymentStatus: publicPaymentStatus,
+            paymentStatus: paymentStatus,
             paymentMethodOptions: paymentMethodOptions,
             customer: customer,
             savedPaymentMethodsOfferSave: Self.makeSavedPaymentMethodsOfferSave(from: savedPaymentMethodsOfferSave),
@@ -395,24 +390,27 @@ extension PaymentPagesAPIResponse {
     }
 }
 
-extension Checkout.StatusType {
-    static func statusType(from string: String) -> Checkout.StatusType {
+extension Checkout.Session.Status {
+    static func status(
+        from string: String,
+        paymentStatus: Checkout.Session.Status.PaymentStatus
+    ) -> Checkout.Session.Status? {
         switch string.lowercased() {
         case "open": return .open
-        case "complete": return .complete
+        case "complete": return .complete(paymentStatus)
         case "expired": return .expired
-        default: return .unknown
+        default: return nil
         }
     }
 }
 
-extension Checkout.PaymentStatus {
-    static func paymentStatus(from string: String) -> Checkout.PaymentStatus {
+extension Checkout.Session.Status.PaymentStatus {
+    static func paymentStatus(from string: String) -> Checkout.Session.Status.PaymentStatus? {
         switch string.lowercased() {
         case "paid": return .paid
         case "unpaid": return .unpaid
         case "no_payment_required": return .noPaymentRequired
-        default: return .unknown
+        default: return nil
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
@@ -26,8 +26,8 @@ struct PaymentPagesAPIResponse: UnknownFieldsDecodable, CustomStringConvertible 
     let currency: String
     let checkoutItems: [CheckoutItem]
     let livemode: Bool
-    let status: String
-    let paymentStatus: String
+    let status: Checkout.Session.Status
+    let paymentStatus: Checkout.Session.Status.PaymentStatus
     let customerEmail: String?
     let url: String?
     let savedPaymentMethodsOfferSave: SavedPaymentMethodsOfferSave?
@@ -144,14 +144,22 @@ struct PaymentPagesAPIResponse: UnknownFieldsDecodable, CustomStringConvertible 
         checkoutItems = decodedCheckoutItems
 
         livemode = try container.decode(Bool.self, forKey: .livemode)
-        status = try container.decode(String.self, forKey: .status)
-        guard ["open", "complete", "expired"].contains(status.lowercased()) else {
-            throw decoder.dataCorrupted("Unsupported Checkout Session status: \(status)")
+        let decodedPaymentStatus = try container.decode(String.self, forKey: .paymentStatus)
+        guard let paymentStatus = Checkout.Session.Status.PaymentStatus.paymentStatus(
+            from: decodedPaymentStatus
+        ) else {
+            throw decoder.dataCorrupted("Unsupported payment_status: \(decodedPaymentStatus)")
         }
-        paymentStatus = try container.decode(String.self, forKey: .paymentStatus)
-        guard ["paid", "unpaid", "no_payment_required"].contains(paymentStatus.lowercased()) else {
-            throw decoder.dataCorrupted("Unsupported payment_status: \(paymentStatus)")
+        self.paymentStatus = paymentStatus
+
+        let decodedStatus = try container.decode(String.self, forKey: .status)
+        guard let status = Checkout.Session.Status.status(
+            from: decodedStatus,
+            paymentStatus: paymentStatus
+        ) else {
+            throw decoder.dataCorrupted("Unsupported Checkout Session status: \(decodedStatus)")
         }
+        self.status = status
         _ = try container.decode([String].self, forKey: .paymentMethodTypes)
 
         customerEmail = try container.decodeIfPresent(String.self, forKey: .customerEmail)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -159,9 +159,9 @@ extension Checkout {
         }
     }
 
-    /// True if the session is still actionable (open or no status yet).
+    /// True if the session is still actionable.
     var sessionIsOpen: Bool {
-        session.status?.type == .open || session.status?.type == nil
+        session.status == .open
     }
 
     // MARK: - Validation

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session.swift
@@ -56,10 +56,7 @@ extension Checkout {
         public let shippingAddress: ShippingAddress?
 
         /// Status of the Checkout Session.
-        ///
-        /// `nil` if the server did not return a status. When non-nil, ``Status.paymentStatus``
-        /// is populated from the top-level payment status.
-        public let status: Checkout.Status?
+        public let status: Status
 
         /// Details about the tax computation status and aggregated tax amounts.
         public let tax: Checkout.Tax
@@ -69,7 +66,7 @@ extension Checkout {
 
         // MARK: - Internal Properties
 
-        let paymentStatus: Checkout.PaymentStatus
+        let paymentStatus: Status.PaymentStatus
         let paymentMethodOptions: STPPaymentMethodOptions?
         let customer: PaymentPagesAPIResponse.Customer?
         let savedPaymentMethodsOfferSave: STPCheckoutSessionSavedPaymentMethodsOfferSave?

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Status.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Status.swift
@@ -9,51 +9,25 @@ import Foundation
 
 @_spi(STP)
 @_spi(ReactNativeSDK)
-extension Checkout {
+extension Checkout.Session {
     /// The status of a checkout session.
-    public struct Status: Sendable, Hashable {
-        /// The type of status (open, expired, or complete).
-        public let type: StatusType
-        /// The payment status. Only meaningful when ``type`` is ``StatusType.complete``.
-        public let paymentStatus: PaymentStatus?
-
-        public init(type: StatusType, paymentStatus: PaymentStatus?) {
-            self.type = type
-            self.paymentStatus = paymentStatus
-        }
-    }
-
-    /// The lifecycle status of a checkout session.
-    public enum StatusType: Sendable, Hashable {
-        /// A status not recognized by this version of the SDK.
-        case unknown
+    public enum Status: Sendable, Hashable {
         /// The checkout session is still in progress. Payment processing has not started.
         case open
-        /// The checkout session is complete. Payment processing may still be in progress.
-        case complete
         /// The checkout session has expired. No further processing will occur.
         case expired
+        /// The checkout session is complete. Payment processing may still be in progress.
+        case complete(PaymentStatus)
+
+        /// The payment status of a completed checkout session.
+        public enum PaymentStatus: Sendable, Hashable {
+            /// The payment funds are available in your account.
+            case paid
+            /// The payment funds are not yet available in your account.
+            case unpaid
+            /// The payment is delayed to a future date, or the session is in setup mode
+            /// and doesn't require a payment at this time.
+            case noPaymentRequired
+        }
     }
-
-    /// The payment status of a checkout session.
-    public enum PaymentStatus: Sendable, Hashable {
-        /// A payment status not recognized by this version of the SDK.
-        case unknown
-        /// The payment funds are available in your account.
-        case paid
-        /// The payment funds are not yet available in your account.
-        case unpaid
-        /// The payment is delayed to a future date, or the session is in setup mode
-        /// and doesn't require a payment at this time.
-        case noPaymentRequired
-    }
-}
-
-// TODO: Change these types to match the proposed API
-extension Checkout.Session {
-    public typealias Status = Checkout.Status
-}
-
-extension Checkout.Status {
-    public typealias PaymentStatus = Checkout.PaymentStatus
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
@@ -23,8 +23,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
 
         let session = checkout.session
         XCTAssertEqual(session.id, checkoutSessionResponse.id)
-        XCTAssertEqual(session.status?.type, .open)
-        XCTAssertEqual(session.status?.paymentStatus, .unpaid)
+        XCTAssertEqual(session.status, .open)
         XCTAssertEqual(session.currency, "usd")
         XCTAssertFalse(session.livemode)
         XCTAssertEqual(session.totals.total.minorUnitsAmount, 2000)
@@ -142,7 +141,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         )
 
         // Session should be refreshed (tax_region was sent to the server)
-        XCTAssertEqual(checkout.session.status?.type, .open)
+        XCTAssertEqual(checkout.session.status, .open)
 
         // Post-tax price, CA sales tax was applied; subtotal unchanged proves the increase is purely tax
         XCTAssertEqual(checkout.session.totals.subtotal.minorUnitsAmount, 5050)
@@ -160,7 +159,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
 
         let session = checkout.session
         XCTAssertEqual(session.id, checkoutSessionResponse.id)
-        XCTAssertEqual(session.status?.type, .open)
+        XCTAssertEqual(session.status, .open)
         XCTAssertEqual(session.totals.total.minorUnitsAmount, 2000)
         XCTAssertEqual(session.expectedAmount(), 2000)
         XCTAssertEqual(session.orderSummaryItems.count, 1)
@@ -226,7 +225,7 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         XCTAssertEqual(storedShipping?.address.postalCode, "90001")
 
         // Session should be refreshed (tax_region was sent to the server)
-        XCTAssertEqual(checkout.session.status?.type, .open)
+        XCTAssertEqual(checkout.session.status, .open)
 
         XCTAssertEqual(checkout.session.totals.subtotal.minorUnitsAmount, 2000)
         XCTAssertEqual(checkout.session.totals.total.minorUnitsAmount, 2195)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -37,7 +37,7 @@ final class CheckoutUnitTests: XCTestCase {
     func testInitSetsLoadedState() async throws {
         let checkout = try await Checkout(configuration: CheckoutTestHelpers.makeConfiguration())
         XCTAssertFalse(checkout.isLoading)
-        XCTAssertEqual(checkout.session.status?.type, .open)
+        XCTAssertEqual(checkout.session.status, .open)
     }
 
     func testGetCurrencySelectorElementReturnsNilWhenAdaptivePricingIsNotAllowed() async throws {
@@ -565,8 +565,7 @@ final class CheckoutUnitTests: XCTestCase {
         try await checkout.commitSession(confirmResponse)
 
         // Then Checkout updates the session and notifies observers
-        XCTAssertEqual(checkout.session.status?.type, .complete)
-        XCTAssertEqual(checkout.session.status?.paymentStatus, .paid)
+        XCTAssertEqual(checkout.session.status, .complete(.paid))
         // There are two emissions: one for the committed session, one for PaymentElement re-syncing the payment option.
         XCTAssertEqual(recorder.sessions.count, 2)
     }
@@ -637,14 +636,14 @@ final class CheckoutUnitTests: XCTestCase {
         let firstConfirm = try PaymentPagesAPIResponse.decode(fromAPIResponse: firstResponse)
 
         try await checkout.commitSession(firstConfirm)
-        XCTAssertEqual(checkout.session.status?.type, .complete)
+        XCTAssertEqual(checkout.session.status, .complete(.paid))
 
         var secondResponse = CheckoutTestHelpers.openSessionJSON
         secondResponse["status"] = "open"
         let secondSession = try PaymentPagesAPIResponse.decode(fromAPIResponse: secondResponse)
 
         try await checkout.commitSession(secondSession)
-        XCTAssertEqual(checkout.session.status?.type, .open)
+        XCTAssertEqual(checkout.session.status, .open)
         XCTAssertEqual(recorder.sessions.count, 4)
     }
 
@@ -652,7 +651,7 @@ final class CheckoutUnitTests: XCTestCase {
 
     func testSessionAvailableAfterInit() async throws {
         let checkout = try await Checkout(configuration: CheckoutTestHelpers.makeConfiguration())
-        XCTAssertEqual(checkout.session.status?.type, .open)
+        XCTAssertEqual(checkout.session.status, .open)
     }
 
     func testIsLoadingFalseAfterInit() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
@@ -57,6 +57,40 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         )
     }
 
+    func testDecodedObjectFromAPIResponseMapsSessionStatus() throws {
+        let testCases: [(status: String, paymentStatus: String, expected: Checkout.Session.Status)] = [
+            ("open", "unpaid", .open),
+            ("expired", "unpaid", .expired),
+            ("complete", "paid", .complete(.paid)),
+            ("complete", "unpaid", .complete(.unpaid)),
+            ("complete", "no_payment_required", .complete(.noPaymentRequired)),
+        ]
+
+        for testCase in testCases {
+            var json = STPTestUtils.jsonNamed("CheckoutSession")!
+            json["status"] = testCase.status
+            json["payment_status"] = testCase.paymentStatus
+
+            let response = try PaymentPagesAPIResponse.decode(fromAPIResponse: json)
+
+            XCTAssertEqual(response.makePublicSession().status, testCase.expected)
+        }
+    }
+
+    func testDecodedObjectFromAPIResponseRejectsUnknownSessionStatus() {
+        var json = STPTestUtils.jsonNamed("CheckoutSession")!
+        json["status"] = "future_status"
+
+        XCTAssertThrowsError(try PaymentPagesAPIResponse.decode(fromAPIResponse: json))
+    }
+
+    func testDecodedObjectFromAPIResponseRejectsUnknownPaymentStatus() {
+        var json = STPTestUtils.jsonNamed("CheckoutSession")!
+        json["payment_status"] = "future_status"
+
+        XCTAssertThrowsError(try PaymentPagesAPIResponse.decode(fromAPIResponse: json))
+    }
+
     func testDecodedObjectFromAPIResponseMalformedElementsSession() {
         var json = STPTestUtils.jsonNamed("CheckoutSession")!
         // Invalid elements_session - missing payment_method_preference
@@ -127,8 +161,8 @@ class PaymentPagesAPIResponseTest: XCTestCase {
 
         // The response object retains API-shaped values without public-model conversion.
         XCTAssertEqual(apiResponse.sessionId, "cs_test_a1b2c3d4e5f6g7h8i9j0")
-        XCTAssertEqual(apiResponse.status, "open")
-        XCTAssertEqual(apiResponse.paymentStatus, "unpaid")
+        XCTAssertEqual(apiResponse.status, .open)
+        XCTAssertEqual(apiResponse.paymentStatus, .unpaid)
         XCTAssertEqual(apiResponse.checkoutItems.first?.key, "ci_1abc")
         XCTAssertEqual(apiResponse.adaptivePricingInfo?.activePresentmentCurrency, "eur")
         XCTAssertEqual(apiResponse.adaptivePricingInfo?.integrationAmount, 12000)
@@ -145,8 +179,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         XCTAssertEqual(session.currency, "usd")
         XCTAssertEqual(session.minorUnitsAmountDivisor, 100)
         XCTAssertEqual(session.paymentStatus, .unpaid)
-        XCTAssertEqual(session.status?.type, .open)  // status is nullable but present in JSON
-        XCTAssertEqual(session.status?.paymentStatus, .unpaid)
+        XCTAssertEqual(session.status, .open)
         XCTAssertEqual(apiResponse.paymentIntentId, "pi_test123456789")
         XCTAssertNil(apiResponse.setupIntentId)
         XCTAssertFalse(session.livemode)
@@ -235,7 +268,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         let session = apiResponse.makePublicSession()
 
         XCTAssertEqual(session.id, "cs_test_minimal")
-        XCTAssertEqual(session.status?.type, .open)
+        XCTAssertEqual(session.status, .open)
         XCTAssertTrue(session.livemode)
 
         XCTAssertEqual(session.totals.subtotal.minorUnitsAmount, 1000)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/EmbeddedPaymentElementTest.swift
@@ -989,7 +989,7 @@ class EmbeddedPaymentElementTest: XCTestCase {
         // Should no-op
         let result = await sut.update(checkout: checkout)
         XCTAssertEqual(result, .succeeded)
-        XCTAssertEqual(checkout.session.status?.type, .complete)
+        XCTAssertEqual(checkout.session.status, .complete(.paid))
     }
 
     func testUpdateCheckoutSessionNoOpsForExpiredSession() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -839,8 +839,7 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
                     return
                 }
                 XCTAssertEqual(loadedSession.id, checkoutSessionId)
-                XCTAssertEqual(loadedSession.status?.type, .open)
-                XCTAssertEqual(loadedSession.status?.paymentStatus, .noPaymentRequired)
+                XCTAssertEqual(loadedSession.status, .open)
                 XCTAssertTrue(loadResult.elementsSession.sessionID.hasPrefix("elements_session_"))
                 XCTAssertTrue(loadResult.elementsSession.orderedPaymentMethodTypes.contains(.card))
             case .failure(let error):

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+CheckoutSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+CheckoutSessionTest.swift
@@ -25,8 +25,7 @@ final class STPAPIClientCheckoutSessionTest: STPNetworkStubbingTestCase {
 
         // Verify checkout session fields
         XCTAssertEqual(checkoutSession.id, checkoutSessionId)
-        XCTAssertEqual(checkoutSession.status?.type, .open)
-        XCTAssertEqual(checkoutSession.status?.paymentStatus, .unpaid)
+        XCTAssertEqual(checkoutSession.status, .open)
         XCTAssertEqual(checkoutSession.currency, "usd")
         XCTAssertFalse(checkoutSession.livemode)
         XCTAssertTrue((apiResponse.allResponseFields["payment_method_types"] as? [String])?.contains("card") ?? false)
@@ -70,8 +69,7 @@ final class STPAPIClientCheckoutSessionTest: STPNetworkStubbingTestCase {
         )
 
         // 5. Verify response
-        XCTAssertEqual(response.makePublicSession().status?.type, .complete)
-        XCTAssertEqual(response.makePublicSession().status?.paymentStatus, .paid)
+        XCTAssertEqual(response.makePublicSession().status, .complete(.paid))
         XCTAssertNotNil(response.paymentIntent)
     }
 
@@ -93,7 +91,7 @@ final class STPAPIClientCheckoutSessionTest: STPNetworkStubbingTestCase {
 
         // Verify standard checkout session fields
         XCTAssertEqual(checkoutSession.id, checkoutSessionId)
-        XCTAssertEqual(checkoutSession.status?.type, .open)
+        XCTAssertEqual(checkoutSession.status, .open)
         XCTAssertFalse(checkoutSession.livemode)
 
         // Verify adaptive pricing is active and currency is localized to EUR
@@ -117,7 +115,7 @@ final class STPAPIClientCheckoutSessionTest: STPNetworkStubbingTestCase {
 
         // Verify standard checkout session fields
         XCTAssertEqual(checkoutSession.id, checkoutSessionId)
-        XCTAssertEqual(checkoutSession.status?.type, .open)
+        XCTAssertEqual(checkoutSession.status, .open)
         XCTAssertFalse(checkoutSession.livemode)
 
         // Adaptive pricing should NOT be active; currency stays as integration currency (USD)
@@ -174,7 +172,7 @@ final class STPAPIClientCheckoutSessionTest: STPNetworkStubbingTestCase {
 
         // 5. Verify the session was returned successfully (proves the API accepted our request)
         XCTAssertEqual(updatedSession.id, checkoutSessionResponse.id)
-        XCTAssertEqual(updatedSession.status?.type, .open)
+        XCTAssertEqual(updatedSession.status, .open)
     }
 
     // TODO(porter): see disabled_testUpdatePaymentMethodExpiry above.
@@ -232,7 +230,7 @@ final class STPAPIClientCheckoutSessionTest: STPNetworkStubbingTestCase {
 
         // 5. Verify the session was returned successfully (proves the API accepted our request)
         XCTAssertEqual(updatedSession.id, checkoutSessionResponse.id)
-        XCTAssertEqual(updatedSession.status?.type, .open)
+        XCTAssertEqual(updatedSession.status, .open)
     }
 
     // MARK: - Setup Mode
@@ -253,8 +251,7 @@ final class STPAPIClientCheckoutSessionTest: STPNetworkStubbingTestCase {
 
         // Verify checkout session fields
         XCTAssertEqual(checkoutSession.id, checkoutSessionId)
-        XCTAssertEqual(checkoutSession.status?.type, .open)
-        XCTAssertEqual(checkoutSession.status?.paymentStatus, .noPaymentRequired)
+        XCTAssertEqual(checkoutSession.status, .open)
         XCTAssertEqual(checkoutSession.currency, "usd")
         XCTAssertFalse(checkoutSession.livemode)
         XCTAssertTrue((apiResponse.allResponseFields["payment_method_types"] as? [String])?.contains("card") ?? false)
@@ -296,8 +293,7 @@ final class STPAPIClientCheckoutSessionTest: STPNetworkStubbingTestCase {
         )
 
         // 5. Verify response
-        XCTAssertEqual(response.makePublicSession().status?.type, .complete)
-        XCTAssertEqual(response.makePublicSession().status?.paymentStatus, .noPaymentRequired)
+        XCTAssertEqual(response.makePublicSession().status, .complete(.noPaymentRequired))
         XCTAssertNotNil(response.setupIntent)
     }
 }


### PR DESCRIPTION
## Summary

Reshape Checkout Session status to match the approved private-preview API.

```text
BEFORE

Session.status: Checkout.Status?

Checkout.Status
+-- type: Checkout.StatusType
|   +-- open
|   +-- complete
|   +-- expired
|   `-- unknown
|
`-- paymentStatus: Checkout.PaymentStatus?
    +-- paid
    +-- unpaid
    +-- noPaymentRequired
    `-- unknown

                     |
                     | reshape + make non-optional
                     v

AFTER

Session.status: Session.Status

Session.Status
+-- open
+-- expired
`-- complete(Session.Status.PaymentStatus)
    +-- paid
    +-- unpaid
    `-- noPaymentRequired
```

Wire values map as follows:

```text
status=open                              -> .open
status=expired                           -> .expired
status=complete + payment_status=paid    -> .complete(.paid)
missing or unknown lifecycle/payment     -> response decoding failure
```

## Motivation

Match the Checkout Elements private-preview API review. The reviewed API deliberately has no unknown enum cases because new server enum values are treated as breaking changes.

## Testing

- After rebasing over corrected canonical Checkout fixtures, passed all 50 `PaymentPagesAPIResponseTest` tests.
- Passed `EmbeddedPaymentElementTest/testUpdateCheckoutSessionNoOpsForCompleteSession`.
- Passed `EmbeddedPaymentElementTest/testUpdateCheckoutSessionNoOpsForExpiredSession`.
- An affected-class batch ran 153 tests: 124 passed; 29 `EmbeddedPaymentElementTest` cases failed because their network stubs interfered in the combined run and attempted live requests. The two status-relevant cases above pass in isolation. Failure details were inspected; no screenshot attachments were produced.

## Changelog

None. Private-preview API reshaping.