### PR TITLE
Add LinkConfiguration.Display.walletButtonHidden case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ MINOR
 ### PaymentSheet
 * [Added] StripePaymentSheet now depends on `StripeFinancialConnectionsLite` to support lightweight bank payment flows. If you use StripePaymentSheet with Carthage or by manually embedding the .xcframeworks, [you must also embed StripeFinancialConnectionsLite.xcframework](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md#migrating-from-versions--2670) in your app. No action is required for CocoaPods or Swift Package Manager users.
 * [Changed] Address autocomplete results sourced from internal service.
-* [Added] Added `PaymentSheet.LinkConfiguration.Display.hidden`, which keeps Link enabled but hides its button from the payment element UI (private preview).
+* [Added] Added `PaymentSheet.LinkConfiguration.Display.walletButtonHidden`, which keeps Link enabled but hides its button from the payment element UI.
 
 ### AddressElement
 * [Changed] Address autocomplete results sourced from internal service.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ MINOR
 ### PaymentSheet
 * [Added] StripePaymentSheet now depends on `StripeFinancialConnectionsLite` to support lightweight bank payment flows. If you use StripePaymentSheet with Carthage or by manually embedding the .xcframeworks, [you must also embed StripeFinancialConnectionsLite.xcframework](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md#migrating-from-versions--2670) in your app. No action is required for CocoaPods or Swift Package Manager users.
 * [Changed] Address autocomplete results sourced from internal service.
+* [Added] Added `PaymentSheet.LinkConfiguration.Display.hidden`, which keeps Link enabled but hides its button from the payment element UI (private preview).
 
 ### AddressElement
 * [Changed] Address autocomplete results sourced from internal service.

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -321,6 +321,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
 
         case automatic
         case never
+        case hidden
     }
 
     enum ForceOnelink: String, PickerEnum {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PaymentSheetTestPlaygroundSettings.swift
@@ -321,7 +321,7 @@ struct PaymentSheetTestPlaygroundSettings: Codable, Equatable {
 
         case automatic
         case never
-        case hidden
+        case walletButtonHidden
     }
 
     enum ForceOnelink: String, PickerEnum {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -14,7 +14,7 @@ import Contacts
 import PassKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
-@_spi(STP) @_spi(PaymentSheetSkipConfirmation) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
+@_spi(STP) @_spi(PaymentSheetSkipConfirmation) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CardFundingFilteringPrivatePreview) @_spi(LinkHiddenWalletButtonPreview) import StripePaymentSheet
 import SwiftUI
 import UIKit
 
@@ -143,6 +143,8 @@ import UIKit
             return PaymentSheet.LinkConfiguration(display: .automatic, brand: brand)
         case .never:
             return PaymentSheet.LinkConfiguration(display: .never, brand: brand)
+        case .hidden:
+            return PaymentSheet.LinkConfiguration(display: .hidden, brand: brand)
         }
     }
     var customerConfiguration: PaymentSheet.CustomerConfiguration? {

--- a/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/PlaygroundController.swift
@@ -14,7 +14,7 @@ import Contacts
 import PassKit
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
-@_spi(STP) @_spi(PaymentSheetSkipConfirmation) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CardFundingFilteringPrivatePreview) @_spi(LinkHiddenWalletButtonPreview) import StripePaymentSheet
+@_spi(STP) @_spi(PaymentSheetSkipConfirmation) @_spi(ExperimentalAllowsRemovalOfLastSavedPaymentMethodAPI) @_spi(PaymentMethodOptionsSetupFutureUsagePreview) @_spi(CardFundingFilteringPrivatePreview) import StripePaymentSheet
 import SwiftUI
 import UIKit
 
@@ -143,8 +143,8 @@ import UIKit
             return PaymentSheet.LinkConfiguration(display: .automatic, brand: brand)
         case .never:
             return PaymentSheet.LinkConfiguration(display: .never, brand: brand)
