### PR TITLE
Add Checkout playground scenarios

### DIFF
--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartView.swift
@@ -24,6 +24,7 @@ struct CheckoutCartView: View {
     let defaultShippingAddress: CheckoutPlayground.DefaultShippingAddress?
     let adaptivePricing: Bool
     let integrationType: CheckoutPlayground.IntegrationType
+    let showsWalletsInPaymentElement: Bool
     let expressCheckoutElementSettings: CheckoutPlayground.ExpressCheckoutElementSettings
     var currencySelectorAppearance = CurrencySelectorElement.Appearance()
     var delayPaymentPagesRequests = false
@@ -145,9 +146,13 @@ struct CheckoutCartView: View {
             )
             if integrationType != .eceOnly {
                 var paymentElementConfiguration = PaymentElement.Configuration()
-                paymentElementConfiguration.applePayConfiguration = PaymentElement.ApplePayConfiguration(
-                    merchantId: "merchant.com.stripe.paymentsheet.example"
-                )
+                if showsWalletsInPaymentElement {
+                    paymentElementConfiguration.applePayConfiguration = PaymentElement.ApplePayConfiguration(
+                        merchantId: "merchant.com.stripe.paymentsheet.example"
+                    )
+                } else {
+                    paymentElementConfiguration.linkConfiguration = PaymentElement.LinkConfiguration(display: .never)
+                }
                 config.paymentElement = paymentElementConfiguration
             }
             config.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutCartViewController.swift
@@ -20,6 +20,7 @@ struct CheckoutCartUIKitView: UIViewControllerRepresentable {
     let defaultShippingAddress: CheckoutPlayground.DefaultShippingAddress?
     let adaptivePricing: Bool
     let integrationType: CheckoutPlayground.IntegrationType
+    let showsWalletsInPaymentElement: Bool
     let expressCheckoutElementSettings: CheckoutPlayground.ExpressCheckoutElementSettings
     let currencySelectorAppearance: CurrencySelectorElement.Appearance
     let delayPaymentPagesRequests: Bool
@@ -31,6 +32,7 @@ struct CheckoutCartUIKitView: UIViewControllerRepresentable {
             defaultShippingAddress: defaultShippingAddress,
             adaptivePricing: adaptivePricing,
             integrationType: integrationType,
+            showsWalletsInPaymentElement: showsWalletsInPaymentElement,
             expressCheckoutElementSettings: expressCheckoutElementSettings,
             currencySelectorAppearance: currencySelectorAppearance,
             delayPaymentPagesRequests: delayPaymentPagesRequests,
@@ -50,6 +52,7 @@ final class CheckoutCartViewController: UIViewController {
     private let defaultShippingAddress: CheckoutPlayground.DefaultShippingAddress?
     private let adaptivePricing: Bool
     private let integrationType: CheckoutPlayground.IntegrationType
+    private let showsWalletsInPaymentElement: Bool
     private let expressCheckoutElementSettings: CheckoutPlayground.ExpressCheckoutElementSettings
     private let currencySelectorAppearance: CurrencySelectorElement.Appearance
     private let delayPaymentPagesRequests: Bool
@@ -83,6 +86,7 @@ final class CheckoutCartViewController: UIViewController {
         defaultShippingAddress: CheckoutPlayground.DefaultShippingAddress?,
         adaptivePricing: Bool,
         integrationType: CheckoutPlayground.IntegrationType,
+        showsWalletsInPaymentElement: Bool,
         expressCheckoutElementSettings: CheckoutPlayground.ExpressCheckoutElementSettings,
         currencySelectorAppearance: CurrencySelectorElement.Appearance,
         delayPaymentPagesRequests: Bool,
@@ -93,6 +97,7 @@ final class CheckoutCartViewController: UIViewController {
         self.defaultShippingAddress = defaultShippingAddress
         self.adaptivePricing = adaptivePricing
         self.integrationType = integrationType
+        self.showsWalletsInPaymentElement = showsWalletsInPaymentElement
         self.expressCheckoutElementSettings = expressCheckoutElementSettings
         self.currencySelectorAppearance = currencySelectorAppearance
         self.delayPaymentPagesRequests = delayPaymentPagesRequests
@@ -199,9 +204,13 @@ final class CheckoutCartViewController: UIViewController {
             )
             if integrationType != .eceOnly {
                 var paymentElementConfiguration = PaymentElement.Configuration()
-                paymentElementConfiguration.applePayConfiguration = PaymentElement.ApplePayConfiguration(
-                    merchantId: "merchant.com.stripe.paymentsheet.example"
-                )
+                if showsWalletsInPaymentElement {
+                    paymentElementConfiguration.applePayConfiguration = PaymentElement.ApplePayConfiguration(
+                        merchantId: "merchant.com.stripe.paymentsheet.example"
+                    )
+                } else {
+                    paymentElementConfiguration.linkConfiguration = PaymentElement.LinkConfiguration(display: .never)
+                }
                 configuration.paymentElement = paymentElementConfiguration
             }
             configuration.defaults.shippingDetails = defaultShippingAddress?.checkoutShippingDetails

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundScenarioView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundScenarioView.swift
@@ -1,0 +1,191 @@
+//
+//  CheckoutPlaygroundScenarioView.swift
+//  PaymentSheet Example
+//
+//  Created by Nick Porter on 9/8/26.
+
+import SwiftUI
+
+struct CheckoutPlaygroundScenarioView: View {
+    let groups: [CheckoutPlayground.ScenarioGroup]
+    let onRun: (CheckoutPlayground.Scenario) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationView {
+            List {
+                Section {
+                    header
+                        .listRowInsets(EdgeInsets(top: 18, leading: 20, bottom: 18, trailing: 20))
+                }
+
+                Section("Choose a category") {
+                    ForEach(groups) { group in
+                        NavigationLink {
+                            CheckoutPlaygroundScenarioGroupView(group: group, onRun: run)
+                        } label: {
+                            CheckoutPlaygroundScenarioGroupRow(group: group)
+                        }
+                        .accessibilityIdentifier("checkout_scenario_group_\(group.id)")
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .navigationTitle("Run a scenario")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    private var header: some View {
+        HStack(alignment: .top, spacing: 14) {
+            Image(systemName: "play.fill")
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(width: 42, height: 42)
+                .background(Color.blue)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Repeatable test configurations")
+                    .font(.headline)
+                Text("Choosing a scenario replaces the current settings and creates a Checkout Session.")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func run(_ scenario: CheckoutPlayground.Scenario) {
+        onRun(scenario)
+        dismiss()
+    }
+}
+
+private struct CheckoutPlaygroundScenarioGroupView: View {
+    let group: CheckoutPlayground.ScenarioGroup
+    let onRun: (CheckoutPlayground.Scenario) -> Void
+
+    var body: some View {
+        List {
+            Section {
+                Text(group.detail)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .padding(.vertical, 6)
+            }
+
+            if !group.groups.isEmpty {
+                Section("Categories") {
+                    ForEach(group.groups) { child in
+                        NavigationLink {
+                            CheckoutPlaygroundScenarioGroupView(group: child, onRun: onRun)
+                        } label: {
+                            CheckoutPlaygroundScenarioGroupRow(group: child)
+                        }
+                        .accessibilityIdentifier("checkout_scenario_group_\(child.id)")
+                    }
+                }
+            }
+
+            if !group.scenarios.isEmpty {
+                Section("Scenarios") {
+                    ForEach(group.scenarios, id: \.id) { scenario in
+                        Button {
+                            onRun(scenario)
+                        } label: {
+                            CheckoutPlaygroundScenarioRow(scenario: scenario, tint: group.style.tint)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityIdentifier("checkout_scenario_\(scenario.id)")
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .navigationTitle(group.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private struct CheckoutPlaygroundScenarioGroupRow: View {
+    let group: CheckoutPlayground.ScenarioGroup
+
+    var body: some View {
+        HStack(spacing: 13) {
+            Image(systemName: group.style.icon)
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(width: 36, height: 36)
+                .background(group.style.tint)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(group.title)
+                    .font(.body.weight(.medium))
+                    .foregroundColor(.primary)
+                Text("\(group.scenarioCount) \(group.scenarioCount == 1 ? "scenario" : "scenarios")")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+private struct CheckoutPlaygroundScenarioRow: View {
+    let scenario: CheckoutPlayground.Scenario
+    let tint: Color
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(scenario.title)
+                    .font(.body.weight(.medium))
+                    .foregroundColor(.primary)
+                Text(scenario.detail)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 12)
+
+            Image(systemName: "play.circle.fill")
+                .font(.system(size: 25))
+                .foregroundColor(tint)
+        }
+        .contentShape(Rectangle())
+        .padding(.vertical, 5)
+    }
+}
+
+private extension CheckoutPlayground.ScenarioGroup.Style {
+    var icon: String {
+        switch self {
+        case .localPaymentMethods: return "globe.americas.fill"
+        case .tax: return "percent"
+        case .savedPaymentMethods: return "person.crop.circle.badge.checkmark"
+        case .elements: return "square.grid.2x2.fill"
+        case .region: return "folder.fill"
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .localPaymentMethods: return .blue
+        case .tax: return .orange
+        case .savedPaymentMethods: return .purple
+        case .elements: return .teal
+        case .region: return .blue
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundScenarios.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundScenarios.swift
@@ -1,0 +1,324 @@
+//
+//  CheckoutPlaygroundScenarios.swift
+//  PaymentSheet Example
+//
+//  Created by Nick Porter on 9/8/26.
+
+import Foundation
+@_spi(STP) import StripePaymentSheet
+
+extension CheckoutPlayground {
+    struct Scenario: Identifiable {
+        let id: String
+        let title: String
+        let detail: String
+        let configuration: Configuration
+
+        struct Configuration {
+            var settings = Settings()
+            var expressCheckoutElement = ExpressCheckoutElementSettings()
+        }
+    }
+
+    struct ScenarioGroup: Identifiable {
+        enum Style {
+            case localPaymentMethods
+            case tax
+            case savedPaymentMethods
+            case elements
+            case region
+        }
+
+        let id: String
+        let title: String
+        let detail: String
+        let style: Style
+        var groups: [ScenarioGroup] = []
+        var scenarios: [Scenario] = []
+
+        var scenarioCount: Int {
+            scenarios.count + groups.reduce(0) { $0 + $1.scenarioCount }
+        }
+    }
+
+    enum ScenarioCatalog {
+        static let groups = [
+            localPaymentMethods,
+            tax,
+            savedPaymentMethods,
+            elements,
+        ]
+
+        private static let localPaymentMethods = ScenarioGroup(
+            id: "local-payment-methods",
+            title: "Local payment methods",
+            detail: "Regional merchant, currency, and payment method combinations.",
+            style: .localPaymentMethods,
+            groups: [
+                regionalGroup(
+                    id: "north-america",
+                    title: "North America",
+                    scenarios: [
+                        regional("us-common", "US common", .us, .usd, ["card", "us_bank_account", "link", "cashapp", "klarna"]),
+                        regional("us-alternatives", "US alternatives", .us, .usd, ["card", "affirm", "afterpay_clearpay", "amazon_pay", "crypto", "sunbit"]),
+                        regional("mexico", "Mexico", .mexico, .mxn, ["card", "oxxo"]),
+                    ]
+                ),
+                regionalGroup(
+                    id: "europe",
+                    title: "Europe",
+                    scenarios: [
+                        regional("euro-bank-methods", "Euro bank methods", .france, .eur, ["card", "ideal", "bancontact", "sepa_debit", "eps"]),
+                        regional("france-alternatives", "France / EU alternatives", .france, .eur, ["card", "alma", "mobilepay"]),
+                        regional("germany", "Germany", .germany, .eur, ["card", "billie", "wero"]),
+                        regional("italy", "Italy", .italy, .eur, ["card", "satispay"]),
+                        regional("spain", "Spain", .spain, .eur, ["card", "sequra"]),
+                        regional("poland", "Poland", .france, .pln, ["card", "blik", "p24"]),
+                        regional("sweden", "Sweden", .france, .sek, ["card", "swish"]),
+                        regional("uk-bank-debit", "UK bank debit", .unitedKingdom, .gbp, ["card", "bacs_debit"]),
+                        regional("gbp-wallets", "GBP wallets", .unitedKingdom, .gbp, ["card", "paypal", "revolut_pay"]),
+                        regional("switzerland", "Switzerland", .unitedKingdom, .chf, ["card", "twint"]),
+                        regional("portugal", "Portugal", .france, .eur, ["card", "multibanco"]),
+                    ]
+                ),
+                regionalGroup(
+                    id: "asia-pacific",
+                    title: "Asia-Pacific",
+                    scenarios: [
+                        regional("australia", "Australia", .australia, .aud, ["card", "au_becs_debit"]),
+                        regional("singapore", "Singapore", .singapore, .sgd, ["card", "grabpay", "paynow"]),
+                        regional("malaysia", "Malaysia", .malaysia, .myr, ["card", "fpx"]),
+                        regional("thailand", "Thailand", .thailand, .thb, ["card", "promptpay"]),
+                        regional("japan", "Japan", .japan, .jpy, ["card", "konbini", "paypay"]),
+                        regional("korea", "Korea", .us, .krw, ["card", "kr_card", "naver_pay", "payco"]),
+                        regional("alipay", "Alipay", .us, .usd, ["card", "klarna", "affirm", "alipay"]),
+                    ]
+                ),
+                regionalGroup(
+                    id: "latin-america",
+                    title: "Latin America",
+                    scenarios: [
+                        regional("brazil", "Brazil", .brazil, .brl, ["card", "boleto"]),
+                    ]
+                ),
+            ]
+        )
+
+        private static let tax = ScenarioGroup(
+            id: "tax",
+            title: "Tax",
+            detail: "Common automatic tax and address collection configurations.",
+            style: .tax,
+            scenarios: [
+                scenario("no-tax", "No tax", "Automatic tax disabled.") {
+                    $0.settings.automaticTax = false
+                },
+                scenario("tax-automatic-billing", "Automatic billing", "Automatic tax with on-demand billing details.") {
+                    $0.settings.merchantCountry = .usTax
+                    $0.settings.automaticTax = true
+                    $0.settings.billingAddressCollection = .automatic
+                    $0.settings.shippingAddressCollection = false
+                },
+                scenario("tax-required-billing", "Required billing", "Automatic tax with a required billing address.") {
+                    $0.settings.merchantCountry = .usTax
+                    $0.settings.automaticTax = true
+                    $0.settings.billingAddressCollection = .required
+                    $0.settings.shippingAddressCollection = false
+                },
+                scenario("tax-shipping", "Shipping address", "Automatic tax calculated from a collected shipping address.") {
+                    $0.settings.merchantCountry = .usTax
+                    $0.settings.automaticTax = true
+                    $0.settings.shippingAddressCollection = true
+                },
+            ]
+        )
+
+        private static let savedPaymentMethods = ScenarioGroup(
+            id: "saved-payment-methods",
+            title: "Saved payment methods",
+            detail: "Guest, new, and returning customer save/remove behavior.",
+            style: .savedPaymentMethods,
+            groups: [
+                ScenarioGroup(
+                    id: "returning-customer",
+                    title: "Returning customer",
+                    detail: "Choose which saved payment method actions are available.",
+                    style: .region,
+                    scenarios: [
+                        returningCustomer("returning-save-remove", "Save and remove", save: true, remove: true),
+                        returningCustomer("returning-save-only", "Save only", save: true, remove: false),
+                        returningCustomer("returning-remove-only", "Remove only", save: false, remove: true),
+                        returningCustomer("returning-view-only", "View only", save: false, remove: false),
+                    ]
+                ),
+            ],
+            scenarios: [
+                scenario("guest", "Guest", "Checkout without a Customer object.") {
+                    $0.settings.customerType = .guest
+                },
+                scenario("new-save-enabled", "New customer — saving enabled", "Create a customer and offer to save the payment method.") {
+                    $0.settings.customerType = .new
+                    $0.settings.checkoutSessionPaymentMethodSave = true
+                },
+                scenario("new-save-disabled", "New customer — saving disabled", "Create a customer without offering to save.") {
+                    $0.settings.customerType = .new
+                    $0.settings.checkoutSessionPaymentMethodSave = false
+                },
+            ]
+        )
+
+        private static let elements = ScenarioGroup(
+            id: "elements",
+            title: "Elements",
+            detail: "Payment, express checkout, shipping, and currency selector layouts.",
+            style: .elements,
+            groups: [
+                ScenarioGroup(
+                    id: "express-checkout-element",
+                    title: "Express Checkout Element",
+                    detail: "Apple Pay and Link combinations for iOS.",
+                    style: .region,
+                    scenarios: [
+                        express("ece-link-apple-pay", "Link and Apple Pay", link: true, applePay: true),
+                        express("ece-link-only", "Link only", link: true, applePay: false),
+                        express("ece-apple-pay-only", "Apple Pay only", link: false, applePay: true),
+                        express("ece-shipping", "Shipping required", link: true, applePay: true, shipping: true),
+                    ]
+                ),
+                ScenarioGroup(
+                    id: "shipping-address-element",
+                    title: "Shipping Address Element",
+                    detail: "Collect or prefill shipping details.",
+                    style: .region,
+                    scenarios: [
+                        scenario("shipping-new", "Collect a new shipping address", "Show an empty Shipping Address Element.") {
+                            $0.settings.shippingAddressCollection = true
+                            $0.settings.defaultShippingAddressOption = .none
+                        },
+                        scenario("shipping-prefilled", "Prefilled US shipping address", "Start with the standard Jenny Rosen test address.") {
+                            $0.settings.shippingAddressCollection = true
+                            $0.settings.defaultShippingAddressOption = .usTestAddress
+                        },
+                    ]
+                ),
+                ScenarioGroup(
+                    id: "currency-selector",
+                    title: "Currency Selector",
+                    detail: "Exercise Adaptive Pricing location overrides.",
+                    style: .region,
+                    scenarios: [
+                        currencySelector("currency-france", "France", .fr),
+                        currencySelector("currency-japan", "Japan", .jp),
+                    ]
+                ),
+            ],
+            scenarios: [
+                scenario("payment-element-card", "Payment Element — card only", "Present a card-only Payment Element without express checkout.") {
+                    $0.settings.integrationType = .flowController
+                    $0.settings.showExpressCheckoutElement = false
+                    $0.settings.showsCurrencySelectorElement = false
+                    $0.settings.automaticPaymentMethods = false
+                    $0.settings.paymentMethodTypes = ["card"]
+                    $0.expressCheckoutElement.isEnabled = false
+                },
+                scenario("all-elements", "All elements", "Payment, express checkout, shipping, and currency selector together.") {
+                    $0.settings.integrationType = .embedded
+                    $0.settings.showExpressCheckoutElement = true
+                    $0.settings.showsWalletsInPaymentElement = false
+                    $0.settings.showsCurrencySelectorElement = true
+                    $0.settings.shippingAddressCollection = true
+                    $0.settings.adaptivePricingCountry = .fr
+                    $0.settings.automaticPaymentMethods = true
+                    $0.expressCheckoutElement.isEnabled = true
+                },
+            ]
+        )
+
+        private static func regionalGroup(
+            id: String,
+            title: String,
+            scenarios: [Scenario]
+        ) -> ScenarioGroup {
+            ScenarioGroup(
+                id: id,
+                title: title,
+                detail: "\(scenarios.count) regional configurations",
+                style: .region,
+                scenarios: scenarios
+            )
+        }
+
+        private static func regional(
+            _ id: String,
+            _ title: String,
+            _ merchant: MerchantCountry,
+            _ currency: Currency,
+            _ paymentMethods: Set<String>
+        ) -> Scenario {
+            scenario(id, title, "\(merchant.displayName) · \(currency.rawValue.uppercased()) · \(paymentMethods.count) methods") {
+                $0.settings.merchantCountry = merchant
+                $0.settings.currency = currency
+                $0.settings.automaticTax = false
+                $0.settings.shippingAddressCollection = false
+                $0.settings.automaticPaymentMethods = false
+                $0.settings.paymentMethodTypes = paymentMethods
+            }
+        }
+
+        private static func returningCustomer(
+            _ id: String,
+            _ title: String,
+            save: Bool,
+            remove: Bool
+        ) -> Scenario {
+            scenario(id, title, "Save \(save ? "on" : "off") · Remove \(remove ? "on" : "off")") {
+                $0.settings.customerType = .returning
+                $0.settings.checkoutSessionPaymentMethodSave = save
+                $0.settings.checkoutSessionPaymentMethodRemove = remove
+            }
+        }
+
+        private static func express(
+            _ id: String,
+            _ title: String,
+            link: Bool,
+            applePay: Bool,
+            shipping: Bool = false
+        ) -> Scenario {
+            scenario(id, title, shipping ? "Collect shipping details in the wallet." : "Express checkout without Payment Element wallets.") {
+                $0.settings.integrationType = .eceOnly
+                $0.settings.showExpressCheckoutElement = true
+                $0.settings.showsWalletsInPaymentElement = false
+                $0.settings.showsCurrencySelectorElement = false
+                $0.settings.automaticPaymentMethods = true
+                $0.expressCheckoutElement.isEnabled = true
+                $0.expressCheckoutElement.linkDisplay = link ? .automatic : .never
+                $0.expressCheckoutElement.applePayDisplay = applePay ? .automatic : .never
+                $0.expressCheckoutElement.shippingAddressRequired = shipping
+            }
+        }
+
+        private static func currencySelector(
+            _ id: String,
+            _ title: String,
+            _ country: AdaptivePricingCountry
+        ) -> Scenario {
+            scenario(id, title, "Mock the customer location as \(country.displayName).") {
+                $0.settings.showsCurrencySelectorElement = true
+                $0.settings.adaptivePricingCountry = country
+            }
+        }
+
+        private static func scenario(
+            _ id: String,
+            _ title: String,
+            _ detail: String,
+            configure: (inout Scenario.Configuration) -> Void
+        ) -> Scenario {
+            var configuration = Scenario.Configuration()
+            configure(&configuration)
+            configuration.settings.showExpressCheckoutElement = configuration.expressCheckoutElement.isEnabled
+            return Scenario(id: id, title: title, detail: detail, configuration: configuration)
+        }
+    }
+}

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundSections.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct CheckoutPlaygroundConfigurationSection: View {
     @Binding var uiFramework: CheckoutPlayground.UIFramework
     @Binding var integrationType: CheckoutPlayground.IntegrationType
+    @Binding var merchantCountry: CheckoutPlayground.MerchantCountry
     @Binding var currency: CheckoutPlayground.Currency
     @Binding var customerType: CheckoutPlayground.CustomerType
     @Binding var checkoutEndpointOption: CheckoutPlayground.EndpointOption
@@ -38,6 +39,12 @@ struct CheckoutPlaygroundConfigurationSection: View {
                     icon: "square.stack.3d.up.fill",
                     selection: $integrationType,
                     tooltip: "Choose the PaymentElement presentation.\n\n• sheet: Presents PaymentElement as a payment method selector.\n• view: Displays PaymentElement in the checkout flow.\n• none: Hides PaymentElement.",
+                    displayText: { $0.displayName }
+                )
+                CheckoutPlayground.PickerRow(
+                    title: "Merchant",
+                    icon: "building.2.fill",
+                    selection: $merchantCountry,
                     displayText: { $0.displayName }
                 )
                 CheckoutPlayground.PickerRow(
@@ -178,6 +185,7 @@ struct CheckoutPlaygroundFeaturesSection: View {
     @Binding var checkoutSessionPaymentMethodSave: Bool
     @Binding var checkoutSessionPaymentMethodRemove: Bool
     @Binding var automaticPaymentMethods: Bool
+    @Binding var showsWalletsInPaymentElement: Bool
     @Binding var linkMode: CheckoutPlayground.LinkMode
 
     private var shouldShowAutomaticTax: Bool {
@@ -217,6 +225,11 @@ struct CheckoutPlaygroundFeaturesSection: View {
                     title: "Automatic Payment Methods",
                     isOn: $automaticPaymentMethods,
                     tooltip: "Sends `automatic_payment_methods: true` instead of an explicit `payment_method_types` array. Stripe selects the best payment methods for the session."
+                )
+                CheckoutPlayground.ToggleRow(
+                    title: "Wallets in PaymentElement",
+                    isOn: $showsWalletsInPaymentElement,
+                    tooltip: "Controls whether Apple Pay and Link can appear in PaymentElement. Turn this off when ExpressCheckoutElement owns wallet presentation."
                 )
                 CheckoutPlayground.PickerRow(
                     title: "Link Mode",

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundTypes.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundTypes.swift
@@ -96,12 +96,21 @@ enum CheckoutPlayground {
         case cad
         case aud
         case jpy
+        case mxn
+        case pln
+        case sek
+        case chf
+        case sgd
+        case myr
+        case thb
+        case krw
+        case brl
 
         var id: String { rawValue }
 
         var symbol: String {
             switch self {
-            case .usd, .cad, .aud:
+            case .usd, .cad, .aud, .sgd:
                 return "$"
             case .eur:
                 return "€"
@@ -109,11 +118,67 @@ enum CheckoutPlayground {
                 return "£"
             case .jpy:
                 return "¥"
+            case .mxn:
+                return "MX$"
+            case .pln:
+                return "zł"
+            case .sek:
+                return "kr"
+            case .chf:
+                return "CHF "
+            case .myr:
+                return "RM "
+            case .thb:
+                return "฿"
+            case .krw:
+                return "₩"
+            case .brl:
+                return "R$"
             }
         }
 
         var isZeroDecimal: Bool {
-            return self == .jpy
+            return self == .jpy || self == .krw
+        }
+    }
+
+    enum MerchantCountry: String, CaseIterable, Identifiable, Codable {
+        case us = "US"
+        case usTax = "us_tax"
+        case mexico = "MX"
+        case france = "FR"
+        case germany = "DE"
+        case italy = "IT"
+        case spain = "ES"
+        case unitedKingdom = "GB"
+        case australia = "AU"
+        case singapore = "SG"
+        case malaysia = "MY"
+        case thailand = "TH"
+        case japan = "JP"
+        case china = "CN"
+        case brazil = "BR"
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .us: return "United States"
+            case .usTax: return "United States (Tax)"
+            case .mexico: return "Mexico"
+            case .france: return "France"
+            case .germany: return "Germany"
+            case .italy: return "Italy"
+            case .spain: return "Spain"
+            case .unitedKingdom: return "United Kingdom"
+            case .australia: return "Australia"
+            case .singapore: return "Singapore"
+            case .malaysia: return "Malaysia"
+            case .thailand: return "Thailand"
+            case .japan: return "Japan"
+            case .china: return "China"
+            case .brazil: return "Brazil"
+            }
         }
     }
 
@@ -261,7 +326,10 @@ enum CheckoutPlayground {
         var uiFramework: UIFramework = .swiftUI
         var integrationType: IntegrationType = .flowController
         var showExpressCheckoutElement = true
+        var showsWalletsInPaymentElement = true
+        var showsCurrencySelectorElement = true
         var linkMode: LinkMode = .native
+        var merchantCountry: MerchantCountry = .usTax
         var currency: Currency = .usd
         var customerType: CustomerType = .guest
         var lineItems: [LineItemConfig] = LineItemConfig.defaults

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundView.swift
@@ -10,6 +10,7 @@ struct CheckoutPlaygroundView: View {
     @StateObject private var viewModel = CheckoutPlayground.ViewModel()
     @State private var showCurrencySelectorAppearance = false
     @State private var showBillingDetailsCollection = false
+    @State private var showScenarios = false
 
     var body: some View {
         Group {
@@ -26,9 +27,12 @@ struct CheckoutPlaygroundView: View {
                             .transition(.move(edge: .top).combined(with: .opacity))
                         }
 
+                        scenarioLauncher
+
                         CheckoutPlaygroundConfigurationSection(
                             uiFramework: $viewModel.uiFramework,
                             integrationType: $viewModel.integrationType,
+                            merchantCountry: $viewModel.merchantCountry,
                             currency: $viewModel.currency,
                             customerType: $viewModel.customerType,
                             checkoutEndpointOption: $viewModel.checkoutEndpointOption,
@@ -52,6 +56,7 @@ struct CheckoutPlaygroundView: View {
                             checkoutSessionPaymentMethodSave: $viewModel.checkoutSessionPaymentMethodSave,
                             checkoutSessionPaymentMethodRemove: $viewModel.checkoutSessionPaymentMethodRemove,
                             automaticPaymentMethods: $viewModel.automaticPaymentMethods,
+                            showsWalletsInPaymentElement: $viewModel.showsWalletsInPaymentElement,
                             linkMode: $viewModel.linkMode
                         )
 
@@ -99,8 +104,9 @@ struct CheckoutPlaygroundView: View {
                             clientSecret: clientSecret,
                             shippingAddressCollection: viewModel.shippingAddressCollection,
                             defaultShippingAddress: viewModel.defaultShippingAddress,
-                            adaptivePricing: true,
+                            adaptivePricing: viewModel.showsCurrencySelectorElement,
                             integrationType: viewModel.integrationType,
+                            showsWalletsInPaymentElement: viewModel.showsWalletsInPaymentElement,
                             expressCheckoutElementSettings: viewModel.expressCheckoutElement,
                             currencySelectorAppearance: viewModel.currencySelectorAppearance,
                             delayPaymentPagesRequests: viewModel.delayPaymentPagesRequests
@@ -110,8 +116,9 @@ struct CheckoutPlaygroundView: View {
                             clientSecret: clientSecret,
                             shippingAddressCollection: viewModel.shippingAddressCollection,
                             defaultShippingAddress: viewModel.defaultShippingAddress,
-                            adaptivePricing: true,
+                            adaptivePricing: viewModel.showsCurrencySelectorElement,
                             integrationType: viewModel.integrationType,
+                            showsWalletsInPaymentElement: viewModel.showsWalletsInPaymentElement,
                             expressCheckoutElementSettings: viewModel.expressCheckoutElement,
                             currencySelectorAppearance: viewModel.currencySelectorAppearance,
                             delayPaymentPagesRequests: viewModel.delayPaymentPagesRequests
@@ -137,6 +144,14 @@ struct CheckoutPlaygroundView: View {
                     }
                 )
             }
+            .sheet(isPresented: $showScenarios) {
+                CheckoutPlaygroundScenarioView(groups: CheckoutPlayground.ScenarioCatalog.groups) { scenario in
+                    viewModel.apply(scenario)
+                    Task {
+                        await viewModel.createSession()
+                    }
+                }
+            }
             .onAppear {
                 viewModel.activateLinkModeOverride()
             }
@@ -151,34 +166,83 @@ struct CheckoutPlaygroundView: View {
         VStack(alignment: .leading, spacing: 12) {
             CheckoutPlayground.SectionHeader(title: "Currency Selector", icon: "paintbrush.fill")
             VStack(spacing: 1) {
-                CheckoutPlayground.AdaptivePricingLocationRow(
-                    selection: $viewModel.adaptivePricingCountry
+                CheckoutPlayground.ToggleRow(
+                    title: "Show Currency Selector",
+                    isOn: $viewModel.showsCurrencySelectorElement
                 )
 
-                Button {
-                    showCurrencySelectorAppearance = true
-                } label: {
-                    HStack {
-                        Image(systemName: "slider.horizontal.3")
-                            .font(.system(size: 16))
-                            .frame(width: 24)
-                            .foregroundColor(.blue)
-                        Text("Customize Appearance")
-                            .font(.subheadline)
-                            .foregroundColor(.primary)
-                        Spacer()
-                        Image(systemName: "chevron.right")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
+                if viewModel.showsCurrencySelectorElement {
+                    CheckoutPlayground.AdaptivePricingLocationRow(
+                        selection: $viewModel.adaptivePricingCountry
+                    )
+
+                    Button {
+                        showCurrencySelectorAppearance = true
+                    } label: {
+                        HStack {
+                            Image(systemName: "slider.horizontal.3")
+                                .font(.system(size: 16))
+                                .frame(width: 24)
+                                .foregroundColor(.blue)
+                            Text("Customize Appearance")
+                                .font(.subheadline)
+                                .foregroundColor(.primary)
+                            Spacer()
+                            Image(systemName: "chevron.right")
+                                .font(.caption)
+                                .foregroundColor(.secondary)
+                        }
+                        .padding(.vertical, 12)
+                        .padding(.horizontal, 16)
+                        .background(Color(uiColor: .secondarySystemGroupedBackground))
                     }
-                    .padding(.vertical, 12)
-                    .padding(.horizontal, 16)
-                    .background(Color(uiColor: .secondarySystemGroupedBackground))
+                    .buttonStyle(PlainButtonStyle())
                 }
-                .buttonStyle(PlainButtonStyle())
             }
             .background(Color(uiColor: .secondarySystemGroupedBackground))
             .clipShape(RoundedRectangle(cornerRadius: 12))
         }
+    }
+
+    private var scenarioLauncher: some View {
+        Button {
+            showScenarios = true
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "play.fill")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(.white)
+                    .frame(width: 32, height: 32)
+                    .background(Color.blue)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Run a scenario")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundColor(.primary)
+                    Text("Choose a repeatable test preset")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(Color(uiColor: .secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color.blue.opacity(0.1), lineWidth: 1)
+            }
+        }
+        .buttonStyle(.plain)
+        .disabled(viewModel.isCreating)
+        .accessibilityIdentifier("checkout_scenarios")
     }
 }

--- a/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Checkout Playground/CheckoutPlaygroundViewModel.swift
@@ -20,9 +20,14 @@ extension CheckoutPlayground {
     @MainActor
     final class ViewModel: ObservableObject {
 
-        // Unified mode currently supports card and Link.
         static let availablePaymentMethods = [
-            "card", "link",
+            "card", "link", "us_bank_account", "cashapp", "klarna", "affirm",
+            "afterpay_clearpay", "amazon_pay", "crypto", "sunbit", "oxxo", "ideal",
+            "bancontact", "sepa_debit", "eps", "alma", "mobilepay", "billie", "wero",
+            "satispay", "sequra", "blik", "p24", "swish", "bacs_debit", "paypal",
+            "revolut_pay", "twint", "multibanco", "au_becs_debit", "grabpay", "paynow",
+            "fpx", "promptpay", "konbini", "paypay", "kr_card", "naver_pay", "payco",
+            "alipay", "boleto",
         ]
 
         @Published var uiFramework: UIFramework
@@ -40,6 +45,8 @@ extension CheckoutPlayground {
                 }
             }
         }
+        @Published var showsWalletsInPaymentElement: Bool
+        @Published var showsCurrencySelectorElement: Bool
         @Published var linkMode: LinkMode {
             didSet {
                 if isLinkModeOverrideActive {
@@ -48,6 +55,7 @@ extension CheckoutPlayground {
             }
         }
         @Published var currency: Currency
+        @Published var merchantCountry: MerchantCountry
         @Published var customerType: CustomerType
         @Published var lineItems: [LineItemConfig]
         @Published var shippingAddressCollection: Bool
@@ -78,7 +86,10 @@ extension CheckoutPlayground {
             uiFramework = settings.uiFramework
             integrationType = settings.integrationType
             expressCheckoutElement = ExpressCheckoutElementSettings(isEnabled: settings.showExpressCheckoutElement)
+            showsWalletsInPaymentElement = settings.showsWalletsInPaymentElement
+            showsCurrencySelectorElement = settings.showsCurrencySelectorElement
             linkMode = settings.linkMode
+            merchantCountry = settings.merchantCountry
             currency = settings.currency
             customerType = settings.customerType
             lineItems = settings.lineItems
@@ -134,6 +145,9 @@ extension CheckoutPlayground {
         }
 
         func createSession() async {
+            guard !isCreating else {
+                return
+            }
             serializeSettingsToNSUserDefaults()
             isCreating = true
             errorMessage = nil
@@ -180,9 +194,14 @@ extension CheckoutPlayground {
             apply(Settings())
         }
 
+        func apply(_ scenario: Scenario) {
+            apply(scenario.configuration.settings)
+            expressCheckoutElement = scenario.configuration.expressCheckoutElement
+        }
+
         private func buildRequestBody() -> [String: Any] {
             var body: [String: Any] = [
-                "merchant_country_code": "us_tax",
+                "merchant_country_code": merchantCountry.rawValue,
                 "mode": "unified",
                 "use_one_time_price": true,
                 "currency": currency.rawValue,
@@ -199,6 +218,7 @@ extension CheckoutPlayground {
                 body["payment_method_types"] = Array(paymentMethodTypes)
             }
             if adaptivePricingCountry != .none {
+                body["adaptive_pricing"] = true
                 let countryCode = adaptivePricingCountry.rawValue.uppercased()
                 body["customer_email"] = "test+location_\(countryCode)@example.com"
             }
@@ -211,7 +231,10 @@ extension CheckoutPlayground {
                 uiFramework: uiFramework,
                 integrationType: integrationType,
                 showExpressCheckoutElement: expressCheckoutElement.isEnabled,
+                showsWalletsInPaymentElement: showsWalletsInPaymentElement,
+                showsCurrencySelectorElement: showsCurrencySelectorElement,
                 linkMode: linkMode,
+                merchantCountry: merchantCountry,
                 currency: currency,
                 customerType: customerType,
                 lineItems: lineItems,
@@ -236,7 +259,10 @@ extension CheckoutPlayground {
             uiFramework = settings.uiFramework
             integrationType = settings.integrationType
             expressCheckoutElement.isEnabled = settings.showExpressCheckoutElement
+            showsWalletsInPaymentElement = settings.showsWalletsInPaymentElement
+            showsCurrencySelectorElement = settings.showsCurrencySelectorElement
             linkMode = settings.linkMode
+            merchantCountry = settings.merchantCountry
             currency = settings.currency
             customerType = settings.customerType
             lineItems = settings.lineItems
@@ -271,7 +297,14 @@ extension CheckoutPlayground {
             }
 
             do {
-                return try JSONDecoder().decode(Settings.self, from: data)
+                guard var values = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                    throw CocoaError(.coderReadCorrupt)
+                }
+                values["showsWalletsInPaymentElement"] = values["showsWalletsInPaymentElement"] ?? true
+                values["showsCurrencySelectorElement"] = values["showsCurrencySelectorElement"] ?? true
+                values["merchantCountry"] = values["merchantCountry"] ?? MerchantCountry.usTax.rawValue
+                let migratedData = try JSONSerialization.data(withJSONObject: values)
+                return try JSONDecoder().decode(Settings.self, from: migratedData)
             } catch {
                 print("Unable to deserialize Checkout playground settings: \(error)")
                 UserDefaults.standard.removeObject(forKey: Settings.nsUserDefaultsKey)

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutElementsUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutElementsUITests.swift
@@ -6,39 +6,6 @@
 import XCTest
 
 final class CheckoutElementsUITests: PaymentSheetUITestCase {
-    func testScenarioCatalogNavigation() {
-        // Given the Checkout Elements playground
-        app.launchEnvironment["STP_CHECKOUT_ELEMENTS"] = "true"
-        app.launch()
-
-        // When the user browses to the North America scenarios
-        app.buttons["checkout_scenarios"].waitForExistenceAndTap()
-        app.buttons["checkout_scenario_group_local-payment-methods"].waitForExistenceAndTap()
-        app.buttons["checkout_scenario_group_north-america"].waitForExistenceAndTap()
-
-        // Then the regional scenarios are available to run
-        XCTAssertTrue(app.buttons["checkout_scenario_us-common"].waitForExistence(timeout: 2))
-        XCTAssertTrue(app.buttons["checkout_scenario_us-alternatives"].exists)
-        XCTAssertTrue(app.buttons["checkout_scenario_mexico"].exists)
-    }
-
-    func testPrefilledShippingScenario() {
-        // Given the Shipping Address Element scenarios
-        app.launchEnvironment["STP_CHECKOUT_ELEMENTS"] = "true"
-        app.launch()
-        app.buttons["checkout_scenarios"].waitForExistenceAndTap()
-        app.buttons["checkout_scenario_group_elements"].waitForExistenceAndTap()
-        app.buttons["checkout_scenario_group_shipping-address-element"].waitForExistenceAndTap()
-
-        // When the user runs the prefilled address scenario
-        app.buttons["checkout_scenario_shipping-prefilled"].waitForExistenceAndTap()
-
-        // Then Checkout starts with the standard test address
-        XCTAssertTrue(app.navigationBars["Your Cart"].waitForExistence(timeout: 15))
-        XCTAssertTrue(app.staticTexts["Jenny Rosen"].waitForExistence(timeout: 10))
-        XCTAssertTrue(app.staticTexts["510 Townsend St"].exists)
-    }
-
     func testElementsStaySynchronizedWithCheckoutSession() throws {
         // Given a Checkout Session
         app.launchEnvironment["STP_CHECKOUT_ELEMENTS"] = "true"

--- a/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutElementsUITests.swift
+++ b/Example/PaymentSheet Example/PaymentSheetUITest/CheckoutElementsUITests.swift
@@ -6,6 +6,39 @@
 import XCTest
 
 final class CheckoutElementsUITests: PaymentSheetUITestCase {
+    func testScenarioCatalogNavigation() {
+        // Given the Checkout Elements playground
+        app.launchEnvironment["STP_CHECKOUT_ELEMENTS"] = "true"
+        app.launch()
+
+        // When the user browses to the North America scenarios
+        app.buttons["checkout_scenarios"].waitForExistenceAndTap()
+        app.buttons["checkout_scenario_group_local-payment-methods"].waitForExistenceAndTap()
+        app.buttons["checkout_scenario_group_north-america"].waitForExistenceAndTap()
+
+        // Then the regional scenarios are available to run
+        XCTAssertTrue(app.buttons["checkout_scenario_us-common"].waitForExistence(timeout: 2))
+        XCTAssertTrue(app.buttons["checkout_scenario_us-alternatives"].exists)
+        XCTAssertTrue(app.buttons["checkout_scenario_mexico"].exists)
+    }
+
+    func testPrefilledShippingScenario() {
+        // Given the Shipping Address Element scenarios
+        app.launchEnvironment["STP_CHECKOUT_ELEMENTS"] = "true"
+        app.launch()
+        app.buttons["checkout_scenarios"].waitForExistenceAndTap()
+        app.buttons["checkout_scenario_group_elements"].waitForExistenceAndTap()
+        app.buttons["checkout_scenario_group_shipping-address-element"].waitForExistenceAndTap()
+
+        // When the user runs the prefilled address scenario
+        app.buttons["checkout_scenario_shipping-prefilled"].waitForExistenceAndTap()
+
+        // Then Checkout starts with the standard test address
+        XCTAssertTrue(app.navigationBars["Your Cart"].waitForExistence(timeout: 15))
+        XCTAssertTrue(app.staticTexts["Jenny Rosen"].waitForExistence(timeout: 10))
+        XCTAssertTrue(app.staticTexts["510 Townsend St"].exists)
+    }
+
     func testElementsStaySynchronizedWithCheckoutSession() throws {
         // Given a Checkout Session
         app.launchEnvironment["STP_CHECKOUT_ELEMENTS"] = "true"


### PR DESCRIPTION
## Summary

Adds runnable presets to the Checkout Elements playground for local payment methods, tax, saved payment methods, and Elements configurations. Choosing a preset replaces the current settings and immediately creates a Checkout Session. The scenario browser uses the iOS equivalents for wallet configurations and keeps the underlying settings available for customization.

## Motivation

Checkout Elements playground parity with https://github.com/stripe/stripe-android/pull/14408

## Testing

No new tests.

- Manually verified all 43 scenarios load Checkout successfully.

## Changelog

N/A
