### PR TITLE
Move Link configuration to PaymentElement

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -61,9 +61,6 @@ extension CheckoutController {
         /// ``CheckoutController.getShippingAddressElement()``.
         public var shippingAddressElement: ShippingAddressElement.Configuration = .init()
 
-        /// Link configuration.
-        public var linkConfiguration: LinkConfiguration?
-
         /// The color styling to use for Checkout UI.
         public var userInterfaceStyle: UserInterfaceStyle = .automatic
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -19,6 +19,9 @@ extension PaymentElement {
         /// Configuration for Apple Pay.
         public var applePayConfiguration: ApplePayConfiguration?
 
+        /// Configuration for Link.
+        public var linkConfiguration: LinkConfiguration?
+
         /// PaymentSheet offers users an option to save some payment methods for later use.
         /// Default value is `.automatic`.
         public var savePaymentMethodOptInBehavior: SavePaymentMethodOptInBehavior = .automatic {
@@ -133,7 +136,6 @@ extension PaymentElement {
             apiClient: STPAPIClient,
             returnURL: String,
             defaults: CheckoutController.Configuration.Defaults,
-            linkConfiguration: CheckoutController.LinkConfiguration?,
             merchantDisplayName: String,
             merchantCountryCode: String,
             userInterfaceStyle: CheckoutController.UserInterfaceStyle
@@ -162,7 +164,6 @@ extension PaymentElement {
             apiClient: STPAPIClient,
             returnURL: String,
             defaults: CheckoutController.Configuration.Defaults,
-            linkConfiguration: CheckoutController.LinkConfiguration?,
             merchantDisplayName: String,
             merchantCountryCode: String,
             userInterfaceStyle: CheckoutController.UserInterfaceStyle
@@ -200,7 +201,7 @@ private extension PaymentElement.ApplePayConfiguration {
 }
 
 private extension PaymentSheet.Configuration {
-    mutating func apply(linkConfiguration: CheckoutController.LinkConfiguration?) {
+    mutating func apply(linkConfiguration: PaymentElement.LinkConfiguration?) {
         switch linkConfiguration?.display {
         case .none, .automatic:
             link.display = .automatic
@@ -213,7 +214,7 @@ private extension PaymentSheet.Configuration {
 }
 
 private extension EmbeddedPaymentElement.Configuration {
-    mutating func apply(linkConfiguration: CheckoutController.LinkConfiguration?) {
+    mutating func apply(linkConfiguration: PaymentElement.LinkConfiguration?) {
         switch linkConfiguration?.display {
         case .none, .automatic:
             link.display = .automatic

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+LinkConfiguration.swift
@@ -1,5 +1,5 @@
 //
-//  Checkout+LinkConfiguration.swift
+//  PaymentElement+LinkConfiguration.swift
 //  StripePaymentSheet
 //
 //  Created by Joyce Qin on 7/22/26.
@@ -7,7 +7,7 @@
 
 @_spi(STP)
 @_spi(ReactNativeSDK)
-extension CheckoutController {
+extension PaymentElement {
     /// Configuration for Link.
     public struct LinkConfiguration {
         /// Controls whether Link is displayed.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -76,7 +76,6 @@ public final class PaymentElement {
             apiClient: checkout.apiClient,
             returnURL: checkout.configuration.returnURL,
             defaults: checkout.configuration.defaults,
-            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             merchantCountryCode: checkout.session.merchantCountryCode,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
@@ -90,7 +89,6 @@ public final class PaymentElement {
             apiClient: checkout.apiClient,
             returnURL: checkout.configuration.returnURL,
             defaults: checkout.configuration.defaults,
-            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             merchantCountryCode: checkout.session.merchantCountryCode,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
@@ -159,7 +157,6 @@ extension PaymentElement {
             apiClient: checkout.apiClient,
             returnURL: checkout.configuration.returnURL,
             defaults: checkout.configuration.defaults,
-            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             merchantCountryCode: checkout.session.merchantCountryCode,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle
@@ -168,7 +165,6 @@ extension PaymentElement {
             apiClient: checkout.apiClient,
             returnURL: checkout.configuration.returnURL,
             defaults: checkout.configuration.defaults,
-            linkConfiguration: checkout.configuration.linkConfiguration,
             merchantDisplayName: checkout.effectiveMerchantDisplayName,
             merchantCountryCode: checkout.session.merchantCountryCode,
             userInterfaceStyle: checkout.configuration.userInterfaceStyle

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -170,22 +170,6 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertTrue(embeddedConfiguration.allowsPaymentMethodsRequiringShippingAddress)
     }
 
-    func testConfigurationSetsLinkDisplay() async throws {
-        // Given Link is hidden in PaymentElement configuration
-        var checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
-        checkoutConfiguration.paymentElement.linkConfiguration = PaymentElement.LinkConfiguration(display: .never)
-
-        // When Checkout creates PaymentElement
-        let checkout = try await CheckoutController(
-            configuration: CheckoutTestHelpers.makeConfiguration(configuration: checkoutConfiguration)
-        )
-        let paymentElement = checkout.getPaymentElement()
-
-        // Then both presentations hide Link
-        XCTAssertEqual(paymentElement.paymentSheetFlowController.configuration.link.display, .never)
-        XCTAssertEqual(paymentElement.embeddedPaymentElement.configuration.link.display, .never)
-    }
-
     func testConfigurationSetsCheckoutDefaultShippingDetails() async throws {
         // Given Checkout shipping defaults
         var checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -169,6 +169,23 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertTrue(embeddedConfiguration.allowsDelayedPaymentMethods)
         XCTAssertTrue(embeddedConfiguration.allowsPaymentMethodsRequiringShippingAddress)
     }
+
+    func testConfigurationSetsLinkDisplay() async throws {
+        // Given Link is hidden in PaymentElement configuration
+        var checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
+        checkoutConfiguration.paymentElement.linkConfiguration = PaymentElement.LinkConfiguration(display: .never)
+
+        // When Checkout creates PaymentElement
+        let checkout = try await CheckoutController(
+            configuration: CheckoutTestHelpers.makeConfiguration(configuration: checkoutConfiguration)
+        )
+        let paymentElement = checkout.getPaymentElement()
+
+        // Then both presentations hide Link
+        XCTAssertEqual(paymentElement.paymentSheetFlowController.configuration.link.display, .never)
+        XCTAssertEqual(paymentElement.embeddedPaymentElement.configuration.link.display, .never)
+    }
+
     func testConfigurationSetsCheckoutDefaultShippingDetails() async throws {
         // Given Checkout shipping defaults
         var checkoutConfiguration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")


### PR DESCRIPTION
## Summary
Moves Link configuration from CheckoutController to PaymentElement.

## Motivation
Link display settings only affect Payment Element. This matches the API review and keeps element-specific configuration together.

## Testing
No new tests.

## Changelog
No changelog entry. This updates an unreleased API.