### PR TITLE
CI — do LPMConfirmFlowTests in separate job

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -32,6 +32,7 @@ pipelines:
         abort_on_fail: true
       update-snapshots: {}
       framework-tests: {}
+      lpm-confirm-flow-tests: {}
       framework-tests-ios-26: {}
       test-builds-xcode-26-1: {}
       install-tests: {}
@@ -333,6 +334,7 @@ workflows:
         - test_repetition_mode: retry_on_failure
         - maximum_test_repetitions: "2"
         - scheme: StripePaymentSheet
+        - xcodebuild_options: -skip-testing:StripePaymentSheetTests/PaymentSheetLPMConfirmFlowTests
         is_always_run: true
     - xcode-test@6:
         inputs:
@@ -411,6 +413,25 @@ workflows:
         - maximum_test_repetitions: "2"
         - scheme: StripeCryptoOnramp
         is_always_run: true
+    - deploy-to-bitrise-io@2: {}
+    - save-spm-cache@1: {}
+    before_run:
+    - install-runtime-16
+    - prep_all
+    after_run: []
+    meta:
+      bitrise.io:
+        stack: osx-xcode-26.4.x
+        machine_type_id: g2.mac.large
+  lpm-confirm-flow-tests:
+    steps:
+    - xcode-test@6:
+        inputs:
+        - destination: $DEFAULT_TEST_DEVICE
+        - test_repetition_mode: retry_on_failure
+        - maximum_test_repetitions: "2"
+        - scheme: StripePaymentSheet
+        - xcodebuild_options: -only-testing:StripePaymentSheetTests/PaymentSheetLPMConfirmFlowTests
     - deploy-to-bitrise-io@2: {}
     - save-spm-cache@1: {}
     before_run:


### PR DESCRIPTION
## Summary
Split LPMConfirmFlowTests into a separate job

## Motivation
framework-tests had become the limiting bottleneck for CI as it has grown. LPMConfirmFlowTests alone account for 12 minutes of this job and can be cleanly split into a separate one

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
