### PR TITLE
Align Payment Pages response decoding

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
@@ -147,7 +147,7 @@ extension PaymentPagesAPIResponse {
                         adjustableQuantity = nil
                     }
                     return CheckoutController.Session.OrderSummaryItem.OneTimePrice.Item(
-                        key: price.id,
+                        key: item.innerItemKey,
                         displayName: product.name,
                         images: product.images,
                         unitAmount: makeAmount(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
@@ -19,7 +19,6 @@ struct PaymentPagesAPIResponse: UnknownFieldsDecodable, CustomStringConvertible 
     var _allResponseFieldsStorage: NonEncodableParameters?
 
     let sessionId: String
-    let clientSecret: String?
     let paymentIntentId: String?
     let paymentIntent: STPPaymentIntent?
     let setupIntentId: String?
@@ -60,7 +59,6 @@ struct PaymentPagesAPIResponse: UnknownFieldsDecodable, CustomStringConvertible 
         let props: [String] = [
             "PaymentPagesAPIResponse",
             "sessionId = \(sessionId)",
-            "clientSecret = <redacted>",
             "currency = \(currency)",
             "mode = \(String(describing: allResponseFields["mode"]))",
             "status = \(status)",
@@ -78,7 +76,6 @@ struct PaymentPagesAPIResponse: UnknownFieldsDecodable, CustomStringConvertible 
 
     private enum CodingKeys: String, CodingKey {
         case sessionId
-        case clientSecret
         case paymentIntent
         case setupIntent
         case currency
@@ -87,7 +84,6 @@ struct PaymentPagesAPIResponse: UnknownFieldsDecodable, CustomStringConvertible 
         case mode
         case status
         case paymentStatus
-        case paymentMethodTypes
         case customerEmail
         case url
         case savedPaymentMethodsOfferSave = "customer_managed_saved_payment_methods_offer_save"
@@ -107,7 +103,6 @@ struct PaymentPagesAPIResponse: UnknownFieldsDecodable, CustomStringConvertible 
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         sessionId = try container.decode(String.self, forKey: .sessionId)
-        clientSecret = try container.decodeIfPresent(String.self, forKey: .clientSecret)
         let decodedPaymentIntent = try container.decodeIfPresent(
             LegacyExpandable<STPPaymentIntent>.self,
             forKey: .paymentIntent
@@ -159,7 +154,6 @@ struct PaymentPagesAPIResponse: UnknownFieldsDecodable, CustomStringConvertible 
             throw decoder.dataCorrupted("Unsupported Checkout Session status: \(decodedStatus)")
         }
         self.status = status
-        _ = try container.decode([String].self, forKey: .paymentMethodTypes)
 
         customerEmail = try container.decodeIfPresent(String.self, forKey: .customerEmail)
         url = try container.decodeIfPresent(String.self, forKey: .url)
@@ -278,6 +272,7 @@ extension PaymentPagesAPIResponse {
     }
 
     struct OneTimePriceItem: Decodable {
+        let innerItemKey: String
         let price: Price
         let quantity: Int
         let unitAmount: Int?
@@ -292,8 +287,6 @@ extension PaymentPagesAPIResponse {
             case innerItemKey
             case price
             case quantity
-            case subtotal
-            case total
             case unitAmount
             case unitAmountDecimal
             case unitLabel
@@ -305,14 +298,12 @@ extension PaymentPagesAPIResponse {
 
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
-            _ = try container.decode(String.self, forKey: .innerItemKey)
+            innerItemKey = try container.decode(String.self, forKey: .innerItemKey)
             price = try container.decode(Price.self, forKey: .price)
             quantity = try container.decode(Int.self, forKey: .quantity)
             guard quantity >= 0 else {
                 throw decoder.dataCorrupted("quantity must not be negative")
             }
-            _ = try container.decode(Int.self, forKey: .subtotal)
-            _ = try container.decode(Int.self, forKey: .total)
             unitAmount = try container.decodeIfPresent(Int.self, forKey: .unitAmount)
 
             if let rawUnitAmountDecimal = try container.decodeIfPresent(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutDefaultsInitializationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutDefaultsInitializationTests.swift
@@ -235,7 +235,6 @@ final class CheckoutDefaultsInitializationTests: XCTestCase {
     ) -> [AnyHashable: Any] {
         var json = CheckoutTestHelpers.openSessionJSON
         json["session_id"] = sessionId
-        json["client_secret"] = clientSecret
         json["tax_context"] = [
             "automatic_tax_enabled": true,
             "automatic_tax_address_source": "session.\(automaticTaxAddressSource)",

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -164,7 +164,7 @@ enum CheckoutTestHelpers {
         stubAllOutgoingRequests: Bool = true
     ) -> CheckoutController.Configuration {
         // Use the production Checkout initializer with a test-controlled API client.
-        let clientSecret = configuration?.clientSecret ?? apiResponse.clientSecret ?? "cs_test_123_secret_abc"
+        let clientSecret = configuration?.clientSecret ?? "\(apiResponse.sessionId)_secret_abc"
         var resolvedConfiguration = configuration ?? CheckoutController.Configuration(clientSecret: clientSecret, returnURL: "stripe-ios-test://checkout-return")
         resolvedConfiguration.apiClient = makeStubbedAPIClient(
             apiResponse: apiResponse,
@@ -180,7 +180,7 @@ enum CheckoutTestHelpers {
         apiResponse: PaymentPagesAPIResponse = makeOpenSession(),
         configuration: CheckoutController.Configuration? = nil
     ) -> CheckoutController.Configuration {
-        let clientSecret = configuration?.clientSecret ?? apiResponse.clientSecret ?? "cs_test_123_secret_abc"
+        let clientSecret = configuration?.clientSecret ?? "\(apiResponse.sessionId)_secret_abc"
         var resolvedConfiguration = configuration ?? CheckoutController.Configuration(clientSecret: clientSecret, returnURL: "stripe-ios-test://checkout-return")
         resolvedConfiguration.adaptivePricing.allowed = true
         return makeConfiguration(apiResponse: apiResponse, configuration: resolvedConfiguration)
@@ -192,7 +192,7 @@ enum CheckoutTestHelpers {
         clientSecret: String? = nil,
         stubAllOutgoingRequests: Bool = true
     ) -> STPAPIClient {
-        let resolvedClientSecret = clientSecret ?? apiResponse.clientSecret ?? "cs_test_123_secret_abc"
+        let resolvedClientSecret = clientSecret ?? "\(apiResponse.sessionId)_secret_abc"
         let sessionId = CheckoutController.extractSessionId(from: resolvedClientSecret)
         let apiClient = APIStubbedTestCase.stubbedAPIClient()
         apiClient.publishableKey = "pk_test_123"
@@ -215,7 +215,6 @@ enum CheckoutTestHelpers {
         }) { _ in
             // Feed CheckoutController(configuration:) the session fixture this test requested.
             var responseJSON = jsonObject(apiResponse.allResponseFields) as? [String: Any] ?? [:]
-            responseJSON["client_secret"] = resolvedClientSecret
             responseJSON["session_id"] = responseJSON["session_id"] ?? sessionId
             let data = try! JSONSerialization.data(withJSONObject: responseJSON, options: [])
             return HTTPStubsResponse(data: data, statusCode: 200, headers: nil)
@@ -226,7 +225,6 @@ enum CheckoutTestHelpers {
                 && request.url?.path == "/v1/payment_pages/\(sessionId)"
         }) { _ in
             var responseJSON = jsonObject(apiResponse.allResponseFields) as? [String: Any] ?? [:]
-            responseJSON["client_secret"] = resolvedClientSecret
             responseJSON["session_id"] = responseJSON["session_id"] ?? sessionId
             let data = try! JSONSerialization.data(withJSONObject: responseJSON, options: [])
             return HTTPStubsResponse(data: data, statusCode: 200, headers: nil)
@@ -291,7 +289,6 @@ enum CheckoutTestHelpers {
     static let openSessionJSON: [AnyHashable: Any] = [
         "session_id": "cs_test_123",
         "object": "checkout.session",
-        "client_secret": "cs_test_123_secret_abc",
         "livemode": false,
         "mode": "modeless",
         "status": "open",

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -669,7 +669,7 @@ final class CheckoutUnitTests: XCTestCase {
                   key: "checkout_item_test"
                   items: [
                     [0] {
-                      key: "price_test"
+                      key: "checkout_item_inner_test"
                       quantity: 1
                       unitAmount: "$10.00"
                       unitAmountDecimal: "$10.00"

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
@@ -35,7 +35,6 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             "livemode",
             "status",
             "payment_status",
-            "payment_method_types",
             "elements_session",
         ]
 
@@ -55,6 +54,21 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             try PaymentPagesAPIResponse.decode(fromAPIResponse: emptyCurrencyJson),
             "should fail to decode with an empty currency"
         )
+    }
+
+    func testDecodedObjectFromAPIResponseDoesNotRequireUnusedFields() throws {
+        var json = CheckoutTestHelpers.makeSessionJSON()
+        json.removeValue(forKey: "payment_method_types")
+        var checkoutItems = json["checkout_items"] as! [[String: Any]]
+        var oneTimePrice = checkoutItems[0]["one_time_price"] as! [String: Any]
+        var items = oneTimePrice["items"] as! [[String: Any]]
+        items[0].removeValue(forKey: "subtotal")
+        items[0].removeValue(forKey: "total")
+        oneTimePrice["items"] = items
+        checkoutItems[0]["one_time_price"] = oneTimePrice
+        json["checkout_items"] = checkoutItems
+
+        XCTAssertNoThrow(try PaymentPagesAPIResponse.decode(fromAPIResponse: json))
     }
 
     func testDecodedObjectFromAPIResponseMapsSessionStatus() throws {
@@ -164,6 +178,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         XCTAssertEqual(apiResponse.status, .open)
         XCTAssertEqual(apiResponse.paymentStatus, .unpaid)
         XCTAssertEqual(apiResponse.checkoutItems.first?.key, "ci_1abc")
+        XCTAssertEqual(apiResponse.checkoutItems.first?.oneTimePrice.items.first?.innerItemKey, "cii_1abc")
         XCTAssertEqual(apiResponse.adaptivePricingInfo?.activePresentmentCurrency, "eur")
         XCTAssertEqual(apiResponse.adaptivePricingInfo?.integrationAmount, 12000)
         XCTAssertEqual(apiResponse.adaptivePricingInfo?.integrationCurrency, "usd")
@@ -173,7 +188,6 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         XCTAssertEqual(apiResponse.adaptivePricingInfo?.localCurrencyOptions.first?.presentmentExchangeRate, "0.90325")
 
         XCTAssertEqual(session.id, "cs_test_a1b2c3d4e5f6g7h8i9j0")
-        XCTAssertEqual(apiResponse.clientSecret, "cs_test_a1b2c3d4e5f6g7h8i9j0_secret_xyz123abc456")
         XCTAssertEqual(session.totals.total.minorUnitsAmount, 2149)
         XCTAssertEqual(session.totals.subtotal.minorUnitsAmount, 2000)
         XCTAssertEqual(session.currency, "usd")
@@ -271,7 +285,6 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         XCTAssertEqual(session.totals.total.minorUnitsAmount, 1000)
         XCTAssertEqual(session.currency, "usd")
         XCTAssertNil(session.presentmentDetails)
-        XCTAssertNil(apiResponse.clientSecret)
         XCTAssertNil(apiResponse.paymentIntentId)
         XCTAssertNil(apiResponse.setupIntentId)
         XCTAssertNil(session.customer)
@@ -576,7 +589,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         XCTAssertEqual(oneTimePrice.key, "checkout_item_abc123")
         XCTAssertNil(oneTimePrice.description)
         XCTAssertEqual(oneTimePrice.items.count, 1)
-        XCTAssertEqual(oneTimePrice.items[0].key, "price_test123")
+        XCTAssertEqual(oneTimePrice.items[0].key, "checkout_item_inner_abc123")
         XCTAssertEqual(oneTimePrice.items[0].displayName, "Classic T-Shirt")
         XCTAssertEqual(oneTimePrice.items[0].images, ["https://example.com/shirt.png"])
         XCTAssertEqual(oneTimePrice.items[0].quantity, 2)
@@ -697,8 +710,6 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             "inner_item_key",
             "price",
             "quantity",
-            "subtotal",
-            "total",
             "tax_amounts",
             "tax_inclusive",
             "tax_exclusive",

--- a/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CheckoutSession.json
+++ b/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CheckoutSession.json
@@ -118,7 +118,6 @@
   "mode": "modeless",
   "status": "open",
   "payment_status": "unpaid",
-  "client_secret": "cs_test_a1b2c3d4e5f6g7h8i9j0_secret_xyz123abc456",
   "customer": {
     "id": "cus_test123456",
     "object": "customer",

--- a/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CheckoutSessionConfirmed.json
+++ b/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CheckoutSessionConfirmed.json
@@ -105,7 +105,6 @@
   "mode": "modeless",
   "status": "complete",
   "payment_status": "paid",
-  "client_secret": "cs_test_a1b2c3d4e5f6g7h8i9j0_secret_xyz123abc456",
   "customer": {
     "id": "cus_test123456",
     "object": "customer",


### PR DESCRIPTION
## Summary

Payment Pages can omit `payment_method_types` and does not return `client_secret`, but the SDK treated both as part of the response contract. It also decoded and discarded per-item totals and exposed Price IDs instead of `inner_item_key` as order summary item keys.

Now decoding only requires fields the SDK uses, and one-time Price item keys use the stable identifier supplied by Payment Pages. Test fixtures also match the Payment Pages response shape.

## Motivation

Checkout Elements API contract audit

## Testing

- New coverage verifies responses decode when unused payment method types and nested totals are absent.
- Existing response mapping coverage verifies the public item key uses `inner_item_key`.
- Existing Checkout initialization and confirmation coverage.

## Changelog

N/A
