### PR TITLE
Validate adjustable quantity bounds

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
@@ -133,15 +133,13 @@ extension PaymentPagesAPIResponse {
                     let unitAmount = item.unitAmount ?? price.unitAmount ?? 0
                     let adjustableQuantity: CheckoutController.Session.AdjustableQuantity?
                     if let rawAdjustableQuantity = item.adjustableQuantity,
-                       rawAdjustableQuantity.enabled {
-                        // TODO: Payment Pages currently models these bounds as optional, although enabled
-                        // adjustable quantity is normally populated with server defaults of 0 and 99.
-                        // Once the response contract requires both bounds when enabled, reject missing
-                        // values during decoding and remove these client-side fallbacks.
+                       rawAdjustableQuantity.enabled,
+                       let maximum = rawAdjustableQuantity.maximum,
+                       let minimum = rawAdjustableQuantity.minimum {
                         adjustableQuantity = CheckoutController.Session.AdjustableQuantity(
                             enabled: true,
-                            maximum: rawAdjustableQuantity.maximum ?? 99,
-                            minimum: rawAdjustableQuantity.minimum ?? 0
+                            maximum: maximum,
+                            minimum: minimum
                         )
                     } else {
                         adjustableQuantity = nil

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
@@ -427,6 +427,24 @@ extension PaymentPagesAPIResponse {
         let enabled: Bool
         let maximum: Int?
         let minimum: Int?
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            enabled = try container.decode(Bool.self, forKey: .enabled)
+            if enabled {
+                maximum = try container.decode(Int.self, forKey: .maximum)
+                minimum = try container.decode(Int.self, forKey: .minimum)
+            } else {
+                maximum = try container.decodeIfPresent(Int.self, forKey: .maximum)
+                minimum = try container.decodeIfPresent(Int.self, forKey: .minimum)
+            }
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case enabled
+            case maximum
+            case minimum
+        }
     }
 
     struct ShippingAddressCollection: Decodable {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
@@ -811,7 +811,11 @@ class PaymentPagesAPIResponseTest: XCTestCase {
 
     func testUnifiedModeSessionMapsAdjustableQuantity() throws {
         let enabledJSON = modifyingOneTimePriceItem {
-            $0["adjustable_quantity"] = ["enabled": true]
+            $0["adjustable_quantity"] = [
+                "enabled": true,
+                "minimum": 2,
+                "maximum": 10,
+            ]
         }
         let enabledResponse = try PaymentPagesAPIResponse.decode(fromAPIResponse: enabledJSON)
         guard case .oneTimePrice(let enabledOneTimePrice) = enabledResponse.makePublicSession().orderSummaryItems.first else {
@@ -819,8 +823,8 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         }
         let enabledQuantity = try XCTUnwrap(enabledOneTimePrice.items.first?.adjustableQuantity)
         XCTAssertTrue(enabledQuantity.enabled)
-        XCTAssertEqual(enabledQuantity.minimum, 0)
-        XCTAssertEqual(enabledQuantity.maximum, 99)
+        XCTAssertEqual(enabledQuantity.minimum, 2)
+        XCTAssertEqual(enabledQuantity.maximum, 10)
 
         let disabledJSON = modifyingOneTimePriceItem {
             $0["adjustable_quantity"] = ["enabled": false]
@@ -830,6 +834,44 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             return XCTFail("Expected one-time Price order summary item")
         }
         XCTAssertNil(disabledOneTimePrice.items.first?.adjustableQuantity)
+    }
+
+    func testUnifiedModeSessionRejectsEnabledAdjustableQuantityWithoutBounds() {
+        for field in ["minimum", "maximum"] {
+            var adjustableQuantity: [String: Any] = [
+                "enabled": true,
+                "minimum": 0,
+                "maximum": 99,
+            ]
+            adjustableQuantity.removeValue(forKey: field)
+            let json = modifyingOneTimePriceItem {
+                $0["adjustable_quantity"] = adjustableQuantity
+            }
+
+            XCTAssertThrowsError(
+                try PaymentPagesAPIResponse.decode(fromAPIResponse: json),
+                "Expected missing \(field) to fail decoding"
+            )
+        }
+    }
+
+    func testUnifiedModeSessionRejectsEnabledAdjustableQuantityWithNullBounds() {
+        for field in ["minimum", "maximum"] {
+            var adjustableQuantity: [String: Any] = [
+                "enabled": true,
+                "minimum": 0,
+                "maximum": 99,
+            ]
+            adjustableQuantity[field] = NSNull()
+            let json = modifyingOneTimePriceItem {
+                $0["adjustable_quantity"] = adjustableQuantity
+            }
+
+            XCTAssertThrowsError(
+                try PaymentPagesAPIResponse.decode(fromAPIResponse: json),
+                "Expected null \(field) to fail decoding"
+            )
+        }
     }
 
     func testUnifiedModeSessionAllowsEmptyNestedItems() throws {


### PR DESCRIPTION
## Summary
Payment Pages always returns minimum and maximum bounds when adjustable quantity is enabled, but we were replacing missing values with server defaults. That made malformed responses look valid. Now enabled adjustable quantity requires both bounds during decoding, while disabled adjustable quantity can still omit them.

Corresponds to item #5 in the audit.

## Motivation
Checkout Sessions

## Testing
- Added coverage that missing and null enabled adjustable quantity bounds fail decoding.
- Updated coverage for mapping server-provided bounds and allowing disabled adjustable quantity without bounds.
- 59 unit tests pass.

## Changelog
N/A