### PR TITLE
Align Checkout configuration with API review

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+LinkConfiguration.swift
@@ -24,6 +24,8 @@ extension CheckoutController {
             case automatic
             /// Never show Link.
             case never
+            /// Keep Link enabled, but hide its button or row in PaymentElement.
+            case walletButtonHidden
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutError.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutError.swift
@@ -9,9 +9,7 @@
 import Foundation
 
 /// An error returned by ``Checkout``.
-@_spi(STP)
-@_spi(ReactNativeSDK)
-public enum CheckoutError: Error, LocalizedError, Sendable {
+enum CheckoutError: Error, LocalizedError, Sendable {
     /// The client secret provided to ``Checkout`` is empty.
     case invalidClientSecret
 
@@ -28,7 +26,7 @@ public enum CheckoutError: Error, LocalizedError, Sendable {
 
     // MARK: - LocalizedError
 
-    public var errorDescription: String? {
+    var errorDescription: String? {
         switch self {
         case .invalidClientSecret:
             return "Checkout was initialized with an empty client secret."

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -134,6 +134,8 @@ extension PaymentElement {
             userInterfaceStyle: CheckoutController.UserInterfaceStyle
         ) -> EmbeddedPaymentElement.Configuration {
             var configuration = embeddedConfiguration
+            configuration.allowsDelayedPaymentMethods = true
+            configuration.allowsPaymentMethodsRequiringShippingAddress = true
             configuration.apiClient = apiClient
             configuration.apply(linkConfiguration: linkConfiguration)
             configuration.merchantDisplayName = merchantDisplayName
@@ -153,6 +155,8 @@ extension PaymentElement {
             userInterfaceStyle: CheckoutController.UserInterfaceStyle
         ) -> PaymentSheet.Configuration {
             var configuration = paymentSheetConfiguration
+            configuration.allowsDelayedPaymentMethods = true
+            configuration.allowsPaymentMethodsRequiringShippingAddress = true
             configuration.apiClient = apiClient
             configuration.apply(linkConfiguration: linkConfiguration)
             configuration.merchantDisplayName = merchantDisplayName

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -226,10 +226,6 @@ extension PaymentElement {
         /// Defaults to `automatic`.
         public var name: CollectionMode = .automatic
 
-        /// How to collect the phone field.
-        /// Defaults to `automatic`.
-        public var phone: CollectionMode = .automatic
-
         /// How to collect the email field.
         /// Defaults to `automatic`.
         /// - Note: Intentionally non-public, unclear what the merchant use case for this is given they need to provide an email up-front.
@@ -262,7 +258,6 @@ private extension PaymentElement.BillingDetailsCollectionConfiguration {
     func paymentSheetConfiguration() -> PaymentSheet.BillingDetailsCollectionConfiguration {
         var configuration = PaymentSheet.BillingDetailsCollectionConfiguration()
         configuration.name = .init(rawValue: name.rawValue)!
-        configuration.phone = .init(rawValue: phone.rawValue)!
         configuration.email = .init(rawValue: email.rawValue)!
         configuration.address = address.paymentSheetAddressCollectionMode
         configuration.attachDefaultsToPaymentMethod = attachDefaultsToPaymentMethod

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -129,11 +129,13 @@ extension PaymentElement {
         func makeEmbeddedConfiguration(
             apiClient: STPAPIClient,
             defaults: CheckoutController.Configuration.Defaults,
+            linkConfiguration: CheckoutController.LinkConfiguration?,
             merchantDisplayName: String,
             userInterfaceStyle: CheckoutController.UserInterfaceStyle
         ) -> EmbeddedPaymentElement.Configuration {
             var configuration = embeddedConfiguration
             configuration.apiClient = apiClient
+            configuration.apply(linkConfiguration: linkConfiguration)
             configuration.merchantDisplayName = merchantDisplayName
             configuration.style = userInterfaceStyle
             configuration.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.paymentSheetConfiguration()
@@ -146,11 +148,13 @@ extension PaymentElement {
         func makePaymentSheetConfiguration(
             apiClient: STPAPIClient,
             defaults: CheckoutController.Configuration.Defaults,
+            linkConfiguration: CheckoutController.LinkConfiguration?,
             merchantDisplayName: String,
             userInterfaceStyle: CheckoutController.UserInterfaceStyle
         ) -> PaymentSheet.Configuration {
             var configuration = paymentSheetConfiguration
             configuration.apiClient = apiClient
+            configuration.apply(linkConfiguration: linkConfiguration)
             configuration.merchantDisplayName = merchantDisplayName
             configuration.style = userInterfaceStyle
             configuration.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.paymentSheetConfiguration()
@@ -158,6 +162,32 @@ extension PaymentElement {
                 configuration.defaultBillingDetails.set(billingDetails)
             }
             return configuration
+        }
+    }
+}
+
+private extension PaymentSheet.Configuration {
+    mutating func apply(linkConfiguration: CheckoutController.LinkConfiguration?) {
+        switch linkConfiguration?.display {
+        case .none, .automatic:
+            link.display = .automatic
+        case .never:
+            link.display = .never
+        case .walletButtonHidden:
+            link.display = .walletButtonHidden
+        }
+    }
+}
+
+private extension EmbeddedPaymentElement.Configuration {
+    mutating func apply(linkConfiguration: CheckoutController.LinkConfiguration?) {
+        switch linkConfiguration?.display {
+        case .none, .automatic:
+            link.display = .automatic
+        case .never:
+            link.display = .never
+        case .walletButtonHidden:
+            link.display = .walletButtonHidden
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -75,6 +75,7 @@ public final class PaymentElement {
         let paymentSheetConfiguration = configuration.makePaymentSheetConfiguration(
             apiClient: checkout.apiClient,
             defaults: checkout.configuration.defaults,
+            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
@@ -86,6 +87,7 @@ public final class PaymentElement {
         let embeddedConfiguration = configuration.makeEmbeddedConfiguration(
             apiClient: checkout.apiClient,
             defaults: checkout.configuration.defaults,
+            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
@@ -140,12 +142,14 @@ extension PaymentElement {
         paymentSheetFlowController.configuration = configuration.makePaymentSheetConfiguration(
             apiClient: checkout.apiClient,
             defaults: checkout.configuration.defaults,
+            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
         embeddedPaymentElement.configuration = configuration.makeEmbeddedConfiguration(
             apiClient: checkout.apiClient,
             defaults: checkout.configuration.defaults,
+            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -113,6 +113,24 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertEqual(embeddedConfiguration.merchantDisplayName, "Dashboard Merchant")
     }
 
+    func testConfigurationAllowsAllCheckoutPaymentMethodRequirements() async throws {
+        // Given a Checkout configuration
+        let checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
+
+        // When Checkout creates PaymentElement
+        let checkout = try await CheckoutController(
+            configuration: CheckoutTestHelpers.makeConfiguration(configuration: checkoutConfiguration)
+        )
+        let paymentElement = checkout.getPaymentElement()
+        let paymentSheetConfiguration = paymentElement.paymentSheetFlowController.configuration
+        let embeddedConfiguration = paymentElement.embeddedPaymentElement.configuration
+
+        // Then both presentations allow payment methods supported by Checkout
+        XCTAssertTrue(paymentSheetConfiguration.allowsDelayedPaymentMethods)
+        XCTAssertTrue(paymentSheetConfiguration.allowsPaymentMethodsRequiringShippingAddress)
+        XCTAssertTrue(embeddedConfiguration.allowsDelayedPaymentMethods)
+        XCTAssertTrue(embeddedConfiguration.allowsPaymentMethodsRequiringShippingAddress)
+    }
     func testConfigurationSetsCheckoutDefaultShippingDetails() async throws {
         // Given Checkout shipping defaults
         var checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")


### PR DESCRIPTION
## Summary
- add `walletButtonHidden` to Checkout Link configuration and thread it through sheet and embedded Payment Element
- enable delayed payment methods and payment methods requiring shipping addresses for Checkout-owned Payment Element
- make `CheckoutError` internal and remove the unproposed Checkout billing phone configuration

## Motivation
Align the iOS Checkout Elements surface with the reviewed API: https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE/edit

## Testing
- added unit coverage for Checkout payment-method requirements
- `ci_scripts/run_tests.rb --scheme StripePaymentSheet --build-only`
- `ci_scripts/lint_modified_files.sh`

## Changelog
No changelog entry; Checkout Elements has not shipped.