### PR TITLE
PMM in PS — Only log display attempt in treatment

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
@@ -168,6 +168,11 @@ class PaymentMethodMessagingPromotionsHelper {
     ///   We could theoretically derive this from whether or not we have promotions data, but for safety/redundancy we require it to be explicitly passed.
     /// The duration reported is the time between when the fetch was initiated and when this display attempt occurs.
     func logDisplayedAnalytic(displayedSuccessfully: Bool) {
+        // A helper also exists in control so those call sites can render their existing fallback UI.
+        // Only treatment represents an attempt to display PMM content.
+        guard experiment.group == .treatment else {
+            return
+        }
         let duration = fetchStartDate.map { Date().timeIntervalSince($0) } ?? 0
         analyticsHelper.logPaymentMethodMessagingDisplayed(duration: duration, displayedSuccessfully: displayedSuccessfully)
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
@@ -348,4 +348,37 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
         XCTAssertEqual(event["displayed_successfully"] as? Bool, false)
         XCTAssertEqual(event["duration"] as? Double, 0)
     }
+
+    func testLogDisplayedAnalytic_controlGroup_doesNotLog() throws {
+        // Given a helper assigned to the control group
+        let analyticsClient = STPTestingAnalyticsClient()
+        let experimentsData = ExperimentsData(
+            arbId: "arb_123",
+            experimentAssignments: [PaymentMethodMessagingPromotionsExperiment.experimentName: .control],
+            allResponseFields: [:]
+        )
+        let elementsSession = STPElementsSession._testValue(experimentsData: experimentsData)
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
+        let intent = Intent.deferredIntent(intentConfig: intentConfig)
+        let configuration = stubbedConfiguration()
+        let analyticsHelper = PaymentSheetAnalyticsHelper(
+            integrationShape: .complete,
+            configuration: configuration,
+            analyticsClient: analyticsClient
+        )
+        let helper = try XCTUnwrap(PaymentMethodMessagingPromotionsHelper(
+            elementsSession: elementsSession,
+            intent: intent,
+            configuration: configuration,
+            paymentMethodTypes: [.stripe(.affirm)],
+            analyticsHelper: analyticsHelper
+        ))
+
+        // When a control UI call site reports that it used fallback content
+        helper.logDisplayedAnalytic(displayedSuccessfully: false)
+
+        // Then no PMM display attempt is logged
+        let displayedEvents = analyticsClient._testLogHistory.filter { $0["event"] as? String == "payment_method_messaging_displayed" }
+        XCTAssertEqual(displayedEvents.count, 0)
+    }
 }


### PR DESCRIPTION
## Summary
Only log that a display was attempted in treatment. 

## Motivation
Previously a display attempt was always logged, even when not in the experiment, creating noise in analytics and being out of alignment with android

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
