### PR TITLE
Rename runServerUpdate closure parameter 🪿✨

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -284,20 +284,20 @@ public final class CheckoutController: ObservableObject {
     /// Runs an async function that calls your server to update the Checkout Session,
     /// then automatically refreshes ``session`` with the latest session data.
     ///
-    /// A 20-second timeout is enforced. If `updateFunction` doesn't complete
+    /// A 20-second timeout is enforced. If `update` doesn't complete
     /// within 20 seconds, this method throws ``CheckoutError.timedOut``.
     ///
-    /// - Parameter updateFunction: An async throwing function that makes a request
+    /// - Parameter update: An async throwing function that makes a request
     ///   to your server to update the Checkout Session.
     /// - Throws: ``CheckoutError`` if the function times out, the session is not
     ///   open, or the refresh fails.
     public func runServerUpdate(
-        _ updateFunction: @escaping () async throws -> Void
+        _ update: @escaping () async throws -> Void
     ) async throws {
         try await enqueueSessionUpdate {
             try self.requireSheetNotPresented()
             let result = await withTimeout(Self.serverUpdateTimeout) {
-                try await updateFunction()
+                try await update()
             }
             if case .failure(let error) = result {
                 if error is TimeoutError {


### PR DESCRIPTION
[Minion run](https://orbit.corp.stripe.com/sessions/ad457673-cd94-47f3-88d7-be3649309028)

#### 🧑‍💻 Human summary
<!-- To be filled out by humans -->

#### 🤖 LLM summary

## Summary
Renames the `runServerUpdate` closure parameter from `updateFunction` to `update` in its declaration, implementation, and documentation.

## Motivation
Uses a concise local parameter name for the server-update closure.

## Testing
Not run; this is a local identifier-only rename. `git diff --check` passes.

## Changelog
No changelog entry; this does not change runtime behavior.