### PR TITLE
Fix Checkout Elements UI test card selection

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutElementsUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutElementsUITests.swift
@@ -33,7 +33,7 @@ final class CheckoutElementsUITests: PaymentSheetUITestCase {
         // When the customer selects a card in Payment Element
         app.buttons["Select payment method"].forceTapWhenHittableInTestCase(self)
         if !app.textFields["Card number"].waitForExistence(timeout: 2) {
-            app.buttons["Card"].forceTapWhenHittableInTestCase(self)
+            app.buttons["+ Add"].forceTapWhenHittableInTestCase(self)
         }
         try fillCardData(app)
         app.stp_dismissKeyboard()


### PR DESCRIPTION
## Summary

[#7030](https://github.com/stripe/stripe-ios/pull/7030) passed on a branch that did not include [#7015](https://github.com/stripe/stripe-ios/pull/7015). Before #7015, Checkout did not pass its Apple Pay configuration to Payment Element. Payment Element opened the card form, so the test never used its `Card` fallback.

#7015 landed before #7030 merged. It passed the Apple Pay configuration to Payment Element, which made FlowController select Apple Pay instead of Card. The test now taps `+ Add`, the card-entry control for this state.

## Motivation

Master CI

## Testing

No new tests.

Verified the Checkout Elements UI test on iPhone 12 mini with iOS 16.4.

## Changelog

N/A
