### PR TITLE
Fix crash related to FC Lite on example apps

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnramp Example.xcodeproj/project.pbxproj
+++ b/Example/CryptoOnramp Example/CryptoOnramp Example.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		0B44B4012E576FAD00B58655 /* StripeUICore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0B44B3FF2E576FAD00B58655 /* StripeUICore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0B44B4032E576FC700B58655 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B44B4022E576FC700B58655 /* StripeFinancialConnections.framework */; };
 		0B44B4042E576FC700B58655 /* StripeFinancialConnections.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0B44B4022E576FC700B58655 /* StripeFinancialConnections.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1A3D03AA10B605C9447FF7E4 /* StripeFinancialConnectionsLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40B4BB65B07DA65BA163B12B /* StripeFinancialConnectionsLite.framework */; };
+		FF6447D9710B3FB24940E05B /* StripeFinancialConnectionsLite.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 40B4BB65B07DA65BA163B12B /* StripeFinancialConnectionsLite.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0B44B4062E576FEC00B58655 /* StripeIdentity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B44B4052E576FEC00B58655 /* StripeIdentity.framework */; };
 		0B44B4072E576FEC00B58655 /* StripeIdentity.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0B44B4052E576FEC00B58655 /* StripeIdentity.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0B44B4092E57700600B58655 /* Stripe.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0B44B4082E57700600B58655 /* Stripe.framework */; };
@@ -53,6 +55,7 @@
 			dstSubfolderSpec = 10;
 			files = (
 				0B44B4042E576FC700B58655 /* StripeFinancialConnections.framework in Embed Frameworks */,
+				FF6447D9710B3FB24940E05B /* StripeFinancialConnectionsLite.framework in Embed Frameworks */,
 				0B44B4072E576FEC00B58655 /* StripeIdentity.framework in Embed Frameworks */,
 				0B44B4012E576FAD00B58655 /* StripeUICore.framework in Embed Frameworks */,
 				0B8EB14B2F68947200D3C114 /* StripeIssuing.framework in Embed Frameworks */,
@@ -79,6 +82,7 @@
 		0B44B3FC2E576F9500B58655 /* StripePaymentsUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripePaymentsUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B44B3FF2E576FAD00B58655 /* StripeUICore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeUICore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B44B4022E576FC700B58655 /* StripeFinancialConnections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeFinancialConnections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		40B4BB65B07DA65BA163B12B /* StripeFinancialConnectionsLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeFinancialConnectionsLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B44B4052E576FEC00B58655 /* StripeIdentity.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeIdentity.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B44B4082E57700600B58655 /* Stripe.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Stripe.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0B44B40B2E57702B00B58655 /* StripeCameraCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripeCameraCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -100,6 +104,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				0B44B4032E576FC700B58655 /* StripeFinancialConnections.framework in Frameworks */,
+				1A3D03AA10B605C9447FF7E4 /* StripeFinancialConnectionsLite.framework in Frameworks */,
 				0B44B4062E576FEC00B58655 /* StripeIdentity.framework in Frameworks */,
 				0B44B4002E576FAD00B58655 /* StripeUICore.framework in Frameworks */,
 				0B8EB14A2F68947200D3C114 /* StripeIssuing.framework in Frameworks */,
@@ -152,6 +157,7 @@
 				0B44B4082E57700600B58655 /* Stripe.framework */,
 				0B44B4052E576FEC00B58655 /* StripeIdentity.framework */,
 				0B44B4022E576FC700B58655 /* StripeFinancialConnections.framework */,
+				40B4BB65B07DA65BA163B12B /* StripeFinancialConnectionsLite.framework */,
 				0B44B3FF2E576FAD00B58655 /* StripeUICore.framework */,
 				0B44B3FC2E576F9500B58655 /* StripePaymentsUI.framework */,
 				0B44B3F92E576F6C00B58655 /* StripePayments.framework */,

--- a/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
+++ b/Example/FinancialConnections Example/FinancialConnections Example.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0A6632AC245E8AD86850685A /* StripeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 03E7365D673694C8D7EDFB20 /* StripeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		0B647212C7B1C5DC253193E0 /* StripeFinancialConnections.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 5785AD2F7A6D71D9470B0DB6 /* StripeFinancialConnections.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1CFF70B5C24C0B66DD61CC8A /* StripeFinancialConnectionsLite.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8D70180F2224B4577209331B /* StripeFinancialConnectionsLite.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		49036F0E2D39512B00354EA7 /* StripePaymentSheet.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496BCB442D32D1A300BFC3EE /* StripePaymentSheet.framework */; };
 		49036F0F2D39512B00354EA7 /* StripePaymentSheet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 496BCB442D32D1A300BFC3EE /* StripePaymentSheet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		49036F1F2D3951EA00354EA7 /* StripePaymentsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49036F1C2D3951BC00354EA7 /* StripePaymentsUI.framework */; };
