### PR TITLE
Move Checkout item amounts to sub-items

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
@@ -231,11 +231,12 @@ extension PaymentPagesAPIResponse {
         var taxInclusive = 0
         var total = 0
         for checkoutItem in checkoutItems {
-            let oneTimePrice = checkoutItem.oneTimePrice
-            subtotal += oneTimePrice.subtotal
-            taxExclusive += oneTimePrice.items.reduce(0) { $0 + $1.taxExclusive }
-            taxInclusive += oneTimePrice.items.reduce(0) { $0 + $1.taxInclusive }
-            total += oneTimePrice.total
+            for item in checkoutItem.oneTimePrice.items {
+                subtotal += item.subtotal
+                taxExclusive += item.taxExclusive
+                taxInclusive += item.taxInclusive
+                total += item.total
+            }
         }
         return CheckoutController.Session.Totals(
             subtotal: makeAmount(subtotal, currency: currency),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse+Session.swift
@@ -24,7 +24,6 @@ extension PaymentPagesAPIResponse {
         }
         let publicOrderSummaryItems = Self.makeOrderSummaryItems(
             from: checkoutItems,
-            defaultCurrency: currency,
             locale: .autoupdatingCurrent
         )
         let publicTotals = Self.makeTotals(from: checkoutItems, currency: currency)
@@ -120,7 +119,6 @@ extension PaymentPagesAPIResponse {
 
     private static func makeOrderSummaryItems(
         from checkoutItems: [CheckoutItem],
-        defaultCurrency: String,
         locale: Locale
     ) -> [CheckoutController.Session.OrderSummaryItem] {
         checkoutItems.map { item in
@@ -144,6 +142,16 @@ extension PaymentPagesAPIResponse {
                     } else {
                         adjustableQuantity = nil
                     }
+                    let taxAmounts = item.taxAmounts.map {
+                        makeSessionTaxAmount(from: $0, currency: currency, locale: locale)
+                    }
+                    let amountDetails = CheckoutController.Session.OrderSummaryItem.OneTimePrice.Item.AmountDetails(
+                        total: makeAmount(Double(item.total), currency: currency, locale: locale),
+                        subtotal: makeAmount(Double(item.subtotal), currency: currency, locale: locale),
+                        taxAmounts: taxAmounts.isEmpty ? nil : taxAmounts,
+                        taxInclusive: makeAmount(Double(item.taxInclusive), currency: currency, locale: locale),
+                        taxExclusive: makeAmount(Double(item.taxExclusive), currency: currency, locale: locale)
+                    )
                     return CheckoutController.Session.OrderSummaryItem.OneTimePrice.Item(
                         key: item.innerItemKey,
                         displayName: product.name,
@@ -163,41 +171,16 @@ extension PaymentPagesAPIResponse {
                         },
                         unitLabel: item.unitLabel,
                         quantity: item.quantity,
-                        adjustableQuantity: adjustableQuantity
+                        adjustableQuantity: adjustableQuantity,
+                        amountDetails: amountDetails
                     )
                 }
 
-            let taxAmounts = oneTimePrice.items.flatMap(\.taxAmounts).map {
-                makeSessionTaxAmount(from: $0, currency: defaultCurrency, locale: locale)
-            }
-            let taxInclusive = oneTimePrice.items.reduce(0) { $0 + $1.taxInclusive }
-            let taxExclusive = oneTimePrice.items.reduce(0) { $0 + $1.taxExclusive }
-            let amountDetails = CheckoutController.Session.OrderSummaryItem.OneTimePrice.AmountDetails(
-                total: makeAmount(Double(oneTimePrice.total), currency: defaultCurrency, locale: locale),
-                subtotal: makeAmount(
-                    Double(oneTimePrice.subtotal),
-                    currency: defaultCurrency,
-                    locale: locale
-                ),
-                taxAmounts: taxAmounts.isEmpty ? nil : taxAmounts,
-                discount: makeAmount(0, currency: defaultCurrency, locale: locale),
-                taxInclusive: makeAmount(
-                    Double(taxInclusive),
-                    currency: defaultCurrency,
-                    locale: locale
-                ),
-                taxExclusive: makeAmount(
-                    Double(taxExclusive),
-                    currency: defaultCurrency,
-                    locale: locale
-                )
-            )
             return .oneTimePrice(
                 CheckoutController.Session.OrderSummaryItem.OneTimePrice(
                     key: item.key,
                     description: nil,
-                    items: publicItems,
-                    amountDetails: amountDetails
+                    items: publicItems
                 )
             )
         }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
@@ -290,8 +290,6 @@ extension PaymentPagesAPIResponse {
 
     struct OneTimePrice: Decodable {
         let items: [OneTimePriceItem]
-        let subtotal: Int
-        let total: Int
     }
 
     struct OneTimePriceItem: Decodable {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/API Models/PaymentPagesAPIResponse.swift
@@ -298,6 +298,8 @@ extension PaymentPagesAPIResponse {
         let innerItemKey: String
         let price: Price
         let quantity: Int
+        let subtotal: Int
+        let total: Int
         let unitAmount: Int?
         let unitAmountDecimal: Double?
         let unitLabel: String?
@@ -310,6 +312,8 @@ extension PaymentPagesAPIResponse {
             case innerItemKey
             case price
             case quantity
+            case subtotal
+            case total
             case unitAmount
             case unitAmountDecimal
             case unitLabel
@@ -327,6 +331,8 @@ extension PaymentPagesAPIResponse {
             guard quantity >= 0 else {
                 throw decoder.dataCorrupted("quantity must not be negative")
             }
+            subtotal = try container.decode(Int.self, forKey: .subtotal)
+            total = try container.decode(Int.self, forKey: .total)
             unitAmount = try container.decodeIfPresent(Int.self, forKey: .unitAmount)
 
             if let rawUnitAmountDecimal = try container.decodeIfPresent(

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session+DebugDescription.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session+DebugDescription.swift
@@ -145,18 +145,17 @@ extension CheckoutController.Session: CustomDebugStringConvertible {
                         "          unitAmount: \(item.unitAmount.debugValue)",
                         "          unitAmountDecimal: \(item.unitAmountDecimal?.debugValue ?? "nil")",
                         "          adjustableQuantity: \(item.adjustableQuantity.debugValue)",
+                        "          subtotal: \(item.amountDetails.subtotal.debugValue)",
+                        "          taxExclusive: \(item.amountDetails.taxExclusive.debugValue)",
+                        "          taxInclusive: \(item.amountDetails.taxInclusive.debugValue)",
+                        "          taxAmountCount: \(item.amountDetails.taxAmounts.map { String($0.count) } ?? "nil")",
+                        "          total: \(item.amountDetails.total.debugValue)",
                         "        }",
                     ])
                 }
 
                 lines.append(contentsOf: [
                     "      ]",
-                    "      subtotal: \(group.amountDetails.subtotal.debugValue)",
-                    "      discount: \(group.amountDetails.discount.debugValue)",
-                    "      taxExclusive: \(group.amountDetails.taxExclusive.debugValue)",
-                    "      taxInclusive: \(group.amountDetails.taxInclusive.debugValue)",
-                    "      taxAmountCount: \(group.amountDetails.taxAmounts.map { String($0.count) } ?? "nil")",
-                    "      total: \(group.amountDetails.total.debugValue)",
                     "    }",
                 ])
             }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session.swift
@@ -111,7 +111,7 @@ extension CheckoutController.Session {
         /// A group of one-time Prices.
         case oneTimePrice(OneTimePrice)
 
-        /// A group of one-time Prices and their aggregated amounts.
+        /// A group of one-time Prices.
         public struct OneTimePrice: Identifiable, Sendable, Hashable {
             /// The stable identity of this group within its Checkout Session.
             public var id: String { key }
@@ -124,9 +124,6 @@ extension CheckoutController.Session {
 
             /// The one-time Prices included in this group.
             public let items: [Item]
-
-            /// Amounts aggregated across all one-time Prices in this group.
-            public let amountDetails: AmountDetails
 
             /// A one-time Price included in the group.
             public struct Item: Identifiable, Sendable, Hashable {
@@ -156,27 +153,27 @@ extension CheckoutController.Session {
 
                 /// The allowed quantity range when the customer can adjust the quantity.
                 public let adjustableQuantity: AdjustableQuantity?
-            }
 
-            /// Amounts aggregated across all one-time Prices in the group.
-            public struct AmountDetails: Sendable, Hashable {
-                /// The total amount for the group.
-                public let total: Amount
+                /// The computed amounts for this Price.
+                public let amountDetails: AmountDetails
 
-                /// The subtotal amount for the group before discounts and exclusive tax.
-                public let subtotal: Amount
+                /// The computed amounts for a one-time Price.
+                public struct AmountDetails: Sendable, Hashable {
+                    /// The total amount for the Price.
+                    public let total: Amount
 
-                /// The tax amounts applied to the group, or `nil` when no tax was applied.
-                public let taxAmounts: [TaxAmount]?
+                    /// The subtotal amount for the Price before exclusive tax.
+                    public let subtotal: Amount
 
-                /// The discount applied to the group.
-                public let discount: Amount
+                    /// The tax amounts applied to the Price, or `nil` when no tax was applied.
+                    public let taxAmounts: [TaxAmount]?
 
-                /// The tax amount included in the prices.
-                public let taxInclusive: Amount
+                    /// The tax amount included in the Price.
+                    public let taxInclusive: Amount
 
-                /// The tax amount added to the prices.
-                public let taxExclusive: Amount
+                    /// The tax amount added to the Price.
+                    public let taxExclusive: Amount
+                }
             }
         }
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTests.swift
@@ -178,12 +178,11 @@ final class CheckoutTests: STPNetworkStubbingTestCase {
         XCTAssertNil(item.unitLabel)
         XCTAssertEqual(item.quantity, 1)
         XCTAssertNil(item.adjustableQuantity)
-        XCTAssertEqual(oneTimePrice.amountDetails.subtotal.minorUnitsAmount, 2000)
-        XCTAssertEqual(oneTimePrice.amountDetails.total.minorUnitsAmount, 2000)
-        XCTAssertNil(oneTimePrice.amountDetails.taxAmounts)
-        XCTAssertEqual(oneTimePrice.amountDetails.discount.minorUnitsAmount, 0)
-        XCTAssertEqual(oneTimePrice.amountDetails.taxInclusive.minorUnitsAmount, 0)
-        XCTAssertEqual(oneTimePrice.amountDetails.taxExclusive.minorUnitsAmount, 0)
+        XCTAssertEqual(item.amountDetails.subtotal.minorUnitsAmount, 2000)
+        XCTAssertEqual(item.amountDetails.total.minorUnitsAmount, 2000)
+        XCTAssertNil(item.amountDetails.taxAmounts)
+        XCTAssertEqual(item.amountDetails.taxInclusive.minorUnitsAmount, 0)
+        XCTAssertEqual(item.amountDetails.taxExclusive.minorUnitsAmount, 0)
     }
 
     func testUpdateShippingAddress() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -700,14 +700,13 @@ final class CheckoutUnitTests: XCTestCase {
                       unitAmount: "$10.00"
                       unitAmountDecimal: "$10.00"
                       adjustableQuantity: nil
+                      subtotal: "$10.00"
+                      taxExclusive: "$0.00"
+                      taxInclusive: "$0.00"
+                      taxAmountCount: nil
+                      total: "$10.00"
                     }
                   ]
-                  subtotal: "$10.00"
-                  discount: "$0.00"
-                  taxExclusive: "$0.00"
-                  taxInclusive: "$0.00"
-                  taxAmountCount: nil
-                  total: "$10.00"
                 }
               ]
               taxStatus: nil

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
@@ -749,7 +749,7 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         XCTAssertEqual(secondAmountDetails.taxAmounts?.first?.displayName, "VAT")
     }
 
-    func testTotalsSumOneTimePrices() {
+    func testTotalsSumOneTimePriceItems() {
         let session = CheckoutTestHelpers.makeSession([
             "checkout_items": [
                 makeOneTimePriceCheckoutItem(
@@ -834,13 +834,11 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             )
         }
 
-        for field in ["items", "subtotal", "total"] {
-            let json = modifyingOneTimePrice { $0.removeValue(forKey: field) }
-            XCTAssertThrowsError(
-                try PaymentPagesAPIResponse.decode(fromAPIResponse: json),
-                "Expected missing one_time_price field \(field) to fail decoding"
-            )
-        }
+        let json = modifyingOneTimePrice { $0.removeValue(forKey: "items") }
+        XCTAssertThrowsError(
+            try PaymentPagesAPIResponse.decode(fromAPIResponse: json),
+            "Expected missing one_time_price items to fail decoding"
+        )
     }
 
     func testUnifiedModeSessionRejectsMissingRequiredNestedItemFields() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentPagesAPIResponseTest.swift
@@ -59,14 +59,6 @@ class PaymentPagesAPIResponseTest: XCTestCase {
     func testDecodedObjectFromAPIResponseDoesNotRequireUnusedFields() throws {
         var json = CheckoutTestHelpers.makeSessionJSON()
         json.removeValue(forKey: "payment_method_types")
-        var checkoutItems = json["checkout_items"] as! [[String: Any]]
-        var oneTimePrice = checkoutItems[0]["one_time_price"] as! [String: Any]
-        var items = oneTimePrice["items"] as! [[String: Any]]
-        items[0].removeValue(forKey: "subtotal")
-        items[0].removeValue(forKey: "total")
-        oneTimePrice["items"] = items
-        checkoutItems[0]["one_time_price"] = oneTimePrice
-        json["checkout_items"] = checkoutItems
 
         XCTAssertNoThrow(try PaymentPagesAPIResponse.decode(fromAPIResponse: json))
     }
@@ -688,9 +680,10 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         XCTAssertEqual(oneTimePrice.items[0].images, ["https://example.com/shirt.png"])
         XCTAssertEqual(oneTimePrice.items[0].quantity, 2)
         XCTAssertEqual(oneTimePrice.items[0].unitAmount.minorUnitsAmount, 1000)
-        XCTAssertEqual(oneTimePrice.amountDetails.subtotal.minorUnitsAmount, 2000)
-        XCTAssertEqual(oneTimePrice.amountDetails.total.minorUnitsAmount, 2148)
-        XCTAssertEqual(oneTimePrice.amountDetails.taxExclusive.minorUnitsAmount, 148)
+        XCTAssertEqual(oneTimePrice.items[0].amountDetails.subtotal.minorUnitsAmount, 2000)
+        XCTAssertEqual(oneTimePrice.items[0].amountDetails.total.minorUnitsAmount, 2148)
+        XCTAssertEqual(oneTimePrice.items[0].amountDetails.taxExclusive.minorUnitsAmount, 148)
+        XCTAssertNil(oneTimePrice.items[0].amountDetails.taxAmounts)
 
         XCTAssertEqual(session.taxAmounts?.count, 1)
         XCTAssertEqual(session.taxAmounts?[0].minorUnitsAmount, 148)
@@ -703,6 +696,57 @@ class PaymentPagesAPIResponseTest: XCTestCase {
         XCTAssertEqual(session.totals.taxExclusive.minorUnitsAmount, 148)
         XCTAssertEqual(session.totals.discount.minorUnitsAmount, 0)
         XCTAssertEqual(session.totals.total.minorUnitsAmount, 2148)
+    }
+
+    func testOneTimePriceMapsAmountDetailsPerItem() throws {
+        let json = modifyingOneTimePrice { oneTimePrice in
+            var firstItem = (oneTimePrice["items"] as! [[String: Any]])[0]
+            firstItem["inner_item_key"] = "first_item"
+            firstItem["subtotal"] = 1000
+            firstItem["total"] = 1100
+            firstItem["tax_inclusive"] = 0
+            firstItem["tax_exclusive"] = 100
+            firstItem["tax_amounts"] = [[
+                "amount": 100,
+                "inclusive": false,
+                "tax_rate": ["display_name": "Sales Tax", "percentage": 10.0],
+            ], ]
+
+            var secondItem = firstItem
+            secondItem["inner_item_key"] = "second_item"
+            secondItem["subtotal"] = 2000
+            secondItem["total"] = 2000
+            secondItem["tax_inclusive"] = 50
+            secondItem["tax_exclusive"] = 0
+            secondItem["tax_amounts"] = [[
+                "amount": 50,
+                "inclusive": true,
+                "tax_rate": ["display_name": "VAT", "percentage": 2.5],
+            ], ]
+
+            oneTimePrice["items"] = [firstItem, secondItem]
+            oneTimePrice["subtotal"] = 3000
+            oneTimePrice["total"] = 3100
+        }
+
+        let session = try PaymentPagesAPIResponse.decode(fromAPIResponse: json).makePublicSession()
+        guard case .oneTimePrice(let oneTimePrice) = session.orderSummaryItems.first else {
+            return XCTFail("Expected one-time price order summary item")
+        }
+
+        let firstAmountDetails = oneTimePrice.items[0].amountDetails
+        XCTAssertEqual(firstAmountDetails.subtotal.minorUnitsAmount, 1000)
+        XCTAssertEqual(firstAmountDetails.total.minorUnitsAmount, 1100)
+        XCTAssertEqual(firstAmountDetails.taxExclusive.minorUnitsAmount, 100)
+        XCTAssertEqual(firstAmountDetails.taxInclusive.minorUnitsAmount, 0)
+        XCTAssertEqual(firstAmountDetails.taxAmounts?.first?.displayName, "Sales Tax")
+
+        let secondAmountDetails = oneTimePrice.items[1].amountDetails
+        XCTAssertEqual(secondAmountDetails.subtotal.minorUnitsAmount, 2000)
+        XCTAssertEqual(secondAmountDetails.total.minorUnitsAmount, 2000)
+        XCTAssertEqual(secondAmountDetails.taxExclusive.minorUnitsAmount, 0)
+        XCTAssertEqual(secondAmountDetails.taxInclusive.minorUnitsAmount, 50)
+        XCTAssertEqual(secondAmountDetails.taxAmounts?.first?.displayName, "VAT")
     }
 
     func testTotalsSumOneTimePrices() {
@@ -804,6 +848,8 @@ class PaymentPagesAPIResponseTest: XCTestCase {
             "inner_item_key",
             "price",
             "quantity",
+            "subtotal",
+            "total",
             "tax_amounts",
             "tax_inclusive",
             "tax_exclusive",


### PR DESCRIPTION
## Summary
Move one-time Price amount details from the Checkout item group to each sub-item, per changes in https://docs.google.com/document/d/1KUPx71jTOsRU4rUpyF21jYG8Pg5oe-FlUInsQ1TWuCU/edit?tab=t.mbyu6dbsos8j#heading=h.8pcoo71xz60e
```
oneTimePrice.amountDetails
  → oneTimePrice.items[].amountDetails
```
Will add discounts in another PR.

## Some context 
 A unified-mode one-time-price checkout item is a group containing one or more configured Prices:
```
  one_time_price
  ├── item: T-shirt × 2
  └── item: Hat × 1

  Payment Pages already computes amounts for each individual Price:

  {
    "one_time_price": {
      "items": [
        {
          "inner_item_key": "shirt",
          "quantity": 2,
          "subtotal": 2000,
          "total": 2148,
          "tax_inclusive": 0,
          "tax_exclusive": 148,
          "tax_amounts": []
        }
      ],
      "subtotal": 2000,
      "total": 2148
    }
  }
```
  So the backend gives us both:
```
  Group totals:     one_time_price.subtotal / total
  Per-price totals: one_time_price.items[].subtotal / total / tax
```
## Testing
- Added coverage showing that two one-time Price sub-items preserve their distinct subtotals, totals, and inclusive or exclusive taxes.
- Updated coverage to verify that responses missing required per-sub-item subtotal or total values are rejected.
