### PR TITLE
Move Checkout Apple Pay configuration to PaymentElement

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -173,7 +173,7 @@ struct CheckoutCartView: View {
             )
             config.adaptivePricing.allowed = adaptivePricing
             config.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails
-            config.applePayConfiguration = CheckoutController.ApplePayConfiguration(
+            config.paymentElement.applePay = PaymentElement.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example"
             )
             config.currencySelectorElement.appearance = currencySelectorAppearance

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -173,7 +173,7 @@ struct CheckoutCartView: View {
             )
             config.adaptivePricing.allowed = adaptivePricing
             config.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails
-            config.paymentElement.applePay = PaymentElement.ApplePayConfiguration(
+            config.paymentElement.applePayConfiguration = PaymentElement.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example"
             )
             config.currencySelectorElement.appearance = currencySelectorAppearance

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
@@ -226,7 +226,7 @@ final class CheckoutCartViewController: UIViewController {
             )
             configuration.adaptivePricing.allowed = adaptivePricing
             configuration.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails
-            configuration.applePayConfiguration = CheckoutController.ApplePayConfiguration(
+            configuration.paymentElement.applePay = PaymentElement.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example"
             )
             var expressCheckoutElementConfig = ExpressCheckoutElement.Configuration()

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
@@ -226,7 +226,7 @@ final class CheckoutCartViewController: UIViewController {
             )
             configuration.adaptivePricing.allowed = adaptivePricing
             configuration.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails
-            configuration.paymentElement.applePay = PaymentElement.ApplePayConfiguration(
+            configuration.paymentElement.applePayConfiguration = PaymentElement.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example"
             )
             var expressCheckoutElementConfig = ExpressCheckoutElement.Configuration()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
