### PR TITLE
[Link] Fix Link tap in FlowController horizontal layout not opening Link sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ MINOR
 
 ## X.Y.Z - changes pending release
 ### PaymentSheet
+* [Fixed] Fixed FlowController not presenting the Link sheet when tapping Link in the horizontal payment method layout.
 * [Added] StripePaymentSheet now depends on `StripeFinancialConnectionsLite` to support lightweight bank payment flows. If you use StripePaymentSheet with Carthage or by manually embedding the .xcframeworks, [you must also embed StripeFinancialConnectionsLite.xcframework](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md#migrating-from-versions--2670) in your app. No action is required for CocoaPods or Swift Package Manager users.
 
 ## 26.6.0 2026-08-10

--- a/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLinkUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/PaymentSheetLinkUITests.swift
@@ -122,13 +122,13 @@ class PaymentSheetLinkUITests: PaymentSheetUITestCase {
 
         app.buttons["Payment method"].waitForExistenceAndTap()
         app.buttons["Link"].waitForExistenceAndTap()
-        app.buttons["Confirm"].waitForExistenceAndTap()
         let codeField = app.textViews["Code field"]
         _ = codeField.waitForExistence(timeout: 5.0)
         codeField.typeText("000000")
         let pwlController = app.otherElements["Stripe.Link.PayWithLinkViewController"]
-        let payButton = pwlController.buttons["Pay $50.99"]
-        _ = payButton.waitForExistenceAndTap()
+        let continueButton = pwlController.buttons["Continue"]
+        _ = continueButton.waitForExistenceAndTap()
+        app.buttons["Confirm"].waitForExistenceAndTap()
         XCTAssertTrue(app.staticTexts["Success!"].waitForExistence(timeout: 10.0))
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -680,10 +680,22 @@ extension PaymentSheetFlowControllerViewController: SavedPaymentOptionsViewContr
                 updateUI()
                 flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
             }
-        case .applePay, .link:
+        case .applePay:
             error = nil
             updateUI()
             if isDismissable {
+                flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+            }
+        case .link:
+            error = nil
+            updateUI()
+            guard isDismissable else { return }
+            if canPresentLinkOnWalletButton {
+                // RUX: present the native Link sheet in place (matches the wallet-header path),
+                // then close the FlowController sheet from presentLink()'s completion.
+                presentLink()
+            } else {
+                // Legacy: report Link (.wallet) as the selection and let the merchant confirm later.
                 flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
             }
         }


### PR DESCRIPTION
## Summary
Fixed click logic of link button in flow controller's horizontal layout carousel.

## Motivation
Merchant upgraded to sdk 26.3.0 which automatically displayed horizontal carousel if there were less than 3 payment methods. Clicking the link button in this layout closed the flow controller sheet without opening a link sheet. The user would have to tap on link again to open the link sheet to continue. Additional context: https://jira.corp.stripe.com/browse/RUN_LINK_MOBILE-239

## Testing
Configure payment sheet in flow controller mode with a returning user in a horizontal layout. Then click the link button to verify if link launches.

## Changelog
[Fixed] Fixed FlowController not presenting the Link sheet when tapping Link in the horizontal payment method layout.

## Recording
| Old | New |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/13a71361-b979-4190-8caa-acf5bcee81ab"/> | <video src="https://github.com/user-attachments/assets/49aeed2d-8bf2-4ffc-b728-9a0959a17c60"/> |