### PR TITLE
[Identity] Hide Merchant Icon

### DIFF
--- a/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
+++ b/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
@@ -45,7 +45,7 @@ class PlaygroundViewController: UIViewController {
     @IBOutlet weak var phoneOtpContainerView: UIStackView!
 
     @IBOutlet weak var fallbackToDocumentSwitch: UISwitch!
-    private let hideBiometricConsentIconSwitch = UISwitch()
+    private let hideWelcomeBrandingHeaderSwitch = UISwitch()
     private let phoneElement: PhoneNumberElement
 
     private let phoneView: UIView
@@ -141,7 +141,7 @@ class PlaygroundViewController: UIViewController {
         verifyButton.addTarget(self, action: #selector(didTapVerifyButton), for: .touchUpInside)
         // TODO(ccen) enable phoneOtpContainerView when backend adds support to PII
         phoneOtpContainerView.isHidden = true
-        addHideBiometricConsentIconSwitch()
+        addBiometricConfigurationSection()
         didChangeNewOrReuse(self)
     }
 
@@ -364,9 +364,9 @@ class PlaygroundViewController: UIViewController {
         var configuration = IdentityVerificationSheet.Configuration(
             brandLogo: UIImage(named: "BrandLogo")!
         )
-        if hideBiometricConsentIconSwitch.isOn {
+        if hideWelcomeBrandingHeaderSwitch.isOn {
             configuration.biometricConsent = .init(
-                showsIcon: false
+                hideBrandingHeader: true
             )
         }
 
@@ -430,22 +430,43 @@ class PlaygroundViewController: UIViewController {
         #endif
     }
 
-    private func addHideBiometricConsentIconSwitch() {
-        let label = UILabel()
-        label.text = "Hide merchant icon"
-        label.adjustsFontForContentSizeCategory = true
+    private func addBiometricConfigurationSection() {
+        let sectionLabel = UILabel()
+        sectionLabel.text = "Biometric configuration:"
+        sectionLabel.adjustsFontForContentSizeCategory = true
 
-        hideBiometricConsentIconSwitch.isOn = false
-        hideBiometricConsentIconSwitch.setContentHuggingPriority(.required, for: .horizontal)
+        let toggleLabel = UILabel()
+        toggleLabel.text = "Hide welcome branding header"
+        toggleLabel.adjustsFontForContentSizeCategory = true
 
-        let stackView = UIStackView(arrangedSubviews: [
-            label,
-            hideBiometricConsentIconSwitch,
+        hideWelcomeBrandingHeaderSwitch.isOn = false
+        hideWelcomeBrandingHeaderSwitch.setContentHuggingPriority(.required, for: .horizontal)
+
+        let toggleStackView = UIStackView(arrangedSubviews: [
+            toggleLabel,
+            hideWelcomeBrandingHeaderSwitch,
         ])
-        stackView.axis = .horizontal
-        stackView.alignment = .center
-        stackView.spacing = 8
-        nativeComponentsOptionsContainerView.addArrangedSubview(stackView)
+        toggleStackView.axis = .horizontal
+        toggleStackView.alignment = .center
+        toggleStackView.spacing = 8
+
+        let toggleContainerView = UIView()
+        toggleStackView.translatesAutoresizingMaskIntoConstraints = false
+        toggleContainerView.addSubview(toggleStackView)
+        NSLayoutConstraint.activate([
+            toggleStackView.topAnchor.constraint(equalTo: toggleContainerView.topAnchor),
+            toggleStackView.leadingAnchor.constraint(equalTo: toggleContainerView.leadingAnchor, constant: 16),
+            toggleStackView.trailingAnchor.constraint(equalTo: toggleContainerView.trailingAnchor),
+            toggleStackView.bottomAnchor.constraint(equalTo: toggleContainerView.bottomAnchor),
+        ])
+
+        let sectionStackView = UIStackView(arrangedSubviews: [
+            sectionLabel,
+            toggleContainerView,
+        ])
+        sectionStackView.axis = .vertical
+        sectionStackView.spacing = 8
+        nativeComponentsOptionsContainerView.addArrangedSubview(sectionStackView)
     }
 
     @IBAction func didChangeVerificationType(_ sender: Any) {

--- a/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
+++ b/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Mel Ludowise on 3/3/21.
 //
 
-import StripeIdentity
+@_spi(STP) import StripeIdentity
 @_spi(STP) import StripeUICore
 import UIKit
 
@@ -45,6 +45,7 @@ class PlaygroundViewController: UIViewController {
     @IBOutlet weak var phoneOtpContainerView: UIStackView!
 
     @IBOutlet weak var fallbackToDocumentSwitch: UISwitch!
+    private let hideBiometricConsentIconSwitch = UISwitch()
     private let phoneElement: PhoneNumberElement
 
     private let phoneView: UIView
@@ -140,6 +141,7 @@ class PlaygroundViewController: UIViewController {
         verifyButton.addTarget(self, action: #selector(didTapVerifyButton), for: .touchUpInside)
         // TODO(ccen) enable phoneOtpContainerView when backend adds support to PII
         phoneOtpContainerView.isHidden = true
+        addHideBiometricConsentIconSwitch()
         didChangeNewOrReuse(self)
     }
 
@@ -359,12 +361,19 @@ class PlaygroundViewController: UIViewController {
             assertionFailure("Did not receive a valid ephemeral key secret.")
             return
         }
+        var configuration = IdentityVerificationSheet.Configuration(
+            brandLogo: UIImage(named: "BrandLogo")!
+        )
+        if hideBiometricConsentIconSwitch.isOn {
+            configuration.biometricConsent = .init(
+                showsIcon: false
+            )
+        }
+
         self.verificationSheet = IdentityVerificationSheet(
             verificationSessionId: verificationSessionId,
             ephemeralKeySecret: ephemeralKeySecret,
-            configuration: IdentityVerificationSheet.Configuration(
-                brandLogo: UIImage(named: "BrandLogo")!
-            )
+            configuration: configuration
         )
     }
 
@@ -419,6 +428,24 @@ class PlaygroundViewController: UIViewController {
             IdentityVerificationSheet.simulatorSelfieCameraImages = [selfieImage]
         }
         #endif
+    }
+
+    private func addHideBiometricConsentIconSwitch() {
+        let label = UILabel()
+        label.text = "Hide merchant icon"
+        label.adjustsFontForContentSizeCategory = true
+
+        hideBiometricConsentIconSwitch.isOn = false
+        hideBiometricConsentIconSwitch.setContentHuggingPriority(.required, for: .horizontal)
+
+        let stackView = UIStackView(arrangedSubviews: [
+            label,
+            hideBiometricConsentIconSwitch,
+        ])
+        stackView.axis = .horizontal
+        stackView.alignment = .center
+        stackView.spacing = 8
+        nativeComponentsOptionsContainerView.addArrangedSubview(stackView)
     }
 
     @IBAction func didChangeVerificationType(_ sender: Any) {

--- a/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
+++ b/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Mel Ludowise on 3/3/21.
 //
 
-@_spi(STP) import StripeIdentity
+import StripeIdentity
 @_spi(STP) import StripeUICore
 import UIKit
 
@@ -45,7 +45,6 @@ class PlaygroundViewController: UIViewController {
     @IBOutlet weak var phoneOtpContainerView: UIStackView!
 
     @IBOutlet weak var fallbackToDocumentSwitch: UISwitch!
-    private let hideWelcomeBrandingHeaderSwitch = UISwitch()
     private let phoneElement: PhoneNumberElement
 
     private let phoneView: UIView
@@ -141,7 +140,6 @@ class PlaygroundViewController: UIViewController {
         verifyButton.addTarget(self, action: #selector(didTapVerifyButton), for: .touchUpInside)
         // TODO(ccen) enable phoneOtpContainerView when backend adds support to PII
         phoneOtpContainerView.isHidden = true
-        addBiometricConfigurationSection()
         didChangeNewOrReuse(self)
     }
 
@@ -361,19 +359,12 @@ class PlaygroundViewController: UIViewController {
             assertionFailure("Did not receive a valid ephemeral key secret.")
             return
         }
-        var configuration = IdentityVerificationSheet.Configuration(
-            brandLogo: UIImage(named: "BrandLogo")!
-        )
-        if hideWelcomeBrandingHeaderSwitch.isOn {
-            configuration.biometricConsent = .init(
-                hideBrandingHeader: true
-            )
-        }
-
         self.verificationSheet = IdentityVerificationSheet(
             verificationSessionId: verificationSessionId,
             ephemeralKeySecret: ephemeralKeySecret,
-            configuration: configuration
+            configuration: IdentityVerificationSheet.Configuration(
+                brandLogo: UIImage(named: "BrandLogo")!
+            )
         )
     }
 
@@ -428,45 +419,6 @@ class PlaygroundViewController: UIViewController {
             IdentityVerificationSheet.simulatorSelfieCameraImages = [selfieImage]
         }
         #endif
-    }
-
-    private func addBiometricConfigurationSection() {
-        let sectionLabel = UILabel()
-        sectionLabel.text = "Biometric configuration:"
-        sectionLabel.adjustsFontForContentSizeCategory = true
-
-        let toggleLabel = UILabel()
-        toggleLabel.text = "Hide welcome branding header"
-        toggleLabel.adjustsFontForContentSizeCategory = true
-
-        hideWelcomeBrandingHeaderSwitch.isOn = false
-        hideWelcomeBrandingHeaderSwitch.setContentHuggingPriority(.required, for: .horizontal)
-
-        let toggleStackView = UIStackView(arrangedSubviews: [
-            toggleLabel,
-            hideWelcomeBrandingHeaderSwitch,
-        ])
-        toggleStackView.axis = .horizontal
-        toggleStackView.alignment = .center
-        toggleStackView.spacing = 8
-
-        let toggleContainerView = UIView()
-        toggleStackView.translatesAutoresizingMaskIntoConstraints = false
-        toggleContainerView.addSubview(toggleStackView)
-        NSLayoutConstraint.activate([
-            toggleStackView.topAnchor.constraint(equalTo: toggleContainerView.topAnchor),
-            toggleStackView.leadingAnchor.constraint(equalTo: toggleContainerView.leadingAnchor, constant: 16),
-            toggleStackView.trailingAnchor.constraint(equalTo: toggleContainerView.trailingAnchor),
-            toggleStackView.bottomAnchor.constraint(equalTo: toggleContainerView.bottomAnchor),
-        ])
-
-        let sectionStackView = UIStackView(arrangedSubviews: [
-            sectionLabel,
-            toggleContainerView,
-        ])
-        sectionStackView.axis = .vertical
-        sectionStackView.spacing = 8
-        nativeComponentsOptionsContainerView.addArrangedSubview(sectionStackView)
     }
 
     @IBAction func didChangeVerificationType(_ sender: Any) {

--- a/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
+++ b/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
@@ -27,16 +27,16 @@ final public class IdentityVerificationSheet {
     public struct Configuration {
         /// Configuration for the biometric consent screen's header.
         @_spi(STP) public struct BiometricConsentConfiguration {
-            /// Whether to display the brand icon above the consent title.
-            public var showsIcon: Bool
+            /// Whether to hide the branding header above the consent title.
+            public var hideBrandingHeader: Bool
 
             /// Initializes a biometric consent header configuration.
             /// - Parameters:
-            ///   - showsIcon: Whether to display the brand icon above the consent title.
+            ///   - hideBrandingHeader: Whether to hide the branding header above the consent title.
             public init(
-                showsIcon: Bool
+                hideBrandingHeader: Bool
             ) {
-                self.showsIcon = showsIcon
+                self.hideBrandingHeader = hideBrandingHeader
             }
         }
 

--- a/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
+++ b/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
@@ -25,12 +25,32 @@ final public class IdentityVerificationSheet {
 
     /// Configuration for an IdentityVerificationSheet
     public struct Configuration {
+        /// Configuration for the biometric consent screen's header.
+        @_spi(STP) public struct BiometricConsentConfiguration {
+            /// Whether to display the brand icon above the consent title.
+            public var showsIcon: Bool
+
+            /// Initializes a biometric consent header configuration.
+            /// - Parameters:
+            ///   - showsIcon: Whether to display the brand icon above the consent title.
+            public init(
+                showsIcon: Bool
+            ) {
+                self.showsIcon = showsIcon
+            }
+        }
+
         /// An image of your customer-facing business logo.
         ///
         /// - Note: The recommended image size is 32 x 32 points. The image will be
         /// displayed in both light and dark modes, if the app supports it. Use a
         /// dynamic UIImage to support different images in light vs dark mode.
         public var brandLogo: UIImage
+
+        /// Configuration for the biometric consent screen's header.
+        ///
+        /// When `nil`, the biometric consent screen uses the default header.
+        @_spi(STP) public var biometricConsent: BiometricConsentConfiguration?
 
         /// Initializes a Configuration.
         /// - Parameters:
@@ -41,6 +61,7 @@ final public class IdentityVerificationSheet {
             brandLogo: UIImage
         ) {
             self.brandLogo = brandLogo
+            self.biometricConsent = nil
         }
     }
 
@@ -91,7 +112,7 @@ final public class IdentityVerificationSheet {
                     ephemeralKeySecret: ephemeralKeySecret
                 ),
                 flowController: VerificationSheetFlowController(
-                    brandLogo: configuration.brandLogo
+                    configuration: configuration
                 ),
                 mlModelLoader: IdentityMLModelLoader(),
                 analyticsClient: IdentityAnalyticsClient(

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -83,6 +83,7 @@ protocol VerificationSheetFlowControllerProtocol: AnyObject {
 final class VerificationSheetFlowController: NSObject {
 
     let brandLogo: UIImage
+    let biometricConsentConfiguration: IdentityVerificationSheet.Configuration.BiometricConsentConfiguration?
 
     weak var delegate: VerificationSheetFlowControllerDelegate?
 
@@ -96,6 +97,14 @@ final class VerificationSheetFlowController: NSObject {
         brandLogo: UIImage
     ) {
         self.brandLogo = brandLogo
+        self.biometricConsentConfiguration = nil
+    }
+
+    init(
+        configuration: IdentityVerificationSheet.Configuration
+    ) {
+        self.brandLogo = configuration.brandLogo
+        self.biometricConsentConfiguration = configuration.biometricConsent
     }
 
     private(set) lazy var navigationController: UINavigationController = {
@@ -633,6 +642,7 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
                 brandLogo: brandLogo,
                 showsStripeLogo: !staticContent.isStripe,
                 consentContent: staticContent.biometricConsent,
+                configuration: biometricConsentConfiguration,
                 sheetController: sheetController
             )
         } catch {

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -94,13 +94,6 @@ final class VerificationSheetFlowController: NSObject {
     private(set) var documentUploader: DocumentUploaderProtocol?
 
     init(
-        brandLogo: UIImage
-    ) {
-        self.brandLogo = brandLogo
-        self.biometricConsentConfiguration = nil
-    }
-
-    init(
         configuration: IdentityVerificationSheet.Configuration
     ) {
         self.brandLogo = configuration.brandLogo

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/BiometricConsentViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/BiometricConsentViewController.swift
@@ -26,6 +26,7 @@ final class BiometricConsentViewController: IdentityFlowViewController {
     let brandLogo: UIImage
     let showsStripeLogo: Bool
     let consentContent: StripeAPI.VerificationPageStaticContentConsentPage
+    let configuration: IdentityVerificationSheet.Configuration.BiometricConsentConfiguration?
 
     struct Style {
         static let contentHorizontalPadding: CGFloat = 32
@@ -102,7 +103,19 @@ final class BiometricConsentViewController: IdentityFlowViewController {
             headerViewModel: .init(
                 backgroundColor: .systemBackground,
                 headerType: {
-                    if sheetController?.flowController.visitedIndividualWelcomePage == true {
+                    if let configuration {
+                        guard configuration.showsIcon else {
+                            return .plain
+                        }
+                        return .banner(
+                            iconViewModel: .init(
+                                iconType: showsStripeLogo ? .brand : .plain,
+                                iconImage: brandLogo,
+                                iconImageContentMode: .scaleToFill,
+                                useLargeIcon: true
+                            )
+                        )
+                    } else if sheetController?.flowController.visitedIndividualWelcomePage == true {
                         // If visited individual page, this is a fallback. Don't show icons
                         return .plain
                     } else {
@@ -133,11 +146,13 @@ final class BiometricConsentViewController: IdentityFlowViewController {
         brandLogo: UIImage,
         showsStripeLogo: Bool,
         consentContent: StripeAPI.VerificationPageStaticContentConsentPage,
+        configuration: IdentityVerificationSheet.Configuration.BiometricConsentConfiguration? = nil,
         sheetController: VerificationSheetControllerProtocol
     ) throws {
         self.brandLogo = brandLogo
         self.showsStripeLogo = showsStripeLogo
         self.consentContent = consentContent
+        self.configuration = configuration
         super.init(sheetController: sheetController, analyticsScreenName: .biometricConsent)
 
         // Set up the content stack view with both main content and privacy policy

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/BiometricConsentViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/BiometricConsentViewController.swift
@@ -104,7 +104,7 @@ final class BiometricConsentViewController: IdentityFlowViewController {
                 backgroundColor: .systemBackground,
                 headerType: {
                     if let configuration {
-                        guard configuration.showsIcon else {
+                        guard !configuration.hideBrandingHeader else {
                             return .plain
                         }
                         return .banner(

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/BiometricConsentViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/BiometricConsentViewController.swift
@@ -103,20 +103,9 @@ final class BiometricConsentViewController: IdentityFlowViewController {
             headerViewModel: .init(
                 backgroundColor: .systemBackground,
                 headerType: {
-                    if let configuration {
-                        guard !configuration.hideBrandingHeader else {
-                            return .plain
-                        }
-                        return .banner(
-                            iconViewModel: .init(
-                                iconType: showsStripeLogo ? .brand : .plain,
-                                iconImage: brandLogo,
-                                iconImageContentMode: .scaleToFill,
-                                useLargeIcon: true
-                            )
-                        )
-                    } else if sheetController?.flowController.visitedIndividualWelcomePage == true {
-                        // If visited individual page, this is a fallback. Don't show icons
+                    if configuration?.hideBrandingHeader == true
+                        || sheetController?.flowController.visitedIndividualWelcomePage == true
+                    {
                         return .plain
                     } else {
                         // Otherwise this is the first screen, show icons

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
@@ -22,7 +22,9 @@ final class VerificationSheetFlowControllerTest: XCTestCase {
         [.biometricConsent], [.idDocumentFront, .idDocumentBack],
     ]
 
-let flowController = VerificationSheetFlowController(brandLogo: UIImage())
+let flowController = VerificationSheetFlowController(
+    configuration: .init(brandLogo: UIImage())
+)
     var mockMLModelLoader: IdentityMLModelLoaderMock!
     var mockSheetController: VerificationSheetControllerMock!
 

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/Coordinators/VerificationSheetFlowControllerTest.swift
@@ -22,9 +22,9 @@ final class VerificationSheetFlowControllerTest: XCTestCase {
         [.biometricConsent], [.idDocumentFront, .idDocumentBack],
     ]
 
-let flowController = VerificationSheetFlowController(
-    configuration: .init(brandLogo: UIImage())
-)
+    let flowController = VerificationSheetFlowController(
+        configuration: .init(brandLogo: UIImage())
+    )
     var mockMLModelLoader: IdentityMLModelLoaderMock!
     var mockSheetController: VerificationSheetControllerMock!
 


### PR DESCRIPTION
## Summary
Adds a config param for hiding the merchant provided icon on the biometric consent screen. Using an @_spi annotation as this is only intended for use internally for now.

## Motivation
Allow client apps to remove the icon header shown on the biometric screen based on design preference.

## Testing
Added this property to the playground and demo'd showing and hiding the provided icon.

## Demo

Note this demo is recorded with a toggle added to the playground for easy demoing. This code wasn't added to this branch as we don't need to expose this users.

https://github.com/user-attachments/assets/fa4642eb-642e-4798-972d-7d883da30f0a



