### PR TITLE
[Identity] Fix simulator export for arm64-only MediaPipe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ MINOR
 ### Identity
 * [Added] Added a server-enabled 3D selfie capture flow with guided front, left, and right captures and MediaPipe face-pose detection. ([#6523](https://github.com/stripe/stripe-ios/pull/6523))
 * [Added] Added `IdentityVerificationSheet.Configuration.brandColor` to customize the native flow's primary action buttons.
-* [Changed] StripeIdentity now supports arm64 simulator builds only. Intel Macs and x86_64 simulator destinations are no longer supported.
+* [Changed] StripeIdentity and StripeCryptoOnramp now support arm64 simulator builds only. Intel Macs and x86_64 simulator destinations are no longer supported for these SDKs.
 
 ### Payments
 * [Added] Added support for the following FPX banks: Agrobank, Bank of China, and MBSB Bank.

--- a/StripeCryptoOnramp.podspec
+++ b/StripeCryptoOnramp.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.platform                       = :ios
   s.ios.deployment_target          = '15.0'
   s.swift_version                  = '5.0'
+  s.pod_target_xcconfig            = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
   s.source_files                   = 'StripeCryptoOnramp/StripeCryptoOnramp/**/*.swift'
   s.ios.resource_bundle            = { 'StripeCryptoOnrampBundle' => 'StripeCryptoOnramp/StripeCryptoOnramp/Resources/**/*.{lproj,json,png,xcassets}' }
   s.dependency                     'StripeCore', "#{s.version}"

--- a/StripeCryptoOnramp/README.md
+++ b/StripeCryptoOnramp/README.md
@@ -48,6 +48,8 @@ StripeCryptoOnramp helps you build a headless crypto onramp flow in your iOS app
 
 The StripeCryptoOnramp iOS SDK is compatible with apps targeting iOS 15.0 or above.
 
+Simulator builds require an arm64 destination on Apple silicon. Intel Macs and x86_64 simulator destinations are not supported.
+
 ## Getting started
 
 ### Integration

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -509,6 +509,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
@@ -542,6 +543,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_MODULE_VERIFIER = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";

--- a/StripeIdentity.podspec
+++ b/StripeIdentity.podspec
@@ -33,7 +33,10 @@ Pod::Spec.new do |s|
   s.private_header_files           = [
     'LocalPackages/MediaPipeSPM/Sources/MediaPipeSPMGraphReferences/**/*.h',
   ]
-  s.pod_target_xcconfig            = { 'OTHER_LDFLAGS' => '$(inherited) -ObjC' }
+  s.pod_target_xcconfig            = {
+    'OTHER_LDFLAGS' => '$(inherited) -ObjC',
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
+  }
   s.vendored_frameworks            = [
     'LocalPackages/MediaPipeSPM/Artifacts/MediaPipeCommonGraphLibraries.xcframework',
     'LocalPackages/MediaPipeSPM/Artifacts/MediaPipeTasksCommon.xcframework',

--- a/StripeIdentity/README.md
+++ b/StripeIdentity/README.md
@@ -34,6 +34,8 @@ The Stripe Identity iOS SDK makes it quick and easy to verify your user's identi
 
 The Stripe Identity iOS SDK is compatible with apps targeting iOS 15.0 or above.
 
+Simulator builds require an arm64 destination on Apple silicon. Intel Macs and x86_64 simulator destinations are not supported.
+
 If you intend to use this SDK with Stripe's Identity service, you must not modify this SDK. Using a modified version of this SDK with Stripe's Identity service, without Stripe's written authorization, is a breach of your agreement with Stripe and may result in your Stripe account being shut down.
 
 

--- a/StripeIdentity/StripeIdentity.xcodeproj/project.pbxproj
+++ b/StripeIdentity/StripeIdentity.xcodeproj/project.pbxproj
@@ -380,6 +380,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = E850C3F1FEA42490F1B3761E /* StripeiOS-Release.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				INFOPLIST_FILE = StripeIdentity/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.stripe-identity";
 				PRODUCT_NAME = StripeIdentity;
@@ -405,6 +406,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = B17C20418C972E7B06B84370 /* StripeiOS-Debug.xcconfig */;
 			buildSettings = {
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
 				INFOPLIST_FILE = StripeIdentity/Info.plist;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.stripe.stripe-identity";
 				PRODUCT_NAME = StripeIdentity;

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -459,6 +459,7 @@ workflows:
         inputs:
         - scheme: AllStripeFrameworks
         - destination: generic/platform=iOS Simulator
+        - xcodebuild_options: ARCHS=arm64
     - deploy-to-bitrise-io@2: {}
     - save-spm-cache@1: {}
     before_run:
@@ -651,6 +652,10 @@ workflows:
         inputs:
         - content: ./ci_scripts/check_image_format.sh
         title: Check png image format is 8-bit
+    - script@1:
+        inputs:
+        - content: ruby ci_scripts/tests/framework_architecture_validator_test.rb
+        title: Test release build scripts
     - fastlane@3:
         inputs:
         - lane: build_extras

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -34,7 +34,6 @@ pipelines:
       framework-tests: {}
       lpm-confirm-flow-tests: {}
       framework-tests-and-builds-xcode-26-1: {}
-      deploy-dry-run: {}
       install-and-integration-tests: {}
       size-report: {}
       ui-tests-paymentsheet:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -34,6 +34,7 @@ pipelines:
       framework-tests: {}
       lpm-confirm-flow-tests: {}
       framework-tests-and-builds-xcode-26-1: {}
+      deploy-dry-run: {}
       install-and-integration-tests: {}
       size-report: {}
       ui-tests-paymentsheet:
@@ -458,7 +459,6 @@ workflows:
         inputs:
         - scheme: AllStripeFrameworks
         - destination: generic/platform=iOS Simulator
-        - xcodebuild_options: ARCHS=arm64
     - deploy-to-bitrise-io@2: {}
     - save-spm-cache@1: {}
     before_run:

--- a/ci_scripts/export_builds.rb
+++ b/ci_scripts/export_builds.rb
@@ -1,8 +1,8 @@
 #!/usr/bin/env ruby
 
 require 'fileutils'
-require 'open3'
 require 'yaml'
+require_relative 'framework_architecture_validator'
 
 DEFAULT_SIMULATOR_ARCHITECTURES = %w[arm64 x86_64].freeze
 
@@ -17,17 +17,10 @@ def die(string)
 end
 
 def verify_architectures(binary_path, expected_architectures)
-  output, error, status = Open3.capture3('lipo', '-archs', binary_path)
-  die "Failed to inspect architectures for #{binary_path}: #{error.strip}" unless status.success?
-
-  actual_architectures = output.split.sort
-  expected_architectures = expected_architectures.sort
-  if actual_architectures == expected_architectures
-    info "Verified architectures for #{binary_path}: #{actual_architectures.join(', ')}"
-    return
-  end
-
-  die "Unexpected architectures for #{binary_path}: expected #{expected_architectures.join(', ')}, found #{actual_architectures.join(', ')}"
+  architectures = FrameworkArchitectureValidator.verify(binary_path, expected_architectures)
+  info "Verified architectures for #{binary_path}: #{architectures.join(', ')}"
+rescue FrameworkArchitectureValidator::VerificationError => error
+  die error.message
 end
 
 # Joins the given strings. If one or more arguments is nil or empty, an exception is raised.

--- a/ci_scripts/export_builds.rb
+++ b/ci_scripts/export_builds.rb
@@ -1,7 +1,10 @@
 #!/usr/bin/env ruby
 
 require 'fileutils'
+require 'open3'
 require 'yaml'
+
+DEFAULT_SIMULATOR_ARCHITECTURES = %w[arm64 x86_64].freeze
 
 # MARK: - Helpers
 
@@ -11,6 +14,17 @@ end
 
 def die(string)
   abort "[#{File.basename(__FILE__)}] [ERROR] #{string}"
+end
+
+def verify_architectures(binary_path, expected_architectures)
+  output, error, status = Open3.capture3('lipo', '-archs', binary_path)
+  die "Failed to inspect architectures for #{binary_path}: #{error.strip}" unless status.success?
+
+  actual_architectures = output.split.sort
+  expected_architectures = expected_architectures.sort
+  return if actual_architectures == expected_architectures
+
+  die "Unexpected architectures for #{binary_path}: expected #{expected_architectures.join(', ')}, found #{actual_architectures.join(', ')}"
 end
 
 # Joins the given strings. If one or more arguments is nil or empty, an exception is raised.
@@ -109,9 +123,21 @@ Dir.chdir(root_dir) do
     scheme = m['scheme']
     framework_name = m['framework_name']
     supports_catalyst = m['supports_catalyst']
+    simulator_architectures = m.fetch('simulator_architectures', DEFAULT_SIMULATOR_ARCHITECTURES)
     platform_frameworks = []
     die 'Module is missing scheme' if scheme.nil? || scheme.empty?
     die 'Module is missing framework_name' if framework_name.nil? || framework_name.empty?
+
+    simulator_binary = File.join_if_safe(
+      build_dir,
+      'StripeFrameworks-sim.xcarchive',
+      'Products',
+      'Library',
+      'Frameworks',
+      "#{framework_name}.framework",
+      framework_name,
+    )
+    verify_architectures(simulator_binary, simulator_architectures)
 
     platform_frameworks.append("-framework \"#{build_dir}/StripeFrameworks-iOS.xcarchive/Products/Library/Frameworks/#{framework_name}.framework\"")
 

--- a/ci_scripts/export_builds.rb
+++ b/ci_scripts/export_builds.rb
@@ -22,7 +22,10 @@ def verify_architectures(binary_path, expected_architectures)
 
   actual_architectures = output.split.sort
   expected_architectures = expected_architectures.sort
-  return if actual_architectures == expected_architectures
+  if actual_architectures == expected_architectures
+    info "Verified architectures for #{binary_path}: #{actual_architectures.join(', ')}"
+    return
+  end
 
   die "Unexpected architectures for #{binary_path}: expected #{expected_architectures.join(', ')}, found #{actual_architectures.join(', ')}"
 end

--- a/ci_scripts/framework_architecture_validator.rb
+++ b/ci_scripts/framework_architecture_validator.rb
@@ -1,0 +1,23 @@
+require 'open3'
+
+module FrameworkArchitectureValidator
+  class VerificationError < StandardError; end
+
+  module_function
+
+  def verify(binary_path, expected_architectures, command_runner: Open3.method(:capture3))
+    output, error, status = command_runner.call('lipo', '-archs', binary_path)
+    unless status.success?
+      raise VerificationError, "Failed to inspect architectures for #{binary_path}: #{error.strip}"
+    end
+
+    actual_architectures = output.split.sort
+    expected_architectures = expected_architectures.sort
+    unless actual_architectures == expected_architectures
+      raise VerificationError,
+        "Unexpected architectures for #{binary_path}: expected #{expected_architectures.join(', ')}, found #{actual_architectures.join(', ')}"
+    end
+
+    actual_architectures
+  end
+end

--- a/ci_scripts/tests/framework_architecture_validator_test.rb
+++ b/ci_scripts/tests/framework_architecture_validator_test.rb
@@ -1,0 +1,77 @@
+require 'minitest/autorun'
+require_relative '../framework_architecture_validator'
+
+class FrameworkArchitectureValidatorTest < Minitest::Test
+  FakeStatus = Struct.new(:successful) do
+    def success?
+      successful
+    end
+  end
+
+  def test_accepts_matching_thin_architecture
+    runner = command_runner(output: "arm64\n")
+
+    result = FrameworkArchitectureValidator.verify(
+      '/tmp/TestFramework',
+      %w[arm64],
+      command_runner: runner,
+    )
+
+    assert_equal %w[arm64], result
+  end
+
+  def test_accepts_matching_architectures_in_any_order
+    runner = command_runner(output: "x86_64 arm64\n")
+
+    result = FrameworkArchitectureValidator.verify(
+      '/tmp/TestFramework',
+      %w[arm64 x86_64],
+      command_runner: runner,
+    )
+
+    assert_equal %w[arm64 x86_64], result
+  end
+
+  def test_rejects_an_architecture_mismatch
+    runner = command_runner(output: "arm64\n")
+
+    error = assert_raises(FrameworkArchitectureValidator::VerificationError) do
+      FrameworkArchitectureValidator.verify(
+        '/tmp/TestFramework',
+        %w[arm64 x86_64],
+        command_runner: runner,
+      )
+    end
+
+    assert_equal(
+      'Unexpected architectures for /tmp/TestFramework: expected arm64, x86_64, found arm64',
+      error.message,
+    )
+  end
+
+  def test_rejects_a_failed_lipo_inspection
+    runner = command_runner(error: 'file is not a Mach-O binary', successful: false)
+
+    error = assert_raises(FrameworkArchitectureValidator::VerificationError) do
+      FrameworkArchitectureValidator.verify(
+        '/tmp/TestFramework',
+        %w[arm64],
+        command_runner: runner,
+      )
+    end
+
+    assert_equal(
+      'Failed to inspect architectures for /tmp/TestFramework: file is not a Mach-O binary',
+      error.message,
+    )
+  end
+
+  private
+
+  def command_runner(output: '', error: '', successful: true)
+    lambda do |*arguments|
+      assert_equal ['lipo', '-archs', '/tmp/TestFramework'], arguments
+      [output, error, FakeStatus.new(successful)]
+    end
+  end
+end

--- a/modules.yaml
+++ b/modules.yaml
@@ -15,6 +15,10 @@
 # - supports_catalyst (required):
 #   Whether the framework supports macOS Catalyst.
 #
+# - simulator_architectures (optional):
+#   Architectures expected in the simulator framework exported by
+#   `export_builds.rb`. Defaults to arm64 and x86_64.
+#
 # - localization_dir (optional):
 #   The source directory to check for localized strings and where a
 #   `Resources/Localizations` directory will be generated.
@@ -140,6 +144,8 @@ modules:
 - podspec: StripeIdentity.podspec
   scheme: StripeIdentity
   framework_name: StripeIdentity
+  simulator_architectures:
+    - arm64
   localization_dir: StripeIdentity/StripeIdentity
   custom_string_convertible_dir: StripeIdentity/StripeIdentity/Source
   supports_catalyst: false
@@ -225,6 +231,8 @@ modules:
 - podspec: StripeCryptoOnramp.podspec
   scheme: StripeCryptoOnramp
   framework_name: StripeCryptoOnramp
+  simulator_architectures:
+    - arm64
   localization_dir: StripeCryptoOnramp/StripeCryptoOnramp
   supports_catalyst: false
   docs:
@@ -253,4 +261,3 @@ pod_push_order:
 - StripeFinancialConnections.podspec
 - StripeConnect.podspec
 - StripeCryptoOnramp.podspec
-


### PR DESCRIPTION
## Summary

Keep mixed-architecture release exports buildable after Project Orion made the bundled MediaPipe simulator artifacts arm64-only.

- Limit the simulator restriction to `StripeIdentity` and its production dependent, `StripeCryptoOnramp`, across Xcode and CocoaPods builds.
- Keep arm64 and x86_64 simulator slices for every unaffected SDK framework.
- Make the release exporter enforce that architecture matrix in nightly and release builds.
- Document the restriction in both SDK requirements pages and the pending changelog.

## Motivation

[Project Orion](https://github.com/stripe/stripe-ios/pull/6523) deliberately strips x86_64 from the bundled MediaPipe simulator artifacts. The release export still tried to link `StripeIdentity` for x86_64, so Xcode discarded MediaPipe and failed with undefined `MPP*` and `mediapipe::*` symbols.

The restriction must also cover `StripeCryptoOnramp`: it imports and links `StripeIdentity` in production and is exported by the same archive. Applying `ARCHS=arm64` to the shared archive would hide the linker failure by dropping Intel simulator support from every Stripe iOS framework.

CocoaPods generates its own targets rather than importing settings from the checked-in Xcode projects. Both podspecs therefore declare the same simulator exclusion so source-based CocoaPods builds enforce the documented architecture boundary too.

The aggregate build-for-testing remains arm64-only because its test bundles consume the thin MediaPipe modules; it cannot exercise the release contract. The nightly dry run and Xcode Cloud release build use the unconstrained exporter, which fails if an affected or unaffected framework contains the wrong simulator slices.

closes [RUN_IDXP-11667](https://jira.corp.stripe.com/browse/RUN_IDXP-11667)

## Testing

- Added a test that accepts a matching arm64-only simulator binary.
- Added a test that accepts matching arm64 and x86_64 slices in either order.
- Added a test that rejects a simulator architecture mismatch and reports the expected and actual slices.
- Added a test that rejects a failed `lipo` inspection and reports the underlying error.
- All four validator tests pass locally with 10 assertions.
- Added release-export integration validation for `StripeIdentity`, `StripeCryptoOnramp`, every unaffected framework, and `Stripe3DS2`.
- Parsed both modified Xcode projects and verified their Debug and Release production target settings.
- Ruby syntax checks passed for both modified podspecs. Static inspection confirmed that Identity preserves its existing linker flags and both pods exclude x86_64 on the simulator. No CocoaPods install or integration build ran locally.
- Parsed the module and Bitrise configuration, including the nightly release-export workflow and feature-PR validator unit gate.
- An earlier feature-branch run of full Xcode archive validation passed in [Bitrise](https://app.bitrise.io/build/911b58b7-2ff8-4702-9dcd-0d842778c844): the two affected frameworks were arm64-only and the other 14 retained arm64 and x86_64. Current feature PRs run the four validator tests; nightly Bitrise and Xcode Cloud release builds run the full exporter.

## Changelog

Updated the pending Identity entry to state that `StripeIdentity` and `StripeCryptoOnramp` are arm64-only on the simulator. Other SDK frameworks retain Intel simulator support.

### Notify
cc @stripe-internal/codeowners-identity-product-services
r?

<!-- context-dump @ 1dc46f5708b
Domain evidence and supporting detail omitted from the skimmable body above.

The failed deploy-dry-run completed its iOS device archive, then failed in the generic iOS Simulator archive. The linker explicitly ignored MediaPipeTasksCommon, MediaPipeCommonGraphLibraries, and MediaPipeTasksVision because each contained arm64 while the target requested x86_64. The resulting undefined Objective-C and C++ symbols came from those discarded binaries.

PR #6523 copies upstream MediaPipe artifacts that include x86_64, then deliberately removes that slice in strip_intel_simulator_slice(). It constrained the Bitrise build-for-test, API-diff, and Periphery paths to arm64 but left ci_scripts/export_builds.rb's generic simulator archive unconstrained.

The aggregate Xcode 26.1 build-for-testing must remain arm64-only. Removing that test-workflow override at f25422ea8bf made StripeIdentityTests fail to resolve MediaPipeSPMGraphReferences even while compiling its arm64 Swift driver ([Bitrise build](https://app.bitrise.io/build/39f8f10e-1f82-467f-85e5-8f62135cfae5)). That workflow validates the test graph, not the multi-architecture release artifact; deploy-dry-run remains unconstrained and authoritative for the exported slice matrix.

StripeCryptoOnramp links StripeIdentity.framework in its production Xcode target, imports StripeIdentity in CryptoOnrampCoordinator.swift, declares StripeIdentity in Package.swift, and depends on StripeIdentity in StripeCryptoOnramp.podspec. It therefore inherits the same simulator architecture floor.

CocoaPods does not import build settings from either checked-in Xcode project, and a dependency's pod target settings do not propagate to its dependents. StripeIdentity.podspec merges the simulator exclusion with its existing `-ObjC` linker flag, while StripeCryptoOnramp.podspec declares the exclusion independently.

The target-level settings let one archive contain arm64-only StripeIdentity and StripeCryptoOnramp frameworks alongside universal simulator frameworks for unaffected products. modules.yaml now records the exceptions; export_builds.rb defaults every other framework, including Stripe3DS2, to arm64+x86_64 and checks the archived binaries with lipo before packaging them.

[RUN_MOBILESDK-2529](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-2529) previously identified the same release-only coverage gap, and [PR #2872](https://github.com/stripe/stripe-ios/pull/2872) added deploy-dry-run to every PR. [PR #4200](https://github.com/stripe/stripe-ios/pull/4200) removed it when release builds moved to Xcode Cloud. The nightly dry run continues to exercise the complete release path without adding a full export to every feature PR; feature PRs run the focused validator unit tests instead.
-->

<!-- assess-pr round 1 @ 6d7074b66fe 2026-08-21T19:03:40Z
verdict: REVISE
findings:
  - [high] verification: Normal PR CI forced ARCHS=arm64 and did not exercise the mixed-architecture release export.
  - [high] completion: The current StripeIdentity and StripeCryptoOnramp requirements pages omitted the new simulator restriction.
  - [nit] description: The summary incorrectly attributed the x86_64 removal to upstream MediaPipe instead of Project Orion's packaging script.
agent summaries:
  - sentinel: no findings
  - verifier: release-export contract untested
  - architect: architecture policy was distributed across target and CI settings
  - reader: no findings
  - completionist: add requirements docs, exact export coverage, and artifact assertions
  - historian: restore deploy-dry-run or equivalent on the exact PR SHA
  - challenger: correct the causal wording; preserve the reviewed Orion compatibility decision
  - decomposer: no findings; target changes are one atomic unit
  - risk-pattern: no findings
  - spec-compliance: static claims confirmed; dynamic export unverified
  - monitoring-critic: no runtime monitoring finding
  - writing-critic: no structural writing findings
  - codex-adversarial: unavailable because codex:codex-rescue is not installed
-->

<!-- assess-pr round 2 @ f25422ea8bf 2026-08-21T19:22:48Z
verdict: REVISE
findings:
  - [high] sentinel: Removing ARCHS=arm64 from the aggregate build-for-testing workflow broke StripeIdentityTests on the exact SHA.
  - [high] verifier: The architecture validator lacked durable tests for success, mismatch, and lipo-failure behavior.
  - [major] decomposer: Recommended splitting target policy, test-workflow behavior, export validation, and CI scheduling into separate PRs.
  - [nit] spec-compliance: One context sentence overstated feature-branch deploy-dry-run coverage as all PR CI.
agent summaries:
  - sentinel: exact Bitrise failure confirmed the aggregate test workflow must remain arm64-only
  - verifier: implementation correct; add four focused validator tests
  - architect: no findings
  - reader: no findings
  - completionist: no missing companion changes
  - historian: prior release-export coverage gap resolved
  - challenger: no findings
  - decomposer: split recommendation
  - risk-pattern: no findings
  - spec-compliance: narrow one context-dump claim to ordinary feature PRs
  - monitoring-critic: no findings
  - writing-critic: PASS after required audit-log constraint was clarified
  - codex-adversarial: unavailable because codex:codex-rescue is not installed
-->

<!-- assess-pr round 3 @ 0ca0f604913 2026-08-21T19:30:01Z
verdict: PASS
findings: none
agent summaries:
  - sentinel: no findings; aggregate test and release-export paths are correctly separated
  - verifier: no findings; four validator tests cover all discriminating branches
  - architect: no findings
  - reader: no findings
  - completionist: no missing companion changes
  - historian: no findings
  - challenger: no findings; one-PR scope is the simplest complete unit
  - decomposer: no findings; behavior, public contract, and verification are atomic
  - risk-pattern: no findings
  - spec-compliance: no findings
  - monitoring-critic: no findings
  - writing-critic: no findings
  - codex-adversarial: unavailable because codex:codex-rescue is not installed
-->

<!-- ship-cert @ 0ca0f604913 2026-08-21T19:59:03Z
All /ship gates passed:
  - clean_state: PASS
  - pr_mergeable: PASS (mergeable: true, mergeStateStatus: BLOCKED only on required review)
  - atomic_decomposition: PASS
  - assess_pr: PASS (round 3 at current HEAD)
  - ci_green: PASS (all GitHub and Bitrise jobs)
  - pr_description: PASS (writing-quality-critic PASS)
  - reviewer_comments: PASS (none outstanding)
diff_hash: b9c58515de383ca1815e1d3040aecec3e9929ae729d7b85f24d72aa49009bd6b
-->

<!-- assess-pr round 4 @ 1dc46f5708b 2026-08-21T23:12:01Z
verdict: PASS
findings:
  - [major, non-blocking structural] decomposer recommended optionally splitting compatibility/docs from dependent release enforcement; synthesis found no correctness need to split and retained the single invariant in one PR
  - [thought, non-blocking] CocoaPods settings are statically correct but lack a generated-project effective-setting assertion for both pod targets
  - [nit, resolved] Jira CI coverage text was stale after the maintainer-approved nightly-only decision; corrected in RUN_IDXP-11667
agent summaries:
  - sentinel: no findings; podspec adapters and nightly/release enforcement fail closed
  - verifier: implementation correct; raised accepted per-PR export tradeoff and CocoaPods integration-proof gaps
  - architect: no findings; policy and adapters have healthy boundaries
  - reader: no findings; description is coherent and testing language is honest
  - completionist: no missing companion changes
  - historian: requested per-PR export based on prior incidents; superseded by explicit maintainer and user policy decision
  - challenger: requested per-PR export unless the team explicitly accepts nightly detection; that acceptance is recorded
  - decomposer: optional two-PR split recommendation retained as non-blocking structural feedback
  - risk-pattern: no findings; malformed release artifacts remain blocked
  - spec-compliance: no findings; 20 of 20 claims verified
  - monitoring-critic: non-blocking CocoaPods effective-setting observability gap
  - writing-critic: no findings after temporal and coverage corrections
  - codex-adversarial: unavailable because codex:codex-rescue is not installed
-->
