### PR TITLE
[Identity] Custom Colors for CTA

### DIFF
--- a/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
+++ b/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Mel Ludowise on 3/3/21.
 //
 
-import StripeIdentity
+@_spi(STP) import StripeIdentity
 @_spi(STP) import StripeUICore
 import UIKit
 
@@ -45,6 +45,7 @@ class PlaygroundViewController: UIViewController {
     @IBOutlet weak var phoneOtpContainerView: UIStackView!
 
     @IBOutlet weak var fallbackToDocumentSwitch: UISwitch!
+    private let monochromePrimaryButtonsSwitch = UISwitch()
     private let phoneElement: PhoneNumberElement
 
     private let phoneView: UIView
@@ -130,6 +131,18 @@ class PlaygroundViewController: UIViewController {
         super.viewDidLoad()
 
         nativeOrWebSelector.isEnabled = true
+
+        let monochromeButtonLabel = UILabel()
+        monochromeButtonLabel.text = "Monochrome primary buttons"
+        monochromeButtonLabel.font = .preferredFont(forTextStyle: .body)
+        monochromeButtonLabel.adjustsFontForContentSizeCategory = true
+        monochromeButtonLabel.numberOfLines = 0
+        monochromePrimaryButtonsSwitch.accessibilityLabel = monochromeButtonLabel.text
+        monochromePrimaryButtonsSwitch.accessibilityHint = "Uses black primary buttons in light mode and white primary buttons in dark mode throughout verification, with opposite text colors."
+        let monochromeButtonRow = UIStackView(arrangedSubviews: [monochromeButtonLabel, monochromePrimaryButtonsSwitch])
+        monochromeButtonRow.alignment = .center
+        monochromeButtonRow.spacing = 8
+        nativeComponentsOptionsContainerView.addArrangedSubview(monochromeButtonRow)
 
         mockDocumentCameraForSimulator()
 
@@ -359,12 +372,19 @@ class PlaygroundViewController: UIViewController {
             assertionFailure("Did not receive a valid ephemeral key secret.")
             return
         }
+        var configuration = IdentityVerificationSheet.Configuration(
+            brandLogo: UIImage(named: "BrandLogo")!
+        )
+        if monochromePrimaryButtonsSwitch.isOn {
+            configuration.primaryButtonStyle = .custom(
+                backgroundColor: .dynamic(light: .black, dark: .white),
+                textColor: .dynamic(light: .white, dark: .black)
+            )
+        }
         self.verificationSheet = IdentityVerificationSheet(
             verificationSessionId: verificationSessionId,
             ephemeralKeySecret: ephemeralKeySecret,
-            configuration: IdentityVerificationSheet.Configuration(
-                brandLogo: UIImage(named: "BrandLogo")!
-            )
+            configuration: configuration
         )
     }
 

--- a/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
+++ b/Example/IdentityVerification Example/IdentityVerification Example/PlaygroundViewController.swift
@@ -5,7 +5,7 @@
 //  Created by Mel Ludowise on 3/3/21.
 //
 
-@_spi(STP) import StripeIdentity
+import StripeIdentity
 @_spi(STP) import StripeUICore
 import UIKit
 
@@ -45,7 +45,6 @@ class PlaygroundViewController: UIViewController {
     @IBOutlet weak var phoneOtpContainerView: UIStackView!
 
     @IBOutlet weak var fallbackToDocumentSwitch: UISwitch!
-    private let monochromePrimaryButtonsSwitch = UISwitch()
     private let phoneElement: PhoneNumberElement
 
     private let phoneView: UIView
@@ -131,18 +130,6 @@ class PlaygroundViewController: UIViewController {
         super.viewDidLoad()
 
         nativeOrWebSelector.isEnabled = true
-
-        let monochromeButtonLabel = UILabel()
-        monochromeButtonLabel.text = "Monochrome primary buttons"
-        monochromeButtonLabel.font = .preferredFont(forTextStyle: .body)
-        monochromeButtonLabel.adjustsFontForContentSizeCategory = true
-        monochromeButtonLabel.numberOfLines = 0
-        monochromePrimaryButtonsSwitch.accessibilityLabel = monochromeButtonLabel.text
-        monochromePrimaryButtonsSwitch.accessibilityHint = "Uses black primary buttons in light mode and white primary buttons in dark mode throughout verification, with opposite text colors."
-        let monochromeButtonRow = UIStackView(arrangedSubviews: [monochromeButtonLabel, monochromePrimaryButtonsSwitch])
-        monochromeButtonRow.alignment = .center
-        monochromeButtonRow.spacing = 8
-        nativeComponentsOptionsContainerView.addArrangedSubview(monochromeButtonRow)
 
         mockDocumentCameraForSimulator()
 
@@ -372,19 +359,12 @@ class PlaygroundViewController: UIViewController {
             assertionFailure("Did not receive a valid ephemeral key secret.")
             return
         }
-        var configuration = IdentityVerificationSheet.Configuration(
-            brandLogo: UIImage(named: "BrandLogo")!
-        )
-        if monochromePrimaryButtonsSwitch.isOn {
-            configuration.primaryButtonStyle = .custom(
-                backgroundColor: .dynamic(light: .black, dark: .white),
-                textColor: .dynamic(light: .white, dark: .black)
-            )
-        }
         self.verificationSheet = IdentityVerificationSheet(
             verificationSessionId: verificationSessionId,
             ephemeralKeySecret: ephemeralKeySecret,
-            configuration: configuration
+            configuration: IdentityVerificationSheet.Configuration(
+                brandLogo: UIImage(named: "BrandLogo")!
+            )
         )
     }
 

--- a/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
+++ b/StripeIdentity/StripeIdentity/Source/IdentityVerificationSheet.swift
@@ -25,6 +25,15 @@ final public class IdentityVerificationSheet {
 
     /// Configuration for an IdentityVerificationSheet
     public struct Configuration {
+        /// The appearance of primary action buttons throughout the native verification flow.
+        @_spi(STP) public enum PrimaryButtonStyle {
+            /// Uses the app's tint color.
+            case `default`
+            /// Uses the supplied background and text colors.
+            /// Provide dynamic colors to support different colors in light and dark mode.
+            case custom(backgroundColor: UIColor, textColor: UIColor)
+        }
+
         /// Configuration for the biometric consent screen's header.
         @_spi(STP) public struct BiometricConsentConfiguration {
             /// Whether to hide the branding header above the consent title.
@@ -46,6 +55,10 @@ final public class IdentityVerificationSheet {
         /// displayed in both light and dark modes, if the app supports it. Use a
         /// dynamic UIImage to support different images in light vs dark mode.
         public var brandLogo: UIImage
+
+        /// The style of primary action buttons throughout the native verification flow.
+        /// Disabled buttons retain the default disabled appearance. Secondary buttons are unaffected.
+        @_spi(STP) public var primaryButtonStyle: PrimaryButtonStyle = .default
 
         /// Configuration for the biometric consent screen's header.
         ///

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Coordinators/VerificationSheetFlowController.swift
@@ -29,6 +29,7 @@ protocol VerificationSheetFlowControllerProtocol: AnyObject {
 
     var documentUploader: DocumentUploaderProtocol? { get }
     var visitedIndividualWelcomePage: Bool { get }
+    var primaryButtonStyle: IdentityVerificationSheet.Configuration.PrimaryButtonStyle { get }
 
     func transitionToNextScreen(
         skipTestMode: Bool,
@@ -83,6 +84,7 @@ protocol VerificationSheetFlowControllerProtocol: AnyObject {
 final class VerificationSheetFlowController: NSObject {
 
     let brandLogo: UIImage
+    let primaryButtonStyle: IdentityVerificationSheet.Configuration.PrimaryButtonStyle
     let biometricConsentConfiguration: IdentityVerificationSheet.Configuration.BiometricConsentConfiguration?
 
     weak var delegate: VerificationSheetFlowControllerDelegate?
@@ -97,6 +99,7 @@ final class VerificationSheetFlowController: NSObject {
         configuration: IdentityVerificationSheet.Configuration
     ) {
         self.brandLogo = configuration.brandLogo
+        self.primaryButtonStyle = configuration.primaryButtonStyle
         self.biometricConsentConfiguration = configuration.biometricConsent
     }
 

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IdentityFlowViewController.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/ViewControllers/IdentityFlowViewController.swift
@@ -103,7 +103,10 @@ class IdentityFlowViewController: UIViewController {
         ) {
         navigationItem.backButtonTitle = backButtonTitle
         do {
-            try flowView.configure(with: viewModel)
+            try flowView.configure(
+                with: viewModel,
+                primaryButtonStyle: sheetController?.flowController.primaryButtonStyle ?? .default
+            )
         } catch {
             if let sheetController = sheetController {
                 sheetController.analyticsClient.logGenericError(

--- a/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityFlowView.swift
+++ b/StripeIdentity/StripeIdentity/Source/NativeComponents/Views/IdentityFlowView.swift
@@ -41,8 +41,11 @@ class IdentityFlowView: UIView {
         )
         static let stackViewSpacing: CGFloat = 8
 
-        static func buttonConfiguration(isPrimary: Bool) -> Button.Configuration {
-            return isPrimary ? .identityPrimary() : .identitySecondary()
+        static func buttonConfiguration(
+            isPrimary: Bool,
+            primaryButtonStyle: IdentityVerificationSheet.Configuration.PrimaryButtonStyle
+        ) -> Button.Configuration {
+            return isPrimary ? .identityPrimary(style: primaryButtonStyle) : .identitySecondary()
         }
     }
 
@@ -159,10 +162,13 @@ class IdentityFlowView: UIView {
     /// - Note: This method changes the view hierarchy and activates new
     /// constraints which can affect screen render performance. It should only be
     /// called from a view controller's `init` or `viewDidLoad`.
-    func configure(with viewModel: ViewModel) throws {
+    func configure(
+        with viewModel: ViewModel,
+        primaryButtonStyle: IdentityVerificationSheet.Configuration.PrimaryButtonStyle = .default
+    ) throws {
         configureHeaderView(with: viewModel.headerViewModel)
         configureContentView(with: viewModel.contentViewModel)
-        configureButtons(with: viewModel.buttons)
+        configureButtons(with: viewModel.buttons, primaryButtonStyle: primaryButtonStyle)
         try configureButtonTop(with: viewModel.buttonTopContentViewModel)
         flowViewDelegate = viewModel.flowViewDelegate
         if let scrollViewDelegate = viewModel.scrollViewDelegate {
@@ -284,7 +290,10 @@ extension IdentityFlowView {
 // MARK: - Private Helpers: View Configurations
 
 extension IdentityFlowView {
-    fileprivate func configureButtons(with buttonViewModels: [ViewModel.Button]) {
+    fileprivate func configureButtons(
+        with buttonViewModels: [ViewModel.Button],
+        primaryButtonStyle: IdentityVerificationSheet.Configuration.PrimaryButtonStyle
+    ) {
         // If there are no buttons to display, hide the container view
         guard buttonViewModels.count > 0 else {
             buttonBackgroundView.isHidden = true
@@ -297,7 +306,7 @@ extension IdentityFlowView {
         defer {
             // Configure buttons
             zip(buttonViewModels, buttons).forEach { (viewModel, button) in
-                button.configure(with: viewModel)
+                button.configure(with: viewModel, primaryButtonStyle: primaryButtonStyle)
             }
 
             // Cache tap actions
@@ -443,10 +452,14 @@ extension StripeUICore.Button {
         return tag
     }
 
-    fileprivate func configure(with viewModel: IdentityFlowView.ViewModel.Button) {
+    fileprivate func configure(
+        with viewModel: IdentityFlowView.ViewModel.Button,
+        primaryButtonStyle: IdentityVerificationSheet.Configuration.PrimaryButtonStyle
+    ) {
         self.title = viewModel.text
         self.configuration = IdentityFlowView.Style.buttonConfiguration(
-            isPrimary: viewModel.isPrimary
+            isPrimary: viewModel.isPrimary,
+            primaryButtonStyle: primaryButtonStyle
         )
         self.isEnabled = viewModel.state == .enabled
         self.isLoading = viewModel.state == .loading
@@ -461,10 +474,14 @@ extension Button.Configuration {
     }
 
     /// The default button configuration.
-    static func identityPrimary() -> Self {
+    static func identityPrimary(style: IdentityVerificationSheet.Configuration.PrimaryButtonStyle = .default) -> Self {
         var configuration: Button.Configuration = .primary()
         configuration.font = buttonFont
         configuration.disabledForegroundColor = .systemGray
+        if case let .custom(backgroundColor, textColor) = style {
+            configuration.backgroundColor = backgroundColor
+            configuration.foregroundColor = textColor
+        }
         return configuration
     }
 

--- a/StripeIdentity/StripeIdentityTests/Helpers/VerificationSheetFlowControllerMock.swift
+++ b/StripeIdentity/StripeIdentityTests/Helpers/VerificationSheetFlowControllerMock.swift
@@ -10,7 +10,8 @@ import Foundation
 import UIKit
 import XCTest
 
-@testable import StripeIdentity
+// swift-format-ignore
+@_spi(STP) @testable import StripeIdentity
 
 /// Mock to help us test behavior that relies on  VerificationSheetFlowController
 final class VerificationSheetFlowControllerMock: VerificationSheetFlowControllerProtocol {
@@ -21,6 +22,7 @@ final class VerificationSheetFlowControllerMock: VerificationSheetFlowController
     var analyticsLastScreen: IdentityFlowViewController?
 
     var visitedIndividualWelcomePage = false
+    var primaryButtonStyle: IdentityVerificationSheet.Configuration.PrimaryButtonStyle = .default
 
     weak var delegate: VerificationSheetFlowControllerDelegate?
 

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/BiometricConsentViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/BiometricConsentViewControllerTest.swift
@@ -7,16 +7,19 @@
 //
 
 import Foundation
+@_spi(STP) import StripeUICore
+import UIKit
 import XCTest
 
-@testable import StripeIdentity
+// swift-format-ignore
+@_spi(STP) @testable import StripeIdentity
 
 final class BiometricConsentViewControllerTest: XCTestCase {
 
     static let mockVerificationPage = try! VerificationPageMock.response200.make()
 
     private var vc: BiometricConsentViewController!
-    private let mockSheetController = VerificationSheetControllerMock()
+    private var mockSheetController = VerificationSheetControllerMock()
 
     override func setUp() {
         super.setUp()
@@ -45,5 +48,119 @@ final class BiometricConsentViewControllerTest: XCTestCase {
 
         // Verify biometricConsent is saved
         XCTAssertEqual(mockSheetController.savedData?.biometricConsent, false)
+    }
+
+    func testDefaultContinueButtonUsesTintColor() throws {
+        for configuration: IdentityVerificationSheet.Configuration.BiometricConsentConfiguration? in [nil, .init(hideBrandingHeader: true)] {
+            // Given the default style, including a header-only configuration
+            let controller = try makeViewController(configuration: configuration)
+            controller.view.tintColor = .magenta
+
+            // When the user has read the consent
+            controller.scrolledToBottom = true
+
+            // Then the Continue button keeps the app's tint color
+            let button = try XCTUnwrap(buttons(in: controller.view).first)
+            XCTAssertEqual(button.backgroundColor, .magenta)
+            let label = try XCTUnwrap(button.subviews.compactMap { $0 as? UILabel }.first)
+            XCTAssertEqual(label.textColor, .white)
+        }
+    }
+
+    func testCustomContinueButtonColors() throws {
+        // Given caller-supplied button colors that differ from the app's tint
+        let controller = try makeViewController(
+            primaryButtonStyle: .custom(backgroundColor: .purple, textColor: .yellow)
+        )
+        controller.view.tintColor = .magenta
+
+        // When the Continue button is enabled
+        controller.scrolledToBottom = true
+        let button = try XCTUnwrap(buttons(in: controller.view).first)
+        let label = try XCTUnwrap(button.subviews.compactMap { $0 as? UILabel }.first)
+
+        // Then the button uses both supplied colors
+        XCTAssertEqual(button.backgroundColor, .purple)
+        XCTAssertEqual(label.textColor, .yellow)
+    }
+
+    func testCustomContinueButtonDynamicColors() throws {
+        // Given dynamic button colors and a custom app tint
+        let controller = try makeViewController(
+            primaryButtonStyle: .custom(
+                backgroundColor: .dynamic(light: .black, dark: .white),
+                textColor: .dynamic(light: .white, dark: .black)
+            )
+        )
+        controller.view.tintColor = .magenta
+        controller.scrolledToBottom = true
+        let consentButtons = buttons(in: controller.view)
+        let button = try XCTUnwrap(consentButtons.first)
+        let label = try XCTUnwrap(button.subviews.compactMap { $0 as? UILabel }.first)
+
+        // When the same button's colors resolve in light and dark mode
+        for style: UIUserInterfaceStyle in [.light, .dark] {
+            let traits = UITraitCollection(userInterfaceStyle: style)
+
+            // Then the background and text use opposite black and white colors
+            XCTAssertEqual(button.backgroundColor?.resolvedColor(with: traits), style == .dark ? .white : .black)
+            XCTAssertEqual(label.textColor.resolvedColor(with: traits), style == .dark ? .black : .white)
+        }
+
+        // ...and the decline button keeps its standard appearance
+        let declineButton = try XCTUnwrap(consentButtons.last)
+        let declineLabel = try XCTUnwrap(declineButton.subviews.compactMap { $0 as? UILabel }.first)
+        XCTAssertEqual(declineLabel.textColor, .magenta)
+        XCTAssertEqual(declineButton.backgroundColor, .secondarySystemFill)
+    }
+
+    func testCustomContinueButtonIsDisabledUntilScrolled() throws {
+        // Given unread consent with custom button colors
+        let controller = try makeViewController(
+            primaryButtonStyle: .custom(backgroundColor: .purple, textColor: .yellow)
+        )
+        let button = try XCTUnwrap(buttons(in: controller.view).first)
+        let label = try XCTUnwrap(button.subviews.compactMap { $0 as? UILabel }.first)
+        XCTAssertFalse(button.isEnabled)
+        for style: UIUserInterfaceStyle in [.light, .dark] {
+            let traits = UITraitCollection(userInterfaceStyle: style)
+            XCTAssertEqual(button.backgroundColor?.resolvedColor(with: traits), UIColor.systemGray4.resolvedColor(with: traits))
+            XCTAssertEqual(label.textColor.resolvedColor(with: traits), UIColor.systemGray.resolvedColor(with: traits))
+        }
+
+        // When the user finishes reading and continues
+        controller.scrolledToBottom = true
+        XCTAssertTrue(button.isEnabled)
+        controller.flowViewModel.buttons.first?.didTap()
+
+        // Then consent is saved as usual
+        XCTAssertEqual(mockSheetController.savedData?.biometricConsent, true)
+    }
+
+    private func makeViewController(
+        configuration: IdentityVerificationSheet.Configuration.BiometricConsentConfiguration? = nil,
+        primaryButtonStyle: IdentityVerificationSheet.Configuration.PrimaryButtonStyle = .default
+    ) throws -> BiometricConsentViewController {
+        var sheetConfiguration = IdentityVerificationSheet.Configuration(brandLogo: UIImage())
+        sheetConfiguration.primaryButtonStyle = primaryButtonStyle
+        mockSheetController = VerificationSheetControllerMock(
+            flowController: VerificationSheetFlowController(configuration: sheetConfiguration)
+        )
+        return try BiometricConsentViewController(
+            brandLogo: UIImage(),
+            showsStripeLogo: !Self.mockVerificationPage.isStripe,
+            consentContent: Self.mockVerificationPage.biometricConsent,
+            configuration: configuration,
+            sheetController: mockSheetController
+        )
+    }
+
+    private func buttons(in view: UIView) -> [Button] {
+        return view.subviews.flatMap { subview in
+            if let button = subview as? Button {
+                return [button]
+            }
+            return buttons(in: subview)
+        }
     }
 }

--- a/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/IdentityFlowViewControllerTest.swift
+++ b/StripeIdentity/StripeIdentityTests/Unit/NativeComponents/ViewControllers/IdentityFlowViewControllerTest.swift
@@ -1,0 +1,97 @@
+//
+//  IdentityFlowViewControllerTest.swift
+//  StripeIdentityTests
+//
+//  Copyright © 2026 Stripe, Inc. All rights reserved.
+//
+
+@_spi(STP) import StripeUICore
+import UIKit
+import XCTest
+
+// swift-format-ignore
+@_spi(STP) @testable import StripeIdentity
+
+final class IdentityFlowViewControllerTest: XCTestCase {
+    func testCustomPrimaryButtonStyleAcrossScreens() throws {
+        // Given a flow configured with dynamic primary button colors
+        var configuration = IdentityVerificationSheet.Configuration(brandLogo: UIImage())
+        configuration.primaryButtonStyle = .custom(
+            backgroundColor: .dynamic(light: .black, dark: .white),
+            textColor: .dynamic(light: .white, dark: .black)
+        )
+        let sheetController = VerificationSheetControllerMock(
+            flowController: VerificationSheetFlowController(configuration: configuration)
+        )
+        let content = try VerificationPageMock.response200.make()
+
+        // When subsequent pages use the same flow
+        let controllers: [IdentityFlowViewController] = [
+            try DocumentWarmupViewController(sheetController: sheetController, staticContent: content.documentSelect),
+            try SelfieWarmupViewController(sheetController: sheetController),
+            IndividualViewController(individualContent: content.individual, missing: [], sheetController: sheetController),
+            SuccessViewController(successContent: content.success, sheetController: sheetController),
+        ]
+
+        // Then each page's primary button uses the configured colors in both appearances
+        for controller in controllers {
+            controller.view.tintColor = .magenta
+            let button = try XCTUnwrap(buttons(in: controller.view).first)
+            let label = try XCTUnwrap(button.subviews.compactMap { $0 as? UILabel }.first)
+            XCTAssertTrue(button.isEnabled, "\(type(of: controller))")
+            for style: UIUserInterfaceStyle in [.light, .dark] {
+                let traits = UITraitCollection(userInterfaceStyle: style)
+                XCTAssertEqual(button.backgroundColor?.resolvedColor(with: traits), style == .dark ? .white : .black, "\(type(of: controller))")
+                XCTAssertEqual(label.textColor.resolvedColor(with: traits), style == .dark ? .black : .white, "\(type(of: controller))")
+            }
+        }
+    }
+
+    func testCustomPrimaryButtonColorsAcrossSubmissionStates() throws {
+        // Given a primary button styled at the flow level
+        var configuration = IdentityVerificationSheet.Configuration(brandLogo: UIImage())
+        configuration.primaryButtonStyle = .custom(backgroundColor: .purple, textColor: .yellow)
+        let sheetController = VerificationSheetControllerMock(
+            flowController: VerificationSheetFlowController(configuration: configuration)
+        )
+        let controller = IdentityFlowViewController(sheetController: sheetController, analyticsScreenName: .individual)
+        let contentView = UIView()
+
+        // When a submission starts and finishes, then input becomes invalid and valid again
+        for state: IdentityFlowView.ViewModel.Button.State in [.enabled, .loading, .enabled, .disabled, .enabled] {
+            controller.configure(
+                backButtonTitle: nil,
+                viewModel: .init(
+                    headerViewModel: nil,
+                    contentView: contentView,
+                    buttons: [.continueButton(state: state, didTap: {})]
+                )
+            )
+            let button = try XCTUnwrap(buttons(in: controller.view).first)
+            let label = try XCTUnwrap(button.subviews.compactMap { $0 as? UILabel }.first)
+            let spinner = try XCTUnwrap(button.subviews.compactMap { $0 as? ActivityIndicator }.first)
+            XCTAssertEqual(button.isEnabled, state == .enabled)
+            XCTAssertEqual(button.isLoading, state == .loading)
+
+            // Then custom colors apply while enabled
+            // ...and loading and disabled states retain the existing gray appearance, including the spinner
+            for style: UIUserInterfaceStyle in [.light, .dark] {
+                let traits = UITraitCollection(userInterfaceStyle: style)
+                let expectedBackground: UIColor = state == .enabled ? .purple : .systemGray4
+                let expectedForeground: UIColor = state == .enabled ? .yellow : .systemGray
+                XCTAssertEqual(button.backgroundColor?.resolvedColor(with: traits), expectedBackground.resolvedColor(with: traits))
+                XCTAssertEqual(label.textColor.resolvedColor(with: traits), expectedForeground.resolvedColor(with: traits))
+                XCTAssertEqual(spinner.tintColor.resolvedColor(with: traits), expectedForeground.resolvedColor(with: traits))
+            }
+        }
+    }
+
+    private func buttons(in view: UIView) -> [Button] {
+        return view.subviews.flatMap { subview in
+            if let button = subview as? Button {
+                return [button]
+            }
+            return buttons(in: subview)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds an internal `primaryButtonStyle` configuration setting to allow Link to edit this style. Previously, a user could edit the `UIWindow.tint` to update this CTA color. Link requires a distinction between this tint color (which is used by native SwiftUI elements and other custom elements of the SDK) and the color used by the CTA (which Link would prefer be black/white depending on dark mode). This is behind a `STP` annotation to signal that it's for internal usage.

## Motivation
Link design would like configuration of the CTAs used in the Identity SDK ([figma](https://www.figma.com/design/UKdEOqZIBMigsA8iw3KZ1C/%E2%9A%93%EF%B8%8F--Project-Iron?node-id=6005-142068&m=dev)).

## Demo

These demos shows the testing done for this future using a non-committed playground toggle to add the black/white button style Link will use. These demos shows that the tint color is still respected while the custom CTA button style is in use.

| Full Demo | Dark/Light Mode |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/d07f4bd0-56d7-464a-ad02-eca45c614bb7" width="300" /> | <video src="https://github.com/user-attachments/assets/da251acd-40cf-493d-8ef4-7cf5f12cebe8" width="300" /> |


