### PR TITLE
[Link] Fix Link "Continue another way" dismissing the FlowController sheet

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/PaymentSheetVerticalViewController.swift
@@ -584,10 +584,25 @@ class PaymentSheetVerticalViewController: UIViewController, FlowControllerViewCo
             intent: intent,
             elementsSession: elementsSession,
             analyticsHelper: analyticsHelper,
-            callback: { [weak self] confirmOption, _, _ in
+            callback: { [weak self] confirmOption, shouldReturnToPaymentSheet, _ in
                 guard let self else { return }
                 self.linkConfirmOption = confirmOption
-                self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+
+                // A Link payment method was selected — report it and close the FlowController sheet.
+                guard confirmOption == nil else {
+                    self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+                    return
+                }
+
+                // The user left Link without selecting it (e.g. tapped "Continue another way") or dismissed the
+                // Link sheet. PayWithNativeLinkController re-presents this sheet automatically, so we must NOT
+                // close the flow here. Clear a lingering Link selection so Link doesn't stay selected after the
+                // user chose to pay another way (matches presentNativeLinkInPlaceOfFlowController).
+                if shouldReturnToPaymentSheet,
+                   case .link(let option) = self.selectedPaymentOption,
+                   case .wallet = option {
+                    self.clearSelection()
+                }
             }
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentSheetFlowControllerViewController.swift
@@ -350,10 +350,25 @@ class PaymentSheetFlowControllerViewController: UIViewController, FlowController
             intent: intent,
             elementsSession: elementsSession,
             analyticsHelper: analyticsHelper
-        ) { [weak self] confirmOption, _, _ in
+        ) { [weak self] confirmOption, shouldReturnToPaymentSheet, _ in
             guard let self else { return }
             self.linkConfirmOption = confirmOption
-            self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+
+            // A Link payment method was selected — report it and close the FlowController sheet.
+            guard confirmOption == nil else {
+                self.flowControllerDelegate?.flowControllerViewControllerShouldClose(self, didCancel: false)
+                return
+            }
+
+            // The user left Link without selecting it (e.g. tapped "Continue another way") or dismissed the
+            // Link sheet. PayWithNativeLinkController re-presents this sheet automatically, so we must NOT
+            // close the flow here. Clear a lingering Link selection so Link doesn't stay selected after the
+            // user chose to pay another way (matches presentNativeLinkInPlaceOfFlowController).
+            if shouldReturnToPaymentSheet,
+               case .link(let option) = self.selectedPaymentOption,
+               case .wallet = option {
+                self.clearSelection()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Clicking "Continue another way" on Link sheet no longer dismisses the FlowController sheet.

## Motivation
Follow up on https://github.com/stripe/stripe-ios/pull/6917

## Testing
Configure payment sheet in flow controller mode with a returning user in a horizontal or vertical layout. Then click the link button, sign in, and click "Continue another way". Verify if the FlowController sheet is still open after Link sheet closes.

## Changelog
- [Fixed] Fixed FlowController dismissing the payment options sheet instead of returning to it when tapping "Continue another way" in the Link sheet.

## Recording
| Before | After |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/ad83480a-2f2c-40ab-bf3d-4d4d99d19549" /> | <video src="https://github.com/user-attachments/assets/2c4d0317-5ee9-42b1-8077-c086c8bda601" /> |
