### PR TITLE
CryptoOnramp SDK: Moves Consumer Session Client Secret to HTTP Headers in GET Requests

### DIFF
--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -906,7 +906,11 @@ private extension CryptoOnrampCoordinator {
         }
 
         // Fetch platform settings and create API client
-        let platformSettings = try await apiClient.getPlatformSettings(cryptoCustomerId: cryptoCustomerId)
+        let platformSettings = try await apiClient.getPlatformSettings(
+            cryptoCustomerId: cryptoCustomerId,
+            linkAccountInfo: linkAccountInfo
+        )
+
         let newPlatformApiClient = STPAPIClient(publishableKey: platformSettings.publishableKey)
         platformApiClient = newPlatformApiClient
         return newPlatformApiClient

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Components/CryptoOnrampCoordinator.swift
@@ -906,11 +906,7 @@ private extension CryptoOnrampCoordinator {
         }
 
         // Fetch platform settings and create API client
-        let platformSettings = try await apiClient.getPlatformSettings(
-            cryptoCustomerId: cryptoCustomerId,
-            linkAccountInfo: linkAccountInfo
-        )
-
+        let platformSettings = try await apiClient.getPlatformSettings(cryptoCustomerId: cryptoCustomerId)
         let newPlatformApiClient = STPAPIClient(publishableKey: platformSettings.publishableKey)
         platformApiClient = newPlatformApiClient
         return newPlatformApiClient

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -127,7 +127,7 @@ extension STPAPIClient {
         let endpoint = "crypto/internal/identifier_requirements"
         return try await get(
             resource: endpoint,
-            parameters: try credentialsParameters(consumerSessionClientSecret: consumerSessionClientSecret)
+            consumerSessionClientSecret: consumerSessionClientSecret
         )
     }
 
@@ -172,7 +172,7 @@ extension STPAPIClient {
         let endpoint = "crypto/internal/crs_carf_declaration"
         return try await get(
             resource: endpoint,
-            parameters: try credentialsParameters(consumerSessionClientSecret: consumerSessionClientSecret)
+            consumerSessionClientSecret: consumerSessionClientSecret
         )
     }
 
@@ -351,31 +351,33 @@ extension STPAPIClient {
     }
 
     /// Retrieves platform settings for the crypto onramp service.
-    /// - Parameter cryptoCustomerId: The ID for the crypto customer.
+    /// - Parameters:
+    ///   - cryptoCustomerId: The ID for the crypto customer.
+    ///   - linkAccountInfo: Information associated with the link account including the client secret.
     /// - Returns: Platform settings including the publishable key.
-    /// Throws if an API error occurs.
+    /// Throws if a client secret doesn’t exist or if an API error occurs.
     func getPlatformSettings(
-        cryptoCustomerId: String
+        cryptoCustomerId: String,
+        linkAccountInfo: PaymentSheetLinkAccountInfoProtocol
     ) async throws -> PlatformSettingsResponse {
+        guard let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret else {
+            throw CryptoOnrampAPIError.missingConsumerSessionClientSecret
+        }
+
         let endpoint = "crypto/internal/platform_settings"
 
         let parameters: [String: Any] = [
             "crypto_customer_id": cryptoCustomerId,
             "ui_mode": "headless",
         ]
-        return try await get(resource: endpoint, parameters: parameters)
+
+        return try await get(resource: endpoint, parameters: parameters, consumerSessionClientSecret: consumerSessionClientSecret)
     }
 
     private func validateSessionState(using linkAccountInfo: PaymentSheetLinkAccountInfoProtocol) throws {
         guard case .verified = linkAccountInfo.sessionState else {
             throw CryptoOnrampAPIError.linkAccountNotVerified
         }
-    }
-
-    private func credentialsParameters(consumerSessionClientSecret: String) throws -> [String: Any] {
-        return try EmptyRequestWithCredentials(
-            consumerSessionClientSecret: consumerSessionClientSecret
-        ).encodeJSONDictionary()
     }
 }
 
@@ -419,9 +421,45 @@ private extension STPAPIClient {
             }
         }
     }
