### PR TITLE
Make Checkout payment option clearing async

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -77,6 +77,18 @@ extension CheckoutController {
         )
     }
 
+    /// Resets billing-based automatic tax to the selected payment option's country.
+    ///
+    /// - Warning: Only call this from an operation already serialized by
+    ///   `enqueueSessionUpdate(_:)`.
+    func resetBillingTaxRegionIfNecessary() async throws {
+        guard session.shouldSendTaxRegion(for: "billing"),
+              let country = session.paymentOption?.billingDetails?.address.country?.nonEmpty else {
+            return
+        }
+        try await applySessionUpdate(.setTaxRegion(Address(country: country)))
+    }
+
     // MARK: - Session Updates
 
     /// Waits for all in-flight session updates (mutations, etc.) to complete.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -71,56 +71,10 @@ extension CheckoutController {
 
     // MARK: - Payment Option
 
-    /// Updates only the published payment option state.
-    /// Use `updatePaymentOption(to:updateElement:)` when the change and its Checkout Session
-    /// side effects must succeed atomically.
     func setPaymentOption(_ paymentOption: Session.PaymentOptionDisplayData?) {
         dangerouslySetSessionDirectly(
             session.makeCopyOverriding(paymentOption: .newValue(paymentOption))
         )
-    }
-
-    /// Updates the Checkout Session and Payment Element with a new payment option.
-    ///
-    /// For billing-based automatic tax, this updates the tax region from the new option's
-    /// billing address. Clearing an option retains only its previous billing country because
-    /// the Checkout Session update endpoint does not support removing the tax region.
-    /// `updateElement` runs only after any required Checkout Session update succeeds.
-    func updatePaymentOption(
-        to paymentOption: Session.PaymentOptionDisplayData?,
-        updateElement: @MainActor @escaping () -> Void
-    ) async throws {
-        try await enqueueSessionUpdate {
-            if let billingTaxRegion = self.billingTaxRegion(for: paymentOption) {
-                try await self.applySessionUpdate(.setTaxRegion(billingTaxRegion))
-            }
-            updateElement()
-            self.setPaymentOption(paymentOption)
-        }
-    }
-
-    private func billingTaxRegion(
-        for paymentOption: Session.PaymentOptionDisplayData?
-    ) -> Address? {
-        guard session.shouldSendTaxRegion(for: "billing") else {
-            return nil
-        }
-        if let billingAddress = paymentOption?.billingDetails?.address,
-           let country = billingAddress.country?.nonEmpty {
-            return Address(
-                country: country,
-                line1: billingAddress.line1?.nonEmpty,
-                line2: billingAddress.line2?.nonEmpty,
-                city: billingAddress.city?.nonEmpty,
-                state: billingAddress.state?.nonEmpty,
-                postalCode: billingAddress.postalCode?.nonEmpty
-            )
-        }
-        guard paymentOption == nil,
-              let country = session.paymentOption?.billingDetails?.address.country?.nonEmpty else {
-            return nil
-        }
-        return Address(country: country)
     }
 
     // MARK: - Session Updates

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -71,7 +71,14 @@ extension CheckoutController {
 
     // MARK: - Payment Option
 
-    func setPaymentOption(_ paymentOption: Session.PaymentOptionDisplayData?) {
+    func setPaymentOption(_ paymentOption: Session.PaymentOptionDisplayData?) async throws {
+        if paymentOption == nil {
+            try await updateBillingTaxRegionIfNecessary(address: nil)
+        }
+        publishPaymentOption(paymentOption)
+    }
+
+    func publishPaymentOption(_ paymentOption: Session.PaymentOptionDisplayData?) {
         dangerouslySetSessionDirectly(
             session.makeCopyOverriding(paymentOption: .newValue(paymentOption))
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -71,22 +71,56 @@ extension CheckoutController {
 
     // MARK: - Payment Option
 
+    /// Updates only the published payment option state.
+    /// Use `updatePaymentOption(to:updateElement:)` when the change and its Checkout Session
+    /// side effects must succeed atomically.
     func setPaymentOption(_ paymentOption: Session.PaymentOptionDisplayData?) {
         dangerouslySetSessionDirectly(
             session.makeCopyOverriding(paymentOption: .newValue(paymentOption))
         )
     }
 
-    /// Resets billing-based automatic tax to the selected payment option's country.
+    /// Updates the Checkout Session and Payment Element with a new payment option.
     ///
-    /// - Warning: Only call this from an operation already serialized by
-    ///   `enqueueSessionUpdate(_:)`.
-    func resetBillingTaxRegionIfNecessary() async throws {
-        guard session.shouldSendTaxRegion(for: "billing"),
-              let country = session.paymentOption?.billingDetails?.address.country?.nonEmpty else {
-            return
+    /// For billing-based automatic tax, this updates the tax region from the new option's
+    /// billing address. Clearing an option retains only its previous billing country because
+    /// the Checkout Session update endpoint does not support removing the tax region.
+    /// `updateElement` runs only after any required Checkout Session update succeeds.
+    func updatePaymentOption(
+        to paymentOption: Session.PaymentOptionDisplayData?,
+        updateElement: @MainActor @escaping () -> Void
+    ) async throws {
+        try await enqueueSessionUpdate {
+            if let billingTaxRegion = self.billingTaxRegion(for: paymentOption) {
+                try await self.applySessionUpdate(.setTaxRegion(billingTaxRegion))
+            }
+            updateElement()
+            self.setPaymentOption(paymentOption)
         }
-        try await applySessionUpdate(.setTaxRegion(Address(country: country)))
+    }
+
+    private func billingTaxRegion(
+        for paymentOption: Session.PaymentOptionDisplayData?
+    ) -> Address? {
+        guard session.shouldSendTaxRegion(for: "billing") else {
+            return nil
+        }
+        if let billingAddress = paymentOption?.billingDetails?.address,
+           let country = billingAddress.country?.nonEmpty {
+            return Address(
+                country: country,
+                line1: billingAddress.line1?.nonEmpty,
+                line2: billingAddress.line2?.nonEmpty,
+                city: billingAddress.city?.nonEmpty,
+                state: billingAddress.state?.nonEmpty,
+                postalCode: billingAddress.postalCode?.nonEmpty
+            )
+        }
+        guard paymentOption == nil,
+              let country = session.paymentOption?.billingDetails?.address.country?.nonEmpty else {
+            return nil
+        }
+        return Address(country: country)
     }
 
     // MARK: - Session Updates

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -71,14 +71,7 @@ extension CheckoutController {
 
     // MARK: - Payment Option
 
-    func setPaymentOption(_ paymentOption: Session.PaymentOptionDisplayData?) async throws {
-        if paymentOption == nil {
-            try await updateBillingTaxRegionIfNecessary(address: nil)
-        }
-        publishPaymentOption(paymentOption)
-    }
-
-    func publishPaymentOption(_ paymentOption: Session.PaymentOptionDisplayData?) {
+    func dangerouslySetPaymentOptionDirectly(_ paymentOption: Session.PaymentOptionDisplayData?) {
         dangerouslySetSessionDirectly(
             session.makeCopyOverriding(paymentOption: .newValue(paymentOption))
         )

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -227,18 +227,31 @@ public final class CheckoutController: ObservableObject {
     /// If automatic tax is enabled and the tax address source is "billing",
     /// the address is sent to the server to compute updated tax amounts.
     ///
-    /// - Parameter address: The billing address to use for tax calculation. To reset tax computation
-    ///   to a country-only region, pass a ``CheckoutController.Address`` with just the country.
+    /// - Parameter address: The billing address to use for tax calculation. Pass `nil` when
+    ///   removing the selected payment option's billing address.
     /// - Throws: ``CheckoutError`` if the session is not open, or if
     ///   the server request fails.
     func updateBillingTaxRegionIfNecessary(
-        address: Address,
+        address: Address?,
         canUpdateWhileSheetPresented: Bool = false
     ) async throws {
-        guard session.shouldSendTaxRegion(for: "billing") else {
-            return
+        guard session.shouldSendTaxRegion(for: "billing") else { return }
+        let taxRegion: Address
+        if let address {
+            taxRegion = address
+        } else {
+            guard let country = session.paymentOption?.billingDetails?.address.country?.nonEmpty else {
+                return
+            }
+            // The Checkout Session update endpoint requires tax_region[country] and does not
+            // support clearing tax_region, so keep the previous country.
+            // TODO(porter) When migrating to the CheckoutClient API, stop sending country only and send nil
+            taxRegion = Address(country: country)
         }
-        try await performUpdate(.setTaxRegion(address), canUpdateWhileSheetPresented: canUpdateWhileSheetPresented)
+        try await performUpdate(
+            .setTaxRegion(taxRegion),
+            canUpdateWhileSheetPresented: canUpdateWhileSheetPresented
+        )
     }
 
     /// Use this method to update the Customer's shipping address.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -212,8 +212,14 @@ public final class CheckoutController: ObservableObject {
     // MARK: - Payment Option
 
     /// Clears the currently selected payment option.
-    public func clearPaymentOption() {
-        paymentElement?.clearPaymentOption()
+    ///
+    /// If the selected payment option supplied the billing address for automatic tax,
+    /// this also updates the Checkout Session to reset tax calculation to its country.
+    /// - Throws: ``CheckoutError`` if the Checkout Session update fails.
+    public func clearPaymentOption() async throws {
+        try await enqueueSessionUpdate {
+            try await self.paymentElement.clearPaymentOption()
+        }
     }
 
     // MARK: - Addresses

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -217,9 +217,7 @@ public final class CheckoutController: ObservableObject {
     /// this also updates the Checkout Session to reset tax calculation to its country.
     /// - Throws: ``CheckoutError`` if the Checkout Session update fails.
     public func clearPaymentOption() async throws {
-        try await enqueueSessionUpdate {
-            try await self.paymentElement.clearPaymentOption()
-        }
+        try await paymentElement.clearPaymentOption()
     }
 
     // MARK: - Addresses

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -214,7 +214,7 @@ public final class CheckoutController: ObservableObject {
     /// Clears the currently selected payment option.
     ///
     /// If the selected payment option supplied the billing address for automatic tax,
-    /// this also updates the Checkout Session to reset tax calculation to its country.
+    /// this also recalculates tax using only that billing address's country.
     /// - Throws: ``CheckoutError`` if the Checkout Session update fails.
     public func clearPaymentOption() async throws {
         try await paymentElement.clearPaymentOption()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -212,10 +212,6 @@ public final class CheckoutController: ObservableObject {
     // MARK: - Payment Option
 
     /// Clears the currently selected payment option.
-    ///
-    /// If the selected payment option supplied the billing address for automatic tax,
-    /// this also recalculates tax using only that billing address's country.
-    /// - Throws: ``CheckoutError`` if the Checkout Session update fails.
     public func clearPaymentOption() async throws {
         try await paymentElement.clearPaymentOption()
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -213,7 +213,7 @@ public final class CheckoutController: ObservableObject {
 
     /// Clears the currently selected payment option.
     public func clearPaymentOption() async throws {
-        try await paymentElement.clearPaymentOption()
+        try await paymentElement?.clearPaymentOption()
     }
 
     // MARK: - Addresses

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -114,7 +114,7 @@ public final class PaymentElement {
                     return
                 }
                 paymentOptionSourceOfTruthIsFlowController = true
-                self.checkout?.setPaymentOption(paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init))
+                self.checkout?.publishPaymentOption(paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init))
             }
             .store(in: &cancellables)
         // We don't know whether to use FC or Embedded's payment option at this point, so we'll use Embedded since it has more info (includes mandate text).
@@ -128,7 +128,7 @@ public final class PaymentElement {
             paymentSheetFlowController.paymentOption?.label == embeddedPaymentElement.paymentOption?.label || flowControllerDefaultsToApplePay,
             "Payment Element assumes that the FlowController's payment option is the same as the Embedded's on first load!"
         )
-        checkout.setPaymentOption(
+        checkout.publishPaymentOption(
             embeddedPaymentElement.paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init)
         )
         paymentOptionSourceOfTruthIsFlowController = false // We used embedded's payment option
@@ -190,7 +190,7 @@ extension PaymentElement {
                 embeddedPaymentElement.paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init)
             }
         }()
-        checkout.setPaymentOption(paymentOption)
+        checkout.publishPaymentOption(paymentOption)
     }
 
     func clearPaymentOption() async throws {
@@ -202,18 +202,8 @@ extension PaymentElement {
             stpAssertionFailure("PaymentElement unexpectedly lost its CheckoutController.")
             return
         }
-        try await checkout.enqueueSessionUpdate {
-            if checkout.session.collectsTaxFromBillingAddress,
-               let country = checkout.session.paymentOption?.billingDetails?.address.country?.nonEmpty {
-                // The update endpoint requires a country, so clear the rest of the tax region
-                // while retaining the selected payment option's country.
-                try await checkout.applySessionUpdate(
-                    .setTaxRegion(CheckoutController.Address(country: country))
-                )
-            }
-            self.embeddedPaymentElement.clearPaymentOption()
-            checkout.setPaymentOption(nil)
-        }
+        try await checkout.setPaymentOption(nil)
+        embeddedPaymentElement.clearPaymentOption()
     }
 }
 
@@ -234,7 +224,7 @@ extension PaymentElement: EmbeddedPaymentElementDelegate {
             return
         }
         paymentOptionSourceOfTruthIsFlowController = false
-        checkout?.setPaymentOption(embeddedPaymentElement.paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init))
+        checkout?.publishPaymentOption(embeddedPaymentElement.paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init))
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -198,8 +198,21 @@ extension PaymentElement {
             assertionFailure("Clearing the payment option after presenting PaymentElement is not implemented. File a feature request if you need this.")
             return
         }
-        try await checkout?.updatePaymentOption(to: nil) { [embeddedPaymentElement] in
-            embeddedPaymentElement.clearPaymentOption()
+        guard let checkout else {
+            stpAssertionFailure("PaymentElement unexpectedly lost its CheckoutController.")
+            return
+        }
+        try await checkout.enqueueSessionUpdate {
+            if checkout.session.collectsTaxFromBillingAddress,
+               let country = checkout.session.paymentOption?.billingDetails?.address.country?.nonEmpty {
+                // The update endpoint requires a country, so clear the rest of the tax region
+                // while retaining the selected payment option's country.
+                try await checkout.applySessionUpdate(
+                    .setTaxRegion(CheckoutController.Address(country: country))
+                )
+            }
+            self.embeddedPaymentElement.clearPaymentOption()
+            checkout.setPaymentOption(nil)
         }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -193,11 +193,12 @@ extension PaymentElement {
         checkout.setPaymentOption(paymentOption)
     }
 
-    func clearPaymentOption() {
+    func clearPaymentOption() async throws {
         guard !paymentSheetFlowController.didPresentAndContinue else {
             assertionFailure("Clearing the payment option after presenting PaymentElement is not implemented. File a feature request if you need this.")
             return
         }
+        try await checkout?.resetBillingTaxRegionIfNecessary()
         embeddedPaymentElement.clearPaymentOption()
         checkout?.setPaymentOption(nil)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -198,9 +198,9 @@ extension PaymentElement {
             assertionFailure("Clearing the payment option after presenting PaymentElement is not implemented. File a feature request if you need this.")
             return
         }
-        try await checkout?.resetBillingTaxRegionIfNecessary()
-        embeddedPaymentElement.clearPaymentOption()
-        checkout?.setPaymentOption(nil)
+        try await checkout?.updatePaymentOption(to: nil) { [embeddedPaymentElement] in
+            embeddedPaymentElement.clearPaymentOption()
+        }
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -114,7 +114,7 @@ public final class PaymentElement {
                     return
                 }
                 paymentOptionSourceOfTruthIsFlowController = true
-                self.checkout?.publishPaymentOption(paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init))
+                self.checkout?.dangerouslySetPaymentOptionDirectly(paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init))
             }
             .store(in: &cancellables)
         // We don't know whether to use FC or Embedded's payment option at this point, so we'll use Embedded since it has more info (includes mandate text).
@@ -128,7 +128,7 @@ public final class PaymentElement {
             paymentSheetFlowController.paymentOption?.label == embeddedPaymentElement.paymentOption?.label || flowControllerDefaultsToApplePay,
             "Payment Element assumes that the FlowController's payment option is the same as the Embedded's on first load!"
         )
-        checkout.publishPaymentOption(
+        checkout.dangerouslySetPaymentOptionDirectly(
             embeddedPaymentElement.paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init)
         )
         paymentOptionSourceOfTruthIsFlowController = false // We used embedded's payment option
@@ -190,7 +190,7 @@ extension PaymentElement {
                 embeddedPaymentElement.paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init)
             }
         }()
-        checkout.publishPaymentOption(paymentOption)
+        checkout.dangerouslySetPaymentOptionDirectly(paymentOption)
     }
 
     func clearPaymentOption() async throws {
@@ -202,7 +202,8 @@ extension PaymentElement {
             stpAssertionFailure("PaymentElement unexpectedly lost its CheckoutController.")
             return
         }
-        try await checkout.setPaymentOption(nil)
+        try await checkout.updateBillingTaxRegionIfNecessary(address: nil)
+        checkout.dangerouslySetPaymentOptionDirectly(nil)
         embeddedPaymentElement.clearPaymentOption()
     }
 }
@@ -224,7 +225,7 @@ extension PaymentElement: EmbeddedPaymentElementDelegate {
             return
         }
         paymentOptionSourceOfTruthIsFlowController = false
-        checkout?.publishPaymentOption(embeddedPaymentElement.paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init))
+        checkout?.dangerouslySetPaymentOptionDirectly(embeddedPaymentElement.paymentOption.map(CheckoutController.Session.PaymentOptionDisplayData.init))
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -134,7 +134,7 @@ final class CheckoutUnitTests: XCTestCase {
         XCTAssertEqual(checkout.session.paymentOption?.label, "•••• 4242")
 
         // When the Checkout payment option is cleared
-        checkout.clearPaymentOption()
+        try await checkout.clearPaymentOption()
 
         // Then the Checkout session payment option is cleared
         XCTAssertNil(checkout.session.paymentOption)
@@ -942,7 +942,7 @@ final class CheckoutUnitTests: XCTestCase {
         XCTAssertEqual(checkout.session.paymentOption?.label, "•••• 4242")
         XCTAssertEqual(checkout.session.paymentOption?.paymentMethodType, "card")
 
-        checkout.clearPaymentOption()
+        try await checkout.clearPaymentOption()
 
         XCTAssertNil(checkout.session.paymentOption)
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -9,7 +9,7 @@ import OHHTTPStubs
 @testable @_spi(STP) import StripeCore
 @testable @_spi(STP) import StripeCoreTestUtils
 @testable @_spi(STP) import StripePayments
-@testable @_spi(STP) import StripePaymentSheet
+@testable @_spi(AppearanceAPIAdditionsPreview) @_spi(STP) import StripePaymentSheet
 @testable @_spi(STP) import StripePaymentsTestUtils
 @testable @_spi(STP) import StripeUICore
 import XCTest
@@ -295,7 +295,9 @@ final class PaymentElementTest: XCTestCase {
         // and the next Checkout Session update will fail
         let (configuration, _) = try stubAutomaticTaxSavedCardCheckout(clearUpdateStatusCode: 500)
         let checkout = try await CheckoutController(configuration: configuration)
+        let embeddedPaymentElement = checkout.getPaymentElement().embeddedPaymentElement
         let selectedPaymentOption = try XCTUnwrap(checkout.session.paymentOption)
+        let selectedEmbeddedPaymentOption = try XCTUnwrap(embeddedPaymentElement.paymentOption)
 
         // When the payment option is cleared
         do {
@@ -309,6 +311,48 @@ final class PaymentElementTest: XCTestCase {
 
         // Then the selection remains available for the merchant to recover
         XCTAssertEqual(checkout.session.paymentOption, selectedPaymentOption)
+        XCTAssertEqual(embeddedPaymentElement.paymentOption, selectedEmbeddedPaymentOption)
+    }
+
+    func testUpdatePaymentOptionUsesReplacementBillingAddressForTaxRegion() async throws {
+        // Given a selected saved card supplies the billing address for automatic tax
+        let (configuration, requestRecorder) = try stubAutomaticTaxSavedCardCheckout()
+        let checkout = try await CheckoutController(configuration: configuration)
+        let embeddedPaymentElement = checkout.getPaymentElement().embeddedPaymentElement
+        let confirmParams = IntentConfirmParams(type: .stripe(.card))
+        let billingDetails = STPPaymentMethodBillingDetails()
+        billingDetails.address = STPPaymentMethodAddress()
+        billingDetails.address?.country = "CA"
+        billingDetails.address?.line1 = "320 Front Street West"
+        billingDetails.address?.city = "Toronto"
+        billingDetails.address?.state = "ON"
+        billingDetails.address?.postalCode = "M5V 3B6"
+        confirmParams.paymentMethodParams.billingDetails = billingDetails
+        let replacementOption = PaymentOption.new(confirmParams: confirmParams)
+        let embeddedDisplayData = EmbeddedPaymentElement.PaymentOptionDisplayData(
+            paymentOption: replacementOption,
+            mandateText: nil,
+            currency: checkout.session.currency,
+            iconStyle: .filled
+        )
+        let checkoutDisplayData = CheckoutController.Session.PaymentOptionDisplayData(embeddedDisplayData)
+
+        // When Payment Element replaces the payment option
+        try await checkout.updatePaymentOption(to: checkoutDisplayData) {
+            embeddedPaymentElement._test_paymentOption = replacementOption
+        }
+
+        // Then Checkout recalculates tax from the replacement and commits it to both sources of state
+        let requests = requestRecorder.requests
+        XCTAssertEqual(requests.map(\.kind), [.initSession, .updateSession, .updateSession])
+        let updateRequest = try XCTUnwrap(requests.last)
+        XCTAssertEqual(updateRequest.params["tax_region[country]"], "CA")
+        XCTAssertEqual(updateRequest.params["tax_region[line1]"], "320 Front Street West")
+        XCTAssertEqual(updateRequest.params["tax_region[city]"], "Toronto")
+        XCTAssertEqual(updateRequest.params["tax_region[state]"], "ON")
+        XCTAssertEqual(updateRequest.params["tax_region[postal_code]"], "M5V 3B6")
+        XCTAssertEqual(checkout.session.paymentOption, checkoutDisplayData)
+        XCTAssertEqual(embeddedPaymentElement.paymentOption, embeddedDisplayData)
     }
 
     func testCheckoutSessionUpdatePreservesFlowControllerPaymentOption() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -268,6 +268,49 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertEqual(checkout.session.paymentOption?.billingDetails?.address.country, "US")
     }
 
+    func testClearPaymentOptionResetsBillingTaxRegionToCountry() async throws {
+        // Given a selected saved card supplies the billing address for automatic tax
+        let (configuration, requestRecorder) = try stubAutomaticTaxSavedCardCheckout()
+        let checkout = try await CheckoutController(configuration: configuration)
+        XCTAssertNotNil(checkout.session.paymentOption)
+
+        // When the payment option is cleared
+        try await checkout.clearPaymentOption()
+
+        // Then Checkout recalculates tax with only the previous country and clears the selection
+        let requests = requestRecorder.requests
+        XCTAssertEqual(requests.map(\.kind), [.initSession, .updateSession, .updateSession])
+        let updateRequest = try XCTUnwrap(requests.last)
+        XCTAssertEqual(updateRequest.params["tax_region[country]"], "US")
+        XCTAssertNil(updateRequest.params["tax_region[line1]"])
+        XCTAssertNil(updateRequest.params["tax_region[line2]"])
+        XCTAssertNil(updateRequest.params["tax_region[city]"])
+        XCTAssertNil(updateRequest.params["tax_region[state]"])
+        XCTAssertNil(updateRequest.params["tax_region[postal_code]"])
+        XCTAssertNil(checkout.session.paymentOption)
+    }
+
+    func testClearPaymentOptionPreservesSelectionWhenTaxUpdateFails() async throws {
+        // Given a selected saved card supplies the billing address for automatic tax
+        // and the next Checkout Session update will fail
+        let (configuration, _) = try stubAutomaticTaxSavedCardCheckout(clearUpdateStatusCode: 500)
+        let checkout = try await CheckoutController(configuration: configuration)
+        let selectedPaymentOption = try XCTUnwrap(checkout.session.paymentOption)
+
+        // When the payment option is cleared
+        do {
+            try await checkout.clearPaymentOption()
+            XCTFail("Expected clearing the payment option to throw")
+        } catch {
+            guard case .apiError = error as? CheckoutError else {
+                return XCTFail("Expected .apiError, got \(error)")
+            }
+        }
+
+        // Then the selection remains available for the merchant to recover
+        XCTAssertEqual(checkout.session.paymentOption, selectedPaymentOption)
+    }
+
     func testCheckoutSessionUpdatePreservesFlowControllerPaymentOption() async throws {
         // Given a Checkout PaymentElement with PayNow available in the real FlowController sheet UI...
         var configuration = CheckoutController.Configuration(clientSecret: "cs_test_123_secret_abc", returnURL: "stripe-ios-test://checkout-return")
@@ -417,7 +460,9 @@ final class PaymentElementTest: XCTestCase {
     }
 
     /// `CheckoutSession.json` already has automatic tax sourced from billing and a saved card with a full billing address.
-    private func stubAutomaticTaxSavedCardCheckout() throws -> (
+    private func stubAutomaticTaxSavedCardCheckout(
+        clearUpdateStatusCode: Int32 = 200
+    ) throws -> (
         configuration: CheckoutController.Configuration,
         requestRecorder: CheckoutSessionRequestRecorder
     ) {
@@ -428,7 +473,12 @@ final class PaymentElementTest: XCTestCase {
         CheckoutTestHelpers.stubCheckoutSessionRequests(
             sessionId: session.sessionId,
             requestRecorder: requestRecorder,
-            sessionJSON: { sessionJSON }
+            sessionJSON: { sessionJSON },
+            updateStatusCode: { updateRequestNumber in
+                // Checkout syncs the initially selected card during setup. Only apply the
+                // configured status code to the update made while clearing it.
+                return updateRequestNumber == 1 ? 200 : clearUpdateStatusCode
+            }
         )
         return (configuration, requestRecorder)
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -9,7 +9,7 @@ import OHHTTPStubs
 @testable @_spi(STP) import StripeCore
 @testable @_spi(STP) import StripeCoreTestUtils
 @testable @_spi(STP) import StripePayments
-@testable @_spi(AppearanceAPIAdditionsPreview) @_spi(STP) import StripePaymentSheet
+@testable @_spi(STP) import StripePaymentSheet
 @testable @_spi(STP) import StripePaymentsTestUtils
 @testable @_spi(STP) import StripeUICore
 import XCTest
@@ -272,7 +272,9 @@ final class PaymentElementTest: XCTestCase {
         // Given a selected saved card supplies the billing address for automatic tax
         let (configuration, requestRecorder) = try stubAutomaticTaxSavedCardCheckout()
         let checkout = try await CheckoutController(configuration: configuration)
+        let embeddedPaymentElement = checkout.getPaymentElement().embeddedPaymentElement
         XCTAssertNotNil(checkout.session.paymentOption)
+        XCTAssertNotNil(embeddedPaymentElement.paymentOption)
 
         // When the payment option is cleared
         try await checkout.clearPaymentOption()
@@ -288,6 +290,7 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertNil(updateRequest.params["tax_region[state]"])
         XCTAssertNil(updateRequest.params["tax_region[postal_code]"])
         XCTAssertNil(checkout.session.paymentOption)
+        XCTAssertNil(embeddedPaymentElement.paymentOption)
     }
 
     func testClearPaymentOptionPreservesSelectionWhenTaxUpdateFails() async throws {
@@ -312,47 +315,6 @@ final class PaymentElementTest: XCTestCase {
         // Then the selection remains available for the merchant to recover
         XCTAssertEqual(checkout.session.paymentOption, selectedPaymentOption)
         XCTAssertEqual(embeddedPaymentElement.paymentOption, selectedEmbeddedPaymentOption)
-    }
-
-    func testUpdatePaymentOptionUsesReplacementBillingAddressForTaxRegion() async throws {
-        // Given a selected saved card supplies the billing address for automatic tax
-        let (configuration, requestRecorder) = try stubAutomaticTaxSavedCardCheckout()
-        let checkout = try await CheckoutController(configuration: configuration)
-        let embeddedPaymentElement = checkout.getPaymentElement().embeddedPaymentElement
-        let confirmParams = IntentConfirmParams(type: .stripe(.card))
-        let billingDetails = STPPaymentMethodBillingDetails()
-        billingDetails.address = STPPaymentMethodAddress()
-        billingDetails.address?.country = "CA"
-        billingDetails.address?.line1 = "320 Front Street West"
-        billingDetails.address?.city = "Toronto"
-        billingDetails.address?.state = "ON"
-        billingDetails.address?.postalCode = "M5V 3B6"
-        confirmParams.paymentMethodParams.billingDetails = billingDetails
-        let replacementOption = PaymentOption.new(confirmParams: confirmParams)
-        let embeddedDisplayData = EmbeddedPaymentElement.PaymentOptionDisplayData(
-            paymentOption: replacementOption,
-            mandateText: nil,
-            currency: checkout.session.currency,
-            iconStyle: .filled
-        )
-        let checkoutDisplayData = CheckoutController.Session.PaymentOptionDisplayData(embeddedDisplayData)
-
-        // When Payment Element replaces the payment option
-        try await checkout.updatePaymentOption(to: checkoutDisplayData) {
-            embeddedPaymentElement._test_paymentOption = replacementOption
-        }
-
-        // Then Checkout recalculates tax from the replacement and commits it to both sources of state
-        let requests = requestRecorder.requests
-        XCTAssertEqual(requests.map(\.kind), [.initSession, .updateSession, .updateSession])
-        let updateRequest = try XCTUnwrap(requests.last)
-        XCTAssertEqual(updateRequest.params["tax_region[country]"], "CA")
-        XCTAssertEqual(updateRequest.params["tax_region[line1]"], "320 Front Street West")
-        XCTAssertEqual(updateRequest.params["tax_region[city]"], "Toronto")
-        XCTAssertEqual(updateRequest.params["tax_region[state]"], "ON")
-        XCTAssertEqual(updateRequest.params["tax_region[postal_code]"], "M5V 3B6")
-        XCTAssertEqual(checkout.session.paymentOption, checkoutDisplayData)
-        XCTAssertEqual(embeddedPaymentElement.paymentOption, embeddedDisplayData)
     }
 
     func testCheckoutSessionUpdatePreservesFlowControllerPaymentOption() async throws {


### PR DESCRIPTION
## Summary

Makes CheckoutController.clearPaymentOption async and throwing so merchants can wait for related Checkout Session updates and handle failures. When billing-based automatic tax uses the selected payment method's address, clearing the option recalculates tax with only its country. A failed update leaves the payment option selected.

## Motivation

CheckoutSessions

## Testing

- Clearing a payment option recalculates automatic tax with only the previous billing country.
- A failed tax update returns an error and keeps the payment option selected.
- Existing Checkout and Payment Element tests.

## Changelog

N/A