### PR TITLE
Add Checkout payment option billing details type

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session+DebugDescription.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session+DebugDescription.swift
@@ -96,7 +96,7 @@ extension CheckoutController.Session: CustomDebugStringConvertible {
         if let billingDetails = paymentOption.billingDetails {
             lines.append(contentsOf: addressDebugDescriptionLines(
                 name: "billingDetails",
-                country: billingDetails.address.country,
+                country: billingDetails.address?.country,
                 indentation: 2
             ))
         } else {

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Session.swift
@@ -229,7 +229,7 @@ extension CheckoutController.Session {
         /// A user facing string representing the payment method; e.g. "Apple Pay" or "····4242" for a card
         public let label: String
         /// The billing details associated with the customer's desired payment method
-        public let billingDetails: PaymentSheet.BillingDetails?
+        public let billingDetails: BillingDetails?
         /// A string representation of the customer's desired payment method
         /// - If this is a Stripe payment method, see https://stripe.com/docs/api/payment_methods/object#payment_method_object-type for possible values.
         /// - If this is an external payment method, see https://stripe.com/docs/payments/external-payment-methods?platform=ios#available-external-payment-methods for possible values.
@@ -237,5 +237,41 @@ extension CheckoutController.Session {
         public let paymentMethodType: String
         /// If you set `configuration.embeddedViewDisplaysMandateText = false`, this text must be displayed in a `UITextView` (so that URLs in the text are handled) to the customer near your “Buy” button to comply with regulations.
         public let mandateText: NSAttributedString?
+
+        /// The billing details collected for a payment method.
+        public struct BillingDetails: Equatable {
+            /// The customer's billing address.
+            public let address: Address?
+
+            /// The customer's email address.
+            public let email: String?
+
+            /// The customer's full name.
+            public let name: String?
+
+            /// The customer's phone number.
+            public let phone: String?
+
+            /// A billing address.
+            public struct Address: Equatable {
+                /// City, district, suburb, town, or village.
+                public let city: String?
+
+                /// Two-letter country code (ISO 3166-1 alpha-2).
+                public let country: String?
+
+                /// Address line 1 (e.g., street, PO Box, or company name).
+                public let line1: String?
+
+                /// Address line 2 (e.g., apartment, suite, unit, or building).
+                public let line2: String?
+
+                /// ZIP or postal code.
+                public let postalCode: String?
+
+                /// State, county, province, or region.
+                public let state: String?
+            }
+        }
     }
 }

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/CheckoutController.swift
@@ -238,7 +238,7 @@ public final class CheckoutController: ObservableObject {
         if let address {
             taxRegion = address
         } else {
-            guard let country = session.paymentOption?.billingDetails?.address.country?.nonEmpty else {
+            guard let country = session.paymentOption?.billingDetails?.address?.country?.nonEmpty else {
                 return
             }
             // The Checkout Session update endpoint requires tax_region[country] and does not

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Payment Element/PaymentElement.swift
@@ -239,7 +239,7 @@ extension CheckoutController.Session.PaymentOptionDisplayData {
         self.init(
             image: paymentOption.image,
             label: paymentOption.label,
-            billingDetails: paymentOption.billingDetails,
+            billingDetails: paymentOption.billingDetails.map(BillingDetails.init),
             paymentMethodType: paymentOption.paymentMethodType,
             mandateText: nil
         )
@@ -249,9 +249,33 @@ extension CheckoutController.Session.PaymentOptionDisplayData {
         self.init(
             image: paymentOption.image,
             label: paymentOption.label,
-            billingDetails: paymentOption.billingDetails,
+            billingDetails: paymentOption.billingDetails.map(BillingDetails.init),
             paymentMethodType: paymentOption.paymentMethodType,
             mandateText: paymentOption.mandateText
+        )
+    }
+}
+
+private extension CheckoutController.Session.PaymentOptionDisplayData.BillingDetails {
+    init(_ billingDetails: PaymentSheet.BillingDetails) {
+        self.init(
+            address: billingDetails.address == .init() ? nil : Address(billingDetails.address),
+            email: billingDetails.email,
+            name: billingDetails.name,
+            phone: billingDetails.phone
+        )
+    }
+}
+
+private extension CheckoutController.Session.PaymentOptionDisplayData.BillingDetails.Address {
+    init(_ address: PaymentSheet.Address) {
+        self.init(
+            city: address.city,
+            country: address.country,
+            line1: address.line1,
+            line2: address.line2,
+            postalCode: address.postalCode,
+            state: address.state
         )
     }
 }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutUnitTests.swift
@@ -805,6 +805,7 @@ final class CheckoutUnitTests: XCTestCase {
                                 city: "San Francisco",
                                 country: "US",
                                 line1: "510 Townsend Street",
+                                line2: nil,
                                 postalCode: "94103",
                                 state: "CA"
                             ),

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/PaymentElementTest.swift
@@ -269,7 +269,33 @@ final class PaymentElementTest: XCTestCase {
 
         // ...and the saved card remains selected after PaymentElement refreshes.
         XCTAssertEqual(checkout.session.paymentOption?.label, "•••• 4242")
-        XCTAssertEqual(checkout.session.paymentOption?.billingDetails?.address.country, "US")
+        let billingDetails = try XCTUnwrap(checkout.session.paymentOption?.billingDetails)
+        XCTAssertEqual(billingDetails.name, "Jenny Rosen")
+        XCTAssertEqual(billingDetails.email, "jenny.rosen@example.com")
+        XCTAssertEqual(billingDetails.phone, "+15555555555")
+        XCTAssertEqual(billingDetails.address?.country, "US")
+        XCTAssertEqual(billingDetails.address?.line1, "354 Oyster Point Blvd")
+        XCTAssertEqual(billingDetails.address?.city, "South San Francisco")
+        XCTAssertEqual(billingDetails.address?.state, "CA")
+        XCTAssertEqual(billingDetails.address?.postalCode, "94080")
+    }
+
+    func testPaymentOptionBillingDetailsOmitsEmptyAddress() {
+        // Given a payment option whose PaymentSheet billing details have no address fields
+        let paymentOption = EmbeddedPaymentElement.PaymentOptionDisplayData(
+            image: UIImage(),
+            label: "•••• 4242",
+            billingDetails: .init(),
+            paymentMethodType: "card",
+            mandateText: nil,
+            shippingDetails: nil
+        )
+
+        // When converting it to Checkout display data
+        let displayData = CheckoutController.Session.PaymentOptionDisplayData(paymentOption)
+
+        // Then Checkout represents the absent address as nil, not an empty Address()
+        XCTAssertNil(displayData.billingDetails?.address)
     }
 
     func testClearPaymentOptionResetsBillingTaxRegionToCountry() async throws {


### PR DESCRIPTION
## Summary
- Add a Checkout-owned billing details model for selected payment options
- Match the Android API nesting and nullable field semantics
- Convert PaymentSheet billing details without exposing PaymentSheet types

## Motivation
Don't use PaymentSheet types in Checkout Elements

## Testing
- Added coverage that selected payment option billing details preserve the customer name, email, and address.
- Added coverage that missing billing addresses are represented as nil.
- Verified session debug descriptions continue masking customer information.