### PR TITLE
Simplify PaymentElement billing details configuration

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -214,14 +214,6 @@ extension PaymentElement {
 
     /// Configuration for how billing details are collected during checkout.
     public struct BillingDetailsCollectionConfiguration: Equatable {
-        /// Billing details fields collection options.
-        public enum CollectionMode: String, CaseIterable {
-            /// The field will be collected depending on the Payment Method's requirements.
-            case automatic
-            /// The field will always be collected, even if it isn't required for the Payment Method.
-            case always
-        }
-
         /// Billing address collection options.
         public enum AddressCollectionMode: String, CaseIterable {
             /// Only the fields required by the Payment Method will be collected, this may be none.
@@ -230,45 +222,21 @@ extension PaymentElement {
             case full
         }
 
-        /// How to collect the name field.
-        /// Defaults to `automatic`.
-        public var name: CollectionMode = .automatic
-
-        /// How to collect the email field.
-        /// Defaults to `automatic`.
-        /// - Note: Intentionally non-public, unclear what the merchant use case for this is given they need to provide an email up-front.
-        let email: CollectionMode = .automatic
-
         /// How to collect the billing address.
         /// Defaults to `automatic`.
         public var address: AddressCollectionMode = .automatic
 
-        /// Whether the values included in `Configuration.defaultBillingDetails` should be attached to the payment
-        /// method, this includes fields that aren't displayed in the form.
-        ///
-        /// If `false` (the default), those values will only be used to prefill the corresponding fields in the form.
-        public var attachDefaultsToPaymentMethod = false
-
         /// A set of two-letter country codes representing countries the customers can select.
         /// If the set is empty (the default), we display all countries.
-        /// Country codes are automatically normalized to uppercase.
         /// - Note: Saved payment methods whose billing address country is not in this list are hidden.
-        public var allowedCountries: Set<String> = [] {
-            didSet {
-                allowedCountries = Set(allowedCountries.map { $0.uppercased() })
-            }
-        }
-
+        public var allowedCountries: Set<String> = []
     }
 }
 
 private extension PaymentElement.BillingDetailsCollectionConfiguration {
     func paymentSheetConfiguration() -> PaymentSheet.BillingDetailsCollectionConfiguration {
         var configuration = PaymentSheet.BillingDetailsCollectionConfiguration()
-        configuration.name = .init(rawValue: name.rawValue)!
-        configuration.email = .init(rawValue: email.rawValue)!
         configuration.address = address.paymentSheetAddressCollectionMode
-        configuration.attachDefaultsToPaymentMethod = attachDefaultsToPaymentMethod
         configuration.allowedCountries = allowedCountries
         return configuration
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -228,8 +228,13 @@ extension PaymentElement {
 
         /// A set of two-letter country codes representing countries the customers can select.
         /// If the set is empty (the default), we display all countries.
+        /// Country codes are automatically normalized to uppercase.
         /// - Note: Saved payment methods whose billing address country is not in this list are hidden.
-        public var allowedCountries: Set<String> = []
+        public var allowedCountries: Set<String> = [] {
+            didSet {
+                allowedCountries = Set(allowedCountries.map { $0.uppercased() })
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- simplify `PaymentElement.BillingDetailsCollectionConfiguration` to expose only address collection and allowed countries
- remove unused name, email, collection mode, and attach-defaults configuration

## Testing
No new tests.