### PR TITLE
Allow clearing Checkout shipping addresses

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -267,6 +267,7 @@ public final class CheckoutController: ObservableObject {
         if session.shouldSendTaxRegion(for: "shipping") {
             // The Checkout Session update endpoint requires tax_region[country] and does not
             // support clearing tax_region, so keep the previous country.
+            // TODO(porter) When migrating to the CheckoutClient API, stop sending country only and send nil
             let countryOnlyAddress = Address(country: shippingAddress.address.country)
             try await performUpdate(
                 .setTaxRegion(countryOnlyAddress),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -237,32 +237,37 @@ public final class CheckoutController: ObservableObject {
         try await performUpdate(.setTaxRegion(address), canUpdateWhileSheetPresented: canUpdateWhileSheetPresented)
     }
 
-    /// Sets the shipping address for this checkout.
+    /// Sets or clears the shipping address for this checkout.
     ///
     /// The address is stored locally and merged into PaymentSheet configuration
     /// when presenting payment UI. If automatic tax is enabled and the tax
     /// address source is "shipping", the address is also sent to the server to
-    /// compute updated tax amounts.
+    /// compute updated tax amounts. Clearing the address removes its detailed tax
+    /// region fields, but keeps its country because the server requires one.
     ///
     /// - Parameters:
     ///   - name: The customer's full name.
-    ///   - address: The shipping address to set. To reset tax computation
+    ///   - address: The shipping address to set, or `nil` to clear it. To reset tax computation
     ///     to a country-only region, pass a ``CheckoutController.Address`` with just the country.
     /// - Throws: ``CheckoutError`` if the session is not open, or if
     ///   the server request fails.
     public func updateShippingAddress(
         name: String? = nil,
-        address: Address
+        address: Address?
     ) async throws {
-        if let allowedCountries = session.allowedShippingCountries,
+        if let address,
+           let allowedCountries = session.allowedShippingCountries,
            !allowedCountries.contains(address.country) {
             throw CheckoutError.invalidShippingCountry(countryCode: address.country)
         }
-        let shippingAddress = Session.ShippingAddress(name: name, address: address)
+        let shippingAddress = address.map { Session.ShippingAddress(name: name, address: $0) }
         guard session.shippingAddress != shippingAddress else { return }
-        if session.shouldSendTaxRegion(for: "shipping") {
+        let taxRegionAddress = address ?? session.shippingAddress.map {
+            Address(country: $0.address.country)
+        }
+        if let taxRegionAddress, session.shouldSendTaxRegion(for: "shipping") {
             try await performUpdate(
-                .setTaxRegion(address),
+                .setTaxRegion(taxRegionAddress),
                 shippingAddress: .newValue(shippingAddress)
             )
         } else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -255,23 +255,38 @@ public final class CheckoutController: ObservableObject {
         name: String? = nil,
         address: Address?
     ) async throws {
-        if let address,
-           let allowedCountries = session.allowedShippingCountries,
+        guard let address else {
+            try await clearShippingAddress()
+            return
+        }
+        if let allowedCountries = session.allowedShippingCountries,
            !allowedCountries.contains(address.country) {
             throw CheckoutError.invalidShippingCountry(countryCode: address.country)
         }
-        let shippingAddress = address.map { Session.ShippingAddress(name: name, address: $0) }
+        let shippingAddress = Session.ShippingAddress(name: name, address: address)
         guard session.shippingAddress != shippingAddress else { return }
-        let taxRegionAddress = address ?? session.shippingAddress.map {
-            Address(country: $0.address.country)
-        }
-        if let taxRegionAddress, session.shouldSendTaxRegion(for: "shipping") {
+        if session.shouldSendTaxRegion(for: "shipping") {
             try await performUpdate(
-                .setTaxRegion(taxRegionAddress),
+                .setTaxRegion(address),
                 shippingAddress: .newValue(shippingAddress)
             )
         } else {
             try await performUpdate(shippingAddress: .newValue(shippingAddress))
+        }
+    }
+
+    private func clearShippingAddress() async throws {
+        guard let shippingAddress = session.shippingAddress else { return }
+        if session.shouldSendTaxRegion(for: "shipping") {
+            // The server requires a country, so keep the previous one when clearing the tax region.
+            let countryOnlyAddress = Address(country: shippingAddress.address.country)
+            try await performUpdate(
+                .setTaxRegion(countryOnlyAddress),
+                shippingAddress: .newValue(nil)
+            )
+        } else {
+            // No server update is needed when shipping isn't the tax address source.
+            try await performUpdate(shippingAddress: .newValue(nil))
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -237,20 +237,7 @@ public final class CheckoutController: ObservableObject {
         try await performUpdate(.setTaxRegion(address), canUpdateWhileSheetPresented: canUpdateWhileSheetPresented)
     }
 
-    /// Sets or clears the shipping address for this checkout.
-    ///
-    /// The address is stored locally and merged into PaymentSheet configuration
-    /// when presenting payment UI. If automatic tax is enabled and the tax
-    /// address source is "shipping", the address is also sent to the server to
-    /// compute updated tax amounts. Clearing the address removes its detailed tax
-    /// region fields, but keeps its country because the server requires one.
-    ///
-    /// - Parameters:
-    ///   - name: The customer's full name.
-    ///   - address: The shipping address to set, or `nil` to clear it. To reset tax computation
-    ///     to a country-only region, pass a ``CheckoutController.Address`` with just the country.
-    /// - Throws: ``CheckoutError`` if the session is not open, or if
-    ///   the server request fails.
+    /// Use this method to update the Customer's shipping address.
     public func updateShippingAddress(
         name: String? = nil,
         address: Address?
@@ -278,7 +265,8 @@ public final class CheckoutController: ObservableObject {
     private func clearShippingAddress() async throws {
         guard let shippingAddress = session.shippingAddress else { return }
         if session.shouldSendTaxRegion(for: "shipping") {
-            // The server requires a country, so keep the previous one when clearing the tax region.
+            // The Checkout Session update endpoint requires tax_region[country] and does not
+            // support clearing tax_region, so keep the previous country.
             let countryOnlyAddress = Address(country: shippingAddress.address.country)
             try await performUpdate(
                 .setTaxRegion(countryOnlyAddress),

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Shipping Address Element/ShippingAddressElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Shipping Address Element/ShippingAddressElement.swift
@@ -11,8 +11,8 @@ import UIKit
 /// Handles Checkout mutations requested by a ShippingAddressElement.
 @MainActor
 protocol ShippingAddressElementDelegate: AnyObject {
-    /// Sets the customer's shipping address.
-    func updateShippingAddress(name: String?, address: CheckoutController.Address) async throws
+    /// Sets or clears the customer's shipping address.
+    func updateShippingAddress(name: String?, address: CheckoutController.Address?) async throws
 }
 
 /// A shipping address form backed by a Checkout Session.

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerSnapshotTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/AddressViewController/AddressViewControllerSnapshotTests.swift
@@ -297,7 +297,7 @@ private final class ShippingAddressElementSnapshotDelegate: ShippingAddressEleme
     var updateExpectation: XCTestExpectation?
     private var updateContinuation: CheckedContinuation<Void, Never>?
 
-    func updateShippingAddress(name: String?, address: CheckoutController.Address) async throws {
+    func updateShippingAddress(name: String?, address: CheckoutController.Address?) async throws {
         updateExpectation?.fulfill()
         await withCheckedContinuation { continuation in
             updateContinuation = continuation

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -217,6 +217,63 @@ final class CheckoutUnitTests: XCTestCase {
         XCTAssertEqual(recorder.loading, [true, false])
     }
 
+    func testUpdateShippingAddress_noTax_clearsLocallyAndEmitsUpdates() async throws {
+        // Given a Checkout with a locally stored shipping address
+        let checkout = try await CheckoutController(configuration: CheckoutTestHelpers.makeConfiguration())
+        try await checkout.updateShippingAddress(
+            name: "John Smith",
+            address: .init(country: "US", line1: "456 Oak Ave", city: "LA", state: "CA", postalCode: "90001")
+        )
+        let recorder = CheckoutEmissionRecorder(checkout)
+
+        // When the shipping address is cleared
+        try await checkout.updateShippingAddress(address: nil)
+
+        // Then Checkout clears its local shipping address
+        XCTAssertNil(checkout.session.shippingAddress)
+        XCTAssertEqual(recorder.sessions.count, 2)
+        XCTAssertEqual(recorder.loading, [true, false])
+    }
+
+    func testUpdateShippingAddress_clearReducesTaxRegionToPreviousCountry() async throws {
+        // Given a Checkout that computes automatic tax from a stored shipping address
+        let (checkout, _, requestRecorder) = try await makeCheckoutWithShippingTax()
+
+        // When the shipping address is cleared
+        try await checkout.updateShippingAddress(address: nil)
+
+        // Then Checkout clears local state and removes all tax region fields except country
+        XCTAssertNil(checkout.session.shippingAddress)
+        XCTAssertEqual(requestRecorder.requests.map(\.kind), [.initSession, .updateSession])
+        let updateParameters = try XCTUnwrap(requestRecorder.requests.last?.params)
+        XCTAssertEqual(updateParameters["tax_region[country]"], "US")
+        XCTAssertNil(updateParameters["tax_region[line1]"])
+        XCTAssertNil(updateParameters["tax_region[line2]"])
+        XCTAssertNil(updateParameters["tax_region[city]"])
+        XCTAssertNil(updateParameters["tax_region[state]"])
+        XCTAssertNil(updateParameters["tax_region[postal_code]"])
+    }
+
+    func testUpdateShippingAddress_clearFailurePreservesPreviousAddress() async throws {
+        // Given a Checkout whose automatic tax update will fail
+        let (checkout, previousAddress, _) = try await makeCheckoutWithShippingTax(
+            updateStatusCode: { _ in 500 }
+        )
+
+        // When the shipping address is cleared
+        do {
+            try await checkout.updateShippingAddress(address: nil)
+            XCTFail("Expected CheckoutError.apiError")
+        } catch CheckoutError.apiError {
+            // Expected
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+
+        // Then Checkout keeps the previous local address
+        XCTAssertEqual(checkout.session.shippingAddress, previousAddress)
+    }
+
     func testShippingAddressElementSaveUpdatesCheckoutSession() async throws {
         // Given a ShippingAddressElement connected to its Checkout
         let checkout = try await CheckoutController(configuration: CheckoutTestHelpers.makeConfiguration())
@@ -1044,6 +1101,47 @@ final class CheckoutUnitTests: XCTestCase {
         XCTAssertNil(params["payment_method_to_update[billing_details][address][line1]"])
         XCTAssertNil(params["payment_method_to_update[billing_details][address][city]"])
         XCTAssertEqual(params.count, 3)
+    }
+
+    private func makeCheckoutWithShippingTax(
+        updateStatusCode: @escaping (_ requestNumber: Int) -> Int32 = { _ in 200 }
+    ) async throws -> (
+        CheckoutController,
+        CheckoutController.Session.ShippingAddress,
+        CheckoutSessionRequestRecorder
+    ) {
+        var json = CheckoutTestHelpers.openSessionJSON
+        json["tax_context"] = [
+            "automatic_tax_enabled": true,
+            "automatic_tax_address_source": "session.shipping",
+        ]
+        let requestRecorder = CheckoutSessionRequestRecorder()
+        CheckoutTestHelpers.stubCheckoutSessionRequests(
+            sessionId: "cs_test_123",
+            requestRecorder: requestRecorder,
+            sessionJSON: { json },
+            updateStatusCode: updateStatusCode
+        )
+        var configuration = CheckoutController.Configuration(
+            clientSecret: "cs_test_123_secret_abc",
+            returnURL: "stripe-ios-test://checkout-return"
+        )
+        configuration.apiClient = STPAPIClient(publishableKey: "pk_test_123")
+        let checkout = try await CheckoutController(configuration: configuration)
+        let shippingAddress = CheckoutController.Session.ShippingAddress(
+            name: "John Smith",
+            address: .init(
+                country: "US",
+                line1: "456 Oak Ave",
+                city: "Los Angeles",
+                state: "CA",
+                postalCode: "90001"
+            )
+        )
+        checkout.dangerouslySetSessionDirectly(
+            checkout.session.makeCopyOverriding(shippingAddress: .newValue(shippingAddress))
+        )
+        return (checkout, shippingAddress, requestRecorder)
     }
 
     private func setOneTimePriceAmounts(

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/ShippingAddressElementPresentationTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/ShippingAddressElementPresentationTests.swift
@@ -292,7 +292,7 @@ private final class ShippingAddressElementDelegateMock: ShippingAddressElementDe
         self.error = error
     }
 
-    func updateShippingAddress(name: String?, address: CheckoutController.Address) async throws {
+    func updateShippingAddress(name: String?, address: CheckoutController.Address?) async throws {
         if let error {
             throw error
         }


### PR DESCRIPTION
## Summary

`updateShippingAddress` can now clear the Checkout Session's local shipping address. When shipping drives automatic tax, clearing the address removes its detailed tax region fields while retaining the previous country required by the server.

## Motivation

Checkout Elements API review

## Testing

- Added coverage for clearing a local shipping address.
- Added coverage that automatic tax clearing retains only the previous country.
- Added coverage that a failed tax update preserves the previous shipping address.
- All Checkout unit tests and Shipping Address Element presentation tests pass.

## Changelog

N/A