@@ -25,6 +26,7 @@
 		6AF9C66D47F81DD9B103FB64 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 03E7365D673694C8D7EDFB20 /* StripeCore.framework */; };
 		B2C9E2F901AC84064C0320DF /* StripeCoreTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3E1E39731621D996DDD83DAC /* StripeCoreTestUtils.framework */; };
 		DA6FA2C369E10A2B4663B434 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5785AD2F7A6D71D9470B0DB6 /* StripeFinancialConnections.framework */; };
+		E1256A693262E5E536213CFA /* StripeFinancialConnectionsLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8D70180F2224B4577209331B /* StripeFinancialConnectionsLite.framework */; };
 		E4B8E60D7957A844D5A75E4B /* StripeCoreTestUtils.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3E1E39731621D996DDD83DAC /* StripeCoreTestUtils.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
@@ -62,6 +64,7 @@
 				0A6632AC245E8AD86850685A /* StripeCore.framework in Embed Frameworks */,
 				49036F262D3951EF00354EA7 /* Stripe3DS2.framework in Embed Frameworks */,
 				0B647212C7B1C5DC253193E0 /* StripeFinancialConnections.framework in Embed Frameworks */,
+				1CFF70B5C24C0B66DD61CC8A /* StripeFinancialConnectionsLite.framework in Embed Frameworks */,
 				49036F0F2D39512B00354EA7 /* StripePaymentSheet.framework in Embed Frameworks */,
 				5C1B372D1660E856988156DA /* StripeUICore.framework in Embed Frameworks */,
 				49036F242D3951ED00354EA7 /* StripeApplePay.framework in Embed Frameworks */,
@@ -85,6 +88,7 @@
 		496515B42D356DFF007B94BB /* FinancialConnections Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = "FinancialConnections Example.entitlements"; path = "FinancialConnections Example/FinancialConnections Example.entitlements"; sourceTree = "<group>"; };
 		496BCB442D32D1A300BFC3EE /* StripePaymentSheet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = StripePaymentSheet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5785AD2F7A6D71D9470B0DB6 /* StripeFinancialConnections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8D70180F2224B4577209331B /* StripeFinancialConnectionsLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnectionsLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		5B50C88219DC0F3F0BFC5CE4 /* FinancialConnections-Example-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "FinancialConnections-Example-Release.xcconfig"; sourceTree = "<group>"; };
 		5B675DEF4776CDFF8309DEB8 /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
 		701003016E153D5DF2B00442 /* FinancialConnections-Example-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "FinancialConnections-Example-Debug.xcconfig"; sourceTree = "<group>"; };
@@ -122,6 +126,7 @@
 			files = (
 				6AF9C66D47F81DD9B103FB64 /* StripeCore.framework in Frameworks */,
 				DA6FA2C369E10A2B4663B434 /* StripeFinancialConnections.framework in Frameworks */,
+				E1256A693262E5E536213CFA /* StripeFinancialConnectionsLite.framework in Frameworks */,
 				49036F0E2D39512B00354EA7 /* StripePaymentSheet.framework in Frameworks */,
 				49036F252D3951EF00354EA7 /* Stripe3DS2.framework in Frameworks */,
 				49036F212D3951EB00354EA7 /* StripePayments.framework in Frameworks */,
@@ -172,6 +177,7 @@
 				49036F132D39515300354EA7 /* Stripe3DS2.framework */,
 				49036F102D39513000354EA7 /* Stripe.framework */,
 				496BCB442D32D1A300BFC3EE /* StripePaymentSheet.framework */,
