### PR TITLE
Prevent unsupported x86_64 CocoaPods builds

### DIFF
--- a/StripeIdentity.podspec
+++ b/StripeIdentity.podspec
@@ -37,6 +37,9 @@ Pod::Spec.new do |s|
     'OTHER_LDFLAGS' => '$(inherited) -ObjC',
     'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
   }
+  s.user_target_xcconfig           = {
+    'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'x86_64',
+  }
   s.vendored_frameworks            = [
     'LocalPackages/MediaPipeSPM/Artifacts/MediaPipeCommonGraphLibraries.xcframework',
     'LocalPackages/MediaPipeSPM/Artifacts/MediaPipeTasksCommon.xcframework',

--- a/Tests/installation_tests/cocoapods/setup.sh
+++ b/Tests/installation_tests/cocoapods/setup.sh
@@ -55,4 +55,8 @@ info "Performing pod install..."
 
 pod install --no-repo-update || die "Executing \`pod install\` failed"
 
+if [[ "${1}" == "with_frameworks_swift" ]]; then
+  "${script_dir}/verify_consumer_architectures.sh" || die "Verifying CocoaPods consumer architectures failed"
+fi
+
 info "All good!"

--- a/Tests/installation_tests/cocoapods/verify_consumer_architectures.sh
+++ b/Tests/installation_tests/cocoapods/verify_consumer_architectures.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../../.." && pwd)"
+fixture_dir="${script_dir}/with_frameworks_swift"
+test_dir="$(mktemp -d)"
+architecture_setting='EXCLUDED_ARCHS[sdk=iphonesimulator*] = x86_64'
+
+trap 'rm -rf "${test_dir}"' EXIT
+
+function die {
+  echo "[$(basename "${0}")] [ERROR] ${1}"
+  exit 1
+}
+
+function verify_setting {
+  local target="${1}"
+  local expected="${2}"
+
+  for configuration in debug release; do
+    local xcconfig="${test_dir}/Pods/Target Support Files/Pods-${target}/Pods-${target}.${configuration}.xcconfig"
+
+    [[ -f "${xcconfig}" ]] || die "Missing generated xcconfig: ${xcconfig}"
+
+    if [[ "${expected}" == "present" ]]; then
+      grep -Fq "${architecture_setting}" "${xcconfig}" || die "${target} ${configuration} does not exclude x86_64"
+    elif grep -Fq "${architecture_setting}" "${xcconfig}"; then
+      die "${target} ${configuration} unexpectedly excludes x86_64"
+    fi
+  done
+}
+
+cp -R "${fixture_dir}/CocoapodsTest.xcodeproj" "${test_dir}/"
+
+cat > "${test_dir}/Podfile" <<EOF
+project 'CocoapodsTest.xcodeproj'
+use_frameworks!
+
+target 'CocoapodsTest' do
+  platform :ios, '15.0'
+  pod 'StripeIdentity', path: '${repo_root}'
+end
+
+target 'CocoapodsTestTests' do
+  platform :ios, '15.0'
+  pod 'StripeCryptoOnramp', path: '${repo_root}'
+end
+
+target 'TestExtension' do
+  platform :ios, '15.0'
+  pod 'StripeCore', path: '${repo_root}'
+end
+EOF
+
+(
+  cd "${test_dir}"
+  pod install --no-repo-update
+)
+
+verify_setting 'CocoapodsTest' 'present'
+verify_setting 'CocoapodsTestTests' 'present'
+verify_setting 'TestExtension' 'absent'

--- a/Tests/installation_tests/cocoapods/verify_consumer_architectures.sh
+++ b/Tests/installation_tests/cocoapods/verify_consumer_architectures.sh
@@ -38,23 +38,23 @@ cat > "${test_dir}/Podfile" <<EOF
 project 'CocoapodsTest.xcodeproj'
 use_frameworks!
 
-target 'CocoapodsTest' do
+abstract_target 'LocalPodspecs' do
   platform :ios, '15.0'
-  # Release branches use an unpublished version, so keep exact-version dependencies local.
-  pod 'Stripe', path: '${repo_root}'
-  pod 'StripeIdentity', path: '${repo_root}'
-  pod 'StripeFinancialConnections', path: '${repo_root}'
-  pod 'StripeCardScan', path: '${repo_root}'
+  # Resolve unpublished release versions locally without adding these pods to an asserted target.
   pod 'StripeApplePay', path: '${repo_root}'
   pod 'StripeCameraCore', path: '${repo_root}'
-  pod 'StripeConnect', path: '${repo_root}'
   pod 'StripeCore', path: '${repo_root}'
-  pod 'StripeUICore', path: '${repo_root}'
+  pod 'StripeFinancialConnectionsLite', path: '${repo_root}'
+  pod 'StripeIdentity', path: '${repo_root}'
+  pod 'StripePaymentSheet', path: '${repo_root}'
   pod 'StripePayments', path: '${repo_root}'
   pod 'StripePaymentsUI', path: '${repo_root}'
-  pod 'StripeFinancialConnectionsLite', path: '${repo_root}'
-  pod 'StripePaymentSheet', path: '${repo_root}'
-  pod 'StripeIssuing', path: '${repo_root}'
+  pod 'StripeUICore', path: '${repo_root}'
+end
+
+target 'CocoapodsTest' do
+  platform :ios, '15.0'
+  pod 'StripeIdentity', path: '${repo_root}'
 end
 
 target 'CocoapodsTestTests' do

--- a/Tests/installation_tests/cocoapods/verify_consumer_architectures.sh
+++ b/Tests/installation_tests/cocoapods/verify_consumer_architectures.sh
@@ -40,11 +40,26 @@ use_frameworks!
 
 target 'CocoapodsTest' do
   platform :ios, '15.0'
+  # Release branches use an unpublished version, so keep exact-version dependencies local.
+  pod 'Stripe', path: '${repo_root}'
   pod 'StripeIdentity', path: '${repo_root}'
+  pod 'StripeFinancialConnections', path: '${repo_root}'
+  pod 'StripeCardScan', path: '${repo_root}'
+  pod 'StripeApplePay', path: '${repo_root}'
+  pod 'StripeCameraCore', path: '${repo_root}'
+  pod 'StripeConnect', path: '${repo_root}'
+  pod 'StripeCore', path: '${repo_root}'
+  pod 'StripeUICore', path: '${repo_root}'
+  pod 'StripePayments', path: '${repo_root}'
+  pod 'StripePaymentsUI', path: '${repo_root}'
+  pod 'StripeFinancialConnectionsLite', path: '${repo_root}'
+  pod 'StripePaymentSheet', path: '${repo_root}'
+  pod 'StripeIssuing', path: '${repo_root}'
 end
 
 target 'CocoapodsTestTests' do
   platform :ios, '15.0'
+  # Keep CryptoOnramp isolated so Identity is resolved only through its dependency graph.
   pod 'StripeCryptoOnramp', path: '${repo_root}'
 end
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -34,6 +34,7 @@ pipelines:
       framework-tests: {}
       lpm-confirm-flow-tests: {}
       framework-tests-and-builds-xcode-26-1: {}
+      deploy-dry-run: {}
       install-and-integration-tests: {}
       size-report: {}
       ui-tests-paymentsheet:


### PR DESCRIPTION
## Summary

CocoaPods apps using StripeIdentity or StripeCryptoOnramp now inherit the supported arm64-only simulator constraint, fixing the 26.8.0 release lint without changing architectures for unrelated Stripe modules.

## Motivation

[PR #6993](https://github.com/stripe/stripe-ios/pull/6993) excluded x86_64 from the StripeIdentity and StripeCryptoOnramp pod targets, but CocoaPods' generated validation app still compiled for x86_64. The 26.8.0 release lint therefore imported an arm64-only StripeCryptoOnramp module and failed with `unsupported Swift architecture`.

`user_target_xcconfig` applies the same exclusion to inheriting, non-overridden application targets. The setting belongs only on StripeIdentity because MediaPipe establishes the constraint; CocoaPods carries it through StripeCryptoOnramp's Identity dependency instead of requiring a duplicate policy declaration.

## Testing

Added PR-gated checks of CocoaPods' generated aggregate xcconfigs that:

- Verify direct StripeIdentity consumers exclude x86_64 in Debug and Release.
- Verify StripeCryptoOnramp consumers inherit the exclusion through StripeIdentity in Debug and Release.
- Verify an unrelated StripeCore-only target does not inherit the exclusion.

ShellCheck and Bash syntax validation pass. The fixture also runs successfully against CocoaPods 1.16.2. The [exact-HEAD macOS Bitrise pipeline](https://app.bitrise.io/app/b220f4ba85d134a7/pipelines/5c76cf02-23d7-4bc1-bccf-fbc82434dbc3) passed, including its CocoaPods/Xcode installation workflow.

## Changelog

N/A. This completes the CocoaPods integration behavior for the simulator restriction already documented by PR #6993.

<!-- context-dump @ 2712692a30e
The failing release workflow is https://app.bitrise.io/build/bdeca141-87b7-4e82-9458-7f5ba758ee73. StripeIdentity and StripeCryptoOnramp correctly produced arm64-only simulator modules, but CocoaPods' generated App target requested x86_64. Importing StripeCryptoOnramp then failed in StripeCryptoOnramp-Swift.h with "unsupported Swift architecture" and reported that the only available swiftmodule was arm64-apple-ios-simulator.

`pod_target_xcconfig` configures only the pod target. `user_target_xcconfig` is required for CocoaPods aggregate/application targets to inherit the architecture constraint unless the application overrides that setting.

The focused regression copies the existing three-target CocoaPods Swift fixture into a temporary directory. It installs StripeIdentity directly into the app target, StripeCryptoOnramp into the test target with Identity only transitively resolved, and StripeCore into the extension target as an unaffected control. It asserts the generated aggregate xcconfigs for both Debug and Release, then the ordinary installation workflow builds the fixture on macOS. A detached abstract target supplies the nine branch-local podspecs in CryptoOnramp's dependency closure without adding them to any asserted consumer target. Release branches can therefore run the test before their new version is published to CocoaPods trunk while the direct, transitive, and unaffected assertions remain causally isolated.
-->

<!-- assess-pr round 4 @ 2712692a30e 2026-08-24T20:25:19Z
verdict: PASS
findings:
  - none
decomposition: PASS — production setting, focused regression, release-safe local sources, and setup hook are one independently shippable unit
monitoring: PASS — build-time failures are loud; PR-gated installation coverage plus nightly/release pod lint are appropriate; no runtime monitoring applies
scope:
  - Complete diff and description reviewed at 2712692a30e.
  - All 12 available named roles completed with no timeouts.
  - Codex adversarial cross-model plugin was unavailable; that 13th role did not run.
ci-boundary: Exact-HEAD install-and-integration execution succeeded against CocoaPods and Xcode; other workflows were still pending at synthesis time.
agent summaries:
  - Sentinel: PASS — CocoaPods 1.16.2 installed the 10-pod closure; direct, transitive, and control aggregates remained isolated across Debug and Release.
  - Verifier: PASS — committed Podfile matched the passing prototype; wrong-placement counterexamples failed; local release resolution and isolation checks passed.
  - Architect: PASS — detached LocalPodspecs preserves dependency direction and policy ownership; explicit closure duplication fails closed on drift.
  - Reader: PASS — xcconfig scope, detached localization, and status-neutral CI language are clear.
  - Completionist: PASS — no missing callers, tests, docs, CI wiring, cleanup, migration, or monitoring.
  - Historian: PASS — stale pre-fix pipeline evidence was replaced with the exact-HEAD pipeline.
  - Challenger: PASS — no materially simpler approach preserves unpublished-version resolution plus all three causal proofs.
  - Decomposer: PASS — the change is one smallest independently shippable unit.
  - Risk Pattern: PASS — no permissive-failure or cross-system contract pattern triggered.
  - Spec Compliance: PASS — all 14 material claims confirmed.
  - Monitoring Critic: PASS — build failures are loud and covered by PR, nightly, and release checks.
  - PR Writing Critic: PASS — no actionable writing issue remains.
  - Writing Quality Critic: PASS — visible body is skim-ready and the context dump contains evidence rather than self-verdict.
-->
