### PR TITLE
Fix network recording from worktrees

### DIFF
--- a/StripePayments/StripePaymentsTestUtils/STPNetworkStubbingTestCase.swift
+++ b/StripePayments/StripePaymentsTestUtils/STPNetworkStubbingTestCase.swift
@@ -141,17 +141,7 @@ import XCTest
                 return fileName
             }
 
-            // The goal is for `basePath` to be e.g. `~/stripe-ios/Stripe/StripeiOSTests`
-            // A little gross/hardcoded (but it works fine); feel free to improve this...
-            let testDirectoryName = "stripe-ios/StripePayments/StripePaymentsTestUtils"
-            var basePath = "\(#file)"
-            while !basePath.hasSuffix(testDirectoryName) {
-                assert(
-                    basePath.contains(testDirectoryName),
-                    "Not in a subdirectory of \(testDirectoryName): \(#file)"
-                )
-                basePath = URL(fileURLWithPath: basePath).deletingLastPathComponent().path
-            }
+            let basePath = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
 
             let recordingPath = URL(fileURLWithPath: basePath)
                 .appendingPathComponent("Resources")


### PR DESCRIPTION
## Summary
Use Swift `#filePath` to locate `StripePaymentsTestUtils` when recording network fixtures.

## Motivation
`STPNetworkStubbingTestCase` previously started with `#file` and walked up the source path until it found the hard-coded suffix `stripe-ios/StripePayments/StripePaymentsTestUtils`. Agent and developer worktrees can have a different checkout directory name, so enabling `STP_RECORD_NETWORK` asserted during `setUp()`, crashed the XCTest host with `SIGTRAP`, and displayed a macOS “quit unexpectedly” dialog.

The removed loop only computed the directory containing `STPNetworkStubbingTestCase.swift`. Swift already exposes the full source-file path as `#filePath`, so deleting its last path component produces that directory directly without depending on the clone or worktree name.

## Testing
Ran the same test under `AllStripeFrameworks-NetworkRecordMode` with `STP_RECORD_NETWORK` enabled:

- Old code from the normal `stripe-ios` clone: passed, confirming the hard-coded suffix happens to match there.
- Old code from a differently named worktree: failed with `Crash: StripePaymentSheetTestHostApp`; reproduced the macOS crash dialog.
- Updated code from that same worktree: passed (1 test, 0 failures) and wrote the recorded fixture to the expected `StripePaymentsTestUtils/Resources/recorded_network_traffic` directory.
- `ci_scripts/lint_modified_files.sh`: passed with 0 violations.

Test: `StripePaymentSheetTests/LinkInlineVerificationViewModelTests/testStartVerificationStoresRateLimitError`

No tests were ignored.

## Changelog
Not user-facing; no changelog entry.