### PR TITLE
Update Currency Selector Element configuration API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 The next release's version bump will so far be:
-PATCH
+MINOR
 
 ## X.Y.Z - changes pending release
+
+### PaymentSheet
+* [Added] Added Currency Selector Element, a Checkout Element that lets customers choose an Adaptive Pricing currency. Provide `CurrencySelectorElement.Configuration` when configuring Checkout to enable the element.
 
 ## 26.8.0 2026-08-24
 ### Payments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
 The next release's version bump will so far be:
-MINOR
+PATCH
 
 ## X.Y.Z - changes pending release
-
-### PaymentSheet
-* [Added] Added Currency Selector Element, a Checkout Element that lets customers choose an Adaptive Pricing currency. Provide `CurrencySelectorElement.Configuration` when configuring Checkout to enable the element.
 
 ## 26.8.0 2026-08-24
 ### Payments

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -171,12 +171,15 @@ struct CheckoutCartView: View {
             config.apiClient = diagnostics.makeAPIClient(
                 paymentPagesRequestDelay: delayPaymentPagesRequests ? 1 : 0
             )
-            config.adaptivePricing.allowed = adaptivePricing
             config.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails
             config.applePayConfiguration = CheckoutController.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example"
             )
-            config.currencySelectorElement.appearance = currencySelectorAppearance
+            if adaptivePricing {
+                var currencySelectorConfiguration = CurrencySelectorElement.Configuration()
+                currencySelectorConfiguration.appearance = currencySelectorAppearance
+                config.currencySelectorElement = currencySelectorConfiguration
+            }
             config.expressCheckoutElement.applePayConfiguration = ExpressCheckoutElement.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example",
                 display: applePayDisplay

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
@@ -224,7 +224,6 @@ final class CheckoutCartViewController: UIViewController {
                 clientSecret: clientSecret,
                 returnURL: "payments-example://stripe-redirect"
             )
-            configuration.adaptivePricing.allowed = adaptivePricing
             configuration.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails
             configuration.applePayConfiguration = CheckoutController.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example"
