### PR TITLE
Add Celo network support

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoNetwork.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoNetwork.swift
@@ -24,4 +24,5 @@ public enum CryptoNetwork: String, Codable, CaseIterable {
     case sui = "sui"
     case arbitrum = "arbitrum"
     case tempo = "tempo"
+    case celo = "celo"
 }


### PR DESCRIPTION
## Summary
- Adds `celo` case to the `CryptoNetwork` enum for wallet address registration support.

## Test plan
- [x] Build verified (`xcodebuild build` passes)
- [ ] Existing tests continue to pass (enum uses `CaseIterable`, no exhaustive switches to update)