### PR TITLE
Remove unsupported Payment Element billing configuration fields 🪿✨

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -214,14 +214,6 @@ extension PaymentElement {
 
     /// Configuration for how billing details are collected during checkout.
     public struct BillingDetailsCollectionConfiguration: Equatable {
-        /// Billing details fields collection options.
-        public enum CollectionMode: String, CaseIterable {
-            /// The field will be collected depending on the Payment Method's requirements.
-            case automatic
-            /// The field will always be collected, even if it isn't required for the Payment Method.
-            case always
-        }
-
         /// Billing address collection options.
         public enum AddressCollectionMode: String, CaseIterable {
             /// Only the fields required by the Payment Method will be collected, this may be none.
@@ -230,24 +222,13 @@ extension PaymentElement {
             case full
         }
 
-        /// How to collect the name field.
-        /// Defaults to `automatic`.
-        public var name: CollectionMode = .automatic
-
         /// How to collect the email field.
         /// Defaults to `automatic`.
-        /// - Note: Intentionally non-public, unclear what the merchant use case for this is given they need to provide an email up-front.
-        let email: CollectionMode = .automatic
+        let email: PaymentSheet.BillingDetailsCollectionConfiguration.CollectionMode = .automatic
 
         /// How to collect the billing address.
         /// Defaults to `automatic`.
         public var address: AddressCollectionMode = .automatic
-
-        /// Whether the values included in `Configuration.defaultBillingDetails` should be attached to the payment
-        /// method, this includes fields that aren't displayed in the form.
-        ///
-        /// If `false` (the default), those values will only be used to prefill the corresponding fields in the form.
-        public var attachDefaultsToPaymentMethod = false
 
         /// A set of two-letter country codes representing countries the customers can select.
         /// If the set is empty (the default), we display all countries.
@@ -265,10 +246,8 @@ extension PaymentElement {
 private extension PaymentElement.BillingDetailsCollectionConfiguration {
     func paymentSheetConfiguration() -> PaymentSheet.BillingDetailsCollectionConfiguration {
         var configuration = PaymentSheet.BillingDetailsCollectionConfiguration()
-        configuration.name = .init(rawValue: name.rawValue)!
-        configuration.email = .init(rawValue: email.rawValue)!
+        configuration.email = email
         configuration.address = address.paymentSheetAddressCollectionMode
-        configuration.attachDefaultsToPaymentMethod = attachDefaultsToPaymentMethod
         configuration.allowedCountries = allowedCountries
         return configuration
     }


### PR DESCRIPTION
[Minion run](https://orbit.corp.stripe.com/sessions/5f0c67e6-e48e-4920-b355-5ac1ca7f2bd4)

#### 🧑‍💻 Human summary
<!-- To be filled out by humans -->

#### 🤖 LLM summary

## Summary
Remove `CollectionMode`, `name`, and `attachDefaultsToPaymentMethod` from `PaymentElement.BillingDetailsCollectionConfiguration`, leaving `address` and `allowedCountries` as its public properties while preserving the internal email mapping.

## Motivation
Align the public API with the [API review](https://docs.google.com/document/d/1mi1xmUzONmuX0tUwjDQ1PUBZZNWgaEuWTje2V1maXuE/edit?tab=t.0#heading=h.wy37pln22zhb).

## Testing
Not run because the required macOS and iOS simulator tooling is unavailable in this environment.

## Changelog
No changelog entry; this removes fields that were not part of the reviewed public API.