### PR TITLE
Fix order-dependent Link URL generator tests

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Link/LinkURLGeneratorTests.swift
@@ -15,6 +15,11 @@ import StripeCoreTestUtils
 import XCTest
 
 class LinkURLGeneratorTests: XCTestCase {
+    override func setUp() {
+        super.setUp()
+        LinkAccountContext.shared.account = nil
+    }
+
     let testParams = LinkURLParams(paymentObject: .link_payment_method,
                                    publishableKey: "pk_test_123",
                                    stripeAccount: "acct_1234",


### PR DESCRIPTION
## Summary
 - Reset shared Link account state before each Link URL generator test.
 - Prevent stale customer emails from causing failures in `legacy-tests-16`.
  
## Motivation
legacy-tests-16 is failing

## Testing
Relying on CI

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
