### PR TITLE
Fix Apple Pay presentation window for Catalyst

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
@@ -18,6 +18,7 @@ extension CheckoutController {
         let apiClient: STPAPIClient
         let returnURL: String
         let merchantDisplayName: String
+        let presentationWindow: UIWindow?
     }
 
     /// The parameters needed to confirm a Checkout Session with Link.
@@ -113,7 +114,8 @@ extension CheckoutController {
                 applePayConfiguration: applePayConfiguration,
                 apiClient: apiClient,
                 returnURL: self.configuration.returnURL,
-                merchantDisplayName: effectiveMerchantDisplayName
+                merchantDisplayName: effectiveMerchantDisplayName,
+                presentationWindow: presentingViewController.view.window
             ))
         case .link(let confirmOption):
             let analyticsHelper = paymentElement.paymentOptionSourceOfTruthIsFlowController

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -12,7 +12,8 @@ import UIKit
 
 extension CheckoutController: ExpressCheckoutElementDelegate {
     func expressCheckoutElementShouldConfirm(
-        _ paymentMethod: ExpressCheckoutElement.PaymentMethod
+        _ paymentMethod: ExpressCheckoutElement.PaymentMethod,
+        presentationWindow: UIWindow?
     ) async -> ConfirmResult {
         let flow: CheckoutConfirmationFlow?
         switch paymentMethod {
@@ -26,7 +27,8 @@ extension CheckoutController: ExpressCheckoutElementDelegate {
                 applePayConfiguration: applePayConfiguration,
                 apiClient: apiClient,
                 returnURL: configuration.returnURL,
-                merchantDisplayName: effectiveMerchantDisplayName
+                merchantDisplayName: effectiveMerchantDisplayName,
+                presentationWindow: presentationWindow
             ))
         case .link:
             // ECE Link needs its own configuration and analytics lifecycle before it can build this flow.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutApplePayContext.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutApplePayContext.swift
@@ -30,6 +30,7 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
     private let merchantLabel: String
     private let apiClient: STPAPIClient
     private let returnURL: String
+    private let presentationWindow: UIWindow?
     let authorizationController: PKPaymentAuthorizationController
 
     // Internal state
@@ -50,6 +51,7 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
         self.merchantLabel = applePayConfirmationParameters.merchantDisplayName
         self.apiClient = applePayConfirmationParameters.apiClient
         self.returnURL = applePayConfirmationParameters.returnURL
+        self.presentationWindow = applePayConfirmationParameters.presentationWindow
         self.authorizationController = authorizationController
         super.init()
     }
@@ -173,6 +175,10 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
                 self._end()
             }
         }
