### PR TITLE
Add email and phone to Checkout defaults 🪿✨

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -147,6 +147,12 @@ extension CheckoutController.Configuration {
         /// Default shipping details.
         public var shippingDetails: ShippingDetails?
 
+        /// The customer's phone number.
+        public var phone: String?
+
+        /// The customer's email address.
+        public var email: String?
+
         /// Creates default customer details.
         public init() {}
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -143,9 +143,7 @@ extension PaymentElement {
             configuration.merchantDisplayName = merchantDisplayName
             configuration.style = userInterfaceStyle
             configuration.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.paymentSheetConfiguration()
-            if let billingDetails = defaults.billingDetails {
-                configuration.defaultBillingDetails.set(billingDetails)
-            }
+            configuration.defaultBillingDetails.set(defaults)
             return configuration
         }
 
@@ -166,9 +164,7 @@ extension PaymentElement {
             configuration.merchantDisplayName = merchantDisplayName
             configuration.style = userInterfaceStyle
             configuration.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.paymentSheetConfiguration()
-            if let billingDetails = defaults.billingDetails {
-                configuration.defaultBillingDetails.set(billingDetails)
-            }
+            configuration.defaultBillingDetails.set(defaults)
             return configuration
         }
     }
@@ -293,9 +289,11 @@ private extension PaymentElement.Configuration {
 }
 
 private extension PaymentSheet.BillingDetails {
-    mutating func set(_ billingDetails: CheckoutController.Configuration.Defaults.BillingDetails) {
-        name = billingDetails.name
-        if let billingAddress = billingDetails.address {
+    mutating func set(_ defaults: CheckoutController.Configuration.Defaults) {
+        email = defaults.email
+        phone = defaults.phone
+        name = defaults.billingDetails?.name
+        if let billingAddress = defaults.billingDetails?.address {
             address.set(billingAddress)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -143,7 +143,11 @@ extension PaymentElement {
             configuration.merchantDisplayName = merchantDisplayName
             configuration.style = userInterfaceStyle
             configuration.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.paymentSheetConfiguration()
-            configuration.defaultBillingDetails.set(defaults)
+            if let billingDetails = defaults.billingDetails {
+                configuration.defaultBillingDetails.set(billingDetails)
+            }
+            configuration.defaultBillingDetails.email = defaults.email
+            configuration.defaultBillingDetails.phone = defaults.phone
             return configuration
         }
 
@@ -164,7 +168,11 @@ extension PaymentElement {
             configuration.merchantDisplayName = merchantDisplayName
             configuration.style = userInterfaceStyle
             configuration.billingDetailsCollectionConfiguration = billingDetailsCollectionConfiguration.paymentSheetConfiguration()
-            configuration.defaultBillingDetails.set(defaults)
+            if let billingDetails = defaults.billingDetails {
+                configuration.defaultBillingDetails.set(billingDetails)
+            }
+            configuration.defaultBillingDetails.email = defaults.email
+            configuration.defaultBillingDetails.phone = defaults.phone
             return configuration
         }
     }
@@ -289,11 +297,9 @@ private extension PaymentElement.Configuration {
 }
 
 private extension PaymentSheet.BillingDetails {
-    mutating func set(_ defaults: CheckoutController.Configuration.Defaults) {
-        email = defaults.email
-        phone = defaults.phone
-        name = defaults.billingDetails?.name
-        if let billingAddress = defaults.billingDetails?.address {
+    mutating func set(_ billingDetails: CheckoutController.Configuration.Defaults.BillingDetails) {
+        name = billingDetails.name
+        if let billingAddress = billingDetails.address {
             address.set(billingAddress)
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -36,6 +36,8 @@ final class PaymentElementTest: XCTestCase {
     func testConfigurationSetsCheckoutDefaultBillingDetails() async throws {
         // Given Checkout billing defaults
         var checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
+        checkoutConfiguration.defaults.email = "test@example.com"
+        checkoutConfiguration.defaults.phone = "+15555550123"
         var billingDetails = CheckoutController.Configuration.Defaults.BillingDetails()
         billingDetails.name = "Jane Doe"
         billingDetails.address = .init(
@@ -58,6 +60,8 @@ final class PaymentElementTest: XCTestCase {
 
         // Then both configurations receive the same default billing details
         XCTAssertEqual(checkout.configuration.returnURL, "stripe-ios-test://checkout-return")
+        XCTAssertEqual(paymentSheetConfiguration.defaultBillingDetails.email, "test@example.com")
+        XCTAssertEqual(paymentSheetConfiguration.defaultBillingDetails.phone, "+15555550123")
         XCTAssertEqual(paymentSheetConfiguration.defaultBillingDetails.name, "Jane Doe")
         XCTAssertEqual(paymentSheetConfiguration.defaultBillingDetails.address.country, "US")
         XCTAssertEqual(paymentSheetConfiguration.defaultBillingDetails.address.line1, "123 Main St")


### PR DESCRIPTION
[Minion run](https://orbit.corp.stripe.com/sessions/9dcc2347-cafb-4db4-8e03-fb381a37757b)

#### 🧑‍💻 Human summary
- Matches the API review

#### 🤖 LLM summary

## Summary
Adds `email` and `phone` to `CheckoutController.Configuration.Defaults` and propagates them to both Payment Element configurations.

## Motivation
Allows Checkout address collection UIs to be prefilled with customer contact details alongside existing billing and shipping defaults.

## Testing
Extended `PaymentElementTest.testConfigurationSetsCheckoutDefaultBillingDetails` to verify email and phone defaults in PaymentSheet and Embedded Payment Element configuration. The test was not run locally because Xcode simulator tooling is unavailable in this environment.

## Changelog
No changelog entry added.