### PR TITLE
Add generic error pane for FC SDK

### DIFF
--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/FinancialConnectionsAsyncAPIClient.swift
@@ -180,6 +180,15 @@ final class FinancialConnectionsAsyncAPIClient {
             do {
                 return try await apiCall()
             } catch {
+                // A client error will never succeed on retry, and its response body may carry
+                // information the caller needs (ex. a server-driven error pane in `extra_fields`),
+                // so surface it right away instead of losing it to `maxRetriesReached`.
+                //
+                // Note that a still-in-progress poll comes back as a decoding error rather than
+                // a client error, so this doesn't cut polling short.
+                if error.isClientError {
+                    throw error
+                }
                 if attempt == maxNumberOfRetries - 1 {
                     throw PollingError.maxRetriesReached
                 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericErrorPane.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericErrorPane.swift
@@ -45,7 +45,7 @@ struct FinancialConnectionsGenericErrorPane: Equatable {
         self.primaryCtaAction = (extraFields["generic_error_pane_primary_cta_action"] as? String)
             .flatMap(PrimaryCtaAction.init(rawValue:))
         self.iconUrl = extraFields["generic_error_pane_icon_url"] as? String
-        self.imageUrl = extraFields["generic_error_pane_image"] as? String
+        self.imageUrl = extraFields["generic_error_pane_image_url"] as? String
     }
 
     /// Extracts a generic error pane from an API error, or returns `nil` if the error

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericErrorPane.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsGenericErrorPane.swift
@@ -1,0 +1,62 @@
+//
+//  FinancialConnectionsGenericErrorPane.swift
+//  StripeFinancialConnections
+//
+//  Created by Mat Schmid on 2026-08-12.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+/// A fully server-controlled error screen.
+///
+/// Unlike every other error pane, the server owns all of the content here. The API error shape
+/// isn't flexible enough to carry a screen definition, so the backend tucks it into the
+/// `extra_fields` object of the error instead. Any endpoint can opt in by setting
+/// `use_generic_error_pane`, so parsing is intentionally endpoint-agnostic.
+struct FinancialConnectionsGenericErrorPane: Equatable {
+    /// What the primary button does.
+    enum PrimaryCtaAction: String {
+        /// Create a new auth session and send the user back through the institution's OAuth flow.
+        case restartAuthFlow = "restart_auth_flow"
+    }
+
+    let heading: String
+    let subheading: String
+    let primaryCta: String
+    /// `nil` when the server sends an action this version of the SDK doesn't know how to handle.
+    let primaryCtaAction: PrimaryCtaAction?
+    let iconUrl: String?
+    let imageUrl: String?
+
+    /// Returns `nil` if any of the content needed to render the pane is missing, which lets
+    /// callers fall back to the standard error handling rather than showing a broken screen.
+    init?(extraFields: [String: Any]) {
+        guard
+            let heading = extraFields["generic_error_pane_heading"] as? String,
+            let subheading = extraFields["generic_error_pane_subheading"] as? String,
+            let primaryCta = extraFields["generic_error_pane_primary_cta"] as? String
+        else {
+            return nil
+        }
+        self.heading = heading
+        self.subheading = subheading
+        self.primaryCta = primaryCta
+        self.primaryCtaAction = (extraFields["generic_error_pane_primary_cta_action"] as? String)
+            .flatMap(PrimaryCtaAction.init(rawValue:))
+        self.iconUrl = extraFields["generic_error_pane_icon_url"] as? String
+        self.imageUrl = extraFields["generic_error_pane_image"] as? String
+    }
+
+    /// Extracts a generic error pane from an API error, or returns `nil` if the error
+    /// doesn't opt into one.
+    static func from(error: Error) -> FinancialConnectionsGenericErrorPane? {
+        guard
+            let extraFields = error.extraFields,
+            extraFields["use_generic_error_pane"] as? Bool == true
+        else {
+            return nil
+        }
+        return FinancialConnectionsGenericErrorPane(extraFields: extraFields)
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/API Bindings/Models/FinancialConnectionsSessionManifest.swift
@@ -37,6 +37,7 @@ struct FinancialConnectionsSessionManifest: Decodable {
         case unparsable
 
         // client-side only panes
+        case genericError = "generic_error"
         case resetFlow = "reset_flow"
         case terminalError = "terminal_error"
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Analytics/FinancialConnectionsAnalyticsClient.swift
@@ -214,6 +214,8 @@ extension FinancialConnectionsAnalyticsClient {
             return .linkLogin
         case is ErrorViewController:
             return .unexpectedError
+        case is GenericErrorViewController:
+            return .genericError
         default:
             return .unparsable
         }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/Error+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/Error+Extensions.swift
@@ -1,0 +1,39 @@
+//
+//  Error+Extensions.swift
+//  StripeFinancialConnections
+//
+//  Created by Mat Schmid on 2026-08-12.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+extension Error {
+    /// The `extra_fields` object of a Stripe API error response, if there is one.
+    ///
+    /// The API exposes some client-actionable details only through `extra_fields`, which is
+    /// untyped, so it comes back as a raw dictionary.
+    var extraFields: [String: Any]? {
+        guard
+            let error = self as? StripeError,
+            case .apiError(let apiError) = error
+        else {
+            return nil
+        }
+        return apiError.allResponseFields["extra_fields"] as? [String: Any]
+    }
+
+    /// Whether this is a Stripe API error with a `4xx` status code.
+    ///
+    /// These are terminal: retrying the same request will fail the same way.
+    var isClientError: Bool {
+        guard
+            let error = self as? StripeError,
+            case .apiError(let apiError) = error,
+            let statusCode = apiError.httpStatusCode
+        else {
+            return false
+        }
+        return (400...499).contains(statusCode)
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/Error+Extensions.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Helpers/Error+Extensions.swift
@@ -23,9 +23,10 @@ extension Error {
         return apiError.allResponseFields["extra_fields"] as? [String: Any]
     }
 
-    /// Whether this is a Stripe API error with a `4xx` status code.
+    /// Whether this is a Stripe API error with a `4xx` status code, excluding ones that are
+    /// transient by design (408 Request Timeout, 429 Too Many Requests) and can succeed on retry.
     ///
-    /// These are terminal: retrying the same request will fail the same way.
+    /// The rest are terminal: retrying the same request will fail the same way.
     var isClientError: Bool {
         guard
             let error = self as? StripeError,
@@ -34,6 +35,7 @@ extension Error {
         else {
             return false
         }
-        return (400...499).contains(statusCode)
+        let transientStatusCodes = [408, 429]
+        return (400...499).contains(statusCode) && !transientStatusCodes.contains(statusCode)
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/AccountPicker/AccountPickerViewController.swift
@@ -27,6 +27,10 @@ protocol AccountPickerViewControllerDelegate: AnyObject {
     )
     func accountPickerViewController(
         _ viewController: AccountPickerViewController,
+        didReceiveError error: Error
+    )
+    func accountPickerViewController(
+        _ viewController: AccountPickerViewController,
         didReceiveEvent event: FinancialConnectionsEvent
     )
 }
@@ -240,7 +244,11 @@ final class AccountPickerViewController: UIViewController {
                         self.displayAccounts(enabledAccounts, disabledAccounts)
                     }
                 case .failure(let error):
-                    if let error = error as? StripeError,
+                    if FinancialConnectionsGenericErrorPane.from(error: error) != nil {
+                        // the server described an error screen for us, so hand off to the
+                        // flow controller to present it in place of this pane
+                        self.delegate?.accountPickerViewController(self, didReceiveError: error)
+                    } else if let error = error as? StripeError,
                         case .apiError(let apiError) = error,
                         let extraFields = apiError.allResponseFields["extra_fields"] as? [String: Any],
                         let reason = extraFields["reason"] as? String,

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/GenericError/GenericErrorDataSource.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/GenericError/GenericErrorDataSource.swift
@@ -1,0 +1,51 @@
+//
+//  GenericErrorDataSource.swift
+//  StripeFinancialConnections
+//
+//  Created by Mat Schmid on 2026-08-12.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+final class GenericErrorDataSource {
+
+    let genericErrorPane: FinancialConnectionsGenericErrorPane
+    let appearance: FinancialConnectionsAppearance
+    let analyticsClient: FinancialConnectionsAnalyticsClient
+    private let authSession: FinancialConnectionsAuthSession?
+    private let apiClient: any FinancialConnectionsAPI
+    private let clientSecret: String
+
+    init(
+        genericErrorPane: FinancialConnectionsGenericErrorPane,
+        authSession: FinancialConnectionsAuthSession?,
+        appearance: FinancialConnectionsAppearance,
+        apiClient: any FinancialConnectionsAPI,
+        clientSecret: String,
+        analyticsClient: FinancialConnectionsAnalyticsClient
+    ) {
+        self.genericErrorPane = genericErrorPane
+        self.authSession = authSession
+        self.appearance = appearance
+        self.apiClient = apiClient
+        self.clientSecret = clientSecret
+        self.analyticsClient = analyticsClient
+    }
+
+    /// Cancels the auth session that got us here, since the user is leaving it behind either
+    /// way. Mirrors `PartnerAuthDataSource.cancelPendingAuthSessionIfNeeded`.
+    func cancelPendingAuthSessionIfNeeded() {
+        guard let authSession else {
+            return
+        }
+        apiClient
+            .cancelAuthSession(
+                clientSecret: clientSecret,
+                authSessionId: authSession.id
+            )
+            .observe { _ in
+                // Fire & forget, we can ignore the result here.
+            }
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/GenericError/GenericErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/GenericError/GenericErrorViewController.swift
@@ -1,0 +1,214 @@
+//
+//  GenericErrorViewController.swift
+//  StripeFinancialConnections
+//
+//  Created by Mat Schmid on 2026-08-12.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+@_spi(STP) import StripeUICore
+import UIKit
+
+protocol GenericErrorViewControllerDelegate: AnyObject {
+    func genericErrorViewControllerDidSelectRestartAuthFlow(_ viewController: GenericErrorViewController)
+    func genericErrorViewControllerDidSelectAnotherBank(_ viewController: GenericErrorViewController)
+}
+
+/// Represents the `generic_error` pane: an error screen whose entire contents are
+/// dictated by the server via the `extra_fields` of an API error.
+final class GenericErrorViewController: UIViewController {
+
+    private let dataSource: GenericErrorDataSource
+    weak var delegate: GenericErrorViewControllerDelegate?
+
+    init(dataSource: GenericErrorDataSource) {
+        self.dataSource = dataSource
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        view.backgroundColor = FinancialConnectionsAppearance.Colors.background
+        // this pane replaces the one the error came from, so there's nothing to go back to.
+        // the user moves forward through the primary CTA instead.
+        navigationItem.hidesBackButton = true
+
+        let genericErrorPane = dataSource.genericErrorPane
+
+        let contentView = PaneLayoutView.createContentView(
+            iconView: {
+                guard let iconUrl = genericErrorPane.iconUrl else { return nil }
+                let institutionIconView = InstitutionIconView()
+                institutionIconView.setImageUrl(iconUrl)
+                return institutionIconView
+            }(),
+            title: genericErrorPane.heading,
+            // the subheading is centered, which `createBodyView` can't do, so it's
+            // built as part of the content view below
+            subtitle: nil,
+            headerAlignment: .center,
+            contentView: CreateContentView(genericErrorPane: genericErrorPane)
+        )
+        let footerView = PaneLayoutView.createFooterView(
+            primaryButtonConfiguration: PaneLayoutView.ButtonConfiguration(
+                title: primaryCtaTitle,
+                accessibilityIdentifier: "generic_error_primary_button",
+                action: { [weak self] in
+                    self?.didSelectPrimaryCta()
+                }
+            ),
+            appearance: dataSource.appearance
+        ).footerView
+
+        PaneLayoutView(
+            contentView: contentView,
+            footerView: footerView
+        ).addTo(view: view)
+
+        dataSource.analyticsClient.logPaneLoaded(pane: .genericError)
+
+        if genericErrorPane.primaryCtaAction == nil {
+            dataSource
+                .analyticsClient
+                .logUnexpectedError(
+                    FinancialConnectionsSheetError.unknown(
+                        debugDescription: "Unhandled generic error pane primary CTA action."
+                    ),
+                    errorName: "GenericErrorPaneUnknownCtaAction",
+                    pane: .genericError
+                )
+        }
+    }
+
+    private var primaryCtaTitle: String {
+        switch dataSource.genericErrorPane.primaryCtaAction {
+        case .restartAuthFlow:
+            return dataSource.genericErrorPane.primaryCta
+        case nil:
+            // we don't know how to perform the action the server asked for, so we fall back
+            // to letting the user pick a different bank. use our own copy for the button so
+            // it can't promise something we won't do.
+            return String.Localized.select_another_bank
+        }
+    }
+
+    private func didSelectPrimaryCta() {
+        let action = dataSource.genericErrorPane.primaryCtaAction
+        dataSource
+            .analyticsClient
+            .log(
+                eventName: "click.primary_cta",
+                parameters: ["action": action?.rawValue ?? "unknown"],
+                pane: .genericError
+            )
+
+        dataSource.cancelPendingAuthSessionIfNeeded()
+
+        switch action {
+        case .restartAuthFlow:
+            delegate?.genericErrorViewControllerDidSelectRestartAuthFlow(self)
+        case nil:
+            delegate?.genericErrorViewControllerDidSelectAnotherBank(self)
+        }
+    }
+}
+
+private func CreateContentView(
+    genericErrorPane: FinancialConnectionsGenericErrorPane
+) -> UIView {
+    let verticalStackView = UIStackView()
+    verticalStackView.axis = .vertical
+    verticalStackView.spacing = 24
+
+    let subheadingLabel = AttributedTextView(
+        font: .body(.medium),
+        boldFont: .body(.mediumEmphasized),
+        linkFont: .body(.mediumEmphasized),
+        textColor: FinancialConnectionsAppearance.Colors.textSubdued,
+        alignment: .center
+    )
+    subheadingLabel.setText(genericErrorPane.subheading)
+    verticalStackView.addArrangedSubview(subheadingLabel)
+
+    if let imageUrl = genericErrorPane.imageUrl {
+        verticalStackView.addArrangedSubview(
+            PrepaneImageView(imageURLString: imageUrl)
+        )
+    }
+
+    return verticalStackView
+}
+
+#if DEBUG
+
+import SwiftUI
+
+private struct GenericErrorViewControllerRepresentable: UIViewControllerRepresentable {
+
+    let genericErrorPane: FinancialConnectionsGenericErrorPane
+
+    func makeUIViewController(context: Context) -> GenericErrorViewController {
+        GenericErrorViewController(
+            dataSource: GenericErrorDataSource(
+                genericErrorPane: genericErrorPane,
+                authSession: nil,
+                appearance: .stripe,
+                apiClient: FinancialConnectionsAsyncAPIClient(apiClient: .shared),
+                clientSecret: "las_123",
+                analyticsClient: FinancialConnectionsAnalyticsClient()
+            )
+        )
+    }
+
+    func updateUIViewController(_ viewController: GenericErrorViewController, context: Context) {}
+}
+
+private func PreviewGenericErrorPane(
+    primaryCtaAction: String? = "restart_auth_flow",
+    iconUrl: String? = "https://b.stripecdn.com/connections-statics-srv/assets/BrandIcon--wellsfargo-4x.png",
+    imageUrl: String? = "https://b.stripecdn.com/connections-statics-srv/assets/ErrorAsset--ownership-wellsfargo-2x.png"
+) -> FinancialConnectionsGenericErrorPane {
+    var extraFields: [String: Any] = [
+        "use_generic_error_pane": true,
+        "generic_error_pane_heading": "There was a problem accessing your account",
+        "generic_error_pane_subheading": "Please try again and be sure to select **Profile information**.",
+        "generic_error_pane_primary_cta": "Try again",
+    ]
+    extraFields["generic_error_pane_icon_url"] = iconUrl
+    extraFields["generic_error_pane_primary_cta_action"] = primaryCtaAction
+    extraFields["generic_error_pane_image"] = imageUrl
+    // swiftlint:disable:next force_unwrapping
+    return FinancialConnectionsGenericErrorPane(extraFields: extraFields)!
+}
+
+struct GenericErrorViewController_Previews: PreviewProvider {
+    static var previews: some View {
+        // matches the design mock
+        GenericErrorViewControllerRepresentable(
+            genericErrorPane: PreviewGenericErrorPane()
+        )
+        .previewDisplayName("Restart auth flow")
+
+        // the image is not always returned by the server
+        GenericErrorViewControllerRepresentable(
+            genericErrorPane: PreviewGenericErrorPane(
+                iconUrl: "https://b.stripecdn.com/connections-statics-srv/assets/BrandIcon--testmodePurpleOauth.svg",
+                imageUrl: nil
+            )
+        )
+        .previewDisplayName("No image")
+
+        // an action we don't know how to handle falls back to "Select another bank"
+        GenericErrorViewControllerRepresentable(
+            genericErrorPane: PreviewGenericErrorPane(primaryCtaAction: "some_future_action")
+        )
+        .previewDisplayName("Unknown CTA action")
+    }
+}
+
+#endif

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/GenericError/GenericErrorViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/GenericError/GenericErrorViewController.swift
@@ -181,7 +181,7 @@ private func PreviewGenericErrorPane(
     ]
     extraFields["generic_error_pane_icon_url"] = iconUrl
     extraFields["generic_error_pane_primary_cta_action"] = primaryCtaAction
-    extraFields["generic_error_pane_image"] = imageUrl
+    extraFields["generic_error_pane_image_url"] = imageUrl
     // swiftlint:disable:next force_unwrapping
     return FinancialConnectionsGenericErrorPane(extraFields: extraFields)!
 }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/NativeFlowController.swift
@@ -691,6 +691,24 @@ extension NativeFlowController {
         // dismiss the current pane
         dismissCurrentPane(animated: false)
 
+        // the server can hand us a fully-formed error screen, in which case we show that
+        // instead of one of our own
+        if let genericErrorPane = FinancialConnectionsGenericErrorPane.from(error: error) {
+            dataManager
+                .analyticsClient
+                .logExpectedError(
+                    error,
+                    errorName: "GenericErrorPaneError",
+                    pane: referrerPane
+                )
+            pushPane(
+                .genericError,
+                parameters: CreatePaneParameters(genericErrorPane: genericErrorPane),
+                animated: false
+            )
+            return
+        }
+
         dataManager.errorPaneError = error
         dataManager.errorPaneReferrerPane = referrerPane
         pushPane(.unexpectedError, animated: false)
@@ -962,6 +980,13 @@ extension NativeFlowController: AccountPickerViewControllerDelegate {
         didReceiveTerminalError error: Error
     ) {
         showTerminalError(error)
+    }
+
+    func accountPickerViewController(
+        _ viewController: AccountPickerViewController,
+        didReceiveError error: Error
+    ) {
+        showErrorPane(forError: error, referrerPane: .accountPicker)
     }
 
     func accountPickerViewController(
@@ -1389,6 +1414,33 @@ extension NativeFlowController: ErrorViewControllerDelegate {
     }
 }
 
+// MARK: - GenericErrorViewControllerDelegate
+
+extension NativeFlowController: GenericErrorViewControllerDelegate {
+    func genericErrorViewControllerDidSelectRestartAuthFlow(_ viewController: GenericErrorViewController) {
+        guard dataManager.institution != nil else {
+            // there's no institution to re-authenticate with, so the best we
+            // can do is let the user pick one
+            genericErrorViewControllerDidSelectAnotherBank(viewController)
+            return
+        }
+        dataManager.authSession = nil // clear any lingering auth sessions
+        // partner auth creates a new auth session and, because of
+        // `autoLaunchAuthSession`, goes straight to the institution's OAuth flow
+        pushPane(
+            .partnerAuth,
+            parameters: CreatePaneParameters(autoLaunchAuthSession: true),
+            animated: true,
+            removeCurrent: true
+        )
+    }
+
+    func genericErrorViewControllerDidSelectAnotherBank(_ viewController: GenericErrorViewController) {
+        dataManager.authSession = nil // clear any lingering auth sessions
+        pushPane(.institutionPicker, animated: true, removeCurrent: true)
+    }
+}
+
 // MARK: - Static Helpers
 
 private func CreatePaneViewController(
@@ -1627,7 +1679,8 @@ private func CreatePaneViewController(
             )
             let partnerAuthViewController = PartnerAuthViewController(
                 dataSource: partnerAuthDataSource,
-                panePresentationStyle: panePresentationStyle
+                panePresentationStyle: panePresentationStyle,
+                autoLaunchAuthSession: parameters?.autoLaunchAuthSession ?? false
             )
             partnerAuthViewController.delegate = nativeFlowController
             viewController = partnerAuthViewController
@@ -1670,6 +1723,23 @@ private func CreatePaneViewController(
         } else {
             // if backend returns `unexpected_error`, the parameters being NULL
             // might be OK and we will go to terminal error
+            viewController = nil
+        }
+    case .genericError:
+        if let genericErrorPane = parameters?.genericErrorPane {
+            let genericErrorDataSource = GenericErrorDataSource(
+                genericErrorPane: genericErrorPane,
+                authSession: dataManager.authSession,
+                appearance: dataManager.manifest.appearance,
+                apiClient: dataManager.apiClient,
+                clientSecret: dataManager.clientSecret,
+                analyticsClient: dataManager.analyticsClient
+            )
+            let genericErrorViewController = GenericErrorViewController(dataSource: genericErrorDataSource)
+            genericErrorViewController.delegate = nativeFlowController
+            viewController = genericErrorViewController
+        } else {
+            assertionFailure("Code logic error. Missing parameters for \(pane).")
             viewController = nil
         }
     case .authOptions:

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/PartnerAuth/PartnerAuthViewController.swift
@@ -59,11 +59,18 @@ final class PartnerAuthViewController: SheetViewController {
         return dataSource.isNetworkingRelinkSession ? .bankAuthRepair : .partnerAuth
     }
 
+    // when true, we skip the prepane and open the institution's authentication flow as
+    // soon as the auth session is created. used when the user has already been told what
+    // to do by a previous pane (ex. the generic error pane's "try again").
+    private let autoLaunchAuthSession: Bool
+
     init(
         dataSource: PartnerAuthDataSource,
-        panePresentationStyle: PanePresentationStyle
+        panePresentationStyle: PanePresentationStyle,
+        autoLaunchAuthSession: Bool = false
     ) {
         self.dataSource = dataSource
+        self.autoLaunchAuthSession = autoLaunchAuthSession
         super.init(panePresentationStyle: panePresentationStyle)
     }
 
@@ -137,6 +144,21 @@ final class PartnerAuthViewController: SheetViewController {
             authSessionId: authSession.id
         )
 
+        if autoLaunchAuthSession, authSession.isOauthNonOptional {
+            dataSource.analyticsClient.log(
+                eventName: "auto_launch_auth_session",
+                parameters: [
+                    "requires_native_redirect": authSession.requiresNativeRedirect,
+                ],
+                pane: pane
+            )
+            // we have no prepane to show behind the browser, so fill the blank space with
+            // a spinner the same way the non-oauth flow does
+            insertLegacyLoadingView()
+            launchAuthSession(authSession)
+            return
+        }
+
         if authSession.isOauthNonOptional, let prepaneModel = authSession.display?.text?.oauthPrepane {
             prepaneViews = nil // the `deinit` of prepane views will remove views
             let prepaneViews = PrepaneViews(
@@ -157,11 +179,7 @@ final class PartnerAuthViewController: SheetViewController {
                         pane: .partnerAuth
                     )
 
-                    if authSession.requiresNativeRedirect {
-                        self.openInstitutionAuthenticationNativeRedirect(authSession: authSession)
-                    } else {
-                        self.openInstitutionAuthenticationWebView(authSession: authSession)
-                    }
+                    self.launchAuthSession(authSession)
                 },
                 didSelectCancel: { [weak self] in
                     guard let self = self else { return }
@@ -195,6 +213,15 @@ final class PartnerAuthViewController: SheetViewController {
         } else {
             insertLegacyLoadingView()
 
+            launchAuthSession(authSession)
+        }
+    }
+
+    /// Hands the user off to the institution, either through the banking app or a browser.
+    private func launchAuthSession(_ authSession: FinancialConnectionsAuthSession) {
+        if authSession.requiresNativeRedirect {
+            openInstitutionAuthenticationNativeRedirect(authSession: authSession)
+        } else {
             openInstitutionAuthenticationWebView(authSession: authSession)
         }
     }

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CreatePaneParameters.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Native/Shared/CreatePaneParameters.swift
@@ -13,8 +13,18 @@ import Foundation
 // pane push.
 struct CreatePaneParameters {
     let nextPaneOrDrawerOnSecondaryCta: String?
+    let genericErrorPane: FinancialConnectionsGenericErrorPane?
+    // Skips the prepane and opens the institution's OAuth flow as soon as the
+    // auth session is created.
+    let autoLaunchAuthSession: Bool
 
-    init(nextPaneOrDrawerOnSecondaryCta: String? = nil) {
+    init(
+        nextPaneOrDrawerOnSecondaryCta: String? = nil,
+        genericErrorPane: FinancialConnectionsGenericErrorPane? = nil,
+        autoLaunchAuthSession: Bool = false
+    ) {
         self.nextPaneOrDrawerOnSecondaryCta = nextPaneOrDrawerOnSecondaryCta
+        self.genericErrorPane = genericErrorPane
+        self.autoLaunchAuthSession = autoLaunchAuthSession
     }
 }

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/APIErrorTestHelpers.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/APIErrorTestHelpers.swift
@@ -1,0 +1,62 @@
+//
+//  APIErrorTestHelpers.swift
+//  StripeFinancialConnectionsTests
+//
+//  Created by Mat Schmid on 2026-08-12.
+//
+
+import Foundation
+@_spi(STP) import StripeCore
+
+private enum APIErrorTestHelpersError: Error {
+    case couldNotBuildResponse
+    case unexpectedlyDecodedErrorBody
+}
+
+/// A response type that can never be decoded from an error body, so that `decodeResponse`
+/// always takes its error-parsing path.
+private struct NeverDecodableResponse: Decodable {
+    let fieldThatNeverAppearsInAnErrorBody: String
+}
+
+/// Builds the `StripeError.apiError` that the SDK would produce for a failed API request.
+///
+/// `StripeAPIError.allResponseFields` (where `extra_fields` lives) can only be populated by
+/// decoding a real response body, so this goes through the same decoding path production does.
+func MakeStripeAPIError(
+    statusCode: Int,
+    extraFields: [String: Any]? = nil,
+    message: String = "Something went wrong.",
+    type: String = "invalid_request_error"
+) throws -> Error {
+    var error: [String: Any] = [
+        "type": type,
+        "message": message,
+    ]
+    error["extra_fields"] = extraFields
+
+    let data = try JSONSerialization.data(withJSONObject: ["error": error])
+    guard
+        let url = URL(string: "https://api.stripe.com/v1/connections/auth_sessions/accounts"),
+        let response = HTTPURLResponse(
+            url: url,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )
+    else {
+        throw APIErrorTestHelpersError.couldNotBuildResponse
+    }
+
+    let result: Result<NeverDecodableResponse, Error> = STPAPIClient.decodeResponse(
+        data: data,
+        error: nil,
+        response: response
+    )
+    switch result {
+    case .success:
+        throw APIErrorTestHelpersError.unexpectedlyDecodedErrorBody
+    case .failure(let error):
+        return error
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAsyncAPIClientTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAsyncAPIClientTests.swift
@@ -305,6 +305,38 @@ class FinancialConnectionsAsyncAPIClientTests: XCTestCase {
         }
     }
 
+    func testPollRetriesOnTransientClientError() async throws {
+        // Given a 4xx that's transient by design and may well succeed on retry
+        let maxRetries = 3
+        for statusCode in [408, 429] {
+            tracker = CallTracker()
+            let transientError = try MakeStripeAPIError(statusCode: statusCode)
+
+            do {
+                // When we poll
+                _ = try await apiClient.poll(
+                    initialPollDelay: 0.01,
+                    maxNumberOfRetries: maxRetries,
+                    retryInterval: 0.01,
+                    sleepAction: { _ in
+                        self.tracker.sleepCallCount += 1
+                    },
+                    apiCall: {
+                        self.tracker.apiCallCount += 1
+                        throw transientError
+                    }
+                )
+                XCTFail("Should throw an error")
+            } catch let error as FinancialConnectionsAsyncAPIClient.PollingError {
+                // Then we retry as usual, rather than aborting after one attempt
+                XCTAssertEqual(error, .maxRetriesReached, "Status code \(statusCode)")
+                XCTAssertEqual(self.tracker.apiCallCount, maxRetries, "Status code \(statusCode)")
+            } catch {
+                XCTFail("Wrong error type for status code \(statusCode): \(error)")
+            }
+        }
+    }
+
     func testDefaultParameters() async throws {
         var callCount = 0
 

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAsyncAPIClientTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsAsyncAPIClientTests.swift
@@ -246,6 +246,65 @@ class FinancialConnectionsAsyncAPIClientTests: XCTestCase {
         }
     }
 
+    func testPollDoesNotRetryOnClientError() async throws {
+        // Given an API call that fails with a 4xx carrying details the caller needs
+        let extraFields: [String: Any] = ["reason": "missing_required_data"]
+        let clientError = try MakeStripeAPIError(statusCode: 400, extraFields: extraFields)
+
+        do {
+            // When we poll
+            _ = try await apiClient.poll(
+                initialPollDelay: 0.01,
+                maxNumberOfRetries: 3,
+                retryInterval: 0.01,
+                sleepAction: { _ in
+                    self.tracker.sleepCallCount += 1
+                },
+                apiCall: {
+                    self.tracker.apiCallCount += 1
+                    throw clientError
+                }
+            )
+            XCTFail("Should throw an error")
+        } catch {
+            // Then the original error surfaces immediately, with its `extra_fields` intact,
+            // rather than being retried and replaced by `maxRetriesReached`
+            XCTAssertEqual(error.extraFields?["reason"] as? String, "missing_required_data")
+            XCTAssertEqual(self.tracker.apiCallCount, 1)
+            // only the initial poll delay, no retry intervals
+            XCTAssertEqual(self.tracker.sleepCallCount, 1)
+        }
+    }
+
+    func testPollRetriesOnServerError() async throws {
+        // Given an API call that fails with a 5xx, which may well succeed on retry
+        let maxRetries = 3
+        let serverError = try MakeStripeAPIError(statusCode: 500)
+
+        do {
+            // When we poll
+            _ = try await apiClient.poll(
+                initialPollDelay: 0.01,
+                maxNumberOfRetries: maxRetries,
+                retryInterval: 0.01,
+                sleepAction: { _ in
+                    self.tracker.sleepCallCount += 1
+                },
+                apiCall: {
+                    self.tracker.apiCallCount += 1
+                    throw serverError
+                }
+            )
+            XCTFail("Should throw an error")
+        } catch let error as FinancialConnectionsAsyncAPIClient.PollingError {
+            // Then we retry as usual
+            XCTAssertEqual(error, .maxRetriesReached)
+            XCTAssertEqual(self.tracker.apiCallCount, maxRetries)
+        } catch {
+            XCTFail("Wrong error type: \(error)")
+        }
+    }
+
     func testDefaultParameters() async throws {
         var callCount = 0
 

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsGenericErrorPaneTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsGenericErrorPaneTests.swift
@@ -1,0 +1,154 @@
+//
+//  FinancialConnectionsGenericErrorPaneTests.swift
+//  StripeFinancialConnectionsTests
+//
+//  Created by Mat Schmid on 2026-08-12.
+//
+
+import XCTest
+
+@_spi(STP) import StripeCore
+@testable @_spi(STP) import StripeFinancialConnections
+
+class FinancialConnectionsGenericErrorPaneTests: XCTestCase {
+
+    private enum TestError: Error {
+        case sampleError
+    }
+
+    private func extraFields(
+        overrides: [String: Any?] = [:]
+    ) -> [String: Any] {
+        var extraFields: [String: Any] = [
+            "reason": "missing_required_data",
+            "use_generic_error_pane": true,
+            "generic_error_pane_heading": "There was a problem accessing your account",
+            "generic_error_pane_subheading": "Please try again and be sure to select **Profile information**.",
+            "generic_error_pane_primary_cta": "Try again",
+            "generic_error_pane_primary_cta_action": "restart_auth_flow",
+            "generic_error_pane_icon_url": "https://b.stripecdn.com/icon.png",
+            "generic_error_pane_image": "https://b.stripecdn.com/image.png",
+        ]
+        for (key, value) in overrides {
+            if let value {
+                extraFields[key] = value
+            } else {
+                extraFields.removeValue(forKey: key)
+            }
+        }
+        return extraFields
+    }
+
+    func testParsesFullPayload() throws {
+        // Given an API error carrying a complete generic error pane
+        let error = try MakeStripeAPIError(statusCode: 400, extraFields: extraFields())
+
+        // When we extract the pane
+        let pane = FinancialConnectionsGenericErrorPane.from(error: error)
+
+        // Then every field is populated
+        XCTAssertEqual(pane?.heading, "There was a problem accessing your account")
+        XCTAssertEqual(pane?.subheading, "Please try again and be sure to select **Profile information**.")
+        XCTAssertEqual(pane?.primaryCta, "Try again")
+        XCTAssertEqual(pane?.primaryCtaAction, .restartAuthFlow)
+        XCTAssertEqual(pane?.iconUrl, "https://b.stripecdn.com/icon.png")
+        XCTAssertEqual(pane?.imageUrl, "https://b.stripecdn.com/image.png")
+    }
+
+    func testReturnsNilWhenNotOptedIn() throws {
+        // Given an API error that doesn't set `use_generic_error_pane`
+        let missing = try MakeStripeAPIError(
+            statusCode: 400,
+            extraFields: extraFields(overrides: ["use_generic_error_pane": nil])
+        )
+        // ...and one that explicitly opts out
+        let explicitlyFalse = try MakeStripeAPIError(
+            statusCode: 400,
+            extraFields: extraFields(overrides: ["use_generic_error_pane": false])
+        )
+
+        // Then neither produces a pane
+        XCTAssertNil(FinancialConnectionsGenericErrorPane.from(error: missing))
+        XCTAssertNil(FinancialConnectionsGenericErrorPane.from(error: explicitlyFalse))
+    }
+
+    func testReturnsNilWhenExtraFieldsAbsent() throws {
+        // Given an API error with no `extra_fields` at all
+        let error = try MakeStripeAPIError(statusCode: 400)
+
+        // Then there's no pane to show
+        XCTAssertNil(FinancialConnectionsGenericErrorPane.from(error: error))
+    }
+
+    func testReturnsNilForNonStripeError() {
+        // Given an error that didn't come from the API
+        // Then there's no pane to show
+        XCTAssertNil(FinancialConnectionsGenericErrorPane.from(error: TestError.sampleError))
+    }
+
+    func testReturnsNilWhenRequiredContentIsMissing() throws {
+        // Given errors that opt in but are missing content we need to render the pane
+        for missingKey in [
+            "generic_error_pane_heading",
+            "generic_error_pane_subheading",
+            "generic_error_pane_primary_cta",
+        ] {
+            let error = try MakeStripeAPIError(
+                statusCode: 400,
+                extraFields: extraFields(overrides: [missingKey: nil])
+            )
+
+            // Then we fall back rather than render a broken screen
+            XCTAssertNil(
+                FinancialConnectionsGenericErrorPane.from(error: error),
+                "Expected no pane when \(missingKey) is missing"
+            )
+        }
+    }
+
+    func testUnknownPrimaryCtaActionParsesAsNil() throws {
+        // Given a CTA action this version of the SDK doesn't know about
+        let error = try MakeStripeAPIError(
+            statusCode: 400,
+            extraFields: extraFields(overrides: ["generic_error_pane_primary_cta_action": "some_future_action"])
+        )
+
+        // When we extract the pane
+        let pane = FinancialConnectionsGenericErrorPane.from(error: error)
+
+        // Then the pane still renders, but with no action we can perform
+        XCTAssertNotNil(pane)
+        XCTAssertNil(pane?.primaryCtaAction)
+        XCTAssertEqual(pane?.heading, "There was a problem accessing your account")
+    }
+
+    func testMissingPrimaryCtaActionParsesAsNil() throws {
+        // Given no CTA action at all
+        let error = try MakeStripeAPIError(
+            statusCode: 400,
+            extraFields: extraFields(overrides: ["generic_error_pane_primary_cta_action": nil])
+        )
+
+        // Then the pane renders with no action we can perform
+        XCTAssertNil(FinancialConnectionsGenericErrorPane.from(error: error)?.primaryCtaAction)
+    }
+
+    func testOptionalImagesAreOptional() throws {
+        // Given a payload without an icon or an image, which the server may not send yet
+        let error = try MakeStripeAPIError(
+            statusCode: 400,
+            extraFields: extraFields(overrides: [
+                "generic_error_pane_icon_url": nil,
+                "generic_error_pane_image": nil,
+            ])
+        )
+
+        // When we extract the pane
+        let pane = FinancialConnectionsGenericErrorPane.from(error: error)
+
+        // Then it still renders, just without imagery
+        XCTAssertNotNil(pane)
+        XCTAssertNil(pane?.iconUrl)
+        XCTAssertNil(pane?.imageUrl)
+    }
+}

--- a/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsGenericErrorPaneTests.swift
+++ b/StripeFinancialConnections/StripeFinancialConnectionsTests/FinancialConnectionsGenericErrorPaneTests.swift
@@ -27,7 +27,7 @@ class FinancialConnectionsGenericErrorPaneTests: XCTestCase {
             "generic_error_pane_primary_cta": "Try again",
             "generic_error_pane_primary_cta_action": "restart_auth_flow",
             "generic_error_pane_icon_url": "https://b.stripecdn.com/icon.png",
-            "generic_error_pane_image": "https://b.stripecdn.com/image.png",
+            "generic_error_pane_image_url": "https://b.stripecdn.com/image.png",
         ]
         for (key, value) in overrides {
             if let value {
@@ -139,7 +139,7 @@ class FinancialConnectionsGenericErrorPaneTests: XCTestCase {
             statusCode: 400,
             extraFields: extraFields(overrides: [
                 "generic_error_pane_icon_url": nil,
-                "generic_error_pane_image": nil,
+                "generic_error_pane_image_url": nil,
             ])
         )
 


### PR DESCRIPTION
## Summary

Adds a new "Generic Error" pane to the Financial Connections flow. The pane is shown when the
`v1/connections/auth_sessions/accounts` API request errors (4xx) and contains the `extra_fields` in the response body, and `use_generic_error_pane` is  `true`. Here's a sample response (example request: https://admin.corp.stripe.com/request-log/req_J3igJnA2sFEAnb):

```json
{
  "error": {
    "extra_fields": {
      "reason": "missing_required_data",
      "use_generic_error_pane": true,
      "generic_error_pane_heading": "There was a problem accessing your account",
      "generic_error_pane_subheading": "Please try again and be sure to select **Profile information**.",
      "generic_error_pane_primary_cta": "Try again",
      "generic_error_pane_primary_cta_action": "restart_auth_flow",
      "generic_error_pane_icon_url": "https://b.stripecdn.com/connections-statics-srv/assets/BrandIcon--testmodePurpleOauth.svg",
      "generic_error_pane_image_url": "https://b.stripecdn.com/connections-statics-srv/assets/ErrorAsset--ownership-wellsfargo-2x.png"
    },
    "message": "Required data permissions were not granted during the authorization flow.",
    "type": "invalid_request_error"
  }
}
```

- Here is a doc that contains more details on this new pane: https://docs.google.com/document/d/1jm8agOCCBRgpAjgsF32k_sdPGfYhvzhADS1W5zddyO8/edit?tab=t.0#heading=h.15lgbps8bk3q
- Here is the PR that implemented the backend work: https://git.corp.stripe.com/stripe-internal/mint/pull/2408372
- Here are the mocks: https://www.figma.com/design/wGzeuVPIAdwFX4snwfHQkD/Bank-Flow-Updates--2026-?node-id=8110-13164&t=fT8sOzYDIhjrGZRM-4

<details>
  <summary>Implementation</summary>
  
  Here is the prompt I used to implement this:

```md
We'd like to introduce a new pane in our StripeFinancialConnections flow, we can name it "GenericError" if that doesn't exist already. The pane is shown when the
v1/connections/auth_sessions/accounts API request errors (4xx) and contains the `extra_fields` in the response body, and `use_generic_error_pane: true`. Here's a sample response:


{
  "error": {
    "extra_fields": {
      "reason": "missing_required_data",
      "use_generic_error_pane": true,
      "generic_error_pane_heading": "There was a problem accessing your account",
      "generic_error_pane_subheading": "Please try again and be sure to select **Profile information**.",
      "generic_error_pane_primary_cta": "Try again",
      "generic_error_pane_primary_cta_action": "restart_auth_flow",
      "generic_error_pane_icon_url": "https://b.stripecdn.com/connections-statics-srv/assets/BrandIcon--testmodePurpleOauth.svg"
    },
    "message": "Required data permissions were not granted during the authorization flow.",
    "type": "invalid_request_error"
  }
}

Here is a doc that might contain more details on this new pane: https://docs.google.com/document/d/1jm8agOCCBRgpAjgsF32k_sdPGfYhvzhADS1W5zddyO8/edit?tab=t.0#heading=h.15lgbps8bk3q, and the PR
that implemented the backend work: https://git.corp.stripe.com/stripe-internal/mint/pull/2408372, which might be helpful in understanding the response shape.

As for designs, here are the mocks: https://www.figma.com/design/wGzeuVPIAdwFX4snwfHQkD/Bank-Flow-Updates--2026-?node-id=8110-13164&t=fT8sOzYDIhjrGZRM-4, it will be presented using the standard
base FC view controller (which makes use of FinancialConnectionsNavigationController), so we don't need to worry about the header. You should be able to derive what each field in the API response
belongs where in the mockups I shared. Note that we haven't added the image to the response yet, but that's coming soon.

Here's another thing, when `generic_error_pane_primary_cta_action` is `restart_auth_flow` (the only possible enum case now), we need to make a new auth session and relaunch the bank's OAuth
flow. It should ideally reuses the logic from the early auth pane to open the oauth window (and get the URL for that). When `generic_error_pane_primary_cta_action` is a case we don't know how to
handle, the CTA should probably be "Chose another bank" and the action should be to present the institution picker screen.
```
  
</details>

## Motivation

https://docs.google.com/document/d/1jm8agOCCBRgpAjgsF32k_sdPGfYhvzhADS1W5zddyO8/edit?tab=t.0#heading=h.15lgbps8bk3q

## Testing

Flow:

https://github.com/user-attachments/assets/00911bcc-d23e-43e5-8c29-f563b782c654

Xcode preview with different states:

https://github.com/user-attachments/assets/c28a49f2-b4ba-401b-aa16-4e05006c9d6b

## Changelog

N/a