### PR TITLE
Document Payment Pages mobile response profile

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
@@ -10,7 +10,12 @@ import Foundation
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
 
-/// Internal response model for the Payment Pages API endpoints.
+/// Internal response model for the Payment Pages API endpoints used by mobile Checkout.
+///
+/// This decoder supports modeless Checkout responses with Elements aggregation, which is a
+/// narrower contract than the generic PaymentPage OpenAPI schema. Checkout requests aggregation
+/// and treats responses that omit required mobile fields, including `elements_session`, as
+/// unsupported.
 ///
 /// Properties in this model mirror the API payload. Conversion to the public Checkout
 /// representation belongs in `makePublicSession()`.

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
@@ -26,7 +26,8 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             "can decode with full json"
         )
 
-        // Required fields per API spec (non-nullable)
+        // Required by the modeless mobile Checkout decoder, which supports a narrower response
+        // profile than the generic PaymentPage API schema.
         let requiredFields = [
             "session_id",
             "currency",


### PR DESCRIPTION
## Summary
Documents that the Payment Pages decoder targets the modeless mobile Checkout response profile with Elements aggregation, not every payload allowed by the generic PaymentPage schema. Updates the decoder test language to describe the SDK contract instead of claiming these fields are universally required by the API spec.

## Motivation
Checkout Sessions contract audit

## Testing
No new tests.

## Changelog
N/A