### PR TITLE
Clarify adaptive pricing country in Checkout playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundComponents.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundComponents.swift
@@ -96,6 +96,70 @@ extension CheckoutPlayground {
         }
     }
 
+    struct AdaptivePricingLocationRow: View {
+        @Binding var selection: AdaptivePricingCountry
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top, spacing: 12) {
+                    Image(systemName: "globe.americas.fill")
+                        .font(.system(size: 18))
+                        .frame(width: 24)
+                        .foregroundColor(.blue)
+
+                    VStack(alignment: .leading, spacing: 3) {
+                        HStack(spacing: 6) {
+                            Text("Adaptive Pricing Location")
+                                .font(.body)
+
+                            InfoButton(
+                                title: "Adaptive Pricing Location",
+                                message: "The playground mocks this location by sending a specially formatted customer email when it creates the Checkout Session. Choose No Override to omit the mock location."
+                            )
+                        }
+
+                        Text("Mocks the customer country Adaptive Pricing uses to localize prices.")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                Menu {
+                    ForEach(AdaptivePricingCountry.allCases) { country in
+                        Button {
+                            selection = country
+                        } label: {
+                            if selection == country {
+                                Label(country.displayName, systemImage: "checkmark")
+                            } else {
+                                Text(country.displayName)
+                            }
+                        }
+                    }
+                } label: {
+                    HStack {
+                        Text(selection.displayName)
+                            .foregroundColor(.primary)
+                        Spacer()
+                        Image(systemName: "chevron.up.chevron.down")
+                            .font(.caption.weight(.semibold))
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.horizontal, 12)
+                    .frame(height: 38)
+                    .background(Color(uiColor: .tertiarySystemFill))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .buttonStyle(.plain)
+                .padding(.leading, 36)
+            }
+            .padding(.vertical, 12)
+            .padding(.horizontal, 16)
+            .background(Color(uiColor: .secondarySystemGroupedBackground))
+        }
+    }
+
     struct InfoButton: View {
         let title: String
         let message: String

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
@@ -168,7 +168,6 @@ struct CheckoutPlaygroundFeaturesSection: View {
     @Binding var automaticTax: Bool
     @Binding var checkoutSessionPaymentMethodSave: Bool
     @Binding var checkoutSessionPaymentMethodRemove: Bool
-    @Binding var adaptivePricingCountry: CheckoutPlayground.AdaptivePricingCountry
     @Binding var automaticPaymentMethods: Bool
 
     private var shouldShowAutomaticTax: Bool {
@@ -211,13 +210,6 @@ struct CheckoutPlaygroundFeaturesSection: View {
                     title: "Payment Method Remove",
                     isOn: $checkoutSessionPaymentMethodRemove,
                     tooltip: "Sets `saved_payment_method_options.payment_method_remove` to `enabled`. When on, Checkout can allow customers to remove saved payment methods."
-                )
-                CheckoutPlayground.PickerRow(
-                    title: "Country",
-                    icon: "globe",
-                    selection: $adaptivePricingCountry,
-                    tooltip: "Simulates the customer's country for adaptive pricing by sending a location-formatted customer_email. 'None' skips the email override.",
-                    displayText: { $0.displayName }
                 )
             }
             .background(Color(uiColor: .secondarySystemGroupedBackground))

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundTypes.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundTypes.swift
@@ -111,13 +111,13 @@ enum CheckoutPlayground {
 
         var displayName: String {
             switch self {
-            case .none: return "None"
-            case .us: return "US"
-            case .fr: return "FR"
-            case .de: return "DE"
-            case .jp: return "JP"
-            case .gb: return "GB"
-            case .br: return "BR"
+            case .none: return "No Override"
+            case .us: return "United States (US)"
+            case .fr: return "France (FR)"
+            case .de: return "Germany (DE)"
+            case .jp: return "Japan (JP)"
+            case .gb: return "United Kingdom (GB)"
+            case .br: return "Brazil (BR)"
             }
         }
     }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
@@ -47,7 +47,6 @@ struct CheckoutPlaygroundView: View {
                             automaticTax: $viewModel.automaticTax,
                             checkoutSessionPaymentMethodSave: $viewModel.checkoutSessionPaymentMethodSave,
                             checkoutSessionPaymentMethodRemove: $viewModel.checkoutSessionPaymentMethodRemove,
-                            adaptivePricingCountry: $viewModel.adaptivePricingCountry,
                             automaticPaymentMethods: $viewModel.automaticPaymentMethods
                         )
 
@@ -117,28 +116,35 @@ struct CheckoutPlaygroundView: View {
     private var currencySelectorAppearanceSection: some View {
         VStack(alignment: .leading, spacing: 12) {
             CheckoutPlayground.SectionHeader(title: "Currency Selector", icon: "paintbrush.fill")
-            Button {
-                showCurrencySelectorAppearance = true
-            } label: {
-                HStack {
-                    Image(systemName: "slider.horizontal.3")
-                        .font(.system(size: 16))
-                        .frame(width: 24)
-                        .foregroundColor(.blue)
-                    Text("Customize Appearance")
-                        .font(.subheadline)
-                        .foregroundColor(.primary)
-                    Spacer()
-                    Image(systemName: "chevron.right")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
+            VStack(spacing: 1) {
+                CheckoutPlayground.AdaptivePricingLocationRow(
+                    selection: $viewModel.adaptivePricingCountry
+                )
+
+                Button {
+                    showCurrencySelectorAppearance = true
+                } label: {
+                    HStack {
+                        Image(systemName: "slider.horizontal.3")
+                            .font(.system(size: 16))
+                            .frame(width: 24)
+                            .foregroundColor(.blue)
+                        Text("Customize Appearance")
+                            .font(.subheadline)
+                            .foregroundColor(.primary)
+                        Spacer()
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 16)
+                    .background(Color(uiColor: .secondarySystemGroupedBackground))
                 }
-                .padding(.vertical, 12)
-                .padding(.horizontal, 16)
-                .background(Color(uiColor: .secondarySystemGroupedBackground))
-                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .buttonStyle(PlainButtonStyle())
             }
-            .buttonStyle(PlainButtonStyle())
+            .background(Color(uiColor: .secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
         }
     }
 }


### PR DESCRIPTION
## Summary

Makes the Checkout Elements playground clear that the country option mocks the customer location Adaptive Pricing uses to localize prices. Moves the control under Currency Selector, adds visible explanatory copy, and uses full country names with a clearer No Override state.

### Screenshots

<table>
  <tr>
    <th>Default</th>
    <th>Country menu</th>
  </tr>
  <tr>
    <td><img width="375" alt="Adaptive Pricing location control under Currency Selector" src="https://github.com/user-attachments/assets/0a7ac0c5-0c9a-4d65-b017-2178ff0994f7" /></td>
    <td><img width="375" alt="Adaptive Pricing country menu" src="https://github.com/user-attachments/assets/23d8e5b1-82f9-4631-a650-bed7c8d7dc8c" /></td>
  </tr>
</table>

## Motivation

Checkout Elements playground cleanup

## Testing

- PaymentSheet Example build
- Formatting and lint

## Changelog

N/A