+    }
+
+    @objc nonisolated func presentationWindow(for controller: PKPaymentAuthorizationController) -> UIWindow? {
+        return presentationWindow
     }
 
     func paymentAuthorizationController(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Express Checkout Element/ExpressCheckoutElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Express Checkout Element/ExpressCheckoutElement.swift
@@ -11,7 +11,8 @@ import UIKit
 @MainActor
 protocol ExpressCheckoutElementDelegate: AnyObject {
     func expressCheckoutElementShouldConfirm(
-        _ paymentMethod: ExpressCheckoutElement.PaymentMethod
+        _ paymentMethod: ExpressCheckoutElement.PaymentMethod,
+        presentationWindow: UIWindow?
     ) async -> CheckoutController.ConfirmResult
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Express Checkout Element/ExpressCheckoutElementUIView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Express Checkout Element/ExpressCheckoutElementUIView.swift
@@ -115,7 +115,10 @@ public final class ExpressCheckoutElementUIView: UIView {
     private func confirm(_ paymentMethod: ExpressCheckoutElement.PaymentMethod) {
         Task { @MainActor [weak self] in
             guard let self else { return }
-            guard let result = await self.delegate?.expressCheckoutElementShouldConfirm(paymentMethod) else { return }
+            guard let result = await self.delegate?.expressCheckoutElementShouldConfirm(
+                paymentMethod,
+                presentationWindow: window
+            ) else { return }
             self.configuration.expressCheckoutElement.confirmHandler(result)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutApplePayContextTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutApplePayContextTests.swift
@@ -14,6 +14,7 @@ import PassKit
 @testable @_spi(STP) import StripePayments
 @testable @_spi(STP) import StripePaymentSheet
 import StripePaymentsObjcTestUtils
+import UIKit
 import XCTest
 
 @MainActor
@@ -55,6 +56,20 @@ final class CheckoutApplePayContextTests: XCTestCase {
         XCTAssertEqual(items[0].label, "Test Store")
         XCTAssertEqual(items[0].type, .pending)
         XCTAssertEqual(items[0].amount, .zero)
+    }
+
+    // MARK: - presentationWindow
+
+    func testPresentationWindowReturnsConfiguredWindow() {
+        // Given
+        let presentationWindow = UIWindow()
+        let (context, authorizationController) = makeContext(presentationWindow: presentationWindow)
+
+        // When
+        let returnedWindow = context.presentationWindow(for: authorizationController)
+
+        // Then
+        XCTAssertIdentical(returnedWindow, presentationWindow)
     }
 
     // MARK: - paymentAuthorizationControllerDidFinish state machine
@@ -126,7 +141,8 @@ final class CheckoutApplePayContextTests: XCTestCase {
 
     private func makeContext(
         sessionId: String = "cs_test_123",
-        apiClient: STPAPIClient? = nil
+        apiClient: STPAPIClient? = nil,
+        presentationWindow: UIWindow? = nil
     ) -> (CheckoutApplePayContext, MockPKPaymentAuthorizationController) {
         let resolvedAPIClient = apiClient ?? APIStubbedTestCase.stubbedAPIClient()
         let response = CheckoutTestHelpers.makeSession([
@@ -135,7 +151,10 @@ final class CheckoutApplePayContextTests: XCTestCase {
             "total_summary": ["subtotal": 1000, "total": 1000, "due": 1000],
         ])
         let session = response.makePublicSession()
-        let applePayConfirmationParameters = CheckoutController.ApplePayConfirmationParameters.makeMock(apiClient: resolvedAPIClient)
+        let applePayConfirmationParameters = CheckoutController.ApplePayConfirmationParameters.makeMock(
+            apiClient: resolvedAPIClient,
+            presentationWindow: presentationWindow
+        )
         let mockController = MockPKPaymentAuthorizationController()
         let context = CheckoutApplePayContext(
             checkoutSession: session,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -14,6 +14,7 @@ import PassKit
 @testable @_spi(STP) import StripeCoreTestUtils
 @testable @_spi(STP) import StripePayments
 @testable @_spi(STP) import StripePaymentSheet
+import UIKit
 import XCTest
 
 extension PaymentPagesAPIResponse {
@@ -382,13 +383,15 @@ extension CheckoutController.ApplePayConfirmationParameters {
         apiClient: STPAPIClient,
         returnURL: String = "stripe-ios-test://checkout-return",
         merchantDisplayName: String = "Test Merchant",
-        applePayConfiguration: CheckoutController.ApplePayConfiguration = CheckoutController.ApplePayConfiguration(merchantId: "merchant.com.test")
+        applePayConfiguration: CheckoutController.ApplePayConfiguration = CheckoutController.ApplePayConfiguration(merchantId: "merchant.com.test"),
+        presentationWindow: UIWindow? = nil
     ) -> CheckoutController.ApplePayConfirmationParameters {
         CheckoutController.ApplePayConfirmationParameters(
             applePayConfiguration: applePayConfiguration,
             apiClient: apiClient,
             returnURL: returnURL,
-            merchantDisplayName: merchantDisplayName
+            merchantDisplayName: merchantDisplayName,
+            presentationWindow: presentationWindow
         )
     }
 }


### PR DESCRIPTION
## Summary
Pass the presenting window through Checkout’s Apple Pay flow and implement the Catalyst-required delegate method.



previous version:
https://github.com/stripe/stripe-ios/pull/6979

## Motivation
Breaks catalyst builds

## Testing
Didn't test exact breakage, but should work.



## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
