### PR TITLE
Revert ConsumerContext from HostedAuthUrlBuilder

### DIFF
--- a/StripeCore/StripeCore/Source/Connections Bindings/HostedAuthUrlBuilder.swift
+++ b/StripeCore/StripeCore/Source/Connections Bindings/HostedAuthUrlBuilder.swift
@@ -8,22 +8,6 @@
 import Foundation
 
 @_spi(STP) public enum HostedAuthUrlBuilder {
-    @_spi(STP) public struct ConsumerContext {
-        let clientSecret: String
-        let publishableKey: String
-        let emailAddress: String
-
-        @_spi(STP) public init(
-            clientSecret: String,
-            publishableKey: String,
-            emailAddress: String
-        ) {
-            self.clientSecret = clientSecret
-            self.publishableKey = publishableKey
-            self.emailAddress = emailAddress
-        }
-    }
-
     /// Builds the Hosted Auth URL by appending various query parameters.
     @_spi(STP) public static func build(
         baseHostedAuthUrl: URL,
@@ -31,8 +15,7 @@ import Foundation
         hasExistingAccountholderToken: Bool,
         elementsSessionContext: ElementsSessionContext?,
         prefillDetailsOverride: PrefillData? = nil,
-        additionalQueryParameters: String? = nil,
-        consumerContext: ConsumerContext? = nil
+        additionalQueryParameters: String? = nil
     ) -> URL {
         var parameters: [String] = []
 
@@ -104,12 +87,6 @@ import Foundation
 
         if let allowRedisplay = elementsSessionContext?.allowRedisplay {
             parameters.append("allow_redisplay=\(allowRedisplay)")
-        }
-
-        if let consumerContext {
-            parameters.append("consumerSessionClientSecret=\(consumerContext.clientSecret)")
-            parameters.append("consumerPublishableKey=\(consumerContext.publishableKey)")
-            parameters.append("consumerEmailAddress=\(consumerContext.emailAddress)")
         }
 
         // Join all values with an &, and URL encode.

--- a/StripeCore/StripeCoreTests/Connections Bindings/HostedAuthUrlBuilderTests.swift
+++ b/StripeCore/StripeCoreTests/Connections Bindings/HostedAuthUrlBuilderTests.swift
@@ -257,30 +257,6 @@ class HostedAuthUrlBuilderTests: XCTestCase {
         XCTAssertFalse(result.absoluteString.contains("linkMobilePhoneCountry="))
     }
 
-    func testPermissionedConsumerContextIsAddedToFragment() {
-        let baseUrl = URL(string: "https://auth.stripe.com/link-accounts#apiKey=pk_merchant")!
-        let consumerContext = HostedAuthUrlBuilder.ConsumerContext(
-            clientSecret: "consumer_session_secret",
-            publishableKey: "pk_consumer",
-            emailAddress: "user@example.com"
-        )
-
-        let result = HostedAuthUrlBuilder.build(
-            baseHostedAuthUrl: baseUrl,
-            isInstantDebits: true,
-            hasExistingAccountholderToken: true,
-            elementsSessionContext: nil,
-            consumerContext: consumerContext
-        )
-
-        let components = URLComponents(url: result, resolvingAgainstBaseURL: false)
-        let fragment = components?.percentEncodedFragment
-        XCTAssertNil(components?.query)
-        XCTAssertTrue(fragment?.contains("consumerSessionClientSecret=consumer_session_secret") == true)
-        XCTAssertTrue(fragment?.contains("consumerPublishableKey=pk_consumer") == true)
-        XCTAssertTrue(fragment?.contains("consumerEmailAddress=user%40example.com") == true)
-    }
-
     // MARK: - URL Edge Cases
 
     func testBaseUrlWithTrailingAmpersand() {

--- a/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
+++ b/StripeFinancialConnections/StripeFinancialConnections/Source/Web/FinancialConnectionsWebFlowViewController.swift
@@ -72,19 +72,6 @@ final class FinancialConnectionsWebFlowViewController: UIViewController {
     private let elementsSessionContext: ElementsSessionContext?
     private let prefillDetailsOverride: WebPrefillDetails?
 
-    private var hostedAuthConsumerContext: HostedAuthUrlBuilder.ConsumerContext? {
-        guard apiClient.hasRequestedDataPermissions,
-              let consumerSession = apiClient.consumerSession,
-              let consumerPublishableKey = apiClient.consumerPublishableKey else {
-            return nil
-        }
-        return HostedAuthUrlBuilder.ConsumerContext(
-            clientSecret: consumerSession.clientSecret,
-            publishableKey: consumerPublishableKey,
-            emailAddress: consumerSession.emailAddress
-        )
-    }
-
     // MARK: - UI
 
     private lazy var closeItem: UIBarButtonItem = {
@@ -183,8 +170,7 @@ extension FinancialConnectionsWebFlowViewController {
             hasExistingAccountholderToken: manifest.accountholderToken != nil,
             elementsSessionContext: elementsSessionContext,
             prefillDetailsOverride: prefillDetailsOverride,
-            additionalQueryParameters: additionalQueryParameters,
-            consumerContext: hostedAuthConsumerContext
+            additionalQueryParameters: additionalQueryParameters
         )
         authSessionManager?
             .start(hostedAuthUrl: updatedHostedAuthUrl)

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteAuthFlowViewController.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteAuthFlowViewController.swift
@@ -14,7 +14,6 @@ import UIKit
 class FCLiteAuthFlowViewController: UIViewController {
     private let manifest: LinkAccountSessionManifest
     private let elementsSessionContext: ElementsSessionContext?
-    private let hostedAuthConsumerContext: HostedAuthUrlBuilder.ConsumerContext?
     private let returnUrl: URL?
     private let onLoad: () -> Void
     private let completion: ((FCLiteWebFlowResult) -> Void)
@@ -27,15 +26,13 @@ class FCLiteAuthFlowViewController: UIViewController {
             baseHostedAuthUrl: manifest.hostedAuthURL,
             isInstantDebits: manifest.isInstantDebits,
             hasExistingAccountholderToken: manifest.hasAccountholderToken,
-            elementsSessionContext: elementsSessionContext,
-            consumerContext: hostedAuthConsumerContext
+            elementsSessionContext: elementsSessionContext
         )
     }
 
     init(
         manifest: LinkAccountSessionManifest,
         elementsSessionContext: ElementsSessionContext?,
-        hostedAuthConsumerContext: HostedAuthUrlBuilder.ConsumerContext?,
         returnUrl: URL?,
         onLoad: @escaping () -> Void,
         completion: @escaping ((FCLiteWebFlowResult) -> Void)
@@ -43,7 +40,6 @@ class FCLiteAuthFlowViewController: UIViewController {
         self.onLoad = onLoad
         self.manifest = manifest
         self.elementsSessionContext = elementsSessionContext
-        self.hostedAuthConsumerContext = hostedAuthConsumerContext
         self.returnUrl = returnUrl
         self.completion = completion
         super.init(nibName: nil, bundle: nil)

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteContainerViewController.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteContainerViewController.swift
@@ -13,7 +13,6 @@ class FCLiteContainerViewController: UIViewController {
     private let returnUrl: URL?
     private let apiClient: FCLiteAPIClient
     private let completion: ((FinancialConnectionsSDKResult) -> Void)
-    private let hostedAuthConsumerContext: HostedAuthUrlBuilder.ConsumerContext?
     private let hasRequestedDataPermissions: Bool
 
     private let spinner = UIActivityIndicatorView(style: .large)
@@ -50,7 +49,6 @@ class FCLiteContainerViewController: UIViewController {
         returnUrl: URL?,
         apiClient: FCLiteAPIClient,
         elementsSessionContext: ElementsSessionContext?,
-        hostedAuthConsumerContext: HostedAuthUrlBuilder.ConsumerContext?,
         hasRequestedDataPermissions: Bool,
         completion: @escaping ((FinancialConnectionsSDKResult) -> Void)
     ) {
@@ -58,7 +56,6 @@ class FCLiteContainerViewController: UIViewController {
         self.returnUrl = returnUrl
         self.apiClient = apiClient
         self.elementsSessionContext = elementsSessionContext
-        self.hostedAuthConsumerContext = hostedAuthConsumerContext
         self.hasRequestedDataPermissions = hasRequestedDataPermissions
         self.completion = completion
         super.init(nibName: nil, bundle: nil)
@@ -187,7 +184,6 @@ class FCLiteContainerViewController: UIViewController {
             authFlowVC = FCLiteSecureAuthFlowViewController(
                 manifest: manifest,
                 elementsSessionContext: elementsSessionContext,
-                hostedAuthConsumerContext: hostedAuthConsumerContext,
                 completion: { [weak self] result in
                     guard let self else { return }
                     DispatchQueue.main.async {
@@ -202,7 +198,6 @@ class FCLiteContainerViewController: UIViewController {
             authFlowVC = FCLiteAuthFlowViewController(
                 manifest: manifest,
                 elementsSessionContext: elementsSessionContext,
-                hostedAuthConsumerContext: hostedAuthConsumerContext,
                 returnUrl: returnUrl,
                 onLoad: {
                     DispatchQueue.main.async {

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteSecureAuthFlowViewController.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/Controllers/FCLiteSecureAuthFlowViewController.swift
@@ -12,7 +12,6 @@ import UIKit
 class FCLiteSecureAuthFlowViewController: UIViewController {
     private let manifest: LinkAccountSessionManifest
     private let elementsSessionContext: ElementsSessionContext?
-    private let hostedAuthConsumerContext: HostedAuthUrlBuilder.ConsumerContext?
     private let completion: ((FCLiteWebFlowResult) -> Void)
 
     /// Stored to maintain a strong reference and prevent deallocation.
@@ -23,20 +22,17 @@ class FCLiteSecureAuthFlowViewController: UIViewController {
             baseHostedAuthUrl: manifest.hostedAuthURL,
             isInstantDebits: manifest.isInstantDebits,
             hasExistingAccountholderToken: manifest.hasAccountholderToken,
-            elementsSessionContext: elementsSessionContext,
-            consumerContext: hostedAuthConsumerContext
+            elementsSessionContext: elementsSessionContext
         )
     }
 
     init(
         manifest: LinkAccountSessionManifest,
         elementsSessionContext: ElementsSessionContext?,
-        hostedAuthConsumerContext: HostedAuthUrlBuilder.ConsumerContext?,
         completion: @escaping ((FCLiteWebFlowResult) -> Void)
     ) {
         self.manifest = manifest
         self.elementsSessionContext = elementsSessionContext
-        self.hostedAuthConsumerContext = hostedAuthConsumerContext
         self.completion = completion
         super.init(nibName: nil, bundle: nil)
     }

--- a/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/FinancialConnectionsLite.swift
+++ b/StripeFinancialConnectionsLite/StripeFinancialConnectionsLite/Source/FinancialConnectionsLite.swift
@@ -61,22 +61,11 @@ import UIKit
             apiClient.consumerPublishableKey = existingConsumer?.publishableKey
         }
 
-        let hostedAuthConsumerContext = existingConsumer.flatMap { consumer in
-            consumer.publishableKey.map { publishableKey in
-                HostedAuthUrlBuilder.ConsumerContext(
-                    clientSecret: consumer.clientSecret,
-                    publishableKey: publishableKey,
-                    emailAddress: consumer.emailAddress
-                )
-            }
-        }
-
         let containerVC = FCLiteContainerViewController(
             clientSecret: clientSecret,
             returnUrl: returnUrl,
             apiClient: apiClient,
             elementsSessionContext: elementsSessionContext,
-            hostedAuthConsumerContext: hasRequestedDataPermissions ? hostedAuthConsumerContext : nil,
             hasRequestedDataPermissions: hasRequestedDataPermissions,
             completion: { [weak self] result in
                 guard let self else { return }


### PR DESCRIPTION
## Summary

Partially reverts https://github.com/stripe/stripe-ios/pull/7009 - we no longer want to attach the ConsumerContext params to the hosted auth URL.

## Motivation

https://stripe.slack.com/archives/C03D0N2R090/p1787953476650029?thread_ts=1787929134.889039&cid=C03D0N2R090

## Testing

Manually verified

## Changelog

N/a