+
+    func get<T: Decodable>(
+        resource: String,
+        parameters: [String: Any] = [:],
+        consumerSessionClientSecret: String
+    ) async throws -> T {
+        let url = apiURL.appendingPathComponent(resource)
+        var request = configuredRequest(
+            for: url,
+            apiVersionOverride: CryptoOnrampAPI.stripeAPIVersion,
+            additionalHeaders: [
+                CryptoOnrampAPI.consumerAuthTokenHeader: consumerSessionClientSecret,
+            ]
+        )
+        request.stp_addParameters(toURL: parameters)
+        request.httpMethod = "GET"
+
+        return try await withCheckedThrowingContinuation { continuation in
+            urlSession.stp_performDataTask(
+                with: request,
+                completionHandler: { data, response, error in
+                    DispatchQueue.main.async {
+                        let result: Result<T, Error> = STPAPIClient.decodeResponse(
+                            data: data,
+                            error: error,
+                            response: response,
+                            request: request
+                        )
+                        continuation.resume(with: result)
+                    }
+                }
+            )
+        }
+    }
 }
 
 private enum CryptoOnrampAPI {
+    static let consumerAuthTokenHeader = "Stripe-Consumer-Auth-Token"
+
     // Use a preview API version for networks and parameters behind preview API features.
     // Bump this when new onramp features require a newer API version.
     static let stripeAPIVersion = "2026-03-25.preview"

--- a/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnramp/Source/Internal/API Bindings/STPAPIClient+CryptoOnramp.swift
@@ -351,27 +351,19 @@ extension STPAPIClient {
     }
 
     /// Retrieves platform settings for the crypto onramp service.
-    /// - Parameters:
-    ///   - cryptoCustomerId: The ID for the crypto customer.
-    ///   - linkAccountInfo: Information associated with the link account including the client secret.
+    /// - Parameter cryptoCustomerId: The ID for the crypto customer.
     /// - Returns: Platform settings including the publishable key.
-    /// Throws if a client secret doesn’t exist or if an API error occurs.
+    /// Throws if an API error occurs.
     func getPlatformSettings(
-        cryptoCustomerId: String,
-        linkAccountInfo: PaymentSheetLinkAccountInfoProtocol
+        cryptoCustomerId: String
     ) async throws -> PlatformSettingsResponse {
-        guard let consumerSessionClientSecret = linkAccountInfo.consumerSessionClientSecret else {
-            throw CryptoOnrampAPIError.missingConsumerSessionClientSecret
-        }
-
         let endpoint = "crypto/internal/platform_settings"
 
         let parameters: [String: Any] = [
             "crypto_customer_id": cryptoCustomerId,
             "ui_mode": "headless",
         ]
-
-        return try await get(resource: endpoint, parameters: parameters, consumerSessionClientSecret: consumerSessionClientSecret)
+        return try await get(resource: endpoint, parameters: parameters)
     }
 
     private func validateSessionState(using linkAccountInfo: PaymentSheetLinkAccountInfoProtocol) throws {

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
@@ -1286,10 +1286,6 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
             XCTAssertEqual(request.url?.path, Constant.getPlatformSettingsAPIPath)
             XCTAssertEqual(request.httpMethod, "GET")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Stripe-Version"), Constant.cryptoOnrampAPIVersion)
-            XCTAssertEqual(
-                request.value(forHTTPHeaderField: Constant.consumerAuthTokenHeader),
-                Constant.requestSecret
-            )
 
             guard let queryParametersString = request.url?.query else {
                 XCTFail("Expected query parameters but found none.")
@@ -1310,10 +1306,7 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         let apiClient = stubbedAPIClient()
 
         do {
-            let response = try await apiClient.getPlatformSettings(
-                cryptoCustomerId: Constant.validCustomerId,
-                linkAccountInfo: Constant.validLinkAccountInfo
-            )
+            let response = try await apiClient.getPlatformSettings(cryptoCustomerId: Constant.validCustomerId)
             XCTAssertEqual(response.publishableKey, Constant.validPublishableKey)
         } catch {
             XCTFail("Expected a success response but got an error: \(error).")
@@ -1331,27 +1324,11 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         let apiClient = stubbedAPIClient()
 
         do {
-            _ = try await apiClient.getPlatformSettings(
-                cryptoCustomerId: Constant.validCustomerId,
-                linkAccountInfo: Constant.validLinkAccountInfo
-            )
+            _ = try await apiClient.getPlatformSettings(cryptoCustomerId: Constant.validCustomerId)
             XCTFail("Expected failure but got success.")
         } catch {
             XCTAssertEqual((error as NSError).domain, Constant.errorDomain)
         }
-    }
-
-    func testGetPlatformSettingsThrowsWithoutConsumerSessionClientSecret() async {
-        let apiClient = stubbedAPIClient()
-
-        var noSecretLinkAccountInfo = Constant.validLinkAccountInfo
-        noSecretLinkAccountInfo.consumerSessionClientSecret = nil
-        await XCTAssertThrowsErrorAsync(
-            _ = try await apiClient.getPlatformSettings(
-                cryptoCustomerId: Constant.validCustomerId,
-                linkAccountInfo: noSecretLinkAccountInfo
-            )
-        )
     }
 }
 

--- a/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
+++ b/StripeCryptoOnramp/StripeCryptoOnrampTests/Unit/STPAPIClient+CryptoOnrampTests.swift
@@ -19,6 +19,7 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
     private enum Constant {
         // Common
         static let requestSecret = "cscs_12345"
+        static let consumerAuthTokenHeader = "Stripe-Consumer-Auth-Token"
         static let errorDomain = "STPAPIClientCryptoOnrampTests.Error"
         static let validCustomerId = "crc_12345"
         static let cryptoOnrampAPIVersion = "2026-03-25.preview"
@@ -448,15 +449,11 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         stub { request in
             XCTAssertEqual(request.url?.path, Constant.retrieveMissingIdentifiersAPIPath)
             XCTAssertEqual(request.httpMethod, "GET")
-
-            guard let queryParametersString = request.url?.query else {
-                XCTFail("Expected query parameters but found none.")
-                return false
-            }
-
-            let parameters = queryParametersString.removingPercentEncoding?.parsedHTTPParametersDictionary ?? [:]
-            XCTAssertEqual(parameters.count, 1)
-            XCTAssertEqual(parameters["credentials[consumer_session_client_secret]"], Constant.requestSecret)
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: Constant.consumerAuthTokenHeader),
+                Constant.requestSecret
+            )
+            XCTAssertTrue(request.url?.query?.isEmpty ?? true)
 
             return true
         } response: { _ in
@@ -579,15 +576,11 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         stub { request in
             XCTAssertEqual(request.url?.path, Constant.userAttestationAPIPath)
             XCTAssertEqual(request.httpMethod, "GET")
-
-            guard let queryParametersString = request.url?.query else {
-                XCTFail("Expected query parameters but found none.")
-                return false
-            }
-
-            let parameters = queryParametersString.removingPercentEncoding?.parsedHTTPParametersDictionary ?? [:]
-            XCTAssertEqual(parameters.count, 1)
-            XCTAssertEqual(parameters["credentials[consumer_session_client_secret]"], Constant.requestSecret)
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: Constant.consumerAuthTokenHeader),
+                Constant.requestSecret
+            )
+            XCTAssertTrue(request.url?.query?.isEmpty ?? true)
 
             return true
         } response: { _ in
@@ -1293,6 +1286,10 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
             XCTAssertEqual(request.url?.path, Constant.getPlatformSettingsAPIPath)
             XCTAssertEqual(request.httpMethod, "GET")
             XCTAssertEqual(request.value(forHTTPHeaderField: "Stripe-Version"), Constant.cryptoOnrampAPIVersion)
+            XCTAssertEqual(
+                request.value(forHTTPHeaderField: Constant.consumerAuthTokenHeader),
+                Constant.requestSecret
+            )
 
             guard let queryParametersString = request.url?.query else {
                 XCTFail("Expected query parameters but found none.")
@@ -1313,7 +1310,10 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         let apiClient = stubbedAPIClient()
 
         do {
-            let response = try await apiClient.getPlatformSettings(cryptoCustomerId: Constant.validCustomerId)
+            let response = try await apiClient.getPlatformSettings(
+                cryptoCustomerId: Constant.validCustomerId,
+                linkAccountInfo: Constant.validLinkAccountInfo
+            )
             XCTAssertEqual(response.publishableKey, Constant.validPublishableKey)
         } catch {
             XCTFail("Expected a success response but got an error: \(error).")
@@ -1331,11 +1331,27 @@ final class STPAPIClientCryptoOnrampTests: APIStubbedTestCase {
         let apiClient = stubbedAPIClient()
 
         do {
-            _ = try await apiClient.getPlatformSettings(cryptoCustomerId: Constant.validCustomerId)
+            _ = try await apiClient.getPlatformSettings(
+                cryptoCustomerId: Constant.validCustomerId,
+                linkAccountInfo: Constant.validLinkAccountInfo
+            )
             XCTFail("Expected failure but got success.")
         } catch {
             XCTAssertEqual((error as NSError).domain, Constant.errorDomain)
         }
+    }
+
+    func testGetPlatformSettingsThrowsWithoutConsumerSessionClientSecret() async {
+        let apiClient = stubbedAPIClient()
+
+        var noSecretLinkAccountInfo = Constant.validLinkAccountInfo
+        noSecretLinkAccountInfo.consumerSessionClientSecret = nil
+        await XCTAssertThrowsErrorAsync(
+            _ = try await apiClient.getPlatformSettings(
+                cryptoCustomerId: Constant.validCustomerId,
+                linkAccountInfo: noSecretLinkAccountInfo
+            )
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
For `GET /v1/crypto/…` APIs that require a consumer session client secret, this parameter has been moved to HTTP headers.

## Motivation
<!-- Why are you making this change? If it's for fixing a bug, if possible, please include a code snippet or example project that demonstrates the issue. -->

Slack Link: [Stripe](https://stripe.slack.com/archives/C094P3BRBL1/p1788279018599289) | [Lickability](https://lickability.slack.com/archives/C094P3BRBL1/p1788279018599289)

## Testing
<!-- How was the code tested? Be as specific as possible. -->
<!-- Ignored Tests: Did you newly ignore a test in this PR?  If so, please open an R4 incident so that the test can be re-enabled as soon as possible-->
1. Created a new EU user, completing KYC, User Attestation, and tax ID collection to ensure I hit the `GET /v1/crypto/internal/crs_carf_declaration` and `GET /v1/crypto/internal/identifier_requirements` endpoints successfully.
2. ~From an existing account, completed a checkout to ensure calls to `GET /v1/crypto/internal/platform_settings` were successful~. This functionality was removed before opening the PR.

## Changelog
<!-- Is this a notable change that affects users? If so, add a line to `CHANGELOG.md` and prefix the line with one of the following:
    - [Added] for new features.
    - [Changed] for changes in existing functionality.
    - [Deprecated] for soon-to-be removed features.
    - [Removed] for now removed features.
    - [Fixed] for any bug fixes.
    - [Security] in case of vulnerabilities.
-->
N/A
