### PR TITLE
Fix resolved Link brand with direct Instant Debits

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/Internal/Link/Controllers/PayWithLinkViewController.swift
@@ -694,9 +694,7 @@ extension PayWithLinkViewController: PayWithLinkCoordinating {
                 },
                 clientAttributionMetadata: clientAttributionMetadata
             ),
-            // Only `.onelink` should be treated as an explicit client override for FC.
-            // A `.link` selection should behave like no override so backend brand updates can still win.
-            linkBrand: context.configuration.link.brand == .onelink ? .onelink : nil,
+            linkBrand: context.configuration.financialConnectionsLinkBrandOverride,
             onEvent: nil,
             from: self,
             completion: { result in

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentElementConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentElementConfiguration.swift
@@ -56,6 +56,16 @@ extension PaymentElementConfiguration {
         return linkAccount?.linkBrand ?? elementsSession.linkBrand ?? .link
     }
 
+    var financialConnectionsLinkBrandOverride: LinkBrand? {
+        // Only Onelink should be treated as an explicit client override for Financial Connections.
+        // Link should behave like no override so backend and authenticated consumer updates can still win.
+        return link.brand == .onelink ? .onelink : nil
+    }
+
+    func financialConnectionsLinkBrandOverride(linkAccount: PaymentSheetLinkAccount?) -> LinkBrand? {
+        return financialConnectionsLinkBrandOverride ?? (linkAccount?.linkBrand == .onelink ? .onelink : nil)
+    }
+
     /// Returns `true` if the merchant requires the collection of _any_ billing detail fields - name, phone, email, address.
     func requiresBillingDetailCollection() -> Bool {
         return billingDetailsCollectionConfiguration.name == .always

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ViewControllers/PaymentMethodFormViewController.swift
@@ -625,6 +625,10 @@ extension PaymentMethodFormViewController {
             break
         }
 
+        let linkBrand = configuration.financialConnectionsLinkBrandOverride(
+            linkAccount: LinkAccountContext.shared.account
+        )
+
         switch intent {
         case .paymentIntent(let paymentIntent):
             client.collectBankAccountForPayment(
@@ -632,6 +636,7 @@ extension PaymentMethodFormViewController {
                 returnURL: configuration.returnURL,
                 additionalParameters: additionalParameters,
                 elementsSessionContext: elementsSessionContext,
+                linkBrand: linkBrand,
                 onEvent: nil,
                 params: params,
                 from: viewController,
@@ -643,6 +648,7 @@ extension PaymentMethodFormViewController {
                 returnURL: configuration.returnURL,
                 additionalParameters: additionalParameters,
                 elementsSessionContext: elementsSessionContext,
+                linkBrand: linkBrand,
                 onEvent: nil,
                 params: params,
                 from: viewController,
@@ -668,6 +674,7 @@ extension PaymentMethodFormViewController {
                 onBehalfOf: intentConfig.onBehalfOf,
                 additionalParameters: additionalParameters,
                 elementsSessionContext: elementsSessionContext,
+                linkBrand: linkBrand,
                 from: viewController,
                 intentType: .deferred,
                 financialConnectionsCompletion: financialConnectionsCompletion
@@ -682,6 +689,7 @@ extension PaymentMethodFormViewController {
                 onBehalfOf: nil,
                 additionalParameters: additionalParameters,
                 elementsSessionContext: elementsSessionContext,
+                linkBrand: linkBrand,
                 from: viewController,
                 intentType: .checkoutSession,
                 financialConnectionsCompletion: financialConnectionsCompletion

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentMethodAvailabilityTests.swift
@@ -38,6 +38,57 @@ final class PaymentMethodAvailabilityTests: XCTestCase {
         XCTAssertEqual(configuration.resolvedLinkBrand(elementsSession: elementsSession, linkAccount: nil), .link)
     }
 
+    func testFinancialConnectionsLinkBrandOverride_onlyOverridesOnelink() {
+        var configuration = PaymentSheet.Configuration()
+
+        XCTAssertNil(configuration.financialConnectionsLinkBrandOverride)
+
+        configuration.link = .init(brand: .link)
+        XCTAssertNil(configuration.financialConnectionsLinkBrandOverride)
+
+        configuration.link = .init(brand: .onelink)
+        XCTAssertEqual(configuration.financialConnectionsLinkBrandOverride, .onelink)
+    }
+
+    func testFinancialConnectionsLinkBrandOverride_usesAuthenticatedConsumerBrand() {
+        // Given an authenticated Onelink consumer
+        let session = ConsumerSession.make(
+            clientSecret: "consumer_session_secret",
+            emailAddress: "test@example.com",
+            redactedFormattedPhoneNumber: "(***) *** **55",
+            unredactedPhoneNumber: nil,
+            phoneNumberCountry: "US",
+            verificationSessions: [.init(type: .sms, state: .verified)],
+            supportedPaymentDetailsTypes: [],
+            mobileFallbackWebviewParams: nil,
+            currentAuthenticationLevel: .twoFactorAuth,
+            minimumAuthenticationLevel: .oneFactorAuth,
+            linkBrand: .onelink
+        )
+        let linkAccount = PaymentSheetLinkAccount(
+            email: "test@example.com",
+            session: session,
+            publishableKey: nil,
+            displayablePaymentDetails: nil,
+            useMobileEndpoints: false,
+            canSyncAttestationState: false
+        )
+        let configuration = PaymentSheet.Configuration()
+
+        // Then the brand is forwarded to Financial Connections without consumer credentials
+        XCTAssertEqual(
+            configuration.financialConnectionsLinkBrandOverride(linkAccount: linkAccount),
+            .onelink
+        )
+    }
+
+    func testFinancialConnectionsLinkBrandOverride_doesNotOverrideLink() {
+        let configuration = PaymentSheet.Configuration()
+
+        // Then the backend Financial Connections brand remains authoritative
+        XCTAssertNil(configuration.financialConnectionsLinkBrandOverride(linkAccount: nil))
+    }
+
     func testResolvedLinkBrand_withSignedOutLinkAccount_fallsBackToElementsSessionBrand() {
         let elementsSession = STPElementsSession._testValue(
             linkSettings: ._testValue(brand: .link)

--- a/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
+++ b/StripePayments/StripePayments/Source/Helpers/STPBankAccountCollector.swift
@@ -234,6 +234,7 @@ public class STPBankAccountCollector: NSObject {
         returnURL: String?,
         additionalParameters: [String: Any] = [:],
         elementsSessionContext: ElementsSessionContext?,
+        linkBrand: LinkBrand? = nil,
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         params: STPCollectBankAccountParams,
         from viewController: UIViewController,
@@ -253,6 +254,7 @@ public class STPBankAccountCollector: NSObject {
             returnURL: returnURL,
             additionalParameters: additionalParameters,
             elementsSessionContext: elementsSessionContext,
+            linkBrand: linkBrand,
             onEvent: onEvent,
             params: params,
             from: viewController,
@@ -265,6 +267,7 @@ public class STPBankAccountCollector: NSObject {
         returnURL: String?,
         additionalParameters: [String: Any] = [:],
         elementsSessionContext: ElementsSessionContext? = nil,
+        linkBrand: LinkBrand? = nil,
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         params: STPCollectBankAccountParams,
         from viewController: UIViewController,
@@ -306,7 +309,7 @@ public class STPBankAccountCollector: NSObject {
                 hasRequestedDataPermissions: false,
                 style: self.style.asFinancialConnectionsConfigurationStyle,
                 elementsSessionContext: elementsSessionContext,
-                linkBrand: nil,
+                linkBrand: linkBrand,
                 onEvent: onEvent,
                 from: viewController
             ) { result in
@@ -530,6 +533,7 @@ public class STPBankAccountCollector: NSObject {
         returnURL: String?,
         additionalParameters: [String: Any] = [:],
         elementsSessionContext: ElementsSessionContext? = nil,
+        linkBrand: LinkBrand? = nil,
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         params: STPCollectBankAccountParams,
         from viewController: UIViewController,
@@ -549,6 +553,7 @@ public class STPBankAccountCollector: NSObject {
             returnURL: returnURL,
             additionalParameters: additionalParameters,
             elementsSessionContext: elementsSessionContext,
+            linkBrand: linkBrand,
             onEvent: onEvent,
             params: params,
             from: viewController,
@@ -561,6 +566,7 @@ public class STPBankAccountCollector: NSObject {
         returnURL: String?,
         additionalParameters: [String: Any] = [:],
         elementsSessionContext: ElementsSessionContext?,
+        linkBrand: LinkBrand? = nil,
         onEvent: ((FinancialConnectionsEvent) -> Void)?,
         params: STPCollectBankAccountParams,
         from viewController: UIViewController,
@@ -601,7 +607,7 @@ public class STPBankAccountCollector: NSObject {
                 hasRequestedDataPermissions: false,
                 style: self.style.asFinancialConnectionsConfigurationStyle,
                 elementsSessionContext: elementsSessionContext,
-                linkBrand: nil,
+                linkBrand: linkBrand,
                 onEvent: onEvent,
                 from: viewController
             ) { result in
@@ -654,6 +660,7 @@ public class STPBankAccountCollector: NSObject {
         onBehalfOf: String?,
         additionalParameters: [String: Any] = [:],
         elementsSessionContext: ElementsSessionContext?,
+        linkBrand: LinkBrand? = nil,
         from viewController: UIViewController,
         intentType: IntentType,
         financialConnectionsCompletion: @escaping (
@@ -699,7 +706,7 @@ public class STPBankAccountCollector: NSObject {
                 hasRequestedDataPermissions: false,
                 style: self.style.asFinancialConnectionsConfigurationStyle,
                 elementsSessionContext: elementsSessionContext,
-                linkBrand: nil,
+                linkBrand: linkBrand,
                 onEvent: onEvent,
                 from: viewController
             ) { result in


### PR DESCRIPTION
## Summary

The resolved Link brand wasn't being passed into the direct Financial Connections flow when launched directly from MPE. It was working when going through the Link wallet -> add bank, but not direct from the MPE bank tab. This fixes that.

## Motivation

Consistent Link / Onelink branding

## Testing

Before:

https://github.com/user-attachments/assets/7e3b9beb-b980-4825-86d6-147bc70e0f04

After:

https://github.com/user-attachments/assets/800b542a-1584-46a3-a809-cfc85058d77d

## Changelog

N/a