+				8D70180F2224B4577209331B /* StripeFinancialConnectionsLite.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples.xcodeproj/project.pbxproj
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples.xcodeproj/project.pbxproj
@@ -10,12 +10,14 @@
 		002758E8FE057ACF7A168646 /* StripeCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A122962D3F1C0C7F56AC4501 /* StripeCore.framework */; };
 		1FA04694E0497168529EBEF9 /* Stripe.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6CA51E7BD0D4D1E0B94075FE /* Stripe.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		21EB5C20341E71683313BC87 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C55D540D77E57684BEBD1773 /* StripeFinancialConnections.framework */; };
+		2319FB5309031D811C5A1B24 /* StripeFinancialConnectionsLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8F5B6BBB1481C8AF4CF1E07 /* StripeFinancialConnectionsLite.framework */; };
 		237E7C2EA6DD82598235F430 /* StripeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A122962D3F1C0C7F56AC4501 /* StripeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		368F4BF044A248B48A527047 /* Stripe3DS2.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3300883AEEEF23265C6CA4BE /* Stripe3DS2.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		41FF78FEBE47A8DC481B55CF /* StripeApplePay.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 951B76B22A5088E944157C23 /* StripeApplePay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		5A6075039E5216D93B8AA113 /* StripeUICore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 9BDD4885AE1CEEEC3A45EC34 /* StripeUICore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		853FB2F6356CD4FA2DD8FE2E /* StripePaymentSheet.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 2ADDFFDCAC5AF682FC6648E8 /* StripePaymentSheet.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		882CBDC0B4F3E0C83AEC0D5E /* StripeFinancialConnections.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C55D540D77E57684BEBD1773 /* StripeFinancialConnections.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		075DBFDB6E4120CF78DBD7D7 /* StripeFinancialConnectionsLite.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8F5B6BBB1481C8AF4CF1E07 /* StripeFinancialConnectionsLite.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9F560040896BEB25E5B4ACCA /* StripePaymentsUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 173B34E97F92E48FBB42E82B /* StripePaymentsUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A8BE2C599C08080AE773D2D8 /* StripeApplePay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 951B76B22A5088E944157C23 /* StripeApplePay.framework */; };
 		AD9A0FE43A089F7CDAFF2DBB /* StripeUICore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9BDD4885AE1CEEEC3A45EC34 /* StripeUICore.framework */; };
@@ -38,6 +40,7 @@
 				41FF78FEBE47A8DC481B55CF /* StripeApplePay.framework in Embed Frameworks */,
 				237E7C2EA6DD82598235F430 /* StripeCore.framework in Embed Frameworks */,
 				882CBDC0B4F3E0C83AEC0D5E /* StripeFinancialConnections.framework in Embed Frameworks */,
+				075DBFDB6E4120CF78DBD7D7 /* StripeFinancialConnectionsLite.framework in Embed Frameworks */,
 				853FB2F6356CD4FA2DD8FE2E /* StripePaymentSheet.framework in Embed Frameworks */,
 				C1F0577CD62C2569EEEAD1E1 /* StripePayments.framework in Embed Frameworks */,
 				9F560040896BEB25E5B4ACCA /* StripePaymentsUI.framework in Embed Frameworks */,
@@ -64,6 +67,7 @@
 		A122962D3F1C0C7F56AC4501 /* StripeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		AECFE22E44BC2764379FB9C1 /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
 		C55D540D77E57684BEBD1773 /* StripeFinancialConnections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8F5B6BBB1481C8AF4CF1E07 /* StripeFinancialConnectionsLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnectionsLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC269156D60D875784B0E074 /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -90,6 +94,7 @@
 				A8BE2C599C08080AE773D2D8 /* StripeApplePay.framework in Frameworks */,
 				002758E8FE057ACF7A168646 /* StripeCore.framework in Frameworks */,
 				21EB5C20341E71683313BC87 /* StripeFinancialConnections.framework in Frameworks */,
+				2319FB5309031D811C5A1B24 /* StripeFinancialConnectionsLite.framework in Frameworks */,
 				F635434F095301C541789E1C /* StripePaymentSheet.framework in Frameworks */,
 				C5C612D49748599F5A09421D /* StripePayments.framework in Frameworks */,
 				B39123ECF62A2C629B4F32D6 /* StripePaymentsUI.framework in Frameworks */,
