### PR TITLE
[Identity] Orion Update to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ The next release's version bump will so far be:
 MINOR
 
 ## X.Y.Z - changes pending release
+### Identity
+* [Added] Added a server-enabled 3D selfie capture flow with guided front, left, and right captures and MediaPipe face-pose detection. ([#6523](https://github.com/stripe/stripe-ios/pull/6523))
+* [Added] Added `IdentityVerificationSheet.Configuration.brandColor` to customize the native flow's primary action buttons.
+* [Changed] StripeIdentity now supports arm64 simulator builds only. Intel Macs and x86_64 simulator destinations are no longer supported.
+
 ### Payments
 * [Added] Added support for the following FPX banks: Agrobank, Bank of China, and MBSB Bank.
 * [Fixed] Fixed an issue where card decline error messages became generic after 3DS authentication.


### PR DESCRIPTION
## Summary

- Adds the missing StripeIdentity changelog entry for Project Orion and the new 3D selfie capture flow.
- Documents the new `IdentityVerificationSheet.Configuration.brandColor` API.
- Calls out that StripeIdentity simulator builds now require arm64 and no longer support Intel Macs or x86_64 simulator destinations.
