### PR TITLE
Remove obsolete Checkout code in FC and EPE `confirm` methods

### DIFF
--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Checkout/Checkout+Internal.swift
@@ -196,19 +196,6 @@ extension CheckoutController {
         return try await typedOperation.value
     }
 
-    /// Non-throwing variant of ``enqueueSessionUpdate(_:)-throws``.
-    ///
-    /// Use this when the enqueued work cannot fail. The operation is still
-    /// serialized behind any in-flight ops in the same FIFO order.
-    func enqueueSessionUpdate<T>(
-        _ body: @MainActor @escaping () async -> T
-    ) async -> T {
-        // Cast body to `throws` so that we call the underlying throwing version
-        // instead of recursing. The try! is safe because body cannot throw.
-        // swiftlint:disable:next force_try
-        return try! await enqueueSessionUpdate(body as (() async throws -> T))
-    }
-
     /// Enqueues a serialized session update.
     ///
     /// - If `update` is non-nil, the side effect (if any) is applied first, then the

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/Embedded/EmbeddedPaymentElement+Internal.swift
@@ -696,35 +696,17 @@ extension EmbeddedPaymentElement {
 
         embeddedPaymentMethodsView.isUserInteractionEnabled = false
 
-        let confirmBlock: () async -> (PaymentSheetResult, STPAnalyticsClient.DeferredIntentConfirmationType?) = {
-            await PaymentSheet.confirm(
-                configuration: self.configuration,
-                authenticationContext: authContext,
-                intent: self.intent,
-                elementsSession: self.elementsSession,
-                paymentOption: paymentOption,
-                paymentHandler: self.paymentHandler,
-                integrationShape: .embedded,
-                confirmationChallenge: self.confirmationChallenge,
-                analyticsHelper: self.analyticsHelper
-            )
-        }
-
-        let result: PaymentSheetResult
-        let deferredIntentConfirmationType: STPAnalyticsClient.DeferredIntentConfirmationType?
-
-        if let checkout {
-            if !checkout.pendingOperations.isEmpty {
-                let errorMessage = "confirm was called while the Checkout session is still loading. Wait until CheckoutController.isUpdating is false."
-                let error = PaymentSheetError.integrationError(nonPIIDebugDescription: errorMessage)
-                return (.failed(error: error), nil)
-            }
-            (result, deferredIntentConfirmationType) = await checkout.enqueueSessionUpdate {
-                await confirmBlock()
-            }
-        } else {
-            (result, deferredIntentConfirmationType) = await confirmBlock()
-        }
+        let (result, deferredIntentConfirmationType) = await PaymentSheet.confirm(
+            configuration: configuration,
+            authenticationContext: authContext,
+            intent: intent,
+            elementsSession: elementsSession,
+            paymentOption: paymentOption,
+            paymentHandler: paymentHandler,
+            integrationShape: .embedded,
+            confirmationChallenge: confirmationChallenge,
+            analyticsHelper: analyticsHelper
+        )
 
         analyticsHelper.logPayment(
             paymentOption: paymentOption,

--- a/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
+++ b/StripePaymentSheet/StripePaymentSheet/Source/PaymentSheet/PaymentSheetFlowController.swift
@@ -739,51 +739,28 @@ extension PaymentSheet {
             }
 
             func confirm() {
-                let confirmBlock = { [self] in
-                    PaymentSheet.confirm(
-                        configuration: self.configuration,
-                        authenticationContext: authenticationContext,
-                        intent: self.intent,
-                        elementsSession: self.elementsSession,
+                PaymentSheet.confirm(
+                    configuration: self.configuration,
+                    authenticationContext: authenticationContext,
+                    intent: self.intent,
+                    elementsSession: self.elementsSession,
+                    paymentOption: paymentOption,
+                    paymentHandler: self.paymentHandler,
+                    integrationShape: .flowController,
+                    confirmationChallenge: self.confirmationChallenge,
+                    analyticsHelper: self.analyticsHelper
+                ) { result, deferredIntentConfirmationType in
+                    self.analyticsHelper.logPayment(
                         paymentOption: paymentOption,
-                        paymentHandler: self.paymentHandler,
-                        integrationShape: .flowController,
-                        confirmationChallenge: self.confirmationChallenge,
-                        analyticsHelper: self.analyticsHelper
-                    ) { result, deferredIntentConfirmationType in
-                        self.analyticsHelper.logPayment(
-                            paymentOption: paymentOption,
-                            result: result,
-                            deferredIntentConfirmationType: deferredIntentConfirmationType
-                        )
-                        if case .completed = result, case .link = paymentOption {
-                            // Remember Link as default payment method for users who just created an account.
-                            CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: self.configuration.customer?.id)
-                        }
+                        result: result,
+                        deferredIntentConfirmationType: deferredIntentConfirmationType
+                    )
+                    if case .completed = result, case .link = paymentOption {
+                        // Remember Link as default payment method for users who just created an account.
+                        CustomerPaymentOption.setDefaultPaymentMethod(.link, forCustomer: self.configuration.customer?.id)
+                    }
 
-                        completion(result)
-                    }
-                }
-
-                if let checkout {
-                    // TODO(porter): Remove assumeIsolated once confirm is @MainActor (blocked on new FC API designs)
-                    if MainActor.assumeIsolated({ !checkout.pendingOperations.isEmpty }) {
-                        stpAssertionFailure("`confirm` should not be called while the Checkout session is loading.")
-                        let error = PaymentSheetError.flowControllerConfirmFailed(
-                            message: "confirmPayment was called while the Checkout session is still loading. Wait until CheckoutController.isUpdating is false."
-                        )
-                        completion(.failed(error: error))
-                        return
-                    }
-                    // We don't need to await this Task, just kick it off, because confirmBlock uses a completion.
-                    // We do need to open a task to use `Checkout`'s `enqueueSessionUpdate`, which uses Swift concurrency.
-                    Task { @MainActor in
-                        await checkout.enqueueSessionUpdate {
-                            confirmBlock()
-                        }
-                    }
-                } else {
-                    confirmBlock()
+                    completion(result)
                 }
             }
         }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutConfirmationStubbedTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutConfirmationStubbedTests.swift
@@ -108,7 +108,7 @@ final class CheckoutConfirmationStubbedTests: APIStubbedTestCase {
         // When a session update is queued behind it
         var updateExecuted = false
         let update = Task { @MainActor in
-            await checkout.enqueueSessionUpdate {
+            try await checkout.enqueueSessionUpdate {
                 updateExecuted = true
             }
         }
@@ -117,7 +117,7 @@ final class CheckoutConfirmationStubbedTests: APIStubbedTestCase {
         // Then the update waits until confirmation has finished
         XCTAssertFalse(updateExecuted)
         assertSucceeded(await confirmation.value)
-        await update.value
+        try await update.value
         XCTAssertTrue(updateExecuted)
         XCTAssertTrue(checkout.pendingOperations.isEmpty)
     }

--- a/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
+++ b/StripePaymentSheet/StripePaymentSheetTests/PaymentSheet/Checkout/CheckoutPendingOperationsTests.swift
@@ -7,10 +7,7 @@
 //
 
 @testable @_spi(STP) import StripeCore
-@testable @_spi(STP) import StripePayments
 @testable @_spi(STP) import StripePaymentSheet
-@testable @_spi(STP) import StripePaymentsTestUtils
-@_spi(STP) import StripeUICore
 import XCTest
 
 @MainActor
@@ -121,124 +118,6 @@ final class CheckoutPendingOperationsTests: XCTestCase {
         try await checkout.awaitPendingOperations(timeout: 1)
 
         XCTAssertTrue(checkout.pendingOperations.isEmpty)
-    }
-
-    // MARK: - Confirm with pending operations
-
-    func testEPEConfirmFailsWhenCheckoutPendingOperationsExist() async throws {
-        await AddressSpecProvider.shared.loadAddressSpecs()
-
-        let checkout = try await CheckoutController(configuration: CheckoutTestHelpers.makeConfiguration())
-        let gate = CheckoutPendingOperationsTestGate()
-
-        let operationTask = Task { @MainActor in
-            try await checkout.enqueueSessionUpdate {
-                await gate.wait()
-            }
-        }
-        defer { gate.open() }
-
-        try await waitUntil {
-            checkout.pendingOperations.count == 1 && gate.isWaiting
-        }
-
-        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
-        let elementsSession = STPElementsSession._testCardValue()
-        let loadResult = PaymentSheetLoader.LoadResult(
-            intent: intent,
-            elementsSession: elementsSession,
-            savedPaymentMethods: [],
-            paymentMethodTypes: [.stripe(.card)],
-            paymentMethodMessagingPromotionsHelper: ._testValue(),
-            paymentMethodOrientation: .vertical
-        )
-        let configuration = EmbeddedPaymentElement.Configuration._testValue_MostPermissive(isApplePayEnabled: false)
-        let sut = EmbeddedPaymentElement(
-            configuration: configuration,
-            loadResult: loadResult,
-            analyticsHelper: ._testValue()
-        )
-        sut.checkout = checkout
-        sut.presentingViewController = UIViewController()
-        sut._test_paymentOption = .new(confirmParams: IntentConfirmParams(type: .stripe(.card)))
-
-        let result = await sut.confirm()
-        switch result {
-        case .failed(let error):
-            XCTAssertTrue(
-                error.nonGenericDescription.contains("Checkout session is still loading"),
-                "Expected error about pending loading state, got: \(error.nonGenericDescription)"
-            )
-        default:
-            XCTFail("Expected confirm to fail due to pending operations, got: \(result)")
-        }
-
-        gate.open()
-        _ = try? await operationTask.value
-    }
-
-    func testFCConfirmFailsWhenCheckoutPendingOperationsExist() async throws {
-        await AddressSpecProvider.shared.loadAddressSpecs()
-
-        let checkout = try await CheckoutController(configuration: CheckoutTestHelpers.makeConfiguration())
-        let gate = CheckoutPendingOperationsTestGate()
-
-        let operationTask = Task { @MainActor in
-            try await checkout.enqueueSessionUpdate {
-                await gate.wait()
-            }
-        }
-        defer { gate.open() }
-
-        try await waitUntil {
-            checkout.pendingOperations.count == 1 && gate.isWaiting
-        }
-
-        let intent = Intent._testPaymentIntent(paymentMethodTypes: [.card])
-        let elementsSession = STPElementsSession._testCardValue()
-        let savedPaymentMethod = STPPaymentMethod._testCard()
-        let loadResult = PaymentSheetLoader.LoadResult(
-            intent: intent,
-            elementsSession: elementsSession,
-            savedPaymentMethods: [savedPaymentMethod],
-            paymentMethodTypes: [.stripe(.card)],
-            paymentMethodMessagingPromotionsHelper: ._testValue(),
-            paymentMethodOrientation: .vertical
-        )
-        var configuration = PaymentSheet.Configuration()
-        configuration.customer = .init(id: "cus_test", ephemeralKeySecret: "ek_test")
-        let fc = PaymentSheet.FlowController(
-            configuration: configuration,
-            loadResult: loadResult,
-            analyticsHelper: ._testValue()
-        )
-        fc.checkout = checkout
-
-        STPAssertTestUtil.shouldSuppressNextSTPAlert = true
-
-        let expectation = expectation(description: "Confirm completes")
-        fc.confirm(from: UIViewController()) { result in
-            switch result {
-            case .failed(let error):
-                XCTAssertTrue(
-                    error.nonGenericDescription.contains("Checkout session is still loading"),
-                    "Expected error about pending loading state, got: \(error.nonGenericDescription)"
-                )
-            default:
-                XCTFail("Expected confirm to fail due to pending operations, got: \(result)")
-            }
-            expectation.fulfill()
-        }
-
-        await fulfillment(of: [expectation], timeout: 2.0)
-
-        XCTAssertTrue(
-            STPAssertTestUtil.lastAssertMessage.contains("Checkout session is loading"),
-            "Expected assertion about Checkout session loading, got: \(STPAssertTestUtil.lastAssertMessage)"
-        )
-
-        gate.open()
-        _ = try? await operationTask.value
     }
 
     // MARK: - Loading & Emission Tests


### PR DESCRIPTION
## Summary
Remove the obsolete Checkout-related code from FlowController and Embedded `confirm` methods.

Also remove the nonthrowing `enqueueSessionUpdate` which is unused now.

## Testing
No new tests.

