### PR TITLE
AddressElement cancellation analytics

### DIFF
--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -205,7 +205,7 @@ import Foundation
     // MARK: - Address Element
     case addressShow = "mc_address_show"
     case addressCompleted = "mc_address_completed"
-    case addressCanceled = "mc_address_canceled"
+    case addressDiscardChanges = "mc_address_discard_changes"
 
     // MARK: - Billing Address
     case mcbillingAddressCompleted = "mc_billing_address_completed"

--- a/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
+++ b/StripeCore/StripeCore/Source/Analytics/STPAnalyticEvent.swift
@@ -205,6 +205,7 @@ import Foundation
     // MARK: - Address Element
     case addressShow = "mc_address_show"
     case addressCompleted = "mc_address_completed"
+    case addressCanceled = "mc_address_canceled"
 
     // MARK: - Billing Address
     case mcbillingAddressCompleted = "mc_billing_address_completed"

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+Address.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+Address.swift
@@ -44,10 +44,10 @@ extension STPAnalyticsClient {
                                   apiClient: apiClient)
     }
 
-    func logAddressCanceled(addressAnalyticData: AddressAnalyticData, apiClient: STPAPIClient) {
+    func logAddressDiscardChanges(addressAnalyticData: AddressAnalyticData, apiClient: STPAPIClient) {
         assert(apiClient.publishableKey?.nonEmpty != nil) // A publishable key is required to be set at this point so we can send it in our analytics payload
         logAddressControllerEvent(
-            event: .addressCanceled,
+            event: .addressDiscardChanges,
             addressAnalyticData: addressAnalyticData,
             apiClient: apiClient
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+Address.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Analytics/STPAnalyticsClient+Address.swift
@@ -44,6 +44,15 @@ extension STPAnalyticsClient {
                                   apiClient: apiClient)
     }
 
+    func logAddressCanceled(addressAnalyticData: AddressAnalyticData, apiClient: STPAPIClient) {
+        assert(apiClient.publishableKey?.nonEmpty != nil) // A publishable key is required to be set at this point so we can send it in our analytics payload
+        logAddressControllerEvent(
+            event: .addressCanceled,
+            addressAnalyticData: addressAnalyticData,
+            apiClient: apiClient
+        )
+    }
+
     func logBillingAddressCompleted(addressCountryCode: String, autoCompleteResultedSelected: Bool, editDistance: Int?, apiClient: STPAPIClient) {
         assert(apiClient.publishableKey?.nonEmpty != nil) // A publishable key is required to be set at this point so we can send it in our analytics payload
         let analyticData = AddressAnalyticData(addressCountryCode: addressCountryCode,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -679,7 +679,7 @@ extension AddressViewController: AddressViewController.IntegrationDelegate {
     }
 
     func didDiscardChanges() {
-        STPAnalyticsClient.sharedClient.logAddressCanceled(
+        STPAnalyticsClient.sharedClient.logAddressDiscardChanges(
             addressAnalyticData: currentAddressAnalyticData,
             apiClient: configuration.apiClient
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/AddressViewController/AddressViewController.swift
@@ -91,6 +91,8 @@ public class AddressViewController: UIViewController {
         func didShow()
         /// Handles cancellation without saving the address.
         func didCancel()
+        /// Handles the customer choosing to discard changes.
+        func didDiscardChanges()
         /// Handles completion with the customer's collected address details.
         func save(addressDetails: AddressDetails) async throws
     }
@@ -458,6 +460,7 @@ extension AddressViewController {
     func discardChanges() {
         // Revert the form to its as-opened state so a reused instance doesn't keep the discarded
         // edits, then finish with the as-opened address (never the edited-but-abandoned values).
+        integrationDelegate?.didDiscardChanges()
         resetFormToInitialSnapshot()
         integrationDelegate?.didCancel()
         delegate?.addressViewControllerDidFinish(self, with: initialAddressDetails)
@@ -675,6 +678,13 @@ extension AddressViewController: AddressViewController.IntegrationDelegate {
     func didCancel() {
     }
 
+    func didDiscardChanges() {
+        STPAnalyticsClient.sharedClient.logAddressCanceled(
+            addressAnalyticData: currentAddressAnalyticData,
+            apiClient: configuration.apiClient
+        )
+    }
+
     func save(addressDetails: AddressDetails) async throws {
         logAddressCompleted()
     }
@@ -695,6 +705,7 @@ extension AddressViewController: AddressViewController.IntegrationDelegate {
 extension AddressViewController.IntegrationDelegate {
     func didShow() {}
     func didCancel() {}
+    func didDiscardChanges() {}
 }
 
 // MARK: - ElementDelegate

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerDismissalTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerDismissalTests.swift
@@ -104,9 +104,9 @@ final class AddressViewControllerDismissalTests: XCTestCase {
         }
     }
 
-    private func addressCanceledWasLogged() -> Bool {
+    private func addressDiscardChangesWasLogged() -> Bool {
         STPAnalyticsClient.sharedClient._testLogHistory.contains {
-            $0["event"] as? String == "mc_address_canceled"
+            $0["event"] as? String == "mc_address_discard_changes"
         }
     }
 
@@ -189,8 +189,8 @@ final class AddressViewControllerDismissalTests: XCTestCase {
         XCTAssertNil(vc.presentedViewController)
         // ...and no completion analytic is logged (cancel is not a completion)
         XCTAssertFalse(addressCompletedWasLogged())
-        // ...and no cancellation analytic is logged because there were no changes to discard
-        XCTAssertFalse(addressCanceledWasLogged())
+        // ...and no discard analytic is logged because there were no changes to discard
+        XCTAssertFalse(addressDiscardChangesWasLogged())
     }
 
     func test_closeWithChanges_presentsDiscardAlertWithoutFinishing() throws {
@@ -390,8 +390,8 @@ final class AddressViewControllerDismissalTests: XCTestCase {
         // ...and the delegate finishes once with the as-opened address, not the edited value
         XCTAssertEqual(delegate.didFinishCallCount, 1)
         XCTAssertEqual(delegate.lastAddress?.address.line1, "510 Townsend St.")
-        // ...and cancellation, rather than completion, is logged
-        XCTAssertTrue(addressCanceledWasLogged())
+        // ...and discarding changes, rather than completion, is logged
+        XCTAssertTrue(addressDiscardChangesWasLogged())
         XCTAssertFalse(addressCompletedWasLogged())
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerDismissalTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerDismissalTests.swift
@@ -104,6 +104,12 @@ final class AddressViewControllerDismissalTests: XCTestCase {
         }
     }
 
+    private func addressCanceledWasLogged() -> Bool {
+        STPAnalyticsClient.sharedClient._testLogHistory.contains {
+            $0["event"] as? String == "mc_address_canceled"
+        }
+    }
+
     // MARK: - Tests
 
     func test_hasChanges_isFalseAfterLoadAndTrueAfterEditingField() {
@@ -183,6 +189,8 @@ final class AddressViewControllerDismissalTests: XCTestCase {
         XCTAssertNil(vc.presentedViewController)
         // ...and no completion analytic is logged (cancel is not a completion)
         XCTAssertFalse(addressCompletedWasLogged())
+        // ...and no cancellation analytic is logged because there were no changes to discard
+        XCTAssertFalse(addressCanceledWasLogged())
     }
 
     func test_closeWithChanges_presentsDiscardAlertWithoutFinishing() throws {
@@ -371,6 +379,7 @@ final class AddressViewControllerDismissalTests: XCTestCase {
         )
         vc.addressSection?.line1?.setText("999 Changed Ave")
         XCTAssertTrue(vc.hasChanges)
+        STPAnalyticsClient.sharedClient._testLogHistory = []
 
         // When the customer discards changes
         vc.discardChanges()
@@ -381,6 +390,9 @@ final class AddressViewControllerDismissalTests: XCTestCase {
         // ...and the delegate finishes once with the as-opened address, not the edited value
         XCTAssertEqual(delegate.didFinishCallCount, 1)
         XCTAssertEqual(delegate.lastAddress?.address.line1, "510 Townsend St.")
+        // ...and cancellation, rather than completion, is logged
+        XCTAssertTrue(addressCanceledWasLogged())
+        XCTAssertFalse(addressCompletedWasLogged())
     }
 
     func test_discardChanges_clearsFieldAddedOverEmptyBaseline() {


### PR DESCRIPTION
## Summary
Add new mc_address_discard_changes analytic to measure customers discarding address changes.

## Motivation
We recently changed the 'X' button to show a cancellation dialog offering the customer to discard the changes instead of saving them, as we previously did. We want to measure how commonly customers intentionally do discard their changes to understand if this was the correct UX change.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
