### PR TITLE
Use natural alignment for RTL legal text

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Elements/InlineSignup/LinkInlineSignupView.swift
@@ -104,7 +104,7 @@ final class LinkInlineSignupView: UIView {
         guard viewModel.mode != .signupOptIn else {
             return nil
         }
-        let legalView = LinkLegalTermsView(textAlignment: .left,
+        let legalView = LinkLegalTermsView(textAlignment: .natural,
                                            mode: viewModel.mode,
                                            brand: viewModel.brand,
                                            delegate: self)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/USBankAccount/InstantDebitsPaymentMethodElement.swift
@@ -391,7 +391,7 @@ private extension PaymentMethodIncentive {
         let formattedString = STPStringUtils.applyLinksToString(template: string, links: links)
 
         let style = NSMutableParagraphStyle()
-        style.alignment = .left
+        style.alignment = .natural
         formattedString.addAttributes(
             [
                 .paragraphStyle: style,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AUBECSMandate.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Views/AUBECSMandate.swift
@@ -36,7 +36,7 @@ final class AUBECSLegalTermsView: UIView {
         return textView
     }()
 
-    init(configuration: PaymentSheetFormFactoryConfig, textAlignment: NSTextAlignment = .left) {
+    init(configuration: PaymentSheetFormFactoryConfig, textAlignment: NSTextAlignment = .natural) {
         self.configuration = configuration
         super.init(frame: .zero)
         self.textView.textAlignment = textAlignment


### PR DESCRIPTION
## Summary
Legal and disclosure text now uses natural alignment instead of always aligning left. This lets Link inline signup, Instant Debits incentives, and AU BECS mandates follow the interface writing direction in RTL locales.

## Motivation
RTL support

## Testing
- Existing tests

## Changelog
N/A