### PR TITLE
Fix Apple Pay presentation window for Catalyst

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm+ApplePay.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm+ApplePay.swift
@@ -9,17 +9,20 @@
 import Foundation
 @_spi(STP) import StripeCore
 @_spi(STP) import StripePayments
+import UIKit
 
 extension CheckoutController {
     static func confirmApplePay(
         checkoutSession: Session,
         applePayConfirmationContext: ApplePayConfirmationContext,
+        presentationWindow: UIWindow?,
         sessionUpdater: ExpressCheckoutSessionUpdater
     ) async -> InternalConfirmResult {
         do {
             let context = try CheckoutApplePayContext.create(
                 checkoutSession: checkoutSession,
                 applePayConfirmationContext: applePayConfirmationContext,
+                presentationWindow: presentationWindow,
                 sessionUpdater: sessionUpdater
             )
             return await context.presentApplePay()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
@@ -169,6 +169,7 @@ extension CheckoutController {
             return await confirmApplePay(
                 checkoutSession: checkoutSession,
                 applePayConfirmationContext: applePayConfirmationContext,
+                presentationWindow: authenticationContext.authenticationPresentingViewController().view.window,
                 sessionUpdater: sessionUpdater
             )
         case .new(let confirmParams):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutApplePayContext.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutApplePayContext.swift
@@ -201,7 +201,7 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
         }
     }
 
-    func presentationWindow(for controller: PKPaymentAuthorizationController) -> UIWindow? {
+    nonisolated func presentationWindow(for controller: PKPaymentAuthorizationController) -> UIWindow? {
         return presentationWindow
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutApplePayContext.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutApplePayContext.swift
@@ -31,6 +31,7 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
     private let merchantLabel: String
     private let apiClient: STPAPIClient
     private let returnURL: String
+    private let presentationWindow: UIWindow?
     let authorizationController: PKPaymentAuthorizationController
 
     // Internal state
@@ -45,6 +46,7 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
     init(
         checkoutSession: CheckoutController.Session,
         applePayConfirmationContext: CheckoutController.ApplePayConfirmationContext,
+        presentationWindow: UIWindow?,
         sessionUpdater: ExpressCheckoutSessionUpdater,
         authorizationController: PKPaymentAuthorizationController
     ) {
@@ -53,6 +55,7 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
         self.merchantLabel = applePayConfirmationContext.merchantDisplayName
         self.apiClient = applePayConfirmationContext.apiClient
         self.returnURL = applePayConfirmationContext.returnURL
+        self.presentationWindow = presentationWindow
         self.authorizationController = authorizationController
         super.init()
     }
@@ -198,6 +201,10 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
         }
     }
 
+    func presentationWindow(for controller: PKPaymentAuthorizationController) -> UIWindow? {
+        return presentationWindow
+    }
+
     func paymentAuthorizationController(
         _ controller: PKPaymentAuthorizationController,
         didSelectPaymentMethod paymentMethod: PKPaymentMethod,
@@ -239,6 +246,7 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
     static func create(
         checkoutSession: CheckoutController.Session,
         applePayConfirmationContext: CheckoutController.ApplePayConfirmationContext,
+        presentationWindow: UIWindow?,
         sessionUpdater: ExpressCheckoutSessionUpdater
     ) throws -> CheckoutApplePayContext {
         let applePayConfig = applePayConfirmationContext.applePayConfiguration
@@ -277,6 +285,7 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
         return CheckoutApplePayContext(
             checkoutSession: checkoutSession,
             applePayConfirmationContext: applePayConfirmationContext,
+            presentationWindow: presentationWindow,
             sessionUpdater: sessionUpdater,
             authorizationController: authorizationController
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutApplePayContextFunctionalTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutApplePayContextFunctionalTest.swift
@@ -83,6 +83,7 @@ class CheckoutApplePayContextFunctionalTest: STPNetworkStubbingTestCase {
         let context = CheckoutApplePayContext(
             checkoutSession: session,
             applePayConfirmationContext: applePayConfirmationContext,
+            presentationWindow: nil,
             sessionUpdater: StubExpressCheckoutSessionUpdater(),
             authorizationController: MockPKPaymentAuthorizationController()
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutApplePayContextTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutApplePayContextTests.swift
@@ -14,6 +14,7 @@ import PassKit
 @testable @_spi(STP) import StripePayments
 @testable @_spi(STP) import StripePaymentSheet
 import StripePaymentsObjcTestUtils
+import UIKit
 import XCTest
 
 @MainActor
@@ -55,6 +56,20 @@ final class CheckoutApplePayContextTests: XCTestCase {
         XCTAssertEqual(items[0].label, "Test Store")
         XCTAssertEqual(items[0].type, .pending)
         XCTAssertEqual(items[0].amount, .zero)
+    }
+
+    // MARK: - presentationWindow
+
+    func testPresentationWindowReturnsConfiguredWindow() {
+        // Given
+        let presentationWindow = UIWindow()
+        let (context, authorizationController) = makeContext(presentationWindow: presentationWindow)
+
+        // When
+        let returnedWindow = context.presentationWindow(for: authorizationController)
+
+        // Then
+        XCTAssertNotNil(returnedWindow)
     }
 
     // MARK: - paymentAuthorizationControllerDidFinish state machine
@@ -126,7 +141,8 @@ final class CheckoutApplePayContextTests: XCTestCase {
 
     private func makeContext(
         sessionId: String = "cs_test_123",
-        apiClient: STPAPIClient? = nil
+        apiClient: STPAPIClient? = nil,
+        presentationWindow: UIWindow? = nil
     ) -> (CheckoutApplePayContext, MockPKPaymentAuthorizationController) {
         let resolvedAPIClient = apiClient ?? APIStubbedTestCase.stubbedAPIClient()
         let response = CheckoutTestHelpers.makeSession([
@@ -140,6 +156,7 @@ final class CheckoutApplePayContextTests: XCTestCase {
         let context = CheckoutApplePayContext(
             checkoutSession: session,
             applePayConfirmationContext: applePayConfirmationContext,
+            presentationWindow: presentationWindow,
             sessionUpdater: StubExpressCheckoutSessionUpdater(),
             authorizationController: mockController
         )


### PR DESCRIPTION
## Summary
Pass the presenting window through Checkout’s Apple Pay flow and implement the Catalyst-required delegate method.

## Motivation
Breaks CI

## Testing
Didn't test exact breakage, but should work.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
