### PR TITLE
Add FC data permissions API to LinkController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ MINOR
 * [Added] Added support for the following FPX banks: Agrobank, Bank of China, and MBSB Bank.
 * [Fixed] Fixed an issue where card decline error messages became generic after 3DS authentication.
 
+### PaymentSheet
+* [Added] Added `financialConnectionsPermissions` to `LinkConfiguration`, allowing `LinkControllerPreview` users to request Financial Connections data permissions (private preview).
+
 ## 26.7.0 2026-08-17
 ### PaymentSheet
 * [Added] StripePaymentSheet now depends on `StripeFinancialConnectionsLite` to support lightweight bank payment flows. If you use StripePaymentSheet with Carthage or by manually embedding the .xcframeworks, [you must also embed StripeFinancialConnectionsLite.xcframework](https://github.com/stripe/stripe-ios/blob/master/MIGRATING.md#migrating-from-versions--2670) in your app. No action is required for CocoaPods or Swift Package Manager users.

--- a/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/ExampleLinkControllerPreviewView.swift
@@ -76,6 +76,29 @@ struct ExampleLinkControllerPreviewView: View {
                         .pickerStyle(.segmented)
                     }
 
+                    DemoSection(title: "Financial Connections Permissions") {
+                        VStack(alignment: .leading, spacing: 16) {
+                            ForEach(LinkControllerDemoConfiguration.FCPermission.allCases, id: \.self) { permission in
+                                Button {
+                                    if configuration.requestedFCPermissions.contains(permission) {
+                                        configuration.requestedFCPermissions.remove(permission)
+                                    } else {
+                                        configuration.requestedFCPermissions.insert(permission)
+                                    }
+                                } label: {
+                                    HStack(spacing: 12) {
+                                        Image(systemName: configuration.requestedFCPermissions.contains(permission) ? "checkmark.square.fill" : "square")
+                                            .foregroundColor(configuration.requestedFCPermissions.contains(permission) ? .blue : .gray)
+                                        Text(permission.displayName)
+                                            .foregroundColor(.primary)
+                                        Spacer()
+                                    }
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+
                     DemoSection(title: "Intent Mode") {
                         VStack(alignment: .leading, spacing: 16) {
                             Picker("Intent Mode", selection: $configuration.intentMode) {

--- a/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoConfiguration.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoConfiguration.swift
@@ -13,6 +13,28 @@ struct LinkControllerDemoConfiguration {
     var paymentMethodTypesMode: PaymentMethodTypesMode = .automatic
     var intentMode: IntentMode = .sdkManaged
     var useCustomAppearance: Bool = false
+    var requestedFCPermissions: Set<FCPermission> = []
+
+    enum FCPermission: String, CaseIterable {
+        case paymentMethod = "payment_method"
+        case balances = "balances"
+        case ownership = "ownership"
+        case transactions = "transactions"
+
+        var displayName: String {
+            switch self {
+            case .paymentMethod: return "payment_method"
+            case .balances: return "balances"
+            case .ownership: return "ownership"
+            case .transactions: return "transactions"
+            }
+        }
+    }
+
+    var financialConnectionsPermissions: [String]? {
+        guard !requestedFCPermissions.isEmpty else { return nil }
+        return requestedFCPermissions.map(\.rawValue).sorted()
+    }
 
     var appearance: LinkAppearance? {
         guard useCustomAppearance else { return nil }

--- a/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/LinkControllerDemoView.swift
@@ -195,7 +195,8 @@ struct LinkControllerDemoView: View {
                 configuration: .init(
                     supportedPaymentMethodTypes: Array(configuration.supportedPaymentMethodTypes),
                     paymentMethodTypes: configuration.paymentMethodTypes,
-                    merchantDisplayName: "Example, Inc."
+                    merchantDisplayName: "Example, Inc.",
+                    financialConnectionsPermissions: configuration.financialConnectionsPermissions
                 )
             )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+PaymentSheet.swift
@@ -87,6 +87,15 @@ extension STPAPIClient {
                     deferredIntent["mode"] = "setup"
                     deferredIntent["currency"] = currency
                     deferredIntent["setup_future_usage"] = setupFutureUsage.rawValue
+                    if let fcPermissions = intentConfig.financialConnectionsPermissions, !fcPermissions.isEmpty {
+                        deferredIntent["payment_method_options"] = [
+                            "link": [
+                                "financial_connections": [
+                                    "permissions": fcPermissions,
+                                ],
+                            ],
+                        ]
+                    }
                 }
                 return deferredIntent
             }()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkConfiguration.swift
@@ -32,6 +32,9 @@ public struct LinkConfiguration {
     /// If `nil`, uses the billing details collection configuration from the `PaymentElementConfiguration` passed at init.
     @_spi(LinkControllerPreview) public let billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration?
 
+    /// The Financial Connections permissions to request. If `nil`, no specific permissions are requested.
+    @_spi(LinkControllerPreview) public let financialConnectionsPermissions: [String]?
+
     /// Creates a new instance of `LinkConfiguration`.
     /// - Parameters:
     ///   - hintMessage: Custom hint message to display in the wallet view. If `nil`, no hint will be shown.
@@ -46,6 +49,7 @@ public struct LinkConfiguration {
         self.paymentMethodTypes = nil
         self.merchantDisplayName = nil
         self.billingDetailsCollectionConfiguration = nil
+        self.financialConnectionsPermissions = nil
     }
 
     /// Creates a new instance of `LinkConfiguration`.
@@ -55,12 +59,14 @@ public struct LinkConfiguration {
     ///   - allowLogout: Whether to allow the user to log out. When `false`, the logout menu button will be hidden. Defaults to `true`.
     ///   - merchantDisplayName: The merchant name displayed in Link UI. If `nil`, defaults to the app's `CFBundleDisplayName`.
     ///   - billingDetailsCollectionConfiguration: Configures billing details collection in the Link sheet. If `nil`, uses the billing details collection configuration from the `PaymentElementConfiguration` passed at init.
+    ///   - financialConnectionsPermissions: The Financial Connections permissions to request. If `nil`, no specific permissions are requested.
     @_spi(LinkControllerPreview) public init(
         supportedPaymentMethodTypes: [LinkPaymentMethodType]? = nil,
         paymentMethodTypes: [String]? = nil,
         allowLogout: Bool = true,
         merchantDisplayName: String? = nil,
-        billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration? = nil
+        billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration? = nil,
+        financialConnectionsPermissions: [String]? = nil
     ) {
         self.hintMessage = nil
         self.allowLogout = allowLogout
@@ -68,5 +74,6 @@ public struct LinkConfiguration {
         self.paymentMethodTypes = paymentMethodTypes
         self.merchantDisplayName = merchantDisplayName
         self.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration
+        self.financialConnectionsPermissions = financialConnectionsPermissions
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Link/LinkController.swift
@@ -1075,7 +1075,7 @@ import UIKit
         analyticsHelper: PaymentSheetAnalyticsHelper
     ) async throws -> PaymentSheetLoader.LoadResult {
         // Stub path: no real intent, PM creation and confirmation handled externally.
-        let intentConfiguration = PaymentSheet.IntentConfiguration(
+        var intentConfiguration = PaymentSheet.IntentConfiguration(
             mode: .setup(
                 currency: nil,
                 setupFutureUsage: .offSession
@@ -1086,6 +1086,7 @@ import UIKit
                 return PaymentSheet.IntentConfiguration.COMPLETE_WITHOUT_CONFIRMING_INTENT
             }
         )
+        intentConfiguration.financialConnectionsPermissions = linkConfiguration?.financialConnectionsPermissions
         let mode: PaymentSheet.InitializationMode = .deferredIntent(intentConfiguration)
 
         let (result, _) = try await PaymentSheetLoader.load(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetIntentConfiguration.swift
@@ -259,6 +259,8 @@ public extension PaymentSheet {
 
         // MARK: - Internal
 
+        @_spi(STP) public var financialConnectionsPermissions: [String]?
+
         @discardableResult
         func validate() -> Error? {
             let errorMessage: String

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkControllerPreviewAPITests.swift
@@ -16,6 +16,7 @@ final class LinkControllerPreviewAPITests: XCTestCase {
         _ = LinkConfiguration(supportedPaymentMethodTypes: [.card], merchantDisplayName: "Example Merchant")
         _ = LinkConfiguration(supportedPaymentMethodTypes: [.card], billingDetailsCollectionConfiguration: .init())
         _ = LinkConfiguration(billingDetailsCollectionConfiguration: .init()).billingDetailsCollectionConfiguration
+        _ = LinkConfiguration(financialConnectionsPermissions: ["payment_method", "balances"]).financialConnectionsPermissions
 
         let result: LinkController.PaymentMethodResult = .canceled
         _ = result

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+PaymentSheetTest.swift
@@ -96,6 +96,54 @@ class STPAPIClient_PaymentSheetTest: XCTestCase {
         XCTAssertEqual(deferredIntent["setup_future_usage"] as? String, "off_session")
     }
 
+    func testElementsSessionParameters_DeferredSetup_WithFCPermissions() throws {
+        var intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD",
+                                                                          setupFutureUsage: .offSession),
+                                                            paymentMethodTypes: ["link"],
+                                                            confirmHandler: { _, _ in return "" })
+        intentConfig.financialConnectionsPermissions = ["payment_method", "balances", "ownership", "transactions"]
+
+        AnalyticsHelper.shared.generateSessionID()
+
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(
+            mode: .deferredIntent(intentConfig),
+            epmConfiguration: nil,
+            cpmConfiguration: nil,
+            clientDefaultPaymentMethod: nil,
+            customerAccessProvider: nil,
+            linkDisallowFundingSourceCreation: []
+        )
+
+        let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as? [String: Any])
+        XCTAssertEqual(deferredIntent["mode"] as? String, "setup")
+        let paymentMethodOptions = try XCTUnwrap(deferredIntent["payment_method_options"] as? [String: Any])
+        let linkOptions = try XCTUnwrap(paymentMethodOptions["link"] as? [String: Any])
+        let financialConnections = try XCTUnwrap(linkOptions["financial_connections"] as? [String: Any])
+        XCTAssertEqual(financialConnections["permissions"] as? [String], ["payment_method", "balances", "ownership", "transactions"])
+    }
+
+    func testElementsSessionParameters_DeferredSetup_NilFCPermissions() throws {
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .setup(currency: "USD",
+                                                                          setupFutureUsage: .offSession),
+                                                            paymentMethodTypes: ["link"],
+                                                            confirmHandler: { _, _ in return "" })
+        // financialConnectionsPermissions is nil by default
+
+        AnalyticsHelper.shared.generateSessionID()
+
+        let parameters = STPAPIClient(publishableKey: "pk_test").makeElementsSessionsParams(
+            mode: .deferredIntent(intentConfig),
+            epmConfiguration: nil,
+            cpmConfiguration: nil,
+            clientDefaultPaymentMethod: nil,
+            customerAccessProvider: nil,
+            linkDisallowFundingSourceCreation: []
+        )
+
+        let deferredIntent = try XCTUnwrap(parameters["deferred_intent"] as? [String: Any])
+        XCTAssertNil(deferredIntent["payment_method_options"])
+    }
+
     func testMakeDeferredElementsSessionsParamsForCustomerSheet() throws {
         let parameters = STPAPIClient(publishableKey: "pk_test").makeDeferredElementsSessionsParamsForCustomerSheet(
             paymentMethodTypes: ["card"],


### PR DESCRIPTION
## Summary

Adds a `financialConnectionsPermissions` field to the `LinkConfiguration` to allow requesting specific FC data permissions.

`financialConnectionsPermissions` is passed as Link Financial Connections permissions in the deferred setup request that initializes LinkController. Leave it as nil (default value) when you do not need to request specific Financial Connections data permissions.

The valid permissions are listed here: https://docs.stripe.com/api/financial_connections/sessions/create?api-version=2026-07-29.preview&rds=1#financial_connections_create_session-permissions

Usage example:

```swift
let configuration = LinkConfiguration(
    supportedPaymentMethodTypes: [.bankAccount],
    merchantDisplayName: "Acme Inc.",
    financialConnectionsPermissions: [
        "payment_method",
        "balances",
        "ownership",
        "transactions",
    ]
)
```

## Motivation

https://docs.google.com/document/d/1P5xutRnjin4gOs_q2ZVRDas9uuA5Ms1hagSRO1Ppt8Y/edit?tab=t.0#heading=h.feg9r3hfqmmf

## Testing

Demo app updated to test this app

<img width=40% src="https://github.com/user-attachments/assets/2d5888d6-b1bc-4658-9f17-707480961d58" />

## Changelog

```
### PaymentSheet
* [Added] Added `financialConnectionsPermissions` to `LinkConfiguration`, allowing `LinkControllerPreview` users to request Financial Connections data permissions (private preview).
```

