### PR TITLE
CryptoOnramp SDK: Addresses Flaky Typing in UI Integration Tests

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITestHelpers.swift
+++ b/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITestHelpers.swift
@@ -23,7 +23,7 @@ extension CryptoOnrampExampleUITests {
     ) {
         let email = "crypto-onramp-ui-tests-\(UUID().uuidString.lowercased())@stripe.com"
         waitForLoadingToFinish(file: file, line: line)
-        enterText(email, in: app.textFields["Enter email address"].firstMatch, file: file, line: line)
+        enterText(email, inTextField: "Enter email address", file: file, line: line)
         enterText("testing1234", in: app.secureTextFields["Enter password"].firstMatch, file: file, line: line)
         app.buttons["Sign Up"].firstMatch.tap()
 
@@ -36,23 +36,12 @@ extension CryptoOnrampExampleUITests {
         )
         waitForLoadingToFinish(file: file, line: line)
         dismissSavePasswordPromptIfPresent()
-        enterText(fullName, in: app.textFields["Enter your full name"].firstMatch, file: file, line: line)
-        enterText(phoneNumber, in: app.textFields["Enter phone number (e.g., +12125551234)"].firstMatch, file: file, line: line)
+        enterText(fullName, inTextField: "Enter your full name", file: file, line: line)
+        enterText(phoneNumber, inTextField: "Enter phone number (e.g., +12125551234)", file: file, line: line)
 
         if countryCode != "US" {
-            let countryField = app.textFields["Country code"].firstMatch
-            XCTAssertTrue(
-                countryField.waitForExistence(timeout: .animationTimeout),
-                "Registration country field should exist",
-                file: file,
-                line: line
-            )
-            countryField.tap()
-
-            // Remove the default "US" value before entering the test country's code.
-            countryField.typeText(
-                String(repeating: XCUIKeyboardKey.delete.rawValue, count: 2) + countryCode
-            )
+            // Replace the default "US" value with the test country's code.
+            enterText(countryCode, inTextField: "Country code", replacingExistingText: true, file: file, line: line)
         }
         dismissKeyboard()
 
@@ -125,27 +114,18 @@ extension CryptoOnrampExampleUITests {
         )
         waitForLoadingToFinish(file: file, line: line)
 
-        let firstNameField = app.textFields["Enter your first name"].firstMatch
-        XCTAssertTrue(
-            firstNameField.waitForExistence(timeout: .animationTimeout),
-            "First name field should exist",
-            file: file,
-            line: line
-        )
-        firstNameField.tap()
-        app.typeText("Crypto" + XCUIKeyboardKey.return.rawValue)
-        app.typeText("Tester" + XCUIKeyboardKey.return.rawValue)
-        app.typeText("000000000")
+        enterText("Crypto", inTextField: "Enter your first name", advancingToNextField: true, file: file, line: line)
+        enterText("Tester", inTextField: "Enter your last name", advancingToNextField: true, file: file, line: line)
+        enterText("000000000", inTextField: "Enter your SSN", file: file, line: line)
 
         setDateOfBirth(file: file, line: line)
 
-        let addressLine1Field = app.textFields["Enter your street address"].firstMatch
         app.typeText(XCUIKeyboardKey.return.rawValue)
-        addressLine1Field.typeText(addressLine1 + XCUIKeyboardKey.return.rawValue)
-        app.typeText(addressLine2 + XCUIKeyboardKey.return.rawValue)
-        app.typeText(city + XCUIKeyboardKey.return.rawValue)
-        app.typeText(state + XCUIKeyboardKey.return.rawValue)
-        app.typeText(postalCode + XCUIKeyboardKey.return.rawValue)
+        enterText(addressLine1, inTextField: "Enter your street address", advancingToNextField: true, file: file, line: line)
+        enterText(addressLine2, inTextField: "Apartment, suite, etc.", advancingToNextField: true, file: file, line: line)
+        enterText(city, inTextField: "Enter your city", advancingToNextField: true, file: file, line: line)
+        enterText(state, inTextField: "Enter your state or province", advancingToNextField: true, file: file, line: line)
+        enterText(postalCode, inTextField: "Enter your postal code", advancingToNextField: true, file: file, line: line)
         app.typeText(XCUIKeyboardKey.return.rawValue)
 
         let submitButton = app.buttons["Submit"].firstMatch
@@ -176,7 +156,7 @@ extension CryptoOnrampExampleUITests {
         )
         addWalletButton.tap()
 
-        enterText(address, in: app.textFields["Enter wallet address"].firstMatch, file: file, line: line)
+        enterText(address, inTextField: "Enter wallet address", file: file, line: line)
         let submitButton = app.buttons["Submit"].firstMatch
         XCTAssertTrue(submitButton.isEnabled, "Wallet Submit button should be enabled", file: file, line: line)
         submitButton.tap()
@@ -191,13 +171,81 @@ extension CryptoOnrampExampleUITests {
 
     func enterText(
         _ text: String,
+        inTextField identifier: String,
+        replacingExistingText: Bool = false,
+        advancingToNextField: Bool = false,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        enterText(text, in: app.textFields[identifier].firstMatch, replacingExistingText: replacingExistingText, advancingToNextField: advancingToNextField, file: file, line: line)
+    }
+
+    func enterText(
+        _ text: String,
         in element: XCUIElement,
+        replacingExistingText: Bool = false,
+        advancingToNextField: Bool = false,
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
         XCTAssertTrue(element.waitForExistence(timeout: .animationTimeout), "Text field should exist", file: file, line: line)
         element.tap()
-        element.typeText(text)
+
+        let shouldVerifyValue = element.elementType == .textField
+        let maximumAttempts = shouldVerifyValue ? 2 : 1
+        var valueMatches = !shouldVerifyValue
+
+        for attempt in 0..<maximumAttempts {
+            if replacingExistingText || attempt > 0 {
+                clearText(in: element)
+            }
+
+            element.typeText(text)
+            valueMatches = !shouldVerifyValue || textFieldValueMatches(element, expectedText: text)
+            if valueMatches {
+                break
+            }
+        }
+
+        if shouldVerifyValue {
+            let actualValue = element.value as? String ?? "nil"
+            XCTAssertTrue(valueMatches, "Text field value should match \(text); found \(actualValue)", file: file, line: line)
+
+            guard valueMatches else {
+                return
+            }
+        }
+
+        if advancingToNextField {
+            element.typeText(XCUIKeyboardKey.return.rawValue)
+        }
+    }
+
+    private func clearText(in element: XCUIElement) {
+        for _ in 0..<2 {
+            guard
+                let value = element.value as? String,
+                !value.isEmpty,
+                value != element.placeholderValue
+            else {
+                return
+            }
+
+            let deleteText = String(repeating: XCUIKeyboardKey.delete.rawValue, count: value.count)
+            element.typeText(deleteText)
+        }
+    }
+
+    private func textFieldValueMatches(_ element: XCUIElement, expectedText: String) -> Bool {
+        guard let actualText = element.value as? String else {
+            return false
+        }
+
+        return normalizedText(actualText) == normalizedText(expectedText)
+    }
+
+    private func normalizedText(_ text: String) -> String {
+        text.components(separatedBy: CharacterSet.alphanumerics.inverted).joined()
     }
 
     func waitForLoadingToFinish(

--- a/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITestHelpers.swift
+++ b/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITestHelpers.swift
@@ -191,6 +191,7 @@ extension CryptoOnrampExampleUITests {
         XCTAssertTrue(element.waitForExistence(timeout: .animationTimeout), "Text field should exist", file: file, line: line)
         element.tap()
 
+        // Password and OTP elements also use this helper, but their accessibility values aren't suitable for plaintext comparison.
         let shouldVerifyValue = element.elementType == .textField
         let maximumAttempts = shouldVerifyValue ? 2 : 1
         var valueMatches = !shouldVerifyValue

--- a/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITests.swift
+++ b/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITests.swift
@@ -58,8 +58,7 @@ final class CryptoOnrampExampleUITests: XCTestCase {
         // Step 1: Enter email and password
         waitForLoadingToFinish()
 
-        let emailField = app.textFields["Enter email address"].firstMatch
-        enterText("onramptest2@stripe.com", in: emailField)
+        enterText("onramptest2@stripe.com", inTextField: "Enter email address")
 
         let passwordField = app.secureTextFields["Enter password"].firstMatch
         enterText("testing1234", in: passwordField)
@@ -193,8 +192,8 @@ final class CryptoOnrampExampleUITests: XCTestCase {
 
         let cardNumberField = app.textFields["Card number"].firstMatch
         enterText("4242424242424242", in: cardNumberField)
-        enterText("1249", in: app.textFields["expiration date"].firstMatch)
-        enterText("123", in: app.textFields["CVC"].firstMatch)
+        enterText("1249", inTextField: "expiration date")
+        enterText("123", inTextField: "CVC")
 
         let zipField = app.textFields["ZIP"].firstMatch
         if zipField.exists {
@@ -293,12 +292,11 @@ final class CryptoOnrampExampleUITests: XCTestCase {
         let updateAddressNavigationBar = app.navigationBars["Update Address"].firstMatch
         XCTAssertTrue(updateAddressNavigationBar.waitForExistence(timeout: .animationTimeout), "Update Address screen should appear")
 
-        let addressLine1Field = app.textFields["Enter your street address"].firstMatch
-        enterText(refreshedAddressLine1 + XCUIKeyboardKey.return.rawValue, in: addressLine1Field)
-        app.typeText(refreshedAddressLine2 + XCUIKeyboardKey.return.rawValue)
-        app.typeText(refreshedCity + XCUIKeyboardKey.return.rawValue)
-        app.typeText(refreshedState + XCUIKeyboardKey.return.rawValue)
-        app.typeText(refreshedPostalCode)
+        enterText(refreshedAddressLine1, inTextField: "Enter your street address", advancingToNextField: true)
+        enterText(refreshedAddressLine2, inTextField: "Apartment, suite, etc.", advancingToNextField: true)
+        enterText(refreshedCity, inTextField: "Enter your city", advancingToNextField: true)
+        enterText(refreshedState, inTextField: "Enter your state or province", advancingToNextField: true)
+        enterText(refreshedPostalCode, inTextField: "Enter your postal code")
         dismissKeyboard()
 
         let submitAddressButton = app.buttons["Submit"].firstMatch
@@ -412,25 +410,20 @@ final class CryptoOnrampExampleUITests: XCTestCase {
         XCTAssertTrue(euResidenceButton.waitForExistence(timeout: .animationTimeout), "EU residence option should exist")
         euResidenceButton.tap()
 
-        let firstNameField = app.textFields["Enter your first name"].firstMatch
-        XCTAssertTrue(firstNameField.waitForExistence(timeout: .animationTimeout), "First name field should exist")
-        firstNameField.tap()
-        app.typeText("Crypto" + XCUIKeyboardKey.return.rawValue)
-        app.typeText("Tester" + XCUIKeyboardKey.return.rawValue)
+        enterText("Crypto", inTextField: "Enter your first name", advancingToNextField: true)
+        enterText("Tester", inTextField: "Enter your last name", advancingToNextField: true)
 
         setDateOfBirth()
 
-        let birthCountryField = app.textFields["Country code"].firstMatch
-        XCTAssertTrue(birthCountryField.waitForExistence(timeout: .animationTimeout), "Birth country field should exist")
-        birthCountryField.typeText(country + XCUIKeyboardKey.return.rawValue)
-        app.typeText(city + XCUIKeyboardKey.return.rawValue)
-        app.typeText("GR, MT" + XCUIKeyboardKey.return.rawValue)
-        app.typeText(addressLine1 + XCUIKeyboardKey.return.rawValue)
-        app.typeText(addressLine2 + XCUIKeyboardKey.return.rawValue)
-        app.typeText(city + XCUIKeyboardKey.return.rawValue)
-        app.typeText(state + XCUIKeyboardKey.return.rawValue)
-        app.typeText(postalCode + XCUIKeyboardKey.return.rawValue)
-        app.typeText(country + XCUIKeyboardKey.return.rawValue)
+        enterText(country, in: app.textFields.matching(identifier: "Country code").element(boundBy: 0), advancingToNextField: true)
+        enterText(city, inTextField: "Enter your city of birth", advancingToNextField: true)
+        enterText("GR, MT", inTextField: "Country codes separated by commas", advancingToNextField: true)
+        enterText(addressLine1, inTextField: "Enter your street address", advancingToNextField: true)
+        enterText(addressLine2, inTextField: "Apartment, suite, etc.", advancingToNextField: true)
+        enterText(city, inTextField: "Enter your city", advancingToNextField: true)
+        enterText(state, inTextField: "Enter your state or province", advancingToNextField: true)
+        enterText(postalCode, inTextField: "Enter your postal code", advancingToNextField: true)
+        enterText(country, in: app.textFields.matching(identifier: "Country code").element(boundBy: 1))
 
         let submitKYCButton = app.buttons["Submit"].firstMatch
         XCTAssertTrue(submitKYCButton.isEnabled, "KYC Submit button should be enabled")


### PR DESCRIPTION
## Summary
In recent sporadic CI failures for the CryptoOnramp UI tests, the artifacts show that occasionally characters are being missed while typing. It's not reliably the first character, so it's unlikely to be due to e.g. not waiting for the keyboard to appear.

Most of text field modification is already running through an `enterText` helper, so these changes use it more consistently, and now that helper checks the field after typing, and retries once if the output does not match the input. 

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->
Sporadic test failures. For example, in this test, the wallet address should have the prefix `DBhBRyb9…` but the `h` is missing.
<img width="1619" height="944" alt="CleanShot 2026-08-10 at 11 38 35" src="https://github.com/user-attachments/assets/2867ccbf-aa86-4393-a618-d3ca1be9b647" />

And in this test, the street address should have "456 Fake St." not "456 ake St."

<img width="300" alt="CleanShot 2026-08-10 at 11 46 41" src="https://github.com/user-attachments/assets/761d7ee6-211a-4f8f-aa33-4658c4fa0f06" />


## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
Ran the updated tests, and ensured they pass locally and on CI.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