@@ -73,6 +73,7 @@ extension PaymentPagesAPIResponse {
             billingAddressCollection: billingAddressCollection.flatMap(CheckoutController.Session.BillingAddressCollection.init(rawValue:)) ?? .automatic,
             automaticTaxEnabled: automaticTaxEnabled,
             automaticTaxAddressSource: automaticTaxAddressSource,
+            merchantCountryCode: elementsSession.merchantCountryCode,
             elementsSession: elementsSessionValue
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
@@ -515,6 +515,7 @@ extension PaymentPagesAPIResponse {
 
     struct ElementsSession: Decodable {
         let businessName: String?
+        let merchantCountryCode: String
         let value: STPElementsSession
 
         private enum CodingKeys: String, CodingKey {
@@ -524,7 +525,13 @@ extension PaymentPagesAPIResponse {
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             businessName = try container.decodeIfPresent(String.self, forKey: .businessName)
-            value = try LegacyDecoded<STPElementsSession>(from: decoder).value
+            let value = try LegacyDecoded<STPElementsSession>(from: decoder).value
+            // TODO: Make merchant_country non-optional in CheckoutClient when Checkout migrates to it.
+            guard let merchantCountryCode = value.merchantCountryCode else {
+                throw decoder.dataCorrupted("Missing required elements_session.merchant_country")
+            }
+            self.merchantCountryCode = merchantCountryCode
+            self.value = value
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+ApplePayConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+ApplePayConfiguration.swift
@@ -9,7 +9,7 @@ import PassKit
 
 /// The merchant identity needed to build an Apple Pay payment request.
 ///
-/// Bridges ``CheckoutController/ApplePayConfiguration`` (Payment Element) and
+/// Bridges ``PaymentElement/ApplePayConfiguration`` (Payment Element) and
 /// ``ExpressCheckoutElement/ApplePayConfiguration`` (ExpressCheckoutElement) so Apple Pay
 /// confirmation code can accept either without caring which surface it came from.
 @_spi(STP)
@@ -24,7 +24,7 @@ public protocol CheckoutApplePayConfiguration {
 
 @_spi(STP)
 @_spi(ReactNativeSDK)
-extension CheckoutController {
+extension PaymentElement {
     /// Configuration for Apple Pay.
     public struct ApplePayConfiguration: CheckoutApplePayConfiguration {
         /// The Apple Pay merchant identifier.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -67,9 +67,6 @@ extension CheckoutController {
         /// ``CheckoutController.getShippingAddressElement()``.
         public var shippingAddressElement: ShippingAddressElement.Configuration = .init()
 
-        /// Apple Pay configuration.
-        public var applePayConfiguration: ApplePayConfiguration?
-
         /// Link configuration.
         public var linkConfiguration: LinkConfiguration?
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
@@ -117,7 +117,7 @@ extension CheckoutController {
         // Normalize Payment Element state here, then build the corresponding confirmation flow.
         switch paymentOption {
         case .applePay:
-            guard let applePayConfiguration = self.configuration.applePayConfiguration else { return nil }
+            guard let applePayConfiguration = self.configuration.paymentElement.applePay else { return nil }
             return .applePay(.init(
                 applePayConfiguration: applePayConfiguration,
                 apiClient: apiClient,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
@@ -117,7 +117,7 @@ extension CheckoutController {
         // Normalize Payment Element state here, then build the corresponding confirmation flow.
         switch paymentOption {
         case .applePay:
-            guard let applePayConfiguration = self.configuration.paymentElement.applePay else { return nil }
+            guard let applePayConfiguration = self.configuration.paymentElement.applePayConfiguration else { return nil }
             return .applePay(.init(
                 applePayConfiguration: applePayConfiguration,
                 apiClient: apiClient,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session+Internal.swift
@@ -150,6 +150,7 @@ extension CheckoutController.Session {
             billingAddressCollection: billingAddressCollection,
             automaticTaxEnabled: automaticTaxEnabled,
             automaticTaxAddressSource: automaticTaxAddressSource,
+            merchantCountryCode: merchantCountryCode,
             elementsSession: elementsSession
         )
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session.swift
@@ -87,6 +87,7 @@ extension CheckoutController {
         let billingAddressCollection: BillingAddressCollection
         let automaticTaxEnabled: Bool
         let automaticTaxAddressSource: String?
+        let merchantCountryCode: String
         let elementsSession: STPElementsSession
 
         enum BillingAddressCollection: String {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutApplePayContext.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutApplePayContext.swift
@@ -237,7 +237,7 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
             applePayConfirmationParameters: applePayConfirmationParameters
         )
 
-        assert(!paymentRequest.merchantIdentifier.isEmpty, "You must set `merchantId` on `CheckoutController.ApplePayConfiguration`.")
+        assert(!paymentRequest.merchantIdentifier.isEmpty, "You must set `merchantId` on `PaymentElement.ApplePayConfiguration`.")
 
         let merchantLabel = applePayConfirmationParameters.merchantDisplayName
         paymentRequest.paymentSummaryItems = CheckoutApplePayContext.makeSummaryItems(for: checkoutSession, label: merchantLabel)
@@ -294,10 +294,9 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
         applePayConfirmationParameters: CheckoutController.ApplePayConfirmationParameters
     ) -> PKPaymentRequest {
         let applePayConfig = applePayConfirmationParameters.applePayConfiguration
-        let countryCode = checkoutSession.elementsSession.merchantCountryCode ?? "US"
         let paymentRequest = StripeAPI.paymentRequest(
             withMerchantIdentifier: applePayConfig.merchantId,
-            country: countryCode,
+            country: checkoutSession.merchantCountryCode,
             currency: checkoutSession.currency ?? "USD"
         )
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -17,7 +17,7 @@ extension PaymentElement {
         public init() {}
 
         /// Configuration for Apple Pay.
-        public var applePay: ApplePayConfiguration?
+        public var applePayConfiguration: ApplePayConfiguration?
 
         /// PaymentSheet offers users an option to save some payment methods for later use.
         /// Default value is `.automatic`.
@@ -144,7 +144,7 @@ extension PaymentElement {
             configuration.apiClient = apiClient
             configuration.returnURL = returnURL
             configuration.apply(linkConfiguration: linkConfiguration)
-            configuration.applePay = applePay?.paymentSheetConfiguration(
+            configuration.applePay = applePayConfiguration?.paymentSheetConfiguration(
                 merchantCountryCode: merchantCountryCode
             )
             configuration.merchantDisplayName = merchantDisplayName
@@ -173,7 +173,7 @@ extension PaymentElement {
             configuration.apiClient = apiClient
             configuration.returnURL = returnURL
             configuration.apply(linkConfiguration: linkConfiguration)
-            configuration.applePay = applePay?.paymentSheetConfiguration(
+            configuration.applePay = applePayConfiguration?.paymentSheetConfiguration(
                 merchantCountryCode: merchantCountryCode
             )
             configuration.merchantDisplayName = merchantDisplayName

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -16,6 +16,9 @@ extension PaymentElement {
         /// Initializes a Configuration with default values.
         public init() {}
 
+        /// Configuration for Apple Pay.
+        public var applePay: ApplePayConfiguration?
+
         /// PaymentSheet offers users an option to save some payment methods for later use.
         /// Default value is `.automatic`.
         public var savePaymentMethodOptInBehavior: SavePaymentMethodOptInBehavior = .automatic {
@@ -132,6 +135,7 @@ extension PaymentElement {
             defaults: CheckoutController.Configuration.Defaults,
             linkConfiguration: CheckoutController.LinkConfiguration?,
             merchantDisplayName: String,
+            merchantCountryCode: String,
             userInterfaceStyle: CheckoutController.UserInterfaceStyle
         ) -> EmbeddedPaymentElement.Configuration {
             var configuration = embeddedConfiguration
@@ -140,6 +144,9 @@ extension PaymentElement {
             configuration.apiClient = apiClient
             configuration.returnURL = returnURL
             configuration.apply(linkConfiguration: linkConfiguration)
+            configuration.applePay = applePay?.paymentSheetConfiguration(
+                merchantCountryCode: merchantCountryCode
+            )
             configuration.merchantDisplayName = merchantDisplayName
             configuration.style = userInterfaceStyle
             configuration.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.paymentSheetConfiguration()
@@ -157,6 +164,7 @@ extension PaymentElement {
             defaults: CheckoutController.Configuration.Defaults,
             linkConfiguration: CheckoutController.LinkConfiguration?,
             merchantDisplayName: String,
+            merchantCountryCode: String,
             userInterfaceStyle: CheckoutController.UserInterfaceStyle
         ) -> PaymentSheet.Configuration {
             var configuration = paymentSheetConfiguration
@@ -165,6 +173,9 @@ extension PaymentElement {
             configuration.apiClient = apiClient
             configuration.returnURL = returnURL
             configuration.apply(linkConfiguration: linkConfiguration)
+            configuration.applePay = applePay?.paymentSheetConfiguration(
+                merchantCountryCode: merchantCountryCode
+            )
             configuration.merchantDisplayName = merchantDisplayName
             configuration.style = userInterfaceStyle
             configuration.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.paymentSheetConfiguration()
@@ -175,6 +186,16 @@ extension PaymentElement {
             configuration.defaultBillingDetails.phone = defaults.phone
             return configuration
         }
+    }
+}
+
+private extension PaymentElement.ApplePayConfiguration {
+    func paymentSheetConfiguration(merchantCountryCode: String) -> PaymentSheet.ApplePayConfiguration {
+        return PaymentSheet.ApplePayConfiguration(
+            merchantId: merchantId,
+            merchantCountryCode: merchantCountryCode,
+            buttonType: buttonType ?? .plain
+        )
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -78,6 +78,7 @@ public final class PaymentElement {
             defaults: checkout.configuration.defaults,
             linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
+            merchantCountryCode: checkout.session.merchantCountryCode,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
         self.paymentSheetFlowController = try await PaymentSheet.FlowController.create(
@@ -91,6 +92,7 @@ public final class PaymentElement {
             defaults: checkout.configuration.defaults,
             linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
+            merchantCountryCode: checkout.session.merchantCountryCode,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
         self.embeddedPaymentElement = try await EmbeddedPaymentElement.create(
@@ -118,7 +120,16 @@ public final class PaymentElement {
             }
             .store(in: &cancellables)
         // We don't know whether to use FC or Embedded's payment option at this point, so we'll use Embedded since it has more info (includes mandate text).
-        stpAssert(paymentSheetFlowController.paymentOption?.label == embeddedPaymentElement.paymentOption?.label, "Payment Element assumes that the FlowController's payment option is the same as the Embedded's on first load!")
+        // FlowController defaults to Apple Pay when it is available, while Embedded starts unselected.
+        let flowControllerDefaultsToApplePay = if case .applePay? = paymentSheetFlowController.internalPaymentOption {
+            embeddedPaymentElement._paymentOption == nil
+        } else {
+            false
+        }
+        stpAssert(
+            paymentSheetFlowController.paymentOption?.label == embeddedPaymentElement.paymentOption?.label || flowControllerDefaultsToApplePay,
+            "Payment Element assumes that the FlowController's payment option is the same as the Embedded's on first load!"
+        )
         checkout.setPaymentOption(
             embeddedPaymentElement.paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init)
         )
@@ -150,6 +161,7 @@ extension PaymentElement {
             defaults: checkout.configuration.defaults,
             linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
+            merchantCountryCode: checkout.session.merchantCountryCode,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
         embeddedPaymentElement.configuration = configuration.makeEmbeddedConfiguration(
@@ -158,6 +170,7 @@ extension PaymentElement {
             defaults: checkout.configuration.defaults,
             linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
+            merchantCountryCode: checkout.session.merchantCountryCode,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -86,6 +86,7 @@ enum CheckoutTestHelpers {
 
     static let minimalElementsSessionJSON: [String: Any] = [
         "session_id": "es_test",
+        "merchant_country": "US",
         "payment_method_preference": ["ordered_payment_method_types": ["card"]],
     ]
 
@@ -383,7 +384,7 @@ extension CheckoutController.ApplePayConfirmationParameters {
         apiClient: STPAPIClient,
         returnURL: String = "stripe-ios-test://checkout-return",
         merchantDisplayName: String = "Test Merchant",
-        applePayConfiguration: CheckoutController.ApplePayConfiguration = CheckoutController.ApplePayConfiguration(merchantId: "merchant.com.test"),
+        applePayConfiguration: PaymentElement.ApplePayConfiguration = PaymentElement.ApplePayConfiguration(merchantId: "merchant.com.test"),
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
         defaultBillingDetails: CheckoutController.Configuration.Defaults.BillingDetails? = nil,
         presentationWindow: UIWindow? = nil

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/ExpressCheckoutElementViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/ExpressCheckoutElementViewTests.swift
@@ -108,6 +108,7 @@ final class ExpressCheckoutElementViewTests: XCTestCase {
     ) -> PaymentPagesAPIResponse {
         var elementsSession: [String: Any] = [
             "session_id": "es_test",
+            "merchant_country": "US",
             "payment_method_preference": ["ordered_payment_method_types": ["card"]],
             "ordered_payment_method_types_and_wallets": walletTypes,
         ]

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -117,6 +117,40 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertEqual(embeddedConfiguration.merchantDisplayName, "Dashboard Merchant")
     }
 
+    func testConfigurationSetsApplePayFromCheckoutSessionMerchantCountry() async throws {
+        // Given Apple Pay configured for a Checkout Session with a non-US merchant country
+        var checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
+        checkoutConfiguration.paymentElement.applePay = PaymentElement.ApplePayConfiguration(
+            merchantId: "merchant.com.example",
+            buttonType: .donate
+        )
+        var sessionJSON = Self.openSessionJSON(paymentMethodTypes: ["card"])
+        var elementsSessionJSON = sessionJSON["elements_session"] as! [String: Any]
+        elementsSessionJSON["merchant_country"] = "GB"
+        sessionJSON["elements_session"] = elementsSessionJSON
+
+        // When Checkout creates PaymentElement
+        let checkout = try await CheckoutController(
+            configuration: CheckoutTestHelpers.makeConfiguration(
+                apiResponse: try PaymentPagesAPIResponse.decode(fromAPIResponse: sessionJSON),
+                configuration: checkoutConfiguration
+            )
+        )
+        let paymentElement = checkout.getPaymentElement()
+        let paymentSheetApplePay = try XCTUnwrap(paymentElement.paymentSheetFlowController.configuration.applePay)
+        let embeddedApplePay = try XCTUnwrap(paymentElement.embeddedPaymentElement.configuration.applePay)
+
+        // Then both presentations use the merchant-provided settings and server-provided country
+        XCTAssertEqual(paymentSheetApplePay.merchantId, "merchant.com.example")
+        XCTAssertEqual(paymentSheetApplePay.buttonType, .donate)
+        XCTAssertEqual(paymentSheetApplePay.merchantCountryCode, "GB")
+        XCTAssertEqual(embeddedApplePay.merchantId, "merchant.com.example")
+        XCTAssertEqual(embeddedApplePay.buttonType, .donate)
+        XCTAssertEqual(embeddedApplePay.merchantCountryCode, "GB")
+        XCTAssertEqual(paymentElement.paymentSheetFlowController.paymentOption?.paymentMethodType, "apple_pay")
+        XCTAssertEqual(paymentElement.embeddedPaymentElement.paymentOption?.paymentMethodType, "apple_pay")
+    }
+
     func testConfigurationAllowsAllCheckoutPaymentMethodRequirements() async throws {
         // Given a Checkout configuration
         let checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -120,7 +120,7 @@ final class PaymentElementTest: XCTestCase {
     func testConfigurationSetsApplePayFromCheckoutSessionMerchantCountry() async throws {
         // Given Apple Pay configured for a Checkout Session with a non-US merchant country
         var checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
-        checkoutConfiguration.paymentElement.applePay = PaymentElement.ApplePayConfiguration(
+        checkoutConfiguration.paymentElement.applePayConfiguration = PaymentElement.ApplePayConfiguration(
             merchantId: "merchant.com.example",
             buttonType: .donate
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
@@ -156,6 +156,15 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         XCTAssertThrowsError(try PaymentPagesAPIResponse.decode(fromAPIResponse: json))
     }
 
+    func testDecodedObjectFromAPIResponseRequiresMerchantCountry() {
+        var json = STPTestUtils.jsonNamed("CheckoutSession")!
+        var elementsSession = json["elements_session"] as! [String: Any]
+        elementsSession.removeValue(forKey: "merchant_country")
+        json["elements_session"] = elementsSession
+
+        XCTAssertThrowsError(try PaymentPagesAPIResponse.decode(fromAPIResponse: json))
+    }
+
     func testDecodingErrorIncludesNestedFieldPath() throws {
         let json = modifyingOneTimePriceItem { item in
             item.removeValue(forKey: "quantity")
@@ -353,6 +362,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             "payment_method_types": ["card"],
             "elements_session": [
                 "session_id": "es_test",
+                "merchant_country": "US",
                 "payment_method_preference": ["ordered_payment_method_types": ["card"]],
             ],
         ]
@@ -1249,6 +1259,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         let session = CheckoutTestHelpers.makeSession([
             "elements_session": [
                 "session_id": "es_123",
+                "merchant_country": "US",
                 "payment_method_preference": ["ordered_payment_method_types": ["card"]],
             ],
             "tax_context": [
@@ -1261,6 +1272,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         let sessionWithoutTax = CheckoutTestHelpers.makeSession([
             "elements_session": [
                 "session_id": "es_123",
+                "merchant_country": "US",
                 "payment_method_preference": ["ordered_payment_method_types": ["card"]],
             ],
         ]).withCustomer().makePublicSession()

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFormFactoryTest.swift
@@ -2457,6 +2457,7 @@ class PaymentSheetFormFactoryTest: XCTestCase {
                 "customer": ["id": "cus_123"],
                 "elements_session": [
                     "session_id": "es_test",
+                    "merchant_country": "US",
                     "payment_method_preference": ["ordered_payment_method_types": ["paypal"]],
                 ],
             ])

--- a/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CheckoutSession.json
+++ b/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CheckoutSession.json
@@ -234,6 +234,7 @@
   },
   "elements_session": {
     "business_name": "CI Stuff",
+    "merchant_country": "US",
     "session_id": "elements_session_test123",
     "payment_method_preference": {
       "ordered_payment_method_types": ["card"]

--- a/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CheckoutSessionConfirmed.json
+++ b/StripePayments/StripePaymentsObjcTestUtils/Resources/Mock Files/CheckoutSessionConfirmed.json
@@ -247,6 +247,7 @@
     }
   },
   "elements_session": {
+    "merchant_country": "US",
     "business_name": "CI Stuff",
     "session_id": "elements_session_test123",
     "payment_method_preference": {


### PR DESCRIPTION
## Summary

- Move Checkout Apple Pay configuration under Payment Element configuration.
- Fix a pre-existing bug where Checkout did not pass its Apple Pay configuration to either underlying Payment Element presentation, preventing Apple Pay from appearing.
- Derive the merchant country from the Checkout Session response and require it during decoding.

This PR is stacked on #7016, which makes FlowController the single resolver for Checkout PaymentElement’s initial selection and seeds EmbeddedPaymentElement with that result.

## Testing

- Added coverage that Checkout rejects responses without a merchant country.
- Added coverage that Apple Pay settings and a server-provided merchant country reach both Payment Element presentations and that both initially select Apple Pay. Without #7016, this test fails because FlowController selects Apple Pay while EmbeddedPaymentElement has no initial selection.