### PR TITLE
Reset Link account after adaptive pricing tests

### DIFF
--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/Checkout+AdaptivePricingTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/Checkout+AdaptivePricingTests.swift
@@ -12,6 +12,12 @@ import XCTest
 
 @MainActor
 final class Checkout_AdaptivePricingTests: STPNetworkStubbingTestCase {
+    override func tearDown() {
+        // Loading the Checkout Session populates Link with the test customer's email, which can leak into other tests.
+        LinkAccountContext.shared.account = nil
+        super.tearDown()
+    }
+
     func testAdaptivePricingUsesIntegrationAndPresentmentCurrencies() async throws {
         // Given a Checkout Session created in USD and localized to EUR
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.createCheckoutSession(


### PR DESCRIPTION
## Summary

The adaptive pricing Checkout test loads a session with a customer email, which populates shared Link account state. Clear that state in tearDown so it does not leak into other tests and make their results order-dependent.

## Motivation

Nightly iOS test failures

## Testing

No new tests. Verified the existing adaptive pricing Checkout flow still passes.

## Changelog

N/A