### PR TITLE
Add Welsh localization support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ MINOR
 ## X.Y.Z - changes pending release
 ### General
 * [Added] Added support for Arabic (Saudi Arabia).
+* [Added] Added support for Welsh.
 
 ### CryptoOnramp (Alpha)
 * [Added] Added Canada SIN, Colombia NIT, and Philippines TIN values to `IdType`, and added `idType` to the `KycInfo` initializer.

--- a/Example/AppClipExample/Info.plist
+++ b/Example/AppClipExample/Info.plist
@@ -7,6 +7,7 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ar-SA</string>
+		<string>cy-GB</string>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>

--- a/Example/CardImageVerification Example/CardImageVerification Example/Info.plist
+++ b/Example/CardImageVerification Example/CardImageVerification Example/Info.plist
@@ -9,6 +9,7 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ar-SA</string>
+		<string>cy-GB</string>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>

--- a/Example/FinancialConnections Example/FinancialConnections Example/Info.plist
+++ b/Example/FinancialConnections Example/FinancialConnections Example/Info.plist
@@ -7,6 +7,7 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ar-SA</string>
+		<string>cy-GB</string>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>

--- a/Example/IdentityVerification Example/IdentityVerification Example/Info.plist
+++ b/Example/IdentityVerification Example/IdentityVerification Example/Info.plist
@@ -7,6 +7,7 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ar-SA</string>
+		<string>cy-GB</string>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>

--- a/Example/Non-Card Payment Examples/Non-Card Payment Examples/Info.plist
+++ b/Example/Non-Card Payment Examples/Non-Card Payment Examples/Info.plist
@@ -7,6 +7,7 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ar-SA</string>
+		<string>cy-GB</string>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>

--- a/Example/PaymentSheet Example/PaymentSheet Example/Info.plist
+++ b/Example/PaymentSheet Example/PaymentSheet Example/Info.plist
@@ -7,6 +7,7 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ar-SA</string>
+		<string>cy-GB</string>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>

--- a/Example/StripeConnectExample/StripeConnectExample/Info.plist
+++ b/Example/StripeConnectExample/StripeConnectExample/Info.plist
@@ -9,6 +9,7 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ar-SA</string>
+		<string>cy-GB</string>
 		<string>bg_BG</string>
 		<string>zh_Hans</string>
 		<string>zh-Hant_HK</string>

--- a/Example/UI Examples/UI Examples/Info.plist
+++ b/Example/UI Examples/UI Examples/Info.plist
@@ -7,6 +7,7 @@
 	<key>CFBundleLocalizations</key>
 	<array>
 		<string>ar-SA</string>
