### PR TITLE
Revert "[CryptoOnramp] Disable existing user end-to-end UI test"

### DIFF
--- a/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITests.swift
+++ b/Example/CryptoOnramp Example/CryptoOnrampExampleUITests/CryptoOnrampExampleUITests.swift
@@ -54,7 +54,7 @@ final class CryptoOnrampExampleUITests: XCTestCase {
     }
 
     /// Tests a happy-path flow from log in (existing account) to successful checkout, followed by re-authentication using seamless sign-in.
-    func disabled_testExistingUserEndToEnd() throws {
+    func testExistingUserEndToEnd() throws {
         // Step 1: Enter email and password
         waitForLoadingToFinish()
 


### PR DESCRIPTION
## Summary
Re-enables the existing-user end-to-end Crypto Onramp UI test by reverting #7096.

## Motivation
The `ir-markers-unanimous` incident is now fully mitigated, so the temporarily disabled test can be restored.

## Testing
No new tests.