@@ -121,6 +126,7 @@
 				951B76B22A5088E944157C23 /* StripeApplePay.framework */,
 				A122962D3F1C0C7F56AC4501 /* StripeCore.framework */,
 				C55D540D77E57684BEBD1773 /* StripeFinancialConnections.framework */,
+				F8F5B6BBB1481C8AF4CF1E07 /* StripeFinancialConnectionsLite.framework */,
 				64F13592DB0CDD803283B035 /* StripePayments.framework */,
 				2ADDFFDCAC5AF682FC6648E8 /* StripePaymentSheet.framework */,
 				173B34E97F92E48FBB42E82B /* StripePaymentsUI.framework */,

--- a/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
+++ b/Example/PaymentSheet Example/PaymentSheet Example.xcodeproj/project.pbxproj
@@ -20,10 +20,12 @@
 		7CD54A47BC36A065ADA952BF /* StripeCoreTestUtils.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7C2D3C4D44C73D619A42CF3A /* StripeCoreTestUtils.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		7ECCD70F9CE16A1854F2633E /* StripeCoreTestUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C2D3C4D44C73D619A42CF3A /* StripeCoreTestUtils.framework */; };
 		95B578013869DFEA1C912A10 /* Stripe3DS2.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C2655A8B1DF0649CD996E045 /* Stripe3DS2.framework */; };
+		1FE9750093E1EDD645253117 /* StripeFinancialConnectionsLite.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B087D02B099A1ECC13A9376 /* StripeFinancialConnectionsLite.framework */; };
 		9F126696AD86BF2E861B5CC5 /* StripeFinancialConnections.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 16547B41C80B97FC2EFD0798 /* StripeFinancialConnections.framework */; };
 		C39CA2EBE08EE768559A8FD1 /* StripeCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1FD1F5193E4A361EA9E8FED3 /* StripeCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		D89C23032CFB732A0CFCD565 /* StripePayments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1E565B552830E657F863C4F8 /* StripePayments.framework */; };
 		FA36E30724AAC6E3EF717A6A /* StripeUICore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9F9C96D25ED549D6255FC274 /* StripeUICore.framework */; };
+		1B09800AE1BB820ACD063B05 /* StripeFinancialConnectionsLite.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 8B087D02B099A1ECC13A9376 /* StripeFinancialConnectionsLite.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FBA21DE7C9261D3BFD53A6CB /* StripeFinancialConnections.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 16547B41C80B97FC2EFD0798 /* StripeFinancialConnections.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		FD441E14EDF702D50D812875 /* iOSSnapshotTestCase in Frameworks */ = {isa = PBXBuildFile; productRef = B195FF5EEDEAC460C45887F1 /* iOSSnapshotTestCase */; };
 		FF1C880D1C27F7C384DD2509 /* StripeApplePay.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 63237DF22FD4600B9D2E8071 /* StripeApplePay.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -67,6 +69,7 @@
 				FF1C880D1C27F7C384DD2509 /* StripeApplePay.framework in Embed Frameworks */,
 				65D034E37B345C1B64785451 /* StripeCore.framework in Embed Frameworks */,
 				FBA21DE7C9261D3BFD53A6CB /* StripeFinancialConnections.framework in Embed Frameworks */,
+				1B09800AE1BB820ACD063B05 /* StripeFinancialConnectionsLite.framework in Embed Frameworks */,
 				75D1997DA514F6DB82FF1CFC /* StripePaymentSheet.framework in Embed Frameworks */,
 				09FA1391DCA2717DBC962562 /* StripePayments.framework in Embed Frameworks */,
 				37CDE2E21F00571F147FCFF7 /* StripePaymentsUI.framework in Embed Frameworks */,