+		<string>cy-GB</string>
 	</array>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Table of contents
 
 **App Clips**: The `StripeApplePay` module provides a [lightweight SDK for offering Apple Pay in an App Clip](https://stripe.com/docs/apple-pay#app-clips).
 
-**Localized**: We support the following localizations: Arabic (Saudi Arabia), Bulgarian, Catalan, Chinese (Hong Kong), Chinese (Simplified), Chinese (Traditional), Croatian, Czech, Danish, Dutch, English (US), English (United Kingdom), Estonian, Filipino, Finnish, French, French (Canada), German, Greek, Hungarian, Indonesian, Italian, Japanese, Korean, Latvian, Lithuanian, Malay, Maltese, Norwegian Bokmål, Norwegian Nynorsk (Norway), Polish, Portuguese, Portuguese (Brazil), Romanian, Russian, Slovak, Slovenian, Spanish, Spanish (Latin America), Swedish, Turkish, Thai and Vietnamese.
+**Localized**: We support the following localizations: Arabic (Saudi Arabia), Bulgarian, Catalan, Chinese (Hong Kong), Chinese (Simplified), Chinese (Traditional), Croatian, Czech, Danish, Dutch, English (US), English (United Kingdom), Estonian, Filipino, Finnish, French, French (Canada), German, Greek, Hungarian, Indonesian, Italian, Japanese, Korean, Latvian, Lithuanian, Malay, Maltese, Norwegian Bokmål, Norwegian Nynorsk (Norway), Polish, Portuguese, Portuguese (Brazil), Romanian, Russian, Slovak, Slovenian, Spanish, Spanish (Latin America), Swedish, Turkish, Thai, Vietnamese and Welsh.
 
 **Identity**: Learn about our [Stripe Identity iOS SDK](StripeIdentity/README.md) to verify the identity of your users.
 

--- a/Stripe/Stripe.xcodeproj/project.pbxproj
+++ b/Stripe/Stripe.xcodeproj/project.pbxproj
@@ -442,6 +442,7 @@
 				"bg-BG",
 				"ca-ES",
 				"cs-CZ",
+				"cy-GB",
 				da,
 				de,
 				"el-GR",

--- a/Stripe3DS2/Stripe3DS2.xcodeproj/project.pbxproj
+++ b/Stripe3DS2/Stripe3DS2.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 				"bg-BG",
 				"ca-ES",
 				"cs-CZ",
+				"cy-GB",
 				da,
 				de,
 				"el-GR",

--- a/Stripe3DS2/Stripe3DS2/Resources/cy-GB.lproj/Localizable.strings
+++ b/Stripe3DS2/Stripe3DS2/Resources/cy-GB.lproj/Localizable.strings
@@ -1,0 +1,44 @@
+/* The text for warning when a debugger is currently attached to the process. */
+"A debugger is attached to the App." = "Mae nodwedd difa chwilod wedi’i chysylltu â’r Ap.";
+
+/* The text for warning when an emulator is being used to run the application. */
+"An emulator is being used to run the App." = "Mae efelychydd yn cael ei ddefnyddio i redeg yr Ap.";
+
+/* The text for the button that cancels the current challenge process. */
+"Cancel" = "Canslo";
+
+/* Accessibility label for expandandable text control to indicate text is hidden. */
+"Collapsed" = "Wedi crebachu";
+
+/* Accessibility label for expandandable text control to indicate that the UI has been expanded and additional text is available. */
+"Expanded" = "Wedi ehangu";
+
+/* Spoken by VoiceOver when the challenge is loading. */
+"Loading" = "Wrthi’n llwytho";
+
+/* The no answer to a yes or no question. */
+"No" = "Na";
+
+/* The title for the challenge response step of an authenticated checkout. */
+"Secure checkout" = "Talu’n ddiogel";
+
+/* Indicates that a button is selected. */
+"Selected" = "Wedi’i ddewis";
+
+/* The text for warning when a device is jailbroken */
+"The device is jailbroken." = "Mae’r ddyfais wedi’i dad-gyfyngu.";
+
+/* The text for warning when the integrity of the SDK has been tampered with */
+"The integrity of the SDK has been tampered." = "Mae rhywbeth wedi ymyrryd ag uniondeb yr SDK.";
+
+/* The text for warning when the SDK is running on an unsupported OS or OS version. */
+"The OS or the OS Version is not supported." = "Does dim modd delio â’r OS na’r Fersiwn OS.";
+
+/* Error description for when a network request times out. English value is as required by UL certification. */
+"Timeout" = "Terfyn amser";
+
+/* Indicates that a button is not selected. */
+"Unselected" = "Heb ddewis";
+
+/* The yes answer to a yes or no question. */
+"Yes" = "Ie";

--- a/StripeCardScan/StripeCardScan.xcodeproj/project.pbxproj
+++ b/StripeCardScan/StripeCardScan.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 				"bg-BG",
 				"ca-ES",
 				"cs-CZ",
+				"cy-GB",
 				da,
 				de,
 				"el-GR",

--- a/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
+++ b/StripeConnect/StripeConnect.xcodeproj/project.pbxproj
@@ -247,6 +247,7 @@
 				"bg-BG",
 				"ca-ES",
 				"cs-CZ",
+				"cy-GB",
 				da,
 				de,
 				"el-GR",

--- a/StripeCore/StripeCore.xcodeproj/project.pbxproj
+++ b/StripeCore/StripeCore.xcodeproj/project.pbxproj
@@ -329,6 +329,7 @@
 				"bg-BG",
 				"ca-ES",
 				"cs-CZ",
+				"cy-GB",
 				da,
 				de,
 				"el-GR",

--- a/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
+++ b/StripeCryptoOnramp/StripeCryptoOnramp.xcodeproj/project.pbxproj
@@ -267,6 +267,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				"ar-SA",
+				"cy-GB",
 				en,
 				Base,
 				es,

--- a/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
+++ b/StripeFinancialConnections/StripeFinancialConnections.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 				"bg-BG",
 				"ca-ES",
 				"cs-CZ",
+				"cy-GB",
 				da,
 				de,
 				"el-GR",

--- a/StripeIdentity/StripeIdentity.xcodeproj/project.pbxproj
+++ b/StripeIdentity/StripeIdentity.xcodeproj/project.pbxproj
@@ -258,6 +258,7 @@
 				"bg-BG",
 				"ca-ES",
 				"cs-CZ",
+				"cy-GB",
 				da,
 				de,
 				"el-GR",

--- a/StripeIssuing/StripeIssuing.xcodeproj/project.pbxproj
+++ b/StripeIssuing/StripeIssuing.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				"ar-SA",
+				"cy-GB",
 				en,
 				Base,
 				de,

--- a/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
+++ b/StripePaymentSheet/StripePaymentSheet.xcodeproj/project.pbxproj
@@ -390,6 +390,7 @@
 				"bg-BG",
 				"ca-ES",
 				"cs-CZ",
+				"cy-GB",
 				da,
 				de,
 				"el-GR",

--- a/StripePayments/StripePayments.xcodeproj/project.pbxproj
+++ b/StripePayments/StripePayments.xcodeproj/project.pbxproj
@@ -481,6 +481,7 @@
 				"bg-BG",
 				"ca-ES",
 				"cs-CZ",
+				"cy-GB",
 				da,
 				de,
 				"el-GR",

--- a/StripePaymentsUI/StripePaymentsUI.xcodeproj/project.pbxproj
+++ b/StripePaymentsUI/StripePaymentsUI.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 				"bg-BG",
 				"ca-ES",
 				"cs-CZ",
+				"cy-GB",
 				da,
 				de,
 				"el-GR",

--- a/StripeUICore/StripeUICore.xcodeproj/project.pbxproj
+++ b/StripeUICore/StripeUICore.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 				"bg-BG",
 				"ca-ES",
 				"cs-CZ",
+				"cy-GB",
 				da,
 				de,
 				"el-GR",

--- a/ci_scripts/l10n/config.rb
+++ b/ci_scripts/l10n/config.rb
@@ -11,6 +11,7 @@ LANGUAGES = %w[
   bg-BG
   ca-ES
   cs-CZ
+  cy-GB
   da
   de
   el-GR


### PR DESCRIPTION
## Summary

Adds Welsh as a supported SDK localization. The Lokalise download now requests cy-GB strings for each localized module, and Xcode recognizes the new region. 3DS2 strings are included manually because it is not part of the Lokalise release download.

## Screenshots

<table>
  <tr>
    <td align="center">
      <strong>Saved-method picker</strong><br>
      <img width="300" alt="PaymentSheet saved payment method picker in Welsh" src="https://github.com/user-attachments/assets/8f448217-c364-4344-ab4a-e2599589a9b4">
    </td>
    <td align="center">
      <strong>Payment-method list</strong><br>
      <img width="300" alt="PaymentSheet payment method list in Welsh" src="https://github.com/user-attachments/assets/dd994242-c76f-462a-8af6-02fe062c965d">
    </td>
  </tr>
  <tr>
    <td align="center">
      <strong>Card form</strong><br>
      <img width="300" alt="PaymentSheet card form in Welsh" src="https://github.com/user-attachments/assets/7d316cd2-0d06-4274-b460-aacda3ef09b5">
    </td>
    <td align="center">
      <strong>3DS2 challenge</strong><br>
      <img width="300" alt="3DS2 challenge in Welsh" src="https://github.com/user-attachments/assets/7f4a5447-4ccb-4865-92c1-30fe03096c44">
    </td>
  </tr>
</table>

## Motivation

Welsh localization

## Testing

No new tests.

Downloaded the localized strings from Lokalise and manually launched the PaymentSheet Example in Welsh.

## Changelog

See diff
