### PR TITLE
Checkout Sessions — Add default shipping address to playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -20,6 +20,7 @@ struct CheckoutCartView: View {
 
     let clientSecret: String
     let shippingAddressCollection: Bool
+    let defaultShippingAddress: CheckoutPlayground.DefaultShippingAddress?
     let adaptivePricing: Bool
     let integrationType: CheckoutPlayground.IntegrationType
     var showExpressCheckoutElement: Bool = false
@@ -35,7 +36,7 @@ struct CheckoutCartView: View {
                 if let checkout {
                     CheckoutCartContentView(
                         checkout: checkout,
-                        showsShippingAddressSection: shippingAddressCollection,
+                        showsShippingAddressSection: shippingAddressCollection || checkout.session.shippingAddress != nil,
                         errorMessage: errorMessage
                     )
                     .overlay(alignment: .bottom) {
@@ -124,6 +125,7 @@ struct CheckoutCartView: View {
                 paymentPagesRequestDelay: delayPaymentPagesRequests ? 1 : 0
             )
             config.adaptivePricing.allowed = adaptivePricing
+            config.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails
             config.applePayConfiguration = Checkout.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example"
             )

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
@@ -17,6 +17,7 @@ struct CheckoutCartUIKitView: UIViewControllerRepresentable {
 
     let clientSecret: String
     let shippingAddressCollection: Bool
+    let defaultShippingAddress: CheckoutPlayground.DefaultShippingAddress?
     let adaptivePricing: Bool
     let integrationType: CheckoutPlayground.IntegrationType
     let showExpressCheckoutElement: Bool
@@ -27,6 +28,7 @@ struct CheckoutCartUIKitView: UIViewControllerRepresentable {
         let viewController = CheckoutCartViewController(
             clientSecret: clientSecret,
             shippingAddressCollection: shippingAddressCollection,
+            defaultShippingAddress: defaultShippingAddress,
             adaptivePricing: adaptivePricing,
             integrationType: integrationType,
             showExpressCheckoutElement: showExpressCheckoutElement,
@@ -45,6 +47,7 @@ final class CheckoutCartViewController: UIViewController {
 
     private let clientSecret: String
     private let shippingAddressCollection: Bool
+    private let defaultShippingAddress: CheckoutPlayground.DefaultShippingAddress?
     private let adaptivePricing: Bool
     private let integrationType: CheckoutPlayground.IntegrationType
     private let showExpressCheckoutElement: Bool
@@ -75,6 +78,7 @@ final class CheckoutCartViewController: UIViewController {
     init(
         clientSecret: String,
         shippingAddressCollection: Bool,
+        defaultShippingAddress: CheckoutPlayground.DefaultShippingAddress?,
         adaptivePricing: Bool,
         integrationType: CheckoutPlayground.IntegrationType,
         showExpressCheckoutElement: Bool,
@@ -84,6 +88,7 @@ final class CheckoutCartViewController: UIViewController {
     ) {
         self.clientSecret = clientSecret
         self.shippingAddressCollection = shippingAddressCollection
+        self.defaultShippingAddress = defaultShippingAddress
         self.adaptivePricing = adaptivePricing
         self.integrationType = integrationType
         self.showExpressCheckoutElement = showExpressCheckoutElement
@@ -202,6 +207,7 @@ final class CheckoutCartViewController: UIViewController {
                 returnURL: "payments-example://stripe-redirect"
             )
             configuration.adaptivePricing.allowed = adaptivePricing
+            configuration.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails
             configuration.applePayConfiguration = Checkout.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example"
             )
@@ -261,7 +267,7 @@ final class CheckoutCartViewController: UIViewController {
 
         contentStackView.addArrangedSubview(makeLineItemsSection(checkout: checkout))
 
-        if shippingAddressCollection {
+        if shippingAddressCollection || checkout.session.shippingAddress != nil {
             contentStackView.addArrangedSubview(makeShippingAddressSection(checkout: checkout))
         }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
@@ -170,6 +170,8 @@ struct CheckoutPlaygroundLineItemCard: View {
 struct CheckoutPlaygroundFeaturesSection: View {
     let customerType: CheckoutPlayground.CustomerType
     @Binding var shippingAddressCollection: Bool
+    @Binding var defaultShippingAddressOption: CheckoutPlayground.DefaultShippingAddressOption
+    @Binding var customDefaultShippingAddress: CheckoutPlayground.DefaultShippingAddress
     @Binding var billingAddressCollection: CheckoutPlayground.BillingAddressCollection
     @Binding var automaticTax: Bool
     @Binding var checkoutSessionPaymentMethodSave: Bool
@@ -189,6 +191,20 @@ struct CheckoutPlaygroundFeaturesSection: View {
                     isOn: $shippingAddressCollection,
                     tooltip: "Sets `shipping_address_collection` to allow specific countries (US, CA, GB, AU). Necessary for physical goods."
                 )
+                CheckoutPlayground.PickerRow(
+                    title: "Default Shipping Address",
+                    selection: $defaultShippingAddressOption,
+                    tooltip: "Sets `Checkout.Configuration.defaults.shippingDetails` before loading Checkout.",
+                    displayText: { $0.displayName }
+                )
+                switch defaultShippingAddressOption {
+                case .none:
+                    EmptyView()
+                case .usTestAddress:
+                    CheckoutPlaygroundShippingAddressPreview(address: .usTestAddress)
+                case .custom:
+                    CheckoutPlaygroundShippingAddressEditor(address: $customDefaultShippingAddress)
+                }
                 CheckoutPlayground.PickerRow(
                     title: "Billing Address",
                     selection: $billingAddressCollection,
@@ -220,6 +236,103 @@ struct CheckoutPlaygroundFeaturesSection: View {
             }
             .background(Color(uiColor: .secondarySystemGroupedBackground))
             .clipShape(RoundedRectangle(cornerRadius: 12))
+        }
+    }
+}
+
+private struct CheckoutPlaygroundShippingAddressPreview: View {
+
+    let address: CheckoutPlayground.DefaultShippingAddress
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "mappin.circle.fill")
+                .font(.system(size: 20))
+                .foregroundColor(.blue)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(address.name)
+                    .font(.subheadline.weight(.semibold))
+                Text(address.line1)
+                Text("\(address.city), \(address.state) \(address.postalCode)")
+                Text(address.country)
+            }
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+
+            Spacer()
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 16)
+        .background(Color(uiColor: .secondarySystemGroupedBackground))
+    }
+}
+
+private struct CheckoutPlaygroundShippingAddressEditor: View {
+
+    @Binding var address: CheckoutPlayground.DefaultShippingAddress
+
+    var body: some View {
+        VStack(spacing: 12) {
+            CheckoutPlaygroundShippingAddressField(
+                title: "Name",
+                placeholder: "Jenny Rosen",
+                text: $address.name
+            )
+            CheckoutPlaygroundShippingAddressField(
+                title: "Address line 1",
+                placeholder: "510 Townsend St",
+                text: $address.line1
+            )
+            CheckoutPlaygroundShippingAddressField(
+                title: "Address line 2",
+                placeholder: "Apartment, suite, etc.",
+                text: $address.line2
+            )
+            CheckoutPlaygroundShippingAddressField(
+                title: "City",
+                placeholder: "San Francisco",
+                text: $address.city
+            )
+            CheckoutPlaygroundShippingAddressField(
+                title: "State",
+                placeholder: "CA",
+                text: $address.state
+            )
+            CheckoutPlaygroundShippingAddressField(
+                title: "ZIP / postal code",
+                placeholder: "94103",
+                text: $address.postalCode
+            )
+            CheckoutPlaygroundShippingAddressField(
+                title: "Country",
+                placeholder: "US",
+                text: $address.country
+            )
+        }
+        .padding(16)
+        .background(Color(uiColor: .secondarySystemGroupedBackground))
+    }
+}
+
+private struct CheckoutPlaygroundShippingAddressField: View {
+
+    let title: String
+    let placeholder: String
+    @Binding var text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            TextField(placeholder, text: $text)
+                .font(.body)
+                .padding(.horizontal, 12)
+                .frame(height: 40)
+                .background(Color(uiColor: .tertiarySystemFill))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .accessibilityLabel(title)
         }
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundTypes.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundTypes.swift
@@ -5,6 +5,7 @@
 //  Created by Nick Porter on 2/24/26.
 
 import Foundation
+@_spi(STP) import StripePaymentSheet
 
 enum CheckoutPlayground {
     enum UIFramework: String, CaseIterable, Identifiable {
@@ -133,6 +134,58 @@ enum CheckoutPlayground {
             case .automatic: return "Auto"
             case .required: return "Required"
             }
+        }
+    }
+
+    enum DefaultShippingAddressOption: String, CaseIterable, Identifiable {
+
+        case none
+        case usTestAddress
+        case custom
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .none: return "No address"
+            case .usTestAddress: return "US test address"
+            case .custom: return "Custom"
+            }
+        }
+    }
+
+    struct DefaultShippingAddress: Equatable {
+
+        var name: String
+        var line1: String
+        var line2: String
+        var city: String
+        var state: String
+        var postalCode: String
+        var country: String
+
+        static let usTestAddress = DefaultShippingAddress(
+            name: "Jenny Rosen",
+            line1: "510 Townsend St",
+            line2: "",
+            city: "San Francisco",
+            state: "CA",
+            postalCode: "94103",
+            country: "US"
+        )
+
+        var checkoutShippingDetails: Checkout.Configuration.Defaults.ShippingDetails {
+            var shippingDetails = Checkout.Configuration.Defaults.ShippingDetails()
+            shippingDetails.name = name
+            shippingDetails.address = Checkout.Address(
+                country: country,
+                line1: line1,
+                line2: line2,
+                city: city,
+                state: state,
+                postalCode: postalCode
+            )
+            return shippingDetails
         }
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
@@ -44,6 +44,8 @@ struct CheckoutPlaygroundView: View {
                         CheckoutPlaygroundFeaturesSection(
                             customerType: viewModel.customerType,
                             shippingAddressCollection: $viewModel.shippingAddressCollection,
+                            defaultShippingAddressOption: $viewModel.defaultShippingAddressOption,
+                            customDefaultShippingAddress: $viewModel.customDefaultShippingAddress,
                             billingAddressCollection: $viewModel.billingAddressCollection,
                             automaticTax: $viewModel.automaticTax,
                             checkoutSessionPaymentMethodSave: $viewModel.checkoutSessionPaymentMethodSave,
@@ -84,6 +86,7 @@ struct CheckoutPlaygroundView: View {
                         CheckoutCartView(
                             clientSecret: clientSecret,
                             shippingAddressCollection: viewModel.shippingAddressCollection,
+                            defaultShippingAddress: viewModel.defaultShippingAddress,
                             adaptivePricing: true,
                             integrationType: viewModel.integrationType,
                             showExpressCheckoutElement: viewModel.expressCheckoutElementOption == .show,
@@ -94,6 +97,7 @@ struct CheckoutPlaygroundView: View {
                         CheckoutCartUIKitView(
                             clientSecret: clientSecret,
                             shippingAddressCollection: viewModel.shippingAddressCollection,
+                            defaultShippingAddress: viewModel.defaultShippingAddress,
                             adaptivePricing: true,
                             integrationType: viewModel.integrationType,
                             showExpressCheckoutElement: viewModel.expressCheckoutElementOption == .show,

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
@@ -34,6 +34,8 @@ extension CheckoutPlayground {
         @Published var customerType: CustomerType = .guest
         @Published var lineItems: [LineItemConfig] = LineItemConfig.defaults
         @Published var shippingAddressCollection = true
+        @Published var defaultShippingAddressOption: DefaultShippingAddressOption = .none
+        @Published var customDefaultShippingAddress = DefaultShippingAddress.usTestAddress
         @Published var billingAddressCollection: BillingAddressCollection = .automatic
         @Published var automaticTax = true
         @Published var checkoutSessionPaymentMethodSave = true
@@ -53,6 +55,17 @@ extension CheckoutPlayground {
 
         var isButtonDisabled: Bool {
             isCreating || (!automaticPaymentMethods && paymentMethodTypes.isEmpty) || lineItems.isEmpty
+        }
+
+        var defaultShippingAddress: DefaultShippingAddress? {
+            switch defaultShippingAddressOption {
+            case .none:
+                return nil
+            case .usTestAddress:
+                return .usTestAddress
+            case .custom:
+                return customDefaultShippingAddress
+            }
         }
 
         func createSession() async {


### PR DESCRIPTION
## Summary
Add default shipping address setting to CS playground

## Motivation
Test default shipping address

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

https://github.com/user-attachments/assets/258aecdc-e194-4206-91bf-5124500c5844



## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
