### PR TITLE
Add SeQura API bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ PATCH
 ## X.Y.Z - changes pending release
 
 ### Payments
+* [Added] Added API bindings for SeQura.
 * [Added] Added API bindings for Korean cards.
 * [Added] Added API bindings for Naver Pay.
 * [Added] Added API bindings for PAYCO.

--- a/Stripe/StripeiOSTests/STPPaymentMethodSequraTest.swift
+++ b/Stripe/StripeiOSTests/STPPaymentMethodSequraTest.swift
@@ -1,0 +1,43 @@
+//
+//  STPPaymentMethodSequraTest.swift
+//  StripeiOSTests
+//
+//  Created by Nick Porter on 8/28/26.
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+@testable@_spi(STP) import StripeCore
+@testable@_spi(STP) import StripePayments
+import XCTest
+
+final class STPPaymentMethodSequraTest: XCTestCase {
+    func testParamsEncoding() {
+        let params = STPPaymentMethodParams(
+            sequra: STPPaymentMethodSequraParams(),
+            billingDetails: nil,
+            metadata: nil
+        )
+
+        let encoded = STPFormEncoder.dictionary(forObject: params)
+
+        XCTAssertEqual(encoded["type"] as? String, "sequra")
+    }
+
+    func testDecoding() {
+        let paymentMethod = STPPaymentMethod.decodedObject(fromAPIResponse: [
+            "id": "pm_sequra",
+            "created": 1_725_000_000,
+            "type": "sequra",
+            "sequra": [:],
+        ])
+
+        XCTAssertEqual(paymentMethod?.type, .sequra)
+        XCTAssertNotNil(paymentMethod?.sequra)
+    }
+
+    func testTypeInitializerCreatesSequraParams() {
+        let params = STPPaymentMethodParams(type: .sequra)
+
+        XCTAssertNotNil(params.sequra)
+    }
+}

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentMethodType.swift
@@ -277,7 +277,7 @@ extension PaymentSheet {
                         .netBanking, .OXXO, .afterpayClearpay, .link, .affirm, .paynow, .zip, .alma,
                         .mobilePay, .vipps, .unknown, .konbini, .promptPay, .swish, .multibanco,
                         .sunbit, .billie, .crypto, .payPay, .wero, .payByBank, .mbWay, .bizum,
-                        .krCard, .naverPay, .payco:
+                        .krCard, .naverPay, .payco, .sequra:
                         return [.unsupportedForSetup]
                     @unknown default:
                         return [.unsupportedForSetup]
@@ -302,7 +302,7 @@ extension PaymentSheet {
                         return [.userSupportsDelayedPaymentMethods]
                     case .bacsDebit:
                         return [.returnURL, .userSupportsDelayedPaymentMethods]
-                    case .link, .krCard, .naverPay, .payco, .unknown:
+                    case .link, .krCard, .naverPay, .payco, .sequra, .unknown:
                         return [.unsupported]
                     @unknown default:
                         return [.unsupported]
@@ -550,7 +550,7 @@ extension STPPaymentMethodParams {
             } else {
                 return "FPX"
             }
-        case .paynow, .zip, .amazonPay, .alma, .mobilePay, .vipps, .konbini, .promptPay, .swish, .sunbit, .billie, .satispay, .crypto, .iDEAL, .SEPADebit, .bacsDebit, .AUBECSDebit, .przelewy24, .EPS, .bancontact, .netBanking, .OXXO, .grabPay, .payPal, .afterpayClearpay, .blik, .weChatPay, .boleto, .link, .klarna, .affirm, .USBankAccount, .cashApp, .revolutPay, .twint, .multibanco, .alipay, .cardPresent, .payPay, .wero, .payByBank, .mbWay, .bizum, .krCard, .naverPay, .payco:
+        case .paynow, .zip, .amazonPay, .alma, .mobilePay, .vipps, .konbini, .promptPay, .swish, .sunbit, .billie, .satispay, .crypto, .iDEAL, .SEPADebit, .bacsDebit, .AUBECSDebit, .przelewy24, .EPS, .bancontact, .netBanking, .OXXO, .grabPay, .payPal, .afterpayClearpay, .blik, .weChatPay, .boleto, .link, .klarna, .affirm, .USBankAccount, .cashApp, .revolutPay, .twint, .multibanco, .alipay, .cardPresent, .payPay, .wero, .payByBank, .mbWay, .bizum, .krCard, .naverPay, .payco, .sequra:
             // Use the label already defined in STPPaymentMethodType; the params object for these types don't contain additional information that affect the display label (like cards do)
             return type.displayName
         case .unknown:

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFormFactory/PaymentSheetFormFactory.swift
@@ -305,7 +305,7 @@ class PaymentSheetFormFactory {
                 return makeAUBECSDebit()
             case .FPX:
                 return makeFPX()
-            case .netBanking, .weChatPay, .link, .cardPresent, .krCard, .naverPay, .payco, .unknown:
+            case .netBanking, .weChatPay, .link, .cardPresent, .krCard, .naverPay, .payco, .sequra, .unknown:
                 return makeUnexpectedEmptyForm(for: paymentMethod)
             @unknown default:
                 return makeUnexpectedEmptyForm(for: paymentMethod)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetLoaderTest.swift
@@ -939,7 +939,7 @@ final class PaymentSheetLoaderTest: STPNetworkStubbingTestCase {
 
         let privatePreviewPaymentMethodTypes: [STPPaymentMethodType] = [.wero, .payByBank]
         // Payment methods whose payment_method_options aren't recognized by /v1/elements/sessions yet
-        let unsupportedPMOPaymentMethodTypes: [STPPaymentMethodType] = [.bizum, .payco, .vipps]
+        let unsupportedPMOPaymentMethodTypes: [STPPaymentMethodType] = [.bizum, .payco, .sequra, .vipps]
         // Test successful load with valid payment method options
         let all_payment_methods_pmo_sfu_values: [STPPaymentMethodType: PaymentSheet.IntentConfiguration.SetupFutureUsage] = STPPaymentMethodType.allCases.reduce([:]) { partialResult, type in
             // Skip unknown, payment methods in private preview, and payment methods with unsupported PMO (not yet recognized by /v1/elements/sessions)

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethod.swift
@@ -108,6 +108,8 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
     @objc private(set) public var naverPay: STPPaymentMethodNaverPay?
     /// If this is a PAYCO PaymentMethod (i.e. `self.type == STPPaymentMethodTypePayco`), this contains additional details.
     @objc private(set) public var payco: STPPaymentMethodPayco?
+    /// If this is a SeQura PaymentMethod (i.e. `self.type == STPPaymentMethodTypeSequra`), this contains additional details.
+    @objc private(set) public var sequra: STPPaymentMethodSequra?
 
     /// This field indicates whether this payment method can be shown again to its customer in a checkout flow
     @objc private(set) public var allowRedisplay: STPPaymentMethodAllowRedisplay
@@ -186,6 +188,7 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
             "krCard = \(String(describing: krCard))",
             "naverPay = \(String(describing: naverPay))",
             "payco = \(String(describing: payco))",
+            "sequra = \(String(describing: sequra))",
             "liveMode = \(liveMode ? "YES" : "NO")",
             "allowRedisplay = \(allResponseFields["allow_redisplay"] as? String ?? "")",
             "type = \(allResponseFields["type"] as? String ?? "")",
@@ -398,6 +401,9 @@ public class STPPaymentMethod: NSObject, STPAPIResponseDecodable {
         )
         paymentMethod.payco = STPPaymentMethodPayco.decodedObject(
             fromAPIResponse: dict.stp_dictionary(forKey: "payco")
+        )
+        paymentMethod.sequra = STPPaymentMethodSequra.decodedObject(
+            fromAPIResponse: dict.stp_dictionary(forKey: "sequra")
         )
         return paymentMethod
     }

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodEnums.swift
@@ -108,6 +108,8 @@ import Foundation
     case naverPay
     /// A PAYCO payment method
     case payco
+    /// A SeQura payment method
+    case sequra
     /// An unknown type.
     case unknown
 
@@ -214,6 +216,8 @@ import Foundation
             return "Naver Pay"
         case .payco:
             return "PAYCO"
+        case .sequra:
+            return "SeQura"
         case .cardPresent,
             .unknown:
             return STPLocalizedString("Unknown", "Default missing source type label")
@@ -323,6 +327,8 @@ import Foundation
             return "naver_pay"
         case .payco:
             return "payco"
+        case .sequra:
+            return "sequra"
         }
     }
 

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/STPPaymentMethodParams.swift
@@ -121,6 +121,8 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
     @objc public var naverPay: STPPaymentMethodNaverPayParams?
     /// If this is a PAYCO PaymentMethod, this contains additional details.
     @objc public var payco: STPPaymentMethodPaycoParams?
+    /// If this is a SeQura PaymentMethod, this contains additional details.
+    @objc public var sequra: STPPaymentMethodSequraParams?
 
     /// Radar options that may contain HCaptcha token
     @objc @_spi(STP) public var radarOptions: STPRadarOptions?
@@ -846,6 +848,24 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
         self.metadata = metadata
     }
 
+    /// Creates params for a SeQura PaymentMethod.
+    /// - Parameters:
+    ///   - sequra:         An object containing additional SeQura details.
+    ///   - billingDetails: Billing information associated with the PaymentMethod.
+    ///   - metadata:       Additional information to attach to the PaymentMethod.
+    @objc
+    public convenience init(
+        sequra: STPPaymentMethodSequraParams,
+        billingDetails: STPPaymentMethodBillingDetails?,
+        metadata: [String: String]?
+    ) {
+        self.init()
+        self.type = .sequra
+        self.sequra = sequra
+        self.billingDetails = billingDetails
+        self.metadata = metadata
+    }
+
     // MARK: - STPFormEncodable
     @objc
     public class func rootObjectName() -> String? {
@@ -895,6 +915,7 @@ public class STPPaymentMethodParams: NSObject, STPFormEncodable {
             NSStringFromSelector(#selector(getter: krCard)): "kr_card",
             NSStringFromSelector(#selector(getter: naverPay)): "naver_pay",
             NSStringFromSelector(#selector(getter: payco)): "payco",
+            NSStringFromSelector(#selector(getter: sequra)): "sequra",
             NSStringFromSelector(#selector(getter: link)): "link",
             NSStringFromSelector(#selector(getter: radarOptions)): "radar_options",
             NSStringFromSelector(#selector(getter: metadata)): "metadata",
@@ -1350,6 +1371,8 @@ extension STPPaymentMethodParams {
             naverPay = STPPaymentMethodNaverPayParams()
         case .payco:
             payco = STPPaymentMethodPaycoParams()
+        case .sequra:
+            sequra = STPPaymentMethodSequraParams()
         case .cardPresent, .paynow, .zip, .konbini, .promptPay, .mbWay, .bizum:
             // These payment methods don't have any params
             break

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodSequra.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodSequra.swift
@@ -1,0 +1,37 @@
+//
+//  STPPaymentMethodSequra.swift
+//  StripePayments
+//
+//  Created by Nick Porter on 8/28/26.
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// A SeQura Payment Method.
+/// - seealso: https://docs.stripe.com/payments/sequra/accept-a-payment?payment-ui=direct-api
+public class STPPaymentMethodSequra: NSObject, STPAPIResponseDecodable {
+    /// :nodoc:
+    @objc private(set) public var allResponseFields: [AnyHashable: Any] = [:]
+
+    /// :nodoc:
+    @objc public override var description: String {
+        let props = [
+            String(format: "%@: %p", NSStringFromClass(STPPaymentMethodSequra.self), self)
+        ]
+        return "<\(props.joined(separator: "; "))>"
+    }
+
+    /// :nodoc:
+    @objc public class func decodedObject(fromAPIResponse response: [AnyHashable: Any]?) -> Self? {
+        guard let response else {
+            return nil
+        }
+        return self.init(dictionary: response)
+    }
+
+    required init(dictionary: [AnyHashable: Any]) {
+        super.init()
+        allResponseFields = dictionary
+    }
+}

--- a/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodSequraParams.swift
+++ b/StripePayments/StripePayments/Source/API Bindings/Models/PaymentMethods/Types/STPPaymentMethodSequraParams.swift
@@ -1,0 +1,22 @@
+//
+//  STPPaymentMethodSequraParams.swift
+//  StripePayments
+//
+//  Created by Nick Porter on 8/28/26.
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+import Foundation
+
+/// An object representing parameters used to create a SeQura Payment Method.
+public class STPPaymentMethodSequraParams: NSObject, STPFormEncodable {
+    @objc public var additionalAPIParameters: [AnyHashable: Any] = [:]
+
+    @objc public class func rootObjectName() -> String? {
+        return "sequra"
+    }
+
+    @objc public class func propertyNamesToFormFieldNamesMapping() -> [String: String] {
+        return [:]
+    }
+}

--- a/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
+++ b/StripePayments/StripePayments/Source/PaymentHandler/STPPaymentHandler.swift
@@ -870,7 +870,8 @@ public class STPPaymentHandler: NSObject {
             .bizum,
             .krCard,
             .naverPay,
-            .payco:
+            .payco,
+            .sequra:
             return false
 
         case .unknown:


### PR DESCRIPTION
## Summary

Adds API bindings for SeQura.

## Motivation

Adds the bindings needed to support SeQura in the mobile SDKs. See [EMEAPP-205](https://jira.corp.stripe.com/browse/EMEAPP-205).

## Testing

Added coverage for decoding and encoding SeQura payment methods and parameters.

Verified deferred intents exclude SeQura from unsupported off-session payment method options.

## Changelog

Added a Payments changelog entry.
