### PR TITLE
Move Checkout wallet configuration under Payment Element

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -172,7 +172,7 @@ struct CheckoutCartView: View {
                 paymentPagesRequestDelay: delayPaymentPagesRequests ? 1 : 0
             )
             config.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails
-            config.applePayConfiguration = CheckoutController.ApplePayConfiguration(
+            config.paymentElement.applePayConfiguration = PaymentElement.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example"
             )
             if adaptivePricing {

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
@@ -225,7 +225,7 @@ final class CheckoutCartViewController: UIViewController {
                 returnURL: "payments-example://stripe-redirect"
             )
             configuration.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails
-            configuration.applePayConfiguration = CheckoutController.ApplePayConfiguration(
+            configuration.paymentElement.applePayConfiguration = PaymentElement.ApplePayConfiguration(
                 merchantId: "merchant.com.stripe.paymentsheet.example"
             )
             var expressCheckoutElementConfig = ExpressCheckoutElement.Configuration()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -61,12 +61,6 @@ extension CheckoutController {
         /// ``CheckoutController.getShippingAddressElement()``.
         public var shippingAddressElement: ShippingAddressElement.Configuration = .init()
 
-        /// Apple Pay configuration.
-        public var applePayConfiguration: ApplePayConfiguration?
-
-        /// Link configuration.
-        public var linkConfiguration: LinkConfiguration?
-
         /// The color styling to use for Checkout UI.
         public var userInterfaceStyle: UserInterfaceStyle = .automatic
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
@@ -117,7 +117,7 @@ extension CheckoutController {
         // Normalize Payment Element state here, then build the corresponding confirmation flow.
         switch paymentOption {
         case .applePay:
-            guard let applePayConfiguration = self.configuration.applePayConfiguration else { return nil }
+            guard let applePayConfiguration = self.configuration.paymentElement.applePayConfiguration else { return nil }
             return .applePay(.init(
                 applePayConfiguration: applePayConfiguration,
                 apiClient: apiClient,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutApplePayContext.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutApplePayContext.swift
@@ -237,7 +237,7 @@ final class CheckoutApplePayContext: NSObject, PKPaymentAuthorizationControllerD
             applePayConfirmationParameters: applePayConfirmationParameters
         )
 
-        assert(!paymentRequest.merchantIdentifier.isEmpty, "You must set `merchantId` on `CheckoutController.ApplePayConfiguration`.")
+        assert(!paymentRequest.merchantIdentifier.isEmpty, "You must set `merchantId` on `PaymentElement.ApplePayConfiguration`.")
 
         let merchantLabel = applePayConfirmationParameters.merchantDisplayName
         paymentRequest.paymentSummaryItems = CheckoutApplePayContext.makeSummaryItems(for: checkoutSession, label: merchantLabel)

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+ApplePayConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+ApplePayConfiguration.swift
@@ -1,5 +1,5 @@
 //
-//  Checkout+ApplePayConfiguration.swift
+//  PaymentElement+ApplePayConfiguration.swift
 //  StripePaymentSheet
 //
 //  Created by Joyce Qin on 7/22/26.
@@ -9,7 +9,7 @@ import PassKit
 
 /// The merchant identity needed to build an Apple Pay payment request.
 ///
-/// Bridges ``CheckoutController/ApplePayConfiguration`` (Payment Element) and
+/// Bridges ``PaymentElement/ApplePayConfiguration`` and
 /// ``ExpressCheckoutElement/ApplePayConfiguration`` (ExpressCheckoutElement) so Apple Pay
 /// confirmation code can accept either without caring which surface it came from.
 @_spi(STP)
@@ -24,7 +24,7 @@ public protocol CheckoutApplePayConfiguration {
 
 @_spi(STP)
 @_spi(ReactNativeSDK)
-extension CheckoutController {
+extension PaymentElement {
     /// Configuration for Apple Pay.
     public struct ApplePayConfiguration: CheckoutApplePayConfiguration {
         /// The Apple Pay merchant identifier.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -16,6 +16,12 @@ extension PaymentElement {
         /// Initializes a Configuration with default values.
         public init() {}
 
+        /// Configuration for Apple Pay.
+        public var applePayConfiguration: ApplePayConfiguration?
+
+        /// Configuration for Link.
+        public var linkConfiguration: LinkConfiguration?
+
         /// PaymentSheet offers users an option to save some payment methods for later use.
         /// Default value is `.automatic`.
         public var savePaymentMethodOptInBehavior: SavePaymentMethodOptInBehavior = .automatic {
@@ -130,7 +136,6 @@ extension PaymentElement {
             apiClient: STPAPIClient,
             returnURL: String,
             defaults: CheckoutController.Configuration.Defaults,
-            linkConfiguration: CheckoutController.LinkConfiguration?,
             merchantDisplayName: String,
             userInterfaceStyle: CheckoutController.UserInterfaceStyle
         ) -> EmbeddedPaymentElement.Configuration {
@@ -155,7 +160,6 @@ extension PaymentElement {
             apiClient: STPAPIClient,
             returnURL: String,
             defaults: CheckoutController.Configuration.Defaults,
-            linkConfiguration: CheckoutController.LinkConfiguration?,
             merchantDisplayName: String,
             userInterfaceStyle: CheckoutController.UserInterfaceStyle
         ) -> PaymentSheet.Configuration {
@@ -179,7 +183,7 @@ extension PaymentElement {
 }
 
 private extension PaymentSheet.Configuration {
-    mutating func apply(linkConfiguration: CheckoutController.LinkConfiguration?) {
+    mutating func apply(linkConfiguration: PaymentElement.LinkConfiguration?) {
         switch linkConfiguration?.display {
         case .none, .automatic:
             link.display = .automatic
@@ -192,7 +196,7 @@ private extension PaymentSheet.Configuration {
 }
 
 private extension EmbeddedPaymentElement.Configuration {
-    mutating func apply(linkConfiguration: CheckoutController.LinkConfiguration?) {
+    mutating func apply(linkConfiguration: PaymentElement.LinkConfiguration?) {
         switch linkConfiguration?.display {
         case .none, .automatic:
             link.display = .automatic

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+LinkConfiguration.swift
@@ -1,5 +1,5 @@
 //
-//  Checkout+LinkConfiguration.swift
+//  PaymentElement+LinkConfiguration.swift
 //  StripePaymentSheet
 //
 //  Created by Joyce Qin on 7/22/26.
@@ -7,7 +7,7 @@
 
 @_spi(STP)
 @_spi(ReactNativeSDK)
-extension CheckoutController {
+extension PaymentElement {
     /// Configuration for Link.
     public struct LinkConfiguration {
         /// Controls whether Link is displayed.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -76,7 +76,6 @@ public final class PaymentElement {
             apiClient: checkout.apiClient,
             returnURL: checkout.configuration.returnURL,
             defaults: checkout.configuration.defaults,
-            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
@@ -89,7 +88,6 @@ public final class PaymentElement {
             apiClient: checkout.apiClient,
             returnURL: checkout.configuration.returnURL,
             defaults: checkout.configuration.defaults,
-            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
@@ -148,7 +146,6 @@ extension PaymentElement {
             apiClient: checkout.apiClient,
             returnURL: checkout.configuration.returnURL,
             defaults: checkout.configuration.defaults,
-            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )
@@ -156,7 +153,6 @@ extension PaymentElement {
             apiClient: checkout.apiClient,
             returnURL: checkout.configuration.returnURL,
             defaults: checkout.configuration.defaults,
-            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
         )

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutTestHelpers.swift
@@ -385,7 +385,7 @@ extension CheckoutController.ApplePayConfirmationParameters {
         apiClient: STPAPIClient,
         returnURL: String = "stripe-ios-test://checkout-return",
         merchantDisplayName: String = "Test Merchant",
-        applePayConfiguration: CheckoutController.ApplePayConfiguration = CheckoutController.ApplePayConfiguration(merchantId: "merchant.com.test"),
+        applePayConfiguration: PaymentElement.ApplePayConfiguration = PaymentElement.ApplePayConfiguration(merchantId: "merchant.com.test"),
         billingDetailsCollectionConfiguration: PaymentSheet.BillingDetailsCollectionConfiguration,
         defaultBillingDetails: CheckoutController.Configuration.Defaults.BillingDetails? = nil,
         presentationWindow: UIWindow? = nil

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -33,6 +33,48 @@ final class PaymentElementTest: XCTestCase {
         super.tearDown()
     }
 
+    func testConfigurationSetsLinkDisplay() async throws {
+        // Given Payment Element configures Link to hide its wallet button
+        var checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
+        checkoutConfiguration.paymentElement.linkConfiguration = PaymentElement.LinkConfiguration(display: .walletButtonHidden)
+
+        // When Checkout creates Payment Element
+        let checkout = try await CheckoutController(
+            configuration: CheckoutTestHelpers.makeConfiguration(configuration: checkoutConfiguration)
+        )
+
+        // Then both Payment Element presentations use the nested Link configuration
+        let paymentElement = checkout.getPaymentElement()
+        XCTAssertEqual(paymentElement.paymentSheetFlowController.configuration.link.display, .walletButtonHidden)
+        XCTAssertEqual(paymentElement.embeddedPaymentElement.configuration.link.display, .walletButtonHidden)
+    }
+
+    func testConfirmationUsesPaymentElementApplePayConfiguration() async throws {
+        // Given Payment Element has an Apple Pay configuration and Apple Pay is selected
+        var checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
+        checkoutConfiguration.paymentElement.applePayConfiguration = PaymentElement.ApplePayConfiguration(
+            merchantId: "merchant.com.test.payment-element"
+        )
+        let checkout = try await CheckoutController(
+            configuration: CheckoutTestHelpers.makeConfiguration(configuration: checkoutConfiguration)
+        )
+        let paymentElement = checkout.getPaymentElement()
+        paymentElement.embeddedPaymentElement._test_paymentOption = .applePay
+
+        // When Checkout creates the confirmation flow
+        let flow = checkout.makeConfirmationFlow(
+            for: paymentElement,
+            presentingViewController: UIViewController()
+        )
+
+        // Then it uses Apple Pay configuration from Payment Element
+        guard case .applePay(let parameters) = flow else {
+            XCTFail("Expected an Apple Pay confirmation flow")
+            return
+        }
+        XCTAssertEqual(parameters.applePayConfiguration.merchantId, "merchant.com.test.payment-element")
+    }
+
     func testConfigurationSetsCheckoutDefaultBillingDetails() async throws {
         // Given Checkout billing defaults
         var checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")


### PR DESCRIPTION
## Summary

Moves Apple Pay and Link configuration from `CheckoutController.Configuration` to `PaymentElement.Configuration`. Payment Element now owns the wallet settings it uses for display and confirmation.

## Motivation

Match the Checkout Sessions API review.

## Testing

- Added coverage that Link display configuration reaches both Payment Element presentations.
- Added coverage that Apple Pay confirmation uses the Payment Element configuration.
- Existing Payment Element tests pass locally.

## Changelog

N/A
