### PR TITLE
Hash pin all GitHub Actions in workflows

### DIFF
--- a/.github/workflows/check-translations.yml
+++ b/.github/workflows/check-translations.yml
@@ -16,13 +16,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # The pull_request ref is a merge commit. We only need it and its
           # base parent to determine which strings the PR adds.
           fetch-depth: 2
       - name: Set up Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: 3.0
       - name: Install dependencies
@@ -49,12 +49,12 @@ jobs:
           else
             echo "Missing translations detected, continue workflow..."
           fi
-      - uses: davidme-stripe/find-comment@v3.0.0
+      - uses: davidme-stripe/find-comment@d5fe37641ad8451bdd80312415672ba26c86575e # v3.0.0
         id: find_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Missing Translations
-      - uses: davidme-stripe/create-or-update-comment@v4
+      - uses: davidme-stripe/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # v4.0.0
         if: steps.missing.outputs.translations
         with:
           body: |

--- a/.github/workflows/close-resolved-issues.yml
+++ b/.github/workflows/close-resolved-issues.yml
@@ -10,7 +10,7 @@ jobs:
       issues: write
     steps:
       - name: Close GitHub Issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/find-dead-code.yml
+++ b/.github/workflows/find-dead-code.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           fetch-depth: 1
 
@@ -67,13 +67,13 @@ jobs:
             echo "No new dead code detected."
           fi
 
-      - uses: davidme-stripe/find-comment@v4
+      - uses: davidme-stripe/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4.0.0
         id: find_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: '[find-dead-code]'
 
-      - uses: davidme-stripe/create-or-update-comment@v5
+      - uses: davidme-stripe/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         id: create_update_comment
         if: env.diff != '' && !contains(github.event.pull_request.labels.*.name, 'skip dead code check')
         with:
@@ -97,7 +97,7 @@ jobs:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: davidme-stripe/create-or-update-comment@v5
+      - uses: davidme-stripe/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         id: create_update_comment_ignored
         if: env.diff != '' && contains(github.event.pull_request.labels.*.name, 'skip dead code check')
         with:
@@ -119,7 +119,7 @@ jobs:
           comment-id: ${{ steps.find_comment.outputs.comment-id }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: davidme-stripe/create-or-update-comment@v5
+      - uses: davidme-stripe/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5.0.0
         id: resolve_comment
         if: env.diff == '' && steps.find_comment.outputs.comment-id != ''
         with:

--- a/.github/workflows/verify-public-interface.yml
+++ b/.github/workflows/verify-public-interface.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 100
 
@@ -45,13 +45,13 @@ jobs:
             echo "diff_result.txt not found, skipping." 
           fi
 
-      - uses: davidme-stripe/find-comment@v1
+      - uses: davidme-stripe/find-comment@d2dae40ed151c634e4189471272b57e76ec19ba8 # v1.3.0
         id: find_comment
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Public API changes detected
 
-      - uses: davidme-stripe/create-or-update-comment@v1
+      - uses: davidme-stripe/create-or-update-comment@a35cf36e5301d70b76f316e867e7788a55a31dae # v1.4.5
         id: create-update-comment
         if: env.diff != ''
         with:


### PR DESCRIPTION
## Summary
Mitigates zizmor's unpinned-uses finding by pinning every `uses:` reference to a full commit SHA (with the resolved version as a trailing comment), following the same remediation used in stripe/stripe-android#13984.

Committed-By-Agent: claude

## Motivation
[SAT-28963](https://security-insights.corp.stripe.com/pathfinder/sats/SAT-28963)
[RUN_MOBILESDK-5601](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5601)

## Testing
CI passes