### PR TITLE
Fix Vipps decoding test after payment attempt expiration

### DIFF
--- a/Stripe/StripeiOSTests/STPPaymentMethodVippsTests.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodVippsTests.swift
@@ -20,8 +20,10 @@ class STPPaymentMethodVippsTests: STPNetworkStubbingTestCase {
             withClientSecret: Self.vippsPaymentIntentClientSecret,
             expand: ["payment_method"]
         ) { paymentIntent, _ in
-            XCTAssertNotNil(paymentIntent?.paymentMethod?.allResponseFields["vipps"])
-            let vippsJSON = try? XCTUnwrap(paymentIntent?.paymentMethod?.vipps?.allResponseFields)
+            // Redirect payment attempts eventually expire and move their PaymentMethod into lastPaymentError.
+            let paymentMethod = paymentIntent?.paymentMethod ?? paymentIntent?.lastPaymentError?.paymentMethod
+            XCTAssertNotNil(paymentMethod?.allResponseFields["vipps"])
+            let vippsJSON = try? XCTUnwrap(paymentMethod?.vipps?.allResponseFields)
             completion(vippsJSON)
         }
     }


### PR DESCRIPTION
## Summary

The fixed Vipps PaymentIntent loses its active payment method after the redirect payment attempt expires, which breaks the no-mocks nightly decoding test. Fall back to the payment method nested in the last payment error, matching the existing PayPal decoding test.

## Motivation

Nightly test failure

## Testing

- Targeted test with the recorded network response
- Targeted test with `STP_NO_NETWORK_MOCKS=1`

## Changelog

N/A
