### PR TITLE
Ensure nightly failures can file Jira tickets

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -729,6 +729,7 @@ workflows:
         is_always_run: true
         title: Set Bundler to use local vendor directory
     - git-clone@8.2:
+        is_always_run: true
         inputs:
         - clone_depth: "1"
     - restore-cache@2.4:


### PR DESCRIPTION
## Summary

When simulator runtime installation failed, Bitrise skipped Git Clone. The notifier still ran, but failed because `ci_scripts/notify_ci.rb` had not been checked out.

Mark Git Clone as always-run so the notification script is available and prerequisite failures file Jira tickets. Fixes [RUN_MOBILESDK-5513](https://jira.corp.stripe.com/browse/RUN_MOBILESDK-5513).

## Testing

No new tests.