### PR TITLE
[Identity] Use .close System Bar Button 

### DIFF
--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IdentityFlowViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IdentityFlowViewController.swift
@@ -39,20 +39,11 @@ class IdentityFlowViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
 
         if shouldShowCancelButton {
-            if LiquidGlassDetector.isEnabledInMerchantApp {
-                navigationItem.rightBarButtonItem = UIBarButtonItem(
-                    barButtonSystemItem: .close,
-                    target: self,
-                    action: #selector(didTapCancelButton)
-                )
-            } else {
-                navigationItem.rightBarButtonItem = UIBarButtonItem(
-                    title: String.Localized.cancel,
-                    style: .plain,
-                    target: self,
-                    action: #selector(didTapCancelButton)
-                )
-            }
+            navigationItem.rightBarButtonItem = UIBarButtonItem(
+                barButtonSystemItem: .close,
+                target: self,
+                action: #selector(didTapCancelButton)
+            )
         }
     }
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IdentityFlowViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IdentityFlowViewController.swift
@@ -39,12 +39,20 @@ class IdentityFlowViewController: UIViewController {
         super.init(nibName: nil, bundle: nil)
 
         if shouldShowCancelButton {
-            navigationItem.rightBarButtonItem = UIBarButtonItem(
-                title: String.Localized.cancel,
-                style: .plain,
-                target: self,
-                action: #selector(didTapCancelButton)
-            )
+            if LiquidGlassDetector.isEnabledInMerchantApp {
+                let closeButton = UIButton(type: .system)
+                closeButton.setImage(UIImage(systemName: "xmark"), for: .normal)
+                closeButton.addTarget(self, action: #selector(didTapCancelButton), for: .touchUpInside)
+                closeButton.accessibilityLabel = String.Localized.cancel
+                navigationItem.rightBarButtonItem = UIBarButtonItem(customView: closeButton)
+            } else {
+                navigationItem.rightBarButtonItem = UIBarButtonItem(
+                    title: String.Localized.cancel,
+                    style: .plain,
+                    target: self,
+                    action: #selector(didTapCancelButton)
+                )
+            }
         }
     }
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IdentityFlowViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IdentityFlowViewController.swift
@@ -40,11 +40,11 @@ class IdentityFlowViewController: UIViewController {
 
         if shouldShowCancelButton {
             if LiquidGlassDetector.isEnabledInMerchantApp {
-                let closeButton = UIButton(type: .system)
-                closeButton.setImage(UIImage(systemName: "xmark"), for: .normal)
-                closeButton.addTarget(self, action: #selector(didTapCancelButton), for: .touchUpInside)
-                closeButton.accessibilityLabel = String.Localized.cancel
-                navigationItem.rightBarButtonItem = UIBarButtonItem(customView: closeButton)
+                navigationItem.rightBarButtonItem = UIBarButtonItem(
+                    barButtonSystemItem: .close,
+                    target: self,
+                    action: #selector(didTapCancelButton)
+                )
             } else {
                 navigationItem.rightBarButtonItem = UIBarButtonItem(
                     title: String.Localized.cancel,


### PR DESCRIPTION
## Summary
Updates the `.cancel` bar button item to use a `.close` style. 

## Motivation
This aligns with iOS design styles pre/post liquid glass (iOS 26).

## Testing
Simulator testing on pre/post iOS 26.0 using custom/non-custom tinting.

## Demos
| | Before | After |
| --- | --- | --- |
| iOS 18 | <img src="https://github.com/user-attachments/assets/40049e15-955a-4a18-ac8e-d62934aa60ea" width="300" /> | <video src="https://github.com/user-attachments/assets/bcd4a00c-4181-426e-9cc6-fdf37dd42602" width="300" /> |
| iOS 26 | <img src="https://github.com/user-attachments/assets/2ef3ef33-f2aa-40bf-b5a3-6bd5f272c73a" width="300" /> | <video src="https://github.com/user-attachments/assets/ebe92900-8f65-477f-a97c-75f8f68df1be" width="300" /> |

