### PR TITLE
Add PAYCO API bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ PATCH
 
 ## X.Y.Z - changes pending release
 
+### Payments
+* [Added] Added API bindings for PAYCO.
+
 ## 26.8.0 2026-08-24
 ### Payments
 * [Added] Added support for the following FPX banks: Agrobank, Bank of China, and MBSB Bank.

--- a/Stripe/StripeiOSTests/STPPaymentMethodPaycoTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodPaycoTest.swift
@@ -1,0 +1,43 @@
+//
+//  STPPaymentMethodPaycoTest.swift
+//  StripeiOSTests
+//
+//  Created by Nick Porter on 8/27/26.
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripePayments
+import XCTest
+
+final class STPPaymentMethodPaycoTest: XCTestCase {
+    func testParamsEncoding() {
+        let params = STPPaymentMethodParams(
+            payco: STPPaymentMethodPaycoParams(),
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        let encoded = STPFormEncoder.dictionary(forObject: params)
+
+        XCTAssertEqual(encoded["type"] as? String, "payco")
+    }
+
+    func testDecoding() {
+        let paymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: [
+            "id": "pm_payco",
+            "created": 1_725_000_000,
+            "type": "payco",
+            "payco": [:],
+        ])
+
+        XCTAssertEqual(paymentMethod?.type, .payco)
+        XCTAssertNotNil(paymentMethod?.payco)
+    }
+
+    func testTypeInitializerCreatesPaycoParams() {
+        let params = STPPaymentMethodParams(type: .payco)
+
+        XCTAssertNotNil(params.payco)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -276,7 +276,8 @@ extension PaymentSheet {
                     case .cardPresent, .blik, .weChatPay, .grabPay, .FPX, .przelewy24, .EPS,
                         .netBanking, .OXXO, .afterpayClearpay, .link, .affirm, .paynow, .zip, .alma,
                         .mobilePay, .vipps, .unknown, .konbini, .promptPay, .swish, .multibanco,
-                        .sunbit, .billie, .crypto, .payPay, .wero, .payByBank, .mbWay, .bizum:
+                        .sunbit, .billie, .crypto, .payPay, .wero, .payByBank, .mbWay, .bizum,
+                        .payco:
                         return [.unsupportedForSetup]
                     @unknown default:
                         return [.unsupportedForSetup]
@@ -301,7 +302,7 @@ extension PaymentSheet {
                         return [.userSupportsDelayedPaymentMethods]
                     case .bacsDebit:
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
-                    case .link, .unknown:
+                    case .link, .payco, .unknown:
                         return [.unsupported]
                     @unknown default:
                         return [.unsupported]
@@ -549,7 +550,7 @@ extension STPPaymentMethodParams {
             } else {
                 return "FPX"
             }
-        case .paynow, .zip, .amazonPay, .alma, .mobilePay, .vipps, .konbini, .promptPay, .swish, .sunbit, .billie, .satispay, .crypto, .iDEAL, .SEPADebit, .bacsDebit, .AUBECSDebit, .przelewy24, .EPS, .bancontact, .netBanking, .OXXO, .grabPay, .payPal, .afterpayClearpay, .blik, .weChatPay, .boleto, .link, .klarna, .affirm, .USBankAccount, .cashApp, .revolutPay, .twint, .multibanco, .alipay, .cardPresent, .payPay, .wero, .payByBank, .mbWay, .bizum:
+        case .paynow, .zip, .amazonPay, .alma, .mobilePay, .vipps, .konbini, .promptPay, .swish, .sunbit, .billie, .satispay, .crypto, .iDEAL, .SEPADebit, .bacsDebit, .AUBECSDebit, .przelewy24, .EPS, .bancontact, .netBanking, .OXXO, .grabPay, .payPal, .afterpayClearpay, .blik, .weChatPay, .boleto, .link, .klarna, .affirm, .USBankAccount, .cashApp, .revolutPay, .twint, .multibanco, .alipay, .cardPresent, .payPay, .wero, .payByBank, .mbWay, .bizum, .payco:
             // Use the label already defined in STPPaymentMethodType; the params object for these types don't contain additional information that affect the display label (like cards do)
             return type.displayName
         case .unknown:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -305,7 +305,7 @@ class PaymentSheetFormFactory {
                 return makeAUBECSDebit()
             case .FPX:
                 return makeFPX()
-            case .netBanking, .weChatPay, .link, .cardPresent, .unknown:
+            case .netBanking, .weChatPay, .link, .cardPresent, .payco, .unknown:
                 return makeUnexpectedEmptyForm(for: paymentMethod)
             @unknown default:
                 return makeUnexpectedEmptyForm(for: paymentMethod)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -939,7 +939,7 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
 
         let privatePreviewPaymentMethodTypes: [STPPaymentMethodType] = [.wero, .payByBank]
         // Payment methods whose payment_method_options aren't recognized by /v1/elements/sessions yet
-        let unsupportedPMOPaymentMethodTypes: [STPPaymentMethodType] = [.bizum, .vipps]
+        let unsupportedPMOPaymentMethodTypes: [STPPaymentMethodType] = [.bizum, .payco, .vipps]
         // Test successful load with valid payment method options
         let all_payment_methods_pmo_sfu_values: [STPPaymentMethodType: PaymentSheet.IntentConfiguration.SetupFutureUsage] = STPPaymentMethodType.allCases.reduce([:]) { partialResult, type in
             // Skip unknown, payment methods in private preview, and payment methods with unsupported PMO (not yet recognized by /v1/elements/sessions)

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
@@ -102,6 +102,8 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
     @objc private(set) public var wero: STPPaymentMethodWero?
     /// If this is a Pay by Bank PaymentMethod (i.e. `self.type == STPPaymentMethodTypePayByBank`), this contains additional details.
     @objc private(set) public var payByBank: STPPaymentMethodPayByBank?
+    /// If this is a PAYCO PaymentMethod (i.e. `self.type == STPPaymentMethodTypePayco`), this contains additional details.
+    @objc private(set) public var payco: STPPaymentMethodPayco?
 
     /// This field indicates whether this payment method can be shown again to its customer in a checkout flow
     @objc private(set) public var allowRedisplay: STPPaymentMethodAllowRedisplay
@@ -177,6 +179,7 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
             "twint = \(String(describing: twint))",
             "wero = \(String(describing: wero))",
             "payByBank = \(String(describing: payByBank))",
+            "payco = \(String(describing: payco))",
             "liveMode = \(liveMode ? "YES" : "NO")",
             "allowRedisplay = \(allResponseFields["allow_redisplay"] as? String ?? "")",
             "type = \(allResponseFields["type"] as? String ?? "")",
@@ -380,6 +383,9 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
         )
         paymentMethod.payByBank = STPPaymentMethodPayByBank.decodedObject(
             fromAPIResponse: dict.stp_dictionary(forKey: "pay_by_bank")
+        )
+        paymentMethod.payco = STPPaymentMethodPayco.decodedObject(
+            fromAPIResponse: dict.stp_dictionary(forKey: "payco")
         )
         return paymentMethod
     }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -102,6 +102,8 @@ import Foundation
     case mbWay
     /// A Bizum payment method
     case bizum
+    /// A PAYCO payment method
+    case payco
     /// An unknown type.
     case unknown
 
@@ -202,6 +204,8 @@ import Foundation
             return "MB WAY"
         case .bizum:
             return "Bizum"
+        case .payco:
+            return "PAYCO"
         case .cardPresent,
             .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
@@ -305,6 +309,8 @@ import Foundation
             return "mb_way"
         case .bizum:
             return "bizum"
+        case .payco:
+            return "payco"
         }
     }
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -115,6 +115,8 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
     @objc public var wero: STPPaymentMethodWeroParams?
     /// If this is a Pay by Bank PaymentMethod, this contains additional details.
     @objc public var payByBank: STPPaymentMethodPayByBankParams?
+    /// If this is a PAYCO PaymentMethod, this contains additional details.
+    @objc public var payco: STPPaymentMethodPaycoParams?
 
     /// Radar options that may contain HCaptcha token
     @objc @_spi(STP) public var radarOptions: STPRadarOptions?
@@ -786,6 +788,24 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
         self.metadata = metadata
     }
 
+    /// Creates params for a PAYCO PaymentMethod.
+    /// - Parameters:
+    ///   - payco:          An object containing additional PAYCO details.
+    ///   - billingDetails: Billing information associated with the PaymentMethod.
+    ///   - metadata:       Additional information to attach to the PaymentMethod.
+    @objc
+    public convenience init(
+        payco: STPPaymentMethodPaycoParams,
+        billingDetails: STPPaymentMethodBillingDetails?,
+        metadata: [String: String]?
+    ) {
+        self.init()
+        self.type = .payco
+        self.payco = payco
+        self.billingDetails = billingDetails
+        self.metadata = metadata
+    }
+
     // MARK: - STPFormEncodable
     @objc
     public class func rootObjectName() -> String? {
@@ -832,6 +852,7 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             NSStringFromSelector(#selector(getter: twint)): "twint",
             NSStringFromSelector(#selector(getter: wero)): "wero",
             NSStringFromSelector(#selector(getter: payByBank)): "pay_by_bank",
+            NSStringFromSelector(#selector(getter: payco)): "payco",
             NSStringFromSelector(#selector(getter: link)): "link",
             NSStringFromSelector(#selector(getter: radarOptions)): "radar_options",
             NSStringFromSelector(#selector(getter: metadata)): "metadata",
@@ -1281,6 +1302,8 @@ extension STPPaymentMethodParams {
             wero = STPPaymentMethodWeroParams()
         case .payByBank:
             payByBank = STPPaymentMethodPayByBankParams()
+        case .payco:
+            payco = STPPaymentMethodPaycoParams()
         case .cardPresent, .paynow, .zip, .konbini, .promptPay, .mbWay, .bizum:
             // These payment methods don't have any params
             break

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodPayco.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodPayco.swift
@@ -1,0 +1,37 @@
+//
+//  STPPaymentMethodPayco.swift
+//  StripePayments
+//
+//  Created by Nick Porter on 8/27/26.
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A PAYCO Payment Method.
+/// - seealso: https://docs.stripe.com/payments/payco/accept-a-payment
+public class STPPaymentMethodPayco: NSObject, STPAPIResponseDecodable {
+    /// :nodoc:
+    @objc private(set) public var allResponseFields: [AnyHashable: Any] = [:]
+
+    /// :nodoc:
+    @objc public override var description: String {
+        let props = [
+            String(format: "%@: %p", NSStringFromClass(STPPaymentMethodPayco.self), self)
+        ]
+        return "<\(props.joined(separator: "; "))>"
+    }
+
+    /// :nodoc:
+    @objc public class func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
+        guard let response else {
+            return nil
+        }
+        return self.init(dictionary: response)
+    }
+
+    required init(dictionary: [AnyHashable: Any]) {
+        super.init()
+        allResponseFields = dictionary
+    }
+}

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodPaycoParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodPaycoParams.swift
@@ -1,0 +1,22 @@
+//
+//  STPPaymentMethodPaycoParams.swift
+//  StripePayments
+//
+//  Created by Nick Porter on 8/27/26.
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An object representing parameters used to create a PAYCO Payment Method.
+public class STPPaymentMethodPaycoParams: NSObject, STPFormEncodable {
+    @objc public var additionalAPIParameters: [AnyHashable: Any] = [:]
+
+    @objc public class func rootObjectName() -> String? {
+        return "payco"
+    }
+
+    @objc public class func propertyNamesToFormFieldNamesMapping() -> [String: String] {
+        return [:]
+    }
+}

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -867,7 +867,8 @@ public class STPPaymentHandler: NSObject {
             .wero,
             .payByBank,
             .mbWay,
-            .bizum:
+            .bizum,
+            .payco:
             return false
 
         case .unknown:


### PR DESCRIPTION
## Summary
Adds StripePayments API bindings for PAYCO.

## Motivation
Korean payment methods

## Testing
- New tests verify PAYCO parameter encoding and response decoding.
- Existing loader coverage verifies unsupported setup future usage values are not sent for PAYCO.

## Changelog
See diff