### PR TITLE
[Identity] Use runtime camera availability in Simulator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ MINOR
 ### PaymentSheet
 * [Added] Added `financialConnectionsPermissions` to `LinkConfiguration`, allowing `LinkControllerPreview` users to request Financial Connections data permissions (private preview).
 
+### Identity
+* [Fixed] Use an available video camera in Simulator instead of always using mock images.
+
 ## 26.7.0 2026-08-17
 ### PaymentSheet
 * [Fixed] Fixed FlowController not presenting the Link sheet when tapping Link in the horizontal payment method layout.

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2021 Stripe, Inc. All rights reserved.
 //
 
+import AVFoundation
 import SafariServices
 @_spi(STP) import StripeCameraCore
 @_spi(STP) import StripeCore
@@ -777,22 +778,24 @@ extension VerificationSheetFlowController: VerificationSheetFlowControllerProtoc
 
     private func makeDocumentCaptureCameraSession() -> CameraSessionProtocol {
         #if targetEnvironment(simulator)
-        return MockSimulatorCameraSession(
-            images: IdentityVerificationSheet.simulatorDocumentCameraImages
-        )
-        #else
-        return CameraSession()
+        if AVCaptureDevice.default(for: .video) == nil {
+            return MockSimulatorCameraSession(
+                images: IdentityVerificationSheet.simulatorDocumentCameraImages
+            )
+        }
         #endif
+        return CameraSession()
     }
 
     private func makeSelfieCaptureCameraSession() -> CameraSessionProtocol {
         #if targetEnvironment(simulator)
-        return MockSimulatorCameraSession(
-            images: IdentityVerificationSheet.simulatorSelfieCameraImages
-        )
-        #else
-        return CameraSession()
+        if AVCaptureDevice.default(for: .video) == nil {
+            return MockSimulatorCameraSession(
+                images: IdentityVerificationSheet.simulatorSelfieCameraImages
+            )
+        }
         #endif
+        return CameraSession()
     }
 
     // MARK: - Collected Fields


### PR DESCRIPTION
## Summary

Stripe Identity currently selects MockSimulatorCameraSession unconditionally when it is built for Simulator. This change keeps the existing simulator fallback only when AVFoundation does not report an available video device. When a camera is available, the document and selfie flows use the same CameraSession implementation as a physical device.

Physical-device behavior is unchanged.

## Motivation

Compile-time Simulator checks prevent virtual camera implementations such as SimCam (https://github.com/kmagiera/simcam) from exercising the same Stripe Identity capture path used on an iPhone, even when AVFoundation exposes a working video device at runtime.

This follows the runtime capability-checking approach adopted by Expo Camera in https://github.com/expo/expo/pull/44159. Checking for an available camera instead of treating every Simulator environment as camera-less keeps the existing fallback for standard Simulator setups while enabling realistic document and selfie capture testing with virtual cameras.

It also allows automated and agentic development environments to validate normal Stripe Identity integrations end to end in Simulator instead of requiring app-specific test flows or physical-device access.

## Testing

No new tests were added.
I tested the SDK with [SimCam](https://simcam.app) and on iOS Simulator I was able to enter document and selfie capture flow where I could see the camera preview from my Mac's camera.

## Changelog

[Fixed] Use an available video camera in Simulator instead of always using mock images.