### PR TITLE
Clear FlowController payment option from Checkout

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -182,8 +182,8 @@ extension PaymentElement {
             throw error
         }
 
-        // Embedded can restore its default payment option during a rebuild. If FlowController
-        // is authoritative and has no selection, keep Embedded cleared too.
+        // Embedded picks its default again when rebuilt. If FlowController was last used and
+        // is empty, clear Embedded to keep them in sync.
         if paymentOptionSourceOfTruthIsFlowController,
            paymentSheetFlowController.paymentOption == nil {
             embeddedPaymentElement.clearPaymentOption()
@@ -211,8 +211,8 @@ extension PaymentElement {
         try await checkout.updateBillingTaxRegionIfNecessary(address: nil)
 
         await checkout.enqueueSessionUpdate {
-            // Clear both UI implementations before publishing Checkout's state. FlowController
-            // preserves the cleared state across rebuilds until the customer continues with an option.
+            // Clear both views before updating Checkout so observers never see mismatched state.
+            // FlowController remembers the clear across rebuilds, so make it the source of truth.
             self.isSuppressingPaymentOptionUpdates = true
             defer {
                 self.isSuppressingPaymentOptionUpdates = false

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -207,6 +207,7 @@ extension PaymentElement {
         }
         try await checkout.updateBillingTaxRegionIfNecessary(address: nil)
         checkout.dangerouslySetPaymentOptionDirectly(nil)
+        paymentSheetFlowController.clearPaymentOption()
         embeddedPaymentElement.clearPaymentOption()
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -182,6 +182,13 @@ extension PaymentElement {
             throw error
         }
 
+        // Embedded can restore its default payment option during a rebuild. If FlowController
+        // is authoritative and has no selection, keep Embedded cleared too.
+        if paymentOptionSourceOfTruthIsFlowController,
+           paymentSheetFlowController.paymentOption == nil {
+            embeddedPaymentElement.clearPaymentOption()
+        }
+
         // Update payment option
         // Problem: Since (unfortunately) we have two sources of truth for payment option (FC and Embedded), we need to know which one to pick. We can't just let them both update payment option - then the last one to update will win, even when it wasn't actually used by the customer.
         // Hacky solution: We determine which one to pick based on which one last reported a payment option update.
@@ -197,18 +204,24 @@ extension PaymentElement {
     }
 
     func clearPaymentOption() async throws {
-        guard !paymentSheetFlowController.didPresentAndContinue else {
-            assertionFailure("Clearing the payment option after presenting PaymentElement is not implemented. File a feature request if you need this.")
-            return
-        }
         guard let checkout else {
             stpAssertionFailure("PaymentElement unexpectedly lost its CheckoutController.")
             return
         }
         try await checkout.updateBillingTaxRegionIfNecessary(address: nil)
-        checkout.dangerouslySetPaymentOptionDirectly(nil)
-        paymentSheetFlowController.clearPaymentOption()
-        embeddedPaymentElement.clearPaymentOption()
+
+        await checkout.enqueueSessionUpdate {
+            // Clear both UI implementations before publishing Checkout's state. FlowController
+            // preserves the cleared state across rebuilds until the customer continues with an option.
+            self.isSuppressingPaymentOptionUpdates = true
+            defer {
+                self.isSuppressingPaymentOptionUpdates = false
+            }
+            self.paymentSheetFlowController.clearPaymentOption()
+            self.embeddedPaymentElement.clearPaymentOption()
+            self.paymentOptionSourceOfTruthIsFlowController = true
+            checkout.dangerouslySetPaymentOptionDirectly(nil)
+        }
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -1059,12 +1059,12 @@ extension PaymentSheet.FlowController {
         return isPresented
     }
 
-    /// Clears the selected payment option until the customer continues with one in the payment options UI.
+    /// Clears the current payment option. It stays cleared until the customer continues with a new one.
     @MainActor
     func clearPaymentOption() {
         hasClearedPaymentOption = true
         viewController.clearSelection()
-        updatePaymentOption()
+        paymentOption = nil
     }
 }
 

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -1059,7 +1059,8 @@ extension PaymentSheet.FlowController {
         return isPresented
     }
 
-    /// Clears the selected payment option until the customer selects one in the payment options UI.
+    /// Clears the selected payment option until the customer continues with one in the payment options UI.
+    @MainActor
     func clearPaymentOption() {
         hasClearedPaymentOption = true
         viewController.clearSelection()

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -282,12 +282,17 @@ extension PaymentSheet {
 
         /// The desired, valid (ie passed client-side checks) payment option from the underlying payment options VC.
         var internalPaymentOption: PaymentOption? {
+            guard !hasClearedPaymentOption else {
+                return nil
+            }
             guard viewController.error == nil else {
                 return nil
             }
 
             return viewController.selectedPaymentOption
         }
+
+        private var hasClearedPaymentOption = false
 
         private var canPresentLinkInPlaceOfFlowController: Bool {
             guard elementsSession.enableFlowControllerRUX(for: configuration) else {
@@ -1053,6 +1058,13 @@ extension PaymentSheet.FlowController {
     var isPresentingPaymentUI: Bool {
         return isPresented
     }
+
+    /// Clears the selected payment option until the customer selects one in the payment options UI.
+    func clearPaymentOption() {
+        hasClearedPaymentOption = true
+        viewController.clearSelection()
+        updatePaymentOption()
+    }
 }
 
 // MARK: - LoadingViewControllerDelegate
@@ -1082,6 +1094,7 @@ extension PaymentSheet.FlowController: FlowControllerViewControllerDelegate {
     ) {
         if !didCancel {
             self.didPresentAndContinue = true
+            self.hasClearedPaymentOption = false
         }
         flowControllerViewController.dismiss(animated: true) {
             if didCancel {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -5,6 +5,7 @@
 //  Created by Yuki Tokuhiro on 7/15/26.
 //
 
+import Combine
 import OHHTTPStubs
 @testable @_spi(STP) import StripeCore
 @testable @_spi(STP) import StripeCoreTestUtils
@@ -299,7 +300,57 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertNil(checkout.session.paymentOption)
         XCTAssertNil(embeddedPaymentElement.paymentOption)
         XCTAssertNil(flowController.paymentOption)
+    }
+
+    func testClearPaymentOptionAfterFlowControllerContinues() async throws {
+        // Given the customer has continued from FlowController with a selected saved card
+        let (configuration, _) = try stubAutomaticTaxSavedCardCheckout()
+        let checkout = try await CheckoutController(configuration: configuration)
+        let paymentElement = checkout.getPaymentElement()
+        let embeddedPaymentElement = paymentElement.embeddedPaymentElement
+        let flowController = paymentElement.paymentSheetFlowController
+        flowController.flowControllerViewControllerShouldClose(flowController.viewController, didCancel: false)
+        XCTAssertTrue(flowController.didPresentAndContinue)
+
+        // Record whether Checkout publishes its cleared state before its elements are cleared
+        var publishedClearBeforeComponentsWereCleared = false
+        var didPublishClearedPaymentOption = false
+        let paymentOptionObserver = checkout.$session.dropFirst().sink { session in
+            guard session.paymentOption == nil else { return }
+            didPublishClearedPaymentOption = true
+            publishedClearBeforeComponentsWereCleared =
+                embeddedPaymentElement.paymentOption != nil || flowController.paymentOption != nil
+        }
+
+        // When the payment option is cleared
+        try await checkout.clearPaymentOption()
+
+        // Then Checkout publishes the cleared state after both elements are cleared
+        XCTAssertNil(checkout.session.paymentOption)
+        XCTAssertNil(embeddedPaymentElement.paymentOption)
+        XCTAssertNil(flowController.paymentOption)
         XCTAssertNil(flowController.internalPaymentOption)
+        XCTAssertTrue(didPublishClearedPaymentOption)
+        XCTAssertFalse(publishedClearBeforeComponentsWereCleared)
+        paymentOptionObserver.cancel()
+    }
+
+    func testClearPaymentOptionStaysClearedAfterPaymentElementUpdate() async throws {
+        // Given a selected saved card is cleared from Checkout and both payment elements
+        let (configuration, _) = try stubAutomaticTaxSavedCardCheckout()
+        let checkout = try await CheckoutController(configuration: configuration)
+        let paymentElement = checkout.getPaymentElement()
+        let embeddedPaymentElement = paymentElement.embeddedPaymentElement
+        let flowController = paymentElement.paymentSheetFlowController
+        try await checkout.clearPaymentOption()
+
+        // When Payment Element refreshes
+        try await paymentElement.update(checkout: checkout)
+
+        // Then the previous default is not restored
+        XCTAssertNil(checkout.session.paymentOption)
+        XCTAssertNil(embeddedPaymentElement.paymentOption)
+        XCTAssertNil(flowController.paymentOption)
     }
 
     func testClearPaymentOptionPreservesSelectionWhenTaxUpdateFails() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -303,7 +303,7 @@ final class PaymentElementTest: XCTestCase {
     }
 
     func testClearPaymentOptionAfterFlowControllerContinues() async throws {
-        // Given the customer has continued from FlowController with a selected saved card
+        // Given the customer selected a saved card in FlowController
         let (configuration, _) = try stubAutomaticTaxSavedCardCheckout()
         let checkout = try await CheckoutController(configuration: configuration)
         let paymentElement = checkout.getPaymentElement()
@@ -312,7 +312,7 @@ final class PaymentElementTest: XCTestCase {
         flowController.flowControllerViewControllerShouldClose(flowController.viewController, didCancel: false)
         XCTAssertTrue(flowController.didPresentAndContinue)
 
-        // Record whether Checkout publishes its cleared state before its elements are cleared
+        // Track whether Checkout clears before both payment elements
         var publishedClearBeforeComponentsWereCleared = false
         var didPublishClearedPaymentOption = false
         let paymentOptionObserver = checkout.$session.dropFirst().sink { session in
@@ -325,7 +325,7 @@ final class PaymentElementTest: XCTestCase {
         // When the payment option is cleared
         try await checkout.clearPaymentOption()
 
-        // Then Checkout publishes the cleared state after both elements are cleared
+        // Then Checkout clears after both payment elements
         XCTAssertNil(checkout.session.paymentOption)
         XCTAssertNil(embeddedPaymentElement.paymentOption)
         XCTAssertNil(flowController.paymentOption)
@@ -336,7 +336,7 @@ final class PaymentElementTest: XCTestCase {
     }
 
     func testClearPaymentOptionStaysClearedAfterPaymentElementUpdate() async throws {
-        // Given a selected saved card is cleared from Checkout and both payment elements
+        // Given Checkout was cleared after starting with a saved card
         let (configuration, _) = try stubAutomaticTaxSavedCardCheckout()
         let checkout = try await CheckoutController(configuration: configuration)
         let paymentElement = checkout.getPaymentElement()
@@ -344,10 +344,10 @@ final class PaymentElementTest: XCTestCase {
         let flowController = paymentElement.paymentSheetFlowController
         try await checkout.clearPaymentOption()
 
-        // When Payment Element refreshes
+        // When Payment Element reloads
         try await paymentElement.update(checkout: checkout)
 
-        // Then the previous default is not restored
+        // Then everything stays cleared
         XCTAssertNil(checkout.session.paymentOption)
         XCTAssertNil(embeddedPaymentElement.paymentOption)
         XCTAssertNil(flowController.paymentOption)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -276,9 +276,12 @@ final class PaymentElementTest: XCTestCase {
         // Given a selected saved card supplies the billing address for automatic tax
         let (configuration, requestRecorder) = try stubAutomaticTaxSavedCardCheckout()
         let checkout = try await CheckoutController(configuration: configuration)
-        let embeddedPaymentElement = checkout.getPaymentElement().embeddedPaymentElement
+        let paymentElement = checkout.getPaymentElement()
+        let embeddedPaymentElement = paymentElement.embeddedPaymentElement
+        let flowController = paymentElement.paymentSheetFlowController
         XCTAssertNotNil(checkout.session.paymentOption)
         XCTAssertNotNil(embeddedPaymentElement.paymentOption)
+        XCTAssertNotNil(flowController.paymentOption)
 
         // When the payment option is cleared
         try await checkout.clearPaymentOption()
@@ -295,6 +298,8 @@ final class PaymentElementTest: XCTestCase {
         XCTAssertNil(updateRequest.params["tax_region[postal_code]"])
         XCTAssertNil(checkout.session.paymentOption)
         XCTAssertNil(embeddedPaymentElement.paymentOption)
+        XCTAssertNil(flowController.paymentOption)
+        XCTAssertNil(flowController.internalPaymentOption)
     }
 
     func testClearPaymentOptionPreservesSelectionWhenTaxUpdateFails() async throws {
@@ -302,9 +307,12 @@ final class PaymentElementTest: XCTestCase {
         // and the next Checkout Session update will fail
         let (configuration, _) = try stubAutomaticTaxSavedCardCheckout(clearUpdateStatusCode: 500)
         let checkout = try await CheckoutController(configuration: configuration)
-        let embeddedPaymentElement = checkout.getPaymentElement().embeddedPaymentElement
+        let paymentElement = checkout.getPaymentElement()
+        let embeddedPaymentElement = paymentElement.embeddedPaymentElement
+        let flowController = paymentElement.paymentSheetFlowController
         let selectedPaymentOption = try XCTUnwrap(checkout.session.paymentOption)
         let selectedEmbeddedPaymentOption = try XCTUnwrap(embeddedPaymentElement.paymentOption)
+        let selectedFlowControllerPaymentOption = try XCTUnwrap(flowController.paymentOption)
 
         // When the payment option is cleared
         do {
@@ -319,6 +327,8 @@ final class PaymentElementTest: XCTestCase {
         // Then the selection remains available for the merchant to recover
         XCTAssertEqual(checkout.session.paymentOption, selectedPaymentOption)
         XCTAssertEqual(embeddedPaymentElement.paymentOption, selectedEmbeddedPaymentOption)
+        XCTAssertEqual(flowController.paymentOption?.label, selectedFlowControllerPaymentOption.label)
+        XCTAssertNotNil(flowController.internalPaymentOption)
     }
 
     func testCheckoutSessionUpdatePreservesFlowControllerPaymentOption() async throws {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -101,6 +101,25 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         XCTAssertNil(sut.paymentOption)
     }
 
+    @MainActor
+    func testClearPaymentOptionClearsHorizontalDefault() {
+        // Given a horizontal FlowController with Link selected as the default payment option
+        let customerID = "cus_test_horizontal_clear_default"
+        defer {
+            CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID)
+        }
+        CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: customerID)
+        let sut = makeHorizontalFlowController(customerID: customerID)
+        XCTAssertNotNil(sut.paymentOption)
+
+        // When the payment option is cleared
+        sut.clearPaymentOption()
+
+        // Then the FlowController no longer exposes a payment option
+        XCTAssertNil(sut.paymentOption)
+        XCTAssertNil(sut.internalPaymentOption)
+    }
+
     // MARK: - PaymentOptionDisplayData Labels Tests
 
     func testPaymentOptionDisplayData_CardLabels() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -120,6 +120,27 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         XCTAssertNil(sut.internalPaymentOption)
     }
 
+    @MainActor
+    func testClearPaymentOptionAllowsNextSelection() {
+        // Given a horizontal FlowController whose default payment option was cleared
+        let customerID = "cus_test_horizontal_select_after_clear"
+        defer {
+            CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID)
+        }
+        CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: customerID)
+        let sut = makeHorizontalFlowController(customerID: customerID)
+        sut.clearPaymentOption()
+
+        // When the customer accepts a new payment option
+        sut.viewController.linkConfirmOption = .wallet(brand: .link)
+        sut.flowControllerViewControllerShouldClose(sut.viewController, didCancel: false)
+        sut.updatePaymentOption()
+
+        // Then the new payment option is exposed
+        XCTAssertEqual(sut.paymentOption?.paymentMethodType, "link")
+        XCTAssertNotNil(sut.internalPaymentOption)
+    }
+
     // MARK: - PaymentOptionDisplayData Labels Tests
 
     func testPaymentOptionDisplayData_CardLabels() {

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/PaymentSheetFlowControllerTests.swift
@@ -103,7 +103,7 @@ class PaymentSheetFlowControllerTests: XCTestCase {
 
     @MainActor
     func testClearPaymentOptionClearsHorizontalDefault() {
-        // Given a horizontal FlowController with Link selected as the default payment option
+        // Given Link is the default in a horizontal FlowController
         let customerID = "cus_test_horizontal_clear_default"
         defer {
             CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID)
@@ -112,17 +112,17 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         let sut = makeHorizontalFlowController(customerID: customerID)
         XCTAssertNotNil(sut.paymentOption)
 
-        // When the payment option is cleared
+        // When we clear the payment option
         sut.clearPaymentOption()
 
-        // Then the FlowController no longer exposes a payment option
+        // Then no payment option is available
         XCTAssertNil(sut.paymentOption)
         XCTAssertNil(sut.internalPaymentOption)
     }
 
     @MainActor
     func testClearPaymentOptionAllowsNextSelection() {
-        // Given a horizontal FlowController whose default payment option was cleared
+        // Given Link was cleared from a horizontal FlowController
         let customerID = "cus_test_horizontal_select_after_clear"
         defer {
             CustomerPaymentOption.setDefaultPaymentMethod(nil, forCustomer: customerID)
@@ -131,12 +131,12 @@ class PaymentSheetFlowControllerTests: XCTestCase {
         let sut = makeHorizontalFlowController(customerID: customerID)
         sut.clearPaymentOption()
 
-        // When the customer accepts a new payment option
+        // When the customer chooses Link again
         sut.viewController.linkConfirmOption = .wallet(brand: .link)
         sut.flowControllerViewControllerShouldClose(sut.viewController, didCancel: false)
         sut.updatePaymentOption()
 
-        // Then the new payment option is exposed
+        // Then Link becomes the current payment option
         XCTAssertEqual(sut.paymentOption?.paymentMethodType, "link")
         XCTAssertNotNil(sut.internalPaymentOption)
     }


### PR DESCRIPTION
## Summary
Clearing the Checkout payment option now clears FlowController along with EmbeddedPaymentElement. This works after FlowController has been presented and keeps both payment element surfaces cleared across Checkout refreshes.

## Motivation
Checkout Elements

## Testing
- Added tests for clearing after FlowController presentation and choosing again after a clear.
- Updated Checkout tests to cover both payment surfaces, refreshes, published state ordering, and failed tax updates.

## Changelog
N/A