### PR TITLE
Add GET request timeout and retry options

### DIFF
--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -272,7 +272,7 @@ extension STPAPIClient {
     /// Make a GET request using the passed parameters.
     /// - Parameters:
     ///   - timeout: Optional timeout for each request attempt. The total request duration can be longer when retries are enabled.
-    ///   - retryCount: Number of times to retry an HTTP 429 response. Defaults to `StripeAPI.maxRetries`.
+    ///   - retriesEnabled: Whether to retry HTTP 429 responses using the standard retry policy.
     @_spi(STP) public func get<T: Decodable>(
         resource: String,
         parameters: [String: Any],
@@ -280,7 +280,7 @@ extension STPAPIClient {
         consumerPublishableKey: String? = nil,
         apiVersionOverride: String? = nil,
         timeout: TimeInterval? = nil,
-        retryCount: Int = StripeAPI.maxRetries,
+        retriesEnabled: Bool = true,
         completion: @escaping (
             Result<T, Error>
         ) -> Void
@@ -293,7 +293,7 @@ extension STPAPIClient {
             apiVersionOverride: apiVersionOverride,
             resource: resource,
             timeout: timeout,
-            retryCount: retryCount,
+            retryCount: retriesEnabled ? StripeAPI.maxRetries : 0,
             completion: completion
         )
     }

--- a/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
+++ b/StripeCore/StripeCore/Source/API Bindings/STPAPIClient.swift
@@ -270,12 +270,17 @@ private let APIBaseURL = "https://api.stripe.com/v1"
 // MARK: Modern bindings
 extension STPAPIClient {
     /// Make a GET request using the passed parameters.
+    /// - Parameters:
+    ///   - timeout: Optional timeout for each request attempt. The total request duration can be longer when retries are enabled.
+    ///   - retryCount: Number of times to retry an HTTP 429 response. Defaults to `StripeAPI.maxRetries`.
     @_spi(STP) public func get<T: Decodable>(
         resource: String,
         parameters: [String: Any],
         ephemeralKeySecret: String? = nil,
         consumerPublishableKey: String? = nil,
         apiVersionOverride: String? = nil,
+        timeout: TimeInterval? = nil,
+        retryCount: Int = StripeAPI.maxRetries,
         completion: @escaping (
             Result<T, Error>
         ) -> Void
@@ -287,6 +292,8 @@ extension STPAPIClient {
             consumerPublishableKey: consumerPublishableKey,
             apiVersionOverride: apiVersionOverride,
             resource: resource,
+            timeout: timeout,
+            retryCount: retryCount,
             completion: completion
         )
     }
@@ -422,6 +429,8 @@ extension STPAPIClient {
         consumerPublishableKey: String?,
         apiVersionOverride: String?,
         resource: String,
+        timeout: TimeInterval? = nil,
+        retryCount: Int = StripeAPI.maxRetries,
         completion: @escaping (Result<T, Error>) -> Void
     ) {
         let url = apiURL.appendingPathComponent(resource)
@@ -432,6 +441,8 @@ extension STPAPIClient {
             consumerPublishableKey: consumerPublishableKey,
             apiVersionOverride: apiVersionOverride,
             url: url,
+            timeout: timeout,
+            retryCount: retryCount,
             completion: completion
         )
     }
@@ -443,9 +454,14 @@ extension STPAPIClient {
         consumerPublishableKey: String?,
         apiVersionOverride: String?,
         url: URL,
+        timeout: TimeInterval? = nil,
+        retryCount: Int = StripeAPI.maxRetries,
         completion: @escaping (Result<T, Error>) -> Void
     ) {
         var request = configuredRequest(for: url, apiVersionOverride: apiVersionOverride)
+        if let timeout {
+            request.timeoutInterval = timeout
+        }
         switch method {
         case .get:
             request.stp_addParameters(toURL: parameters)
@@ -478,7 +494,11 @@ extension STPAPIClient {
             request.setValue(nil, forHTTPHeaderField: "Stripe-Account")
         }
 
-        self.sendRequest(request: request, completion: completion)
+        self.sendRequest(
+            request: request,
+            retryCount: retryCount,
+            completion: completion
+        )
     }
 
     /// Make a POST request using the passed Encodable object.
@@ -559,6 +579,7 @@ extension STPAPIClient {
 
     func sendRequest<T: Decodable>(
         request: URLRequest,
+        retryCount: Int = StripeAPI.maxRetries,
         completion: @escaping (Result<T, Error>) -> Void
     ) {
         urlSession.stp_performDataTask(
@@ -569,7 +590,8 @@ extension STPAPIClient {
                         STPAPIClient.decodeResponse(data: data, error: error, response: response, request: request)
                     )
                 }
-            }
+            },
+            retryCount: retryCount
         )
     }
 

--- a/StripeCore/StripeCoreTests/API Bindings/STPAPIClientTest.swift
+++ b/StripeCore/StripeCoreTests/API Bindings/STPAPIClientTest.swift
@@ -13,7 +13,7 @@ import StripeCoreTestUtils
 import XCTest
 
 final class STPAPIClientTest: APIStubbedTestCase {
-    func testGetAppliesTimeoutAndRetryCount() {
+    func testGetAppliesTimeoutAndDisablesRetries() {
         // Given a 429 response and a default retry count greater than zero
         let originalMaxRetries = StripeAPI.maxRetries
         StripeAPI.maxRetries = 1
@@ -43,7 +43,7 @@ final class STPAPIClientTest: APIStubbedTestCase {
             resource: "test",
             parameters: [:],
             timeout: expectedTimeout,
-            retryCount: 0
+            retriesEnabled: false
         ) { (result: Result<EmptyResponse, Error>) in
             guard case .failure = result else {
                 XCTFail("Expected the 429 response to fail")

--- a/StripeCore/StripeCoreTests/API Bindings/STPAPIClientTest.swift
+++ b/StripeCore/StripeCoreTests/API Bindings/STPAPIClientTest.swift
@@ -1,0 +1,79 @@
+//
+//  STPAPIClientTest.swift
+//  StripeCoreTests
+//
+//  Created by Yuki Tokuhiro on 8/22/26.
+//
+
+import Foundation
+import OHHTTPStubs
+import OHHTTPStubsSwift
+@testable @_spi(STP) import StripeCore
+import StripeCoreTestUtils
+import XCTest
+
+final class STPAPIClientTest: APIStubbedTestCase {
+    func testGetAppliesTimeoutAndRetryCount() {
+        // Given a 429 response and a default retry count greater than zero
+        let originalMaxRetries = StripeAPI.maxRetries
+        StripeAPI.maxRetries = 1
+        defer { StripeAPI.maxRetries = originalMaxRetries }
+
+        let recorder = RequestRecorder()
+        stub(condition: { _ in true }) { request in
+            recorder.record(request)
+            return HTTPStubsResponse(
+                jsonObject: [
+                    "error": [
+                        "type": "api_error",
+                        "message": "Rate limited",
+                    ],
+                ],
+                statusCode: 429,
+                headers: nil
+            )
+        }
+
+        let completion = expectation(description: "Request completed")
+        let apiClient = stubbedAPIClient()
+        let expectedTimeout: TimeInterval = 0.25
+
+        // When GET is called with a custom timeout and no retries
+        apiClient.get(
+            resource: "test",
+            parameters: [:],
+            timeout: expectedTimeout,
+            retryCount: 0
+        ) { (result: Result<EmptyResponse, Error>) in
+            guard case .failure = result else {
+                XCTFail("Expected the 429 response to fail")
+                completion.fulfill()
+                return
+            }
+            completion.fulfill()
+        }
+
+        wait(for: [completion], timeout: 5)
+
+        // Then the timeout is applied and the 429 is not retried
+        XCTAssertEqual(recorder.requestCount, 1)
+        XCTAssertEqual(recorder.timeoutInterval, expectedTimeout, accuracy: 0.001)
+    }
+}
+
+private final class RequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var requests: [URLRequest] = []
+
+    var requestCount: Int {
+        lock.withLock { requests.count }
+    }
+
+    var timeoutInterval: TimeInterval {
+        lock.withLock { requests.last?.timeoutInterval ?? 0 }
+    }
+
+    func record(_ request: URLRequest) {
+        lock.withLock { requests.append(request) }
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagePollResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagePollResponse.swift
@@ -16,6 +16,7 @@ struct PaymentPagePollResponse: Decodable, Equatable {
 
     enum State: String, Decodable {
         case active
+        case failedAsyncPayment = "failed_async_payment"
         case pendingAsyncCustomerAction = "pending_async_customer_action"
         case processingSubscription = "processing_subscription"
         case processingAsyncPayment = "processing_async_payment"

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagePollResponseTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagePollResponseTests.swift
@@ -13,6 +13,7 @@ final class PaymentPagePollResponseTests: XCTestCase {
     func testDecodesEveryState() throws {
         let cases: [(String, PaymentPagePollResponse.State)] = [
             ("active", .active),
+            ("failed_async_payment", .failedAsyncPayment),
             ("pending_async_customer_action", .pendingAsyncCustomerAction),
             ("processing_subscription", .processingSubscription),
             ("processing_async_payment", .processingAsyncPayment),
@@ -42,7 +43,9 @@ final class PaymentPagePollResponseTests: XCTestCase {
 
         for rawValue in [
             "canceled",
+            "expired",
             "processing",
+            "processing_sync",
             "requires_action",
             "requires_capture",
             "requires_confirmation",


### PR DESCRIPTION
## Summary
- Allow modern STPAPIClient GET requests to set a per-attempt timeout
- Allow callers to control HTTP 429 retry attempts while preserving existing defaults

## Motivation
Will be useful later when CheckoutSessions confirm code polls and wants to control this

## Testing
- Verifies a custom GET timeout is applied to the outgoing URL request.
- Verifies a GET request configured with zero retries makes only one request after an HTTP 429 response.