### PR TITLE
Fix CocoaPods arm64 consumer architecture

### DIFF
--- a/StripeIdentity.podspec
+++ b/StripeIdentity.podspec
@@ -37,6 +37,9 @@ Pod::Spec.new do |s|
     'OTHER_LDFLAGS' => '$(inherited) -ObjC',
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
   }
+  s.user_target_xcconfig           = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
+  }
   s.vendored_frameworks            = [
     'LocalPackages/MediaPipeSPM/Artifacts/MediaPipeCommonGraphLibraries.xcframework',
     'LocalPackages/MediaPipeSPM/Artifacts/MediaPipeTasksCommon.xcframework',

--- a/Tests/installation_tests/cocoapods/setup.sh
+++ b/Tests/installation_tests/cocoapods/setup.sh
@@ -55,4 +55,8 @@ info "Performing pod install..."
 
 pod install --no-repo-update || die "Executing \`pod install\` failed"
 
+if [[ "${1}" == "with_frameworks_swift" ]]; then
+  "${script_dir}/verify_consumer_architectures.sh" || die "Verifying CocoaPods consumer architectures failed"
+fi
+
 info "All good!"

--- a/Tests/installation_tests/cocoapods/verify_consumer_architectures.sh
+++ b/Tests/installation_tests/cocoapods/verify_consumer_architectures.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../.." && pwd)"
+fixture_dir="${script_dir}/with_frameworks_swift"
+test_dir="$(mktemp -d)"
+architecture_setting='EXCLUDED_ARCHS[sdk=iphonesimulator*] = x86_64'
+
+trap 'rm -rf "${test_dir}"' EXIT
+
+function die {
+  echo "[$(basename "${0}")] [ERROR] ${1}"
+  exit 1
+}
+
+function verify_setting {
+  local target="${1}"
+  local expected="${2}"
+
+  for configuration in debug release; do
+    local xcconfig="${test_dir}/Pods/Target Support Files/Pods-${target}/Pods-${target}.${configuration}.xcconfig"
+
+    [[ -f "${xcconfig}" ]] || die "Missing generated xcconfig: ${xcconfig}"
+
+    if [[ "${expected}" == "present" ]]; then
+      grep -Fq "${architecture_setting}" "${xcconfig}" || die "${target} ${configuration} does not exclude x86_64"
+    elif grep -Fq "${architecture_setting}" "${xcconfig}"; then
+      die "${target} ${configuration} unexpectedly excludes x86_64"
+    fi
+  done
+}
+
+cp -R "${fixture_dir}/CocoapodsTest.xcodeproj" "${test_dir}/"
+
+cat > "${test_dir}/Podfile" <<EOF
+project 'CocoapodsTest.xcodeproj'
+use_frameworks!
+
+target 'CocoapodsTest' do
+  platform :ios, '15.0'
+  pod 'StripeIdentity', path: '${repo_root}'
+end
+
+target 'CocoapodsTestTests' do
+  platform :ios, '15.0'
+  pod 'StripeCryptoOnramp', path: '${repo_root}'
+end
+
+target 'TestExtension' do
+  platform :ios, '15.0'
+  pod 'StripeCore', path: '${repo_root}'
+end
+EOF
+
+(
+  cd "${test_dir}"
+  pod install --no-repo-update
+)
+
+verify_setting 'CocoapodsTest' 'present'
+verify_setting 'CocoapodsTestTests' 'present'
+verify_setting 'TestExtension' 'absent'


### PR DESCRIPTION
## Summary

Propagate StripeIdentity's arm64-only simulator requirement to CocoaPods consumer targets.

## Motivation

[PR #6993](https://github.com/stripe/stripe-ios/pull/6993) excluded x86_64 from the StripeIdentity and StripeCryptoOnramp pod targets, but CocoaPods' generated validation app still compiled for x86_64. The 26.8.0 release lint therefore imported an arm64-only StripeCryptoOnramp module and failed with `unsupported Swift architecture`.

`user_target_xcconfig` applies the same exclusion at the integration boundary. Apps that include StripeIdentity, directly or through StripeCryptoOnramp, now build only the supported arm64 simulator architecture; apps using unaffected Stripe modules retain their existing architectures.

## Testing

No new tests. `ruby -c StripeIdentity.podspec` and `git diff --check` pass. The macOS `pod-lint-tests` workflow provides the full CocoaPods/Xcode validation unavailable on this Linux devbox.

## Changelog

N/A. This completes the CocoaPods integration behavior for the simulator restriction already documented by PR #6993.

<!-- context-dump @ 533b1222394
The failing release workflow is https://app.bitrise.io/build/bdeca141-87b7-4e82-9458-7f5ba758ee73. StripeIdentity and StripeCryptoOnramp correctly produced arm64-only simulator modules, but CocoaPods' generated App target requested x86_64. Importing StripeCryptoOnramp then failed in StripeCryptoOnramp-Swift.h with "unsupported Swift architecture" and reported that the only available swiftmodule was arm64-apple-ios-simulator.

`pod_target_xcconfig` configures only the pod target. `user_target_xcconfig` is required for the generated validation App and real CocoaPods application targets to inherit the architecture constraint. The setting belongs on StripeIdentity because MediaPipe establishes the constraint; CocoaPods aggregates it for both direct Identity consumers and the transitive StripeCryptoOnramp dependency path.
-->
