### PR TITLE
Deflake IntegrationTester UI tests

### DIFF
--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUIPMTests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUIPMTests.swift
@@ -151,8 +151,12 @@ class IntegrationTesterUIPMTests: IntegrationTesterUITests {
         rowForPaymentMethod.scrollToAndTap(in: app)
 
         let buyButton = app.buttons["Buy"]
-        XCTAssertTrue(buyButton.waitForExistence(timeout: 10.0))
-        buyButton.forceTapElement()
+        // A tap during list deceleration can highlight the row without navigating.
+        if !buyButton.waitForExistence(timeout: 10.0), rowForPaymentMethod.exists {
+            rowForPaymentMethod.forceTapElement()
+        }
+        XCTAssertTrue(buyButton.waitForExistence(timeout: 60.0))
+        buyButton.forceTapWhenHittableInTestCase(self)
 
         // Klarna uses ASWebAuthenticationSession, tap continue to allow the web view to open.
         // Confirming the PaymentIntent requires a network round-trip to fetch the redirect URL
@@ -160,7 +164,7 @@ class IntegrationTesterUIPMTests: IntegrationTesterUITests {
         // ahead before the "Continue" button appears.
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
         XCTAssertTrue(
-            springboard.buttons["Continue"].waitForExistenceAndTap(timeout: 30),
+            springboard.buttons["Continue"].waitForExistenceAndTap(timeout: 60),
             "ASWebAuthenticationSession consent (\"Continue\") button never appeared"
         )
 

--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
@@ -62,6 +62,7 @@ class IntegrationTesterUITests: XCTestCase {
         numberField.typeText(number)
         let expField = app.textFields["expiration date"]
         _ = expField.waitForExistence(timeout: 10)
+        expField.tap()
         expField.typeText("1228")
         let cvcField = app.textFields["CVC"]
         if STPCardValidator.brand(forNumber: number) == .amex {
@@ -79,7 +80,7 @@ class IntegrationTesterUITests: XCTestCase {
         let tablesQuery = app.collectionViews
 
         let cardExampleElement = tablesQuery.cells.buttons["Card"]
-        cardExampleElement.tap()
+        cardExampleElement.forceTapWhenHittableInTestCase(self)
         try! fillCardData(app, number: cardNumber)
 
         let buyButton = app.buttons["Buy"]

--- a/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
+++ b/Testers/IntegrationTester/IntegrationTesterUITests/IntegrationTesterUITests.swift
@@ -121,8 +121,8 @@ class IntegrationTesterUITests: XCTestCase {
 
         let oobChallengeScreenPredicate = NSPredicate(format: "label ==[c] 'OTP'")
         let challengeText = app.staticTexts.matching(oobChallengeScreenPredicate).element
-        XCTAssertTrue(challengeText.waitForExistence(timeout: 10))
-        challengeText.forceTapElement()
+        XCTAssertTrue(challengeText.waitForExistence(timeout: 60))
+        challengeText.forceTapWhenHittableInTestCase(self)
 
         let submitButton = app.buttons["Submit"]
         XCTAssertTrue(submitButton.waitForExistence(timeout: 10.0))


### PR DESCRIPTION
## Summary

Deflakes three IntegrationTester UI tests by synchronizing interactions with the UI states they depend on.

- Waits for card-entry navigation and explicit field focus.
- Allows the HSBC ACS to load and become interactive before tapping.
- Retries a dropped Klarna navigation tap, waits for Buy to become hittable, and allows the consent sheet network round-trip to finish.

The changes remain scoped to test code and continue to surface genuine backend failures.

## Motivation

Recent Bitrise runs showed intermittent failures caused by navigation taps during transitions or list deceleration, controls appearing before they were hittable, and external web or network flows exceeding short timeouts.

## Testing

No new tests.

## Changelog

N/A