### PR TITLE
Consume passive captcha tokens after use

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ConfirmationChallenge/ConfirmationChallenge.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ConfirmationChallenge/ConfirmationChallenge.swift
@@ -46,12 +46,11 @@ actor ConfirmationChallenge {
 
     func fetchTokensWithTimeout() async -> ChallengeTokens {
         let startTime = Date()
-        let isReady = await passiveCaptchaChallenge?.isTokenReady ?? false
-        let getPassiveCaptchaToken: () async throws -> String? = {
+        let getPassiveCaptchaToken: () async throws -> PassiveCaptchaChallenge.ConsumedToken? = {
             guard let passiveCaptchaChallenge = self.passiveCaptchaChallenge else {
                 return nil
             }
-            return try await passiveCaptchaChallenge.fetchToken()
+            return try await passiveCaptchaChallenge.consumeToken()
         }
 
         let getAttestationAssertion: () async throws -> StripeAttest.Assertion? = {
@@ -64,8 +63,8 @@ actor ConfirmationChallenge {
         let (hcaptchaTokenResult, assertionResult) = await withTimeout(timeout, getPassiveCaptchaToken, getAttestationAssertion)
         if let passiveCaptchaChallenge {
             switch hcaptchaTokenResult {
-            case .success:
-                STPAnalyticsClient.sharedClient.logPassiveCaptchaAttach(siteKey: passiveCaptchaChallenge.passiveCaptchaData.siteKey, isReady: isReady, duration: Date().timeIntervalSince(startTime))
+            case .success(let consumedToken):
+                STPAnalyticsClient.sharedClient.logPassiveCaptchaAttach(siteKey: passiveCaptchaChallenge.passiveCaptchaData.siteKey, isReady: consumedToken?.wasReady ?? false, duration: Date().timeIntervalSince(startTime))
             case .failure(let error):
                 if error is TimeoutError {
                     STPAnalyticsClient.sharedClient.logPassiveCaptchaError(error: error, siteKey: passiveCaptchaChallenge.passiveCaptchaData.siteKey, duration: Date().timeIntervalSince(startTime))
@@ -75,7 +74,7 @@ actor ConfirmationChallenge {
         if case .failure(let error) = assertionResult, error is TimeoutError {
             STPAnalyticsClient.sharedClient.logAttestationConfirmationError(error: error, duration: Date().timeIntervalSince(startTime))
         }
-        let hcaptchaToken: String? = try? hcaptchaTokenResult.get()
+        let hcaptchaToken: String? = try? hcaptchaTokenResult.get()?.value
         let assertion: StripeAttest.Assertion? = try? assertionResult.get()
         return (hcaptchaToken: hcaptchaToken, assertion: assertion)
     }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ConfirmationChallenge/PassiveCaptchaChallenge.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/ConfirmationChallenge/PassiveCaptchaChallenge.swift
@@ -51,11 +51,17 @@ struct PassiveCaptchaData: Equatable, Hashable {
 }
 
 actor PassiveCaptchaChallenge {
+    struct ConsumedToken {
+        let value: String
+        let wasReady: Bool
+    }
+
     let passiveCaptchaData: PassiveCaptchaData
     private let hcaptchaFactory: HCaptchaFactory
     private var tokenTask: Task<String, Error>?
+    private var shouldStartInitialPreload = true
     var isTokenReady: Bool { // used for the attach analytic to indicate whether it's blocking checkout
-        return hasFetchedToken && !hasSessionExpired
+        return tokenTask != nil && hasFetchedToken && !hasSessionExpired
     }
     private var hasFetchedToken: Bool = false
     private var sessionExpirationDate: Date?
@@ -74,7 +80,7 @@ actor PassiveCaptchaChallenge {
         // Use [weak self] so this task does not prevent the actor from being deallocated.
         // When the actor is deallocated, deinit cancels tokenTask.
         Task { [weak self] in
-            _ = try? await self?.fetchToken()
+            await self?.preloadToken()
         }
     }
 
@@ -84,20 +90,52 @@ actor PassiveCaptchaChallenge {
         tokenTask?.cancel()
     }
 
-    public func fetchToken() async throws -> String {
+    func consumeToken() async throws -> ConsumedToken {
+        // Prevent the initialization task from starting a preload after an
+        // immediate consumer has already claimed its own token task.
+        shouldStartInitialPreload = false
+
         if hasSessionExpired {
             resetSession()
         }
 
-        if let tokenTask {
-            return try await withTaskCancellationHandler {
-                try await tokenTask.value
-            } onCancel: {
-                tokenTask.cancel()
-            }
-        }
+        let wasReady = isTokenReady
+        let tokenTask = tokenTask ?? Self.makeTokenTask(
+            passiveCaptchaData: passiveCaptchaData,
+            hcaptchaFactory: hcaptchaFactory,
+            owner: self
+        )
 
-        let tokenTask = Task<String, Error> { [siteKey = passiveCaptchaData.siteKey, rqdata = passiveCaptchaData.rqdata, hcaptchaFactory, weak self] () -> String in
+        // Tokens can only be used once. Remove this task from the cache before
+        // awaiting it so concurrent consumers cannot receive the same token.
+        resetSession()
+        defer { resetSession() }
+
+        let token = try await withTaskCancellationHandler {
+            try await tokenTask.value
+        } onCancel: {
+            tokenTask.cancel()
+        }
+        return ConsumedToken(value: token, wasReady: wasReady)
+    }
+
+    private func preloadToken() {
+        guard shouldStartInitialPreload else { return }
+        shouldStartInitialPreload = false
+
+        tokenTask = Self.makeTokenTask(
+            passiveCaptchaData: passiveCaptchaData,
+            hcaptchaFactory: hcaptchaFactory,
+            owner: self
+        )
+    }
+
+    private static func makeTokenTask(
+        passiveCaptchaData: PassiveCaptchaData,
+        hcaptchaFactory: HCaptchaFactory,
+        owner: PassiveCaptchaChallenge
+    ) -> Task<String, Error> {
+        Task<String, Error> { [siteKey = passiveCaptchaData.siteKey, rqdata = passiveCaptchaData.rqdata, hcaptchaFactory, weak owner] () -> String in
             STPAnalyticsClient.sharedClient.logPassiveCaptchaInit(siteKey: siteKey)
             let startTime = Date()
             do {
@@ -112,7 +150,7 @@ actor PassiveCaptchaChallenge {
                             Task { @MainActor in // MainActor to prevent continuation from different threads
                                 do {
                                     let token = try result.dematerialize()
-                                    await self?.setSessionExpirationDate()
+                                    await owner?.setSessionExpirationDate()
                                     nillableContinuation?.resume(returning: token)
                                     nillableContinuation = nil
                                 } catch {
@@ -130,7 +168,7 @@ actor PassiveCaptchaChallenge {
                 // Check cancellation after continuation
                 try Task.checkCancellation()
                 // Mark as complete
-                await self?.setValidationComplete()
+                await owner?.setValidationComplete()
                 let duration = Date().timeIntervalSince(startTime)
                 STPAnalyticsClient.sharedClient.logPassiveCaptchaSuccess(siteKey: siteKey, duration: duration)
                 return result
@@ -140,12 +178,6 @@ actor PassiveCaptchaChallenge {
                 STPAnalyticsClient.sharedClient.logPassiveCaptchaError(error: error, siteKey: siteKey, duration: duration)
                 throw error
             }
-        }
-        self.tokenTask = tokenTask
-        return try await withTaskCancellationHandler {
-            try await tokenTask.value
-        } onCancel: {
-            tokenTask.cancel()
         }
     }
 

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ConfirmationChallenge/ConfirmationChallengeTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ConfirmationChallenge/ConfirmationChallengeTests.swift
@@ -195,6 +195,21 @@ class ConfirmationChallengeTests: XCTestCase {
         await confirmationChallenge.complete()
     }
 
+    func testMakeRadarOptionsConsumesPassiveCaptchaTask() async {
+        // Given a challenge whose captcha creation fails deterministically
+        let counter = PassiveCaptchaCreateCounter()
+        let factory = CountingFailingPassiveCaptchaFactory(counter: counter)
+        let confirmationChallenge = ConfirmationChallenge(elementsSession: elementsSession, stripeAttest: stripeAttest, hcaptchaFactory: factory)
+
+        // When radar options are requested twice
+        _ = await confirmationChallenge.makeRadarOptions(for: .card)
+        _ = await confirmationChallenge.makeRadarOptions(for: .card)
+
+        // Then each request should execute its own captcha challenge
+        XCTAssertEqual(counter.count, 2)
+        await confirmationChallenge.complete()
+    }
+
     func testMakeRadarOptionsForLink() async throws {
         let confirmationChallenge = ConfirmationChallenge(elementsSession: elementsSession, stripeAttest: stripeAttest)
         await confirmationChallenge.setTimeout(timeout: 30)

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ConfirmationChallenge/PassiveCaptchaChallengeTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/ConfirmationChallenge/PassiveCaptchaChallengeTests.swift
@@ -9,6 +9,36 @@
 @_spi(STP) @testable import StripePaymentSheet
 import XCTest
 
+enum PassiveCaptchaTestError: Error {
+    case expected
+}
+
+final class PassiveCaptchaCreateCounter {
+    private let lock = NSLock()
+    private var value = 0
+
+    var count: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return value
+    }
+
+    func increment() {
+        lock.lock()
+        defer { lock.unlock() }
+        value += 1
+    }
+}
+
+struct CountingFailingPassiveCaptchaFactory: HCaptchaFactory {
+    let counter: PassiveCaptchaCreateCounter
+
+    func create(siteKey: String, rqdata: String?) throws -> HCaptcha {
+        counter.increment()
+        throw PassiveCaptchaTestError.expected
+    }
+}
+
 class PassiveCaptchaChallengeTests: XCTestCase {
     var window: UIWindow?
 
@@ -49,15 +79,29 @@ class PassiveCaptchaChallengeTests: XCTestCase {
     // OCS mobile test key from https://dashboard.hcaptcha.com/sites/edit/143aadb6-fb60-4ab6-b128-f7fe53426d4a
     let siteKey = "143aadb6-fb60-4ab6-b128-f7fe53426d4a"
 
+    private func waitUntilTokenIsReady(_ passiveCaptchaChallenge: PassiveCaptchaChallenge) async throws {
+        try await withTimeout(30) {
+            while !(await passiveCaptchaChallenge.isTokenReady) {
+                try await Task.sleep(nanoseconds: 100_000_000)
+            }
+        }.get()
+    }
+
     func testPassiveCaptcha() async throws {
         let passiveCaptchaData = PassiveCaptchaData(siteKey: siteKey, rqdata: nil)
         let passiveCaptchaChallenge = PassiveCaptchaChallenge(passiveCaptchaData: passiveCaptchaData)
-        // wait to make sure that the token will be ready by the time we call fetchToken
-        try await Task.sleep(nanoseconds: 6_000_000_000)
-        let hcaptchaToken = try await passiveCaptchaChallenge.fetchToken()
-        XCTAssertNotNil(hcaptchaToken)
-        let isReady = await passiveCaptchaChallenge.isTokenReady
-        XCTAssertTrue(isReady, "Token should be ready if not expired")
+
+        // Wait to make sure that the token will be ready by the time we consume it
+        try await waitUntilTokenIsReady(passiveCaptchaChallenge)
+        let isReadyBeforeConsumption = await passiveCaptchaChallenge.isTokenReady
+        XCTAssertTrue(isReadyBeforeConsumption, "Token should be ready if not expired")
+
+        let hcaptchaToken = try await passiveCaptchaChallenge.consumeToken()
+        XCTAssertFalse(hcaptchaToken.value.isEmpty)
+        XCTAssertTrue(hcaptchaToken.wasReady)
+        let isReadyAfterConsumption = await passiveCaptchaChallenge.isTokenReady
+        XCTAssertFalse(isReadyAfterConsumption, "Token should be discarded after consumption")
+
         let passiveCaptchaEvents = STPAnalyticsClient.sharedClient._testLogHistory.map({ $0["event"] as? String }).filter({ $0?.starts(with: "elements.captcha.passive") ?? false })
         XCTAssertEqual(passiveCaptchaEvents, ["elements.captcha.passive.init", "elements.captcha.passive.execute", "elements.captcha.passive.success"])
         let successAnalytic = STPAnalyticsClient.sharedClient._testLogHistory.first(where: { $0["event"] as? String == "elements.captcha.passive.success" })
@@ -69,7 +113,7 @@ class PassiveCaptchaChallengeTests: XCTestCase {
         let passiveCaptchaChallenge = PassiveCaptchaChallenge(passiveCaptchaData: passiveCaptchaData, hcaptchaFactory: TestDelayHCaptchaFactory())
         let startTime = Date()
         let hcaptchaTokenResult = await withTimeout(1) {
-            try await passiveCaptchaChallenge.fetchToken()
+            try await passiveCaptchaChallenge.consumeToken()
         }
         XCTAssertLessThan(Date().timeIntervalSince(startTime), 1.5)
         // should return TimeoutError
@@ -84,54 +128,56 @@ class PassiveCaptchaChallengeTests: XCTestCase {
         let passiveCaptchaChallenge = PassiveCaptchaChallenge(passiveCaptchaData: passiveCaptchaData)
         let startTime = Date()
         let hcaptchaToken = try await withTimeout(30) {
-            try await passiveCaptchaChallenge.fetchToken()
+            try await passiveCaptchaChallenge.consumeToken()
         }.get()
         // didn't time out because it finished early
         XCTAssertLessThan(Date().timeIntervalSince(startTime), 10)
-        XCTAssertNotNil(hcaptchaToken)
+        XCTAssertFalse(hcaptchaToken.value.isEmpty)
     }
 
     func testTokenResetAndRefetchAfterExpiration() async throws {
-        // Use a very short expiration time (5 seconds) for testing
-        let passiveCaptchaData = PassiveCaptchaData(siteKey: siteKey, rqdata: nil, tokenTimeoutSeconds: 5)
+        // Use a very short expiration time for testing
+        let passiveCaptchaData = PassiveCaptchaData(siteKey: siteKey, rqdata: nil, tokenTimeoutSeconds: 2)
         let passiveCaptchaChallenge = PassiveCaptchaChallenge(passiveCaptchaData: passiveCaptchaData, hcaptchaFactory: PassiveHCaptchaFactory())
 
-        // Fetch first token
-        let token = try await passiveCaptchaChallenge.fetchToken()
-        XCTAssertNotNil(token)
-
-        // Verify token is ready
-        var isReadyBefore = await passiveCaptchaChallenge.isTokenReady
-        XCTAssertTrue(isReadyBefore, "Token should be ready after first fetch")
-
-        // Fetch a token before expiration - should succeed without fetching a new token
-        let sameToken = try await passiveCaptchaChallenge.fetchToken()
-        XCTAssertNotNil(sameToken)
-
-        // Verify token is ready
-        isReadyBefore = await passiveCaptchaChallenge.isTokenReady
-        XCTAssertTrue(isReadyBefore, "Token should be ready after first fetch")
-
-        let passiveCaptchaEvents = STPAnalyticsClient.sharedClient._testLogHistory.map({ $0["event"] as? String }).filter({ $0?.starts(with: "elements.captcha.passive") ?? false })
-        // We should not see these events more than once because we shouldn't need to fetch more than once
-        XCTAssertEqual(passiveCaptchaEvents, ["elements.captcha.passive.init", "elements.captcha.passive.execute", "elements.captcha.passive.success"])
+        // Wait for the preloaded token to be ready
+        try await waitUntilTokenIsReady(passiveCaptchaChallenge)
+        let isReadyBefore = await passiveCaptchaChallenge.isTokenReady
+        XCTAssertTrue(isReadyBefore, "Token should be ready before expiration")
 
         // Wait for session to expire
-        try await Task.sleep(nanoseconds: 5_000_000_000)
+        try await Task.sleep(nanoseconds: 2_100_000_000)
 
         // Check that expiration triggers reset
         let isReadyAfter = await passiveCaptchaChallenge.isTokenReady
         XCTAssertFalse(isReadyAfter, "Token should not be ready after session expiration")
 
-        // Fetch a new token after expiration - should succeed with a new token
-        let newToken = try await passiveCaptchaChallenge.fetchToken()
-        XCTAssertNotNil(newToken)
+        // Consume after expiration - should fetch a new token
+        let newToken = try await passiveCaptchaChallenge.consumeToken()
+        XCTAssertFalse(newToken.value.isEmpty)
+        XCTAssertFalse(newToken.wasReady)
 
-        // Verify token is ready again after successful refetch
+        // Consuming the new token should leave no token cached
         let isReadyFinal = await passiveCaptchaChallenge.isTokenReady
-        XCTAssertTrue(isReadyFinal, "Token should be ready after refetch")
+        XCTAssertFalse(isReadyFinal, "Token should be discarded after consumption")
 
         let passiveCaptchaExecuteEvents = STPAnalyticsClient.sharedClient._testLogHistory.map({ $0["event"] as? String }).filter({ $0?.starts(with: "elements.captcha.passive.execute") ?? false })
         XCTAssertEqual(passiveCaptchaExecuteEvents.count, 2, "Should have re-fetched token after expiration")
+    }
+
+    func testConcurrentConsumeTokenRequestsDoNotShareTask() async {
+        // Given a preloaded token task that fails deterministically
+        let counter = PassiveCaptchaCreateCounter()
+        let factory = CountingFailingPassiveCaptchaFactory(counter: counter)
+        let passiveCaptchaData = PassiveCaptchaData(siteKey: siteKey, rqdata: nil)
+        let passiveCaptchaChallenge = PassiveCaptchaChallenge(passiveCaptchaData: passiveCaptchaData, hcaptchaFactory: factory)
+
+        // When two callers consume concurrently
+        let firstTokenTask = Task { try? await passiveCaptchaChallenge.consumeToken() }
+        let secondTokenTask = Task { try? await passiveCaptchaChallenge.consumeToken() }
+        _ = await (firstTokenTask.value, secondTokenTask.value)
+
+        // Then each caller should execute its own challenge
+        XCTAssertEqual(counter.count, 2)
     }
 }


### PR DESCRIPTION
## Summary

Consume passive CAPTCHA tokens when they are retrieved for a request so the same single-use token cannot be returned again.

The initial token is still preloaded, but replacement tokens are created on demand instead of being prefetched automatically.

## Motivation

`PassiveCaptchaChallenge` cached its completed token task until time-based expiration. A second payment method creation or confirmation attempt could therefore reuse a token that had already been sent and invalidated.

https://stripe.slack.com/archives/CFA2HJ99A/p1788976177411529?thread_ts=1788906921.701889&cid=CFA2HJ99A

## Testing

- Added coverage that simultaneous consumers start separate CAPTCHA challenges.
- Added coverage that repeated card Radar option requests each start a fresh CAPTCHA challenge.
- Updated passive CAPTCHA coverage to verify consumed tokens are no longer cached and unused expired tokens are replaced.

## Changelog

N/A
