### PR TITLE
Use STPPostalCodeValidator for STPPaymentCardTextField postal validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@ The next release's version bump will so far be:
 MINOR
 
 ## X.Y.Z - changes pending release
+### Payments
+* [Fixed] `STPPaymentCardTextField.isValid` no longer returns `true` while the US ZIP field holds an incomplete postal code. Postal validation now goes through `STPPostalCodeValidator`, matching `STPCardFormView`.
+
 ### PaymentSheet
 * [Added] StripePaymentSheet now depends on `StripeFinancialConnectionsLite` to support lightweight bank payment flows. If you use StripePaymentSheet with Carthage or by manually embedding the .xcframeworks, [you must also embed StripeFinancialConnectionsLite.xcframework](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md#migrating-from-versions--2670) in your app. No action is required for CocoaPods or Swift Package Manager users.
 

--- a/Stripe/StripeiOSTests/STPPaymentCardTextFieldViewModelTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentCardTextFieldViewModelTest.swift
@@ -80,6 +80,54 @@ class STPPaymentCardTextFieldViewModelTest: XCTestCase {
         XCTAssertFalse(viewModel!.isValid)
     }
 
+    func testValidationStateForUSPostalCode() {
+        viewModel?.postalCodeRequested = true
+        viewModel?.postalCodeCountryCode = "US"
+
+        let tests: [(String, STPCardValidationState)] = [
+            ("", .incomplete),
+            ("1", .incomplete),
+            ("1234", .incomplete),
+            ("12345", .valid),
+            ("12345-6789", .valid),
+            ("1234a", .invalid),
+        ]
+        for (postalCode, expected) in tests {
+            viewModel?.postalCode = postalCode
+            XCTAssertEqual(
+                viewModel?.validationStateForPostalCode(),
+                expected,
+                "Unexpected validation state for US postal code \"\(postalCode)\""
+            )
+        }
+    }
+
+    func testValidationStateForNonUSPostalCode() {
+        // Non-US postal codes stay permissive: any non-empty value is valid.
+        viewModel?.postalCodeRequested = true
+        viewModel?.postalCodeCountryCode = "GB"
+
+        viewModel?.postalCode = ""
+        XCTAssertEqual(viewModel?.validationStateForPostalCode(), .incomplete)
+
+        viewModel?.postalCode = "1"
+        XCTAssertEqual(viewModel?.validationStateForPostalCode(), .valid)
+    }
+
+    func testValidityRequiresCompleteUSPostalCode() {
+        viewModel?.postalCodeRequested = true
+        viewModel?.postalCodeCountryCode = "US"
+        viewModel?.cardNumber = "4242424242424242"
+        viewModel?.rawExpiration = "12/40"
+        viewModel?.cvc = "123"
+
+        viewModel?.postalCode = "1"
+        XCTAssertFalse(viewModel!.isValid)
+
+        viewModel?.postalCode = "12345"
+        XCTAssertTrue(viewModel!.isValid)
+    }
+
     func testCompressedCardNumber() {
         viewModel?.cardNumber = nil
         // Should use default placeholder

--- a/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPPaymentCardTextFieldViewModel.swift
+++ b/StripePaymentsUI/StripePaymentsUI/Source/Internal/UI/Views/STPPaymentCardTextFieldViewModel.swift
@@ -194,11 +194,10 @@ class STPPaymentCardTextFieldViewModel: NSObject {
     }
 
     func validationStateForPostalCode() -> STPCardValidationState {
-        if (postalCode?.count ?? 0) > 0 {
-            return .valid
-        } else {
-            return .incomplete
-        }
+        return STPPostalCodeValidator.validationState(
+            forPostalCode: postalCode,
+            countryCode: postalCodeCountryCode
+        )
     }
 
     func validationStateForCardNumber(handler: @escaping (STPCardValidationState) -> Void) {


### PR DESCRIPTION
Fixes #6927.

### Summary

`STPPaymentCardTextFieldViewModel.validationStateForPostalCode()` treated any non-empty string as valid:

```swift
if (postalCode?.count ?? 0) > 0 {
    return .valid
} else {
    return .incomplete
}
```

So `STPPaymentCardTextField.isValid` returns `true` while the US ZIP field holds a single digit. An integration that gates its pay button on `isValid` — the documented way to do it — enables submission of an incomplete postal code, which is an avoidable AVS decline rather than a caught client-side error.

### Fix

Delegate to `STPPostalCodeValidator`, which is already the project's answer to this question and already handles 5-digit ZIPs, ZIP+4, and non-numeric input:

```swift
func validationStateForPostalCode() -> STPCardValidationState {
    return STPPostalCodeValidator.validationState(
        forPostalCode: postalCode,
        countryCode: postalCodeCountryCode
    )
}
```

`STPCardFormView`'s validator already routes through this, so this makes the two card entry surfaces agree rather than introducing a new rule.

### Why this looks like an oversight rather than a deliberate leniency

- The validator is correct; only this call site bypasses it.
- #5138 hardened two sibling paths in this same view model but not this one.
- A localized `your_zip_is_incomplete` string already exists, and the legacy field can never surface it — there is no state in which it would fire.

### Behaviour changes

- **US:** an incomplete ZIP now reports `.incomplete` instead of `.valid`, so `isValid` is false until 5 digits are entered.
- **Non-US:** unchanged — `STPPostalCodeValidator` stays permissive for any non-empty value.

An integration relying on the old behaviour would be one relying on `isValid` returning true for input Stripe would decline, so I'd expect this to fix bugs rather than cause them. Happy to gate it behind a flag if you'd rather stage the change.

### Tests

Three added to `STPPaymentCardTextFieldViewModelTest`:

- `testValidationStateForUSPostalCode` — `""`/`"1"`/`"1234"` → `.incomplete`, `"12345"`/`"12345-6789"` → `.valid`, `"1234a"` → `.invalid`
- `testValidationStateForNonUSPostalCode` — GB stays permissive
- `testValidityRequiresCompleteUSPostalCode` — full-form `isValid` false at `"1"`, true at `"12345"`

CHANGELOG entry included under Payments.

Found while wiring `STPPaymentCardTextField` into a production app, where the pay button went live after the first ZIP digit.
