### PR TITLE
Update walletButtonHidden to show Link button on MPE for existing users

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheet+PaymentMethodAvailability.swift
@@ -87,8 +87,20 @@ extension PaymentSheet {
 
     /// Canonical source of truth for whether the Link button/row should be rendered in the payment element UI.
     /// Link may remain functionally enabled (see `isLinkEnabled`) even when its button is hidden, e.g. to support automatic Link verification without a visible entry point.
+    /// When `.walletButtonHidden` is configured, the button is still shown if the load-time lookup found an existing Link user.
     static func shouldShowLinkButton(elementsSession: STPElementsSession, configuration: PaymentElementConfiguration) -> Bool {
-        return isLinkEnabled(elementsSession: elementsSession, configuration: configuration) && configuration.link.shouldShowButton
+        guard isLinkEnabled(elementsSession: elementsSession, configuration: configuration) else {
+            return false
+        }
+
+        switch configuration.link.display {
+        case .automatic:
+            return true
+        case .walletButtonHidden:
+            return LinkAccountContext.shared.account?.isRegistered == true
+        case .never:
+            return false
+        }
     }
 
     /// Canonical source of truth for reasons why Link is disabled

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetConfiguration.swift
@@ -514,8 +514,8 @@ extension PaymentSheet {
             case automatic
             /// Link will never be displayed.
             case never
-            /// Link remains enabled (e.g. for automatic Link verification, Instant Bank Payments, Link Card Brand, and inline signup)
-            /// but its button/row will not be shown in the payment element UI.
+            /// Link remains enabled (e.g. for automatic Link verification, Instant Bank Payments, Link Card Brand, and inline signup).
+            /// Its button/row is shown when an existing Link user is detected and hidden otherwise.
             case walletButtonHidden
         }
 
@@ -523,13 +523,6 @@ extension PaymentSheet {
             switch display {
             case .automatic, .walletButtonHidden: true
             case .never: false
-            }
-        }
-
-        var shouldShowButton: Bool {
-            switch display {
-            case .automatic: true
-            case .walletButtonHidden, .never: false
             }
         }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
@@ -12,6 +12,11 @@
 import XCTest
 
 final class PaymentMethodAvailabilityTests: XCTestCase {
+    override func tearDown() {
+        LinkAccountContext.shared.account = nil
+        super.tearDown()
+    }
+
     func testResolvedLinkBrand_usesElementsSessionBrand() {
         let elementsSession = STPElementsSession._testValue(
             linkSettings: ._testValue(brand: .onelink)
@@ -216,21 +221,50 @@ final class PaymentMethodAvailabilityTests: XCTestCase {
         )
         var configuration = PaymentSheet.Configuration()
         configuration.link = .init(display: .never)
+        LinkAccountContext.shared.account = ._testValue(email: "john@doe.com", isRegistered: true)
         let shouldShowLinkButton = PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration)
 
-        XCTAssertFalse(shouldShowLinkButton, "Link button should not be shown when display is set to .never")
+        XCTAssertFalse(shouldShowLinkButton, "Link button should not be shown when display is set to .never, even for an existing Link user")
     }
 
-    func testShouldShowLinkButton_linkDisplayWalletButtonHidden_buttonNotShown() {
+    func testShouldShowLinkButton_linkDisplayWalletButtonHidden_newUser_buttonNotShown() {
         let elementsSession = STPElementsSession._testValue(
             paymentMethodTypes: ["card"],
             isLinkPassthroughModeEnabled: true
         )
         var configuration = PaymentSheet.Configuration()
         configuration.link = .init(display: .walletButtonHidden)
+        LinkAccountContext.shared.account = ._testValue(email: "john@doe.com", isRegistered: false)
 
         XCTAssertTrue(PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration), "Link should remain enabled when display is set to .walletButtonHidden")
-        XCTAssertFalse(PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration), "Link button should not be shown when display is set to .walletButtonHidden, even though Link remains enabled")
+        XCTAssertFalse(PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration), "Link button should not be shown when display is set to .walletButtonHidden and no existing Link user was found")
+    }
+
+    func testShouldShowLinkButton_linkDisplayWalletButtonHidden_noUser_buttonNotShown() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card"],
+            isLinkPassthroughModeEnabled: true
+        )
+        var configuration = PaymentSheet.Configuration()
+        configuration.link = .init(display: .walletButtonHidden)
+        LinkAccountContext.shared.account = nil
+
+        XCTAssertTrue(PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration), "Link should remain enabled when display is set to .walletButtonHidden")
+        XCTAssertFalse(PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration), "Link button should not be shown when display is set to .walletButtonHidden and no Link user was found")
+    }
+
+    func testShouldShowLinkButton_linkDisplayWalletButtonHidden_existingUser_buttonShown() {
+        let elementsSession = STPElementsSession._testValue(
+            paymentMethodTypes: ["card"],
+            isLinkPassthroughModeEnabled: true
+        )
+        var configuration = PaymentSheet.Configuration()
+        configuration.link = .init(display: .walletButtonHidden)
+        LinkAccountContext.shared.account = makeLinkAccountRequiringVerification()
+
+        XCTAssertTrue(PaymentSheet.isLinkEnabled(elementsSession: elementsSession, configuration: configuration), "Link should remain enabled when display is set to .walletButtonHidden")
+        XCTAssertEqual(LinkAccountContext.shared.account?.sessionState, .requiresVerification)
+        XCTAssertTrue(PaymentSheet.shouldShowLinkButton(elementsSession: elementsSession, configuration: configuration), "Link button should be shown when display is set to .walletButtonHidden and an existing Link user was found")
     }
 
     func testIsLinkEnabled_automaticTaxBilling_linkDisabled() {


### PR DESCRIPTION
## Summary

Tweaks the behavior of the LinkConfiguration.Display.walletButtonHidden case to show the Link wallet button in MPE for existing users. Non-Link users will continue to not see the wallet button.

## Motivation

Allow users get back into Link after dismissing it.

## Testing

Video: https://stripe.slack.com/archives/C0BJF9G69PA/p1788359924578119?thread_ts=1788201768.723969&cid=C0BJF9G69PA

## Changelog

N/a