### PR TITLE
Align Checkout API documentation with review

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Address.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Address.swift
@@ -11,7 +11,7 @@ import Foundation
 @_spi(STP)
 @_spi(ReactNativeSDK)
 extension CheckoutController {
-    /// A postal address used by Checkout's billing and shipping address APIs.
+    /// A postal address.
     public struct Address: Equatable, Hashable, Sendable {
         /// Two-letter country code (ISO 3166-1 alpha-2). Always required.
         public let country: String

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+ApplePayConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+ApplePayConfiguration.swift
@@ -25,12 +25,15 @@ public protocol CheckoutApplePayConfiguration {
 @_spi(STP)
 @_spi(ReactNativeSDK)
 extension PaymentElement {
-    /// Configuration for Apple Pay.
+    /// Configuration related to Apple Pay
     public struct ApplePayConfiguration: CheckoutApplePayConfiguration {
-        /// The Apple Pay merchant identifier.
+        /// The Apple Merchant Identifier to use during Apple Pay transactions.
+        /// To obtain one, see https://stripe.com/docs/apple-pay#native
         public var merchantId: String
 
-        /// The type of Apple Pay button to display. Defaults to `.plain` when `nil`.
+        /// Defines the label that will be displayed in the Apple Pay button.
+        /// See <https://developer.apple.com/design/human-interface-guidelines/technologies/apple-pay/buttons-and-marks/>
+        /// for all available options.
         public var buttonType: PKPaymentButtonType?
 
         /// Creates an Apple Pay configuration.

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Configuration.swift
@@ -13,19 +13,7 @@ import Foundation
 extension CheckoutController {
     public typealias UserInterfaceStyle = PaymentSheet.UserInterfaceStyle
 
-    /// Configuration options for a ``Checkout`` instance.
-    ///
-    /// Supply a configuration when creating a ``Checkout`` to customize behavior:
-    ///
-    /// ```swift
-    /// var config = CheckoutController.Configuration(
-    ///     clientSecret: "cs_xxx_secret_yyy",
-    ///     returnURL: "my-app://stripe-redirect"
-    /// )
-    /// config.currencySelectorElement = .init()
-    ///
-    /// let checkout = try await CheckoutController(configuration: config)
-    /// ```
+    /// Configuration for initializing a CheckoutController.
     public struct Configuration {
         /// The client secret for your Checkout Session.
         public var clientSecret: String
@@ -67,9 +55,9 @@ extension CheckoutController {
         /// The color styling to use for Checkout UI.
         public var userInterfaceStyle: UserInterfaceStyle = .automatic
 
-        /// Creates a configuration.
-        /// - Parameter clientSecret: The client secret for your Checkout Session.
-        /// - Parameter returnURL: A custom URL scheme that redirects back to your app after authenticating a payment method, e.g. `my-app://stripe-redirect`. Register this URL scheme in your app and forward incoming URLs to `StripeAPI.handleURLCallback(with:)`.
+        /// Initializes a `CheckoutController.Configuration` with default values.
+        /// - Parameter clientSecret: The CheckoutSession client secret.
+        /// - Parameter returnURL: A URL that redirects back to your app after authenticating a payment method.
         public init(clientSecret: String, returnURL: String) {
             self.clientSecret = clientSecret
             self.returnURL = returnURL

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+PresentmentDetails.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+PresentmentDetails.swift
@@ -12,7 +12,7 @@ import Foundation
 extension CheckoutController.Session {
     /// Details about the currency presented to the customer when adaptive pricing is active.
     public struct PresentmentDetails: Sendable, Hashable {
-        /// Three-letter ISO 4217 presentment currency code in lowercase.
+        /// Currency presented to the customer during payment.
         public let presentmentCurrency: String
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session.swift
@@ -222,17 +222,20 @@ extension CheckoutController.Session {
         public let minimum: Int
     }
 
-    /// Display data for the currently selected payment option.
+    /// Contains details about a payment method that can be displayed to the customer
     public struct PaymentOptionDisplayData: Equatable {
-        /// An image representing a payment method, such as the Apple Pay logo or a card brand.
+        /// An image representing a payment method; e.g. the Apple Pay logo or a VISA logo
         public let image: UIImage
-        /// A customer-facing label representing the payment option.
+        /// A user facing string representing the payment method; e.g. "Apple Pay" or "····4242" for a card
         public let label: String
-        /// The billing details associated with the selected payment option.
+        /// The billing details associated with the customer's desired payment method
         public let billingDetails: PaymentSheet.BillingDetails?
-        /// A string representation of the selected payment method type.
+        /// A string representation of the customer's desired payment method
+        /// - If this is a Stripe payment method, see https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for possible values.
+        /// - If this is an external payment method, see https://stripe.com/docs/payments/external-payment-methods?platform=ios#available-external-payment-methods for possible values.
+        /// - If this is Apple Pay, the value is "apple_pay"
         public let paymentMethodType: String
-        /// Mandate text that must be displayed when the PaymentElement is configured not to display it.
+        /// If you set `configuration.embeddedViewDisplaysMandateText = false`, this text must be displayed in a `UITextView` (so that URLs in the text are handled) to the customer near your “Buy” button to comply with regulations.
         public let mandateText: NSAttributedString?
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -13,17 +13,8 @@ import Foundation
 @_spi(STP) import StripePayments
 import UIKit
 
-/// Manages a Checkout Session lifecycle.
-///
-/// ```swift
-/// let checkout = try await CheckoutController(configuration: .init(clientSecret: "cs_xxx_secret_yyy"))
-/// print(checkout.session)
-/// ```
-///
-/// The async initializer loads the session from Stripe before returning.
-///
-/// Observe loading state and session changes with ``isUpdating`` and ``session``
-/// (published via `ObservableObject`).
+/// Use this class to build a [Checkout elements](todo) integration.
+/// It manages a CheckoutSession object and UI elements (e.g. PaymentElement, ShippingAddressElement).
 @_spi(STP)
 @_spi(ReactNativeSDK)
 @MainActor
@@ -34,7 +25,7 @@ public final class CheckoutController: ObservableObject {
     /// Use this to disable interactive UI e.g. your buy button.
     @Published public internal(set) var isUpdating: Bool = false
 
-    /// The Checkout Session, updated from Stripe after every mutation.
+    /// The Session object is a view of the Checkout Session API object and represents your customer's session in your checkout flow.
     @Published public private(set) var session: Session
 
     /// The configuration supplied at initialization.
@@ -91,10 +82,7 @@ public final class CheckoutController: ObservableObject {
 
     // MARK: - Initialization
 
-    /// Loads a Checkout Session from Stripe and returns a ready-to-use instance.
-    ///
-    /// - Parameter configuration: Configuration options for the checkout.
-    /// - Throws: ``CheckoutError`` if the client secret is invalid or the session cannot be loaded.
+    /// Initializes a CheckoutController instance
     public init(configuration: Configuration) async throws {
         var configuration = configuration
         let clientSecret = configuration.clientSecret
@@ -203,15 +191,12 @@ public final class CheckoutController: ObservableObject {
 
     // MARK: - Promotion Codes
 
-    /// Applies a promotion code to the session.
-    /// - Parameter promotionCode: The promotion code to apply.
-    /// - Throws: ``CheckoutError`` if applying the promotion code fails.
+    /// Use this method to apply a promotion code that your customer enters.
     public func applyPromotionCode(_ promotionCode: String) async throws {
         try await performUpdate(.setPromotionCode(promotionCode))
     }
 
-    /// Removes the currently applied promotion code.
-    /// - Throws: ``CheckoutError`` if removing the promotion code fails.
+    /// Use this method to remove the currently applied promotion code, if applicable.
     public func removePromotionCode() async throws {
         try await performUpdate(.setPromotionCode(""))
     }
@@ -301,16 +286,8 @@ public final class CheckoutController: ObservableObject {
 
     // MARK: - Server Updates
 
-    /// Runs an async function that calls your server to update the Checkout Session,
-    /// then automatically refreshes ``session`` with the latest session data.
-    ///
-    /// A 20-second timeout is enforced. If `update` doesn't complete
-    /// within 20 seconds, this method throws ``CheckoutError.timedOut``.
-    ///
-    /// - Parameter update: An async throwing function that makes a request
-    ///   to your server to update the Checkout Session.
-    /// - Throws: ``CheckoutError`` if the function times out, the session is not
-    ///   open, or the refresh fails.
+    /// Use this method to wrap an async closure that makes a request to your server to update the Checkout Session.
+    /// The closure must return when your server has completed the update or throw an error if the update fails.
     public func runServerUpdate(
         _ update: @escaping () async throws -> Void
     ) async throws {
@@ -341,7 +318,8 @@ public final class CheckoutController: ObservableObject {
 
     // MARK: - Element methods
 
-    /// Returns the PaymentElement for this CheckoutController instance.
+    /// Returns a PaymentElement instance.
+    /// Multiple invocations return the same instance.
     public func getPaymentElement() -> PaymentElement {
         assert(configuration.paymentElement != nil, "Set Configuration.paymentElement before calling getPaymentElement().")
         stpAssert(paymentElement != nil, "PaymentElement should be initialized when Configuration.paymentElement is set.")
@@ -371,8 +349,8 @@ public final class CheckoutController: ObservableObject {
     // MARK: - Confirm
 
     /// Use this method to confirm the Checkout Session.
-    /// - Parameter presentingViewController: The view controller used to present any view controllers required e.g. to authenticate the customer. If you're using SwiftUI, you may pass nil and it will use the topmost UIViewController from the key window (not compatible with multi-scene apps).
-    /// - Returns: A `ConfirmResult` enum - either completed, canceled, or failed.
+    /// - Parameter presentingViewController: The view controller used to present any view controllers required e.g. to authenticate the customer. If you're using SwiftUI, you may pass nil and it will use the topmost UIViewController from the key window.
+    /// Returns a ConfirmResult enum - either completed, canceled, or failed.
     public func confirm(from presentingViewController: UIViewController? = nil) async -> ConfirmResult {
         guard let presentingViewController = presentingViewController ?? UIWindow.visibleViewController else {
             let errorMessage = "CheckoutController.confirm(from:) could not find a presenting view controller."

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+Configuration.swift
@@ -90,7 +90,7 @@ extension PaymentElement {
         }
 
         /// The layout of payment methods in the sheet. Defaults to `.automatic`.
-        /// - Note: Only used if you call `PaymentElement.present(from:)`.
+        /// - Note: Only used if you call `presentPaymentElement`.
         public var paymentMethodLayout: PaymentMethodLayout = .automatic {
             didSet {
                 paymentSheetConfiguration.paymentMethodLayout = paymentMethodLayout
@@ -98,7 +98,7 @@ extension PaymentElement {
         }
 
         /// Controls whether the PaymentElement displays mandate text at the bottom for payment methods that require it. If set to `false`, your integration must display `PaymentOptionDisplayData.mandateText` to the customer near your “Buy” button to comply with regulations.
-        /// - Note: This doesn't affect mandates displayed in the sheet and is ignored if you call `PaymentElement.present(from:)`.
+        /// - Note: This doesn't affect mandates displayed in the sheet and is ignored if you call `presentPaymentElement`.
         public var displaysMandateText: Bool = false {
             didSet {
                 embeddedConfiguration.embeddedViewDisplaysMandateText = displaysMandateText
@@ -106,7 +106,7 @@ extension PaymentElement {
         }
 
         /// Determines the behavior when a row is selected.
-        /// - Note: Ignored if you call `PaymentElement.present(from:)`.
+        /// - Note: Ignored if you call `presentPaymentElement`
         public var rowSelectionBehavior: RowSelectionBehavior = .default {
             didSet {
                 embeddedConfiguration.rowSelectionBehavior = embeddedRowSelectionBehavior

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+LinkConfiguration.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement+LinkConfiguration.swift
@@ -8,9 +8,9 @@
 @_spi(STP)
 @_spi(ReactNativeSDK)
 extension PaymentElement {
-    /// Configuration for Link.
+    /// Configuration related to Link
     public struct LinkConfiguration {
-        /// Controls whether Link is displayed.
+        /// The Link display mode.
         public var display: Display = .automatic
 
         /// Creates a Link configuration.
@@ -18,13 +18,14 @@ extension PaymentElement {
             self.display = display
         }
 
-        /// Controls whether Link is displayed.
+        /// Display configuration for Link
         public enum Display: String {
-            /// Show Link when it is available.
+            /// Link will be displayed when available.
             case automatic
-            /// Never show Link.
+            /// Link will never be displayed.
             case never
-            /// Keep Link enabled, but hide its button or row in PaymentElement.
+            /// Link remains enabled (e.g. for automatic Link verification, Instant Bank Payments, Link Card Brand, and inline signup)
+            /// but its button/row will not be shown in the payment element UI.
             case walletButtonHidden
         }
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -37,7 +37,7 @@ public final class PaymentElement {
 
     /// Presents a sheet that displays payment methods.
     /// - Parameter from: The view controller that presents the sheet. If you're using SwiftUI, you may pass nil and it will use the topmost UIViewController from the key window.
-    /// - Parameter completion: Called when the sheet is dismissed.
+    /// Returns when the sheet is dismissed.
     public func present(from viewController: UIViewController? = nil, completion: (() -> Void)? = nil) {
         guard let presentingViewController = viewController ?? UIWindow.visibleViewController else {
             let errorMessage = "PaymentElement.present(from:) could not find a presenting view controller."

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElementView.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElementView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 import UIKit
 
-/// A SwiftUI view that displays payment methods.
+/// A view that displays payment methods.
 @_spi(STP)
 public struct PaymentElementView: View {
     @ObservedObject private var viewModel: PaymentElementViewModel


### PR DESCRIPTION
## Summary
Aligns CheckoutController and Payment Element API comments with the approved Checkout Elements mobile API review. This also restores the canonical Apple Pay, Link, and payment option documentation copied by the review.

## Motivation
MOBILE_APIREVIEW-227

## Testing
No new tests.

## Changelog
N/A