@@ -92,6 +95,7 @@
 /* Begin PBXFileReference section */
 		0F208CB855923E7FD7BB0DC3 /* PaymentSheetLocalizationScreenshotGenerator-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "PaymentSheetLocalizationScreenshotGenerator-Debug.xcconfig"; sourceTree = "<group>"; };
 		16547B41C80B97FC2EFD0798 /* StripeFinancialConnections.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnections.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8B087D02B099A1ECC13A9376 /* StripeFinancialConnectionsLite.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeFinancialConnectionsLite.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E565B552830E657F863C4F8 /* StripePayments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripePayments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1FD1F5193E4A361EA9E8FED3 /* StripeCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripeCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		240DDF52B887E788853A838B /* StripePaymentSheet.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = StripePaymentSheet.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -164,6 +168,7 @@
 				1094816DB7E9DFAF01815365 /* StripeApplePay.framework in Frameworks */,
 				11DDC6610B393BFF4C6DF02C /* StripeCore.framework in Frameworks */,
 				9F126696AD86BF2E861B5CC5 /* StripeFinancialConnections.framework in Frameworks */,
+				1FE9750093E1EDD645253117 /* StripeFinancialConnectionsLite.framework in Frameworks */,
 				551DB033DB4C8257ABAADA8F /* StripePaymentSheet.framework in Frameworks */,
 				D89C23032CFB732A0CFCD565 /* StripePayments.framework in Frameworks */,
 				000D59C19A60AB637CE65EE9 /* StripePaymentsUI.framework in Frameworks */,
@@ -207,6 +212,7 @@
 				1FD1F5193E4A361EA9E8FED3 /* StripeCore.framework */,
 				7C2D3C4D44C73D619A42CF3A /* StripeCoreTestUtils.framework */,
 				16547B41C80B97FC2EFD0798 /* StripeFinancialConnections.framework */,
+				8B087D02B099A1ECC13A9376 /* StripeFinancialConnectionsLite.framework */,
 				1E565B552830E657F863C4F8 /* StripePayments.framework */,
 				240DDF52B887E788853A838B /* StripePaymentSheet.framework */,
 				89E47F13DA6D394178F06849 /* StripePaymentsUI.framework */,


### PR DESCRIPTION
## Summary

Fixes a crash in some of our example apps where FC Lite wasn't properly linked after it was extracted into its own module. This didn't surface in the original PR extracting FC Lite because building these apps from Xcode worked - it's only when opening these apps from Springboard that the crash occurs. 

Claude explains it like this:

```md
When Xcode runs an app on the simulator, it doesn't launch it the way SpringBoard does. It attaches via `lldb`/`debugserver` (effectively `simctl spawn`-style) and injects `DYLD_FRAMEWORK_PATH`/`DYLD_LIBRARY_PATH` (the simulator env-var equivalents are `SIMCTL_CHILD_DYLD_FRAMEWORK_PATH` / `SIMCTL_CHILD_DYLD_LIBRARY_PATH`) pointing at the workspace's `DerivedData/.../Products/Debug-iphonesimulator` directory. Since `StripeFinancialConnectionsLite.framework` *is* a build product sitting right there (StripePaymentSheet's dependency graph still builds it, it's just never copied into the app bundle's `Frameworks/` folder), dyld finds it via that injected search path and the app launches fine.

Kill the app and re-tap the icon on the Home Screen, and none of that applies. SpringBoard launches the binary directly with no Xcode-injected `DYLD_*` variables. dyld falls back to its normal resolution order for the `@rpath` load command — which is exactly what the crash log shows it trying: the simulator runtime's `usr/lib/swift`, the plain `/usr/lib/swift`, and finally the app bundle's own `Frameworks/` directory. Since the framework was never embedded there (the gap we just found and fixed in the four Example `.xcodeproj` files), all three lookups fail and dyld aborts before `main()` even runs — hence `"terminated at launch; ignore backtrace"`.

So the bug was latent the whole time; only a "real" launch path (Home Screen, TestFlight, App Store) ever exercised the missing embed, while iterating from Xcode masked it completely.
```

## Motivation

Fix crash

## Testing

Before:


https://github.com/user-attachments/assets/3c1a099f-f35e-4fa1-b84e-4f245f9d455a



<img width="1112" height="912" alt="image" src="https://github.com/user-attachments/assets/97ddd22b-e635-41fd-892a-cb43dc11b1a9" />

After:


https://github.com/user-attachments/assets/4c8e579f-2655-4d8e-8861-13c00df85e4b



## Changelog

N/a
