### PR TITLE
Speed up translation workflow checkout

### DIFF
--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -16,9 +16,11 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
         with:
-            fetch-depth: 0
+          # The pull_request ref is a merge commit. We only need it and its
+          # base parent to determine which strings the PR adds.
+          fetch-depth: 2
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -28,6 +30,7 @@ jobs:
       - name: Run translation check script
         env:
           LOKALISE_API_KEY: ${{ secrets.LOKALISE_API_KEY_READONLY }}
+          TRANSLATION_DIFF_BASE: HEAD^1
         run: ruby ci_scripts/check_for_untranslated_strings.rb
       - name: Read missing translations
         id: missing

--- a/ci_scripts/check_for_untranslated_strings.rb
+++ b/ci_scripts/check_for_untranslated_strings.rb
@@ -19,11 +19,12 @@ end
 
 def get_added_strings(current_dir)
   new_strings = {}
+  diff_base = ENV.fetch('TRANSLATION_DIFF_BASE', 'origin/master...')
 
-  strings_files = `git diff --name-only origin/master...`.split("\n").select { |f| f.end_with?(".strings") }
+  strings_files = `git diff --name-only #{diff_base}`.split("\n").select { |f| f.end_with?(".strings") }
 
   strings_files.each do |file|
-    added_lines = `git diff origin/master... -- #{file}`.split("\n").select do |line|
+    added_lines = `git diff #{diff_base} -- #{file}`.split("\n").select do |line|
       line.start_with?('+') && !line.start_with?('+++') && line.include?('=') && !line.match(/^\/\//)
     end
 


### PR DESCRIPTION
## Summary

The translation check spends most of its runtime cloning the repository’s full history. Shallow-checks out the synthetic PR merge commit and its base parent instead, then uses that parent to find strings added by the PR.

## Motivation

CI performance

## Testing

- Validated the workflow YAML and Ruby syntax
- Compared the shallow diff with the existing full-history diff using a synthetic PR merge
- Verified the checker finds the expected added string from a depth-2 clone

## Changelog

N/A