### PR TITLE
Rename applyPromotionCode parameter for API review 🪿✨

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -197,10 +197,10 @@ public final class CheckoutController: ObservableObject {
     // MARK: - Promotion Codes
 
     /// Applies a promotion code to the session.
-    /// - Parameter code: The promotion code to apply.
+    /// - Parameter promotionCode: The promotion code to apply.
     /// - Throws: ``CheckoutError`` if applying the promotion code fails.
-    public func applyPromotionCode(_ code: String) async throws {
-        try await performUpdate(.setPromotionCode(code))
+    public func applyPromotionCode(_ promotionCode: String) async throws {
+        try await performUpdate(.setPromotionCode(promotionCode))
     }
 
     /// Removes the currently applied promotion code.


### PR DESCRIPTION
[Minion run](https://orbit.corp.stripe.com/sessions/40736937-36e4-4f2b-9034-711a49d528f3)

#### 🧑‍💻 Human summary
<!-- To be filled out by humans -->

#### 🤖 LLM summary

## Summary
Renames the local `applyPromotionCode` parameter from `code` to `promotionCode` and updates its documentation and use.

Matches API review

## Motivation
Uses a specific parameter name that matches the value passed to `setPromotionCode`.

## Testing

## Changelog
No changelog entry; this is a source-compatible local parameter rename.