### PR TITLE
Add clear payment option to Checkout playground

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -25,11 +25,11 @@ struct CheckoutCartPaymentMethodSection: View {
 
                 Spacer()
 
-                if session.paymentOption != nil {
+                if integrationType == .embedded, session.paymentOption != nil {
                     Button(role: .destructive) {
                         clearPaymentOption()
                     } label: {
-                        Label("Clear", systemImage: "xmark.circle")
+                        Text("Clear payment option")
                             .font(.subheadline.weight(.medium))
                     }
                     .disabled(checkout.isUpdating)

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -13,14 +13,30 @@ struct CheckoutCartPaymentMethodSection: View {
     let integrationType: CheckoutPlayground.IntegrationType
 
     @State private var showEmbeddedScreen = false
+    @State private var clearPaymentOptionErrorMessage: String?
 
     private var session: CheckoutController.Session { checkout.session }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("Payment Method")
-                .font(.title2).bold()
-                .padding(.horizontal)
+            HStack {
+                Text("Payment Method")
+                    .font(.title2).bold()
+
+                Spacer()
+
+                if session.paymentOption != nil {
+                    Button(role: .destructive) {
+                        clearPaymentOption()
+                    } label: {
+                        Label("Clear", systemImage: "xmark.circle")
+                            .font(.subheadline.weight(.medium))
+                    }
+                    .disabled(checkout.isUpdating)
+                    .accessibilityLabel("Clear payment method selection")
+                }
+            }
+            .padding(.horizontal)
 
             Button {
                 presentPaymentElement()
@@ -44,6 +60,21 @@ struct CheckoutCartPaymentMethodSection: View {
             .sheet(isPresented: $showEmbeddedScreen) {
                 CheckoutEmbeddedScreen(paymentElement: checkout.getPaymentElement())
             }
+            .alert(
+                "Unable to clear payment method",
+                isPresented: Binding(
+                    get: { clearPaymentOptionErrorMessage != nil },
+                    set: { if !$0 { clearPaymentOptionErrorMessage = nil } }
+                ),
+                actions: {
+                    Button("OK", role: .cancel) {
+                        clearPaymentOptionErrorMessage = nil
+                    }
+                },
+                message: {
+                    Text(clearPaymentOptionErrorMessage ?? "")
+                }
+            )
         }
     }
 
@@ -83,6 +114,16 @@ struct CheckoutCartPaymentMethodSection: View {
             showEmbeddedScreen = true
         case .eceOnly:
             break
+        }
+    }
+
+    private func clearPaymentOption() {
+        Task { @MainActor in
+            do {
+                try await checkout.clearPaymentOption()
+            } catch {
+                clearPaymentOptionErrorMessage = error.localizedDescription
+            }
         }
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartPaymentButton.swift
@@ -33,7 +33,6 @@ struct CheckoutCartPaymentMethodSection: View {
                             .font(.subheadline.weight(.medium))
                     }
                     .disabled(checkout.isUpdating)
-                    .accessibilityLabel("Clear payment method selection")
                 }
             }
             .padding(.horizontal)
@@ -61,7 +60,7 @@ struct CheckoutCartPaymentMethodSection: View {
                 CheckoutEmbeddedScreen(paymentElement: checkout.getPaymentElement())
             }
             .alert(
-                "Unable to clear payment method",
+                "Unable to clear payment option",
                 isPresented: Binding(
                     get: { clearPaymentOptionErrorMessage != nil },
                     set: { if !$0 { clearPaymentOptionErrorMessage = nil } }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
@@ -298,7 +298,9 @@ final class CheckoutCartViewController: UIViewController {
                 makeSection(
                     title: "Payment Method",
                     content: makeCard(containing: makePaymentMethodRow(session: session)),
-                    accessory: session.paymentOption == nil ? nil : makeClearPaymentOptionButton()
+                    accessory: integrationType == .embedded && session.paymentOption != nil
+                        ? makeClearPaymentOptionButton()
+                        : nil
                 )
             )
         }
@@ -619,10 +621,8 @@ final class CheckoutCartViewController: UIViewController {
 
     private func makeClearPaymentOptionButton() -> UIButton {
         let button = UIButton(type: .system)
-        button.setImage(UIImage(systemName: "xmark.circle"), for: .normal)
-        button.setTitle(" Clear", for: .normal)
+        button.setTitle("Clear payment option", for: .normal)
         button.setTitleColor(.systemRed, for: .normal)
-        button.tintColor = .systemRed
         button.titleLabel?.font = .preferredFont(forTextStyle: .subheadline)
         button.addTarget(self, action: #selector(clearPaymentOptionButtonTapped), for: .touchUpInside)
         button.accessibilityLabel = "Clear payment method selection"

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
@@ -297,7 +297,8 @@ final class CheckoutCartViewController: UIViewController {
             contentStackView.addArrangedSubview(
                 makeSection(
                     title: "Payment Method",
-                    content: makeCard(containing: makePaymentMethodRow(session: session))
+                    content: makeCard(containing: makePaymentMethodRow(session: session)),
+                    accessory: session.paymentOption == nil ? nil : makeClearPaymentOptionButton()
                 )
             )
         }
@@ -616,6 +617,18 @@ final class CheckoutCartViewController: UIViewController {
         return rowView
     }
 
+    private func makeClearPaymentOptionButton() -> UIButton {
+        let button = UIButton(type: .system)
+        button.setImage(UIImage(systemName: "xmark.circle"), for: .normal)
+        button.setTitle(" Clear", for: .normal)
+        button.setTitleColor(.systemRed, for: .normal)
+        button.tintColor = .systemRed
+        button.titleLabel?.font = .preferredFont(forTextStyle: .subheadline)
+        button.addTarget(self, action: #selector(clearPaymentOptionButtonTapped), for: .touchUpInside)
+        button.accessibilityLabel = "Clear payment method selection"
+        return button
+    }
+
     private func makeCheckoutButton(
         checkout: CheckoutController,
         session: CheckoutController.Session
@@ -662,13 +675,20 @@ final class CheckoutCartViewController: UIViewController {
         return button
     }
 
-    private func makeSection(title: String, content: UIView) -> UIView {
+    private func makeSection(title: String, content: UIView, accessory: UIView? = nil) -> UIView {
         let titleLabel = UILabel()
         titleLabel.text = title
         titleLabel.font = .preferredFont(forTextStyle: .title2)
         titleLabel.adjustsFontForContentSizeCategory = true
 
-        let stackView = UIStackView(arrangedSubviews: [titleLabel, content])
+        let headerStackView = UIStackView(arrangedSubviews: [titleLabel])
+        headerStackView.alignment = .center
+        if let accessory {
+            accessory.setContentHuggingPriority(.required, for: .horizontal)
+            headerStackView.addArrangedSubview(accessory)
+        }
+
+        let stackView = UIStackView(arrangedSubviews: [headerStackView, content])
         stackView.axis = .vertical
         stackView.spacing = 16
         return stackView
@@ -846,6 +866,20 @@ final class CheckoutCartViewController: UIViewController {
             present(UINavigationController(rootViewController: viewController), animated: true)
         case .eceOnly:
             break
+        }
+    }
+
+    @objc private func clearPaymentOptionButtonTapped() {
+        guard let checkout else { return }
+
+        Task {
+            errorMessage = nil
+            do {
+                try await checkout.clearPaymentOption()
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+            renderCheckout()
         }
     }
 

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
@@ -625,7 +625,6 @@ final class CheckoutCartViewController: UIViewController {
         button.setTitleColor(.systemRed, for: .normal)
         button.titleLabel?.font = .preferredFont(forTextStyle: .subheadline)
         button.addTarget(self, action: #selector(clearPaymentOptionButtonTapped), for: .touchUpInside)
-        button.accessibilityLabel = "Clear payment method selection"
         return button
     }
 
@@ -878,8 +877,8 @@ final class CheckoutCartViewController: UIViewController {
                 try await checkout.clearPaymentOption()
             } catch {
                 errorMessage = error.localizedDescription
+                renderCheckout()
             }
-            renderCheckout()
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds a Clear payment option button to the Checkout playground when using Payment Element as a view. This lets us exercise `clearPaymentOption()` in both the SwiftUI and UIKit playgrounds.
- Uses the existing Checkout loading state while clear is in progress. `isUpdating` disables the playground UI and shows the existing loading indicator when a Checkout Session update is needed.
- Displays errors using the playground’s existing error UI.


https://github.com/user-attachments/assets/7db8a778-f8dd-44b3-99fa-8e5698d8fd44



## Motivation
- CheckoutSessions

## Testing
No new tests.

- Built the PaymentSheet Example app.

## Changelog
N/A