### PR TITLE
Rename Checkout ConfirmResult success case to completed 🪿✨

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -133,7 +133,7 @@ struct CheckoutCartView: View {
 
     private var confirmResultAlertTitle: String {
         switch confirmResult {
-        case .succeeded: return "Success"
+        case .completed: return "Success"
         case .canceled: return "Canceled"
         case .failed: return "Unable to complete checkout"
         case nil: return ""
@@ -142,7 +142,7 @@ struct CheckoutCartView: View {
 
     private var confirmResultAlertMessage: String {
         switch confirmResult {
-        case .succeeded(let paymentStatus): return "Payment status: \(paymentStatus)"
+        case .completed(let paymentStatus): return "Payment status: \(paymentStatus)"
         case .canceled: return "The payment was canceled."
         case .failed(let error):
             return "Localized: \(error.localizedDescription)\n\nDebug: \(String(reflecting: error))"
@@ -152,7 +152,7 @@ struct CheckoutCartView: View {
 
     private func acknowledgeConfirmResult() {
         let confirmationSucceeded: Bool
-        if case .succeeded = confirmResult {
+        if case .completed = confirmResult {
             confirmationSucceeded = true
         } else {
             confirmationSucceeded = false

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
@@ -871,7 +871,7 @@ final class CheckoutCartViewController: UIViewController {
             let message: String
             let dismissOnAcknowledgment: Bool
             switch result {
-            case .succeeded(let paymentStatus):
+            case .completed(let paymentStatus):
                 title = "Success"
                 message = "Payment status: \(paymentStatus)"
                 dismissOnAcknowledgment = true

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Confirm.swift
@@ -252,7 +252,7 @@ extension CheckoutController {
     static func mapConfirmationResult(_ result: InternalConfirmResult) -> ConfirmResult {
         switch result {
         case .completed(let response):
-            return .succeeded(paymentStatus: response.paymentStatus)
+            return .completed(paymentStatus: response.paymentStatus)
         case .canceled:
             return .canceled
         case .failed(let error, _):

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -337,7 +337,7 @@ public final class CheckoutController: ObservableObject {
 
     /// Use this method to confirm the Checkout Session.
     /// - Parameter presentingViewController: The view controller used to present any view controllers required e.g. to authenticate the customer. If you're using SwiftUI, you may pass nil and it will use the topmost UIViewController from the key window (not compatible with multi-scene apps).
-    /// - Returns: A `ConfirmResult` enum - either succeeded, canceled, or failed.
+    /// - Returns: A `ConfirmResult` enum - either completed, canceled, or failed.
     public func confirm(from presentingViewController: UIViewController? = nil) async -> ConfirmResult {
         guard let presentingViewController = presentingViewController ?? UIWindow.visibleViewController else {
             let errorMessage = "CheckoutController.confirm(from:) could not find a presenting view controller."
@@ -357,9 +357,9 @@ public final class CheckoutController: ObservableObject {
     /// The result of an attempt to confirm a Checkout Session.
     /// This is a convenience abstraction over the underlying Checkout Session's status and paymentStatus properties.
     public enum ConfirmResult {
-        /// The Checkout Session succeeded.
+        /// The Checkout Session completed.
         /// - Parameter paymentStatus: The payment status of the Checkout Session, one of `paid`, `unpaid`, or `no_payment_required`.
-        case succeeded(paymentStatus: Session.Status.PaymentStatus)
+        case completed(paymentStatus: Session.Status.PaymentStatus)
         /// The customer canceled the confirmation attempt.
         case canceled
         /// Confirmation failed with an error.

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutConfirmationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutConfirmationTests.swift
@@ -27,8 +27,8 @@ final class CheckoutConfirmationTests: APIStubbedTestCase {
         let result = await checkout.confirm(makePaymentMethodFlow(for: checkout))
 
         // Then it maps the result and commits the returned Checkout Session
-        guard case .succeeded(let paymentStatus) = result else {
-            XCTFail("Expected confirmation to succeed, got \(result)")
+        guard case .completed(let paymentStatus) = result else {
+            XCTFail("Expected confirmation to complete, got \(result)")
             return
         }
         XCTAssertEqual(paymentStatus, .paid)
@@ -857,8 +857,8 @@ final class CheckoutConfirmationTests: APIStubbedTestCase {
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
-        guard case .succeeded(let paymentStatus) = result else {
-            XCTFail("Expected confirmation to succeed, got \(result)", file: file, line: line)
+        guard case .completed(let paymentStatus) = result else {
+            XCTFail("Expected confirmation to complete, got \(result)", file: file, line: line)
             return
         }
         XCTAssertEqual(paymentStatus, .paid, file: file, line: line)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -937,8 +937,8 @@ final class CheckoutUnitTests: XCTestCase {
         let result = CheckoutController.mapConfirmationResult(.completed(response))
 
         // Then success preserves the Checkout Session payment status
-        guard case .succeeded(let paymentStatus) = result else {
-            return XCTFail("Expected confirmation to succeed")
+        guard case .completed(let paymentStatus) = result else {
+            return XCTFail("Expected confirmation to complete")
         }
         XCTAssertEqual(paymentStatus, .paid)
     }


### PR DESCRIPTION
[Minion run](https://orbit.corp.stripe.com/sessions/abfd11af-db3c-42f8-bdfd-34b0790bd3fc)

#### 🧑‍💻 Human summary
<!-- To be filled out by humans -->

#### 🤖 LLM summary

## Summary
Rename `CheckoutController.ConfirmResult.succeeded(paymentStatus:)` to `completed(paymentStatus:)` and update result mapping, tests, and Checkout Playground examples accordingly.

## Motivation
Align the iOS API with the proposed `Completed` success-case name. API review: https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE/edit?tab=t.0#heading=h.wy37pln22zhb

## Testing
Focused tests could not run because Xcode simulator tooling is unavailable in the current environment. `git diff --check` passes.

## Changelog
No changelog update; the existing changelog already describes the rename from `Succeeded` to `Completed`.