-        case .hidden:
-            return PaymentSheet.LinkConfiguration(display: .hidden, brand: brand)
+        case .walletButtonHidden:
+            return PaymentSheet.LinkConfiguration(display: .walletButtonHidden, brand: brand)
         }
     }
     var customerConfiguration: PaymentSheet.CustomerConfiguration? {

--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -277,6 +277,8 @@
 				"zh-Hans",
 				"zh-Hant",
 				Base,
+				"nn-NO",
+				th,
 			);
 			mainGroup = 7879CBA341D7E807714A831B;
 			packageReferences = (

--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -277,8 +277,6 @@
 				"zh-Hans",
 				"zh-Hant",
 				Base,
-				"nn-NO",
-				th,
 			);
 			mainGroup = 7879CBA341D7E807714A831B;
 			packageReferences = (

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -33,7 +33,7 @@ extension EmbeddedPaymentElement {
         // - Only restored if the previous input resulted in a completed form i.e. partial or invalid input is still discarded
 
         let shouldShowApplePay = PaymentSheet.isApplePayEnabled(elementsSession: loadResult.elementsSession, configuration: configuration)
-        let shouldShowLink = PaymentSheet.isLinkEnabled(elementsSession: loadResult.elementsSession, configuration: configuration)
+        let shouldShowLink = PaymentSheet.shouldShowLinkButton(elementsSession: loadResult.elementsSession, configuration: configuration)
         let savedPaymentMethodAccessoryType = RowButton.RightAccessoryButton.getAccessoryButtonType(
             savedPaymentMethodsCount: loadResult.savedPaymentMethods.count,
             isFirstCardCoBranded: loadResult.savedPaymentMethods.first?.isCoBrandedCard ?? false,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement.swift
@@ -237,7 +237,7 @@ public final class EmbeddedPaymentElement {
                 case .applePay:
                     return PaymentSheet.isApplePayEnabled(elementsSession: loadResult.elementsSession, configuration: configuration)
                 case .link:
-                    return PaymentSheet.isLinkEnabled(elementsSession: loadResult.elementsSession, configuration: configuration)
+                    return PaymentSheet.shouldShowLinkButton(elementsSession: loadResult.elementsSession, configuration: configuration)
                 case .saved(paymentMethod: let paymentMethod, confirmParams: _):
                     return loadResult.savedPaymentMethods.contains(paymentMethod)
                 case .new(confirmParams: let confirmParams):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -83,6 +83,12 @@ extension PaymentSheet {
         return linkDisabledReasons(elementsSession: elementsSession, configuration: configuration).isEmpty
     }
 
+    /// Canonical source of truth for whether the Link button/row should be rendered in the payment element UI.
+    /// Link may remain functionally enabled (see `isLinkEnabled`) even when its button is hidden, e.g. to support automatic Link verification without a visible entry point.
+    static func shouldShowLinkButton(elementsSession: STPElementsSession, configuration: PaymentElementConfiguration) -> Bool {
+        return isLinkEnabled(elementsSession: elementsSession, configuration: configuration) && configuration.link.shouldShowButton
+    }
+
     /// Canonical source of truth for reasons why Link is disabled
     static func linkDisabledReasons(elementsSession: STPElementsSession, configuration: PaymentElementConfiguration) -> [LinkDisabledReason] {
         var reasons = [LinkDisabledReason]()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -512,14 +512,24 @@ extension PaymentSheet {
         public enum Display: String {
             /// Link will be displayed when available.
             case automatic
-            /// Link will never be displayed.
+            /// Link will never be displayed, and will not be enabled.
             case never
+            /// Link remains enabled (e.g. for automatic Link verification, Instant Bank Payments, Link Card Brand, and inline signup)
+            /// but its button/row will not be shown in the payment element UI.
+            @_spi(LinkHiddenWalletButtonPreview) case hidden
         }
 
         var shouldDisplay: Bool {
             switch display {
-            case .automatic: true
+            case .automatic, .hidden: true
             case .never: false
+            }
+        }
+
+        var shouldShowButton: Bool {
+            switch display {
+            case .automatic: true
+            case .hidden, .never: false
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -512,7 +512,7 @@ extension PaymentSheet {
         public enum Display: String {
             /// Link will be displayed when available.
             case automatic
-            /// Link will never be displayed, and will not be enabled.
+            /// Link will never be displayed.
             case never
             /// Link remains enabled (e.g. for automatic Link verification, Instant Bank Payments, Link Card Brand, and inline signup)
             /// but its button/row will not be shown in the payment element UI.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -516,12 +516,12 @@ extension PaymentSheet {
             case never
             /// Link remains enabled (e.g. for automatic Link verification, Instant Bank Payments, Link Card Brand, and inline signup)
             /// but its button/row will not be shown in the payment element UI.
-            @_spi(LinkHiddenWalletButtonPreview) case hidden
+            case walletButtonHidden
         }
 
         var shouldDisplay: Bool {
             switch display {
-            case .automatic, .hidden: true
+            case .automatic, .walletButtonHidden: true
             case .never: false
             }
         }
@@ -529,7 +529,7 @@ extension PaymentSheet {
         var shouldShowButton: Bool {
             switch display {
             case .automatic: true
-            case .hidden, .never: false
+            case .walletButtonHidden, .never: false
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetLoader.swift
@@ -104,7 +104,7 @@ final class PaymentSheetLoader {
             let elementsSessionAndIntent = try await elementsSessionAndIntentTask.value
             let intent = elementsSessionAndIntent.intent
             let elementsSession = elementsSessionAndIntent.elementsSession
-            let (isLinkEnabled, didLinkLookupTimeOut) = await loadLink(
+            let (_, didLinkLookupTimeOut) = await loadLink(
                 elementsSession: elementsSession,
                 configuration: configuration,
                 analyticsHelper: analyticsHelper,
@@ -169,7 +169,7 @@ final class PaymentSheetLoader {
                 savedPaymentMethods: filteredSavedPaymentMethods,
                 customerID: configuration.customer?.id,
                 showApplePay: integrationShape.canDefaultToLinkOrApplePay ? isApplePayEnabled : false,
-                showLink: integrationShape.canDefaultToLinkOrApplePay ? isLinkEnabled : false,
+                showLink: integrationShape.canDefaultToLinkOrApplePay ? PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration) : false,
                 elementsSession: elementsSession,
                 defaultPaymentMethod: elementsSession.customer?.getDefaultPaymentMethod()
             )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -182,7 +182,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
         self.walletButtonsShownExternally = walletButtonsViewState.isVisible
         self.shouldShowApplePayInList = PaymentSheet.isApplePayEnabled(elementsSession: elementsSession, configuration: configuration) && isFlowController && Self.walletButtonsViewAllowsExpressType(.applePay, walletButtonsViewState: walletButtonsViewState, configuration: configuration)
         // Edge case: If Apple Pay isn't in the list, show Link as a wallet button and not in the list
-        self.shouldShowLinkInList = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration) && isFlowController && (shouldShowApplePayInList || walletButtonsViewState.showApplePay) && Self.walletButtonsViewAllowsExpressType(.link, walletButtonsViewState: walletButtonsViewState, configuration: configuration)
+        self.shouldShowLinkInList = PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration) && isFlowController && (shouldShowApplePayInList || walletButtonsViewState.showApplePay) && Self.walletButtonsViewAllowsExpressType(.link, walletButtonsViewState: walletButtonsViewState, configuration: configuration)
         self.analyticsHelper = analyticsHelper
         super.init(nibName: nil, bundle: nil)
         // Link can be the customer's default even when it is rendered as a wallet button instead of a selected row.
@@ -220,7 +220,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
             && !configuration.willUseWalletButtonsView {
             walletOptions.insert(.applePay)
         }
-        if PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
+        if PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration)
             && !shouldShowLinkInList
             && !walletButtonsShownExternally
             && !configuration.willUseWalletButtonsView {
@@ -621,7 +621,7 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
             visiblePaymentMethods.append(RowButtonType.applePay.analyticsIdentifier)
         }
         // if Link is showing as an express button
-        if PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration), !shouldShowLinkInList {
+        if PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration), !shouldShowLinkInList {
             visiblePaymentMethods.append(RowButtonType.link.analyticsIdentifier)
         }
         paymentMethodListViewController?.rowButtons.forEach { rowButton in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -193,7 +193,7 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
         self.elementsSession = loadResult.elementsSession
         self.checkout = checkout
         self.isApplePayEnabled = PaymentSheet.isApplePayEnabled(elementsSession: elementsSession, configuration: configuration)
-        self.isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
+        self.isLinkEnabled = PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration)
         self.couldShowLinkInHeader = isLinkEnabled && !isApplePayEnabled
         self.configuration = configuration
         self.analyticsHelper = analyticsHelper

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetViewController.swift
@@ -156,7 +156,7 @@ class PaymentSheetViewController: UIViewController, PaymentSheetViewControllerPr
         self.elementsSession = loadResult.elementsSession
         self.configuration = configuration
         self.isApplePayEnabled = PaymentSheet.isApplePayEnabled(elementsSession: elementsSession, configuration: configuration)
-        self.isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
+        self.isLinkEnabled = PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration)
         self.isCVCRecollectionEnabled = isCVCRecollectionEnabled
         self.delegate = delegate
         self.savedPaymentOptionsViewController = SavedPaymentOptionsViewController(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/WalletButtonsView/WalletButtonsView.swift
@@ -98,7 +98,7 @@ typealias ExpressType = PaymentSheet.WalletButtonsVisibility.ExpressType
         for type in flowController.elementsSession.orderedPaymentMethodTypesAndWallets {
             switch type {
             case "link":
-                if PaymentSheet.isLinkEnabled(elementsSession: flowController.elementsSession, configuration: flowController.configuration) {
+                if PaymentSheet.shouldShowLinkButton(elementsSession: flowController.elementsSession, configuration: flowController.configuration) {
                     appendIfAllowed(.link)
                 }
             case "apple_pay":
@@ -110,7 +110,7 @@ typealias ExpressType = PaymentSheet.WalletButtonsVisibility.ExpressType
             }
         }
 
-        if flowController.elementsSession.linkPassthroughModeEnabled && PaymentSheet.isLinkEnabled(elementsSession: flowController.elementsSession, configuration: flowController.configuration) {
+        if flowController.elementsSession.linkPassthroughModeEnabled && PaymentSheet.shouldShowLinkButton(elementsSession: flowController.elementsSession, configuration: flowController.configuration) {
             // Link in passthrough mode won't be in `orderedPaymentMethodTypesAndWallets`, so we append it.
             appendIfAllowed(.link)
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
@@ -7,7 +7,7 @@
 
 @testable @_spi(STP) import StripeCore
 @testable @_spi(STP) import StripePayments
-@testable @_spi(STP) import StripePaymentSheet
+@testable @_spi(STP) @_spi(LinkHiddenWalletButtonPreview) import StripePaymentSheet
 @testable @_spi(STP) import StripePaymentsTestUtils
 import XCTest
 
@@ -183,6 +183,54 @@ final class PaymentMethodAvailabilityTests: XCTestCase {
         let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
 
         XCTAssertFalse(isLinkEnabled, "Link should be disabled when display is set to .never")
+    }
+
+    func testIsLinkEnabled_linkDisplayHidden_linkStillEnabled() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card"],
+            isLinkPassthroughModeEnabled: true
+        )
+        var configuration = PaymentSheet.Configuration()
+        configuration.link = .init(display: .hidden)
+        let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
+
+        XCTAssertTrue(isLinkEnabled, "Link should remain enabled when display is set to .hidden")
+    }
+
+    func testShouldShowLinkButton_linkDisplayAutomatic_buttonShown() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card"],
+            isLinkPassthroughModeEnabled: true
+        )
+        var configuration = PaymentSheet.Configuration()
+        configuration.link = .init(display: .automatic)
+        let shouldShowLinkButton = PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration)
+
+        XCTAssertTrue(shouldShowLinkButton, "Link button should be shown when display is set to .automatic")
+    }
+
+    func testShouldShowLinkButton_linkDisplayNever_buttonNotShown() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card"],
+            isLinkPassthroughModeEnabled: true
+        )
+        var configuration = PaymentSheet.Configuration()
+        configuration.link = .init(display: .never)
+        let shouldShowLinkButton = PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration)
+
+        XCTAssertFalse(shouldShowLinkButton, "Link button should not be shown when display is set to .never")
+    }
+
+    func testShouldShowLinkButton_linkDisplayHidden_buttonNotShown() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card"],
+            isLinkPassthroughModeEnabled: true
+        )
+        var configuration = PaymentSheet.Configuration()
+        configuration.link = .init(display: .hidden)
+
+        XCTAssertTrue(PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration), "Link should remain enabled when display is set to .hidden")
+        XCTAssertFalse(PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration), "Link button should not be shown when display is set to .hidden, even though Link remains enabled")
     }
 
     func testIsLinkEnabled_automaticTaxBilling_linkDisabled() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
@@ -7,7 +7,7 @@
 
 @testable @_spi(STP) import StripeCore
 @testable @_spi(STP) import StripePayments
-@testable @_spi(STP) @_spi(LinkHiddenWalletButtonPreview) import StripePaymentSheet
+@testable @_spi(STP) import StripePaymentSheet
 @testable @_spi(STP) import StripePaymentsTestUtils
 import XCTest
 
@@ -185,16 +185,16 @@ final class PaymentMethodAvailabilityTests: XCTestCase {
         XCTAssertFalse(isLinkEnabled, "Link should be disabled when display is set to .never")
     }
 
-    func testIsLinkEnabled_linkDisplayHidden_linkStillEnabled() {
+    func testIsLinkEnabled_linkDisplayWalletButtonHidden_linkStillEnabled() {
         let elementsSession = STPElementsSession._testValue(
             paymentMethodTypes: ["card"],
             isLinkPassthroughModeEnabled: true
         )
         var configuration = PaymentSheet.Configuration()
-        configuration.link = .init(display: .hidden)
+        configuration.link = .init(display: .walletButtonHidden)
         let isLinkEnabled = PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration)
 
-        XCTAssertTrue(isLinkEnabled, "Link should remain enabled when display is set to .hidden")
+        XCTAssertTrue(isLinkEnabled, "Link should remain enabled when display is set to .walletButtonHidden")
     }
 
     func testShouldShowLinkButton_linkDisplayAutomatic_buttonShown() {
@@ -221,16 +221,16 @@ final class PaymentMethodAvailabilityTests: XCTestCase {
         XCTAssertFalse(shouldShowLinkButton, "Link button should not be shown when display is set to .never")
     }
 
-    func testShouldShowLinkButton_linkDisplayHidden_buttonNotShown() {
+    func testShouldShowLinkButton_linkDisplayWalletButtonHidden_buttonNotShown() {
         let elementsSession = STPElementsSession._testValue(
             paymentMethodTypes: ["card"],
             isLinkPassthroughModeEnabled: true
         )
         var configuration = PaymentSheet.Configuration()
-        configuration.link = .init(display: .hidden)
+        configuration.link = .init(display: .walletButtonHidden)
 
-        XCTAssertTrue(PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration), "Link should remain enabled when display is set to .hidden")
-        XCTAssertFalse(PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration), "Link button should not be shown when display is set to .hidden, even though Link remains enabled")
+        XCTAssertTrue(PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration), "Link should remain enabled when display is set to .walletButtonHidden")
+        XCTAssertFalse(PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration), "Link button should not be shown when display is set to .walletButtonHidden, even though Link remains enabled")
     }
 
     func testIsLinkEnabled_automaticTaxBilling_linkDisabled() {


### PR DESCRIPTION
## Summary

Adds a new `walletButtonHidden` case to the `LinkConfiguration.Display` enum that hides the Link wallet button from MPE, but keeps Link otherwise enabled.

## Motivation

https://docs.google.com/document/d/1NxBuePHYBRJcDv4uMJV3pPTzXa_yO3tuj3eZEN5Jw3w/edit?usp=sharing

## Testing


https://github.com/user-attachments/assets/6a44e34d-6174-4fba-9d97-efef0d7568cb



## Changelog

```md
### PaymentSheet
* [Added] Added `PaymentSheet.LinkConfiguration.Display.walletButtonHidden`, which keeps Link enabled but hides its button from the payment element UI.
```
