### PR TITLE
Fix standard custom card 3DS2 UI test

### DIFF
--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUICardTests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUICardTests.swift
@@ -12,7 +12,7 @@ import XCTest
 class IntegrationTesterUICardTests: IntegrationTesterUITests {
 
     func testStandardCustomCard3DS2() throws {
-        testOOBAuthentication(cardNumber: "4000000000003220")
+        testAuthentication(cardNumber: "4000000000003220", confirmationBehavior: .threeDS2)
     }
 
     let alwaysOobCard = "4000582600000094"

--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
@@ -94,9 +94,9 @@ class IntegrationTesterUITests: XCTestCase {
             XCTAssertTrue(completeAuth.waitForExistence(timeout: 60.0))
             completeAuth.forceTapElement()
         case .threeDS2:
-            let completeAuth = app.scrollViews.otherElements.staticTexts["Complete Authentication"]
+            let completeAuth = app.buttons["COMPLETE"]
             XCTAssertTrue(completeAuth.waitForExistence(timeout: 60.0))
-            completeAuth.tap()
+            completeAuth.forceTapElement()
         }
 
         let statusView = app.staticTexts["Payment status view"]


### PR DESCRIPTION
## Summary
The standard custom card now displays the generic Stripe 3DS2 test challenge instead of the OOB challenge. Updates the UI test to complete that flow while keeping OOB coverage on the dedicated always-OOB card.

## Motivation
CI

## Testing
No new tests.

- Existing standard and OOB 3DS2 UI tests

## Changelog
N/A