### PR TITLE
SAE — Remove setLoading() from IntegrationDelegate

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -85,7 +85,7 @@ public class AddressViewController: UIViewController {
     @MainActor
     protocol IntegrationDelegate: AnyObject {
         /// Handles completion with the customer's collected address details.
-        func save(addressDetails: AddressDetails, setLoading: (Bool) -> Void) async throws
+        func save(addressDetails: AddressDetails) async throws
     }
 
     weak var integrationDelegate: IntegrationDelegate?
@@ -373,13 +373,9 @@ extension AddressViewController {
                 stpAssertionFailure("AddressViewController attempted to continue with an invalid address.")
                 return
             }
+            setLoading(true)
             do {
-                try await self.integrationDelegate?.save(
-                    addressDetails: addressDetails,
-                    setLoading: { [weak self] isLoading in
-                        self?.setLoading(isLoading)
-                    }
-                )
+                try await self.integrationDelegate?.save(addressDetails: addressDetails)
                 // Re-baseline change tracking only after the save succeeds. If it fails, the
                 // customer can still retry or discard the unsaved values.
                 captureInitialSnapshot()
@@ -388,6 +384,7 @@ extension AddressViewController {
             } catch {
                 self.latestError = error
             }
+            setLoading(false)
         }
     }
 
@@ -642,7 +639,7 @@ extension AddressViewController {
 // MARK: - IntegrationDelegate
 // Default implementation that logs completion and forwards address details to the merchant delegate
 extension AddressViewController: AddressViewController.IntegrationDelegate {
-    func save(addressDetails: AddressDetails, setLoading: (Bool) -> Void) async throws {
+    func save(addressDetails: AddressDetails) async throws {
         logAddressCompleted()
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Shipping Address Element/ShippingAddressElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Shipping Address Element/ShippingAddressElement.swift
@@ -115,17 +115,12 @@ public final class ShippingAddressElement {
 }
 
 extension ShippingAddressElement: AddressViewController.IntegrationDelegate {
-    func save(
-        addressDetails: AddressViewController.AddressDetails,
-        setLoading: (Bool) -> Void
-    ) async throws {
+    func save(addressDetails: AddressViewController.AddressDetails) async throws {
         guard let delegate else {
             stpAssertionFailure("ShippingAddressElement does not have a delegate.")
             return
         }
 
-        setLoading(true)
-        defer { setLoading(false) }
         try await delegate.updateShippingAddress(
             name: addressDetails.name,
             address: Checkout.Address(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerTests.swift
@@ -116,7 +116,7 @@ final class AddressViewControllerTests: XCTestCase {
         merchantDelegate.completionExpectation = expectation(description: "Merchant completion")
         let integrationDelegate = IntegrationDelegate()
         integrationDelegate.waitsForCompletion = true
-        integrationDelegate.loadingExpectation = expectation(description: "Loading started")
+        integrationDelegate.saveExpectation = expectation(description: "Save started")
         let viewController = makeViewController(
             configuration: makeConfiguration(defaultAddress: .init(
                 city: "San Francisco",
@@ -133,7 +133,7 @@ final class AddressViewControllerTests: XCTestCase {
 
         // When address collection completes and the save begins
         viewController.didContinue()
-        await fulfillment(of: [integrationDelegate.loadingExpectation!])
+        await fulfillment(of: [integrationDelegate.saveExpectation!])
 
         // Then the form, navigation, and save button are disabled while the button shows loading
         XCTAssertFalse(viewController.view.isUserInteractionEnabled)
@@ -225,7 +225,6 @@ private final class MerchantDelegate: AddressViewControllerDelegate {
 @MainActor
 private final class IntegrationDelegate: AddressViewController.IntegrationDelegate {
     var saveExpectation: XCTestExpectation?
-    var loadingExpectation: XCTestExpectation?
     var receivedAddressDetails: [AddressViewController.AddressDetails] = []
     var waitsForCompletion = false
     private let error: Error?
@@ -235,19 +234,13 @@ private final class IntegrationDelegate: AddressViewController.IntegrationDelega
         self.error = error
     }
 
-    func save(
-        addressDetails: AddressViewController.AddressDetails,
-        setLoading: (Bool) -> Void
-    ) async throws {
+    func save(addressDetails: AddressViewController.AddressDetails) async throws {
         receivedAddressDetails.append(addressDetails)
         saveExpectation?.fulfill()
         if waitsForCompletion {
-            setLoading(true)
-            loadingExpectation?.fulfill()
             await withCheckedContinuation { continuation in
                 saveContinuation = continuation
             }
-            setLoading(false)
         }
         if let error {
             throw error

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -188,7 +188,6 @@ final class CheckoutUnitTests: XCTestCase {
         // Given a ShippingAddressElement connected to its Checkout
         let checkout = try await Checkout(configuration: CheckoutTestHelpers.makeConfiguration())
         let shippingAddressElement = checkout.getShippingAddressElement()
-        var loadingStates: [Bool] = []
 
         // When the element saves a collected address
         try await shippingAddressElement.save(
@@ -202,12 +201,10 @@ final class CheckoutUnitTests: XCTestCase {
                     state: "WA"
                 ),
                 name: "Jane Doe"
-            ),
-            setLoading: { loadingStates.append($0) }
+            )
         )
 
-        // Then the Checkout Session is the source of truth and loading spans the update
-        XCTAssertEqual(loadingStates, [true, false])
+        // Then the Checkout Session is the source of truth
         XCTAssertEqual(checkout.session.shippingAddress?.name, "Jane Doe")
         XCTAssertEqual(checkout.session.shippingAddress?.address.line1, "123 Main St.")
         XCTAssertEqual(checkout.session.shippingAddress?.address.line2, "Apt. 4")


### PR DESCRIPTION
## Summary
Always set loading to true/false during save instead of giving this control to the IntegrationDelegate.

## Motivation
Originally control was passed to avoid turning on the loading state for the legacy AE case (which saves synchronously). However upon further testing, always setting it results in an expected UX.

## Testing

https://github.com/user-attachments/assets/d5ea0499-4f66-4886-97e7-005c9abd545f



## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
