### PR TITLE
Deflake IntegrationTester Apple Pay UI test

### DIFF
--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUIPMTests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUIPMTests.swift
@@ -57,16 +57,6 @@ class IntegrationTesterUIPMTests: IntegrationTesterUITests {
             XCTAssertTrue(payButton.waitForExistence(timeout: 10.0))
             payButton.forceTapElement()
         } else {
-            let amexPredicate = NSPredicate(format: "label CONTAINS 'Simulated Card - AmEx, ‪•••• 1234‬'")
-            let amexButton = applePay.buttons.containing(amexPredicate).firstMatch
-            XCTAssertTrue(amexButton.waitForExistence(timeout: 10.0))
-            amexButton.forceTapElement()
-
-            let mastercardPredicate = NSPredicate(format: "label CONTAINS 'Simulated Card - MasterCard, ‪•••• 1234‬'")
-            let mastercardButton = applePay.buttons.containing(mastercardPredicate).firstMatch
-            XCTAssertTrue(mastercardButton.waitForExistence(timeout: 10.0))
-            mastercardButton.forceTapElement()
-
             let payButton = applePay.buttons["Pay with Passcode"]
             XCTAssertTrue(payButton.waitForExistence(timeout: 10.0))
             payButton.forceTapElement()


### PR DESCRIPTION
## Summary

Remove the simulated-card taps from the Apple Pay integration test’s iOS 16.4 path. The iOS 26+ path is unchanged.

Nick added the two AmEx taps in [`e986f13`](https://github.com/stripe/stripe-ios/commit/e986f130eaefb29ed6f922f72426877e12bd4bb3) as a Touch ID workaround. Mat changed the second tap to MasterCard in [`9414555`](https://github.com/stripe/stripe-ios/commit/941455582244e0d0fbd6dc38800172f1eff71af0) while fixing flaky integration tests.

The test does not assert card selection. We reproduced a failure on iOS 16.4 where these taps opened shipping methods, so MasterCard never appeared. `Pay with Passcode` is already available; removing the taps preserves the Apple Pay completion coverage.

## Testing

No new tests.