### PR TITLE
Add Checkout session diagnostics to playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -12,9 +12,11 @@ import SwiftUI
 struct CheckoutCartView: View {
     @Environment(\.dismiss) private var dismiss
     @State private var checkout: Checkout?
+    @StateObject private var diagnostics = CheckoutSessionDiagnostics()
 
     @State private var isLoading = false
     @State private var errorMessage: String?
+    @State private var showsCheckoutDetails = false
 
     let clientSecret: String
     let shippingAddressCollection: Bool
@@ -90,6 +92,24 @@ struct CheckoutCartView: View {
                             .foregroundColor(.primary)
                     }
                 }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button {
+                        showsCheckoutDetails = true
+                    } label: {
+                        Image(systemName: "ladybug")
+                    }
+                    .disabled(checkout == nil)
+                    .opacity(checkout == nil ? 0 : 1)
+                    .accessibilityLabel("Session diagnostics")
+                }
+            }
+            .sheet(isPresented: $showsCheckoutDetails) {
+                if let checkout {
+                    CheckoutSessionDetailsView(
+                        diagnostics: diagnostics,
+                        sessionID: checkout.session.id
+                    )
+                }
             }
             .task {
                 await loadCheckout()
@@ -102,6 +122,7 @@ struct CheckoutCartView: View {
         errorMessage = nil
         do {
             var config = Checkout.Configuration(clientSecret: clientSecret, returnURL: "payments-example://stripe-redirect")
+            config.apiClient = diagnostics.makeAPIClient()
             config.adaptivePricing.allowed = adaptivePricing
             config.applePayConfiguration = Checkout.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example"

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
@@ -48,6 +48,7 @@ final class CheckoutCartViewController: UIViewController {
     private let showExpressCheckoutElement: Bool
     private let currencySelectorAppearance: CurrencySelectorElement.Appearance
     private let closeAction: () -> Void
+    private let diagnostics = CheckoutSessionDiagnostics()
 
     private var checkout: Checkout?
     private var cancellables = Set<AnyCancellable>()
@@ -200,15 +201,24 @@ final class CheckoutCartViewController: UIViewController {
                 merchantId: "merchant.com.stripe.paymentsheet.example"
             )
             configuration.currencySelectorElement.appearance = currencySelectorAppearance
+            configuration.apiClient = diagnostics.makeAPIClient()
 
             let checkout = try await Checkout(configuration: configuration)
             self.checkout = checkout
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                image: UIImage(systemName: "ladybug"),
+                style: .plain,
+                target: self,
+                action: #selector(checkoutDetailsButtonTapped)
+            )
+            navigationItem.rightBarButtonItem?.accessibilityLabel = "Session diagnostics"
             observeCheckout(checkout)
             statusContainerView.isHidden = true
             scrollView.isHidden = false
             renderCheckout()
         } catch {
             checkout = nil
+            navigationItem.rightBarButtonItem = nil
             errorMessage = error.localizedDescription
             showFailureStatus()
         }
@@ -710,6 +720,20 @@ final class CheckoutCartViewController: UIViewController {
 
     @objc private func closeButtonTapped() {
         closeAction()
+    }
+
+    @objc private func checkoutDetailsButtonTapped() {
+        guard let checkout else { return }
+        let detailsView = CheckoutSessionDetailsView(
+            diagnostics: diagnostics,
+            sessionID: checkout.session.id
+        )
+        let viewController = UIHostingController(rootView: detailsView)
+        if let sheetPresentationController = viewController.sheetPresentationController {
+            sheetPresentationController.detents = [.medium(), .large()]
+            sheetPresentationController.prefersGrabberVisible = true
+        }
+        present(viewController, animated: true)
     }
 
     @objc private func retryButtonTapped() {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutRequestCaptureURLProtocol.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutRequestCaptureURLProtocol.swift
@@ -1,0 +1,179 @@
+//
+//  CheckoutRequestCaptureURLProtocol.swift
+//  PaymentSheet Example
+//
+//  Created by Nick Porter on 8/11/26.
+//
+
+import Foundation
+
+/// Adds request-ID observation to a single URL session without changing the configuration used
+/// to perform its requests.
+final class CheckoutRequestCapture {
+    /// Metadata for a completed Stripe API request.
+    struct Response: Sendable {
+        let requestID: String
+        let method: String
+        let path: String
+    }
+
+    let sessionConfiguration: URLSessionConfiguration
+
+    private let captureID = UUID().uuidString
+
+    init(
+        forwardingConfiguration: URLSessionConfiguration,
+        didReceiveResponse: @escaping @Sendable (Response) -> Void
+    ) {
+        guard let sessionConfiguration = forwardingConfiguration.copy() as? URLSessionConfiguration else {
+            preconditionFailure("URLSessionConfiguration must support copying")
+        }
+
+        CheckoutRequestCaptureRegistry.register(
+            captureID: captureID,
+            forwardingConfiguration: forwardingConfiguration,
+            didReceiveResponse: didReceiveResponse
+        )
+
+        var additionalHeaders = sessionConfiguration.httpAdditionalHeaders ?? [:]
+        additionalHeaders[CheckoutRequestCaptureURLProtocol.captureIDHeader] = captureID
+        sessionConfiguration.httpAdditionalHeaders = additionalHeaders
+        sessionConfiguration.protocolClasses = [CheckoutRequestCaptureURLProtocol.self]
+            + (sessionConfiguration.protocolClasses ?? [])
+        self.sessionConfiguration = sessionConfiguration
+    }
+
+    deinit {
+        CheckoutRequestCaptureRegistry.unregister(captureID: captureID)
+    }
+}
+
+private enum CheckoutRequestCaptureRegistry {
+    struct Context {
+        let forwardingConfiguration: URLSessionConfiguration
+        let didReceiveResponse: @Sendable (CheckoutRequestCapture.Response) -> Void
+    }
+
+    private static let lock = NSLock()
+    private static var contexts: [String: Context] = [:]
+
+    static func register(
+        captureID: String,
+        forwardingConfiguration: URLSessionConfiguration,
+        didReceiveResponse: @escaping @Sendable (CheckoutRequestCapture.Response) -> Void
+    ) {
+        lock.lock()
+        contexts[captureID] = Context(
+            forwardingConfiguration: forwardingConfiguration,
+            didReceiveResponse: didReceiveResponse
+        )
+        lock.unlock()
+    }
+
+    static func unregister(captureID: String) {
+        lock.lock()
+        contexts[captureID] = nil
+        lock.unlock()
+    }
+
+    static func context(for captureID: String) -> Context? {
+        lock.lock()
+        let context = contexts[captureID]
+        lock.unlock()
+        return context
+    }
+}
+
+private class CheckoutRequestCaptureURLProtocol: URLProtocol {
+    static let captureIDHeader = "X-Checkout-Playground-Capture-ID"
+
+    private static let handledRequestKey = "CheckoutPlaygroundHandledRequest"
+
+    private enum State {
+        case loading
+        case stopped
+        case completed
+    }
+
+    private let stateLock = NSLock()
+    private var state = State.loading
+    private var dataTask: URLSessionDataTask?
+    private var forwardingSession: URLSession?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        return request.value(forHTTPHeaderField: captureIDHeader) != nil
+            && URLProtocol.property(forKey: handledRequestKey, in: request) == nil
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        return request
+    }
+
+    override func startLoading() {
+        guard let captureID = request.value(forHTTPHeaderField: Self.captureIDHeader),
+              let context = CheckoutRequestCaptureRegistry.context(for: captureID),
+              let forwardedRequest = (request as NSURLRequest).mutableCopy() as? NSMutableURLRequest else {
+            client?.urlProtocol(self, didFailWithError: URLError(.badURL))
+            return
+        }
+
+        forwardedRequest.setValue(nil, forHTTPHeaderField: Self.captureIDHeader)
+        URLProtocol.setProperty(true, forKey: Self.handledRequestKey, in: forwardedRequest)
+
+        let forwardingSession = URLSession(configuration: context.forwardingConfiguration)
+        self.forwardingSession = forwardingSession
+        dataTask = forwardingSession.dataTask(with: forwardedRequest as URLRequest) { [weak self] data, response, error in
+            guard let self, beginCompletion() else { return }
+            defer { forwardingSession.finishTasksAndInvalidate() }
+
+            guard let response else {
+                client?.urlProtocol(self, didFailWithError: error ?? URLError(.badServerResponse))
+                return
+            }
+
+            if let httpResponse = response as? HTTPURLResponse,
+               let requestID = httpResponse.value(forHTTPHeaderField: "request-id") {
+                context.didReceiveResponse(
+                    CheckoutRequestCapture.Response(
+                        requestID: requestID,
+                        method: forwardedRequest.httpMethod ?? "REQUEST",
+                        path: forwardedRequest.url?.path ?? "Stripe API"
+                    )
+                )
+            }
+
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            if let data {
+                client?.urlProtocol(self, didLoad: data)
+            }
+            if let error {
+                client?.urlProtocol(self, didFailWithError: error)
+            } else {
+                client?.urlProtocolDidFinishLoading(self)
+            }
+        }
+        dataTask?.resume()
+    }
+
+    override func stopLoading() {
+        guard stopIfLoading() else { return }
+        dataTask?.cancel()
+        forwardingSession?.invalidateAndCancel()
+    }
+
+    private func beginCompletion() -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard state == .loading else { return false }
+        state = .completed
+        return true
+    }
+
+    private func stopIfLoading() -> Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        guard state == .loading else { return false }
+        state = .stopped
+        return true
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutSessionDetailsComponents.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutSessionDetailsComponents.swift
@@ -1,0 +1,180 @@
+//
+//  CheckoutSessionDetailsComponents.swift
+//  PaymentSheet Example
+//
+//  Created by Nick Porter on 8/11/26.
+//
+
+import SwiftUI
+
+private enum CheckoutDiagnosticStyle {
+    static let stripe = Color(red: 99.0 / 255.0, green: 91.0 / 255.0, blue: 1)
+}
+
+struct CheckoutDiagnosticSectionHeader: View {
+    let title: String
+    var count: Int?
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Text(title.uppercased())
+                .font(.caption.weight(.semibold))
+                .foregroundColor(.secondary)
+                .tracking(0.4)
+
+            if let count {
+                Text("\(count)")
+                    .font(.caption2.weight(.bold))
+                    .foregroundColor(CheckoutDiagnosticStyle.stripe)
+                    .padding(.horizontal, 7)
+                    .padding(.vertical, 3)
+                    .background(CheckoutDiagnosticStyle.stripe.opacity(0.1))
+                    .clipShape(Capsule())
+            }
+        }
+        .padding(.horizontal, 4)
+    }
+}
+
+struct CheckoutDiagnosticIdentifierCard: View {
+    let title: String
+    let value: String
+    let systemImage: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            diagnosticIcon(systemImage)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.subheadline.weight(.medium))
+                Text(value)
+                    .font(.caption.monospaced())
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+
+            Spacer(minLength: 8)
+            CheckoutDiagnosticCopyButton(value: value)
+        }
+        .padding(14)
+        .checkoutDiagnosticCard()
+    }
+}
+
+struct CheckoutDiagnosticRequestCard: View {
+    let request: CheckoutSessionDiagnostics.Request
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 12) {
+                diagnosticIcon("arrow.up.arrow.down")
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(request.displayName)
+                        .font(.subheadline.weight(.medium))
+                    Text(request.date, style: .time)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+                CheckoutDiagnosticCopyButton(value: request.requestID)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(request.requestID)
+                    .font(.caption.monospaced())
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+                Text(request.endpoint)
+                    .font(.caption2.monospaced())
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .padding(.leading, 44)
+        }
+        .padding(14)
+        .checkoutDiagnosticCard()
+    }
+}
+
+struct CheckoutDiagnosticEmptyRequestsView: View {
+    var body: some View {
+        HStack(spacing: 12) {
+            diagnosticIcon("arrow.triangle.2.circlepath")
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Waiting for Stripe")
+                    .font(.subheadline.weight(.medium))
+                Text("Request IDs appear here as Checkout communicates with Stripe.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .checkoutDiagnosticCard()
+    }
+}
+
+struct CheckoutDiagnosticCopyButton: View {
+    let value: String
+
+    @State private var isCopied = false
+    @State private var resetTask: Task<Void, Never>?
+
+    var body: some View {
+        Button {
+            UIPasteboard.general.string = value
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            withAnimation(.easeInOut(duration: 0.15)) {
+                isCopied = true
+            }
+            resetTask?.cancel()
+            resetTask = Task {
+                try? await Task.sleep(nanoseconds: 1_500_000_000)
+                guard !Task.isCancelled else { return }
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    isCopied = false
+                }
+            }
+        } label: {
+            Label(isCopied ? "Copied" : "Copy", systemImage: isCopied ? "checkmark" : "doc.on.doc")
+                .font(.caption.weight(.semibold))
+                .foregroundColor(CheckoutDiagnosticStyle.stripe)
+                .padding(.horizontal, 10)
+                .frame(height: 30)
+                .background(CheckoutDiagnosticStyle.stripe.opacity(0.1))
+                .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isCopied ? "Copied" : "Copy \(value)")
+        .onDisappear {
+            resetTask?.cancel()
+        }
+    }
+}
+
+private func diagnosticIcon(_ systemName: String) -> some View {
+    Image(systemName: systemName)
+        .font(.system(size: 15, weight: .semibold))
+        .foregroundColor(CheckoutDiagnosticStyle.stripe)
+        .frame(width: 32, height: 32)
+        .background(CheckoutDiagnosticStyle.stripe.opacity(0.1))
+        .clipShape(RoundedRectangle(cornerRadius: 9))
+}
+
+private extension View {
+    func checkoutDiagnosticCard() -> some View {
+        background(Color(uiColor: .secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 14))
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(Color(uiColor: .separator).opacity(0.25), lineWidth: 0.5)
+            )
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutSessionDetailsView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutSessionDetailsView.swift
@@ -1,0 +1,91 @@
+//
+//  CheckoutSessionDetailsView.swift
+//  PaymentSheet Example
+//
+//  Created by Nick Porter on 8/11/26.
+//
+
+import SwiftUI
+
+struct CheckoutSessionDetailsView: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var diagnostics: CheckoutSessionDiagnostics
+
+    let sessionID: String
+
+    @ViewBuilder
+    var body: some View {
+        if #available(iOS 16.0, *) {
+            content
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
+        } else {
+            content
+        }
+    }
+
+    private var content: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    CheckoutDiagnosticSectionHeader(title: "Checkout session")
+                    CheckoutDiagnosticIdentifierCard(
+                        title: "Session ID",
+                        value: sessionID,
+                        systemImage: "cart.fill"
+                    )
+
+                    CheckoutDiagnosticSectionHeader(
+                        title: "API activity",
+                        count: diagnostics.requests.count
+                    )
+                    .padding(.top, 10)
+
+                    if diagnostics.requests.isEmpty {
+                        CheckoutDiagnosticEmptyRequestsView()
+                    } else {
+                        LazyVStack(spacing: 10) {
+                            ForEach(diagnostics.requests) { request in
+                                CheckoutDiagnosticRequestCard(request: request)
+                            }
+                        }
+                    }
+                }
+                .padding(20)
+            }
+        }
+        .background(Color(uiColor: .systemGroupedBackground).ignoresSafeArea())
+    }
+
+    private var header: some View {
+        HStack(spacing: 16) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Session diagnostics")
+                    .font(.title2.bold())
+                Text("IDs and Stripe API activity for this checkout")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            Button {
+                dismiss()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .bold))
+                    .foregroundColor(.secondary)
+                    .frame(width: 32, height: 32)
+                    .background(Color(uiColor: .secondarySystemGroupedBackground))
+                    .clipShape(Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close session diagnostics")
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 16)
+        .background(Color(uiColor: .systemGroupedBackground))
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutSessionDiagnostics.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutSessionDiagnostics.swift
@@ -1,0 +1,78 @@
+//
+//  CheckoutSessionDiagnostics.swift
+//  PaymentSheet Example
+//
+//  Created by Nick Porter on 8/11/26.
+//
+
+@_spi(STP) import StripeCore
+import SwiftUI
+
+@MainActor
+final class CheckoutSessionDiagnostics: ObservableObject {
+    struct Request: Identifiable, Sendable {
+        let requestID: String
+        let method: String
+        let path: String
+        let date: Date
+
+        var id: String { requestID }
+
+        var endpoint: String {
+            "\(method) \(path)"
+        }
+
+        var displayName: String {
+            if path.hasSuffix("/init") {
+                return "Initialize session"
+            }
+            if path.hasSuffix("/confirm") {
+                return "Confirm session"
+            }
+            if path.contains("/payment_pages/") {
+                return "Update session"
+            }
+            return "Stripe API request"
+        }
+    }
+
+    @Published private(set) var requests: [Request] = []
+
+    private var requestCapture: CheckoutRequestCapture?
+    private var captureGeneration = UUID()
+
+    /// Returns a copy of the shared API client that records Stripe request IDs for this cart.
+    func makeAPIClient() -> STPAPIClient {
+        requests.removeAll()
+        let captureGeneration = UUID()
+        self.captureGeneration = captureGeneration
+
+        let apiClient = STPAPIClient.shared.makeCopy()
+        let requestCapture = CheckoutRequestCapture(
+            forwardingConfiguration: apiClient.urlSession.configuration
+        ) { [weak self] response in
+            let request = Request(
+                requestID: response.requestID,
+                method: response.method,
+                path: response.path,
+                date: Date()
+            )
+            Task { @MainActor in
+                self?.record(request, captureGeneration: captureGeneration)
+            }
+        }
+        self.requestCapture = requestCapture
+        apiClient.urlSession = URLSession(configuration: requestCapture.sessionConfiguration)
+        return apiClient
+    }
+
+    private func record(_ request: Request, captureGeneration: UUID) {
+        guard captureGeneration == self.captureGeneration else {
+            return
+        }
+        guard !requests.contains(where: { $0.requestID == request.requestID }) else {
+            return
+        }
+        requests.insert(request, at: 0)
+    }
+}


### PR DESCRIPTION
## Summary
Adds a diagnostics sheet to the SwiftUI and UIKit Checkout Playground carts. It shows the Checkout Session ID and Stripe request IDs for the current cart, with quick copy actions for each.

### Screenshot

<img width="390" alt="Checkout session diagnostics" src="https://github.com/user-attachments/assets/8b85e118-28fc-4240-bd61-95f7e4ac8c1f" />

## Motivation
CheckoutSessions

## Testing
- Manual
- PaymentSheet Example build

## Changelog
N/A