@@ -232,7 +231,11 @@ final class CheckoutCartViewController: UIViewController {
             var expressCheckoutElementConfig = ExpressCheckoutElement.Configuration()
             expressCheckoutElementConfig.billingDetailsCollectionConfiguration = eceBillingDetailsCollectionConfiguration
             configuration.expressCheckoutElement = expressCheckoutElementConfig
-            configuration.currencySelectorElement.appearance = currencySelectorAppearance
+            if adaptivePricing {
+                var currencySelectorConfiguration = CurrencySelectorElement.Configuration()
+                currencySelectorConfiguration.appearance = currencySelectorAppearance
+                configuration.currencySelectorElement = currencySelectorConfiguration
+            }
             configuration.expressCheckoutElement.applePayConfiguration = ExpressCheckoutElement.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example",
                 display: applePayDisplay

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -22,7 +22,7 @@ extension CheckoutController {
     ///     clientSecret: "cs_xxx_secret_yyy",
     ///     returnURL: "my-app://stripe-redirect"
     /// )
-    /// config.adaptivePricing.allowed = true
+    /// config.currencySelectorElement = .init()
     ///
     /// let checkout = try await CheckoutController(configuration: config)
     /// ```
@@ -45,23 +45,17 @@ extension CheckoutController {
         /// Default customer details used to pre-populate Checkout integrations.
         public var defaults: Defaults = Defaults()
 
-        /// Controls whether adaptive pricing is requested for this session.
-        ///
-        /// When allowed, Stripe may present prices in the customer's local
-        /// currency alongside the merchant's settlement currency.
-        ///
-        /// Default: ``AdaptivePricing.init()`` (`allowed: false`).
-        public var adaptivePricing: AdaptivePricing = AdaptivePricing()
-
         /// Configuration for PaymentElement.
         public var paymentElement: PaymentElement.Configuration = .init()
 
         /// Configuration for ExpressCheckoutElement.
         public var expressCheckoutElement: ExpressCheckoutElement.Configuration = .init()
 
-        /// Configuration for the Adaptive Pricing currency selector returned by
-        /// ``CheckoutController.getCurrencySelectorElement()``.
-        public var currencySelectorElement: CurrencySelectorElement.Configuration = .init()
+        /// Configuration for Currency Selector Element.
+        ///
+        /// Set this property to enable Currency Selector Element when Adaptive
+        /// Pricing is available. The default value is `nil`.
+        public var currencySelectorElement: CurrencySelectorElement.Configuration?
 
         /// Configuration for the shipping address form returned by
         /// ``CheckoutController.getShippingAddressElement()``.
@@ -179,29 +173,5 @@ extension CheckoutController.Configuration {
             /// Creates default shipping details.
             public init() {}
         }
-    }
-}
-
-@_spi(STP)
-@_spi(ReactNativeSDK)
-extension CheckoutController.Configuration {
-    /// Options for adaptive pricing behavior.
-    ///
-    /// Adaptive pricing lets customers see prices converted to their local
-    /// currency. When ``allowed`` is `true`, the Checkout Session
-    /// init request tells Stripe that the integration supports adaptive pricing;
-    /// Stripe then decides whether to activate it based on the session's
-    /// server-side configuration.
-    public struct AdaptivePricing {
-        /// Whether the integration allows adaptive pricing for this session.
-        ///
-        /// Set to `true` to have Stripe activate adaptive pricing,
-        /// returning localized currency amounts.
-        ///
-        /// Default: `false`.
-        public var allowed: Bool = false
-
-        /// Creates an adaptive pricing configuration with default values.
-        public init() {}
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -112,7 +112,7 @@ public final class CheckoutController: ObservableObject {
             // Call /init
             let apiResponse = try await configuration.apiClient.initCheckoutSession(
                 checkoutSessionId: sessionId,
-                adaptivePricingAllowed: configuration.adaptivePricing.allowed
+                adaptivePricingAllowed: configuration.currencySelectorElement != nil
             )
             let loadedSession = apiResponse.makePublicSession()
             self.session = loadedSession
@@ -148,10 +148,10 @@ public final class CheckoutController: ObservableObject {
             )
 
             // 4. CSE
-            if configuration.adaptivePricing.allowed {
+            if let currencySelectorConfiguration = configuration.currencySelectorElement {
                 self.currencySelectorElement = await CurrencySelectorElement(
                     sessionSource: sessionSource,
-                    configuration: configuration.currencySelectorElement,
+                    configuration: currencySelectorConfiguration,
                     delegate: self
                 )
             }
@@ -301,7 +301,7 @@ public final class CheckoutController: ObservableObject {
             do {
                 refreshedCheckoutSession = try await self.apiClient.initCheckoutSession(
                     checkoutSessionId: sessionId,
-                    adaptivePricingAllowed: self.configuration.adaptivePricing.allowed
+                    adaptivePricingAllowed: self.configuration.currencySelectorElement != nil
                 )
             } catch {
                 throw CheckoutError.apiError(message: error.nonGenericDescription)
@@ -322,7 +322,8 @@ public final class CheckoutController: ObservableObject {
         return expressCheckoutElement
     }
 
-    /// Returns the CurrencySelectorElement when Adaptive Pricing is available for this CheckoutController instance.
+    /// Returns Currency Selector Element when it was configured and Adaptive
+    /// Pricing is available for this Checkout instance.
     public func getCurrencySelectorElement() -> CurrencySelectorElement? {
         return currencySelectorElement
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Currency Selector Element/CurrencySelectorElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Currency Selector Element/CurrencySelectorElement+Configuration.swift
@@ -8,14 +8,11 @@
 @_spi(STP)
 @_spi(ReactNativeSDK)
 extension CurrencySelectorElement {
-    /// Configuration for ``CurrencySelectorElement``.
+    /// Configuration for Currency Selector Element.
     public struct Configuration {
-        // MARK: - Public
-
-        /// Creates a configuration with default values.
-        public init() {}
-
-        /// Describes the appearance of the currency selector.
+        /// The appearance of Currency Selector Element.
         public var appearance: Appearance = .init()
+
+        public init() {}
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/Checkout+AdaptivePricingTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/Checkout+AdaptivePricingTests.swift
@@ -28,7 +28,7 @@ final class Checkout_AdaptivePricingTests: STPNetworkStubbingTestCase {
             clientSecret: checkoutSessionResponse.clientSecret,
             returnURL: "stripe-ios-test://checkout-return"
         )
-        configuration.adaptivePricing.allowed = true
+        configuration.currencySelectorElement = .init()
         configuration.apiClient = STPAPIClient(publishableKey: checkoutSessionResponse.publishableKey)
 
         // When Checkout loads the session

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorElementSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorElementSnapshotTests.swift
@@ -38,7 +38,9 @@ final class CheckoutCurrencySelectorElementSnapshotTests: STPSnapshotTestCase {
     ) async throws -> some View {
         let session = CheckoutTestHelpers.makeAdaptivePricingSession(currency: selectedCurrency)
         var configuration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
-        configuration.currencySelectorElement.appearance = appearance
+        var currencySelectorConfiguration = CurrencySelectorElement.Configuration()
+        currencySelectorConfiguration.appearance = appearance
+        configuration.currencySelectorElement = currencySelectorConfiguration
         let checkout = try await CheckoutController(
             configuration: CheckoutTestHelpers.makeCurrencySelectorConfiguration(
                 apiResponse: session,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorViewSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorViewSnapshotTests.swift
@@ -175,7 +175,9 @@ final class CheckoutCurrencySelectorViewSnapshotTests: STPSnapshotTestCase {
     ) async throws -> CurrencySelectorElementUIView {
         let session = makeSession(selectedCurrency: selectedCurrency)
         var configuration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
-        configuration.currencySelectorElement.appearance = appearance
+        var currencySelectorConfiguration = CurrencySelectorElement.Configuration()
+        currencySelectorConfiguration.appearance = appearance
+        configuration.currencySelectorElement = currencySelectorConfiguration
         let checkout = try await CheckoutController(
             configuration: CheckoutTestHelpers.makeCurrencySelectorConfiguration(
                 apiResponse: session,

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorViewTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutCurrencySelectorViewTests.swift
@@ -37,7 +37,9 @@ final class CheckoutCurrencySelectorViewTests: XCTestCase {
 
     func testLabelsUpdateWhenSessionAmountChanges() async throws {
         var configuration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
-        configuration.currencySelectorElement.appearance.labelContent = .amount
+        var currencySelectorConfiguration = CurrencySelectorElement.Configuration()
+        currencySelectorConfiguration.appearance.labelContent = .amount
+        configuration.currencySelectorElement = currencySelectorConfiguration
         let session = makeSession(integrationAmount: 1200, localAmount: 1000)
         let checkout = try await CheckoutController(
             configuration: CheckoutTestHelpers.makeCurrencySelectorConfiguration(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -176,7 +176,7 @@ enum CheckoutTestHelpers {
         return resolvedConfiguration
     }
 
-    /// Builds a stubbed Checkout configuration that opts into Adaptive Pricing.
+    /// Builds a stubbed Checkout configuration that enables Currency Selector Element.
     @MainActor
     static func makeCurrencySelectorConfiguration(
         apiResponse: PaymentPagesAPIResponse = makeOpenSession(),
@@ -184,7 +184,9 @@ enum CheckoutTestHelpers {
     ) -> CheckoutController.Configuration {
         let clientSecret = configuration?.clientSecret ?? "\(apiResponse.sessionId)_secret_abc"
         var resolvedConfiguration = configuration ?? CheckoutController.Configuration(clientSecret: clientSecret, returnURL: "stripe-ios-test://checkout-return")
-        resolvedConfiguration.adaptivePricing.allowed = true
+        if resolvedConfiguration.currencySelectorElement == nil {
+            resolvedConfiguration.currencySelectorElement = .init()
+        }
         return makeConfiguration(apiResponse: apiResponse, configuration: resolvedConfiguration)
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -59,13 +59,27 @@ final class CheckoutUnitTests: XCTestCase {
         XCTAssertEqual(paymentElement.embeddedPaymentElement.configuration.returnURL, returnURL)
     }
 
-    func testGetCurrencySelectorElementReturnsNilWhenAdaptivePricingIsNotAllowed() async throws {
-        let checkout = try await CheckoutController(configuration: CheckoutTestHelpers.makeConfiguration())
+    func testCurrencySelectorElementConfigurationDefaultsToNil() {
+        let configuration = CheckoutController.Configuration(
+            clientSecret: "cs_test_123_secret_abc",
+            returnURL: "stripe-ios-test://checkout-return"
+        )
 
+        XCTAssertNil(configuration.currencySelectorElement)
+    }
+
+    func testGetCurrencySelectorElementReturnsNilWhenNotConfigured() async throws {
+        // Given an Adaptive Pricing session without Currency Selector Element configuration
+        let session = CheckoutTestHelpers.makeAdaptivePricingSession()
+        let checkout = try await CheckoutController(
+            configuration: CheckoutTestHelpers.makeConfiguration(apiResponse: session)
+        )
+
+        // Then Currency Selector Element is disabled
         XCTAssertNil(checkout.getCurrencySelectorElement())
     }
 
-    func testGetCurrencySelectorElementReturnsStableInstanceWhenAdaptivePricingIsAllowed() async throws {
+    func testGetCurrencySelectorElementReturnsStableInstanceWhenConfigured() async throws {
         let session = CheckoutTestHelpers.makeAdaptivePricingSession()
         let checkout = try await CheckoutController(
             configuration: CheckoutTestHelpers.makeCurrencySelectorConfiguration(apiResponse: session)


### PR DESCRIPTION
## Summary
Removes the separate Adaptive Pricing configuration and makes Currency Selector Element configuration the opt-in for Adaptive Pricing. Checkout now requests Adaptive Pricing and creates CSE only when the merchant provides that optional configuration. The Checkout Playground and tests use the reviewed API.

## Motivation
https://jira.corp.stripe.com/browse/MOBILE_APIREVIEW-237

## Testing
- Verified Currency Selector Element configuration is nil by default.
- Verified Currency Selector Element remains unavailable without configuration, even when the initial session includes Adaptive Pricing data.
- Existing Checkout and Currency Selector Element tests pass.

## Changelog
See diff