### PR TITLE
Fix embedded payment method row layout

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentMethodsView.swift
@@ -215,8 +215,8 @@ class EmbeddedPaymentMethodsView: UIView {
             if let initialSelectedRowChangeButtonState {
                 selectedRowChangeButtonState = initialSelectedRowChangeButtonState
                 if initialSelectedRowChangeButtonState.shouldShowChangeButton {
-                    rowButtonMatchingInitialSelection.addChangeButton()
-                    rowButtonMatchingInitialSelection.setSublabel(text: initialSelectedRowChangeButtonState.sublabel)
+                    rowButtonMatchingInitialSelection.addChangeButton(animated: false)
+                    rowButtonMatchingInitialSelection.setSublabel(text: initialSelectedRowChangeButtonState.sublabel, animated: false)
                 }
             }
             self.selectedRowButton = rowButtonMatchingInitialSelection
@@ -600,16 +600,20 @@ extension Array where Element == STPPaymentMethod {
 }
 
 extension RowButton {
-    func addChangeButton() {
+    func addChangeButton(animated: Bool = true) {
         // Hack: We assume the accessory view is "Change >"
         self.accessoryView?.isHidden = false
+        makeSameHeightAsOtherRowButtonsIfNecessary()
+        guard animated else {
+            self.accessoryView?.alpha = 1
+            return
+        }
         self.setNeedsLayout()
         self.layoutIfNeeded()
         self.accessoryView?.alpha = 0
         UIView.animate(withDuration: 0.2) {
             self.accessoryView?.alpha = 1
         }
-        makeSameHeightAsOtherRowButtonsIfNecessary()
     }
 
     func removeChangeButton(shouldClearSublabel: Bool) {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Vertical Main Screen/RowButton.swift
@@ -306,6 +306,9 @@ class RowButton: UIView, EventHandler {
     // MARK: Helper
 
     func makeSameHeightAsOtherRowButtonsIfNecessary() {
+        heightConstraint?.isActive = false
+        heightConstraint = nil
+
         // To make all RowButtons the same height, set our height to the tallest
         // standard variant (a RowButton with text and a plain sublabel).
 
@@ -314,13 +317,11 @@ class RowButton: UIView, EventHandler {
         //   2. The sublabel variant requires unlimited height
         if (isFlatWithCheckmarkOrChevronStyle && isDisplayingAccessoryView)
             || sublabel.needsUnlimitedHeight {
-            heightConstraint?.isActive = false
             return
         }
 
         // Don't constrain if we *are* the tallest variant; otherwise we'll infinite loop!
         guard !sublabel.hasText else {
-            heightConstraint?.isActive = false
             return
         }
         heightConstraint = heightAnchor.constraint(equalToConstant: Self.calculateTallestHeight(appearance: appearance, isEmbedded: isEmbedded))


### PR DESCRIPTION
## Summary

- Avoid forcing layout while restoring an initially selected embedded payment method row.
- Keep row height constraints idempotent when the row state changes.

## Motivation

Fixes the layout constraint break reported in [RUN_MOBILESDK-5410](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5410).

## Testing

No new tests.

Verified the existing embedded update flow completes without broken constraint alerts.


https://github.com/user-attachments/assets/b4525c72-d453-4466-8314-8d906c92d1ca



## Changelog

Not user-facing.