### PR TITLE
PMM in PS — Treat unsupported PMM countries as expected failure case

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodMessagingPromotionsHelper.swift
@@ -138,14 +138,18 @@ class PaymentMethodMessagingPromotionsHelper {
                 let response = try await PaymentMethodMessagingElement.get(configuration: pmmeConfig)
                 promotions = response.paymentSheetPromotionContents(apiClient: configuration.apiClient)
             } catch {
-                logUnexpectedPMMEError(
-                    error: error,
-                    apiClient: configuration.apiClient,
-                    analyticsClient: STPAnalyticsClient.sharedClient,
-                    additionalNonPIIParams: [
-                        "failure_reason": "promotion_prefetch_request_failed",
-                    ]
-                )
+                // PMM availability is narrower than PaymentSheet availability, so the country from
+                // Elements Session can legitimately be unsupported by the PMM endpoint.
+                if !error.isUnsupportedCountryError {
+                    logUnexpectedPMMEError(
+                        error: error,
+                        apiClient: configuration.apiClient,
+                        analyticsClient: STPAnalyticsClient.sharedClient,
+                        additionalNonPIIParams: [
+                            "failure_reason": "promotion_prefetch_request_failed",
+                        ]
+                    )
+                }
                 promotions = [:]
             }
         }
@@ -166,6 +170,21 @@ class PaymentMethodMessagingPromotionsHelper {
     func logDisplayedAnalytic(displayedSuccessfully: Bool) {
         let duration = fetchStartDate.map { Date().timeIntervalSince($0) } ?? 0
         analyticsHelper.logPaymentMethodMessagingDisplayed(duration: duration, displayedSuccessfully: displayedSuccessfully)
+    }
+}
+
+private extension Error {
+    /// Matches the expected error returned when PaymentSheet supports the country but PMM does not.
+    /// Keep this narrow so other invalid requests continue to use the unexpected-error path.
+    var isUnsupportedCountryError: Bool {
+        guard let stripeError = self as? StripeError,
+              case let .apiError(apiError) = stripeError else {
+            return false
+        }
+        return apiError.httpStatusCode == 400
+            && apiError.type == .invalidRequestError
+            && apiError.param == "country"
+            && apiError.message?.hasPrefix("unsupported_country:") == true
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodMessagingPromotionsHelperTests.swift
@@ -169,6 +169,54 @@ final class PaymentMethodMessagingPromotionsHelperTests: APIStubbedTestCase {
         XCTAssertNil(helper.promotion(for: .stripe(.cashApp)))
     }
 
+    func testFetchData_unsupportedCountry_doesNotLogUnexpectedError() async throws {
+        // Given an otherwise eligible treatment session whose country is unsupported by PMM
+        stub { urlRequest in
+            urlRequest.url?.host == "ppm.stripe.com"
+        } response: { _ in
+            let json: [String: Any] = [
+                "error": [
+                    "param": "country",
+                    "message": "unsupported_country: PR",
+                    "type": "invalid_request_error",
+                ],
+            ]
+            return HTTPStubsResponse(jsonObject: json, statusCode: 400, headers: nil)
+        }
+        STPAnalyticsClient.sharedClient._testLogHistory = []
+        defer {
+            STPAnalyticsClient.sharedClient._testLogHistory = []
+        }
+
+        let experimentsData = ExperimentsData(
+            arbId: "arb_123",
+            experimentAssignments: [PaymentMethodMessagingPromotionsExperiment.experimentName: .treatment],
+            allResponseFields: [:]
+        )
+        let elementsSession = STPElementsSession._testValue(countryCode: "PR", experimentsData: experimentsData)
+        let intentConfig = PaymentSheet.IntentConfiguration(mode: .payment(amount: 1000, currency: "USD")) { _, _ in return "" }
+        let intent = Intent.deferredIntent(intentConfig: intentConfig)
+        let configuration = stubbedConfiguration()
+        let helper = try XCTUnwrap(PaymentMethodMessagingPromotionsHelper(
+            elementsSession: elementsSession,
+            intent: intent,
+            configuration: configuration,
+            paymentMethodTypes: [.stripe(.affirm)],
+            analyticsHelper: PaymentSheetAnalyticsHelper._testValue()
+        ))
+
+        // When fetching promotion content
+        helper.fetchData()
+        await helper.fetchTask?.value
+
+        // Then the expected response produces no unexpected-error analytic and no promotion
+        let unexpectedErrorEvents = STPAnalyticsClient.sharedClient._testLogHistory.filter {
+            $0["event"] as? String == "unexpected_error.paymentmethodmessagingelement"
+        }
+        XCTAssertEqual(unexpectedErrorEvents.count, 0)
+        XCTAssertNil(helper.promotion(for: .stripe(.affirm)))
+    }
+
     // MARK: - Analytics
 
     func testFetchData_logsFetchBeginEvent() async throws {


### PR DESCRIPTION
## Summary
Don't log unexpected error when the API error was for the country being unsupported.

## Motivation
There are expected cases in which the PS attempts to fetch PMM data when the customer is in a country that the PMM endpoint does not support. In these cases, we should treat the API error as expected and not log it.

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
