### PR TITLE
Add Checkout Session retrieve and poll API bindings

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+CheckoutSession.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/API Bindings/STPAPIClient+CheckoutSession.swift
@@ -68,6 +68,31 @@ extension STPAPIClient {
         )
     }
 
+    /// Retrieves the latest full Checkout Session.
+    func retrieveCheckoutSession(
+        checkoutSessionId: String
+    ) async throws -> PaymentPagesAPIResponse {
+        return try await get(
+            endpoint: "payment_pages/\(checkoutSessionId)",
+            parameters: [
+                "elements_session_client": [
+                    "is_aggregation_expected": true,
+                ],
+            ]
+        )
+    }
+
+    /// Retrieves the small state object used to determine whether a Checkout
+    /// Session transition is still in progress.
+    func pollCheckoutSession(
+        checkoutSessionId: String
+    ) async throws -> PaymentPagePollResponse {
+        return try await get(
+            endpoint: "payment_pages/\(checkoutSessionId)/poll",
+            parameters: [:]
+        )
+    }
+
     func detachPaymentMethod(
         _ paymentMethodId: String,
         fromCheckoutSession checkoutSessionId: String
@@ -216,6 +241,24 @@ extension STPAPIClient {
         do {
             return try await withCheckedThrowingContinuation { continuation in
                 post(resource: endpoint, parameters: parameters) { result in
+                    continuation.resume(with: result)
+                }
+            }
+        } catch {
+            if error is DecodingError {
+                reportUnexpectedPaymentPagesParsingError(error, apiClient: self)
+            }
+            throw error
+        }
+    }
+
+    private func get<T: Decodable>(
+        endpoint: String,
+        parameters: [String: Any]
+    ) async throws -> T {
+        do {
+            return try await withCheckedThrowingContinuation { continuation in
+                get(resource: endpoint, parameters: parameters) { (result: Result<T, Error>) in
                     continuation.resume(with: result)
                 }
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagePollResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagePollResponse.swift
@@ -5,8 +5,6 @@
 //  Created by Yuki Tokuhiro on 8/22/26.
 //
 
-@_spi(STP) import StripeCore
-
 /// The small response returned by the Checkout Session poll endpoint.
 ///
 /// This response is used to decide when to stop waiting. It does not contain
@@ -16,7 +14,7 @@ struct PaymentPagePollResponse: Decodable, Equatable {
     let state: State
     let paymentObjectStatus: PaymentObjectStatus?
 
-    enum State: String, SafeEnumDecodable {
+    enum State: String, Decodable {
         case active
         case pendingAsyncCustomerAction = "pending_async_customer_action"
         case processingSubscription = "processing_subscription"
@@ -25,19 +23,18 @@ struct PaymentPagePollResponse: Decodable, Equatable {
         case succeeded
         case invalid
         case expired
-        case unparsable = ""
     }
 
-    enum PaymentObjectStatus: String, SafeEnumDecodable {
-        case canceled
-        case processing
-        case requiresAction = "requires_action"
-        case requiresCapture = "requires_capture"
-        case requiresConfirmation = "requires_confirmation"
-        case requiresPaymentMethod = "requires_payment_method"
-        case requiresReauthorization = "requires_reauthorization"
-        case succeeded
-        case unparsable = ""
+    /// The client only needs to distinguish a failed payment from every other
+    /// payment object status. The poll response is not used as session data.
+    enum PaymentObjectStatus: Decodable, Equatable {
+        case requiresPaymentMethod
+        case other
+
+        init(from decoder: Decoder) throws {
+            let rawValue = try decoder.singleValueContainer().decode(String.self)
+            self = rawValue == "requires_payment_method" ? .requiresPaymentMethod : .other
+        }
     }
 
     private enum CodingKeys: String, CodingKey {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagePollResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagePollResponse.swift
@@ -1,0 +1,48 @@
+//
+//  PaymentPagePollResponse.swift
+//  StripePaymentSheet
+//
+//  Created by Yuki Tokuhiro on 8/22/26.
+//
+
+@_spi(STP) import StripeCore
+
+/// The small response returned by the Checkout Session poll endpoint.
+///
+/// This response is used to decide when to stop waiting. It does not contain
+/// enough data to replace a `PaymentPagesAPIResponse`.
+struct PaymentPagePollResponse: Decodable, Equatable {
+    let sessionId: String
+    let state: State
+    let paymentObjectStatus: PaymentObjectStatus?
+
+    enum State: String, SafeEnumDecodable {
+        case active
+        case pendingAsyncCustomerAction = "pending_async_customer_action"
+        case processingSubscription = "processing_subscription"
+        case processingAsyncPayment = "processing_async_payment"
+        case processingSyncPayment = "processing_sync_payment"
+        case succeeded
+        case invalid
+        case expired
+        case unparsable = ""
+    }
+
+    enum PaymentObjectStatus: String, SafeEnumDecodable {
+        case canceled
+        case processing
+        case requiresAction = "requires_action"
+        case requiresCapture = "requires_capture"
+        case requiresConfirmation = "requires_confirmation"
+        case requiresPaymentMethod = "requires_payment_method"
+        case requiresReauthorization = "requires_reauthorization"
+        case succeeded
+        case unparsable = ""
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case sessionId = "session_id"
+        case state
+        case paymentObjectStatus = "payment_object_status"
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagePollResponseTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagePollResponseTests.swift
@@ -1,0 +1,80 @@
+//
+//  PaymentPagePollResponseTests.swift
+//  StripePaymentSheetTests
+//
+//  Created by Yuki Tokuhiro on 8/22/26.
+//
+
+@testable @_spi(STP) import StripeCore
+@testable @_spi(STP) import StripePaymentSheet
+import XCTest
+
+final class PaymentPagePollResponseTests: XCTestCase {
+    func testDecodesEveryState() throws {
+        let cases: [(String, PaymentPagePollResponse.State)] = [
+            ("active", .active),
+            ("pending_async_customer_action", .pendingAsyncCustomerAction),
+            ("processing_subscription", .processingSubscription),
+            ("processing_async_payment", .processingAsyncPayment),
+            ("processing_sync_payment", .processingSyncPayment),
+            ("succeeded", .succeeded),
+            ("invalid", .invalid),
+            ("expired", .expired),
+            ("new_state", .unparsable),
+        ]
+
+        for (rawValue, expected) in cases {
+            let response = try decode(state: rawValue)
+            XCTAssertEqual(response.state, expected, rawValue)
+        }
+    }
+
+    func testDecodesEveryPaymentObjectStatus() throws {
+        let cases: [(String, PaymentPagePollResponse.PaymentObjectStatus)] = [
+            ("canceled", .canceled),
+            ("processing", .processing),
+            ("requires_action", .requiresAction),
+            ("requires_capture", .requiresCapture),
+            ("requires_confirmation", .requiresConfirmation),
+            ("requires_payment_method", .requiresPaymentMethod),
+            ("requires_reauthorization", .requiresReauthorization),
+            ("succeeded", .succeeded),
+            ("new_status", .unparsable),
+        ]
+
+        for (rawValue, expected) in cases {
+            let response = try decode(paymentObjectStatus: rawValue)
+            XCTAssertEqual(response.paymentObjectStatus, expected, rawValue)
+        }
+    }
+
+    func testPaymentObjectStatusCanBeNullOrMissing() throws {
+        XCTAssertNil(try decode(paymentObjectStatus: nil).paymentObjectStatus)
+
+        let json: [String: Any] = [
+            "session_id": "cs_test_123",
+            "state": "active",
+        ]
+        XCTAssertNil(try decode(json).paymentObjectStatus)
+    }
+
+    private func decode(
+        state: String = "active",
+        paymentObjectStatus: String? = nil
+    ) throws -> PaymentPagePollResponse {
+        var json: [String: Any] = [
+            "session_id": "cs_test_123",
+            "state": state,
+            "payment_object_status": NSNull(),
+        ]
+        if let paymentObjectStatus {
+            json["payment_object_status"] = paymentObjectStatus
+        }
+        return try decode(json)
+    }
+
+    private func decode(_ json: [String: Any]) throws -> PaymentPagePollResponse {
+        let data = try JSONSerialization.data(withJSONObject: json)
+        return try StripeJSONDecoder().decode(PaymentPagePollResponse.self, from: data)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagePollResponseTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagePollResponseTests.swift
@@ -20,7 +20,6 @@ final class PaymentPagePollResponseTests: XCTestCase {
             ("succeeded", .succeeded),
             ("invalid", .invalid),
             ("expired", .expired),
-            ("new_state", .unparsable),
         ]
 
         for (rawValue, expected) in cases {
@@ -29,22 +28,33 @@ final class PaymentPagePollResponseTests: XCTestCase {
         }
     }
 
-    func testDecodesEveryPaymentObjectStatus() throws {
-        let cases: [(String, PaymentPagePollResponse.PaymentObjectStatus)] = [
-            ("canceled", .canceled),
-            ("processing", .processing),
-            ("requires_action", .requiresAction),
-            ("requires_capture", .requiresCapture),
-            ("requires_confirmation", .requiresConfirmation),
-            ("requires_payment_method", .requiresPaymentMethod),
-            ("requires_reauthorization", .requiresReauthorization),
-            ("succeeded", .succeeded),
-            ("new_status", .unparsable),
-        ]
+    func testUnknownStateFailsToDecode() throws {
+        XCTAssertThrowsError(try decode(state: "new_state")) { error in
+            XCTAssertTrue(error is DecodingError)
+        }
+    }
 
-        for (rawValue, expected) in cases {
-            let response = try decode(paymentObjectStatus: rawValue)
-            XCTAssertEqual(response.paymentObjectStatus, expected, rawValue)
+    func testPaymentObjectStatusOnlyDistinguishesRequiresPaymentMethod() throws {
+        XCTAssertEqual(
+            try decode(paymentObjectStatus: "requires_payment_method").paymentObjectStatus,
+            .requiresPaymentMethod
+        )
+
+        for rawValue in [
+            "canceled",
+            "processing",
+            "requires_action",
+            "requires_capture",
+            "requires_confirmation",
+            "requires_reauthorization",
+            "succeeded",
+            "new_status",
+        ] {
+            XCTAssertEqual(
+                try decode(paymentObjectStatus: rawValue).paymentObjectStatus,
+                .other,
+                rawValue
+            )
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+CheckoutSessionTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/STPAPIClient+CheckoutSessionTest.swift
@@ -14,6 +14,48 @@ import XCTest
 
 final class STPAPIClientCheckoutSessionTest: STPNetworkStubbingTestCase {
 
+    func testRetrieveCheckoutSession() async throws {
+        // Given an initialized Checkout Session
+        let checkoutSessionResponse = try await STPTestingAPIClient.shared.createCheckoutSession()
+        let sessionId = checkoutSessionResponse.id
+        let apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        _ = try await apiClient.initCheckoutSession(
+            checkoutSessionId: sessionId,
+            adaptivePricingAllowed: false
+        )
+
+        // When the full session is retrieved
+        let response = try await apiClient.retrieveCheckoutSession(
+            checkoutSessionId: sessionId
+        )
+
+        // Then the latest full Checkout Session is returned
+        XCTAssertEqual(response.sessionId, sessionId)
+        XCTAssertEqual(response.status, .open)
+        XCTAssertEqual(response.currency, "usd")
+    }
+
+    func testPollCheckoutSession() async throws {
+        // Given an initialized Checkout Session
+        let checkoutSessionResponse = try await STPTestingAPIClient.shared.createCheckoutSession()
+        let sessionId = checkoutSessionResponse.id
+        let apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
+        _ = try await apiClient.initCheckoutSession(
+            checkoutSessionId: sessionId,
+            adaptivePricingAllowed: false
+        )
+
+        // When the session is polled
+        let response = try await apiClient.pollCheckoutSession(
+            checkoutSessionId: sessionId
+        )
+
+        // Then its current poll state is returned
+        XCTAssertEqual(response.sessionId, sessionId)
+        XCTAssertEqual(response.state, .active)
+        XCTAssertNil(response.paymentObjectStatus)
+    }
+
     func testInitCheckoutSessionPayment() async throws {
         // Create a fresh checkout session with the test backend
         let checkoutSessionResponse = try await STPTestingAPIClient.shared.createCheckoutSession()

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testPollCheckoutSession/0000_post_create_checkout_session_unified.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testPollCheckoutSession/0000_post_create_checkout_session_unified.tail
@@ -1,0 +1,17 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_checkout_session_unified$
+200
+text/html
+x-content-type-options: nosniff
+x-cloud-trace-context: 9fd134c350ab321e3b006793d9340050;o=1
+Content-Type: text/html;charset=utf-8
+Set-Cookie: rack.session=xf8YqxV1SYhhbOqMMmMtv8Yh2A4RcjxjW%2B2yZoV0eXV6dimDSGSzo0D9eIs1sShHBxG1ghenualOicR104Rb%2BUaVifAkNgdmdLgbRe9WUT3SrGDj1UjlRlhTEC1gcOI1QlMnvYTDdN3VI6i6ZqJLqvMcTM69MmDiZittw3z4P3RQ826cmmshfnuRXPCaMGJCjbT6NgTARDCaUd9X7Pfc%2FEX7ZPd2SvC4t5WjDsYKk%2Fk%3D; path=/
+Server: Google Frontend
+Via: 1.1 google
+Date: Sat, 22 Aug 2026 18:15:41 GMT
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+Content-Length: 293
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+
+{"id":"cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg","client_secret":"cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg_secret_fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdwbEhqYWAnPydmcHZxamgneCUl","publishable_key":"pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testPollCheckoutSession/0001_post_v1_payment_pages_cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg_init.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testPollCheckoutSession/0001_post_v1_payment_pages_cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg_init.tail
@@ -1,0 +1,1097 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_pages\/cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg\/init$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=8sQeaWuwd7NT_hG9I5j8EyUpRAI-ghGhFRbrZpZoQU9LO7WA7eD_9xQzdUrZWYD9uCfPJhwVAxhVyVgs; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=8sQeaWuwd7NT_hG9I5j8EyUpRAI-ghGhFRbrZpZoQU9LO7WA7eD_9xQzdUrZWYD9uCfPJhwVAxhVyVgs&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=8sQeaWuwd7NT_hG9I5j8EyUpRAI-ghGhFRbrZpZoQU9LO7WA7eD_9xQzdUrZWYD9uCfPJhwVAxhVyVgs&t=1"}],"include_subdomains":true}
+request-id: req_KoAky9krTaVnqr
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 40048
+Vary: Origin
+Date: Sat, 22 Aug 2026 18:15:41 GMT
+original-request: req_KoAky9krTaVnqr
+stripe-version: 2020-08-27
+idempotency-key: d58f9580-3fa3-4d47-9034-2eeedce82b65
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: adaptive_pricing\[allowed]=false&browser_locale=.*&browser_timezone=.*&eid=.*&elements_session_client\[is_aggregation_expected]=true&elements_session_client\[locale]=.*&elements_session_client\[mobile_app_id]=.*&redirect_type=embedded
+
+{
+  "lpm_settings" : null,
+  "sepa_debit_info" : null,
+  "automatic_payment_method_types" : false,
+  "is_unclaimed_anonymous_sandbox" : false,
+  "tax_context" : {
+    "automatic_tax_error" : null,
+    "tax_id_collection_required" : "never",
+    "automatic_tax_enabled" : false,
+    "automatic_tax_taxability_reason" : null,
+    "dynamic_tax_enabled" : false,
+    "tax_id_collection_enabled" : false,
+    "automatic_tax_exempt" : null,
+    "automatic_tax_address_collection_precision" : null,
+    "customer_tax_country" : null,
+    "has_maximum_tax_ids" : false,
+    "automatic_tax_address_source" : null
+  },
+  "payment_method_types" : [
+    "card"
+  ],
+  "payment_method_options" : null,
+  "bnpl_in_link_ui_enabled" : false,
+  "consent_collection" : null,
+  "experiment_data" : [
+    {
+      "variant" : "control",
+      "name" : "guacamole_resend_otp",
+      "event_id" : "93edc442-0332-4ec3-b90b-26c67173da6f",
+      "exposure_event_name" : "experiment_exposure"
+    },
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs_aa",
+      "event_id" : "d032fece-4f87-48f6-9955-fff8974e06ed",
+      "exposure_event_name" : ""
+    },
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs",
+      "event_id" : "fbd29b74-24a3-41ee-aff2-5606e1688b6b",
+      "exposure_event_name" : ""
+    }
+  ],
+  "origin_context" : null,
+  "enforcement_mode" : "open",
+  "blocked_billing_address_countries" : [
+
+  ],
+  "id" : "ppage_1U7JSDFY0qyl6XeWmYWVESAJ",
+  "subscription_settings" : null,
+  "consent" : null,
+  "does_not_collect_postal_code_for_non_us_card_transactions" : false,
+  "use_payment_methods" : true,
+  "application" : null,
+  "payment_method_collection" : "automatic",
+  "setup_intent" : null,
+  "integration_identifier" : null,
+  "checkout_items" : [
+    {
+      "pricing_plan_subscription_item" : null,
+      "sub_mode_subscription_v1" : null,
+      "metronome_commit" : null,
+      "subscription" : null,
+      "key" : "checkout_item_V7YZ9HI4",
+      "type" : "one_time_price",
+      "rate_card_subscription_item" : null,
+      "one_time_price" : {
+        "items" : [
+          {
+            "quantity" : 1,
+            "inner_item_key" : "inner_item_V7YZM2hi",
+            "tax_exclusive" : 0,
+            "total" : 2000,
+            "tax_amounts" : [
+
+            ],
+            "unit_amount" : 2000,
+            "subtotal" : 2000,
+            "price" : {
+              "id" : "price_1U7JSCFY0qyl6XeW1J8OZG1o",
+              "livemode" : false,
+              "active" : true,
+              "product" : {
+                "object" : "product",
+                "active" : true,
+                "addons" : null,
+                "id" : "prod_V7YZH9Q2hDvTTI",
+                "images" : [
+
+                ],
+                "livemode" : false,
+                "url" : null,
+                "attributes" : [
+
+                ],
+                "description" : null,
+                "name" : "Test",
+                "unit_label" : null
+              },
+              "tax_behavior" : "exclusive",
+              "custom_unit_amount" : null,
+              "transform_quantity" : null,
+              "type" : "one_time",
+              "unit_amount" : 2000,
+              "unit_amount_decimal" : "2000",
+              "object" : "price",
+              "billing_scheme" : "per_unit",
+              "recurring" : null,
+              "currency" : "usd",
+              "tiers_mode" : null
+            },
+            "unit_amount_decimal" : "2000.0",
+            "adjustable_quantity" : null,
+            "tax_inclusive" : 0,
+            "unit_label" : null
+          }
+        ],
+        "subtotal" : 2000,
+        "total" : 2000
+      }
+    }
+  ],
+  "shipping_options" : [
+
+  ],
+  "setup_future_usage_for_payment_method_type" : {
+
+  },
+  "capture_method" : null,
+  "statement_descriptor" : "mobile",
+  "session_id" : "cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg",
+  "shipping_address_collection" : null,
+  "konbini_confirmation_number" : null,
+  "setup_future_usage" : null,
+  "invoice_creation" : {
+    "enabled" : false
+  },
+  "has_dynamic_tax_rates" : false,
+  "receipt_emails_enabled" : false,
+  "link_settings" : {
+    "link_consumer_incentive" : null,
+    "link_payment_session_context" : null,
+    "consumer_found" : null,
+    "hcaptcha_rqdata" : null,
+    "link_supported_payment_methods_onboarding_enabled" : [
+
+    ],
+    "enable_partner_lookup" : false,
+    "link_us_bank_account_funding_source_enabled" : false,
+    "link_funding_sources" : [
+
+    ],
+    "hcaptcha_site_key" : null,
+    "link_brand" : "link",
+    "link_mode" : null,
+    "link_supported_payment_methods" : [
+
+    ]
+  },
+  "object" : "checkout.session",
+  "customer" : null,
+  "shipping_rate" : null,
+  "success_url" : null,
+  "utm_codes" : null,
+  "beta_versions" : null,
+  "has_async_attached_payment_method" : false,
+  "feature_flags" : {
+    "checkout_enable_pay_by_bank_remember_bank_selection" : true,
+    "checkout_enable_link_api_passive_hcaptcha" : true,
+    "checkout_enable_hcaptcha_async_token_logging" : true,
+    "checkout_show_swish_factoring_notice" : true,
+    "checkout_custom_google_pay_for_automatic_tax" : true,
+    "checkout_us_bank_account_require_billing_address_non_us" : true,
+    "checkout_ewcs_optional_items" : true,
+    "checkout_link_purchase_protections_rollout" : true,
+    "checkout_pe_inline_billing_address_autocomplete_enabled" : true,
+    "enable_custom_checkout_name_collection" : true,
+    "checkout_item_order_summary_enabled" : true,
+    "checkout_payto_alias_resolution_enabled" : true,
+    "checkout_link_phone_registration_treatment_1_enabled" : true,
+    "checkout_tide_remount_override_replay" : true,
+    "sandboxes_rebrand_testmode" : true,
+    "checkout_address_autocomplete_enabled" : true,
+    "checkout_guacamole_custom_amounts" : true,
+    "checkout_optional_items" : true,
+    "checkout_passive_captcha" : true,
+    "checkout_link_enable_mfa" : true,
+    "checkout_apple_pay_old_devices_tax_address_collection" : true,
+    "checkout_enable_link_api_hcaptcha_rqdata" : true,
+    "checkout_enable_new_google_places_api" : true,
+    "checkout_hcaptcha_redundancy_control_enabled" : true,
+    "checkout_link_in_habanero_enabled" : true
+  },
+  "locale" : null,
+  "custom_text" : {
+    "shipping_address" : null,
+    "terms_of_service_acceptance" : null,
+    "submit" : null,
+    "after_submit" : null
+  },
+  "route_to_orchestration_interface" : false,
+  "customer_email" : null,
+  "payment_collection_context" : null,
+  "custom_components" : [
+
+  ],
+  "ui_mode" : "custom",
+  "url" : null,
+  "developer_tool_context" : {
+    "disabled_third_party_wallets" : {
+      "LINK_BUTTON" : {
+        "disabled_reason" : "merchant_payment_methods_settings"
+      },
+      "KLARNA_EXPRESS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "PAYPAL_ECS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "AMAZON_PAY" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      }
+    },
+    "adaptive_pricing" : {
+      "reason" : "not_allowed_for_ui",
+      "active" : false
+    },
+    "payment_method_configuration_details" : null
+  },
+  "token_notification_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "init_checksum" : "VjISyq2g21JLNm4UGZl29jJXYkMsak5L",
+  "tax_exclusion_from_total_is_allowed" : false,
+  "bnpl_link_experiment_payment_method_type" : null,
+  "tax_meta" : {
+    "status" : null,
+    "error_reason" : null,
+    "computation_type" : "manual",
+    "customer_tax_exempt" : null
+  },
+  "payment_status" : "unpaid",
+  "enabled_third_party_wallets" : [
+    {
+      "apple_pay" : {
+        "required_version" : 2
+      },
+      "id" : "APPLE_PAY",
+      "enabled" : true,
+      "carousel_enabled" : true
+    },
+    {
+      "id" : "GOOGLE_PAY",
+      "enabled" : true,
+      "google_pay" : {
+        "id" : "GOOGLE_PAY",
+        "version_minor" : 0,
+        "version_major" : 2
+      },
+      "carousel_enabled" : false
+    },
+    {
+      "id" : "AMAZON_PAY",
+      "carousel_enabled" : false,
+      "enabled" : false
+    },
+    {
+      "id" : "KLARNA_EXPRESS",
+      "carousel_enabled" : false,
+      "enabled" : false
+    }
+  ],
+  "klarna_info" : null,
+  "visible_custom_component_locations" : [
+    "checkout_form_before",
+    "checkout_form_after",
+    "submit_button_before",
+    "submit_button_after",
+    "contact_before",
+    "contact_after",
+    "express_checkout_before",
+    "express_checkout_after",
+    "payment_details_before",
+    "payment_details_after"
+  ],
+  "display_consent_collection_promotions" : false,
+  "policies" : {
+    "contacts" : {
+      "display_phone" : true,
+      "display_url" : true,
+      "enabled" : false,
+      "display_email" : true
+    },
+    "legal" : {
+      "agreement_required" : false,
+      "enabled" : false
+    },
+    "returns" : {
+      "custom_message" : null,
+      "exchanges_accepted" : false,
+      "returns_accepted" : null,
+      "fee_type" : null,
+      "fee_required" : null,
+      "policy_url" : null,
+      "window_start" : null,
+      "refunds_accepted" : null,
+      "window" : null,
+      "enabled" : false,
+      "exceptions_apply" : false,
+      "logistics" : [
+
+      ]
+    }
+  },
+  "card_brands" : {
+    "mastercard" : true,
+    "troy" : false,
+    "link" : true,
+    "carnet" : false,
+    "accel" : false,
+    "elo" : false,
+    "rupay" : false,
+    "maestro" : false,
+    "unionpay" : true,
+    "amex" : true,
+    "jaywan" : false,
+    "conecs" : false,
+    "jcb" : true,
+    "visa" : true,
+    "cartes_bancaires" : false,
+    "pulse" : false,
+    "discover" : true,
+    "star" : false,
+    "eftpos_au" : false,
+    "diners" : true,
+    "girocard" : false,
+    "nyce" : false
+  },
+  "geocoding" : {
+    "country_code" : "US",
+    "region_name" : "CA"
+  },
+  "account_settings" : {
+    "assets" : {
+      "use_logo" : false,
+      "icon" : null,
+      "logo" : null
+    },
+    "specified_commercial_transactions_act_url" : null,
+    "business_url" : "https:\/\/github.com\/stripe\/stripe-ios",
+    "privacy_policy_url" : null,
+    "branding" : {
+      "button_color" : "#0074d4",
+      "background_color" : "#ffffff",
+      "border_style" : "default",
+      "font_family" : "default"
+    },
+    "statement_descriptor" : "mobile",
+    "support_email" : null,
+    "display_name" : "CI Stuff",
+    "merchant_of_record_country" : "US",
+    "order_summary_display_name" : "CI Stuff",
+    "support_phone" : "+12105550123",
+    "merchant_of_record_display_name" : "CI Stuff",
+    "support_url" : null,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "country" : "US",
+    "terms_of_service_url" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "recurring_details" : {
+    "subtotal" : 2000,
+    "total_discount_amounts" : [
+
+    ],
+    "total_tax_amounts" : [
+
+    ],
+    "total_summary" : {
+      "total_discount_amounts" : [
+
+      ],
+      "total_tax_amounts" : [
+
+      ],
+      "subtotal" : 2000,
+      "total" : 2000,
+      "total_discount_amount_aggregate" : 0,
+      "total_proration_amount_aggregate" : 0,
+      "due" : 2000
+    },
+    "total" : 2000
+  },
+  "server_built_elements_session_params" : {
+    "client_betas" : [
+
+    ],
+    "expand" : [
+
+    ],
+    "checkout_session_id" : "cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg",
+    "locale" : "en-US",
+    "country_override" : "US",
+    "browser_timezone" : "America\/Los_Angeles",
+    "mobile_app_id" : "com.stripe.StripeiOSTestHostApp",
+    "type" : "deferred_intent",
+    "deferred_intent" : {
+      "amount" : 2000,
+      "currency" : "usd",
+      "payment_method_types" : [
+        "card"
+      ],
+      "setup_future_usage" : "off_session",
+      "mode" : "subscription"
+    }
+  },
+  "billing_address_collection" : null,
+  "shipping_tax_amounts" : null,
+  "elements_options" : {
+    "amount" : 2000,
+    "__checkout_config_id" : "be079c50-e21b-40e2-a66f-3a8abded825f",
+    "__checkout_country_override" : "US",
+    "__checkout_session_id" : "cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg",
+    "__checkout_automatic_payment_method_types" : false,
+    "__payment_pages_experiments" : [
+      {
+        "variant" : "control",
+        "name" : "guacamole_resend_otp",
+        "event_id" : "93edc442-0332-4ec3-b90b-26c67173da6f",
+        "exposure_event_name" : "experiment_exposure"
+      },
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs_aa",
+        "event_id" : "d032fece-4f87-48f6-9955-fff8974e06ed",
+        "exposure_event_name" : ""
+      },
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs",
+        "event_id" : "fbd29b74-24a3-41ee-aff2-5606e1688b6b",
+        "exposure_event_name" : ""
+      }
+    ],
+    "mode" : "subscription",
+    "__disable_link_in_session" : false,
+    "currency" : "usd",
+    "__link_consumer_data" : {
+
+    },
+    "payment_method_types" : [
+      "card"
+    ]
+  },
+  "experiments_data" : {
+    "event_id" : "f2ef383b-5308-4168-a61a-b968267ec384",
+    "experiment_metadata" : {
+      "ocs_buyer_xp_cpl_lpm_holdback" : {
+        "heldback_special_wallets" : [
+
+        ]
+      }
+    },
+    "experiment_assignments" : {
+      "ocs_buyer_xp_cpl_terms_above_submit" : "control",
+      "link_ab_test_aa" : "control",
+      "ff_checkout_cpl_lid_promo_badge_color_opt" : "control",
+      "ocs_buyer_xp_cpl_guacamole_a2w_expanded_vs_compact" : "control",
+      "ocs_buyer_xp_remove_name_field_guac_related_pms" : "control",
+      "ocs_buyer_xp_cpl_progressive_ece" : "control",
+      "cpl_unified_order_summary_experiment" : "control",
+      "ocs_buyer_xp_cpl_ap_currency_label_removal" : "control",
+      "ocs_buyer_xp_cpl_a2w_holdback" : "control",
+      "ocs_buyer_xp_cpl_embedded_pay_button" : "control",
+      "ocs_buyer_xp_cpl_rtl_auto_locales" : "control",
+      "ocs_buyer_xp_cpl_cost_aware_payment_method_ranking" : "control",
+      "cpl_guacamole" : "control",
+      "ocs_buyer_xp_cpl_ece_kakao_naver" : "control",
+      "ocs_buyer_xp_cpl_lpm_content_simplification" : "control",
+      "ocs_buyer_xp_cpl_single_column_checkout" : "control",
+      "ocs_buyer_xp_cpl_theme_pay_button" : "control",
+      "link_risk_based_disable_auto_prompting_checkout" : "control",
+      "ocs_buyer_xp_cpl_currency_symbol_optimization" : "control",
+      "ocs_buyer_xp_cpl_save_card_checkbox_copy" : "control",
+      "ocs_buyer_xp_cpl_lpm_dynamic_filtering_threshold" : "control",
+      "checkout_li_larger_image_size" : "control",
+      "connections_checkout_us_bank_account_picker_icons" : "control",
+      "ff_checkout_test_frontend_eff" : "control",
+      "ocs_buyer_xp_cpl_apple_pay_button_type" : "control",
+      "ocs_buyer_xp_cpl_ece_google_pay_skeleton" : "control",
+      "ff_checkout_custom_flag_server_updates_on_canconfirm" : "control",
+      "ocs_buyer_xp_cpl_link_signup_in_form" : "control",
+      "emea_wallets_ideal_wero_rebranding" : "treatment",
+      "cpl_spicy_guacamole" : "control",
+      "ocs_buyer_xp_cpl_easy_opt_link_signup_in_form" : "control",
+      "ocs_buyer_xp_cpl_android_a2w_holdback" : "control",
+      "ocs_buyer_xp_cpl_ece_skeleton" : "control"
+    }
+  },
+  "return_url" : null,
+  "mode" : "modeless",
+  "cancel_url" : null,
+  "elements_session" : {
+    "payment_method_preference" : {
+      "country_code" : "US",
+      "object" : "payment_method_preference",
+      "type" : "deferred_intent",
+      "ordered_payment_method_types" : [
+        "card"
+      ]
+    },
+    "capability_enabled_card_networks" : [
+      "cartes_bancaires",
+      "jcb",
+      "diners",
+      "discover"
+    ],
+    "flags" : {
+      "enable_tax_id_suspicious_pattern_check" : false,
+      "elements_easel_enable_elements_inspector_for_advanced_integrations_backend" : true,
+      "link_enable_signup_in_summary_in_habanero" : true,
+      "financial_connections_enable_deferred_intent_flow" : true,
+      "elements_enable_remove_last_validation" : true,
+      "apple_pay_prb_killswitch" : false,
+      "elements_enable_easel_for_pi" : true,
+      "elements_mobile_card_funding_filtering" : true,
+      "link_payment_element_minor_signup_ui_updates" : false,
+      "link_enable_ncdv_usage_id_selectors_l3" : true,
+      "elements_link_instant_bank_payments_require_billing_address_for_non_us_merchants" : false,
+      "elements_disable_express_checkout_button_amazon_pay" : false,
+      "elements_easel_disable_appearance_api" : false,
+      "link_auth_partner_enable_link_auth_token_login" : true,
+      "link_enable_ncdv_recall_id_selectors_l3" : true,
+      "elements_disable_link_email_otp" : false,
+      "restrict_taxid_selection_to_buyer_address" : false,
+      "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
+      "ocs_buyer_xp_elements_card_brand_choice_toggle" : true,
+      "paypal_billing_address_support_in_ece" : true,
+      "elements_enable_pay_by_bank_remember_bank_selection" : true,
+      "link_auth_partner_enable_ios_instagram" : true,
+      "link_user_action_attempt_login_using_stored_credentials" : true,
+      "elements_disable_sepa_debit_eea_address_requirement" : false,
+      "elements_enable_instant_debits_postal_code_collection" : false,
+      "elements_financial_connections_canada_enabled" : false,
+      "elements_easel_disable_feedback" : false,
+      "link_enable_link_session_key_financial_connections" : true,
+      "elements_us_bank_account_manual_entry_first" : false,
+      "elements_extend_hcaptcha_refresh_time" : true,
+      "link_auth_partner_consume_link_auth_intent" : true,
+      "ocs_buyer_xp_elements_remove_cpm_redirect_text" : false,
+      "elements_enable_klarna_ece_webkit_26_5_2" : false,
+      "elements_enable_south_korea_market_underlying_pms" : false,
+      "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text" : false,
+      "link_enable_apple_pay_in_safari_returning_in_guacamole" : true,
+      "elements_disable_payment_element_card_country_zip_validations" : false,
+      "link_payment_element_default_value_auto_open_modal" : true,
+      "link_payment_element_steerage_enabled" : true,
+      "elements_enable_link_name_prefill" : true,
+      "elements_ewcs_allow_spm_incomplete_billing" : false,
+      "elements_enable_link_card_brand_in_saved_payment_methods" : true,
+      "elements_disable_link_global_holdback_lookup" : false,
+      "elements_enable_pbb_uk_new_banks" : false,
+      "financial_connections_enable_ca_accounts" : false,
+      "link_enable_link_session_key_klarna" : true,
+      "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : false,
+      "elements_easel_disable_address_fill" : false,
+      "ocs_buyer_xp_elements_remove_redirect_lpm_content" : false,
+      "elements_enable_payment_method_options_setup_future_usage" : true,
+      "enable_custom_checkout_currency_selector_element" : false,
+      "elements_mobile_android_tap_to_add_enabled" : false,
+      "link_enable_address_country_restrictions" : false,
+      "link_auth_partner_enable_android_fb" : true,
+      "checkout_kr_lpm_no_billing_address_collection" : false,
+      "elements_easel_disable_health_check" : false,
+      "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
+      "elements_disable_paypal_express" : false,
+      "disable_confirmation_modal_bacs" : false,
+      "legacy_customer_session_payment_element_features" : false,
+      "link_habanero_no_otp_required_for_non_link_pm_signup" : true,
+      "elements_enable_express_checkout_element_custom_payment_methods" : false,
+      "elements_enable_terms_element" : false,
+      "smor_ewcs_vf_terms" : false,
+      "checkout_habanero_returning_user_expanded_accordion" : false,
+      "link_auth_partner_enable_authentication_element" : true,
+      "elements_allow_manual_payment_method_creation_with_spm" : false,
+      "elements_easel_disable" : false,
+      "elements_us_bank_account_require_billing_address_for_non_us_merchant" : true,
+      "link_enable_auth_partner_communication" : true,
+      "elements_apply_amex_icon_sorting" : false,
+      "elements_hide_card_brand_icons" : false,
+      "elements_mobile_android_nfc_scanning_enabled" : false,
+      "elements_easel_disable_customer_location_mocking" : false,
+      "disable_legal_text_on_non_confirmation_modal_bacs" : false,
+      "elements_easel_disable_position_customization" : false,
+      "elements_enable_appearance_recompute" : false,
+      "link_enable_link_session_key_confirm_and_start_verification" : true,
+      "link_ulm_screen_height_updates" : false,
+      "elements_enable_19_digit_pans" : false,
+      "always_show_ece_paypal_recurring_button" : false,
+      "enable_payment_method_api_shop_pay" : true,
+      "enable_elements_tax_id_type_filtering" : false,
+      "elements_human_security_enabled" : false,
+      "link_enable_white_ece_button_theme" : false,
+      "elements_webmcp_tools_enabled" : false,
+      "link_in_accordion_layout_available_in_stripejs" : false,
+      "link_payment_element_widget_view_enabled" : true,
+      "ocs_mobile_enable_analytics_to_r" : true,
+      "elements_easel_disable_magic_fill" : false,
+      "avoid_redundant_billing_details_for_klarna" : false,
+      "distinctly_link_payment_element_ramp" : true,
+      "link_enable_ewcs_customer_name_prefill" : false,
+      "smor_enable_visible_pms_override_link_saved" : false,
+      "link_auth_partner_bypass_bridge_check" : false,
+      "link_disable_cookie_login" : false,
+      "elements_disable_express_checkout_button_shop_pay" : false,
+      "payment_element_link_modal_preload_killswitch" : false,
+      "link_enable_pass_checkout_session_id_to_signup" : true,
+      "elements_enable_hcaptcha_async_token_logging" : true,
+      "elements_enable_jp_card_installments" : true,
+      "elements_show_expanded_spm" : false,
+      "disable_payment_element_if_required_billing_config" : false,
+      "elements_enable_link_otp_takeover_in_guacamole" : false,
+      "elements_enable_link_spm" : true,
+      "elements_enable_read_allow_redisplay" : false,
+      "elements_enable_save_for_future_payments_pre_check" : false,
+      "checkout_habanero_automatic_tax_legacy_minimal_address_precision" : false,
+      "link_forest_enable_ece_bank_use_shipping_as_billing" : false,
+      "elements_disable_express_checkout_button_klarna" : false,
+      "distinctly_link_cbc_killswitch" : false,
+      "elements_disable_express_checkout_element_custom_payment_methods" : false,
+      "elements_prefer_fc_lite" : false,
+      "elements_disable_payment_element_custom_payment_methods_byof" : false,
+      "elements_mobile_cardscan_use_mlkit" : true,
+      "elements_enable_link_takeover_in_guacamole" : false,
+      "link_disable_auth_partner_ua_check" : false,
+      "link_enable_link_session_key_incentives_and_status" : true,
+      "elements_easel_disable_optimizations_check" : false,
+      "elements_enable_passive_captcha" : true,
+      "link_fresh_session_sync_enabled" : false,
+      "distinctly_link_payment_element_opt_out_merchant_blocklist" : false,
+      "link_enable_non_blocking_doi_signup" : false,
+      "elements_enable_new_google_places_api" : true,
+      "checkout_form_automatic_tax_address_collection_precision" : true,
+      "elements_enable_express_checkout_button_demo_pay" : false,
+      "disable_cbc_in_link_popup" : false,
+      "elements_enable_installments_on_deferred_intents" : true,
+      "elements_enable_payto_resolve_alias" : true,
+      "elements_sepa_debit_instant_microdeposits" : false,
+      "elements_spm_set_as_default" : true,
+      "elements_does_not_collect_postal_code_for_non_us_card_transactions_killswitch" : false,
+      "link_disable_login_if_signed_up_outside_of_elements" : true,
+      "elements_enable_link_autofill_prompt_padding_fix" : false,
+      "elements_mobile_attest_on_intent_confirmation" : false,
+      "link_trusted_origin_skip_secure_click" : true,
+      "elements_stop_move_focus_to_first_errored_field" : true,
+      "ocs_buyer_xp_enable_payment_element_accordion_box_shadow" : false,
+      "elements_enable_customer_address" : true,
+      "elements_mobile_allow_stripecardscan" : false,
+      "elements_use_checkout_app_id_for_human_security" : false,
+      "link_enable_klarna_in_lae" : false,
+      "sandboxes_rebrand_testmode" : true,
+      "link_enable_card_brand_choice" : true,
+      "link_auth_partner_enable_ppac" : false,
+      "link_payment_element_keep_optional_doi_open_rollout" : true,
+      "adaptive_pricing_for_elements_with_payment_intents" : false,
+      "elements_allow_custom_payment_method_creation" : false,
+      "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+      "elements_mobile_link_inline_signup_with_saved_pm_enabled" : false,
+      "link_purchase_protections_rollout" : true,
+      "link_ulm_dark_mode" : true,
+      "elements_disable_fc_lite" : false,
+      "link_auth_partner_delay_recognition" : true,
+      "elements_enable_payment_element_custom_payment_methods_byof" : false,
+      "ocs_mobile_should_use_autocomplete_proxy_endpoints" : true,
+      "show_swish_factoring_notice" : true,
+      "elements_enable_cup_apple_pay" : false,
+      "elements_enable_nme_for_us_bank_account_skip_verification" : false,
+      "ocs_buyer_xp_elements_remove_wallets_redirect_text" : false,
+      "elements_easel_enable_elements_inspector" : true,
+      "elements_google_pay_mit_fields" : false,
+      "apple_pay_pe_killswitch" : false,
+      "disable_link_on_obo_self" : false,
+      "paypal_phone_number_support_in_ece" : false,
+      "elements_enable_pay_by_bank_multi_country_bank_selector_rollout_countries" : false,
+      "elements_easel_disable_payment_fill" : false,
+      "elements_easel_disable_tax_id_fill" : false,
+      "elements_enable_link_ulm_in_guacamole" : false,
+      "elements_spm_max_visible_payment_methods" : false,
+      "id_bank_transfers_v1_integration" : false,
+      "checkout_habanero_early_ece_ready_enabled" : true,
+      "elements_enable_mx_card_installments" : true,
+      "link_enable_link_session_key_cross_region_apis" : false,
+      "elements_easel_disable_appearance_api_per_element_options" : true,
+      "elements_enable_easel_for_pi_killswitch" : false,
+      "elements_easel_disable_pi_migrate_to_ewcs_warning" : false,
+      "elements_disable_link_lpms_in_guacamole" : true,
+      "enable_pe_options_for_billing_details_collection" : false,
+      "elements_spm_messages" : false,
+      "link_enable_link_session_key_shipping_addresses" : true,
+      "elements_easel_disable_session_summary" : false,
+      "apple_pay_ece_killswitch" : false,
+      "distinctly_link_pe_purchase_protection" : true,
+      "link_enable_link_session_key_consumer_person_details" : true,
+      "link_auth_partner_delay_android_fb_cookie_login" : false,
+      "elements_ae_hide_name_field" : false,
+      "legacy_confirmation_tokens" : false,
+      "link_auth_partner_enable_ece" : true,
+      "elements_easel_disable_elements_inspector_for_pi" : false,
+      "link_enable_link_session_key_payment_details" : true,
+      "distinctly_link_pe_backup_payment_method" : true,
+      "link_dedupe_shipping_address_creation" : true,
+      "ece_apple_pay_payment_request_passthrough" : false,
+      "checkout_link_pay_token_enabled" : false,
+      "link_enable_link_session_key_link_onboarding_session" : true,
+      "elements_mobile_force_vertical_payment_method_layout" : false,
+      "elements_enable_card_billing_details_tax_id" : false,
+      "payto_enable_modal_in_payment_element" : true,
+      "checkout_link_in_habanero_enabled" : true,
+      "elements_disable_progressive_cursor" : false,
+      "link_enable_auth_partner_sizing_logging" : true,
+      "enable_checkout_session_update_customer" : false,
+      "elements_human_security_replaces_hcaptcha" : false
+    },
+    "merchant_logo_url" : null,
+    "merchant_of_record_country" : "US",
+    "session_id" : "elements_session_1pIT95eYcOa",
+    "card_installments_enabled" : false,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "config_id" : "d78770fd-b963-4dc6-bb77-8853c4bd0e72",
+    "merchant_currency" : "usd",
+    "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+    "card_brand_choice" : {
+      "eligible" : false,
+      "preferred_networks" : [
+        "cartes_bancaires"
+      ],
+      "supported_cobranded_networks" : {
+        "cartes_bancaires" : false
+      }
+    },
+    "shipping_address_settings" : {
+      "autocomplete_allowed" : false
+    },
+    "external_payment_method_data" : null,
+    "custom_payment_method_data" : null,
+    "meta_pay_signed_container_context" : null,
+    "apple_pay_preference" : "enabled",
+    "country_override" : "US",
+    "managed_payments_enabled" : false,
+    "google_pay_preference" : "enabled",
+    "merchant_country" : "US",
+    "experiments_data" : {
+      "arb_id" : "708fafd4-d778-448e-8d1b-a8799a6a9d39",
+      "experiment_metadata" : {
+        "seed" : "4e3b58adcab79eaf00ed0ffa2780c6f7ccf3ec437786470b48f06d5797d60ac4",
+        "semi_dominant_payment_methods" : [
+
+        ],
+        "lpm_holdback_t1_payment_methods" : [
+
+        ],
+        "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false,
+        "lpm_holdback_t2_payment_methods" : [
+
+        ]
+      },
+      "experiment_assignments" : {
+        "link_pe_signup_toggle" : "control",
+        "ocs_mobile_card_art" : "control",
+        "link_pe_signup_copy_aa" : "control",
+        "link_optional_doi_signup_holdback" : "control",
+        "link_dl_pe_inline_entrypoint" : "control",
+        "ocs_mobile_nfc_scanning_feature_holdback" : "control",
+        "elements_card_brand_icons" : "control",
+        "ff_elements_currency_card_brand_blocking_fe_eff" : "control",
+        "billing_address_link_opt_in" : "control",
+        "ff_elements_currency_card_brand_blocking_be_eff" : "control",
+        "ff_elements_pe_wallet_details_eff" : "treatment",
+        "ff_elements_card_brand_funding_filtering_eff" : "control",
+        "link_pe_signup_copy" : "control",
+        "connections_elements_variable_incentives_for_ibp_recurring_payments" : "control",
+        "link_lpm_elements_klarna_powered_by_link" : "control",
+        "link_pe_row_prominent_signup" : "control",
+        "ocs_mobile_horizontal_mode" : "control",
+        "link_growth_ncdv_exp_pipeline" : "control",
+        "link_sign_up_form_container_aa" : "control",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_ui_phase_2" : "control",
+        "link_pe_hide_signup_email" : "control",
+        "link_ce_conversion_cookie_aa" : "control",
+        "pbb_label_change_elements" : "control",
+        "elements_ae_postal_cjk_normalization_aa" : "control",
+        "link_ulm_in_ece" : "control",
+        "ff_checkout_show_pbb_logos_eff" : "control",
+        "paypal_payment_handler" : "control",
+        "link_pe_signup_ui_variant_comparison" : "control",
+        "link_sign_up_form_container" : "control",
+        "link_pe_signup_green_logo_aa" : "control",
+        "link_pe_signup_ui_variant_comparison_aa" : "control",
+        "ff_elements_ece_payer_failure_reasons_eff" : "control",
+        "link_signup_name_from_billing_ae" : "control",
+        "elements_hcaptcha_init_timeout" : "control",
+        "ff_elements_submit_link_payment_method" : "control",
+        "link_spm_show_checkbox_signup_aa" : "control",
+        "ff_link_ulm_modal_in_modal" : "control",
+        "ibp_localized_featured_institutions_accordion" : "treatment",
+        "link_ce_conversion_unrecognized_aa" : "control",
+        "link_ce_conversion_unrecognized_copy_change" : "control",
+        "ff_elements_autocomplete_partial_autofill_eff" : "control",
+        "ibp_bank_tab_name_aa" : "control",
+        "link_dl_pe_inline_entrypoint_aa" : "control",
+        "link_ab_test_aa" : "control",
+        "link_growth_ece_ncdv" : "control",
+        "pmme_financing_as_low_as" : "control",
+        "ff_elements_ewcs_allow_spm_incomplete_billing_eff" : "control",
+        "link_pe_row_prominent_signup_aa" : "control",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_copy" : "control",
+        "elements_ae_postal_cjk_normalization" : "control",
+        "link_optional_doi_signup_holdback_aa" : "control",
+        "link_lpm_elements_klarna_powered_by_link_aa" : "control",
+        "link_ce_conversion_recognized_loading_animation" : "control",
+        "ff_elements_test_frontend_eff" : "control",
+        "link_ce_conversion_ncdv_aa" : "control",
+        "link_ce_conversion_unrecognized_post_entry_aa" : "control",
+        "ff_elements_ae_expanded_autocomplete_eff" : "control",
+        "link_growth_ece_ncdv_aa" : "control",
+        "ocs_mobile_horizontal_mode_aa" : "control",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_ui_phase_1" : "control",
+        "ff_elements_ae_default_values_equality" : "treatment",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_ui_phase_3" : "control",
+        "ff_checkout_habanero_combined_contact_payment_view_eff" : "treatment",
+        "ff_elements_preserve_klarna_and_financial_partner_button_availability" : "treatment",
+        "ff_elements_ae_autofill_validation" : "control",
+        "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : "control",
+        "link_pe_hide_signup_email_aa" : "control",
+        "link_ulm_in_ece_aa" : "control",
+        "ff_elements_enable_appearance_recompute_eff" : "control",
+        "link_spm_show_checkbox_signup" : "control",
+        "billing_address_link_opt_in_aa" : "control",
+        "br_card_lpa_elements_synapse_lpa_fields" : "control",
+        "link_growth_ncdv_exp_pipeline_aa" : "control",
+        "ibp_bank_tab_name" : "control",
+        "ff_ece_block_3p_financial_partner_on_custom_amount" : "treatment",
+        "ff_elements_pe_auto_tax_binding_eff" : "treatment",
+        "link_pe_signup_green_logo" : "control"
+      }
+    },
+    "legacy_customer" : null,
+    "link_settings" : {
+      "link_passthrough_mode_enabled" : false,
+      "link_payment_element_smart_defaults_enabled" : false,
+      "link_mobile_attestation_state_sync_enabled" : false,
+      "link_no_code_default_values_recall" : true,
+      "link_funding_sources" : [
+
+      ],
+      "link_crypto_onramp_force_cvc_reverification" : false,
+      "link_enable_signup_in_express_checkout_element" : false,
+      "link_modal_disable_in_ece" : false,
+      "link_consumer_incentive" : null,
+      "link_crypto_onramp_bank_upsell" : false,
+      "link_ece_browser_compatibility_override" : false,
+      "link_wanderlust_in_elements_enabled" : false,
+      "link_use_current_authentication_level_for_is_verified" : false,
+      "link_enable_email_otp_for_link_popup" : false,
+      "link_crypto_onramp_elements_logout_disabled" : false,
+      "link_popup_enable_new_google_places_api" : false,
+      "link_no_code_default_values_identification" : true,
+      "link_pay_button_element_enabled" : true,
+      "link_payment_element_enable_webauthn_login" : false,
+      "link_bank_onboarding_enabled" : false,
+      "link_enable_instant_debits_in_testmode" : false,
+      "link_enable_sensitive_changes" : true,
+      "link_payment_element_disabled_by_targeting" : false,
+      "link_sign_up_opt_in_feature_enabled" : false,
+      "link_only_for_payment_method_types_enabled" : false,
+      "link_disabled_reasons" : {
+        "payment_element_payment_method_mode" : [
+          "link_not_specified_in_payment_method_types"
+        ],
+        "payment_element_passthrough_mode" : [
+          "link_not_enabled_on_payment_config"
+        ]
+      },
+      "link_sign_up_opt_in_initial_value" : false,
+      "link_popup_disable_in_ece" : false,
+      "link_mobile_use_attestation_endpoints" : false,
+      "link_popup_shorten_signup_redirect_timeout" : false,
+      "link_elements_pageload_sign_up_disabled" : false,
+      "link_disable_pe_signup_prompt" : false,
+      "link_elements_is_crypto_onramp" : false,
+      "link_no_code_default_values_usage" : true,
+      "link_enable_webauthn_for_link_popup" : false,
+      "link_email_verification_login_enabled" : false,
+      "link_popup_webview_option" : "shared",
+      "link_targeting_results" : {
+        "payment_element_passthrough_mode" : null
+      },
+      "link_trusted_merchant_check_enabled" : false,
+      "link_global_holdback_on" : false,
+      "link_show_prefer_debit_card_hint" : false,
+      "link_local_storage_login_enabled" : false,
+      "link_payment_session_context" : null,
+      "link_session_storage_login_enabled" : false,
+      "link_brand" : "link",
+      "link_disable_in_safari_private_browsing" : false,
+      "link_mobile_disable_rux_in_flow_controller" : false,
+      "link_authenticated_change_event_enabled" : false,
+      "link_popup_ios26_trampoline_enabled" : false,
+      "link_pm_killswitch_on_in_elements" : false,
+      "link_supported_payment_methods_onboarding_enabled" : [
+
+      ],
+      "link_hcaptcha_site_key" : null,
+      "link_payment_element_disable_signup" : false,
+      "link_enable_displayable_default_values_in_ece" : false,
+      "link_disable_email_otp" : false,
+      "link_hcaptcha_rqdata" : null,
+      "link_default_opt_in" : "NONE",
+      "link_supported_payment_methods" : [
+
+      ],
+      "link_mobile_disable_default_opt_in" : false,
+      "link_mode" : null,
+      "link_mobile_disable_signup" : false,
+      "link_popup_smart_defaults_enabled" : false
+    },
+    "passive_captcha" : {
+      "rqdata" : null,
+      "captcha_provider_payload" : null,
+      "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+      "token_timeout_seconds" : 1770
+    },
+    "payment_method_configuration_id" : null,
+    "payment_method_specs" : [
+      {
+        "async" : false,
+        "type" : "card",
+        "fields" : [
+
+        ]
+      }
+    ],
+    "paypal_express_config" : {
+      "client_id" : null,
+      "client_token" : null,
+      "paypal_merchant_id" : null
+    },
+    "prefill_selectors" : {
+      "default_values" : {
+        "email" : [
+
+        ],
+        "merchant_provides_default_values_on_update" : true
+      },
+      "default_values_exp" : {
+        "merchant_provides_default_values_on_update" : true,
+        "selectors_by_surface" : {
+
+        }
+      }
+    },
+    "unactivated_payment_method_types" : [
+
+    ],
+    "order" : null,
+    "unverified_payment_methods_on_domain" : [
+      "apple_pay"
+    ],
+    "link_purchase_protections_data" : {
+      "type" : null,
+      "is_eligible" : false
+    },
+    "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+    "blocked_card_brands" : [
+
+    ],
+    "customer" : null,
+    "klarna_express_config" : {
+      "klarna_mid" : null
+    },
+    "lpm_killswitches" : {
+      "express_checkout" : [
+
+      ],
+      "payment_element" : [
+
+      ]
+    },
+    "business_name" : "CI Stuff",
+    "ordered_payment_method_types_and_wallets" : [
+      "card",
+      "apple_pay",
+      "google_pay"
+    ],
+    "customer_error" : null
+  },
+  "stripe_hosted_url" : "https:\/\/checkout.stripe.com\/c\/pay\/cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWkB3dnxIQEpRcGFWb1RXPW1tNVN3VHcwXTU1PXZHXUJKcDMnKSdjd2poVmB3c2B3Jz9xd3BgKSdnZGZuYndqcGthRmppancnPycmY2NjY2NjJyknaWR8anBxUXx1YCc%2FJ3Zsa2JpYFpscWBoJyknYGtkZ2lgVWlkZmBtamlhYHd2Jz9xd3BgeCUl",
+  "prefilled" : null,
+  "redirect_on_completion" : null,
+  "blob" : null,
+  "client_reference_id" : null,
+  "status" : "open",
+  "submit_type" : null,
+  "email_collection" : null,
+  "permissions" : null,
+  "custom_fields" : [
+
+  ],
+  "phone_number_collection" : {
+    "enabled" : false
+  },
+  "livemode" : false,
+  "ordered_payment_method_types" : [
+    "card",
+    "apple_pay",
+    "google_pay"
+  ],
+  "state" : "active",
+  "currency" : "usd",
+  "subscription_data" : null,
+  "customer_managed_saved_payment_methods_offer_save" : null,
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping" : null,
+  "crypto_in_link_ui_enabled" : false,
+  "rqdata" : "\/xr6axwCPY9fGkYdpZG37\/UiMDwHUE67PItXnV6PurnLzTof6eLsrR5\/lX70+uG4AadHTD0sGy+3TFYWE\/3Tqa3uoI4YIpXkHWuOj83O2H\/0ZTg6By+UbSCtwNg\/U5JTDf9WnWVeZnE5evgDU32CO5gpzxOibMMMYvZHfiGCWOtESVf0\/dc9\/LFQn7xkrHhGQO9oQ+RqtaCGr8X8QyWMhytZVc+J\/04WBRxArPV5FQgWPsgwkACPCSfKOOJzuL0rGJxTa1ojSyFITvuWV8wSD\/qF08M0ckuU3sL52HzsQwF+tE40raqEB1V0+Q==fJzpwwPTm73xNSfM",
+  "total_summary" : {
+    "total_discount_amounts" : [
+
+    ],
+    "total_tax_amounts" : [
+
+    ],
+    "applied_balance" : 0,
+    "amount_due_applied_to_balance" : false,
+    "subtotal" : 2000,
+    "total" : 2000,
+    "total_discount_amount_aggregate" : 0,
+    "total_proration_amount_aggregate" : 0,
+    "due" : 2000
+  },
+  "on_behalf_of" : null,
+  "cross_sell_group" : null,
+  "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+  "checkout_multistep_ui" : false,
+  "eid" : "5F933A04-DE0E-4EB8-ACF0-9967359D644E",
+  "line_item_group" : null,
+  "managed_payments" : null,
+  "name_collection" : null,
+  "payment_intent" : null,
+  "config_id" : "be079c50-e21b-40e2-a66f-3a8abded825f",
+  "is_sandbox_merchant" : false
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testPollCheckoutSession/0002_get_v1_payment_pages_cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg_poll.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testPollCheckoutSession/0002_get_v1_payment_pages_cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg_poll.tail
@@ -1,0 +1,41 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_pages\/cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg\/poll\?$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=M_AelTk7J4HWvSlxj6AnGYMt79euMaKfkaQRt5PlI1LsMsiDul87EIQlVK1fg1AbGxFvfsKcrVUUaWzm; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=M_AelTk7J4HWvSlxj6AnGYMt79euMaKfkaQRt5PlI1LsMsiDul87EIQlVK1fg1AbGxFvfsKcrVUUaWzm&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=M_AelTk7J4HWvSlxj6AnGYMt79euMaKfkaQRt5PlI1LsMsiDul87EIQlVK1fg1AbGxFvfsKcrVUUaWzm&t=1"}],"include_subdomains":true}
+request-id: req_rec00kR7TTLWYd
+Content-Length: 399
+Vary: Origin
+Date: Sat, 22 Aug 2026 18:15:42 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+
+{
+  "id" : "ppage_1U7JSDFY0qyl6XeWmYWVESAJ",
+  "state" : "active",
+  "invoice_receipt_url" : null,
+  "livemode" : false,
+  "invoice_url" : null,
+  "return_url" : null,
+  "locale" : null,
+  "mode" : "modeless",
+  "success_url" : null,
+  "payment_object_status" : null,
+  "session_id" : "cs_test_a1TTJqAdGFe287l2yLReMf1h3Hnp13OEDosDfPnqkVxkit5V9VZF2De7Zg",
+  "is_sandbox_merchant" : false,
+  "ui_mode" : "custom"
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testRetrieveCheckoutSession/0000_post_create_checkout_session_unified.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testRetrieveCheckoutSession/0000_post_create_checkout_session_unified.tail
@@ -1,0 +1,17 @@
+POST
+https:\/\/stp-mobile-ci-test-backend-e1b3\.stripedemos\.com\/create_checkout_session_unified$
+200
+text/html
+x-content-type-options: nosniff
+x-cloud-trace-context: 8e61c6dc3a1329bb069ab371f8ebf43d;o=1
+Content-Type: text/html;charset=utf-8
+Set-Cookie: rack.session=FtfDuUKQK2%2BBqKdEuaDGOZnvTBdjccVYy5KQccS7tV%2Bg7aUYHeZYCsS3cI21XWudPKAqZm9iO3y6iYJ9dNm1q6BhPIBJT757%2FpeXH8nJglF%2BcOgry6eoQxW6t84Xg%2BLpA020wu51HTO4oDcTtnpJTerccVoDMF2xR0quZHWYd8IFCSz3BbUVxnfMmxQxBVlNG6x1Y7OoSd%2BZFTjDRgXmU%2FgjJj3GRPvHpJKr1CZnFk4%3D; path=/
+Server: Google Frontend
+Via: 1.1 google
+Date: Sat, 22 Aug 2026 18:15:05 GMT
+x-frame-options: SAMEORIGIN
+x-xss-protection: 1; mode=block
+Content-Length: 293
+Alt-Svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+
+{"id":"cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4","client_secret":"cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4_secret_fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdwbEhqYWAnPydmcHZxamgneCUl","publishable_key":"pk_test_ErsyMEOTudSjQR8hh0VrQr5X008sBXGOu6"}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testRetrieveCheckoutSession/0001_post_v1_payment_pages_cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4_init.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testRetrieveCheckoutSession/0001_post_v1_payment_pages_cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4_init.tail
@@ -1,0 +1,1097 @@
+POST
+https:\/\/api\.stripe\.com\/v1\/payment_pages\/cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4\/init$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=cJISlD3hN7wGyQhq5PFsjXwx8CaDFi9GJ9spdYn5ix57GiFeyjU9OJUpj_bLld9GZZR7NraqGUG20YDx; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=cJISlD3hN7wGyQhq5PFsjXwx8CaDFi9GJ9spdYn5ix57GiFeyjU9OJUpj_bLld9GZZR7NraqGUG20YDx&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+stripe-should-retry: false
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=cJISlD3hN7wGyQhq5PFsjXwx8CaDFi9GJ9spdYn5ix57GiFeyjU9OJUpj_bLld9GZZR7NraqGUG20YDx&t=1"}],"include_subdomains":true}
+request-id: req_tvFNNcJ1AxCb65
+x-stripe-routing-context-priority-tier: api-testmode
+Content-Length: 40048
+Vary: Origin
+Date: Sat, 22 Aug 2026 18:15:05 GMT
+original-request: req_tvFNNcJ1AxCb65
+stripe-version: 2020-08-27
+idempotency-key: 99d60de7-8a68-4d16-8651-82a67afa8890
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+X-Stripe-Mock-Request: adaptive_pricing\[allowed]=false&browser_locale=.*&browser_timezone=.*&eid=.*&elements_session_client\[is_aggregation_expected]=true&elements_session_client\[locale]=.*&elements_session_client\[mobile_app_id]=.*&redirect_type=embedded
+
+{
+  "lpm_settings" : null,
+  "sepa_debit_info" : null,
+  "automatic_payment_method_types" : false,
+  "is_unclaimed_anonymous_sandbox" : false,
+  "tax_context" : {
+    "automatic_tax_error" : null,
+    "tax_id_collection_required" : "never",
+    "automatic_tax_enabled" : false,
+    "automatic_tax_taxability_reason" : null,
+    "dynamic_tax_enabled" : false,
+    "tax_id_collection_enabled" : false,
+    "automatic_tax_exempt" : null,
+    "automatic_tax_address_collection_precision" : null,
+    "customer_tax_country" : null,
+    "has_maximum_tax_ids" : false,
+    "automatic_tax_address_source" : null
+  },
+  "payment_method_types" : [
+    "card"
+  ],
+  "payment_method_options" : null,
+  "bnpl_in_link_ui_enabled" : false,
+  "consent_collection" : null,
+  "experiment_data" : [
+    {
+      "variant" : "control",
+      "name" : "guacamole_resend_otp",
+      "event_id" : "4c0ebcc4-b165-41bd-93f1-27bca4de6385",
+      "exposure_event_name" : "experiment_exposure"
+    },
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs_aa",
+      "event_id" : "d1554507-692d-4808-ad33-4ef51bf381e3",
+      "exposure_event_name" : ""
+    },
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs",
+      "event_id" : "35ed57e7-36ac-4ce2-a37b-df8b02397fbc",
+      "exposure_event_name" : ""
+    }
+  ],
+  "origin_context" : null,
+  "enforcement_mode" : "open",
+  "blocked_billing_address_countries" : [
+
+  ],
+  "id" : "ppage_1U7JRdFY0qyl6XeWZWC1Vyvc",
+  "subscription_settings" : null,
+  "consent" : null,
+  "does_not_collect_postal_code_for_non_us_card_transactions" : false,
+  "use_payment_methods" : true,
+  "application" : null,
+  "payment_method_collection" : "automatic",
+  "setup_intent" : null,
+  "integration_identifier" : null,
+  "checkout_items" : [
+    {
+      "pricing_plan_subscription_item" : null,
+      "sub_mode_subscription_v1" : null,
+      "metronome_commit" : null,
+      "subscription" : null,
+      "key" : "checkout_item_V7YYFwmM",
+      "type" : "one_time_price",
+      "rate_card_subscription_item" : null,
+      "one_time_price" : {
+        "items" : [
+          {
+            "quantity" : 1,
+            "inner_item_key" : "inner_item_V7YYgDcr",
+            "tax_exclusive" : 0,
+            "total" : 2000,
+            "tax_amounts" : [
+
+            ],
+            "unit_amount" : 2000,
+            "subtotal" : 2000,
+            "price" : {
+              "id" : "price_1U7JRcFY0qyl6XeWELfXG1SB",
+              "livemode" : false,
+              "active" : true,
+              "product" : {
+                "object" : "product",
+                "active" : true,
+                "addons" : null,
+                "id" : "prod_V7YYJhbWAYcrph",
+                "images" : [
+
+                ],
+                "livemode" : false,
+                "url" : null,
+                "attributes" : [
+
+                ],
+                "description" : null,
+                "name" : "Test",
+                "unit_label" : null
+              },
+              "tax_behavior" : "exclusive",
+              "custom_unit_amount" : null,
+              "transform_quantity" : null,
+              "type" : "one_time",
+              "unit_amount" : 2000,
+              "unit_amount_decimal" : "2000",
+              "object" : "price",
+              "billing_scheme" : "per_unit",
+              "recurring" : null,
+              "currency" : "usd",
+              "tiers_mode" : null
+            },
+            "unit_amount_decimal" : "2000.0",
+            "adjustable_quantity" : null,
+            "tax_inclusive" : 0,
+            "unit_label" : null
+          }
+        ],
+        "subtotal" : 2000,
+        "total" : 2000
+      }
+    }
+  ],
+  "shipping_options" : [
+
+  ],
+  "setup_future_usage_for_payment_method_type" : {
+
+  },
+  "capture_method" : null,
+  "statement_descriptor" : "mobile",
+  "session_id" : "cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4",
+  "shipping_address_collection" : null,
+  "konbini_confirmation_number" : null,
+  "setup_future_usage" : null,
+  "invoice_creation" : {
+    "enabled" : false
+  },
+  "has_dynamic_tax_rates" : false,
+  "receipt_emails_enabled" : false,
+  "link_settings" : {
+    "link_consumer_incentive" : null,
+    "link_payment_session_context" : null,
+    "consumer_found" : null,
+    "hcaptcha_rqdata" : null,
+    "link_supported_payment_methods_onboarding_enabled" : [
+
+    ],
+    "enable_partner_lookup" : false,
+    "link_us_bank_account_funding_source_enabled" : false,
+    "link_funding_sources" : [
+
+    ],
+    "hcaptcha_site_key" : null,
+    "link_brand" : "link",
+    "link_mode" : null,
+    "link_supported_payment_methods" : [
+
+    ]
+  },
+  "object" : "checkout.session",
+  "customer" : null,
+  "shipping_rate" : null,
+  "success_url" : null,
+  "utm_codes" : null,
+  "beta_versions" : null,
+  "has_async_attached_payment_method" : false,
+  "feature_flags" : {
+    "checkout_enable_pay_by_bank_remember_bank_selection" : true,
+    "checkout_enable_link_api_passive_hcaptcha" : true,
+    "checkout_enable_hcaptcha_async_token_logging" : true,
+    "checkout_show_swish_factoring_notice" : true,
+    "checkout_custom_google_pay_for_automatic_tax" : true,
+    "checkout_us_bank_account_require_billing_address_non_us" : true,
+    "checkout_ewcs_optional_items" : true,
+    "checkout_link_purchase_protections_rollout" : true,
+    "checkout_pe_inline_billing_address_autocomplete_enabled" : true,
+    "enable_custom_checkout_name_collection" : true,
+    "checkout_item_order_summary_enabled" : true,
+    "checkout_payto_alias_resolution_enabled" : true,
+    "checkout_link_phone_registration_treatment_1_enabled" : true,
+    "checkout_tide_remount_override_replay" : true,
+    "sandboxes_rebrand_testmode" : true,
+    "checkout_address_autocomplete_enabled" : true,
+    "checkout_guacamole_custom_amounts" : true,
+    "checkout_optional_items" : true,
+    "checkout_passive_captcha" : true,
+    "checkout_link_enable_mfa" : true,
+    "checkout_apple_pay_old_devices_tax_address_collection" : true,
+    "checkout_enable_link_api_hcaptcha_rqdata" : true,
+    "checkout_enable_new_google_places_api" : true,
+    "checkout_hcaptcha_redundancy_control_enabled" : true,
+    "checkout_link_in_habanero_enabled" : true
+  },
+  "locale" : null,
+  "custom_text" : {
+    "shipping_address" : null,
+    "terms_of_service_acceptance" : null,
+    "submit" : null,
+    "after_submit" : null
+  },
+  "route_to_orchestration_interface" : false,
+  "customer_email" : null,
+  "payment_collection_context" : null,
+  "custom_components" : [
+
+  ],
+  "ui_mode" : "custom",
+  "url" : null,
+  "developer_tool_context" : {
+    "disabled_third_party_wallets" : {
+      "LINK_BUTTON" : {
+        "disabled_reason" : "merchant_payment_methods_settings"
+      },
+      "KLARNA_EXPRESS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "PAYPAL_ECS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "AMAZON_PAY" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      }
+    },
+    "adaptive_pricing" : {
+      "reason" : "not_allowed_for_ui",
+      "active" : false
+    },
+    "payment_method_configuration_details" : null
+  },
+  "token_notification_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "init_checksum" : "jGfYWe9qGgt3aXJPCkzw1m7dzQzr0dnb",
+  "tax_exclusion_from_total_is_allowed" : false,
+  "bnpl_link_experiment_payment_method_type" : null,
+  "tax_meta" : {
+    "status" : null,
+    "error_reason" : null,
+    "computation_type" : "manual",
+    "customer_tax_exempt" : null
+  },
+  "payment_status" : "unpaid",
+  "enabled_third_party_wallets" : [
+    {
+      "apple_pay" : {
+        "required_version" : 2
+      },
+      "id" : "APPLE_PAY",
+      "enabled" : true,
+      "carousel_enabled" : true
+    },
+    {
+      "id" : "GOOGLE_PAY",
+      "enabled" : true,
+      "google_pay" : {
+        "id" : "GOOGLE_PAY",
+        "version_minor" : 0,
+        "version_major" : 2
+      },
+      "carousel_enabled" : false
+    },
+    {
+      "id" : "AMAZON_PAY",
+      "carousel_enabled" : false,
+      "enabled" : false
+    },
+    {
+      "id" : "KLARNA_EXPRESS",
+      "carousel_enabled" : false,
+      "enabled" : false
+    }
+  ],
+  "klarna_info" : null,
+  "visible_custom_component_locations" : [
+    "checkout_form_before",
+    "checkout_form_after",
+    "submit_button_before",
+    "submit_button_after",
+    "contact_before",
+    "contact_after",
+    "express_checkout_before",
+    "express_checkout_after",
+    "payment_details_before",
+    "payment_details_after"
+  ],
+  "display_consent_collection_promotions" : false,
+  "policies" : {
+    "contacts" : {
+      "display_phone" : true,
+      "display_url" : true,
+      "enabled" : false,
+      "display_email" : true
+    },
+    "legal" : {
+      "agreement_required" : false,
+      "enabled" : false
+    },
+    "returns" : {
+      "custom_message" : null,
+      "exchanges_accepted" : false,
+      "returns_accepted" : null,
+      "fee_type" : null,
+      "fee_required" : null,
+      "policy_url" : null,
+      "window_start" : null,
+      "refunds_accepted" : null,
+      "window" : null,
+      "enabled" : false,
+      "exceptions_apply" : false,
+      "logistics" : [
+
+      ]
+    }
+  },
+  "card_brands" : {
+    "mastercard" : true,
+    "troy" : false,
+    "link" : true,
+    "carnet" : false,
+    "accel" : false,
+    "elo" : false,
+    "rupay" : false,
+    "maestro" : false,
+    "unionpay" : true,
+    "amex" : true,
+    "jaywan" : false,
+    "conecs" : false,
+    "jcb" : true,
+    "visa" : true,
+    "cartes_bancaires" : false,
+    "pulse" : false,
+    "discover" : true,
+    "star" : false,
+    "eftpos_au" : false,
+    "diners" : true,
+    "girocard" : false,
+    "nyce" : false
+  },
+  "geocoding" : {
+    "country_code" : "US",
+    "region_name" : "CA"
+  },
+  "account_settings" : {
+    "assets" : {
+      "use_logo" : false,
+      "icon" : null,
+      "logo" : null
+    },
+    "specified_commercial_transactions_act_url" : null,
+    "business_url" : "https:\/\/github.com\/stripe\/stripe-ios",
+    "privacy_policy_url" : null,
+    "branding" : {
+      "button_color" : "#0074d4",
+      "background_color" : "#ffffff",
+      "border_style" : "default",
+      "font_family" : "default"
+    },
+    "statement_descriptor" : "mobile",
+    "support_email" : null,
+    "display_name" : "CI Stuff",
+    "merchant_of_record_country" : "US",
+    "order_summary_display_name" : "CI Stuff",
+    "support_phone" : "+12105550123",
+    "merchant_of_record_display_name" : "CI Stuff",
+    "support_url" : null,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "country" : "US",
+    "terms_of_service_url" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "recurring_details" : {
+    "subtotal" : 2000,
+    "total_discount_amounts" : [
+
+    ],
+    "total_tax_amounts" : [
+
+    ],
+    "total_summary" : {
+      "total_discount_amounts" : [
+
+      ],
+      "total_tax_amounts" : [
+
+      ],
+      "subtotal" : 2000,
+      "total" : 2000,
+      "total_discount_amount_aggregate" : 0,
+      "total_proration_amount_aggregate" : 0,
+      "due" : 2000
+    },
+    "total" : 2000
+  },
+  "server_built_elements_session_params" : {
+    "client_betas" : [
+
+    ],
+    "expand" : [
+
+    ],
+    "checkout_session_id" : "cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4",
+    "locale" : "en-US",
+    "country_override" : "US",
+    "browser_timezone" : "America\/Los_Angeles",
+    "mobile_app_id" : "com.stripe.StripeiOSTestHostApp",
+    "type" : "deferred_intent",
+    "deferred_intent" : {
+      "amount" : 2000,
+      "currency" : "usd",
+      "payment_method_types" : [
+        "card"
+      ],
+      "setup_future_usage" : "off_session",
+      "mode" : "subscription"
+    }
+  },
+  "billing_address_collection" : null,
+  "shipping_tax_amounts" : null,
+  "elements_options" : {
+    "amount" : 2000,
+    "__checkout_config_id" : "9f2ac162-bcd1-459a-acab-8d90071db8cc",
+    "__checkout_country_override" : "US",
+    "__checkout_session_id" : "cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4",
+    "__checkout_automatic_payment_method_types" : false,
+    "__payment_pages_experiments" : [
+      {
+        "variant" : "control",
+        "name" : "guacamole_resend_otp",
+        "event_id" : "4c0ebcc4-b165-41bd-93f1-27bca4de6385",
+        "exposure_event_name" : "experiment_exposure"
+      },
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs_aa",
+        "event_id" : "d1554507-692d-4808-ad33-4ef51bf381e3",
+        "exposure_event_name" : ""
+      },
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs",
+        "event_id" : "35ed57e7-36ac-4ce2-a37b-df8b02397fbc",
+        "exposure_event_name" : ""
+      }
+    ],
+    "mode" : "subscription",
+    "__disable_link_in_session" : false,
+    "currency" : "usd",
+    "__link_consumer_data" : {
+
+    },
+    "payment_method_types" : [
+      "card"
+    ]
+  },
+  "experiments_data" : {
+    "event_id" : "a00d160f-1a4d-45d4-870d-0f830f77b125",
+    "experiment_metadata" : {
+      "ocs_buyer_xp_cpl_lpm_holdback" : {
+        "heldback_special_wallets" : [
+
+        ]
+      }
+    },
+    "experiment_assignments" : {
+      "ocs_buyer_xp_cpl_terms_above_submit" : "control",
+      "link_ab_test_aa" : "control",
+      "ff_checkout_cpl_lid_promo_badge_color_opt" : "control",
+      "ocs_buyer_xp_cpl_guacamole_a2w_expanded_vs_compact" : "control",
+      "ocs_buyer_xp_remove_name_field_guac_related_pms" : "control",
+      "ocs_buyer_xp_cpl_progressive_ece" : "control",
+      "cpl_unified_order_summary_experiment" : "control",
+      "ocs_buyer_xp_cpl_ap_currency_label_removal" : "control",
+      "ocs_buyer_xp_cpl_a2w_holdback" : "control",
+      "ocs_buyer_xp_cpl_embedded_pay_button" : "control",
+      "ocs_buyer_xp_cpl_rtl_auto_locales" : "control",
+      "ocs_buyer_xp_cpl_cost_aware_payment_method_ranking" : "control",
+      "cpl_guacamole" : "control",
+      "ocs_buyer_xp_cpl_ece_kakao_naver" : "control",
+      "ocs_buyer_xp_cpl_lpm_content_simplification" : "control",
+      "ocs_buyer_xp_cpl_single_column_checkout" : "control",
+      "ocs_buyer_xp_cpl_theme_pay_button" : "control",
+      "link_risk_based_disable_auto_prompting_checkout" : "control",
+      "ocs_buyer_xp_cpl_currency_symbol_optimization" : "control",
+      "ocs_buyer_xp_cpl_save_card_checkbox_copy" : "control",
+      "ocs_buyer_xp_cpl_lpm_dynamic_filtering_threshold" : "control",
+      "checkout_li_larger_image_size" : "control",
+      "connections_checkout_us_bank_account_picker_icons" : "control",
+      "ff_checkout_test_frontend_eff" : "control",
+      "ocs_buyer_xp_cpl_apple_pay_button_type" : "control",
+      "ocs_buyer_xp_cpl_ece_google_pay_skeleton" : "control",
+      "ff_checkout_custom_flag_server_updates_on_canconfirm" : "control",
+      "ocs_buyer_xp_cpl_link_signup_in_form" : "control",
+      "emea_wallets_ideal_wero_rebranding" : "treatment",
+      "cpl_spicy_guacamole" : "control",
+      "ocs_buyer_xp_cpl_easy_opt_link_signup_in_form" : "control",
+      "ocs_buyer_xp_cpl_android_a2w_holdback" : "control",
+      "ocs_buyer_xp_cpl_ece_skeleton" : "control"
+    }
+  },
+  "return_url" : null,
+  "mode" : "modeless",
+  "cancel_url" : null,
+  "elements_session" : {
+    "payment_method_preference" : {
+      "country_code" : "US",
+      "object" : "payment_method_preference",
+      "type" : "deferred_intent",
+      "ordered_payment_method_types" : [
+        "card"
+      ]
+    },
+    "capability_enabled_card_networks" : [
+      "cartes_bancaires",
+      "jcb",
+      "diners",
+      "discover"
+    ],
+    "flags" : {
+      "enable_tax_id_suspicious_pattern_check" : false,
+      "elements_easel_enable_elements_inspector_for_advanced_integrations_backend" : true,
+      "link_enable_signup_in_summary_in_habanero" : true,
+      "financial_connections_enable_deferred_intent_flow" : true,
+      "elements_enable_remove_last_validation" : true,
+      "apple_pay_prb_killswitch" : false,
+      "elements_enable_easel_for_pi" : true,
+      "elements_mobile_card_funding_filtering" : true,
+      "link_payment_element_minor_signup_ui_updates" : false,
+      "link_enable_ncdv_usage_id_selectors_l3" : true,
+      "elements_link_instant_bank_payments_require_billing_address_for_non_us_merchants" : false,
+      "elements_disable_express_checkout_button_amazon_pay" : false,
+      "elements_easel_disable_appearance_api" : false,
+      "link_auth_partner_enable_link_auth_token_login" : true,
+      "link_enable_ncdv_recall_id_selectors_l3" : true,
+      "elements_disable_link_email_otp" : false,
+      "restrict_taxid_selection_to_buyer_address" : false,
+      "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
+      "ocs_buyer_xp_elements_card_brand_choice_toggle" : true,
+      "paypal_billing_address_support_in_ece" : true,
+      "elements_enable_pay_by_bank_remember_bank_selection" : true,
+      "link_auth_partner_enable_ios_instagram" : true,
+      "link_user_action_attempt_login_using_stored_credentials" : true,
+      "elements_disable_sepa_debit_eea_address_requirement" : false,
+      "elements_enable_instant_debits_postal_code_collection" : false,
+      "elements_financial_connections_canada_enabled" : false,
+      "elements_easel_disable_feedback" : false,
+      "link_enable_link_session_key_financial_connections" : true,
+      "elements_us_bank_account_manual_entry_first" : false,
+      "elements_extend_hcaptcha_refresh_time" : true,
+      "link_auth_partner_consume_link_auth_intent" : true,
+      "ocs_buyer_xp_elements_remove_cpm_redirect_text" : false,
+      "elements_enable_klarna_ece_webkit_26_5_2" : false,
+      "elements_enable_south_korea_market_underlying_pms" : false,
+      "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text" : false,
+      "link_enable_apple_pay_in_safari_returning_in_guacamole" : true,
+      "elements_disable_payment_element_card_country_zip_validations" : false,
+      "link_payment_element_default_value_auto_open_modal" : true,
+      "link_payment_element_steerage_enabled" : true,
+      "elements_enable_link_name_prefill" : true,
+      "elements_ewcs_allow_spm_incomplete_billing" : false,
+      "elements_enable_link_card_brand_in_saved_payment_methods" : true,
+      "elements_disable_link_global_holdback_lookup" : false,
+      "elements_enable_pbb_uk_new_banks" : false,
+      "financial_connections_enable_ca_accounts" : false,
+      "link_enable_link_session_key_klarna" : true,
+      "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : false,
+      "elements_easel_disable_address_fill" : false,
+      "ocs_buyer_xp_elements_remove_redirect_lpm_content" : false,
+      "elements_enable_payment_method_options_setup_future_usage" : true,
+      "enable_custom_checkout_currency_selector_element" : false,
+      "elements_mobile_android_tap_to_add_enabled" : false,
+      "link_enable_address_country_restrictions" : false,
+      "link_auth_partner_enable_android_fb" : true,
+      "checkout_kr_lpm_no_billing_address_collection" : false,
+      "elements_easel_disable_health_check" : false,
+      "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
+      "elements_disable_paypal_express" : false,
+      "disable_confirmation_modal_bacs" : false,
+      "legacy_customer_session_payment_element_features" : false,
+      "link_habanero_no_otp_required_for_non_link_pm_signup" : true,
+      "elements_enable_express_checkout_element_custom_payment_methods" : false,
+      "elements_enable_terms_element" : false,
+      "smor_ewcs_vf_terms" : false,
+      "checkout_habanero_returning_user_expanded_accordion" : false,
+      "link_auth_partner_enable_authentication_element" : true,
+      "elements_allow_manual_payment_method_creation_with_spm" : false,
+      "elements_easel_disable" : false,
+      "elements_us_bank_account_require_billing_address_for_non_us_merchant" : true,
+      "link_enable_auth_partner_communication" : true,
+      "elements_apply_amex_icon_sorting" : false,
+      "elements_hide_card_brand_icons" : false,
+      "elements_mobile_android_nfc_scanning_enabled" : false,
+      "elements_easel_disable_customer_location_mocking" : false,
+      "disable_legal_text_on_non_confirmation_modal_bacs" : false,
+      "elements_easel_disable_position_customization" : false,
+      "elements_enable_appearance_recompute" : false,
+      "link_enable_link_session_key_confirm_and_start_verification" : true,
+      "link_ulm_screen_height_updates" : false,
+      "elements_enable_19_digit_pans" : false,
+      "always_show_ece_paypal_recurring_button" : false,
+      "enable_payment_method_api_shop_pay" : true,
+      "enable_elements_tax_id_type_filtering" : false,
+      "elements_human_security_enabled" : false,
+      "link_enable_white_ece_button_theme" : false,
+      "elements_webmcp_tools_enabled" : false,
+      "link_in_accordion_layout_available_in_stripejs" : false,
+      "link_payment_element_widget_view_enabled" : true,
+      "ocs_mobile_enable_analytics_to_r" : true,
+      "elements_easel_disable_magic_fill" : false,
+      "avoid_redundant_billing_details_for_klarna" : false,
+      "distinctly_link_payment_element_ramp" : true,
+      "link_enable_ewcs_customer_name_prefill" : false,
+      "smor_enable_visible_pms_override_link_saved" : false,
+      "link_auth_partner_bypass_bridge_check" : false,
+      "link_disable_cookie_login" : false,
+      "elements_disable_express_checkout_button_shop_pay" : false,
+      "payment_element_link_modal_preload_killswitch" : false,
+      "link_enable_pass_checkout_session_id_to_signup" : true,
+      "elements_enable_hcaptcha_async_token_logging" : true,
+      "elements_enable_jp_card_installments" : true,
+      "elements_show_expanded_spm" : false,
+      "disable_payment_element_if_required_billing_config" : false,
+      "elements_enable_link_otp_takeover_in_guacamole" : false,
+      "elements_enable_link_spm" : true,
+      "elements_enable_read_allow_redisplay" : false,
+      "elements_enable_save_for_future_payments_pre_check" : false,
+      "checkout_habanero_automatic_tax_legacy_minimal_address_precision" : false,
+      "link_forest_enable_ece_bank_use_shipping_as_billing" : false,
+      "elements_disable_express_checkout_button_klarna" : false,
+      "distinctly_link_cbc_killswitch" : false,
+      "elements_disable_express_checkout_element_custom_payment_methods" : false,
+      "elements_prefer_fc_lite" : false,
+      "elements_disable_payment_element_custom_payment_methods_byof" : false,
+      "elements_mobile_cardscan_use_mlkit" : true,
+      "elements_enable_link_takeover_in_guacamole" : false,
+      "link_disable_auth_partner_ua_check" : false,
+      "link_enable_link_session_key_incentives_and_status" : true,
+      "elements_easel_disable_optimizations_check" : false,
+      "elements_enable_passive_captcha" : true,
+      "link_fresh_session_sync_enabled" : false,
+      "distinctly_link_payment_element_opt_out_merchant_blocklist" : false,
+      "link_enable_non_blocking_doi_signup" : false,
+      "elements_enable_new_google_places_api" : true,
+      "checkout_form_automatic_tax_address_collection_precision" : true,
+      "elements_enable_express_checkout_button_demo_pay" : false,
+      "disable_cbc_in_link_popup" : false,
+      "elements_enable_installments_on_deferred_intents" : true,
+      "elements_enable_payto_resolve_alias" : true,
+      "elements_sepa_debit_instant_microdeposits" : false,
+      "elements_spm_set_as_default" : true,
+      "elements_does_not_collect_postal_code_for_non_us_card_transactions_killswitch" : false,
+      "link_disable_login_if_signed_up_outside_of_elements" : true,
+      "elements_enable_link_autofill_prompt_padding_fix" : false,
+      "elements_mobile_attest_on_intent_confirmation" : false,
+      "link_trusted_origin_skip_secure_click" : true,
+      "elements_stop_move_focus_to_first_errored_field" : true,
+      "ocs_buyer_xp_enable_payment_element_accordion_box_shadow" : false,
+      "elements_enable_customer_address" : true,
+      "elements_mobile_allow_stripecardscan" : false,
+      "elements_use_checkout_app_id_for_human_security" : false,
+      "link_enable_klarna_in_lae" : false,
+      "sandboxes_rebrand_testmode" : true,
+      "link_enable_card_brand_choice" : true,
+      "link_auth_partner_enable_ppac" : false,
+      "link_payment_element_keep_optional_doi_open_rollout" : true,
+      "adaptive_pricing_for_elements_with_payment_intents" : false,
+      "elements_allow_custom_payment_method_creation" : false,
+      "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+      "elements_mobile_link_inline_signup_with_saved_pm_enabled" : false,
+      "link_purchase_protections_rollout" : true,
+      "link_ulm_dark_mode" : true,
+      "elements_disable_fc_lite" : false,
+      "link_auth_partner_delay_recognition" : true,
+      "elements_enable_payment_element_custom_payment_methods_byof" : false,
+      "ocs_mobile_should_use_autocomplete_proxy_endpoints" : true,
+      "show_swish_factoring_notice" : true,
+      "elements_enable_cup_apple_pay" : false,
+      "elements_enable_nme_for_us_bank_account_skip_verification" : false,
+      "ocs_buyer_xp_elements_remove_wallets_redirect_text" : false,
+      "elements_easel_enable_elements_inspector" : true,
+      "elements_google_pay_mit_fields" : false,
+      "apple_pay_pe_killswitch" : false,
+      "disable_link_on_obo_self" : false,
+      "paypal_phone_number_support_in_ece" : false,
+      "elements_enable_pay_by_bank_multi_country_bank_selector_rollout_countries" : false,
+      "elements_easel_disable_payment_fill" : false,
+      "elements_easel_disable_tax_id_fill" : false,
+      "elements_enable_link_ulm_in_guacamole" : false,
+      "elements_spm_max_visible_payment_methods" : false,
+      "id_bank_transfers_v1_integration" : false,
+      "checkout_habanero_early_ece_ready_enabled" : true,
+      "elements_enable_mx_card_installments" : true,
+      "link_enable_link_session_key_cross_region_apis" : false,
+      "elements_easel_disable_appearance_api_per_element_options" : true,
+      "elements_enable_easel_for_pi_killswitch" : false,
+      "elements_easel_disable_pi_migrate_to_ewcs_warning" : false,
+      "elements_disable_link_lpms_in_guacamole" : true,
+      "enable_pe_options_for_billing_details_collection" : false,
+      "elements_spm_messages" : false,
+      "link_enable_link_session_key_shipping_addresses" : true,
+      "elements_easel_disable_session_summary" : false,
+      "apple_pay_ece_killswitch" : false,
+      "distinctly_link_pe_purchase_protection" : true,
+      "link_enable_link_session_key_consumer_person_details" : true,
+      "link_auth_partner_delay_android_fb_cookie_login" : false,
+      "elements_ae_hide_name_field" : false,
+      "legacy_confirmation_tokens" : false,
+      "link_auth_partner_enable_ece" : true,
+      "elements_easel_disable_elements_inspector_for_pi" : false,
+      "link_enable_link_session_key_payment_details" : true,
+      "distinctly_link_pe_backup_payment_method" : true,
+      "link_dedupe_shipping_address_creation" : true,
+      "ece_apple_pay_payment_request_passthrough" : false,
+      "checkout_link_pay_token_enabled" : false,
+      "link_enable_link_session_key_link_onboarding_session" : true,
+      "elements_mobile_force_vertical_payment_method_layout" : false,
+      "elements_enable_card_billing_details_tax_id" : false,
+      "payto_enable_modal_in_payment_element" : true,
+      "checkout_link_in_habanero_enabled" : true,
+      "elements_disable_progressive_cursor" : false,
+      "link_enable_auth_partner_sizing_logging" : true,
+      "enable_checkout_session_update_customer" : false,
+      "elements_human_security_replaces_hcaptcha" : false
+    },
+    "merchant_logo_url" : null,
+    "merchant_of_record_country" : "US",
+    "session_id" : "elements_session_1zyUqf2Oav3",
+    "card_installments_enabled" : false,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "config_id" : "2672a87e-d89a-4858-9deb-a42f15af3e3c",
+    "merchant_currency" : "usd",
+    "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+    "card_brand_choice" : {
+      "eligible" : false,
+      "preferred_networks" : [
+        "cartes_bancaires"
+      ],
+      "supported_cobranded_networks" : {
+        "cartes_bancaires" : false
+      }
+    },
+    "shipping_address_settings" : {
+      "autocomplete_allowed" : false
+    },
+    "external_payment_method_data" : null,
+    "custom_payment_method_data" : null,
+    "meta_pay_signed_container_context" : null,
+    "apple_pay_preference" : "enabled",
+    "country_override" : "US",
+    "managed_payments_enabled" : false,
+    "google_pay_preference" : "enabled",
+    "merchant_country" : "US",
+    "experiments_data" : {
+      "arb_id" : "6676d5b3-db50-47ab-9c63-8635a4f06e6d",
+      "experiment_metadata" : {
+        "seed" : "4e3b58adcab79eaf00ed0ffa2780c6f7ccf3ec437786470b48f06d5797d60ac4",
+        "semi_dominant_payment_methods" : [
+
+        ],
+        "lpm_holdback_t1_payment_methods" : [
+
+        ],
+        "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false,
+        "lpm_holdback_t2_payment_methods" : [
+
+        ]
+      },
+      "experiment_assignments" : {
+        "link_pe_signup_toggle" : "control",
+        "ocs_mobile_card_art" : "control",
+        "link_pe_signup_copy_aa" : "control",
+        "link_optional_doi_signup_holdback" : "control",
+        "link_dl_pe_inline_entrypoint" : "control",
+        "ocs_mobile_nfc_scanning_feature_holdback" : "control",
+        "elements_card_brand_icons" : "control",
+        "ff_elements_currency_card_brand_blocking_fe_eff" : "control",
+        "billing_address_link_opt_in" : "control",
+        "ff_elements_currency_card_brand_blocking_be_eff" : "control",
+        "ff_elements_pe_wallet_details_eff" : "treatment",
+        "ff_elements_card_brand_funding_filtering_eff" : "control",
+        "link_pe_signup_copy" : "control",
+        "connections_elements_variable_incentives_for_ibp_recurring_payments" : "control",
+        "link_lpm_elements_klarna_powered_by_link" : "control",
+        "link_pe_row_prominent_signup" : "control",
+        "ocs_mobile_horizontal_mode" : "control",
+        "link_growth_ncdv_exp_pipeline" : "control",
+        "link_sign_up_form_container_aa" : "control",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_ui_phase_2" : "control",
+        "link_pe_hide_signup_email" : "control",
+        "link_ce_conversion_cookie_aa" : "control",
+        "pbb_label_change_elements" : "control",
+        "elements_ae_postal_cjk_normalization_aa" : "control",
+        "link_ulm_in_ece" : "control",
+        "ff_checkout_show_pbb_logos_eff" : "control",
+        "paypal_payment_handler" : "control",
+        "link_pe_signup_ui_variant_comparison" : "control",
+        "link_sign_up_form_container" : "control",
+        "link_pe_signup_green_logo_aa" : "control",
+        "link_pe_signup_ui_variant_comparison_aa" : "control",
+        "ff_elements_ece_payer_failure_reasons_eff" : "control",
+        "link_signup_name_from_billing_ae" : "control",
+        "elements_hcaptcha_init_timeout" : "control",
+        "ff_elements_submit_link_payment_method" : "control",
+        "link_spm_show_checkbox_signup_aa" : "control",
+        "ff_link_ulm_modal_in_modal" : "control",
+        "ibp_localized_featured_institutions_accordion" : "treatment",
+        "link_ce_conversion_unrecognized_aa" : "control",
+        "link_ce_conversion_unrecognized_copy_change" : "control",
+        "ff_elements_autocomplete_partial_autofill_eff" : "control",
+        "ibp_bank_tab_name_aa" : "control",
+        "link_dl_pe_inline_entrypoint_aa" : "control",
+        "link_ab_test_aa" : "control",
+        "link_growth_ece_ncdv" : "control",
+        "pmme_financing_as_low_as" : "control",
+        "ff_elements_ewcs_allow_spm_incomplete_billing_eff" : "control",
+        "link_pe_row_prominent_signup_aa" : "control",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_copy" : "control",
+        "elements_ae_postal_cjk_normalization" : "control",
+        "link_optional_doi_signup_holdback_aa" : "control",
+        "link_lpm_elements_klarna_powered_by_link_aa" : "control",
+        "link_ce_conversion_recognized_loading_animation" : "control",
+        "ff_elements_test_frontend_eff" : "control",
+        "link_ce_conversion_ncdv_aa" : "control",
+        "link_ce_conversion_unrecognized_post_entry_aa" : "control",
+        "ff_elements_ae_expanded_autocomplete_eff" : "control",
+        "link_growth_ece_ncdv_aa" : "control",
+        "ocs_mobile_horizontal_mode_aa" : "control",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_ui_phase_1" : "control",
+        "ff_elements_ae_default_values_equality" : "treatment",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_ui_phase_3" : "control",
+        "ff_checkout_habanero_combined_contact_payment_view_eff" : "treatment",
+        "ff_elements_preserve_klarna_and_financial_partner_button_availability" : "treatment",
+        "ff_elements_ae_autofill_validation" : "control",
+        "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : "control",
+        "link_pe_hide_signup_email_aa" : "control",
+        "link_ulm_in_ece_aa" : "control",
+        "ff_elements_enable_appearance_recompute_eff" : "control",
+        "link_spm_show_checkbox_signup" : "control",
+        "billing_address_link_opt_in_aa" : "control",
+        "br_card_lpa_elements_synapse_lpa_fields" : "control",
+        "link_growth_ncdv_exp_pipeline_aa" : "control",
+        "ibp_bank_tab_name" : "control",
+        "ff_ece_block_3p_financial_partner_on_custom_amount" : "treatment",
+        "ff_elements_pe_auto_tax_binding_eff" : "treatment",
+        "link_pe_signup_green_logo" : "control"
+      }
+    },
+    "legacy_customer" : null,
+    "link_settings" : {
+      "link_passthrough_mode_enabled" : false,
+      "link_payment_element_smart_defaults_enabled" : false,
+      "link_mobile_attestation_state_sync_enabled" : false,
+      "link_no_code_default_values_recall" : true,
+      "link_funding_sources" : [
+
+      ],
+      "link_crypto_onramp_force_cvc_reverification" : false,
+      "link_enable_signup_in_express_checkout_element" : false,
+      "link_modal_disable_in_ece" : false,
+      "link_consumer_incentive" : null,
+      "link_crypto_onramp_bank_upsell" : false,
+      "link_ece_browser_compatibility_override" : false,
+      "link_wanderlust_in_elements_enabled" : false,
+      "link_use_current_authentication_level_for_is_verified" : false,
+      "link_enable_email_otp_for_link_popup" : false,
+      "link_crypto_onramp_elements_logout_disabled" : false,
+      "link_popup_enable_new_google_places_api" : false,
+      "link_no_code_default_values_identification" : true,
+      "link_pay_button_element_enabled" : true,
+      "link_payment_element_enable_webauthn_login" : false,
+      "link_bank_onboarding_enabled" : false,
+      "link_enable_instant_debits_in_testmode" : false,
+      "link_enable_sensitive_changes" : true,
+      "link_payment_element_disabled_by_targeting" : false,
+      "link_sign_up_opt_in_feature_enabled" : false,
+      "link_only_for_payment_method_types_enabled" : false,
+      "link_disabled_reasons" : {
+        "payment_element_payment_method_mode" : [
+          "link_not_specified_in_payment_method_types"
+        ],
+        "payment_element_passthrough_mode" : [
+          "link_not_enabled_on_payment_config"
+        ]
+      },
+      "link_sign_up_opt_in_initial_value" : false,
+      "link_popup_disable_in_ece" : false,
+      "link_mobile_use_attestation_endpoints" : false,
+      "link_popup_shorten_signup_redirect_timeout" : false,
+      "link_elements_pageload_sign_up_disabled" : false,
+      "link_disable_pe_signup_prompt" : false,
+      "link_elements_is_crypto_onramp" : false,
+      "link_no_code_default_values_usage" : true,
+      "link_enable_webauthn_for_link_popup" : false,
+      "link_email_verification_login_enabled" : false,
+      "link_popup_webview_option" : "shared",
+      "link_targeting_results" : {
+        "payment_element_passthrough_mode" : null
+      },
+      "link_trusted_merchant_check_enabled" : false,
+      "link_global_holdback_on" : false,
+      "link_show_prefer_debit_card_hint" : false,
+      "link_local_storage_login_enabled" : false,
+      "link_payment_session_context" : null,
+      "link_session_storage_login_enabled" : false,
+      "link_brand" : "link",
+      "link_disable_in_safari_private_browsing" : false,
+      "link_mobile_disable_rux_in_flow_controller" : false,
+      "link_authenticated_change_event_enabled" : false,
+      "link_popup_ios26_trampoline_enabled" : false,
+      "link_pm_killswitch_on_in_elements" : false,
+      "link_supported_payment_methods_onboarding_enabled" : [
+
+      ],
+      "link_hcaptcha_site_key" : null,
+      "link_payment_element_disable_signup" : false,
+      "link_enable_displayable_default_values_in_ece" : false,
+      "link_disable_email_otp" : false,
+      "link_hcaptcha_rqdata" : null,
+      "link_default_opt_in" : "NONE",
+      "link_supported_payment_methods" : [
+
+      ],
+      "link_mobile_disable_default_opt_in" : false,
+      "link_mode" : null,
+      "link_mobile_disable_signup" : false,
+      "link_popup_smart_defaults_enabled" : false
+    },
+    "passive_captcha" : {
+      "rqdata" : null,
+      "captcha_provider_payload" : null,
+      "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+      "token_timeout_seconds" : 1770
+    },
+    "payment_method_configuration_id" : null,
+    "payment_method_specs" : [
+      {
+        "async" : false,
+        "type" : "card",
+        "fields" : [
+
+        ]
+      }
+    ],
+    "paypal_express_config" : {
+      "client_id" : null,
+      "client_token" : null,
+      "paypal_merchant_id" : null
+    },
+    "prefill_selectors" : {
+      "default_values" : {
+        "email" : [
+
+        ],
+        "merchant_provides_default_values_on_update" : true
+      },
+      "default_values_exp" : {
+        "merchant_provides_default_values_on_update" : true,
+        "selectors_by_surface" : {
+
+        }
+      }
+    },
+    "unactivated_payment_method_types" : [
+
+    ],
+    "order" : null,
+    "unverified_payment_methods_on_domain" : [
+      "apple_pay"
+    ],
+    "link_purchase_protections_data" : {
+      "type" : null,
+      "is_eligible" : false
+    },
+    "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+    "blocked_card_brands" : [
+
+    ],
+    "customer" : null,
+    "klarna_express_config" : {
+      "klarna_mid" : null
+    },
+    "lpm_killswitches" : {
+      "express_checkout" : [
+
+      ],
+      "payment_element" : [
+
+      ]
+    },
+    "business_name" : "CI Stuff",
+    "ordered_payment_method_types_and_wallets" : [
+      "card",
+      "apple_pay",
+      "google_pay"
+    ],
+    "customer_error" : null
+  },
+  "stripe_hosted_url" : "https:\/\/checkout.stripe.com\/c\/pay\/cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWkB3dnxIQEpRcGFWb1RXPW1tNVN3VHcwXTU1PXZHXUJKcDMnKSdjd2poVmB3c2B3Jz9xd3BgKSdnZGZuYndqcGthRmppancnPycmY2NjY2NjJyknaWR8anBxUXx1YCc%2FJ3Zsa2JpYFpscWBoJyknYGtkZ2lgVWlkZmBtamlhYHd2Jz9xd3BgeCUl",
+  "prefilled" : null,
+  "redirect_on_completion" : null,
+  "blob" : null,
+  "client_reference_id" : null,
+  "status" : "open",
+  "submit_type" : null,
+  "email_collection" : null,
+  "permissions" : null,
+  "custom_fields" : [
+
+  ],
+  "phone_number_collection" : {
+    "enabled" : false
+  },
+  "livemode" : false,
+  "ordered_payment_method_types" : [
+    "card",
+    "apple_pay",
+    "google_pay"
+  ],
+  "state" : "active",
+  "currency" : "usd",
+  "subscription_data" : null,
+  "customer_managed_saved_payment_methods_offer_save" : null,
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping" : null,
+  "crypto_in_link_ui_enabled" : false,
+  "rqdata" : "h8GNWDAVh0A\/8tq6nImLZBTd4xe2bGHB5X2rEcUacmchdaOH6FLBNopdlZyP3AMLXnW5qdKIQhpySPSuR+XEx2fjdgzL1\/6o4mhunyeC3uQoOiI1chpXP77drabN1JFyuz05xfchd6JVUUL\/x8Ik+Hopxto8ZVCeLjkL5diS2lSIy5fN5Ax23G9zko1QoEN4Ql8YC6LFHcN7jLz6cFqeV7g005T1vb4iTFQbzOBsiVHA5qf4qHFmA25Ll3RzAOotiJd8U82APsISDbqSUcGrgSED3pIbRfitpNMZjn47YWnowbiHUIMcPM+6jQ==PmydYFxPqsgNsIVW",
+  "total_summary" : {
+    "total_discount_amounts" : [
+
+    ],
+    "total_tax_amounts" : [
+
+    ],
+    "applied_balance" : 0,
+    "amount_due_applied_to_balance" : false,
+    "subtotal" : 2000,
+    "total" : 2000,
+    "total_discount_amount_aggregate" : 0,
+    "total_proration_amount_aggregate" : 0,
+    "due" : 2000
+  },
+  "on_behalf_of" : null,
+  "cross_sell_group" : null,
+  "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+  "checkout_multistep_ui" : false,
+  "eid" : "FE490402-3501-4DF6-BE7D-24F59F99E2D0",
+  "line_item_group" : null,
+  "managed_payments" : null,
+  "name_collection" : null,
+  "payment_intent" : null,
+  "config_id" : "9f2ac162-bcd1-459a-acab-8d90071db8cc",
+  "is_sandbox_merchant" : false
+}

--- a/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testRetrieveCheckoutSession/0002_get_v1_payment_pages_cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4.tail
+++ b/StripePayments/StripePaymentsTestUtils/Resources/recorded_network_traffic/STPAPIClientCheckoutSessionTest/testRetrieveCheckoutSession/0002_get_v1_payment_pages_cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4.tail
@@ -1,0 +1,1085 @@
+GET
+https:\/\/api\.stripe\.com\/v1\/payment_pages\/cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4\?elements_session_client%5Bis_aggregation_expected%5D=true$
+200
+application/json
+access-control-allow-methods: GET, HEAD, PUT, PATCH, POST, DELETE
+content-security-policy: base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none'; img-src 'self'; script-src 'self' 'report-sample'; style-src 'self'; worker-src 'none'; upgrade-insecure-requests; report-uri https://q.stripe.com/csp-violation?q=JGwXMoW_uNypO5IwqOGQ8ca2WkaQxJuGnzhPMhE7Z-IU3GpXSa7URn01t1EA4LZ8ZwrP9FZmLq9noKr4; report-to csp
+Server: nginx
+Cache-Control: no-cache, no-store
+reporting-endpoints: csp="https://q.stripe.com/csp-report-v2?q=JGwXMoW_uNypO5IwqOGQ8ca2WkaQxJuGnzhPMhE7Z-IU3GpXSa7URn01t1EA4LZ8ZwrP9FZmLq9noKr4&t=1"
+stripe-notice: You are using an outdated API version (2020-08-27). We recommend upgrading to the latest API version, 2026-07-29.dahlia. See https://docs.stripe.com/upgrades
+x-wc: 3c3
+Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+Access-Control-Allow-Origin: *
+x-stripe-routing-context-priority-tier: api-testmode
+x-stripe-priority-routing-enabled: true
+report-to: {"group":"csp","max_age":8640,"endpoints":[{"url":"https://q.stripe.com/csp-report-v2?q=JGwXMoW_uNypO5IwqOGQ8ca2WkaQxJuGnzhPMhE7Z-IU3GpXSa7URn01t1EA4LZ8ZwrP9FZmLq9noKr4&t=1"}],"include_subdomains":true}
+request-id: req_a8lAi4qooWz6ZZ
+Content-Length: 39773
+Vary: Origin
+Date: Sat, 22 Aug 2026 18:15:06 GMT
+stripe-version: 2020-08-27
+access-control-expose-headers: Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-External-Auth-Required, X-Stripe-Privileged-Session-Required
+access-control-max-age: 300
+access-control-allow-credentials: true
+Content-Type: application/json
+
+{
+  "lpm_settings" : null,
+  "sepa_debit_info" : null,
+  "automatic_payment_method_types" : false,
+  "is_unclaimed_anonymous_sandbox" : false,
+  "tax_context" : {
+    "automatic_tax_error" : null,
+    "tax_id_collection_required" : "never",
+    "automatic_tax_enabled" : false,
+    "automatic_tax_taxability_reason" : null,
+    "dynamic_tax_enabled" : false,
+    "tax_id_collection_enabled" : false,
+    "automatic_tax_exempt" : null,
+    "automatic_tax_address_collection_precision" : null,
+    "customer_tax_country" : null,
+    "has_maximum_tax_ids" : false,
+    "automatic_tax_address_source" : null
+  },
+  "payment_method_types" : [
+    "card"
+  ],
+  "payment_method_options" : null,
+  "bnpl_in_link_ui_enabled" : false,
+  "consent_collection" : null,
+  "experiment_data" : [
+    {
+      "variant" : "control",
+      "name" : "guacamole_resend_otp",
+      "event_id" : "a0b44119-9ef4-4afe-8b88-3417728c11fe",
+      "exposure_event_name" : "experiment_exposure"
+    },
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs_aa",
+      "event_id" : "bc4799fe-1d12-478e-aa34-57e9eb81bb2e",
+      "exposure_event_name" : ""
+    },
+    {
+      "variant" : "control",
+      "name" : "link_global_holdback_ewcs",
+      "event_id" : "f4ad09c0-b5a2-4fbe-9539-32e9e6601b72",
+      "exposure_event_name" : ""
+    }
+  ],
+  "origin_context" : null,
+  "enforcement_mode" : "open",
+  "blocked_billing_address_countries" : [
+
+  ],
+  "id" : "ppage_1U7JRdFY0qyl6XeWZWC1Vyvc",
+  "subscription_settings" : null,
+  "consent" : null,
+  "does_not_collect_postal_code_for_non_us_card_transactions" : false,
+  "use_payment_methods" : true,
+  "application" : null,
+  "payment_method_collection" : "automatic",
+  "setup_intent" : null,
+  "integration_identifier" : null,
+  "checkout_items" : [
+    {
+      "pricing_plan_subscription_item" : null,
+      "sub_mode_subscription_v1" : null,
+      "metronome_commit" : null,
+      "subscription" : null,
+      "key" : "checkout_item_V7YYFwmM",
+      "type" : "one_time_price",
+      "rate_card_subscription_item" : null,
+      "one_time_price" : {
+        "items" : [
+          {
+            "quantity" : 1,
+            "inner_item_key" : "inner_item_V7YYgDcr",
+            "tax_exclusive" : 0,
+            "total" : 2000,
+            "tax_amounts" : [
+
+            ],
+            "unit_amount" : 2000,
+            "subtotal" : 2000,
+            "price" : {
+              "id" : "price_1U7JRcFY0qyl6XeWELfXG1SB",
+              "livemode" : false,
+              "active" : true,
+              "product" : {
+                "object" : "product",
+                "active" : true,
+                "addons" : null,
+                "id" : "prod_V7YYJhbWAYcrph",
+                "images" : [
+
+                ],
+                "livemode" : false,
+                "url" : null,
+                "attributes" : [
+
+                ],
+                "description" : null,
+                "name" : "Test",
+                "unit_label" : null
+              },
+              "tax_behavior" : "exclusive",
+              "custom_unit_amount" : null,
+              "transform_quantity" : null,
+              "type" : "one_time",
+              "unit_amount" : 2000,
+              "unit_amount_decimal" : "2000",
+              "object" : "price",
+              "billing_scheme" : "per_unit",
+              "recurring" : null,
+              "currency" : "usd",
+              "tiers_mode" : null
+            },
+            "unit_amount_decimal" : "2000.0",
+            "adjustable_quantity" : null,
+            "tax_inclusive" : 0,
+            "unit_label" : null
+          }
+        ],
+        "subtotal" : 2000,
+        "total" : 2000
+      }
+    }
+  ],
+  "shipping_options" : [
+
+  ],
+  "setup_future_usage_for_payment_method_type" : {
+
+  },
+  "capture_method" : null,
+  "statement_descriptor" : "mobile",
+  "session_id" : "cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4",
+  "shipping_address_collection" : null,
+  "konbini_confirmation_number" : null,
+  "setup_future_usage" : null,
+  "invoice_creation" : {
+    "enabled" : false
+  },
+  "has_dynamic_tax_rates" : false,
+  "receipt_emails_enabled" : false,
+  "link_settings" : {
+    "link_consumer_incentive" : null,
+    "link_payment_session_context" : null,
+    "consumer_found" : null,
+    "hcaptcha_rqdata" : null,
+    "link_supported_payment_methods_onboarding_enabled" : [
+
+    ],
+    "enable_partner_lookup" : false,
+    "link_us_bank_account_funding_source_enabled" : false,
+    "link_funding_sources" : [
+
+    ],
+    "hcaptcha_site_key" : null,
+    "link_brand" : "link",
+    "link_mode" : null,
+    "link_supported_payment_methods" : [
+
+    ]
+  },
+  "object" : "checkout.session",
+  "customer" : null,
+  "shipping_rate" : null,
+  "success_url" : null,
+  "utm_codes" : null,
+  "beta_versions" : null,
+  "has_async_attached_payment_method" : false,
+  "feature_flags" : {
+    "checkout_enable_pay_by_bank_remember_bank_selection" : true,
+    "checkout_enable_link_api_passive_hcaptcha" : true,
+    "checkout_enable_hcaptcha_async_token_logging" : true,
+    "checkout_show_swish_factoring_notice" : true,
+    "checkout_custom_google_pay_for_automatic_tax" : true,
+    "checkout_us_bank_account_require_billing_address_non_us" : true,
+    "checkout_ewcs_optional_items" : true,
+    "checkout_link_purchase_protections_rollout" : true,
+    "checkout_pe_inline_billing_address_autocomplete_enabled" : true,
+    "enable_custom_checkout_name_collection" : true,
+    "checkout_item_order_summary_enabled" : true,
+    "checkout_payto_alias_resolution_enabled" : true,
+    "checkout_link_phone_registration_treatment_1_enabled" : true,
+    "checkout_tide_remount_override_replay" : true,
+    "sandboxes_rebrand_testmode" : true,
+    "checkout_address_autocomplete_enabled" : true,
+    "checkout_guacamole_custom_amounts" : true,
+    "checkout_optional_items" : true,
+    "checkout_passive_captcha" : true,
+    "checkout_link_enable_mfa" : true,
+    "checkout_apple_pay_old_devices_tax_address_collection" : true,
+    "checkout_enable_link_api_hcaptcha_rqdata" : true,
+    "checkout_enable_new_google_places_api" : true,
+    "checkout_hcaptcha_redundancy_control_enabled" : true,
+    "checkout_link_in_habanero_enabled" : true
+  },
+  "locale" : null,
+  "custom_text" : {
+    "shipping_address" : null,
+    "terms_of_service_acceptance" : null,
+    "submit" : null,
+    "after_submit" : null
+  },
+  "route_to_orchestration_interface" : false,
+  "customer_email" : null,
+  "payment_collection_context" : null,
+  "custom_components" : [
+
+  ],
+  "ui_mode" : "custom",
+  "url" : null,
+  "developer_tool_context" : {
+    "disabled_third_party_wallets" : {
+      "LINK_BUTTON" : {
+        "disabled_reason" : "merchant_payment_methods_settings"
+      },
+      "KLARNA_EXPRESS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "PAYPAL_ECS" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      },
+      "AMAZON_PAY" : {
+        "disabled_reason" : "not_in_payment_method_types"
+      }
+    },
+    "adaptive_pricing" : {
+      "reason" : "not_allowed_for_ui",
+      "active" : false
+    },
+    "payment_method_configuration_details" : null
+  },
+  "token_notification_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+  "init_checksum" : "jGfYWe9qGgt3aXJPCkzw1m7dzQzr0dnb",
+  "tax_exclusion_from_total_is_allowed" : false,
+  "bnpl_link_experiment_payment_method_type" : null,
+  "tax_meta" : {
+    "status" : null,
+    "error_reason" : null,
+    "computation_type" : "manual",
+    "customer_tax_exempt" : null
+  },
+  "payment_status" : "unpaid",
+  "enabled_third_party_wallets" : [
+    {
+      "apple_pay" : {
+        "required_version" : 2
+      },
+      "id" : "APPLE_PAY",
+      "enabled" : true,
+      "carousel_enabled" : true
+    },
+    {
+      "id" : "GOOGLE_PAY",
+      "enabled" : true,
+      "google_pay" : {
+        "id" : "GOOGLE_PAY",
+        "version_minor" : 0,
+        "version_major" : 2
+      },
+      "carousel_enabled" : false
+    },
+    {
+      "id" : "AMAZON_PAY",
+      "carousel_enabled" : false,
+      "enabled" : false
+    },
+    {
+      "id" : "KLARNA_EXPRESS",
+      "carousel_enabled" : false,
+      "enabled" : false
+    }
+  ],
+  "klarna_info" : null,
+  "visible_custom_component_locations" : [
+    "checkout_form_before",
+    "checkout_form_after",
+    "submit_button_before",
+    "submit_button_after",
+    "contact_before",
+    "contact_after",
+    "express_checkout_before",
+    "express_checkout_after",
+    "payment_details_before",
+    "payment_details_after"
+  ],
+  "display_consent_collection_promotions" : false,
+  "policies" : {
+    "contacts" : {
+      "display_phone" : true,
+      "display_url" : true,
+      "enabled" : false,
+      "display_email" : true
+    },
+    "legal" : {
+      "agreement_required" : false,
+      "enabled" : false
+    },
+    "returns" : {
+      "custom_message" : null,
+      "exchanges_accepted" : false,
+      "returns_accepted" : null,
+      "fee_type" : null,
+      "fee_required" : null,
+      "policy_url" : null,
+      "window_start" : null,
+      "refunds_accepted" : null,
+      "window" : null,
+      "enabled" : false,
+      "exceptions_apply" : false,
+      "logistics" : [
+
+      ]
+    }
+  },
+  "card_brands" : {
+    "mastercard" : true,
+    "troy" : false,
+    "link" : true,
+    "carnet" : false,
+    "accel" : false,
+    "elo" : false,
+    "rupay" : false,
+    "maestro" : false,
+    "unionpay" : true,
+    "amex" : true,
+    "jaywan" : false,
+    "conecs" : false,
+    "jcb" : true,
+    "visa" : true,
+    "cartes_bancaires" : false,
+    "pulse" : false,
+    "discover" : true,
+    "star" : false,
+    "eftpos_au" : false,
+    "diners" : true,
+    "girocard" : false,
+    "nyce" : false
+  },
+  "geocoding" : {
+    "country_code" : "US",
+    "region_name" : "CA"
+  },
+  "account_settings" : {
+    "assets" : {
+      "use_logo" : false,
+      "icon" : null,
+      "logo" : null
+    },
+    "specified_commercial_transactions_act_url" : null,
+    "business_url" : "https:\/\/github.com\/stripe\/stripe-ios",
+    "privacy_policy_url" : null,
+    "branding" : {
+      "button_color" : "#0074d4",
+      "background_color" : "#ffffff",
+      "border_style" : "default",
+      "font_family" : "default"
+    },
+    "statement_descriptor" : "mobile",
+    "support_email" : null,
+    "display_name" : "CI Stuff",
+    "merchant_of_record_country" : "US",
+    "order_summary_display_name" : "CI Stuff",
+    "support_phone" : "+12105550123",
+    "merchant_of_record_display_name" : "CI Stuff",
+    "support_url" : null,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "country" : "US",
+    "terms_of_service_url" : null
+  },
+  "payment_method_specs" : [
+    {
+      "async" : false,
+      "type" : "card",
+      "fields" : [
+
+      ]
+    }
+  ],
+  "recurring_details" : {
+    "subtotal" : 2000,
+    "total_discount_amounts" : [
+
+    ],
+    "total_tax_amounts" : [
+
+    ],
+    "total_summary" : {
+      "total_discount_amounts" : [
+
+      ],
+      "total_tax_amounts" : [
+
+      ],
+      "subtotal" : 2000,
+      "total" : 2000,
+      "total_discount_amount_aggregate" : 0,
+      "total_proration_amount_aggregate" : 0,
+      "due" : 2000
+    },
+    "total" : 2000
+  },
+  "server_built_elements_session_params" : {
+    "client_betas" : [
+
+    ],
+    "expand" : [
+
+    ],
+    "checkout_session_id" : "cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4",
+    "country_override" : "US",
+    "browser_timezone" : "America\/Los_Angeles",
+    "type" : "deferred_intent",
+    "deferred_intent" : {
+      "amount" : 2000,
+      "currency" : "usd",
+      "payment_method_types" : [
+        "card"
+      ],
+      "setup_future_usage" : "off_session",
+      "mode" : "subscription"
+    }
+  },
+  "billing_address_collection" : null,
+  "shipping_tax_amounts" : null,
+  "elements_options" : {
+    "amount" : 2000,
+    "mode" : "subscription",
+    "__checkout_country_override" : "US",
+    "__checkout_session_id" : "cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4",
+    "__payment_pages_experiments" : [
+      {
+        "variant" : "control",
+        "name" : "guacamole_resend_otp",
+        "event_id" : "a0b44119-9ef4-4afe-8b88-3417728c11fe",
+        "exposure_event_name" : "experiment_exposure"
+      },
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs_aa",
+        "event_id" : "bc4799fe-1d12-478e-aa34-57e9eb81bb2e",
+        "exposure_event_name" : ""
+      },
+      {
+        "variant" : "control",
+        "name" : "link_global_holdback_ewcs",
+        "event_id" : "f4ad09c0-b5a2-4fbe-9539-32e9e6601b72",
+        "exposure_event_name" : ""
+      }
+    ],
+    "payment_method_types" : [
+      "card"
+    ],
+    "currency" : "usd"
+  },
+  "experiments_data" : {
+    "event_id" : "cd5d2dd6-e1d7-46c9-a3c1-74d5201c0cd0",
+    "experiment_metadata" : {
+      "ocs_buyer_xp_cpl_lpm_holdback" : {
+        "heldback_special_wallets" : [
+
+        ]
+      }
+    },
+    "experiment_assignments" : {
+      "ocs_buyer_xp_cpl_terms_above_submit" : "control",
+      "link_ab_test_aa" : "control",
+      "ff_checkout_cpl_lid_promo_badge_color_opt" : "control",
+      "ocs_buyer_xp_cpl_guacamole_a2w_expanded_vs_compact" : "control",
+      "ocs_buyer_xp_remove_name_field_guac_related_pms" : "control",
+      "ocs_buyer_xp_cpl_progressive_ece" : "control",
+      "cpl_unified_order_summary_experiment" : "control",
+      "ocs_buyer_xp_cpl_ap_currency_label_removal" : "control",
+      "ocs_buyer_xp_cpl_a2w_holdback" : "control",
+      "ocs_buyer_xp_cpl_embedded_pay_button" : "control",
+      "ocs_buyer_xp_cpl_rtl_auto_locales" : "control",
+      "ocs_buyer_xp_cpl_cost_aware_payment_method_ranking" : "control",
+      "cpl_guacamole" : "control",
+      "ocs_buyer_xp_cpl_ece_kakao_naver" : "control",
+      "ocs_buyer_xp_cpl_lpm_content_simplification" : "control",
+      "ocs_buyer_xp_cpl_single_column_checkout" : "control",
+      "ocs_buyer_xp_cpl_theme_pay_button" : "control",
+      "link_risk_based_disable_auto_prompting_checkout" : "control",
+      "ocs_buyer_xp_cpl_currency_symbol_optimization" : "control",
+      "ocs_buyer_xp_cpl_save_card_checkbox_copy" : "control",
+      "ocs_buyer_xp_cpl_lpm_dynamic_filtering_threshold" : "control",
+      "checkout_li_larger_image_size" : "control",
+      "connections_checkout_us_bank_account_picker_icons" : "control",
+      "ff_checkout_test_frontend_eff" : "control",
+      "ocs_buyer_xp_cpl_apple_pay_button_type" : "control",
+      "ocs_buyer_xp_cpl_ece_google_pay_skeleton" : "control",
+      "ff_checkout_custom_flag_server_updates_on_canconfirm" : "control",
+      "ocs_buyer_xp_cpl_link_signup_in_form" : "control",
+      "emea_wallets_ideal_wero_rebranding" : "treatment",
+      "cpl_spicy_guacamole" : "control",
+      "ocs_buyer_xp_cpl_easy_opt_link_signup_in_form" : "control",
+      "ocs_buyer_xp_cpl_android_a2w_holdback" : "control",
+      "ocs_buyer_xp_cpl_ece_skeleton" : "control"
+    }
+  },
+  "return_url" : null,
+  "mode" : "modeless",
+  "cancel_url" : null,
+  "elements_session" : {
+    "payment_method_preference" : {
+      "country_code" : "US",
+      "object" : "payment_method_preference",
+      "type" : "deferred_intent",
+      "ordered_payment_method_types" : [
+        "card"
+      ]
+    },
+    "capability_enabled_card_networks" : [
+      "cartes_bancaires",
+      "jcb",
+      "diners",
+      "discover"
+    ],
+    "flags" : {
+      "enable_tax_id_suspicious_pattern_check" : false,
+      "elements_easel_enable_elements_inspector_for_advanced_integrations_backend" : true,
+      "link_enable_signup_in_summary_in_habanero" : true,
+      "financial_connections_enable_deferred_intent_flow" : true,
+      "elements_enable_remove_last_validation" : true,
+      "apple_pay_prb_killswitch" : false,
+      "elements_enable_easel_for_pi" : true,
+      "elements_mobile_card_funding_filtering" : true,
+      "link_payment_element_minor_signup_ui_updates" : false,
+      "link_enable_ncdv_usage_id_selectors_l3" : true,
+      "elements_link_instant_bank_payments_require_billing_address_for_non_us_merchants" : false,
+      "elements_disable_express_checkout_button_amazon_pay" : false,
+      "elements_easel_disable_appearance_api" : false,
+      "link_auth_partner_enable_link_auth_token_login" : true,
+      "link_enable_ncdv_recall_id_selectors_l3" : true,
+      "elements_disable_link_email_otp" : false,
+      "restrict_taxid_selection_to_buyer_address" : false,
+      "enable_afterpay_clearpay_cbt_afterpay_rails" : false,
+      "ocs_buyer_xp_elements_card_brand_choice_toggle" : true,
+      "paypal_billing_address_support_in_ece" : true,
+      "elements_enable_pay_by_bank_remember_bank_selection" : true,
+      "link_auth_partner_enable_ios_instagram" : true,
+      "link_user_action_attempt_login_using_stored_credentials" : true,
+      "elements_disable_sepa_debit_eea_address_requirement" : false,
+      "elements_enable_instant_debits_postal_code_collection" : false,
+      "elements_financial_connections_canada_enabled" : false,
+      "elements_easel_disable_feedback" : false,
+      "link_enable_link_session_key_financial_connections" : true,
+      "elements_us_bank_account_manual_entry_first" : false,
+      "elements_extend_hcaptcha_refresh_time" : true,
+      "link_auth_partner_consume_link_auth_intent" : true,
+      "ocs_buyer_xp_elements_remove_cpm_redirect_text" : false,
+      "elements_enable_klarna_ece_webkit_26_5_2" : false,
+      "elements_enable_south_korea_market_underlying_pms" : false,
+      "elements_mobile_force_setup_future_use_behavior_and_new_mandate_text" : false,
+      "link_enable_apple_pay_in_safari_returning_in_guacamole" : true,
+      "elements_disable_payment_element_card_country_zip_validations" : false,
+      "link_payment_element_default_value_auto_open_modal" : true,
+      "link_payment_element_steerage_enabled" : true,
+      "elements_enable_link_name_prefill" : true,
+      "elements_ewcs_allow_spm_incomplete_billing" : false,
+      "elements_enable_link_card_brand_in_saved_payment_methods" : true,
+      "elements_disable_link_global_holdback_lookup" : false,
+      "elements_enable_pbb_uk_new_banks" : false,
+      "financial_connections_enable_ca_accounts" : false,
+      "link_enable_link_session_key_klarna" : true,
+      "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : false,
+      "elements_easel_disable_address_fill" : false,
+      "ocs_buyer_xp_elements_remove_redirect_lpm_content" : false,
+      "elements_enable_payment_method_options_setup_future_usage" : true,
+      "enable_custom_checkout_currency_selector_element" : false,
+      "elements_mobile_android_tap_to_add_enabled" : false,
+      "link_enable_address_country_restrictions" : false,
+      "link_auth_partner_enable_android_fb" : true,
+      "checkout_kr_lpm_no_billing_address_collection" : false,
+      "elements_easel_disable_health_check" : false,
+      "link_mobile_express_checkout_element_inline_otp_killswitch" : false,
+      "elements_disable_paypal_express" : false,
+      "disable_confirmation_modal_bacs" : false,
+      "legacy_customer_session_payment_element_features" : false,
+      "link_habanero_no_otp_required_for_non_link_pm_signup" : true,
+      "elements_enable_express_checkout_element_custom_payment_methods" : false,
+      "elements_enable_terms_element" : false,
+      "smor_ewcs_vf_terms" : false,
+      "checkout_habanero_returning_user_expanded_accordion" : false,
+      "link_auth_partner_enable_authentication_element" : true,
+      "elements_allow_manual_payment_method_creation_with_spm" : false,
+      "elements_easel_disable" : false,
+      "elements_us_bank_account_require_billing_address_for_non_us_merchant" : true,
+      "link_enable_auth_partner_communication" : true,
+      "elements_apply_amex_icon_sorting" : false,
+      "elements_hide_card_brand_icons" : false,
+      "elements_mobile_android_nfc_scanning_enabled" : false,
+      "elements_easel_disable_customer_location_mocking" : false,
+      "disable_legal_text_on_non_confirmation_modal_bacs" : false,
+      "elements_easel_disable_position_customization" : false,
+      "elements_enable_appearance_recompute" : false,
+      "link_enable_link_session_key_confirm_and_start_verification" : true,
+      "link_ulm_screen_height_updates" : false,
+      "elements_enable_19_digit_pans" : false,
+      "always_show_ece_paypal_recurring_button" : false,
+      "enable_payment_method_api_shop_pay" : true,
+      "enable_elements_tax_id_type_filtering" : false,
+      "elements_human_security_enabled" : false,
+      "link_enable_white_ece_button_theme" : false,
+      "elements_webmcp_tools_enabled" : false,
+      "link_in_accordion_layout_available_in_stripejs" : false,
+      "link_payment_element_widget_view_enabled" : true,
+      "ocs_mobile_enable_analytics_to_r" : true,
+      "elements_easel_disable_magic_fill" : false,
+      "avoid_redundant_billing_details_for_klarna" : false,
+      "distinctly_link_payment_element_ramp" : true,
+      "link_enable_ewcs_customer_name_prefill" : false,
+      "smor_enable_visible_pms_override_link_saved" : false,
+      "link_auth_partner_bypass_bridge_check" : false,
+      "link_disable_cookie_login" : false,
+      "elements_disable_express_checkout_button_shop_pay" : false,
+      "payment_element_link_modal_preload_killswitch" : false,
+      "link_enable_pass_checkout_session_id_to_signup" : true,
+      "elements_enable_hcaptcha_async_token_logging" : true,
+      "elements_enable_jp_card_installments" : true,
+      "elements_show_expanded_spm" : false,
+      "disable_payment_element_if_required_billing_config" : false,
+      "elements_enable_link_otp_takeover_in_guacamole" : false,
+      "elements_enable_link_spm" : true,
+      "elements_enable_read_allow_redisplay" : false,
+      "elements_enable_save_for_future_payments_pre_check" : false,
+      "checkout_habanero_automatic_tax_legacy_minimal_address_precision" : false,
+      "link_forest_enable_ece_bank_use_shipping_as_billing" : false,
+      "elements_disable_express_checkout_button_klarna" : false,
+      "distinctly_link_cbc_killswitch" : false,
+      "elements_disable_express_checkout_element_custom_payment_methods" : false,
+      "elements_prefer_fc_lite" : false,
+      "elements_disable_payment_element_custom_payment_methods_byof" : false,
+      "elements_mobile_cardscan_use_mlkit" : true,
+      "elements_enable_link_takeover_in_guacamole" : false,
+      "link_disable_auth_partner_ua_check" : false,
+      "link_enable_link_session_key_incentives_and_status" : true,
+      "elements_easel_disable_optimizations_check" : false,
+      "elements_enable_passive_captcha" : true,
+      "link_fresh_session_sync_enabled" : false,
+      "distinctly_link_payment_element_opt_out_merchant_blocklist" : false,
+      "link_enable_non_blocking_doi_signup" : false,
+      "elements_enable_new_google_places_api" : true,
+      "checkout_form_automatic_tax_address_collection_precision" : true,
+      "elements_enable_express_checkout_button_demo_pay" : false,
+      "disable_cbc_in_link_popup" : false,
+      "elements_enable_installments_on_deferred_intents" : true,
+      "elements_enable_payto_resolve_alias" : true,
+      "elements_sepa_debit_instant_microdeposits" : false,
+      "elements_spm_set_as_default" : true,
+      "elements_does_not_collect_postal_code_for_non_us_card_transactions_killswitch" : false,
+      "link_disable_login_if_signed_up_outside_of_elements" : true,
+      "elements_enable_link_autofill_prompt_padding_fix" : false,
+      "elements_mobile_attest_on_intent_confirmation" : false,
+      "link_trusted_origin_skip_secure_click" : true,
+      "elements_stop_move_focus_to_first_errored_field" : true,
+      "ocs_buyer_xp_enable_payment_element_accordion_box_shadow" : false,
+      "elements_enable_customer_address" : true,
+      "elements_mobile_allow_stripecardscan" : false,
+      "elements_use_checkout_app_id_for_human_security" : false,
+      "link_enable_klarna_in_lae" : false,
+      "sandboxes_rebrand_testmode" : true,
+      "link_enable_card_brand_choice" : true,
+      "link_auth_partner_enable_ppac" : false,
+      "link_payment_element_keep_optional_doi_open_rollout" : true,
+      "adaptive_pricing_for_elements_with_payment_intents" : false,
+      "elements_allow_custom_payment_method_creation" : false,
+      "elements_disable_recurring_express_checkout_button_amazon_pay" : false,
+      "elements_mobile_link_inline_signup_with_saved_pm_enabled" : false,
+      "link_purchase_protections_rollout" : true,
+      "link_ulm_dark_mode" : true,
+      "elements_disable_fc_lite" : false,
+      "link_auth_partner_delay_recognition" : true,
+      "elements_enable_payment_element_custom_payment_methods_byof" : false,
+      "ocs_mobile_should_use_autocomplete_proxy_endpoints" : true,
+      "show_swish_factoring_notice" : true,
+      "elements_enable_cup_apple_pay" : false,
+      "elements_enable_nme_for_us_bank_account_skip_verification" : false,
+      "ocs_buyer_xp_elements_remove_wallets_redirect_text" : false,
+      "elements_easel_enable_elements_inspector" : true,
+      "elements_google_pay_mit_fields" : false,
+      "apple_pay_pe_killswitch" : false,
+      "disable_link_on_obo_self" : false,
+      "paypal_phone_number_support_in_ece" : false,
+      "elements_enable_pay_by_bank_multi_country_bank_selector_rollout_countries" : false,
+      "elements_easel_disable_payment_fill" : false,
+      "elements_easel_disable_tax_id_fill" : false,
+      "elements_enable_link_ulm_in_guacamole" : false,
+      "elements_spm_max_visible_payment_methods" : false,
+      "id_bank_transfers_v1_integration" : false,
+      "checkout_habanero_early_ece_ready_enabled" : true,
+      "elements_enable_mx_card_installments" : true,
+      "link_enable_link_session_key_cross_region_apis" : false,
+      "elements_easel_disable_appearance_api_per_element_options" : true,
+      "elements_enable_easel_for_pi_killswitch" : false,
+      "elements_easel_disable_pi_migrate_to_ewcs_warning" : false,
+      "elements_disable_link_lpms_in_guacamole" : true,
+      "enable_pe_options_for_billing_details_collection" : false,
+      "elements_spm_messages" : false,
+      "link_enable_link_session_key_shipping_addresses" : true,
+      "elements_easel_disable_session_summary" : false,
+      "apple_pay_ece_killswitch" : false,
+      "distinctly_link_pe_purchase_protection" : true,
+      "link_enable_link_session_key_consumer_person_details" : true,
+      "link_auth_partner_delay_android_fb_cookie_login" : false,
+      "elements_ae_hide_name_field" : false,
+      "legacy_confirmation_tokens" : false,
+      "link_auth_partner_enable_ece" : true,
+      "elements_easel_disable_elements_inspector_for_pi" : false,
+      "link_enable_link_session_key_payment_details" : true,
+      "distinctly_link_pe_backup_payment_method" : true,
+      "link_dedupe_shipping_address_creation" : true,
+      "ece_apple_pay_payment_request_passthrough" : false,
+      "checkout_link_pay_token_enabled" : false,
+      "link_enable_link_session_key_link_onboarding_session" : true,
+      "elements_mobile_force_vertical_payment_method_layout" : false,
+      "elements_enable_card_billing_details_tax_id" : false,
+      "payto_enable_modal_in_payment_element" : true,
+      "checkout_link_in_habanero_enabled" : true,
+      "elements_disable_progressive_cursor" : false,
+      "link_enable_auth_partner_sizing_logging" : true,
+      "enable_checkout_session_update_customer" : false,
+      "elements_human_security_replaces_hcaptcha" : false
+    },
+    "merchant_logo_url" : null,
+    "merchant_of_record_country" : "US",
+    "session_id" : "elements_session_1qQ6uy4GYdC",
+    "card_installments_enabled" : false,
+    "account_id" : "acct_1G6m1pFY0qyl6XeW",
+    "config_id" : "932349f2-779e-40d6-894d-933453e316f4",
+    "merchant_currency" : "usd",
+    "merchant_id" : "acct_1G6m1pFY0qyl6XeW",
+    "card_brand_choice" : {
+      "eligible" : false,
+      "preferred_networks" : [
+        "cartes_bancaires"
+      ],
+      "supported_cobranded_networks" : {
+        "cartes_bancaires" : false
+      }
+    },
+    "shipping_address_settings" : {
+      "autocomplete_allowed" : false
+    },
+    "external_payment_method_data" : null,
+    "custom_payment_method_data" : null,
+    "meta_pay_signed_container_context" : null,
+    "apple_pay_preference" : "enabled",
+    "country_override" : "US",
+    "managed_payments_enabled" : false,
+    "google_pay_preference" : "enabled",
+    "merchant_country" : "US",
+    "experiments_data" : {
+      "arb_id" : "c323f435-ae23-4cc2-8857-bc3393c336c6",
+      "experiment_metadata" : {
+        "seed" : "4e3b58adcab79eaf00ed0ffa2780c6f7ccf3ec437786470b48f06d5797d60ac4",
+        "semi_dominant_payment_methods" : [
+
+        ],
+        "lpm_holdback_t1_payment_methods" : [
+
+        ],
+        "lpm_adoption_ranking_upe_v2_ignore_fixed_lpms" : false,
+        "lpm_holdback_t2_payment_methods" : [
+
+        ]
+      },
+      "experiment_assignments" : {
+        "link_pe_signup_toggle" : "control",
+        "ocs_mobile_card_art" : "control",
+        "link_pe_signup_copy_aa" : "control",
+        "link_optional_doi_signup_holdback" : "control",
+        "link_dl_pe_inline_entrypoint" : "control",
+        "ocs_mobile_nfc_scanning_feature_holdback" : "control",
+        "elements_card_brand_icons" : "control",
+        "ff_elements_currency_card_brand_blocking_fe_eff" : "control",
+        "billing_address_link_opt_in" : "control",
+        "ff_elements_currency_card_brand_blocking_be_eff" : "control",
+        "ff_elements_pe_wallet_details_eff" : "treatment",
+        "ff_elements_card_brand_funding_filtering_eff" : "control",
+        "link_pe_signup_copy" : "control",
+        "connections_elements_variable_incentives_for_ibp_recurring_payments" : "control",
+        "link_lpm_elements_klarna_powered_by_link" : "control",
+        "link_pe_row_prominent_signup" : "control",
+        "ocs_mobile_horizontal_mode" : "control",
+        "link_growth_ncdv_exp_pipeline" : "control",
+        "link_sign_up_form_container_aa" : "control",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_ui_phase_2" : "control",
+        "link_pe_hide_signup_email" : "control",
+        "link_ce_conversion_cookie_aa" : "control",
+        "pbb_label_change_elements" : "control",
+        "elements_ae_postal_cjk_normalization_aa" : "control",
+        "link_ulm_in_ece" : "control",
+        "ff_checkout_show_pbb_logos_eff" : "control",
+        "paypal_payment_handler" : "control",
+        "link_pe_signup_ui_variant_comparison" : "control",
+        "link_sign_up_form_container" : "control",
+        "link_pe_signup_green_logo_aa" : "control",
+        "link_pe_signup_ui_variant_comparison_aa" : "control",
+        "ff_elements_ece_payer_failure_reasons_eff" : "control",
+        "link_signup_name_from_billing_ae" : "control",
+        "elements_hcaptcha_init_timeout" : "control",
+        "ff_elements_submit_link_payment_method" : "control",
+        "link_spm_show_checkbox_signup_aa" : "control",
+        "ff_link_ulm_modal_in_modal" : "control",
+        "ibp_localized_featured_institutions_accordion" : "treatment",
+        "link_ce_conversion_unrecognized_aa" : "control",
+        "link_ce_conversion_unrecognized_copy_change" : "control",
+        "ff_elements_autocomplete_partial_autofill_eff" : "control",
+        "ibp_bank_tab_name_aa" : "control",
+        "link_dl_pe_inline_entrypoint_aa" : "control",
+        "link_ab_test_aa" : "control",
+        "link_growth_ece_ncdv" : "control",
+        "pmme_financing_as_low_as" : "control",
+        "ff_elements_ewcs_allow_spm_incomplete_billing_eff" : "control",
+        "link_pe_row_prominent_signup_aa" : "control",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_copy" : "control",
+        "elements_ae_postal_cjk_normalization" : "control",
+        "link_optional_doi_signup_holdback_aa" : "control",
+        "link_lpm_elements_klarna_powered_by_link_aa" : "control",
+        "link_ce_conversion_recognized_loading_animation" : "control",
+        "ff_elements_test_frontend_eff" : "control",
+        "link_ce_conversion_ncdv_aa" : "control",
+        "link_ce_conversion_unrecognized_post_entry_aa" : "control",
+        "ff_elements_ae_expanded_autocomplete_eff" : "control",
+        "link_growth_ece_ncdv_aa" : "control",
+        "ocs_mobile_horizontal_mode_aa" : "control",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_ui_phase_1" : "control",
+        "ff_elements_ae_default_values_equality" : "treatment",
+        "elements_instant_debits_returning_user_bank_add_incentive_steerage_ui_phase_3" : "control",
+        "ff_checkout_habanero_combined_contact_payment_view_eff" : "treatment",
+        "ff_elements_preserve_klarna_and_financial_partner_button_availability" : "treatment",
+        "ff_elements_ae_autofill_validation" : "control",
+        "ocs_buyer_xp_elements_link_opt_in_on_payment_select" : "control",
+        "link_pe_hide_signup_email_aa" : "control",
+        "link_ulm_in_ece_aa" : "control",
+        "ff_elements_enable_appearance_recompute_eff" : "control",
+        "link_spm_show_checkbox_signup" : "control",
+        "billing_address_link_opt_in_aa" : "control",
+        "br_card_lpa_elements_synapse_lpa_fields" : "control",
+        "link_growth_ncdv_exp_pipeline_aa" : "control",
+        "ibp_bank_tab_name" : "control",
+        "ff_ece_block_3p_financial_partner_on_custom_amount" : "treatment",
+        "ff_elements_pe_auto_tax_binding_eff" : "treatment",
+        "link_pe_signup_green_logo" : "control"
+      }
+    },
+    "legacy_customer" : null,
+    "link_settings" : {
+      "link_passthrough_mode_enabled" : false,
+      "link_payment_element_smart_defaults_enabled" : false,
+      "link_mobile_attestation_state_sync_enabled" : false,
+      "link_no_code_default_values_recall" : true,
+      "link_funding_sources" : [
+
+      ],
+      "link_crypto_onramp_force_cvc_reverification" : false,
+      "link_enable_signup_in_express_checkout_element" : false,
+      "link_modal_disable_in_ece" : false,
+      "link_consumer_incentive" : null,
+      "link_crypto_onramp_bank_upsell" : false,
+      "link_ece_browser_compatibility_override" : false,
+      "link_wanderlust_in_elements_enabled" : false,
+      "link_use_current_authentication_level_for_is_verified" : false,
+      "link_enable_email_otp_for_link_popup" : false,
+      "link_crypto_onramp_elements_logout_disabled" : false,
+      "link_popup_enable_new_google_places_api" : false,
+      "link_no_code_default_values_identification" : true,
+      "link_pay_button_element_enabled" : true,
+      "link_payment_element_enable_webauthn_login" : false,
+      "link_bank_onboarding_enabled" : false,
+      "link_enable_instant_debits_in_testmode" : false,
+      "link_enable_sensitive_changes" : true,
+      "link_payment_element_disabled_by_targeting" : false,
+      "link_sign_up_opt_in_feature_enabled" : false,
+      "link_only_for_payment_method_types_enabled" : false,
+      "link_disabled_reasons" : {
+        "payment_element_payment_method_mode" : [
+          "link_not_specified_in_payment_method_types"
+        ],
+        "payment_element_passthrough_mode" : [
+          "link_not_enabled_on_payment_config"
+        ]
+      },
+      "link_sign_up_opt_in_initial_value" : false,
+      "link_popup_disable_in_ece" : false,
+      "link_mobile_use_attestation_endpoints" : false,
+      "link_popup_shorten_signup_redirect_timeout" : false,
+      "link_elements_pageload_sign_up_disabled" : false,
+      "link_disable_pe_signup_prompt" : false,
+      "link_elements_is_crypto_onramp" : false,
+      "link_no_code_default_values_usage" : true,
+      "link_enable_webauthn_for_link_popup" : false,
+      "link_email_verification_login_enabled" : false,
+      "link_popup_webview_option" : "shared",
+      "link_targeting_results" : {
+        "payment_element_passthrough_mode" : null
+      },
+      "link_trusted_merchant_check_enabled" : false,
+      "link_global_holdback_on" : false,
+      "link_show_prefer_debit_card_hint" : false,
+      "link_local_storage_login_enabled" : false,
+      "link_payment_session_context" : null,
+      "link_session_storage_login_enabled" : false,
+      "link_brand" : "link",
+      "link_disable_in_safari_private_browsing" : false,
+      "link_mobile_disable_rux_in_flow_controller" : false,
+      "link_authenticated_change_event_enabled" : false,
+      "link_popup_ios26_trampoline_enabled" : false,
+      "link_pm_killswitch_on_in_elements" : false,
+      "link_supported_payment_methods_onboarding_enabled" : [
+
+      ],
+      "link_hcaptcha_site_key" : null,
+      "link_payment_element_disable_signup" : false,
+      "link_enable_displayable_default_values_in_ece" : false,
+      "link_disable_email_otp" : false,
+      "link_hcaptcha_rqdata" : null,
+      "link_default_opt_in" : "NONE",
+      "link_supported_payment_methods" : [
+
+      ],
+      "link_mobile_disable_default_opt_in" : false,
+      "link_mode" : null,
+      "link_mobile_disable_signup" : false,
+      "link_popup_smart_defaults_enabled" : false
+    },
+    "passive_captcha" : {
+      "rqdata" : null,
+      "captcha_provider_payload" : null,
+      "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+      "token_timeout_seconds" : 1770
+    },
+    "payment_method_configuration_id" : null,
+    "payment_method_specs" : [
+      {
+        "async" : false,
+        "type" : "card",
+        "fields" : [
+
+        ]
+      }
+    ],
+    "paypal_express_config" : {
+      "client_id" : null,
+      "client_token" : null,
+      "paypal_merchant_id" : null
+    },
+    "prefill_selectors" : {
+      "default_values" : {
+        "email" : [
+
+        ],
+        "merchant_provides_default_values_on_update" : true
+      },
+      "default_values_exp" : {
+        "merchant_provides_default_values_on_update" : true,
+        "selectors_by_surface" : {
+
+        }
+      }
+    },
+    "unactivated_payment_method_types" : [
+
+    ],
+    "order" : null,
+    "unverified_payment_methods_on_domain" : [
+      "apple_pay"
+    ],
+    "link_purchase_protections_data" : {
+      "type" : null,
+      "is_eligible" : false
+    },
+    "apple_pay_merchant_token_webhook_url" : "https:\/\/pm-hooks.stripe.com\/apple_pay\/merchant_token\/pDq7tf9uieoQWMVJixFwuOve\/acct_1G6m1pFY0qyl6XeW\/",
+    "blocked_card_brands" : [
+
+    ],
+    "customer" : null,
+    "klarna_express_config" : {
+      "klarna_mid" : null
+    },
+    "lpm_killswitches" : {
+      "express_checkout" : [
+
+      ],
+      "payment_element" : [
+
+      ]
+    },
+    "business_name" : "CI Stuff",
+    "ordered_payment_method_types_and_wallets" : [
+      "card",
+      "apple_pay",
+      "google_pay"
+    ],
+    "customer_error" : null
+  },
+  "stripe_hosted_url" : "https:\/\/checkout.stripe.com\/c\/pay\/cs_test_a1Xfb4gg2xt8eVJ50T7ry3EZQ1MYcRIfvaP1iGQnNPN5DrFb7koaQVFSd4#fidnandhYHdWcXxpYCc%2FJ2FgY2RwaXEnKSdkdWxOYHwnPyd1blpxYHZxWkB3dnxIQEpRcGFWb1RXPW1tNVN3VHcwXTU1PXZHXUJKcDMnKSdjd2poVmB3c2B3Jz9xd3BgKSdnZGZuYndqcGthRmppancnPycmY2NjY2NjJyknaWR8anBxUXx1YCc%2FJ3Zsa2JpYFpscWBoJyknYGtkZ2lgVWlkZmBtamlhYHd2Jz9xd3BgeCUl",
+  "prefilled" : null,
+  "redirect_on_completion" : null,
+  "blob" : null,
+  "client_reference_id" : null,
+  "status" : "open",
+  "submit_type" : null,
+  "email_collection" : null,
+  "permissions" : null,
+  "custom_fields" : [
+
+  ],
+  "phone_number_collection" : {
+    "enabled" : false
+  },
+  "livemode" : false,
+  "ordered_payment_method_types" : [
+    "card",
+    "apple_pay",
+    "google_pay"
+  ],
+  "state" : "active",
+  "currency" : "usd",
+  "subscription_data" : null,
+  "customer_managed_saved_payment_methods_offer_save" : null,
+  "card_brand_choice" : {
+    "eligible" : false,
+    "preferred_networks" : [
+      "cartes_bancaires"
+    ],
+    "supported_cobranded_networks" : {
+      "cartes_bancaires" : false
+    }
+  },
+  "shipping" : null,
+  "crypto_in_link_ui_enabled" : false,
+  "rqdata" : "jz6IELKwiefHGj+4v34CpKcWVFXq7LIqtZls6KCRJzq1E70UFlI+VFSeYjTM3TBbS\/DaM496fbHKE1YgmsJf8wMXrOKfS6n3e\/+CmGHe5WoF1LeuggsUQy3AOSjd6MP9WfnG1GmyQiSW9+0l37bjxx5jCi3A57WRtUi7uyldQLhZJCnm\/bJC54hyonCtwu+TwGIZYpBcvjd1M89lgHlsRHXzhMOnI1sdtNP0tivL4hg7tNIM2w9lRX1Lx0bQbkRFR3fKWI6pn4Uq4hAwLEugpNlSRSmNbQrCYb9Ec9qHu811jLEHz9ZI1prFAw==T5f0P+s+iNlKrMfU",
+  "total_summary" : {
+    "total_discount_amounts" : [
+
+    ],
+    "total_tax_amounts" : [
+
+    ],
+    "applied_balance" : 0,
+    "amount_due_applied_to_balance" : false,
+    "subtotal" : 2000,
+    "total" : 2000,
+    "total_discount_amount_aggregate" : 0,
+    "total_proration_amount_aggregate" : 0,
+    "due" : 2000
+  },
+  "on_behalf_of" : null,
+  "cross_sell_group" : null,
+  "site_key" : "20000000-ffff-ffff-ffff-000000000002",
+  "checkout_multistep_ui" : false,
+  "eid" : "6d880756-e9ee-43ce-8118-518bb055b51a",
+  "line_item_group" : null,
+  "managed_payments" : null,
+  "name_collection" : null,
+  "payment_intent" : null,
+  "config_id" : "9f2ac162-bcd1-459a-acab-8d90071db8cc",
+  "is_sandbox_merchant" : false
+}


### PR DESCRIPTION
## Summary
- Add /retrieve payment pages API binding
- Add /poll payment pages API binding

## Testing
- Verifies retrieving a full initialized Checkout Session from its recorded API response.
- Verifies polling an initialized Checkout Session and decoding its current state.
- Verifies supported, unknown, null, and missing poll response values.