### PR TITLE
Reject empty Payment Pages cart groups

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
@@ -275,6 +275,22 @@ extension PaymentPagesAPIResponse {
         let items: [OneTimePriceItem]
         let subtotal: Int
         let total: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case items
+            case subtotal
+            case total
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            items = try container.decode([OneTimePriceItem].self, forKey: .items)
+            guard !items.isEmpty else {
+                throw decoder.dataCorrupted("one_time_price items must not be empty")
+            }
+            subtotal = try container.decode(Int.self, forKey: .subtotal)
+            total = try container.decode(Int.self, forKey: .total)
+        }
     }
 
     struct OneTimePriceItem: Decodable {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
@@ -832,14 +832,19 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         XCTAssertNil(disabledOneTimePrice.items.first?.adjustableQuantity)
     }
 
-    func testUnifiedModeSessionAllowsEmptyNestedItems() throws {
+    func testUnifiedModeSessionRejectsEmptyOneTimePriceItems() {
         let json = modifyingOneTimePrice { $0["items"] = [] }
-        let response = try PaymentPagesAPIResponse.decode(fromAPIResponse: json)
-        guard case .oneTimePrice(let oneTimePrice) = response.makePublicSession().orderSummaryItems.first else {
-            return XCTFail("Expected one-time Price order summary item")
-        }
 
-        XCTAssertTrue(oneTimePrice.items.isEmpty)
+        XCTAssertThrowsError(try PaymentPagesAPIResponse.decode(fromAPIResponse: json)) { error in
+            guard case .dataCorrupted(let context) = error as? DecodingError else {
+                return XCTFail("Expected dataCorrupted, got \(error)")
+            }
+            XCTAssertEqual(
+                context.codingPath.map(\.stringValue),
+                ["checkoutItems", "0", "oneTimePrice"]
+            )
+            XCTAssertEqual(context.debugDescription, "one_time_price items must not be empty")
+        }
     }
 
     func testMerchantWillSavePaymentMethod_paymentModeWithoutSetupFutureUsage() {


### PR DESCRIPTION
## Summary
Payment Pages can omit every row in a one-time Price group when it fails to correlate configured items with bill items. We previously decoded that as a valid empty cart group. Now Checkout fails to load that malformed group instead of exposing an empty order summary.

## Motivation
Payment Pages response contract audit #9

## Testing
- Added coverage that rejects Payment Pages responses containing an empty one-time Price group.
- Existing Payment Pages response decoder tests pass.

## Changelog
N/A